### PR TITLE
tabletserver: DML workaround for MariaDB

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -59,6 +59,7 @@ type QueryEngine struct {
 	spotCheckFreq    sync2.AtomicInt64
 	strictMode       sync2.AtomicInt64
 	maxResultSize    sync2.AtomicInt64
+	maxDMLRows       sync2.AtomicInt64
 	streamBufferSize sync2.AtomicInt64
 	strictTableAcl   bool
 
@@ -161,6 +162,7 @@ func NewQueryEngine(config Config) *QueryEngine {
 	}
 	qe.strictTableAcl = config.StrictTableAcl
 	qe.maxResultSize = sync2.AtomicInt64(config.MaxResultSize)
+	qe.maxDMLRows = sync2.AtomicInt64(config.MaxDMLRows)
 	qe.streamBufferSize = sync2.AtomicInt64(config.StreamBufferSize)
 
 	// loggers
@@ -168,6 +170,7 @@ func NewQueryEngine(config Config) *QueryEngine {
 
 	// Stats
 	stats.Publish("MaxResultSize", stats.IntFunc(qe.maxResultSize.Get))
+	stats.Publish("MaxDMLRows", stats.IntFunc(qe.maxDMLRows.Get))
 	stats.Publish("StreamBufferSize", stats.IntFunc(qe.streamBufferSize.Get))
 	stats.Publish("QueryTimeout", stats.DurationFunc(qe.queryTimeout.Get))
 	queryStats = stats.NewTimings("Queries")

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -34,6 +34,7 @@ func init() {
 	flag.IntVar(&qsConfig.TransactionCap, "queryserver-config-transaction-cap", DefaultQsConfig.TransactionCap, "query server transaction cap")
 	flag.Float64Var(&qsConfig.TransactionTimeout, "queryserver-config-transaction-timeout", DefaultQsConfig.TransactionTimeout, "query server transaction timeout")
 	flag.IntVar(&qsConfig.MaxResultSize, "queryserver-config-max-result-size", DefaultQsConfig.MaxResultSize, "query server max result size")
+	flag.IntVar(&qsConfig.MaxDMLRows, "queryserver-config-max-dml-rows", DefaultQsConfig.MaxDMLRows, "query server max dml rows per statement")
 	flag.IntVar(&qsConfig.StreamBufferSize, "queryserver-config-stream-buffer-size", DefaultQsConfig.StreamBufferSize, "query server stream buffer size")
 	flag.IntVar(&qsConfig.QueryCacheSize, "queryserver-config-query-cache-size", DefaultQsConfig.QueryCacheSize, "query server query cache size")
 	flag.Float64Var(&qsConfig.SchemaReloadTime, "queryserver-config-schema-reload-time", DefaultQsConfig.SchemaReloadTime, "query server schema reload time")
@@ -96,6 +97,7 @@ type Config struct {
 	TransactionCap     int
 	TransactionTimeout float64
 	MaxResultSize      int
+	MaxDMLRows         int
 	StreamBufferSize   int
 	QueryCacheSize     int
 	SchemaReloadTime   float64
@@ -122,6 +124,7 @@ var DefaultQsConfig = Config{
 	TransactionCap:     20,
 	TransactionTimeout: 30,
 	MaxResultSize:      10000,
+	MaxDMLRows:         500,
 	QueryCacheSize:     5000,
 	SchemaReloadTime:   30 * 60,
 	QueryTimeout:       0,

--- a/test/queryservice_tests/nocache_cases.py
+++ b/test/queryservice_tests/nocache_cases.py
@@ -652,6 +652,39 @@ cases = [
       Case(sql='select * from vtocc_a where eid=2',
            result=[])]),
 
+  MultiCase(
+      'update many rows',
+      ['begin',
+      "insert into vtocc_a(eid, id, name, foo) values (3, 1, '', ''), (3, 2, '', ''), (3, 3, '', '')",
+      'commit',
+      'begin',
+      Case(sql="update vtocc_a set foo='fghi' where eid = 3",
+           rewritten=[
+               'select eid, id from vtocc_a where eid = 3 limit 10001 for update',
+               "update vtocc_a set foo = 'fghi' where (eid = 3 and id = 1) or (eid = 3 and id = 2) or (eid = 3 and id = 3) /* _stream vtocc_a (eid id ) (3 1 ) (3 2 ) (3 3 )"]),
+      'commit',
+      "set vt_max_dml_rows=2",
+      'begin',
+      Case(sql="update vtocc_a set eid=2 where eid = 3",
+           rewritten=[
+               'select eid, id from vtocc_a where eid = 3 limit 10001 for update',
+               "update vtocc_a set eid = 2 where (eid = 3 and id = 1) or (eid = 3 and id = 2) /* _stream vtocc_a (eid id ) (3 1 ) (3 2 ) (2 1 ) (2 2 )",
+               "update vtocc_a set eid = 2 where (eid = 3 and id = 3) /* _stream vtocc_a (eid id ) (3 3 ) (2 3 )"]),
+      Case(sql="update vtocc_a set foo='fghi' where eid = 2",
+           rewritten=[
+               'select eid, id from vtocc_a where eid = 2 limit 10001 for update',
+               "update vtocc_a set foo = 'fghi' where (eid = 2 and id = 1) or (eid = 2 and id = 2) /* _stream vtocc_a (eid id ) (2 1 ) (2 2 )",
+               "update vtocc_a set foo = 'fghi' where (eid = 2 and id = 3) /* _stream vtocc_a (eid id ) (2 3 )"]),
+      Case(sql="delete from vtocc_a where eid = 2",
+           rewritten=[
+               'select eid, id from vtocc_a where eid = 2 limit 10001 for update',
+               "delete from vtocc_a where (eid = 2 and id = 1) or (eid = 2 and id = 2) /* _stream vtocc_a (eid id ) (2 1 ) (2 2 )",
+               "delete from vtocc_a where (eid = 2 and id = 3) /* _stream vtocc_a (eid id ) (2 3 )"]),
+      'commit',
+      "set vt_max_dml_rows=500",
+      Case(sql='select * from vtocc_a where eid=2',
+           result=[])]),
+
   # data types test
   MultiCase(
       'integer data types',


### PR DESCRIPTION
It turns out that MariaDB's optimizer triggers
a full table scan if the number of rows affected by a DML
exceeds a rather low amount. So, we need to break up our
updates into multiple chunks if we need to modify too many
rows. Default is set at 500.
