### PR TITLE
fix time sql serialization.

### DIFF
--- a/go/sqltypes/sqltypes.go
+++ b/go/sqltypes/sqltypes.go
@@ -242,7 +242,7 @@ func BuildValue(goval interface{}) (v Value, err error) {
 	case []byte:
 		v = Value{String(bindVal)}
 	case time.Time:
-		v = Value{String([]byte(bindVal.Format("'2006-01-02 15:04:05'")))}
+		v = Value{String([]byte(bindVal.Format("2006-01-02 15:04:05")))}
 	case Numeric, Fractional, String:
 		v = Value{bindVal.(InnerValue)}
 	case Value:

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -56,6 +56,20 @@ func TestNumeric(t *testing.T) {
 	}
 }
 
+func TestTime(t *testing.T) {
+    date := time.Date(1999, 1, 2, 3, 4, 5, 0, time.UTC)
+    v, _ := BuildValue(date)
+    if !v.IsString() || v.String() != "1999-01-02 03:04:05" {
+        t.Errorf("Expecting 1999-01-02 03:04:05, got %s", v.String())
+    }
+
+    b := &bytes.Buffer{}
+    v.EncodeSql(b)
+    if b.String() != "'1999-01-02 03:04:05'" {
+        t.Errorf("Expecting '1999-01-02 03:04:05', got %s", b.String())
+    }
+}
+
 const (
 	INVALIDNEG = "-9223372036854775809"
 	MINNEG     = "-9223372036854775808"
@@ -243,8 +257,8 @@ func TestBuildValue(t *testing.T) {
 	if err != nil {
 		t.Errorf("%v", err)
 	}
-	if !v.IsString() || v.String() != "'2012-02-24 23:19:43'" {
-		t.Errorf("Expecting '2012-02-24 23:19:43', received %T: %s", v.Inner, v.String())
+	if !v.IsString() || v.String() != "2012-02-24 23:19:43" {
+		t.Errorf("Expecting 2012-02-24 23:19:43, received %T: %s", v.Inner, v.String())
 	}
 	v, err = BuildValue(Numeric([]byte("123")))
 	if err != nil {


### PR DESCRIPTION
In the original implementation, time values were incorrectly encoded as sql strings with 4 single quotes, i.e.,
''2006-01-02 15:04:05''.  This is of course invalid.
