### PR TITLE
CreateBlpCheckpoint uses TRUNCATE TABLE to ensure the table is emtpy

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -462,8 +462,9 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 	}
 }
 
-// CreateBlpCheckpoint returns the statements required to create
-// the _vt.blp_checkpoint table
+// CreateBlpCheckpoint returns the statements required to create the
+// _vt.blp_checkpoint table and ensure it is empty.  If the database or
+// table already exist they will not be re-created.
 func CreateBlpCheckpoint() []string {
 	return []string{
 		"CREATE DATABASE IF NOT EXISTS _vt",
@@ -476,7 +477,8 @@ func CreateBlpCheckpoint() []string {
   transaction_timestamp BIGINT(20) UNSIGNED NOT NULL,
   flags VARBINARY(250) DEFAULT NULL,
   PRIMARY KEY (source_shard_uid)
-) ENGINE=InnoDB`, mysql.MaximumPositionSize)}
+) ENGINE=InnoDB`, mysql.MaximumPositionSize),
+		"TRUNCATE TABLE _vt.blp_checkpoint"}
 }
 
 // PopulateBlpCheckpoint returns a statement to populate the first value into


### PR DESCRIPTION
See: https://github.com/youtube/vitess/issues/3431

Under some situations when rebuilding an existing setup that had vitess data on it the table may have existed and this table may not be empty. This extra TRUNCATE TABLE ensures the table is cleaned prior to later trying to insert data.