### PR TITLE
Don't mess with replication if running with --disable_active_reparents

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -52,6 +52,16 @@ import (
 )
 
 var (
+	// DisableActiveReparents is a flag to disable active
+	// reparents for safety reasons. It is used in three places:
+	// 1. in this file to skip registering the commands.
+	// 2. in vtctld so it can be exported to the UI (different
+	// package, that's why it's exported). That way we can disable
+	// menu items there, using features.
+	// 3. prevents the vtworker from updating replication topology
+	// after restarting replication after a split clone/diff.
+	DisableActiveReparents = flag.Bool("disable_active_reparents", false, "if set, do not allow active reparents. Use this to protect a cluster using external reparents.")
+
 	dbaPoolSize    = flag.Int("dba_pool_size", 20, "Size of the connection pool for dba connections")
 	dbaIdleTimeout = flag.Duration("dba_idle_timeout", time.Minute, "Idle timeout for dba connections")
 	appPoolSize    = flag.Int("app_pool_size", 40, "Size of the connection pool for app connections")

--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	workflowpb "vitess.io/vitess/go/vt/proto/workflow"
 	"vitess.io/vitess/go/vt/topo"
@@ -1276,7 +1277,7 @@ func (shardSwap *shardSchemaSwap) reparentFromMaster(masterTablet *topodatapb.Ta
 	defer shardSwap.markStepDone(shardSwap.reparentUINode, &err)
 
 	shardSwap.addShardLog(fmt.Sprintf("Reparenting away from master %v", masterTablet.Alias))
-	if *vtctl.DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents {
 		hk := &hook.Hook{
 			Name: "reparent_away",
 		}

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -25,15 +25,8 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"
 
+	"vitess.io/vitess/go/vt/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-)
-
-var (
-	// DisableActiveReparents is a flag to disable active
-	// reparents for safety reasons. It is used in vtctld so it can be
-	// exported to the UI (different package, that's why it's exported).
-	// That way we can disable menu items there, using features.
-	DisableActiveReparents = flag.Bool("disable_active_reparents", false, "if set, do not allow active reparents. Use this to protect a cluster using external reparents.")
 )
 
 func init() {
@@ -61,7 +54,7 @@ func init() {
 }
 
 func commandReparentTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	if *DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents {
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
@@ -79,7 +72,7 @@ func commandReparentTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 }
 
 func commandInitShardMaster(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	if *DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents {
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
@@ -103,7 +96,7 @@ func commandInitShardMaster(ctx context.Context, wr *wrangler.Wrangler, subFlags
 }
 
 func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	if *DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents {
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
@@ -146,7 +139,7 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 }
 
 func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	if *DisableActiveReparents {
+	if *mysqlctl.DisableActiveReparents {
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -39,6 +39,7 @@ import (
 	"vitess.io/vitess/go/vt/workflow"
 	"vitess.io/vitess/go/vt/wrangler"
 
+	"vitess.io/vitess/go/vt/mysqlctl"
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -505,7 +506,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		}
 
 		resp := make(map[string]interface{})
-		resp["activeReparents"] = !*vtctl.DisableActiveReparents
+		resp["activeReparents"] = !*mysqlctl.DisableActiveReparents
 		resp["showStatus"] = *enableRealtimeStats
 		resp["showTopologyCRUD"] = *showTopologyCRUD
 		resp["showWorkflows"] = *workflowManagerInit

--- a/go/vt/vttablet/tabletmanager/replication_reporter.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter.go
@@ -61,14 +61,18 @@ func (r *replicationReporter) Report(isSlaveType, shouldQueryServiceBeRunning bo
 		if !r.agent.slaveStopped() {
 			// As far as we've been told, it isn't stopped on purpose,
 			// so let's try to start it.
-			log.Infof("Slave is stopped. Trying to reconnect to master...")
-			ctx, cancel := context.WithTimeout(r.agent.batchCtx, 5*time.Second)
-			if err := repairReplication(ctx, r.agent); err != nil {
-				log.Infof("Failed to reconnect to master: %v", err)
+			if *mysqlctl.DisableActiveReparents {
+				log.Infof("Slave is stopped. Running with --disable_active_reparents so will not try to reconnect to master...")
+			} else {
+				log.Infof("Slave is stopped. Trying to reconnect to master...")
+				ctx, cancel := context.WithTimeout(r.agent.batchCtx, 5*time.Second)
+				if err := repairReplication(ctx, r.agent); err != nil {
+					log.Infof("Failed to reconnect to master: %v", err)
+				}
+				cancel()
+				// Check status again.
+				status, statusErr = r.agent.MysqlDaemon.SlaveStatus()
 			}
-			cancel()
-			// Check status again.
-			status, statusErr = r.agent.MysqlDaemon.SlaveStatus()
 		}
 	}
 	if statusErr != nil {
@@ -105,6 +109,10 @@ func (r *replicationReporter) HTMLName() template.HTML {
 // repairReplication tries to connect this slave to whoever is
 // the current master of the shard, and start replicating.
 func repairReplication(ctx context.Context, agent *ActionAgent) error {
+	if *mysqlctl.DisableActiveReparents {
+		return fmt.Errorf("can't repair replication with --disable_active_reparents")
+	}
+
 	ts := agent.TopoServer
 	tablet := agent.Tablet()
 	si, err := ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
@@ -113,9 +121,6 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 	}
 	if !si.HasMaster() {
 		return fmt.Errorf("no master tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
-	}
-	if *mysqlctl.DisableActiveReparents {
-		return agent.StartSlave(ctx)
 	}
 	return agent.setMasterLocked(ctx, si.MasterAlias, 0, true)
 }

--- a/go/vt/vttablet/tabletmanager/replication_reporter.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/health"
+	"vitess.io/vitess/go/vt/mysqlctl"
 )
 
 var (
@@ -112,6 +113,9 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 	}
 	if !si.HasMaster() {
 		return fmt.Errorf("no master tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
+	}
+	if *mysqlctl.DisableActiveReparents {
+		return agent.StartSlave(ctx)
 	}
 	return agent.setMasterLocked(ctx, si.MasterAlias, 0, true)
 }


### PR DESCRIPTION
This is useful if your replication topology is entirely managed outside of Vitess. Even if Vitess reparents are never used Vitess will still occasionally update the replication settings when starting/stopping replication after for example an offline split clone or a split diff.