### PR TITLE
libzookeeper_mt prior to 3.4.x doesn't handle IPv6, so prune the resolve...

### DIFF
--- a/go/netutil/netutil.go
+++ b/go/netutil/netutil.go
@@ -138,3 +138,19 @@ func ResolveIpAddr(addr string) (string, error) {
 	}
 	return net.JoinHostPort(ipAddrs[0], port), nil
 }
+
+// ResolveIpAddr resolves the address:port part into an IP address:port pair
+func ResolveIPv4Addr(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	ipAddrs, err := net.LookupIP(host)
+	for _, ipAddr := range ipAddrs {
+		ipv4 := ipAddr.To4()
+		if ipv4 != nil {
+			return net.JoinHostPort(ipv4.String(), port), nil
+		}
+	}
+	return "", fmt.Errorf("no IPv4addr for name %v", host)
+}

--- a/go/zk/zkconn.go
+++ b/go/zk/zkconn.go
@@ -150,7 +150,8 @@ func resolveZkAddr(zkAddr string) (string, error) {
 	parts := strings.Split(zkAddr, ",")
 	resolved := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if r, err := netutil.ResolveIpAddr(part); err != nil {
+		// The zookeeper client cannot handle IPv6 addresses before version 3.4.x.
+		if r, err := netutil.ResolveIPv4Addr(part); err != nil {
 			log.Infof("cannot resolve %v, will not use it: %v", part, err)
 		} else {
 			resolved = append(resolved, r)


### PR DESCRIPTION
...d addresses we give the library for now.

The other option would be to bundle zk 3.4.5 instead. Up to you. I'm using 3.4.5 elsewhere and it's a much more stable version that 3.3.5.
