### PR TITLE
add logging.debug to enviroment.run to print debug info

### DIFF
--- a/test/environment.py
+++ b/test/environment.py
@@ -69,6 +69,7 @@ def reserve_ports(count):
 # simple run command, cannot use utils.run to avoid circular dependencies
 def run(args, raise_on_error=True, **kargs):
   try:
+    logging.debug("run: %s %s", str(args), ', '.join('%s=%s' % x for x in kargs.iteritems()))
     proc = subprocess.Popen(args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,

--- a/test/topo_flavor/zookeeper.py
+++ b/test/topo_flavor/zookeeper.py
@@ -50,6 +50,7 @@ class ZkTopoServer(server.TopoServer):
       }
       json.dump(zk_cell_mapping, f)
     os.environ['ZK_CLIENT_CONFIG'] = config
+    logging.debug('Using ZK_CLIENT_CONFIG=%s', str(config))
     run(binary_args('zk') + ['touch', '-p', '/zk/test_nj/vt'])
     run(binary_args('zk') + ['touch', '-p', '/zk/test_ny/vt'])
     run(binary_args('zk') + ['touch', '-p', '/zk/test_ca/vt'])


### PR DESCRIPTION
I try to use tests file to find out how to setup vitess and reappear the process by shell command.
But the zkctld command was missed, and without this command we cannot setup vitess manually.

```
python tabletmanager.py  -d -v 
```

So I add the logging.debug to the test files.

![qq 20141117184410](https://cloud.githubusercontent.com/assets/1264866/5068488/c04cd9d6-6e89-11e4-89a6-5ed64cde663b.jpg)
