### PR TITLE
Avoid divide-by-zero and fix units in cgzip_test.

### DIFF
--- a/go/cgzip/cgzip_test.go
+++ b/go/cgzip/cgzip_test.go
@@ -25,18 +25,26 @@ func newPrettyTimer(name string) *prettyTimer {
 }
 
 func (pt *prettyTimer) stopAndPrintCompress(t *testing.T, size, processed int) {
-	durationMs := int(int64(time.Now().Sub(pt.before)) / 1000)
+	duration := time.Since(pt.before)
 	t.Log(pt.name + ":")
 	t.Log("  size :", size)
-	t.Log("  time :", durationMs, "ms")
-	t.Log("  speed:", processed*1000/durationMs, "KB/s")
+	t.Log("  time :", duration.String())
+	if duration != 0 {
+		t.Logf("  speed: %.0f KB/s", float64(processed)/duration.Seconds()/1024.0)
+	} else {
+		t.Log("  processed:", processed, "B")
+	}
 }
 
 func (pt *prettyTimer) stopAndPrintUncompress(t *testing.T, processed int) {
-	durationMs := int(int64(time.Now().Sub(pt.before)) / 1000)
+	duration := time.Since(pt.before)
 	t.Log("     " + pt.name + ":")
-	t.Log("       time :", durationMs, "ms")
-	t.Log("       speed:", processed*1000/durationMs, "KB/s")
+	t.Log("       time :", duration.String())
+	if duration != 0 {
+		t.Logf("       speed: %.0f KB/s", float64(processed)/duration.Seconds()/1024.0)
+	} else {
+		t.Log("       processed:", processed, "B")
+	}
 }
 
 func compareCompressedBuffer(t *testing.T, source []byte, compressed *bytes.Buffer) {


### PR DESCRIPTION
A user reported the following flaky failure in cgzip_test:

```
    cgzip_test.go:79: Checksums:
    cgzip_test.go:37:      go crc64:
    cgzip_test.go:38:        time : 3790 ms
    cgzip_test.go:39:        speed: 276669 KB/s
    cgzip_test.go:37:      go adler32:
    cgzip_test.go:38:        time : 0 ms
```

panic: runtime error: integer divide by zero [recovered]
panic: runtime error: integer divide by zero

I don't see why the time would be 0ms; in fact, the units were wrong in the code so it's actually measuring 0us. Surely it couldn't be that fast if it's actually working, since it takes about 1ms on my machine (after fixing the time units). In any case, we shouldn't be dividing by zero.
