### PR TITLE
vtctl: add workflow commands

### DIFF
--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -202,6 +202,15 @@ func (*SwapWorkflowFactory) Init(_ *workflow.Manager, workflowProto *workflowpb.
 	return nil
 }
 
+// GetData is part of the workflow.Factory interface.
+func (*SwapWorkflowFactory) GetData(_ *workflow.Manager, workflowProto *workflowpb.Workflow) (workflow.Data, error) {
+	data := &swapWorkflowData{}
+	if err := json.Unmarshal(workflowProto.Data, data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 // Instantiate is a part of workflow.Factory interface. It instantiates workflow.Workflow object from
 // workflowpb.Workflow protobuf object.
 func (*SwapWorkflowFactory) Instantiate(_ *workflow.Manager, workflowProto *workflowpb.Workflow, rootNode *workflow.Node) (workflow.Workflow, error) {

--- a/go/vt/vtctl/workflow.go
+++ b/go/vt/vtctl/workflow.go
@@ -24,8 +24,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/workflow"
-	"github.com/youtube/vitess/go/vt/workflow/resharding"
-	"github.com/youtube/vitess/go/vt/workflow/topovalidator"
 	"github.com/youtube/vitess/go/vt/wrangler"
 
 	workflowpb "github.com/youtube/vitess/go/vt/proto/workflow"
@@ -42,11 +40,6 @@ var (
 )
 
 func init() {
-	// Register the various workflow factories to enable the WorkflowShow
-	// introspection commands to function
-	topovalidator.Register()
-	resharding.Register()
-
 	addCommandGroup(workflowsGroupName)
 
 	addCommand(workflowsGroupName, command{

--- a/go/vt/workflow/resharding/horizontal_resharding_workflow.go
+++ b/go/vt/workflow/resharding/horizontal_resharding_workflow.go
@@ -102,6 +102,15 @@ func (*HorizontalReshardingWorkflowFactory) Init(m *workflow.Manager, w *workflo
 	return nil
 }
 
+// GetData is part of the workflow.Factory interface.
+func (*HorizontalReshardingWorkflowFactory) GetData(_ *workflow.Manager, w *workflowpb.Workflow) (workflow.Data, error) {
+	checkpoint := &workflowpb.WorkflowCheckpoint{}
+	if err := proto.Unmarshal(w.Data, checkpoint); err != nil {
+		return nil, err
+	}
+	return checkpoint, nil
+}
+
 // Instantiate is part the workflow.Factory interface.
 func (*HorizontalReshardingWorkflowFactory) Instantiate(m *workflow.Manager, w *workflowpb.Workflow, rootNode *workflow.Node) (workflow.Workflow, error) {
 	rootNode.Message = "This is a workflow to execute horizontal resharding automatically."

--- a/go/vt/workflow/resharding/test_workflow_test.go
+++ b/go/vt/workflow/resharding/test_workflow_test.go
@@ -86,6 +86,15 @@ func (*TestWorkflowFactory) Init(_ *workflow.Manager, w *workflowpb.Workflow, ar
 	return nil
 }
 
+// GetData is part the workflow.Factory interface.
+func (*TestWorkflowFactory) GetData(m *workflow.Manager, w *workflowpb.Workflow) (workflow.Data, error) {
+	checkpoint := &workflowpb.WorkflowCheckpoint{}
+	if err := proto.Unmarshal(w.Data, checkpoint); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
 // Instantiate is part the workflow.Factory interface.
 func (*TestWorkflowFactory) Instantiate(m *workflow.Manager, w *workflowpb.Workflow, rootNode *workflow.Node) (workflow.Workflow, error) {
 	checkpoint := &workflowpb.WorkflowCheckpoint{}

--- a/go/vt/workflow/sleep_workflow.go
+++ b/go/vt/workflow/sleep_workflow.go
@@ -230,6 +230,15 @@ func (f *SleepWorkflowFactory) Init(_ *Manager, w *workflowpb.Workflow, args []s
 	return nil
 }
 
+// GetData is part of the workflow.Factory interface.
+func (f *SleepWorkflowFactory) GetData(_ *Manager, w *workflowpb.Workflow) (Data, error) {
+	data := &SleepWorkflowData{}
+	if err := json.Unmarshal(w.Data, data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
 // Instantiate is part of the workflow.Factory interface.
 func (f *SleepWorkflowFactory) Instantiate(_ *Manager, w *workflowpb.Workflow, rootNode *Node) (Workflow, error) {
 	rootNode.Message = "This workflow is a test workflow that just sleeps for the provided amount of time."

--- a/go/vt/workflow/topovalidator/validator.go
+++ b/go/vt/workflow/topovalidator/validator.go
@@ -218,6 +218,11 @@ func (f *WorkflowFactory) Init(_ *workflow.Manager, w *workflowpb.Workflow, args
 	return nil
 }
 
+// GetData is part of the workflow.Factory interface.
+func (f *WorkflowFactory) GetData(_ *workflow.Manager, w *workflowpb.Workflow) (workflow.Data, error) {
+	return "", nil
+}
+
 // Instantiate is part of the workflow.Factory interface.
 func (f *WorkflowFactory) Instantiate(_ *workflow.Manager, w *workflowpb.Workflow, rootNode *workflow.Node) (workflow.Workflow, error) {
 	rootNode.Message = "Validates the Topology and proposes fixes for known issues."


### PR DESCRIPTION
Add two new vtctl commands WorkflowShow and WorkflowNames which expose the contents of running workflows to the CLI.

This is based on #3382. Will rebase once that merges but I wanted to get initial thoughts.


