### PR TITLE
Add tracing for refreshTablet and action unlock.

### DIFF
--- a/go/vt/tabletmanager/actionnode/utils.go
+++ b/go/vt/tabletmanager/actionnode/utils.go
@@ -37,7 +37,13 @@ func (n *ActionNode) LockKeyspace(ctx context.Context, ts topo.Server, keyspace 
 }
 
 // UnlockKeyspace unlocks a previously locked keyspace.
-func (n *ActionNode) UnlockKeyspace(ts topo.Server, keyspace string, lockPath string, actionError error) error {
+func (n *ActionNode) UnlockKeyspace(ctx context.Context, ts topo.Server, keyspace string, lockPath string, actionError error) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.UnlockKeyspaceForAction")
+	span.Annotate("action", n.Action)
+	span.Annotate("keyspace", keyspace)
+	defer span.Finish()
+
 	// first update the actionNode
 	if actionError != nil {
 		log.Infof("Unlocking keyspace %v for action %v with error %v", keyspace, n.Action, actionError)
@@ -75,7 +81,14 @@ func (n *ActionNode) LockShard(ctx context.Context, ts topo.Server, keyspace, sh
 }
 
 // UnlockShard unlocks a previously locked shard.
-func (n *ActionNode) UnlockShard(ts topo.Server, keyspace, shard string, lockPath string, actionError error) error {
+func (n *ActionNode) UnlockShard(ctx context.Context, ts topo.Server, keyspace, shard string, lockPath string, actionError error) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.UnlockShardForAction")
+	span.Annotate("action", n.Action)
+	span.Annotate("keyspace", keyspace)
+	span.Annotate("shard", shard)
+	defer span.Finish()
+
 	// first update the actionNode
 	if actionError != nil {
 		log.Infof("Unlocking shard %v/%v for action %v with error %v", keyspace, shard, n.Action, actionError)
@@ -114,7 +127,15 @@ func (n *ActionNode) LockSrvShard(ctx context.Context, ts topo.Server, cell, key
 }
 
 // UnlockSrvShard unlocks a previously locked serving shard.
-func (n *ActionNode) UnlockSrvShard(ts topo.Server, cell, keyspace, shard string, lockPath string, actionError error) error {
+func (n *ActionNode) UnlockSrvShard(ctx context.Context, ts topo.Server, cell, keyspace, shard string, lockPath string, actionError error) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.UnlockSrvShardForAction")
+	span.Annotate("action", n.Action)
+	span.Annotate("keyspace", keyspace)
+	span.Annotate("shard", shard)
+	span.Annotate("cell", cell)
+	defer span.Finish()
+
 	// first update the actionNode
 	if actionError != nil {
 		log.Infof("Unlocking serving shard %v/%v/%v for action %v with error %v", cell, keyspace, shard, n.Action, actionError)

--- a/go/vt/tabletmanager/after_action.go
+++ b/go/vt/tabletmanager/after_action.go
@@ -11,8 +11,11 @@ import (
 	"reflect"
 	"strings"
 
+	"code.google.com/p/go.net/context"
+
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/binlog"
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
@@ -121,7 +124,11 @@ func (agent *ActionAgent) disallowQueries() {
 
 // changeCallback is run after every action that might
 // have changed something in the tablet record.
-func (agent *ActionAgent) changeCallback(oldTablet, newTablet *topo.Tablet) error {
+func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTablet *topo.Tablet) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartLocal("ActionAgent.changeCallback")
+	defer span.Finish()
+
 	allowQuery := newTablet.IsRunningQueryService()
 
 	// Read the shard to get SourceShards / TabletControlMap if

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -388,9 +388,9 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 	}
 
 	// release the lock in any case, and run refreshTablet if necessary
-	err = actionNode.UnlockShard(agent.TopoServer, tablet.Keyspace, tablet.Shard, lockPath, err)
+	err = actionNode.UnlockShard(ctx, agent.TopoServer, tablet.Keyspace, tablet.Shard, lockPath, err)
 	if runAfterAction {
-		if refreshErr := agent.refreshTablet("RPC(TabletExternallyReparented)"); refreshErr != nil {
+		if refreshErr := agent.refreshTablet(ctx, "RPC(TabletExternallyReparented)"); refreshErr != nil {
 			if err == nil {
 				// no error yet, now we have one
 				err = refreshErr
@@ -792,7 +792,7 @@ func (agent *ActionAgent) Snapshot(ctx context.Context, args *actionnode.Snapsho
 	}
 
 	// let's update our internal state (stop query service and other things)
-	if err := agent.refreshTablet("snapshotStart"); err != nil {
+	if err := agent.refreshTablet(ctx, "snapshotStart"); err != nil {
 		return nil, fmt.Errorf("failed to update state before snaphost: %v", err)
 	}
 

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -215,7 +215,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 	}
 
 	// run the post action callbacks, not much we can do with returned error
-	if err := agent.refreshTablet("healthcheck"); err != nil {
+	if err := agent.refreshTablet(context.TODO(), "healthcheck"); err != nil {
 		log.Warningf("refreshTablet failed: %v", err)
 	}
 }
@@ -253,7 +253,7 @@ func (agent *ActionAgent) terminateHealthChecks(targetTabletType topo.TabletType
 	// ourself as OnTermSync (synchronous). The rest can be done asynchronously.
 	go func() {
 		// Run the post action callbacks (let them shutdown the query service)
-		if err := agent.refreshTablet("terminatehealthcheck"); err != nil {
+		if err := agent.refreshTablet(context.TODO(), "terminatehealthcheck"); err != nil {
 			log.Warningf("refreshTablet failed: %v", err)
 		}
 	}()

--- a/go/vt/tabletmanager/rpc_server.go
+++ b/go/vt/tabletmanager/rpc_server.go
@@ -54,7 +54,7 @@ func (agent *ActionAgent) rpcWrapper(ctx context.Context, name string, args, rep
 		log.Infof("TabletManager.%v(%v)(from %v): %#v", name, args, from, reply)
 	}
 	if runAfterAction {
-		err = agent.refreshTablet("RPC(" + name + ")")
+		err = agent.refreshTablet(ctx, "RPC("+name+")")
 	}
 	return
 }

--- a/go/vt/topotools/rebuild.go
+++ b/go/vt/topotools/rebuild.go
@@ -108,7 +108,7 @@ func RebuildShard(ctx context.Context, log logutil.Logger, ts topo.Server, keysp
 			rebuildErr := rebuildCellSrvShard(ctx, log, ts, shardInfo, cell, tablets)
 
 			// and unlock
-			if err := actionNode.UnlockSrvShard(ts, cell, keyspace, shard, lockPath, rebuildErr); err != nil {
+			if err := actionNode.UnlockSrvShard(ctx, ts, cell, keyspace, shard, lockPath, rebuildErr); err != nil {
 				rec.RecordError(err)
 			}
 		}(cell)

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -27,7 +27,7 @@ func (wr *Wrangler) lockKeyspace(keyspace string, actionNode *actionnode.ActionN
 }
 
 func (wr *Wrangler) unlockKeyspace(keyspace string, actionNode *actionnode.ActionNode, lockPath string, actionError error) error {
-	return actionNode.UnlockKeyspace(wr.ts, keyspace, lockPath, actionError)
+	return actionNode.UnlockKeyspace(context.TODO(), wr.ts, keyspace, lockPath, actionError)
 }
 
 // SetKeyspaceShardingInfo locks a keyspace and sets its ShardingColumnName

--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -20,7 +20,7 @@ func (wr *Wrangler) lockShard(keyspace, shard string, actionNode *actionnode.Act
 }
 
 func (wr *Wrangler) unlockShard(keyspace, shard string, actionNode *actionnode.ActionNode, lockPath string, actionError error) error {
-	return actionNode.UnlockShard(wr.ts, keyspace, shard, lockPath, actionError)
+	return actionNode.UnlockShard(context.TODO(), wr.ts, keyspace, shard, lockPath, actionError)
 }
 
 // updateShardCellsAndMaster will update the 'Cells' and possibly


### PR DESCRIPTION
@alainjobart 

After this, we should be fully accounting for all the time in TabletExternallyReparented. I'll go ahead and start working on the proposal though since these changes only fill in the last 4% of time.
