### PR TITLE
Fix upgrade.sh by setting db-config args whose defaults were removed.

### DIFF
--- a/data/bootstrap/upgrade.sh
+++ b/data/bootstrap/upgrade.sh
@@ -10,18 +10,23 @@ fi
 
 mysql_port=33306
 tablet_uid=99999
+logdir=$VTDATAROOT/tmp
 tablet_dir=$VTDATAROOT/vt_0000099999
+
+mysqlctl_args="-log_dir $logdir -db-config-dba-uname vt_dba -db-config-dba-charset utf8 -tablet_uid $tablet_uid -mysql_port $mysql_port"
 
 set -e
 
+mkdir -p $logdir
+
 echo Starting mysqld
-mysqlctl -tablet_uid=$tablet_uid -mysql_port=$mysql_port init -skip_schema
+mysqlctl $mysqlctl_args init -skip_schema
 
 echo Running mysql_upgrade
 mysql_upgrade --socket=$tablet_dir/mysql.sock --user=vt_dba 
 
 echo Stopping mysqld
-mysqlctl -tablet_uid=$tablet_uid -mysql_port=$mysql_port shutdown
+mysqlctl $mysqlctl_args shutdown
 
 newfile=mysql-db-dir_$(cat $tablet_dir/data/mysql_upgrade_info).tbz
 


### PR DESCRIPTION
mysqlctl connects with vt_dba as part of checking that mysqld is up.
#190 strikes again :)
