### PR TITLE
tabletserver: bug fix for update statements

### DIFF
--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -367,13 +367,11 @@ func (qre *QueryExecutor) execDMLPKRows(conn dbconnpool.PoolConnection, pkRows [
 	}
 
 	bsc := buildStreamComment(qre.plan.TableInfo, pkRows, secondaryList)
-	bv := map[string]interface{}{
-		"#pk": sqlparser.TupleEqualityList{
-			Columns: qre.plan.TableInfo.Indexes[0].Columns,
-			Rows:    pkRows,
-		},
+	qre.bindVars["#pk"] = sqlparser.TupleEqualityList{
+		Columns: qre.plan.TableInfo.Indexes[0].Columns,
+		Rows:    pkRows,
 	}
-	result = qre.directFetch(conn, qre.plan.OuterQuery, bv, nil, bsc)
+	result = qre.directFetch(conn, qre.plan.OuterQuery, qre.bindVars, nil, bsc)
 	if invalidator == nil {
 		return result
 	}

--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -152,6 +152,7 @@ class TestNocache(framework.TestCase):
       self.env.execute("insert into vtocc_a(eid, id, name, foo) values (8, 2, '', '') on duplicate key update id = 2+1")
       self.env.execute("update vtocc_a set eid = 1+1 where eid = 1 and id = 1")
       self.env.execute("insert into vtocc_d(eid, id) values (1, 1)")
+      self.env.execute("update vtocc_a set eid = :eid where eid = 1 and id = 1", {"eid": 3})
     finally:
       self.env.conn.rollback()
       self.env.execute("set vt_strict_mode=1")


### PR DESCRIPTION
For update statements, the new bind vars have to be added
to the original bind vars (instead of replacing them). This
is because SET clauses can use bind vars.
