### PR TITLE
Make queryservice healthcheck failure string sane.

### DIFF
--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -206,7 +206,8 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	if err := IsHealthy(); err != nil {
-		w.Write([]byte("notok"))
+		w.Write([]byte("not ok"))
+		return
 	}
 	w.Write([]byte("ok"))
 }


### PR DESCRIPTION
It was "notokok", which makes no sense. "not ok" is perfectly clear and
equally valid.
