### PR TITLE
rename splitsPerShard to splits

### DIFF
--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessConf.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessConf.java
@@ -10,7 +10,7 @@ public class VitessConf {
   public static final String CONN_TIMEOUT_MS = "vitess.vtgate.conn_timeout_ms";
   public static final String INPUT_KEYSPACE = "vitess.vtgate.hadoop.keyspace";
   public static final String INPUT_QUERY = "vitess.vtgate.hadoop.input_query";
-  public static final String SPLITS_PER_SHARD = "vitess.vtgate.hadoop.splits_per_shard";
+  public static final String SPLITS = "vitess.vtgate.hadoop.splits";
   public static final String HOSTS_DELIM = ",";
 
   private Configuration conf;
@@ -51,11 +51,11 @@ public class VitessConf {
     conf.set(INPUT_QUERY, query);
   }
 
-  public int getSplitsPerShard() {
-    return conf.getInt(SPLITS_PER_SHARD, 1);
+  public int getSplits() {
+    return conf.getInt(SPLITS, 1);
   }
 
-  public void setSplitsPerShard(int splitsPerShard) {
-    conf.setInt(SPLITS_PER_SHARD, splitsPerShard);
+  public void setSplits(int splits) {
+    conf.setInt(SPLITS, splits);
   }
 }

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessInputFormat.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessInputFormat.java
@@ -33,7 +33,7 @@ public class VitessInputFormat extends InputFormat<NullWritable, RowWritable> {
       VitessConf conf = new VitessConf(context.getConfiguration());
       VtGate vtgate = VtGate.connect(conf.getHosts(), conf.getTimeoutMs());
       Map<Query, Long> queries =
-          vtgate.splitQuery(conf.getKeyspace(), conf.getInputQuery(), conf.getSplitsPerShard());
+          vtgate.splitQuery(conf.getKeyspace(), conf.getInputQuery(), conf.getSplits());
       List<InputSplit> splits = new LinkedList<>();
       for (Query query : queries.keySet()) {
         Long size = queries.get(query);
@@ -62,12 +62,12 @@ public class VitessInputFormat extends InputFormat<NullWritable, RowWritable> {
       String hosts,
       String keyspace,
       String query,
-      int splitsPerShard) {
+      int splits) {
     job.setInputFormatClass(VitessInputFormat.class);
     VitessConf vtConf = new VitessConf(job.getConfiguration());
     vtConf.setHosts(hosts);
     vtConf.setKeyspace(keyspace);
     vtConf.setInputQuery(query);
-    vtConf.setSplitsPerShard(splitsPerShard);
+    vtConf.setSplits(splits);
   }
 }


### PR DESCRIPTION
Vtgate's SplitsQuery only supports total number of splits
and calculate per shard split number based on it. Therefore,
rename VitessConf and VitessInputFormat to reflect this behavior.
