### PR TITLE
dbconfigs: remove defaults, they cause confusion.

### DIFF
--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -16,26 +16,7 @@ import (
 )
 
 // Offer a default config.
-var DefaultDBConfigs = DBConfigs{
-	App: DBConfig{
-		ConnectionParams: mysql.ConnectionParams{
-			Uname:   "vt_app",
-			Charset: "utf8",
-		},
-	},
-	Dba: mysql.ConnectionParams{
-		Uname:   "vt_dba",
-		Charset: "utf8",
-	},
-	Filtered: mysql.ConnectionParams{
-		Uname:   "vt_filtered",
-		Charset: "utf8",
-	},
-	Repl: mysql.ConnectionParams{
-		Uname:   "vt_repl",
-		Charset: "utf8",
-	},
-}
+var DefaultDBConfigs = DBConfigs{}
 
 // We keep a global singleton for the db configs, and that's the one
 // the flags will change


### PR DESCRIPTION
DB config defaults are a source of confusion. It's better
to make these explicit. It was already the case, mostly.
This CL removes the few places that are not.
