### PR TITLE
Lowercase shards for ResilientSrvTopoServer.GetEndPoints.

### DIFF
--- a/go/vt/vtgate/srv_topo_server.go
+++ b/go/vt/vtgate/srv_topo_server.go
@@ -294,6 +294,7 @@ func (server *ResilientSrvTopoServer) GetSrvKeyspace(context context.Context, ce
 
 // GetEndPoints return all endpoints for the given cell, keyspace, shard, and tablet type.
 func (server *ResilientSrvTopoServer) GetEndPoints(context context.Context, cell, keyspace, shard string, tabletType topo.TabletType) (result *topo.EndPoints, err error) {
+	shard = strings.ToLower(shard)
 	key := []string{cell, keyspace, shard, string(tabletType)}
 
 	server.counts.Add(queryCategory, 1)


### PR DESCRIPTION
This prevents using duplicative cache entries and counters for
essentially the same value.
