### PR TITLE
Fix status section out of order problem

### DIFF
--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -186,6 +186,9 @@ google.setOnLoadCallback(function() {
 `
 )
 
+// For use by plugins which wish to avoid racing when registering status page parts.
+var onStatusRegistered func()
+
 func init() {
 	servenv.OnRun(func() {
 		servenv.AddStatusPart("Topology Cache", topoTemplate, func() interface{} {
@@ -194,5 +197,8 @@ func init() {
 		servenv.AddStatusPart("Stats", statsTemplate, func() interface{} {
 			return nil
 		})
+		if onStatusRegistered != nil {
+			onStatusRegistered()
+		}
 	})
 }

--- a/go/cmd/vtocc/status.go
+++ b/go/cmd/vtocc/status.go
@@ -5,8 +5,14 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver"
 )
 
+// For use by plugins which wish to avoid racing when registering status page parts.
+var onStatusRegistered func()
+
 func init() {
 	servenv.OnRun(func() {
 		tabletserver.AddStatusPart()
+		if onStatusRegistered != nil {
+			onStatusRegistered()
+		}
 	})
 }


### PR DESCRIPTION
mutiple status.go in go/cmd add status section in vt status server
for system monitoring purpose. However, the problem is they use init
function and may cause potential section out of order problem on
status page if there is another place to also add a new section.

The fix is to introduce a pluggable hook in each status.go so that
whenever another place want to add a new section, it could do so by
assign the hook in its init method.
