### PR TITLE
Use "go generate" for bsongen instead of Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,39 +152,4 @@ v3_test:
 	cd test && ./vtgatev3_test.py
 
 bson:
-	bsongen -file ./go/mysql/proto/structs.go -type QueryResult -o ./go/mysql/proto/query_result_bson.go
-	bsongen -file ./go/mysql/proto/structs.go -type Field -o ./go/mysql/proto/field_bson.go
-	bsongen -file ./go/mysql/proto/structs.go -type Charset -o ./go/mysql/proto/charset_bson.go
-	bsongen -file ./go/vt/key/key.go -type KeyRange -o ./go/vt/key/key_range_bson.go
-	bsongen -file ./go/vt/key/key.go -type KeyspaceId -o ./go/vt/key/keyspace_id_bson.go
-	bsongen -file ./go/vt/key/key.go -type KeyspaceIdType -o ./go/vt/key/keyspace_id_type_bson.go
-	bsongen -file ./go/vt/tabletserver/proto/structs.go -type Query -o ./go/vt/tabletserver/proto/query_bson.go
-	bsongen -file ./go/vt/tabletserver/proto/structs.go -type Session -o ./go/vt/tabletserver/proto/session_bson.go
-	bsongen -file ./go/vt/tabletserver/proto/structs.go -type BoundQuery -o ./go/vt/tabletserver/proto/bound_query_bson.go
-	bsongen -file ./go/vt/tabletserver/proto/structs.go -type QueryList -o ./go/vt/tabletserver/proto/query_list_bson.go
-	bsongen -file ./go/vt/tabletserver/proto/structs.go -type QueryResultList -o ./go/vt/tabletserver/proto/query_result_list_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type Query -o ./go/vt/vtgate/proto/query_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type QueryShard -o ./go/vt/vtgate/proto/query_shard_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type BatchQueryShard -o ./go/vt/vtgate/proto/batch_query_shard_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type KeyspaceIdQuery -o ./go/vt/vtgate/proto/keyspace_id_query_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type KeyRangeQuery -o ./go/vt/vtgate/proto/key_range_query_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type EntityId -o ./go/vt/vtgate/proto/entity_id_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type EntityIdsQuery -o ./go/vt/vtgate/proto/entity_ids_query_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type KeyspaceIdBatchQuery -o ./go/vt/vtgate/proto/keyspace_id_batch_query_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type Session -o ./go/vt/vtgate/proto/session_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type ShardSession -o ./go/vt/vtgate/proto/shard_session_bson.go
-	bsongen -file ./go/vt/vtgate/proto/vtgate_proto.go -type QueryResult -o ./go/vt/vtgate/proto/query_result_bson.go
-	bsongen -file ./go/vt/topo/srvshard.go -type SrvShard -o ./go/vt/topo/srvshard_bson.go
-	bsongen -file ./go/vt/topo/srvshard.go -type SrvKeyspace -o ./go/vt/topo/srvkeyspace_bson.go
-	bsongen -file ./go/vt/topo/srvshard.go -type KeyspacePartition -o ./go/vt/topo/keyspace_partition_bson.go
-	bsongen -file ./go/vt/topo/tablet.go -type TabletType -o ./go/vt/topo/tablet_type_bson.go
-	bsongen -file ./go/vt/topo/toporeader.go -type GetSrvKeyspaceNamesArgs -o ./go/vt/topo/get_srv_keyspace_names_args_bson.go
-	bsongen -file ./go/vt/topo/toporeader.go -type GetSrvKeyspaceArgs -o ./go/vt/topo/get_srv_keyspace_args_bson.go
-	bsongen -file ./go/vt/topo/toporeader.go -type SrvKeyspaceNames -o ./go/vt/topo/srv_keyspace_names_bson.go
-	bsongen -file ./go/vt/topo/toporeader.go -type GetEndPointsArgs -o ./go/vt/topo/get_end_points_args_bson.go
-	bsongen -file ./go/vt/binlog/proto/binlog_player.go -type BlpPosition -o ./go/vt/binlog/proto/blp_position_bson.go
-	bsongen -file ./go/vt/binlog/proto/binlog_player.go -type BlpPositionList -o ./go/vt/binlog/proto/blp_position_list_bson.go
-	bsongen -file ./go/vt/binlog/proto/binlog_transaction.go -type BinlogTransaction -o ./go/vt/binlog/proto/binlog_transaction_bson.go
-	bsongen -file ./go/vt/binlog/proto/binlog_transaction.go -type Statement -o ./go/vt/binlog/proto/statement_bson.go
-	bsongen -file ./go/vt/binlog/proto/stream_event.go -type StreamEvent -o ./go/vt/binlog/proto/stream_event_bson.go
-
+	go generate ./go/...

--- a/go/mysql/proto/structs.go
+++ b/go/mysql/proto/structs.go
@@ -41,11 +41,13 @@ const (
 	VT_GEOMETRY    = 255
 )
 
-// Field described a column returned by mysql
+// Field describes a column returned by MySQL.
 type Field struct {
 	Name string
 	Type int64
 }
+
+//go:generate bsongen -file $GOFILE -type Field -o field_bson.go
 
 // QueryResult is the structure returned by the mysql library.
 // When transmitted over the wire, the Rows all come back as strings
@@ -58,6 +60,8 @@ type QueryResult struct {
 	Rows         [][]sqltypes.Value
 }
 
+//go:generate bsongen -file $GOFILE -type QueryResult -o query_result_bson.go
+
 // Charset contains the per-statement character set settings that accompany
 // binlog QUERY_EVENT entries.
 type Charset struct {
@@ -65,6 +69,8 @@ type Charset struct {
 	Conn   int // @@session.collation_connection
 	Server int // @@session.collation_server
 }
+
+//go:generate bsongen -file $GOFILE -type Charset -o charset_bson.go
 
 // Convert takes a type and a value, and returns the type:
 // - nil for NULL value

--- a/go/vt/binlog/proto/binlog_player.go
+++ b/go/vt/binlog/proto/binlog_player.go
@@ -18,10 +18,14 @@ type BlpPosition struct {
 	Position myproto.ReplicationPosition
 }
 
+//go:generate bsongen -file $GOFILE -type BlpPosition -o blp_position_bson.go
+
 // BlpPositionList is a list of BlpPosition, not sorted.
 type BlpPositionList struct {
 	Entries []BlpPosition
 }
+
+//go:generate bsongen -file $GOFILE -type BlpPositionList -o blp_position_list_bson.go
 
 // FindBlpPositionById returns the BlpPosition with the given id, or error
 func (bpl *BlpPositionList) FindBlpPositionById(id uint32) (*BlpPosition, error) {

--- a/go/vt/binlog/proto/binlog_transaction.go
+++ b/go/vt/binlog/proto/binlog_transaction.go
@@ -41,12 +41,16 @@ type BinlogTransaction struct {
 	GTIDField  myproto.GTIDField
 }
 
+//go:generate bsongen -file $GOFILE -type BinlogTransaction -o binlog_transaction_bson.go
+
 // Statement represents one statement as read from the binlog.
 type Statement struct {
 	Category int
 	Charset  *mproto.Charset
 	Sql      []byte
 }
+
+//go:generate bsongen -file $GOFILE -type Statement -o statement_bson.go
 
 // String pretty-prints a statement.
 func (s Statement) String() string {

--- a/go/vt/binlog/proto/stream_event.go
+++ b/go/vt/binlog/proto/stream_event.go
@@ -27,3 +27,5 @@ type StreamEvent struct {
 	// POS
 	GTIDField myproto.GTIDField
 }
+
+//go:generate bsongen -file $GOFILE -type StreamEvent -o stream_event_bson.go

--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -26,6 +26,8 @@ var MaxKey = KeyspaceId("")
 // KeyspaceId is the type we base sharding on.
 type KeyspaceId string
 
+//go:generate bsongen -file $GOFILE -type KeyspaceId -o keyspace_id_bson.go
+
 // Hex prints a KeyspaceId in lower case hex.
 func (kid KeyspaceId) Hex() HexKeyspaceId {
 	return HexKeyspaceId(hex.EncodeToString([]byte(kid)))
@@ -84,6 +86,8 @@ func (hkid HexKeyspaceId) Unhex() (KeyspaceId, error) {
 // Usually we don't care, but some parts of the code will need that info.
 type KeyspaceIdType string
 
+//go:generate bsongen -file $GOFILE -type KeyspaceIdType -o keyspace_id_type_bson.go
+
 const (
 	// unset - no type for this KeyspaceId
 	KIT_UNSET = KeyspaceIdType("")
@@ -119,11 +123,13 @@ func IsKeyspaceIdTypeInList(typ KeyspaceIdType, types []KeyspaceIdType) bool {
 //
 
 // KeyRange is an interval of KeyspaceId values. It contains Start,
-// but excludes End. In other words, it is: [Start, End[
+// but excludes End. In other words, it is: [Start, End)
 type KeyRange struct {
 	Start KeyspaceId
 	End   KeyspaceId
 }
+
+//go:generate bsongen -file $GOFILE -type KeyRange -o key_range_bson.go
 
 func (kr KeyRange) MapKey() string {
 	return string(kr.Start) + "-" + string(kr.End)

--- a/go/vt/tabletserver/proto/structs.go
+++ b/go/vt/tabletserver/proto/structs.go
@@ -27,6 +27,8 @@ type Query struct {
 	TransactionId int64
 }
 
+//go:generate bsongen -file $GOFILE -type Query -o query_bson.go
+
 // String prints a readable version of Query, and also truncates
 // data if it's too long
 func (query *Query) String() string {
@@ -59,20 +61,28 @@ type BoundQuery struct {
 	BindVariables map[string]interface{}
 }
 
+//go:generate bsongen -file $GOFILE -type BoundQuery -o bound_query_bson.go
+
 type QueryList struct {
 	Queries       []BoundQuery
 	SessionId     int64
 	TransactionId int64
 }
 
+//go:generate bsongen -file $GOFILE -type QueryList -o query_list_bson.go
+
 type QueryResultList struct {
 	List []mproto.QueryResult
 }
+
+//go:generate bsongen -file $GOFILE -type QueryResultList -o query_result_list_bson.go
 
 type Session struct {
 	SessionId     int64
 	TransactionId int64
 }
+
+//go:generate bsongen -file $GOFILE -type Session -o session_bson.go
 
 type TransactionInfo struct {
 	TransactionId int64

--- a/go/vt/topo/srvshard.go
+++ b/go/vt/topo/srvshard.go
@@ -34,6 +34,8 @@ type SrvShard struct {
 	version int64
 }
 
+//go:generate bsongen -file $GOFILE -type SrvShard -o srvshard_bson.go
+
 // SrvShardArray is used for sorting SrvShard arrays
 type SrvShardArray []SrvShard
 
@@ -77,6 +79,8 @@ type KeyspacePartition struct {
 	Shards []SrvShard
 }
 
+//go:generate bsongen -file $GOFILE -type KeyspacePartition -o keyspace_partition_bson.go
+
 // HasShard returns true if this KeyspacePartition has the shard with
 // the given name in it.
 func (kp *KeyspacePartition) HasShard(name string) bool {
@@ -113,6 +117,8 @@ type SrvKeyspace struct {
 	// For atomic updates
 	version int64
 }
+
+//go:generate bsongen -file $GOFILE -type SrvKeyspace -o srvkeyspace_bson.go
 
 // NewSrvKeyspace returns an empty SrvKeyspace with the given version.
 func NewSrvKeyspace(version int64) *SrvKeyspace {

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -121,6 +121,8 @@ func (tal TabletAliasList) Swap(i, j int) {
 // - the uptime expectancy
 type TabletType string
 
+//go:generate bsongen -file $GOFILE -type TabletType -o tablet_type_bson.go
+
 const (
 	// idle -  no keyspace, shard or type assigned
 	TYPE_IDLE = TabletType("idle")

--- a/go/vt/topo/toporeader.go
+++ b/go/vt/topo/toporeader.go
@@ -24,16 +24,22 @@ type GetSrvKeyspaceNamesArgs struct {
 	Cell string
 }
 
+//go:generate bsongen -file $GOFILE -type GetSrvKeyspaceNamesArgs -o get_srv_keyspace_names_args_bson.go
+
 // GetSrvKeyspaceArgs is the parameters for TopoReader.GetSrvKeyspace
 type GetSrvKeyspaceArgs struct {
 	Cell     string
 	Keyspace string
 }
 
+//go:generate bsongen -file $GOFILE -type GetSrvKeyspaceArgs -o get_srv_keyspace_args_bson.go
+
 // SrvKeyspaceNames is the response for TopoReader.GetSrvKeyspaceNames
 type SrvKeyspaceNames struct {
 	Entries []string
 }
+
+//go:generate bsongen -file $GOFILE -type SrvKeyspaceNames -o srv_keyspace_names_bson.go
 
 // GetEndPointsArgs is the parameters for TopoReader.GetEndPoints
 type GetEndPointsArgs struct {
@@ -42,3 +48,5 @@ type GetEndPointsArgs struct {
 	Shard      string
 	TabletType TabletType
 }
+
+//go:generate bsongen -file $GOFILE -type GetEndPointsArgs -o get_end_points_args_bson.go

--- a/go/vt/vtgate/proto/vtgate_proto.go
+++ b/go/vt/vtgate/proto/vtgate_proto.go
@@ -21,6 +21,8 @@ type Session struct {
 	ShardSessions []*ShardSession
 }
 
+//go:generate bsongen -file $GOFILE -type Session -o session_bson.go
+
 func (session *Session) String() string {
 	return fmt.Sprintf("InTransaction: %v, ShardSession: %+v", session.InTransaction, session.ShardSessions)
 }
@@ -32,6 +34,8 @@ type ShardSession struct {
 	TabletType    topo.TabletType
 	TransactionId int64
 }
+
+//go:generate bsongen -file $GOFILE -type ShardSession -o shard_session_bson.go
 
 func (shardSession *ShardSession) String() string {
 	return fmt.Sprintf("Keyspace: %v, Shard: %v, TabletType: %v, TransactionId: %v", shardSession.Keyspace, shardSession.Shard, shardSession.TabletType, shardSession.TransactionId)
@@ -45,6 +49,8 @@ type Query struct {
 	Session       *Session
 }
 
+//go:generate bsongen -file $GOFILE -type Query -o query_bson.go
+
 // QueryShard represents a query request for the
 // specified list of shards.
 type QueryShard struct {
@@ -55,6 +61,8 @@ type QueryShard struct {
 	TabletType    topo.TabletType
 	Session       *Session
 }
+
+//go:generate bsongen -file $GOFILE -type QueryShard -o query_shard_bson.go
 
 // KeyspaceIdQuery represents a query request for the
 // specified list of keyspace IDs.
@@ -67,6 +75,8 @@ type KeyspaceIdQuery struct {
 	Session       *Session
 }
 
+//go:generate bsongen -file $GOFILE -type KeyspaceIdQuery -o keyspace_id_query_bson.go
+
 // KeyRangeQuery represents a query request for the
 // specified list of keyranges.
 type KeyRangeQuery struct {
@@ -78,11 +88,15 @@ type KeyRangeQuery struct {
 	Session       *Session
 }
 
+//go:generate bsongen -file $GOFILE -type KeyRangeQuery -o key_range_query_bson.go
+
 // EntityId represents a tuple of external_id and keyspace_id
 type EntityId struct {
 	ExternalID interface{}
 	KeyspaceID kproto.KeyspaceId
 }
+
+//go:generate bsongen -file $GOFILE -type EntityId -o entity_id_bson.go
 
 // EntityIdsQuery represents a query request for the specified KeyspaceId map.
 type EntityIdsQuery struct {
@@ -95,12 +109,16 @@ type EntityIdsQuery struct {
 	Session           *Session
 }
 
+//go:generate bsongen -file $GOFILE -type EntityIdsQuery -o entity_ids_query_bson.go
+
 // QueryResult is mproto.QueryResult+Session (for now).
 type QueryResult struct {
 	Result  *mproto.QueryResult
 	Session *Session
 	Error   string
 }
+
+//go:generate bsongen -file $GOFILE -type QueryResult -o query_result_bson.go
 
 // BatchQueryShard represents a batch query request
 // for the specified shards.
@@ -112,6 +130,8 @@ type BatchQueryShard struct {
 	Session    *Session
 }
 
+//go:generate bsongen -file $GOFILE -type BatchQueryShard -o batch_query_shard_bson.go
+
 // KeyspaceIdBatchQuery represents a batch query request
 // for the specified keyspace IDs.
 type KeyspaceIdBatchQuery struct {
@@ -121,6 +141,8 @@ type KeyspaceIdBatchQuery struct {
 	TabletType  topo.TabletType
 	Session     *Session
 }
+
+//go:generate bsongen -file $GOFILE -type KeyspaceIdBatchQuery -o keyspace_id_batch_query_bson.go
 
 // QueryResultList is mproto.QueryResultList+Session
 type QueryResultList struct {


### PR DESCRIPTION
Now the bsongen command can live next to the type it operates on.

Note that you need Go 1.4 to run "go generate", but that only needs
to be done when you've modified a type that is the subject of a
generate command.
