### PR TITLE
Changing documentation about ramdisk to use 4g instead of 2g

### DIFF
--- a/doc/TestingOnARamDisk.md
+++ b/doc/TestingOnARamDisk.md
@@ -4,13 +4,13 @@ The `integration_test` testsuite contains tests that may time-out if run against
 
 # Setup
 
-First, set up a normal vitess development environment by running `bootstrap.sh` and sourcing `dev.env` (see [GettingStarted](GettingStarted.md)). Then overwrite the testing temporary directories and make a 2GiB ramdisk at the location of your choice (this example uses `/tmp/vt`):
+First, set up a normal vitess development environment by running `bootstrap.sh` and sourcing `dev.env` (see [GettingStarted](GettingStarted.md)). Then overwrite the testing temporary directories and make a 4GiB (smaller sizes may work, if you're constrained on RAM) ramdisk at the location of your choice (this example uses `/tmp/vt`):
 
 ```sh
 export TEST_TMPDIR=/tmp/vt
 
 mkdir ${TEST_TMPDIR}
-sudo mount -t tmpfs -o size=2g tmpfs ${TEST_TMPDIR}
+sudo mount -t tmpfs -o size=4g tmpfs ${TEST_TMPDIR}
 
 export VTDATAROOT=${TEST_TMPDIR}
 export TEST_UNDECLARED_OUTPUTS_DIR=${TEST_TMPDIR}


### PR DESCRIPTION
When following the instructions, I found that a 2g ramdisk wasn't large enough. I saw errors like:

"log: exiting because of error: write /tmp/vt/tmp/mysqlctl.aaijazi.aaijazi.log.INFO.20141030-110215.31092: no space left on device"

Bumping ramdisk size to 4g (who doesn't love powers of 2?) made tests pass successfully.

@enisoc 
