### PR TITLE
Demote "Logged transaction:" log messages from warning to info.

### DIFF
--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -246,7 +246,7 @@ func (txc *TxConnection) discard(conclusion string) {
 	// Ensure PoolConnection won't be accessed after Recycle.
 	txc.PoolConnection = nil
 	if txc.LogToFile.Get() != 0 {
-		log.Warningf("Logged transaction: %s", txc.Format(nil))
+		log.Infof("Logged transaction: %s", txc.Format(nil))
 	}
 	TxLogger.Send(txc)
 }


### PR DESCRIPTION
@alainjobart @sougou 

There are already error-level messages highlighting this state, and
marking these as "warnings" adds nothing to problem discoverability
(while obscuring other, probably more useful warnings).  They are
useful informational messages, but "info" logging is sufficient here.
