### PR TITLE
Rebuilding the serving graph in all cells upon reparent

### DIFF
--- a/go/vt/wrangler/reparent_action.go
+++ b/go/vt/wrangler/reparent_action.go
@@ -427,8 +427,10 @@ func (wr *Wrangler) finishReparent(oldMaster, masterElect *topo.TabletInfo, majo
 		relog.Warning("minority reparent, manual fixes are needed, leaving master-elect read-only, change with: vtctl SetReadWrite %v", masterElect.Alias())
 	}
 
+	// we can't be smart and just do the old and new master cells,
+	// as we export master record everywhere.
 	relog.Info("rebuilding shard serving graph data")
-	return wr.rebuildShard(masterElect.Keyspace, masterElect.Shard, []string{oldMaster.Cell, masterElect.Cell})
+	return wr.rebuildShard(masterElect.Keyspace, masterElect.Shard, nil)
 }
 
 func (wr *Wrangler) breakReplication(slaveMap map[topo.TabletAlias]*topo.TabletInfo, masterElect *topo.TabletInfo) error {

--- a/go/vt/wrangler/reparent_external.go
+++ b/go/vt/wrangler/reparent_external.go
@@ -76,9 +76,11 @@ func (wr *Wrangler) reparentShardExternal(slaveTabletMap map[topo.TabletAlias]*t
 		return err
 	}
 
-	// and rebuild the shard graph
+	// and rebuild the shard graph.
+	// we can't be smart and just do the old and new master cells,
+	// as we export master record everywhere.
 	relog.Info("rebuilding shard serving graph data")
-	return wr.rebuildShard(masterElectTablet.Keyspace, masterElectTablet.Shard, []string{masterTablet.Cell, masterElectTablet.Cell})
+	return wr.rebuildShard(masterElectTablet.Keyspace, masterElectTablet.Shard, nil)
 }
 
 func (wr *Wrangler) restartSlavesExternal(slaveTabletMap map[topo.TabletAlias]*topo.TabletInfo, masterTablet, masterElectTablet *topo.TabletInfo, scrapStragglers bool) error {


### PR DESCRIPTION
As we export the master record everywhere.
