### PR TITLE
make vtgate topo agnostic

### DIFF
--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtgate"
-	_ "github.com/youtube/vitess/go/vt/zktopo"
 )
 
 var (


### PR DESCRIPTION
Topo server support is controlled by plugins. Not everyone needs
zookeeper support.

Review: https://codereview.appspot.com/111420043/
