### PR TITLE
rename _vtocc, _vts and _mysql in vitess server

### DIFF
--- a/doc/ZookeeperData.md
+++ b/doc/ZookeeperData.md
@@ -329,9 +329,9 @@ $ zk cat /zk/nyc/vt/ns/rlookup/0/master
       "host": "nyc-db274.nyc.youtube.com",
       "port": 0,
       "named_port_map": {
-        "_mysql": 3306,
-        "_vtocc": 8101,
-        "_vts": 8102
+        "mysql": 3306,
+        "vt": 8101,
+        "vts": 8102
       }
     }
   ]

--- a/go/vt/tabletmanager/binlog.go
+++ b/go/vt/tabletmanager/binlog.go
@@ -243,7 +243,11 @@ func (bpc *BinlogPlayerController) Iteration() (err error) {
 		return fmt.Errorf("empty source tablet list for %v %v %v", bpc.cell, bpc.sourceShard.String(), topo.TYPE_REPLICA)
 	}
 	newServerIndex := rand.Intn(len(addrs.Entries))
-	addr := fmt.Sprintf("%v:%v", addrs.Entries[newServerIndex].Host, addrs.Entries[newServerIndex].NamedPortMap["_vtocc"])
+	port, ok := addrs.Entries[newServerIndex].NamedPortMap["vt"]
+	if !ok {
+		port = addrs.Entries[newServerIndex].NamedPortMap["_vtocc"]
+	}
+	addr := fmt.Sprintf("%v:%v", addrs.Entries[newServerIndex].Host, port)
 
 	// save our current server
 	bpc.playerMutex.Lock()

--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -45,11 +45,19 @@ func DialTablet(ctx context.Context, endPoint topo.EndPoint, keyspace, shard str
 	var addr string
 	var config *tls.Config
 	if *tabletBsonEncrypted {
-		addr = fmt.Sprintf("%v:%v", endPoint.Host, endPoint.NamedPortMap["_vts"])
+		port, ok := endPoint.NamedPortMap["vts"]
+		if !ok {
+			port = endPoint.NamedPortMap["_vts"]
+		}
+		addr = fmt.Sprintf("%v:%v", endPoint.Host, port)
 		config = &tls.Config{}
 		config.InsecureSkipVerify = true
 	} else {
-		addr = fmt.Sprintf("%v:%v", endPoint.Host, endPoint.NamedPortMap["_vtocc"])
+		port, ok := endPoint.NamedPortMap["vt"]
+		if !ok {
+			port = endPoint.NamedPortMap["_vtocc"]
+		}
+		addr = fmt.Sprintf("%v:%v", endPoint.Host, port)
 	}
 
 	conn := &TabletBson{endPoint: endPoint}

--- a/go/vt/topo/naming.go
+++ b/go/vt/topo/naming.go
@@ -29,7 +29,7 @@ import (
 const (
 	// DefaultPortName is the port named used by SrvEntries
 	// if "" is given as the named port.
-	DefaultPortName = "_vtocc"
+	DefaultPortName = "vt"
 )
 
 // EndPoint describes a tablet (maybe composed of multiple processes)

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -396,15 +396,19 @@ func (tablet *Tablet) EndPoint() (*EndPoint, error) {
 		return nil, err
 	}
 
-	// TODO(szopa): Rename _vtocc to vt.
-	entry.NamedPortMap = map[string]int{
-		"_vtocc": tablet.Portmap["vt"],
+	entry.NamedPortMap = map[string]int{}
+
+	if port, ok := tablet.Portmap["vt"]; ok {
+		entry.NamedPortMap["_vtocc"] = port
+		entry.NamedPortMap["vt"] = port
 	}
 	if port, ok := tablet.Portmap["mysql"]; ok {
 		entry.NamedPortMap["_mysql"] = port
+		entry.NamedPortMap["mysql"] = port
 	}
 	if port, ok := tablet.Portmap["vts"]; ok {
 		entry.NamedPortMap["_vts"] = port
+		entry.NamedPortMap["vts"] = port
 	}
 
 	if len(tablet.Health) > 0 {

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -27,7 +27,7 @@ func CheckServingGraph(t *testing.T, ts topo.Server) {
 			topo.EndPoint{
 				Uid:          1,
 				Host:         "host1",
-				NamedPortMap: map[string]int{"_vt": 1234, "_mysql": 1235, "_vts": 1236},
+				NamedPortMap: map[string]int{"vt": 1234, "mysql": 1235, "vts": 1236},
 			},
 		},
 	}
@@ -46,7 +46,7 @@ func CheckServingGraph(t *testing.T, ts topo.Server) {
 	if len(addrs.Entries) != 1 || addrs.Entries[0].Uid != 1 {
 		t.Errorf("GetEndPoints(1): %v", addrs)
 	}
-	if pm := addrs.Entries[0].NamedPortMap; pm["_vt"] != 1234 || pm["_mysql"] != 1235 || pm["_vts"] != 1236 {
+	if pm := addrs.Entries[0].NamedPortMap; pm["vt"] != 1234 || pm["mysql"] != 1235 || pm["vts"] != 1236 {
 		t.Errorf("GetSrcTabletType(1).NamedPortmap: want %v, got %v", endPoints.Entries[0].NamedPortMap, pm)
 	}
 

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -210,7 +210,7 @@ var commands = []commandGroup{
 		"Generic", []command{
 			command{"Resolve", commandResolve,
 				"<keyspace>.<shard>.<db type>:<port name>",
-				"Read a list of addresses that can answer this query. The port name is usually _mysql or _vtocc."},
+				"Read a list of addresses that can answer this query. The port name is usually mysql or vt."},
 			command{"Validate", commandValidate,
 				"[-ping-tablets]",
 				"Validate all nodes reachable from global replication graph and all tablets in all discoverable cells are consistent."},

--- a/go/zk/zkns/zkns.go
+++ b/go/zk/zkns/zkns.go
@@ -79,11 +79,6 @@ func (zaddrs *ZknsAddrs) IsValidSRV() bool {
 		if zaddr.Host == "" || zaddr.IPv4 != "" || len(zaddr.NamedPortMap) == 0 {
 			return false
 		}
-		for portName, _ := range zaddr.NamedPortMap {
-			if portName != "" && portName[0] != '_' {
-				return false
-			}
-		}
 	}
 	return true
 }


### PR DESCRIPTION
Rename _vtocc, _vts and _mysql ports in the portmap to vt, vts and mysql.

This change do renaming for all server code.
In addition, we store both old and new names in Endpoint in go/vt/topo/tablet.go so that old clients still could be served after this change. 
