### PR TITLE
let travis build status ref master branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vitess <p align="right">[![Build Status](https://travis-ci.org/youtube/vitess.svg)](https://travis-ci.org/youtube/vitess) [![Coverage Status](https://coveralls.io/repos/youtube/vitess/badge.png)](https://coveralls.io/r/youtube/vitess)</p>
+# Vitess <p align="right">[![Build Status](https://travis-ci.org/youtube/vitess.svg?branch=master)](https://travis-ci.org/youtube/vitess/builds) [![Coverage Status](https://coveralls.io/repos/youtube/vitess/badge.png)](https://coveralls.io/r/youtube/vitess)</p>
 
 Vitess is a set of servers and tools meant to facilitate scaling of MySQL
 databases for the web. It's been developed since 2011, and is currently used as


### PR DESCRIPTION
@henryanand @enisoc 

Travis build status should always ref to master branch; otherwise, failed build in other branches will be reflected in the master branch which is kind of misleading. In addition, modified the hyper link so that it leads us to the build history page instead of the most recent build page (which ref to the build triggered by the most recent pull/push request regardless of branch). 
