### PR TITLE
Handle hosts with colons (IPv6)

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
@@ -180,7 +181,7 @@ func main() {
 	dbconfigs.RegisterFlags(flags)
 	flag.Parse()
 
-	tabletAddr = fmt.Sprintf("%v:%v", "localhost", *port)
+	tabletAddr = netutil.JoinHostPort("localhost", *port)
 	mycnf := mysqlctl.NewMycnf(uint32(*tabletUid), *mysqlPort)
 
 	if *mysqlSocket != "" {

--- a/go/cmd/vtctld/plugin_zktopo.go
+++ b/go/cmd/vtctld/plugin_zktopo.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/cmd/vtctld/proto"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"github.com/youtube/vitess/go/zk"
@@ -124,7 +125,7 @@ func (ex ZkExplorer) addTabletLinks(data string, result *ZkResult) {
 	}
 
 	if port, ok := t.Portmap["vt"]; ok {
-		result.Links["status"] = template.URL(fmt.Sprintf("http://%v:%v/debug/status", t.Hostname, port))
+		result.Links["status"] = template.URL(fmt.Sprintf("http://%v/debug/status", netutil.JoinHostPort(t.Hostname, port)))
 	}
 
 	if !t.Parent.IsZero() {

--- a/go/netutil/netutil.go
+++ b/go/netutil/netutil.go
@@ -77,7 +77,7 @@ func SortRfc2782(srvs []*net.SRV) {
 }
 
 // SplitHostPort is an extension to net.SplitHostPort that also parses the
-// integer port
+// integer port.
 func SplitHostPort(addr string) (string, int, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -88,6 +88,12 @@ func SplitHostPort(addr string) (string, int, error) {
 		return "", 0, fmt.Errorf("can't parse port %q: %v", port, err)
 	}
 	return host, int(p), nil
+}
+
+// JoinHostPort is an extension to net.JoinHostPort that also formats the
+// integer port.
+func JoinHostPort(host string, port int) string {
+	return net.JoinHostPort(host, strconv.FormatInt(int64(port), 10))
 }
 
 // FullyQualifiedHostname returns the full hostname with domain
@@ -115,9 +121,9 @@ func FullyQualifiedHostnameOrPanic() string {
 }
 
 // ResolveAddr can resolve an address where the host has been left
-// blank, like ":3306"
+// blank, like ":3306".
 func ResolveAddr(addr string) (string, error) {
-	host, port, err := SplitHostPort(addr)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}
@@ -127,7 +133,7 @@ func ResolveAddr(addr string) (string, error) {
 			return "", err
 		}
 	}
-	return fmt.Sprintf("%v:%v", host, port), nil
+	return net.JoinHostPort(host, port), nil
 }
 
 // ResolveIpAddr resolves the address:port part into an IP address:port pair

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -64,3 +64,39 @@ func testWeighting(t *testing.T, margin float64) {
 func TestWeighting(t *testing.T) {
 	testWeighting(t, 0.05)
 }
+
+func TestSplitHostPort(t *testing.T) {
+	type addr struct {
+		host string
+		port int
+	}
+	table := map[string]addr{
+		"host-name:132": addr{host: "host-name", port: 132},
+		"[::1]:321":     addr{host: "::1", port: 321},
+	}
+	for input, want := range table {
+		gotHost, gotPort, err := SplitHostPort(input)
+		if err != nil {
+			t.Errorf("SplitHostPort error: %v", err)
+		}
+		if gotHost != want.host || gotPort != want.port {
+			t.Errorf("SplitHostPort(%#v) = (%v, %v), want (%v, %v)", input, gotHost, gotPort, want.host, want.port)
+		}
+	}
+}
+
+func TestJoinHostPort(t *testing.T) {
+	type addr struct {
+		host string
+		port int
+	}
+	table := map[string]addr{
+		"host-name:132": addr{host: "host-name", port: 132},
+		"[::1]:321":     addr{host: "::1", port: 321},
+	}
+	for want, input := range table {
+		if got := JoinHostPort(input.host, input.port); got != want {
+			t.Errorf("SplitHostPort(%v, %v) = %#v, want %#v", input.host, input.port, got, want)
+		}
+	}
+}

--- a/go/vt/etcdtopo/explorer.go
+++ b/go/vt/etcdtopo/explorer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coreos/go-etcd/etcd"
 	ctlproto "github.com/youtube/vitess/go/cmd/vtctld/proto"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/topo"
 )
 
@@ -200,7 +201,7 @@ func addTabletLinks(result *explorerResult, data string) {
 	}
 
 	if port, ok := t.Portmap["vt"]; ok {
-		result.Links["status"] = template.URL(fmt.Sprintf("http://%v:%v/debug/status", t.Hostname, port))
+		result.Links["status"] = template.URL(fmt.Sprintf("http://%v/debug/status", netutil.JoinHostPort(t.Hostname, port)))
 	}
 
 	if !t.Parent.IsZero() {

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -486,7 +486,7 @@ func deleteTopDir(dir string) (removalErr error) {
 // Addr returns the fully qualified host name + port for this instance.
 func (mysqld *Mysqld) Addr() string {
 	hostname := netutil.FullyQualifiedHostnameOrPanic()
-	return fmt.Sprintf("%v:%v", hostname, mysqld.config.MysqlPort)
+	return netutil.JoinHostPort(hostname, mysqld.config.MysqlPort)
 }
 
 // IpAddr returns the IP address for this instance

--- a/go/vt/mysqlctl/proto/replication.go
+++ b/go/vt/mysqlctl/proto/replication.go
@@ -215,7 +215,7 @@ func (rs *ReplicationStatus) SlaveRunning() bool {
 
 // MasterAddr returns the host:port address of the master.
 func (rs *ReplicationStatus) MasterAddr() string {
-	return fmt.Sprintf("%v:%v", rs.MasterHost, rs.MasterPort)
+	return netutil.JoinHostPort(rs.MasterHost, rs.MasterPort)
 }
 
 // NewReplicationStatus creates a ReplicationStatus pointing to masterAddr.

--- a/go/vt/mysqlctl/proto/replication_test.go
+++ b/go/vt/mysqlctl/proto/replication_test.go
@@ -528,13 +528,20 @@ func TestReplicationStatusSlaveSQLNotRunning(t *testing.T) {
 }
 
 func TestReplicationStatusMasterAddr(t *testing.T) {
-	input := &ReplicationStatus{
-		MasterHost: "master-host",
-		MasterPort: 1234,
+	table := map[string]*ReplicationStatus{
+		"master-host:1234": &ReplicationStatus{
+			MasterHost: "master-host",
+			MasterPort: 1234,
+		},
+		"[::1]:4321": &ReplicationStatus{
+			MasterHost: "::1",
+			MasterPort: 4321,
+		},
 	}
-	want := "master-host:1234"
-	if got := input.MasterAddr(); got != want {
-		t.Errorf("%#v.MasterAddr() = %v, want %v", input, got, want)
+	for want, input := range table {
+		if got := input.MasterAddr(); got != want {
+			t.Errorf("%#v.MasterAddr() = %v, want %v", input, got, want)
+		}
 	}
 }
 

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -19,7 +19,6 @@ package servenv
 
 import (
 	"flag"
-	"fmt"
 	"net/url"
 	"os"
 	"runtime"
@@ -103,7 +102,7 @@ func populateListeningURL() {
 	}
 	ListeningURL = url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%v:%v", host, *Port),
+		Host:   netutil.JoinHostPort(host, *Port),
 		Path:   "/",
 	}
 }

--- a/go/vt/tabletmanager/binlog.go
+++ b/go/vt/tabletmanager/binlog.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
@@ -247,7 +248,7 @@ func (bpc *BinlogPlayerController) Iteration() (err error) {
 	if !ok {
 		port = addrs.Entries[newServerIndex].NamedPortMap["_vtocc"]
 	}
-	addr := fmt.Sprintf("%v:%v", addrs.Entries[newServerIndex].Host, port)
+	addr := netutil.JoinHostPort(addrs.Entries[newServerIndex].Host, port)
 
 	// save our current server
 	bpc.playerMutex.Lock()

--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
 	"github.com/youtube/vitess/go/vt/rpc"
@@ -49,7 +50,7 @@ func DialTablet(ctx context.Context, endPoint topo.EndPoint, keyspace, shard str
 		if !ok {
 			port = endPoint.NamedPortMap["_vts"]
 		}
-		addr = fmt.Sprintf("%v:%v", endPoint.Host, port)
+		addr = netutil.JoinHostPort(endPoint.Host, port)
 		config = &tls.Config{}
 		config.InsecureSkipVerify = true
 	} else {
@@ -57,7 +58,7 @@ func DialTablet(ctx context.Context, endPoint topo.EndPoint, keyspace, shard str
 		if !ok {
 			port = endPoint.NamedPortMap["_vtocc"]
 		}
-		addr = fmt.Sprintf("%v:%v", endPoint.Host, port)
+		addr = netutil.JoinHostPort(endPoint.Host, port)
 	}
 
 	conn := &TabletBson{endPoint: endPoint}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -16,6 +16,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/jscfg"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/key"
 )
@@ -420,19 +421,19 @@ func (tablet *Tablet) EndPoint() (*EndPoint, error) {
 	return entry, nil
 }
 
-// Addr returns hostname:vt port
+// Addr returns hostname:vt port.
 func (tablet *Tablet) Addr() string {
-	return fmt.Sprintf("%v:%v", tablet.Hostname, tablet.Portmap["vt"])
+	return netutil.JoinHostPort(tablet.Hostname, tablet.Portmap["vt"])
 }
 
-// MysqlAddr returns hostname:mysql port
+// MysqlAddr returns hostname:mysql port.
 func (tablet *Tablet) MysqlAddr() string {
-	return fmt.Sprintf("%v:%v", tablet.Hostname, tablet.Portmap["mysql"])
+	return netutil.JoinHostPort(tablet.Hostname, tablet.Portmap["mysql"])
 }
 
-// MysqlIpAddr returns ip:mysql port
+// MysqlIpAddr returns ip:mysql port.
 func (tablet *Tablet) MysqlIpAddr() string {
-	return fmt.Sprintf("%v:%v", tablet.IPAddr, tablet.Portmap["mysql"])
+	return netutil.JoinHostPort(tablet.IPAddr, tablet.Portmap["mysql"])
 }
 
 // DbName is usually implied by keyspace. Having the shard information in the

--- a/go/vt/topotools/topology.go
+++ b/go/vt/topotools/topology.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/topo"
 )
@@ -28,7 +29,7 @@ func (tn *TabletNode) ShortName() string {
 	if tn.Port == 0 {
 		return hostPart
 	}
-	return fmt.Sprintf("%v:%v", hostPart, tn.Port)
+	return netutil.JoinHostPort(hostPart, tn.Port)
 }
 
 func newTabletNodeFromTabletInfo(ti *topo.TabletInfo) *TabletNode {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/flagutil"
 	"github.com/youtube/vitess/go/jscfg"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/client2"
 	hk "github.com/youtube/vitess/go/vt/hook"
 	"github.com/youtube/vitess/go/vt/key"
@@ -1617,7 +1618,7 @@ func commandResolve(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string
 		return err
 	}
 	for _, addr := range addrs {
-		wr.Logger().Printf("%v:%v\n", addr.Target, addr.Port)
+		wr.Logger().Printf("%v\n", netutil.JoinHostPort(addr.Target, int(addr.Port)))
 	}
 	return nil
 }


### PR DESCRIPTION
We should use the (Join|Split)HostPort functions instead of manually splitting or joining with ":". This may not be sufficient to fix support for IPv6 addresses, but it's necessary.
