### PR TITLE
Added additional logging to split_clone.go so that we can see overlapping shards

### DIFF
--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -14,6 +14,7 @@ import (
 	"code.google.com/p/go.net/context"
 
 	"github.com/youtube/vitess/go/event"
+	"github.com/youtube/vitess/go/jscfg"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
@@ -267,6 +268,7 @@ func (scw *SplitCloneWorker) init() error {
 	if os == nil {
 		return fmt.Errorf("the specified shard %v/%v is not in any overlapping shard", scw.keyspace, scw.shard)
 	}
+	scw.wr.Logger().Infof("Found overlapping shards: %v\n", jscfg.ToJson(os))
 
 	// one side should have served types, the other one none,
 	// figure out wich is which, then double check them all


### PR DESCRIPTION
@alainjobart 

Seems like the best we can do, unless we want to add logging to the toposerver itself.
