### PR TITLE
helm: Allow non-leader Orchestrator instances to accept requests

### DIFF
--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -11,9 +11,9 @@ COPY --from=k8s /vt/bin/vtctlclient /usr/bin/
 RUN apt-get update && \
     apt-get upgrade -qq && \
     apt-get install wget -qq --no-install-recommends && \
-    wget https://github.com/github/orchestrator/releases/download/v3.0.6/orchestrator_3.0.6_amd64.deb && \
-    dpkg -i orchestrator_3.0.6_amd64.deb && \
-    rm orchestrator_3.0.6_amd64.deb && \
+    wget https://github.com/github/orchestrator/releases/download/v3.0.11/orchestrator_3.0.11_amd64.deb && \
+    dpkg -i orchestrator_3.0.11_amd64.deb && \
+    rm orchestrator_3.0.11_amd64.deb && \
     apt-get purge wget -qq && \
     apt-get autoremove -qq && \
     apt-get clean && \

--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -8,9 +8,9 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 RUN apt-get update && \
     apt-get upgrade -qq && \
     apt-get install wget -qq --no-install-recommends && \
-    wget https://www.percona.com/redir/downloads/pmm-client/1.6.1/binary/debian/stretch/x86_64/pmm-client_1.6.1-1.stretch_amd64.deb && \
-    dpkg -i pmm-client_1.6.1-1.stretch_amd64.deb && \
-    rm pmm-client_1.6.1-1.stretch_amd64.deb && \
+    wget https://www.percona.com/redir/downloads/pmm-client/1.10.0/binary/debian/stretch/x86_64/pmm-client_1.10.0-1.stretch_amd64.deb && \
+    dpkg -i pmm-client_1.10.0-1.stretch_amd64.deb && \
+    rm pmm-client_1.10.0-1.stretch_amd64.deb && \
     apt-get purge wget -qq && \
     apt-get autoremove -qq && \
     apt-get clean && \

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -46,6 +46,7 @@ data:
     "HostnameResolveMethod": "none",
     "HTTPAuthPassword": "",
     "HTTPAuthUser": "",
+    "HTTPAdvertise": "http://POD_NAME.orchestrator-headless.{{ $namespace }}:3000",
     "InstanceBulkOperationsWaitTimeoutSeconds": 10,
     "InstancePollSeconds": 5,
     "ListenAddress": ":3000",

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -23,11 +23,9 @@ spec:
   type: ClusterIP
 
 ---
-
 ###################################
 # Headless Orchestrator Service
 ###################################
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -43,9 +41,6 @@ spec:
     - name: web
       port: 80
       targetPort: 3000
-    - name: raft
-      port: 10008
-      targetPort: 10008
   selector:
     component: orchestrator
     app: vitess
@@ -109,7 +104,7 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: "/api/leader-check"
+              path: "/api/raft-health"
               port: 3000
             timeoutSeconds: 10
 

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -65,7 +65,7 @@ spec:
 
           env:
             - name: DISABLE_UPDATES
-              value: "true"
+              value: "false"
 
             - name: DISABLE_TELEMETRY
               value: {{ $pmm.server.env.disableTelemetry | quote }}

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -215,11 +215,11 @@ pmm:
       # It is recommended to set this limit to roughly 2/3 of the total memory that you are planning to allow for Prometheus.
       metricsMemory: "600000"
 
-# Orchestrator requires at least Kubernetes 1.9 to work
+# Orchestrator requires at least version >= 3.0.9 and Kubernetes 1.9 to work
 # Default values for orchestrator resources
 orchestrator:
   enabled: false
-  image: "vitess/orchestrator:3.0.6"
+  image: "vitess/orchestrator:3.0.11"
   replicas: 3
   resources:
     requests:

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -163,7 +163,7 @@ vttablet:
 # Default values for pmm
 pmm:
   enabled: false
-  pmmTag: "1.6.1"
+  pmmTag: "1.10.0"
   client:
     resources:
       requests:


### PR DESCRIPTION
Orchestrator 3.0.7 added a proxy that forwards master only requests, so we don’t have to workaround that by having perpetually unready pods via the /api/leader-check endpoint

cc @shlomi-noach @enisoc