### PR TITLE
Add ExternalID parameter to TabletExternallyReparented.

### DIFF
--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -513,13 +513,13 @@ func agentRpcTestStartSlave(ctx context.Context, t *testing.T, client tmclient.T
 
 var testTabletExternallyReparentedCalled = false
 
-func (fra *fakeRpcAgent) TabletExternallyReparented(ctx context.Context, actionTimeout time.Duration) error {
+func (fra *fakeRpcAgent) TabletExternallyReparented(ctx context.Context, externalID string, actionTimeout time.Duration) error {
 	testTabletExternallyReparentedCalled = true
 	return nil
 }
 
 func agentRpcTestTabletExternallyReparented(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo) {
-	err := client.TabletExternallyReparented(ctx, ti, time.Minute)
+	err := client.TabletExternallyReparented(ctx, ti, "", time.Minute)
 	compareError(t, "TabletExternallyReparented", err, true, testTabletExternallyReparentedCalled)
 }
 

--- a/go/vt/tabletmanager/gorpcproto/structs.go
+++ b/go/vt/tabletmanager/gorpcproto/structs.go
@@ -78,3 +78,7 @@ type MultiSnapshotStreamingReply struct {
 	Log    *logutil.LoggerEvent
 	Result *actionnode.MultiSnapshotReply
 }
+
+type TabletExternallyReparentedArgs struct {
+	ExternalID string
+}

--- a/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
+++ b/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
@@ -214,8 +214,8 @@ func (client *GoRpcTabletManagerClient) StartSlave(ctx context.Context, tablet *
 	return client.rpcCallTablet(ctx, tablet, actionnode.TABLET_ACTION_START_SLAVE, "", &rpc.Unused{}, waitTime)
 }
 
-func (client *GoRpcTabletManagerClient) TabletExternallyReparented(ctx context.Context, tablet *topo.TabletInfo, waitTime time.Duration) error {
-	return client.rpcCallTablet(ctx, tablet, actionnode.TABLET_ACTION_EXTERNALLY_REPARENTED, "", &rpc.Unused{}, waitTime)
+func (client *GoRpcTabletManagerClient) TabletExternallyReparented(ctx context.Context, tablet *topo.TabletInfo, externalID string, waitTime time.Duration) error {
+	return client.rpcCallTablet(ctx, tablet, actionnode.TABLET_ACTION_EXTERNALLY_REPARENTED, &gorpcproto.TabletExternallyReparentedArgs{ExternalID: externalID}, &rpc.Unused{}, waitTime)
 }
 
 func (client *GoRpcTabletManagerClient) GetSlaves(ctx context.Context, tablet *topo.TabletInfo, waitTime time.Duration) ([]string, error) {

--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
@@ -219,12 +219,12 @@ func (tm *TabletManager) StartSlave(ctx context.Context, args *rpc.Unused, reply
 	})
 }
 
-func (tm *TabletManager) TabletExternallyReparented(ctx context.Context, args *rpc.Unused, reply *rpc.Unused) error {
+func (tm *TabletManager) TabletExternallyReparented(ctx context.Context, args *gorpcproto.TabletExternallyReparentedArgs, reply *rpc.Unused) error {
 	// TODO(alainjobart) we should forward the RPC deadline from
 	// the original gorpc call. Until we support that, use a
-	// reasonnable hard-coded value.
+	// reasonable hard-coded value.
 	return tm.agent.RpcWrapLock(ctx, actionnode.TABLET_ACTION_EXTERNALLY_REPARENTED, args, reply, false, func() error {
-		return tm.agent.TabletExternallyReparented(ctx, 30*time.Second)
+		return tm.agent.TabletExternallyReparented(ctx, args.ExternalID, 30*time.Second)
 	})
 }
 

--- a/go/vt/tabletmanager/tmclient/rpc_client_api.go
+++ b/go/vt/tabletmanager/tmclient/rpc_client_api.go
@@ -113,8 +113,13 @@ type TabletManagerClient interface {
 	// StartSlave starts the mysql replication
 	StartSlave(ctx context.Context, tablet *topo.TabletInfo, waitTime time.Duration) error
 
-	// TabletExternallyReparented tells a tablet it is now the master
-	TabletExternallyReparented(ctx context.Context, tablet *topo.TabletInfo, waitTime time.Duration) error
+	// TabletExternallyReparented tells a tablet it is now the master, after an
+	// external tool has already promoted the underlying mysqld to master and
+	// reparented the other mysqld servers to it.
+	//
+	// externalID is an optional string provided by the external tool that
+	// vttablet will emit in logs to facilitate cross-referencing.
+	TabletExternallyReparented(ctx context.Context, tablet *topo.TabletInfo, externalID string, waitTime time.Duration) error
 
 	// GetSlaves returns the addresses of the slaves
 	GetSlaves(ctx context.Context, tablet *topo.TabletInfo, waitTime time.Duration) ([]string, error)

--- a/go/vt/topotools/events/reparent.go
+++ b/go/vt/topotools/events/reparent.go
@@ -17,4 +17,5 @@ type Reparent struct {
 
 	ShardInfo            topo.ShardInfo
 	OldMaster, NewMaster topo.Tablet
+	ExternalID           string
 }

--- a/go/vt/topotools/events/reparent_syslog.go
+++ b/go/vt/topotools/events/reparent_syslog.go
@@ -13,9 +13,9 @@ import (
 
 // Syslog writes a Reparent event to syslog.
 func (r *Reparent) Syslog() (syslog.Priority, string) {
-	return syslog.LOG_INFO, fmt.Sprintf("%s/%s [reparent %v -> %v] %s",
+	return syslog.LOG_INFO, fmt.Sprintf("%s/%s [reparent %v -> %v] %s (%s)",
 		r.ShardInfo.Keyspace(), r.ShardInfo.ShardName(),
-		r.OldMaster.Alias, r.NewMaster.Alias, r.Status)
+		r.OldMaster.Alias, r.NewMaster.Alias, r.Status, r.ExternalID)
 }
 
 var _ syslogger.Syslogger = (*Reparent)(nil) // compile-time interface check

--- a/go/vt/topotools/events/reparent_syslog_test.go
+++ b/go/vt/topotools/events/reparent_syslog_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestReparentSyslog(t *testing.T) {
-	wantSev, wantMsg := syslog.LOG_INFO, "keyspace-123/shard-123 [reparent cell-0000012345 -> cell-0000054321] status"
+	wantSev, wantMsg := syslog.LOG_INFO, "keyspace-123/shard-123 [reparent cell-0000012345 -> cell-0000054321] status (123-456-789)"
 	tc := &Reparent{
 		ShardInfo: *topo.NewShardInfo("keyspace-123", "shard-123", nil, -1),
 		OldMaster: topo.Tablet{
@@ -28,6 +28,7 @@ func TestReparentSyslog(t *testing.T) {
 				Uid:  54321,
 			},
 		},
+		ExternalID:    "123-456-789",
 		StatusUpdater: base.StatusUpdater{Status: "status"},
 	}
 	gotSev, gotMsg := tc.Syslog()

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1237,7 +1237,7 @@ func commandShardExternallyReparented(wr *wrangler.Wrangler, subFlags *flag.Flag
 		if err != nil {
 			return err
 		}
-		return wr.TabletManagerClient().TabletExternallyReparented(context.TODO(), ti, wr.ActionTimeout())
+		return wr.TabletManagerClient().TabletExternallyReparented(context.TODO(), ti, "", wr.ActionTimeout())
 	}
 	return wr.ShardExternallyReparented(keyspace, shard, tabletAlias)
 }


### PR DESCRIPTION
@alainjobart 

This ID can optionally be provided by the external tool doing the
reparnt. The ID gets printed in logs to allow cross-referencing with
logs from the external tool.
