### PR TITLE
Don't check ctx.Err() unless ctx.Done() was closed.

### DIFF
--- a/go/vt/zktopo/lock.go
+++ b/go/vt/zktopo/lock.go
@@ -50,7 +50,9 @@ func (zkts *Server) lockForAction(ctx context.Context, actionDir, contents strin
 	if err != nil {
 		var errToReturn error
 		switch err {
-		case zk.ErrInterrupted, zk.ErrTimeout:
+		case zk.ErrTimeout:
+			errToReturn = topo.ErrTimeout
+		case zk.ErrInterrupted:
 			// the context failed, get the error from it
 			if ctx.Err() == context.DeadlineExceeded {
 				errToReturn = topo.ErrTimeout


### PR DESCRIPTION
@alainjobart 

The zktopo lock tests have been flaky, with errors saying "interrupted".
This was because there's a race condition where ZK can time out before
the ctx.Done() channel has been closed, so ctx.Err() returns nil and we
return the wrong topo error (interrupted instead of timeout).
