### PR TITLE
Cleanup vtworkers - simplify strategies, make vertical_split_clone consistent with split_clone

### DIFF
--- a/go/cmd/vtworker/split_clone.go
+++ b/go/cmd/vtworker/split_clone.go
@@ -53,7 +53,7 @@ const splitCloneHTML2 = `
       <LABEL for="excludeTables">Exclude Tables: </LABEL>
         <INPUT type="text" id="excludeTables" name="excludeTables" value="moving.*"></BR>
       <LABEL for="strategy">Strategy: </LABEL>
-        <INPUT type="text" id="strategy" name="strategy" value="-populate_blp_checkpoint -write_masters_only"></BR>
+        <INPUT type="text" id="strategy" name="strategy" value="-populate_blp_checkpoint"></BR>
       <LABEL for="sourceReaderCount">Source Reader Count: </LABEL>
         <INPUT type="text" id="sourceReaderCount" name="sourceReaderCount" value="{{.DefaultSourceReaderCount}}"></BR>
       <LABEL for="destinationPackCount">Destination Pack Count: </LABEL>
@@ -72,15 +72,7 @@ const splitCloneHTML2 = `
     <ul>
       <li><b>populateBlpCheckpoint</b>: creates (if necessary) and populates the blp_checkpoint table in the destination. Required for filtered replication to start.</li>
       <li><b>dontStartBinlogPlayer</b>: (requires populateBlpCheckpoint) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
-      <li><b>skipAutoIncrement(TTT)</b>: we won't add the AUTO_INCREMENT back to that table.</li>
       <li><b>skipSetSourceShards</b>: we won't set SourceShards on the destination shards, disabling filtered replication. Useful for worker tests.</li>
-    </ul>
-    <p>The following flags are also supported, but their use is very strongly discouraged:</p>
-    <ul>
-      <li><b>delayPrimaryKey</b>: we won't add the primary key until after the table is populated.</li>
-      <li><b>delaySecondaryIndexes</b>: we won't add the secondary indexes until after the table is populated.</li>
-      <li><b>useMyIsam</b>: create the table as MyISAM, then convert it to InnoDB after population.</li>
-      <li><b>writeBinLogs</b>: write all operations to the binlogs.</li>
     </ul>
   </body>
 `
@@ -97,7 +89,7 @@ func commandSplitClone(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []str
 	destinationWriterCount := subFlags.Int("destination_writer_count", defaultDestinationWriterCount, "number of concurrent RPCs to execute on the destination")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("command SplitClone requires <keyspace/shard|zk shard path>")
+		log.Fatalf("command SplitClone requires <keyspace/shard>")
 	}
 
 	keyspace, shard := shardParamToKeyspaceShard(subFlags.Arg(0))
@@ -234,6 +226,6 @@ func interactiveSplitClone(wr *wrangler.Wrangler, w http.ResponseWriter, r *http
 func init() {
 	addCommand("Clones", command{"SplitClone",
 		commandSplitClone, interactiveSplitClone,
-		"[--exclude_tables=''] [--strategy=''] <keyspace/shard|zk shard path>",
+		"[--exclude_tables=''] [--strategy=''] <keyspace/shard>",
 		"Replicates the data and creates configuration for a horizontal split."})
 }

--- a/go/cmd/vtworker/vertical_split_clone.go
+++ b/go/cmd/vtworker/vertical_split_clone.go
@@ -77,15 +77,7 @@ const verticalSplitCloneHTML2 = `
     <ul>
       <li><b>populateBlpCheckpoint</b>: creates (if necessary) and populates the blp_checkpoint table in the destination. Required for filtered replication to start.</li>
       <li><b>dontStartBinlogPlayer</b>: (requires populateBlpCheckpoint) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
-      <li><b>skipAutoIncrement(TTT)</b>: we won't add the AUTO_INCREMENT back to that table.</li>
       <li><b>skipSetSourceShards</b>: we won't set SourceShards on the destination shards, disabling filtered replication. Useful for worker tests.</li>
-    </ul>
-    <p>The following flags are also supported, but their use is very strongly discouraged:</p>
-    <ul>
-      <li><b>delayPrimaryKey</b>: we won't add the primary key until after the table is populated.</li>
-      <li><b>delaySecondaryIndexes</b>: we won't add the secondary indexes until after the table is populated.</li>
-      <li><b>useMyIsam</b>: create the table as MyISAM, then convert it to InnoDB after population.</li>
-      <li><b>writeBinLogs</b>: write all operations to the binlogs.</li>
     </ul>
   </body>
 `
@@ -102,7 +94,7 @@ func commandVerticalSplitClone(wr *wrangler.Wrangler, subFlags *flag.FlagSet, ar
 	destinationWriterCount := subFlags.Int("destination_writer_count", defaultDestinationWriterCount, "number of concurrent RPCs to execute on the destination")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("command VerticalSplitClone requires <destination keyspace/shard|zk shard path>")
+		log.Fatalf("command VerticalSplitClone requires <destination keyspace/shard>")
 	}
 
 	keyspace, shard := shardParamToKeyspaceShard(subFlags.Arg(0))
@@ -234,6 +226,6 @@ func interactiveVerticalSplitClone(wr *wrangler.Wrangler, w http.ResponseWriter,
 func init() {
 	addCommand("Clones", command{"VerticalSplitClone",
 		commandVerticalSplitClone, interactiveVerticalSplitClone,
-		"[--tables=''] [--strategy=''] <destination keyspace/shard|zk shard path>",
+		"[--tables=''] [--strategy=''] <destination keyspace/shard>",
 		"Replicates the data and creates configuration for a vertical split."})
 }

--- a/go/vt/mysqlctl/split_strategy.go
+++ b/go/vt/mysqlctl/split_strategy.go
@@ -14,26 +14,6 @@ import (
 
 // SplitStrategy is the configuration for a split clone.
 type SplitStrategy struct {
-	// DelayPrimaryKey will create the table without primary keys,
-	// and then apply them later as an alter
-	DelayPrimaryKey bool
-
-	// DelaySecondaryIndexes will delay creating the secondary indexes
-	DelaySecondaryIndexes bool
-
-	// SkipAutoIncrement will remove the auto increment field
-	// form the given tables
-	SkipAutoIncrement []string
-
-	// UseMyIsam will use MyIsam tables to restore, then convert to InnoDB
-	UseMyIsam bool
-
-	// DelayAutoIncrement will delay the addition of the auto-increment column
-	DelayAutoIncrement bool
-
-	// WriteBinLogs will enable writing to the bin logs
-	WriteBinLogs bool
-
 	// PopulateBlpCheckpoint will drive the population of the blp_checkpoint table
 	PopulateBlpCheckpoint bool
 
@@ -42,9 +22,6 @@ type SplitStrategy struct {
 
 	// SkipSetSourceShards will not set the source shards at the end of restore
 	SkipSetSourceShards bool
-
-	// WriteMastersOnly will write only to the master of the destination shard, with binlog enabled so that replicas can catch up
-	WriteMastersOnly bool
 }
 
 func NewSplitStrategy(logger logutil.Logger, argsStr string) (*SplitStrategy, error) {
@@ -58,69 +35,25 @@ func NewSplitStrategy(logger logutil.Logger, argsStr string) (*SplitStrategy, er
 		logger.Printf("Strategy flag has the following options:\n")
 		flagSet.PrintDefaults()
 	}
-	delayPrimaryKey := flagSet.Bool("delay_primary_key", false, "delays the application of the primary key until after the data population")
-	delaySecondaryIndexes := flagSet.Bool("delay_secondary_indexes", false, "delays the application of secondary indexes until after the data population")
-	skipAutoIncrementStr := flagSet.String("skip_auto_increment", "", "comma spearated list of tables on which not to re-introduce auto-increment")
-	useMyIsam := flagSet.Bool("use_my_isam", false, "uses MyISAM table types for restores, then switches to InnoDB")
-	delayAutoIncrement := flagSet.Bool("delay_auto_increment", false, "don't add auto_increment at table creation, but re-introduces them later")
-	writeBinLogs := flagSet.Bool("write_bin_logs", false, "write write to the binlogs on the destination")
 	populateBlpCheckpoint := flagSet.Bool("populate_blp_checkpoint", false, "populates the blp checkpoint table")
 	dontStartBinlogPlayer := flagSet.Bool("dont_start_binlog_player", false, "do not start the binlog player after restore is complete")
 	skipSetSourceShards := flagSet.Bool("skip_set_source_shards", false, "do not set the SourceShar field on destination shards")
-	writeMastersOnly := flagSet.Bool("write_masters_only", false, "write only to the master of the destination shard, with binlog enabled so that replicas can catch up")
 	if err := flagSet.Parse(args); err != nil {
 		return nil, fmt.Errorf("cannot parse strategy: %v", err)
 	}
 	if flagSet.NArg() > 0 {
 		return nil, fmt.Errorf("strategy doesn't have positional arguments")
 	}
-	var skipAutoIncrement []string
-	if *skipAutoIncrementStr != "" {
-		skipAutoIncrement = strings.Split(*skipAutoIncrementStr, ",")
-	}
+
 	return &SplitStrategy{
-		DelayPrimaryKey:       *delayPrimaryKey,
-		DelaySecondaryIndexes: *delaySecondaryIndexes,
-		SkipAutoIncrement:     skipAutoIncrement,
-		UseMyIsam:             *useMyIsam,
-		DelayAutoIncrement:    *delayAutoIncrement,
-		WriteBinLogs:          *writeBinLogs,
 		PopulateBlpCheckpoint: *populateBlpCheckpoint,
 		DontStartBinlogPlayer: *dontStartBinlogPlayer,
 		SkipSetSourceShards:   *skipSetSourceShards,
-		WriteMastersOnly:      *writeMastersOnly,
 	}, nil
-}
-
-func (strategy *SplitStrategy) SkipAutoIncrementOnTable(table string) bool {
-	for _, t := range strategy.SkipAutoIncrement {
-		if t == table {
-			return true
-		}
-	}
-	return false
 }
 
 func (strategy *SplitStrategy) String() string {
 	var result []string
-	if strategy.DelayPrimaryKey {
-		result = append(result, "-delay_primary_key")
-	}
-	if strategy.DelaySecondaryIndexes {
-		result = append(result, "-delay_secondary_indexes")
-	}
-	if len(strategy.SkipAutoIncrement) > 0 {
-		result = append(result, "-skip_auto_increment="+strings.Join(strategy.SkipAutoIncrement, ","))
-	}
-	if strategy.UseMyIsam {
-		result = append(result, "-use_my_isam")
-	}
-	if strategy.DelayAutoIncrement {
-		result = append(result, "-delay_auto_increment")
-	}
-	if strategy.WriteBinLogs {
-		result = append(result, "-write_bin_logs")
-	}
 	if strategy.PopulateBlpCheckpoint {
 		result = append(result, "-populate_blp_checkpoint")
 	}
@@ -129,9 +62,6 @@ func (strategy *SplitStrategy) String() string {
 	}
 	if strategy.SkipSetSourceShards {
 		result = append(result, "-skip_set_source_shards")
-	}
-	if strategy.WriteMastersOnly {
-		result = append(result, "-write_masters_only")
 	}
 	return strings.Join(result, " ")
 }

--- a/test/binlog.py
+++ b/test/binlog.py
@@ -103,7 +103,7 @@ def setUpModule():
     logging.debug("Running the clone worker to start binlog stream...")
     utils.run_vtworker(['--cell', 'test_nj',
                         'SplitClone',
-                        '--strategy=-populate_blp_checkpoint -write_masters_only',
+                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/0'],

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -382,7 +382,7 @@ index by_msg (msg)
                         '--command_display_interval', '10ms',
                         'SplitClone',
                         '--exclude_tables' ,'unrelated',
-                        '--strategy=-populate_blp_checkpoint -write_masters_only',
+                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/0'],

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -581,7 +581,7 @@ primary key (name)
                         '--command_display_interval', '10ms',
                         'SplitClone',
                         '--exclude_tables' ,'unrelated',
-                        '--strategy=-populate_blp_checkpoint -write_masters_only',
+                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/80-'],


### PR DESCRIPTION
@alainjobart mostly cleanup work, think I found (and fixed) a bug with which tablet schemas we reload after worker executes
