### PR TITLE
fix: don't eat the next value when a streaming rpc call ends as expected

### DIFF
--- a/go/rpcplus/client.go
+++ b/go/rpcplus/client.go
@@ -135,10 +135,10 @@ func (client *Client) input() {
 			// error if there is one.
 			if !(call.Stream && response.Error == lastStreamResponseError) {
 				call.Error = ServerError(response.Error)
-			}
-			err = client.codec.ReadResponseBody(nil)
-			if err != nil {
-				err = errors.New("reading error payload: " + err.Error())
+				err = client.codec.ReadResponseBody(nil)
+				if err != nil {
+					err = errors.New("reading error payload: " + err.Error())
+				}
 			}
 			client.done(seq)
 		case call.Stream:


### PR DESCRIPTION
I was just wiring up a MsgPack codec that doesn't support decoding into nil values (I didn't know that the gob decoder allowed you to discard values in that way -- interesting!) and I noticed that my decoder was always returning an error after the last stream response.  In any case, I think that it's a bug to discard the next value on the connection after the last stream response.  Cheers!
