### PR TITLE
Stopping replication before copying data in clone workers.

### DIFF
--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -358,6 +358,8 @@ index by_msg (msg)
                           '--min_table_size_for_split', '1',
                           'test_keyspace/0'],
                          auto_log=True)
+      utils.run_vtctl(['ChangeSlaveType', shard_rdonly.tablet_alias, 'rdonly'],
+                      auto_log=True)
 
     else:
       # take the snapshot for the split

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -534,6 +534,8 @@ primary key (name)
                           '--min_table_size_for_split', '1',
                           'test_keyspace/80-c0'],
                          auto_log=True)
+      utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly.tablet_alias, 'rdonly'],
+                      auto_log=True)
 
       # TODO(alainjobart): experiment with the dontStartBinlogPlayer option
 

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -324,6 +324,8 @@ index by_msg (msg)
                           '--min_table_size_for_split', '1',
                           'destination_keyspace/0'],
                          auto_log=True)
+      utils.run_vtctl(['ChangeSlaveType', source_rdonly.tablet_alias, 'rdonly'],
+                      auto_log=True)
 
     else:
       # take the snapshot for the split


### PR DESCRIPTION
@enisoc 
Then we change the type of the servers back to 'spare' and restart replication.
That way when they catch up (and if healthcheck is enabled) they
come back to serving state.
