### PR TITLE
Implement TableACL checks for multiple tables.

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -83,7 +83,7 @@
 "select * from a,b"
 {
   "PlanID": "PASS_SELECT",
-  "TableName": "",
+  "TableName": "a",
   "FieldQuery": "select * from a, b where 1 != 1",
   "FullQuery": "select * from a, b limit :#maxLimit"
 }
@@ -1172,7 +1172,7 @@ options:PassthroughDMLs
 
 # nextval on non-existent table
 "select next value from id"
-"table id not found in schema"
+"table id of [id] not found in schema"
 
 # int
 "set  a=1"
@@ -1300,19 +1300,19 @@ options:PassthroughDMLs
 
 # table not found select
 "select * from aaaa"
-"table aaaa not found in schema"
+"table aaaa of [aaaa] not found in schema"
 
 # table not found update
 "update aaaa set a=1"
-"table aaaa not found in schema"
+"table aaaa of [aaaa] not found in schema"
 
 # table not found update
 "delete from aaaa"
-"table aaaa not found in schema"
+"table aaaa of [aaaa] not found in schema"
 
 # table not found update
 "insert into aaaa values(1)"
-"table aaaa not found in schema"
+"table aaaa of [aaaa] not found in schema"
 
 # column not found insert with subquery
 "insert into a(missing) select * from b"

--- a/go/cmd/vtclient/vtclient_test.go
+++ b/go/cmd/vtclient/vtclient_test.go
@@ -115,7 +115,7 @@ func TestVtclient(t *testing.T) {
 		},
 		{
 			args:   []string{"SELECT * FROM nonexistent"},
-			errMsg: "table nonexistent not found in schema",
+			errMsg: "table nonexistent of [nonexistent] not found in schema",
 		},
 	}
 

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -172,7 +172,7 @@ func TestErrors(t *testing.T) {
 
 		{
 			SQL: "SELECT * FROM table_not_in_schema",
-			Err: "vtexplain execute error in 'SELECT * FROM table_not_in_schema': target: ks_unsharded.-.master, used tablet: explainCell-0 (ks_unsharded/-), table table_not_in_schema not found in schema",
+			Err: "vtexplain execute error in 'SELECT * FROM table_not_in_schema': target: ks_unsharded.-.master, used tablet: explainCell-0 (ks_unsharded/-), table table_not_in_schema of [table_not_in_schema] not found in schema",
 		},
 	}
 

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -167,7 +167,7 @@ func TestQueries(t *testing.T) {
 
 	// Try a simple error case.
 	_, err = conn.ExecuteFetch("select * from aa", 1000, true)
-	if err == nil || !strings.Contains(err.Error(), "table aa not found in schema") {
+	if err == nil || !strings.Contains(err.Error(), "table aa of [aa] not found in schema") {
 		t.Fatalf("expected error but got: %v", err)
 	}
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/ddl.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/ddl.go
@@ -49,7 +49,7 @@ func analyzeDDL(ddl *sqlparser.DDL, tables map[string]*schema.Table) *Plan {
 	// TODO(sougou): Add support for sequences.
 	plan := &Plan{
 		PlanID:  PlanDDL,
-		Table:   tables[ddl.Table.Name.String()],
+		Tables:  []*schema.Table{tables[ddl.Table.Name.String()]},
 		NewName: ddl.NewName.Name,
 	}
 	// this can become a whitelist of fully supported ddl actions as support grows

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -189,7 +189,7 @@ func TestMessageStreamingPlan(t *testing.T) {
 
 	wantPlan := &Plan{
 		PlanID: PlanMessageStream,
-		Table:  testSchema["msg"],
+		Tables: []*schema.Table{testSchema["msg"]},
 	}
 	bout, _ = toJSON(wantPlan)
 	wantJSON := string(bout)

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -126,7 +126,7 @@ func TestGetMessageStreamPlan(t *testing.T) {
 	}
 	wantPlan := &planbuilder.Plan{
 		PlanID: planbuilder.PlanMessageStream,
-		Table:  qe.tables["msg"],
+		Tables: []*schema.Table{qe.tables["msg"]},
 	}
 	if !reflect.DeepEqual(plan.Plan, wantPlan) {
 		t.Errorf("GetMessageStreamPlan(msg): %v, want %v", plan.Plan, wantPlan)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -47,15 +47,16 @@ import (
 
 // QueryExecutor is used for executing a query request.
 type QueryExecutor struct {
-	query            string
-	trailingComments string
-	bindVars         map[string]*querypb.BindVariable
-	transactionID    int64
-	options          *querypb.ExecuteOptions
-	plan             *TabletPlan
-	ctx              context.Context
-	logStats         *tabletenv.LogStats
-	tsv              *TabletServer
+	query                                 string
+	trailingComments                      string
+	bindVars                              map[string]*querypb.BindVariable
+	transactionID                         int64
+	options                               *querypb.ExecuteOptions
+	plan                                  *TabletPlan
+	ctx                                   context.Context
+	logStats                              *tabletenv.LogStats
+	tsv                                   *TabletServer
+	enableTableACLChecksForMultipleTables bool
 }
 
 // NewQueryExecutor creates a new QueryExecutor with the given contents. It is
@@ -371,8 +372,27 @@ func (qre *QueryExecutor) checkPermissions() error {
 		// field to an "acl.DenyAllACL" ACL if no ACL was found.
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "table acl error: nil acl")
 	}
-	if !qre.plan.TableName().IsEmpty() {
-		return qre.checkAccess(qre.plan.Authorized, qre.plan.TableName(), callerID)
+
+	// TODO(b/72787743) drop this after we have rolled out and
+	// tested the flag enableTableACLChecksForMultipleTables in
+	// prod.
+	if !qre.enableTableACLChecksForMultipleTables {
+		if !qre.plan.TableName().IsEmpty() {
+			return qre.checkAccess(qre.plan.Authorized, qre.plan.TableName(), callerID)
+		}
+		return nil
+	}
+
+	for _, table := range qre.plan.Tables {
+		if (table == nil) || (table.Name.IsEmpty()) {
+			continue
+		}
+
+		err := qre.checkAccess(qre.plan.Authorized, table.Name, callerID)
+		if err != nil {
+			log.Warningf("Found select query targeting multiple tables with tableACL missing for table %q in query: %q", table.Name.String(), qre.query)
+			return err
+		}
 	}
 	return nil
 }
@@ -450,7 +470,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 		return nil, fmt.Errorf("invalid increment for sequence %s: %d", tableName, inc)
 	}
 
-	t := qre.plan.Table
+	t := qre.plan.Tables[0]
 	t.SequenceInfo.Lock()
 	defer t.SequenceInfo.Unlock()
 	if t.SequenceInfo.NextVal == 0 || t.SequenceInfo.NextVal+inc > t.SequenceInfo.LastVal {
@@ -541,7 +561,7 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 }
 
 func (qre *QueryExecutor) execInsertPK(conn *TxConnection) (*sqltypes.Result, error) {
-	pkRows, err := buildValueList(qre.plan.Table, qre.plan.PKValues, qre.bindVars)
+	pkRows, err := buildValueList(qre.plan.Tables[0], qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +570,7 @@ func (qre *QueryExecutor) execInsertPK(conn *TxConnection) (*sqltypes.Result, er
 
 func (qre *QueryExecutor) execInsertMessage(conn *TxConnection) (*sqltypes.Result, error) {
 	qre.bindVars["#time_now"] = sqltypes.Int64BindVariable(time.Now().UnixNano())
-	pkRows, err := buildValueList(qre.plan.Table, qre.plan.PKValues, qre.bindVars)
+	pkRows, err := buildValueList(qre.plan.Tables[0], qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +583,7 @@ func (qre *QueryExecutor) execInsertMessage(conn *TxConnection) (*sqltypes.Resul
 	// If so, we have to populate it.
 	if qr.InsertID != 0 {
 		id := int64(qr.InsertID)
-		idPKIndex := qre.plan.Table.MessageInfo.IDPKIndex
+		idPKIndex := qre.plan.Tables[0].MessageInfo.IDPKIndex
 		for _, row := range pkRows {
 			if !row[idPKIndex].IsNull() {
 				// If a value was supplied, either it was not the auto-inc column
@@ -582,11 +602,11 @@ func (qre *QueryExecutor) execInsertMessage(conn *TxConnection) (*sqltypes.Resul
 	// Re-read the inserted rows to prime the cache.
 	extras := map[string]sqlparser.Encodable{
 		"#pk": &sqlparser.TupleEqualityList{
-			Columns: qre.plan.Table.Indexes[0].Columns,
+			Columns: qre.plan.Tables[0].Indexes[0].Columns,
 			Rows:    pkRows,
 		},
 	}
-	tableName := qre.plan.Table.Name.String()
+	tableName := qre.plan.Tables[0].Name.String()
 	loadMessages, err := qre.tsv.messager.GenerateLoadMessagesQuery(tableName)
 	if err != nil {
 		return nil, err
@@ -624,10 +644,10 @@ func (qre *QueryExecutor) execInsertSubquery(conn *TxConnection) (*sqltypes.Resu
 	}
 	pkRows := make([][]sqltypes.Value, len(innerRows))
 	for i, innerRow := range innerRows {
-		pkRows[i] = applyFilterWithPKDefaults(qre.plan.Table, qre.plan.SubqueryPKColumns, innerRow)
+		pkRows[i] = applyFilterWithPKDefaults(qre.plan.Tables[0], qre.plan.SubqueryPKColumns, innerRow)
 	}
 	// Validating first row is sufficient
-	if err := validateRow(qre.plan.Table, qre.plan.Table.PKColumns, pkRows[0]); err != nil {
+	if err := validateRow(qre.plan.Tables[0], qre.plan.Tables[0].PKColumns, pkRows[0]); err != nil {
 		return nil, err
 	}
 
@@ -641,11 +661,11 @@ func (qre *QueryExecutor) execInsertPKRows(conn *TxConnection, extras map[string
 	var bsc []byte
 	// Build comments only if we're not in RBR mode.
 	if qre.tsv.qe.binlogFormat != connpool.BinlogFormatRow {
-		secondaryList, err := buildSecondaryList(qre.plan.Table, pkRows, qre.plan.SecondaryPKValues, qre.bindVars)
+		secondaryList, err := buildSecondaryList(qre.plan.Tables[0], pkRows, qre.plan.SecondaryPKValues, qre.bindVars)
 		if err != nil {
 			return nil, err
 		}
-		bsc = buildStreamComment(qre.plan.Table, pkRows, secondaryList)
+		bsc = buildStreamComment(qre.plan.Tables[0], pkRows, secondaryList)
 	}
 	return qre.txFetch(conn, qre.plan.OuterQuery, qre.bindVars, extras, bsc, false, true)
 }
@@ -657,14 +677,14 @@ func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, er
 	}
 
 	// For statement or mixed mode, we have to split into two ops.
-	pkRows, err := buildValueList(qre.plan.Table, qre.plan.PKValues, qre.bindVars)
+	pkRows, err := buildValueList(qre.plan.Tables[0], qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
 	// We do not need to build the secondary list for the insert part.
 	// But the part that updates will build it if it gets executed,
 	// because it's the one that can change the primary keys.
-	bsc := buildStreamComment(qre.plan.Table, pkRows, nil)
+	bsc := buildStreamComment(qre.plan.Tables[0], pkRows, nil)
 	result, err := qre.txFetch(conn, qre.plan.OuterQuery, qre.bindVars, nil, bsc, false, true)
 	if err == nil {
 		return result, nil
@@ -694,7 +714,7 @@ func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, er
 }
 
 func (qre *QueryExecutor) execDMLPK(conn *TxConnection) (*sqltypes.Result, error) {
-	pkRows, err := buildValueList(qre.plan.Table, qre.plan.PKValues, qre.bindVars)
+	pkRows, err := buildValueList(qre.plan.Tables[0], qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +733,7 @@ func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.Par
 	if len(pkRows) == 0 {
 		return &sqltypes.Result{RowsAffected: 0}, nil
 	}
-	secondaryList, err := buildSecondaryList(qre.plan.Table, pkRows, qre.plan.SecondaryPKValues, qre.bindVars)
+	secondaryList, err := buildSecondaryList(qre.plan.Tables[0], pkRows, qre.plan.SecondaryPKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
@@ -733,11 +753,11 @@ func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.Par
 		var bsc []byte
 		// Build comments only if we're not in RBR mode.
 		if qre.tsv.qe.binlogFormat != connpool.BinlogFormatRow {
-			bsc = buildStreamComment(qre.plan.Table, pkRows, secondaryList)
+			bsc = buildStreamComment(qre.plan.Tables[0], pkRows, secondaryList)
 		}
 		extras := map[string]sqlparser.Encodable{
 			"#pk": &sqlparser.TupleEqualityList{
-				Columns: qre.plan.Table.Indexes[0].Columns,
+				Columns: qre.plan.Tables[0].Indexes[0].Columns,
 				Rows:    pkRows,
 			},
 		}
@@ -753,12 +773,12 @@ func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.Par
 		// DMLs should all return RowsAffected.
 		result.RowsAffected += r.RowsAffected
 	}
-	if qre.plan.Table.Type == schema.Message {
-		ids := conn.ChangedMessages[qre.plan.Table.Name.String()]
+	if qre.plan.Tables[0].Type == schema.Message {
+		ids := conn.ChangedMessages[qre.plan.Tables[0].Name.String()]
 		for _, pkrow := range pkRows {
-			ids = append(ids, pkrow[qre.plan.Table.MessageInfo.IDPKIndex].ToString())
+			ids = append(ids, pkrow[qre.plan.Tables[0].MessageInfo.IDPKIndex].ToString())
 		}
-		conn.ChangedMessages[qre.plan.Table.Name.String()] = ids
+		conn.ChangedMessages[qre.plan.Tables[0].Name.String()] = ids
 	}
 	return result, nil
 }

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -39,7 +39,7 @@ func TestQueryzHandler(t *testing.T) {
 
 	plan1 := &TabletPlan{
 		Plan: &planbuilder.Plan{
-			Table:  &schema.Table{Name: sqlparser.NewTableIdent("test_table")},
+			Tables: []*schema.Table{&schema.Table{Name: sqlparser.NewTableIdent("test_table")}},
 			PlanID: planbuilder.PlanPassSelect,
 			Reason: planbuilder.ReasonTable,
 		},
@@ -49,7 +49,7 @@ func TestQueryzHandler(t *testing.T) {
 
 	plan2 := &TabletPlan{
 		Plan: &planbuilder.Plan{
-			Table:  &schema.Table{Name: sqlparser.NewTableIdent("test_table")},
+			Tables: []*schema.Table{&schema.Table{Name: sqlparser.NewTableIdent("test_table")}},
 			PlanID: planbuilder.PlanDDL,
 			Reason: planbuilder.ReasonDefault,
 		},
@@ -59,7 +59,7 @@ func TestQueryzHandler(t *testing.T) {
 
 	plan3 := &TabletPlan{
 		Plan: &planbuilder.Plan{
-			Table:  &schema.Table{Name: sqlparser.NewTableIdent("")},
+			Tables: []*schema.Table{&schema.Table{Name: sqlparser.NewTableIdent("")}},
 			PlanID: planbuilder.PlanOtherRead,
 			Reason: planbuilder.ReasonDefault,
 		},
@@ -70,7 +70,7 @@ func TestQueryzHandler(t *testing.T) {
 
 	plan4 := &TabletPlan{
 		Plan: &planbuilder.Plan{
-			Table:  &schema.Table{Name: sqlparser.NewTableIdent("")},
+			Tables: []*schema.Table{&schema.Table{Name: sqlparser.NewTableIdent("")}},
 			PlanID: planbuilder.PlanOtherRead,
 			Reason: planbuilder.ReasonDefault,
 		},

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -97,6 +97,9 @@ func init() {
 	flag.DurationVar(&Config.HeartbeatInterval, "heartbeat_interval", DefaultQsConfig.HeartbeatInterval, "How frequently to read and write replication heartbeat.")
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
+
+	flag.BoolVar(&Config.EnableTableACLChecksForMultipleTables, "enable_table_acl_checks_for_multiple_tables", DefaultQsConfig.EnableTableACLChecksForMultipleTables, "This will enable table ACL checks for queries that are touching multiple tables, e.g. a join.")
+
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -163,7 +166,8 @@ type TabletConfig struct {
 	HeartbeatEnable   bool
 	HeartbeatInterval time.Duration
 
-	EnforceStrictTransTables bool
+	EnforceStrictTransTables              bool
+	EnableTableACLChecksForMultipleTables bool
 }
 
 // TransactionLimitConfig captures configuration of transaction pool slots
@@ -234,6 +238,8 @@ var DefaultQsConfig = TabletConfig{
 	HeartbeatInterval: 1 * time.Second,
 
 	EnforceStrictTransTables: true,
+
+	EnableTableACLChecksForMultipleTables: false,
 }
 
 // defaultTxThrottlerConfig formats the default throttlerdata.Configuration

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -168,6 +168,8 @@ type TabletServer struct {
 
 	// alias is used for identifying this tabletserver in healthcheck responses.
 	alias topodatapb.TabletAlias
+
+	enableTableACLChecksForMultipleTables bool
 }
 
 // RegisterFunction is a callback type to be called when we
@@ -205,6 +207,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 		history:                history.New(10),
 		topoServer:             topoServer,
 		alias:                  alias,
+		enableTableACLChecksForMultipleTables: config.EnableTableACLChecksForMultipleTables,
 	}
 	tsv.se = schema.NewEngine(tsv, config)
 	tsv.qe = NewQueryEngine(tsv, tsv.se, config)
@@ -893,6 +896,7 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 				ctx:              ctx,
 				logStats:         logStats,
 				tsv:              tsv,
+				enableTableACLChecksForMultipleTables: tsv.enableTableACLChecksForMultipleTables,
 			}
 			extras := tsv.watcher.ComputeExtras(options)
 			result, err = qre.Execute()
@@ -933,6 +937,7 @@ func (tsv *TabletServer) StreamExecute(ctx context.Context, target *querypb.Targ
 				ctx:              ctx,
 				logStats:         logStats,
 				tsv:              tsv,
+				enableTableACLChecksForMultipleTables: tsv.enableTableACLChecksForMultipleTables,
 			}
 			return qre.Stream(callback)
 		},
@@ -1136,6 +1141,7 @@ func (tsv *TabletServer) MessageStream(ctx context.Context, target *querypb.Targ
 				ctx:      ctx,
 				logStats: logStats,
 				tsv:      tsv,
+				enableTableACLChecksForMultipleTables: tsv.enableTableACLChecksForMultipleTables,
 			}
 			return qre.MessageStream(callback)
 		},
@@ -1577,6 +1583,7 @@ func newSplitQuerySQLExecuter(
 		ctx:      ctx,
 		logStats: logStats,
 		tsv:      tsv,
+		enableTableACLChecksForMultipleTables: tsv.enableTableACLChecksForMultipleTables,
 	}
 	result := &splitQuerySQLExecuter{
 		queryExecutor: queryExecutor,

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -793,7 +793,7 @@ class TestVTGateFunctions(unittest.TestCase):
     lcursor = vtgate_conn.cursor(
         tablet_type='master', keyspace='lookup', writable=True)
     with self.assertRaisesRegexp(
-        dbexceptions.DatabaseError, '.*table vt_user not found in schema.*'):
+        dbexceptions.DatabaseError, '.*table vt_user .*not found in schema.*'):
       lcursor.execute('select id, name from vt_user', {})
 
   def test_user2(self):


### PR DESCRIPTION
This change replaces Plan.Table by a field Plan.Tables so that it can
hold a reference to more than one table. QueryExecutor now leverages
this to check each table's ACL. Fixes #3627.

I've put all changes behind a flag as we'll need to carefully roll
this out to prod. I've also decided against using a walk as originally
suggested by Matt as this would have required a change of the
interface of setTable()/setTables(). Lastly, I've also dropped the
plan to selectively log the issue as this CL has involved into a fix,
rather than merely aprobe into the issue.

Once approved, please do not merge right away as I'd like to get a Go readability review on this as well.