### PR TITLE
Remove CheckAccessActor from interface.

### DIFF
--- a/go/acl/acl.go
+++ b/go/acl/acl.go
@@ -36,9 +36,6 @@ var (
 // Policy defines the interface that needs to be satisfied by
 // ACL policy implementors.
 type Policy interface {
-	// CheckAccessActor can be called to verify if an actor
-	// has access to the role.
-	CheckAccessActor(actor, role string) error
 	// CheckAccessHTTP can be called to verify if an actor in
 	// the http request has access to the role.
 	CheckAccessHTTP(req *http.Request, role string) error
@@ -64,16 +61,6 @@ func savePolicy() {
 		log.Warningf("policy %s not found, using fallback policy", *securityPolicy)
 		currentPolicy = FallbackPolicy{}
 	}
-}
-
-// CheckAccessActor uses the current security policy to
-// verify if an actor has access to the role.
-func CheckAccessActor(actor, role string) error {
-	once.Do(savePolicy)
-	if currentPolicy != nil {
-		return currentPolicy.CheckAccessActor(actor, role)
-	}
-	return nil
 }
 
 // CheckAccessHTTP uses the current security policy to

--- a/go/acl/acl_test.go
+++ b/go/acl/acl_test.go
@@ -12,13 +12,6 @@ import (
 
 type TestPolicy struct{}
 
-func (tp TestPolicy) CheckAccessActor(actor, role string) error {
-	if role == ADMIN {
-		return errors.New("not allowed")
-	}
-	return nil
-}
-
 func (tp TestPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 	if role == ADMIN {
 		return errors.New("not allowed")
@@ -32,17 +25,8 @@ func init() {
 
 func TestSimplePolicy(t *testing.T) {
 	currentPolicy = policies["test"]
-	err := CheckAccessActor("", ADMIN)
 	want := "not allowed"
-	if err == nil || err.Error() != want {
-		t.Errorf("got %v, want %s", err, want)
-	}
-	err = CheckAccessActor("", DEBUGGING)
-	if err != nil {
-		t.Errorf("got %v, want no error", err)
-	}
-
-	err = CheckAccessHTTP(nil, ADMIN)
+	err := CheckAccessHTTP(nil, ADMIN)
 	if err == nil || err.Error() != want {
 		t.Errorf("got %v, want %s", err, want)
 	}
@@ -54,16 +38,7 @@ func TestSimplePolicy(t *testing.T) {
 
 func TestEmptyPolicy(t *testing.T) {
 	currentPolicy = nil
-	err := CheckAccessActor("", ADMIN)
-	if err != nil {
-		t.Errorf("got %v, want no error", err)
-	}
-	err = CheckAccessActor("", DEBUGGING)
-	if err != nil {
-		t.Errorf("got %v, want no error", err)
-	}
-
-	err = CheckAccessHTTP(nil, ADMIN)
+	err := CheckAccessHTTP(nil, ADMIN)
 	if err != nil {
 		t.Errorf("got %v, want no error", err)
 	}

--- a/go/acl/fallback_policy.go
+++ b/go/acl/fallback_policy.go
@@ -16,11 +16,6 @@ var fallbackError = errors.New("not allowed: fallback policy")
 // access.
 type FallbackPolicy struct{}
 
-// CheckAccessActor disallows all actor access.
-func (fp FallbackPolicy) CheckAccessActor(actor, role string) error {
-	return fallbackError
-}
-
 // CheckAccessHTTP disallows all HTTP access.
 func (fp FallbackPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 	return fallbackError


### PR DESCRIPTION
Remove unused interface member and supporting code / tests.
