### PR TITLE
Fix for update stream test.

### DIFF
--- a/py/vtdb/update_stream_service.py
+++ b/py/vtdb/update_stream_service.py
@@ -17,7 +17,7 @@ class ReplPosition(object):
     self.MasterFilename = master_filename
     self.MasterPosition = master_position
 
-class BinlogPosition(object):
+class Coord(object):
   Position = None
   Timestamp = None
   Xid = None
@@ -51,8 +51,8 @@ class EventData(object):
 
 
 class UpdateStreamResponse(object):
-  BinlogPosition = None
-  EventData = None
+  Coord = None
+  Data = None
   Error = None
 
   def __init__(self, response_dict):
@@ -64,8 +64,8 @@ class UpdateStreamResponse(object):
       self.Error = None
     else:
       self.Error = self.raw_response['Error']
-    self.BinlogPosition = self.raw_response['BinlogPosition']
-    self.EventData = EventData(self.raw_response['EventData']).__dict__
+    self.Coord = self.raw_response['Coord']
+    self.Data = EventData(self.raw_response['Data']).__dict__
 
 class UpdateStreamConnection(object):
   def __init__(self, addr, timeout, user=None, password=None, encrypted=False, keyfile=None, certfile=None):
@@ -90,7 +90,7 @@ class UpdateStreamConnection(object):
     except:
       logging.exception('gorpc low-level error')
       raise
-    return update_stream_response.BinlogPosition, update_stream_response.EventData, update_stream_response.Error
+    return update_stream_response.Coord, update_stream_response.Data, update_stream_response.Error
 
   def stream_next(self):
     try:
@@ -103,4 +103,4 @@ class UpdateStreamConnection(object):
     except:
       logging.exception('gorpc low-level error')
       raise
-    return update_stream_response.BinlogPosition, update_stream_response.EventData, update_stream_response.Error
+    return update_stream_response.Coord, update_stream_response.Data, update_stream_response.Error

--- a/test/rowcache_invalidator.py
+++ b/test/rowcache_invalidator.py
@@ -41,7 +41,7 @@ primary key (id)
 
 def _get_master_current_position():
   res = utils.mysql_query(62344, 'vt_test_keyspace', 'show master status')
-  start_position = update_stream_service.BinlogPosition(res[0][0], res[0][1])
+  start_position = update_stream_service.Coord(res[0][0], res[0][1])
   return start_position.__dict__
 
 
@@ -55,7 +55,7 @@ def _get_repl_current_position():
   slave_dict = res[0]
   master_log = slave_dict['File']
   master_pos = slave_dict['Position']
-  start_position = update_stream_service.BinlogPosition(master_log, master_pos)
+  start_position = update_stream_service.Coord(master_log, master_pos)
   return start_position.__dict__
 
 

--- a/third_party/mysql.patch
+++ b/third_party/mysql.patch
@@ -55,7 +55,7 @@ index 8158783..8b137c0 100644
  				$(top_srcdir)/mysys/base64.c
  mysqlbinlog_LDADD =		$(LDADD) $(CXXLDFLAGS)
  
-+vt_mysqlbinlog_SOURCES =	mysqlbinlog.cc \
++vt_mysqlbinlog_SOURCES =	vt_mysqlbinlog.cc \
 +				$(top_srcdir)/mysys/checksum.c \
 +				$(top_srcdir)/mysys/mf_tempdir.c \
 +				$(top_srcdir)/mysys/my_new.cc \


### PR DESCRIPTION
@sougou, @alainjobart, @ryszard 

This includes
- fix for mysql.patch to fix the vt_mysqlbinlog binary. Needs bootstrap to be run again.
- Fixes the bson encoding for update stream by using named variables rather than embedded variables.
- Corresponding change in py/vtdb/update_stream_service.py and rowcache_invalidator.go
