### PR TITLE
Enhanced shard targeting part I 

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -53,7 +53,7 @@ import (
 )
 
 var (
-	errNoKeyspace     = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspace in database name specified. Supported database name format: keyspace[:shard][@type]")
+	errNoKeyspace     = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspace in database name specified. Supported database name format (items in <> are optional): keyspace<:shard><@type> or keyspace<[range]><@type>")
 	defaultTabletType topodatapb.TabletType
 )
 
@@ -213,12 +213,32 @@ func (e *Executor) execute(ctx context.Context, safeSession *SafeSession, sql st
 }
 
 func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
-	if target.Shard != "" {
-		// V1 mode or V3 mode with a forced shard target
+	keyRange, err := parseRange(safeSession.TargetString)
+	if err != nil {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not parse target %s (%s)", safeSession.TargetString, err.Error())
+	}
+
+	if keyRange != nil || target.Shard != "" {
+		// V1 mode or V3 mode with a forced shard or range target
 		// TODO(sougou): change this flow to go through V3 functions
 		// which will allow us to benefit from the autocommitable flag.
-		sql = sqlannotation.AnnotateIfDML(sql, nil)
+		if target.Keyspace == "" {
+			return nil, errNoKeyspace
+		}
 
+		var destination key.Destination
+		if keyRange != nil {
+			stmtType := sqlparser.Preview(sql)
+			if stmtType == sqlparser.StmtInsert {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "range queries not supported for inserts: %s", safeSession.TargetString)
+			}
+			destination = key.DestinationExactKeyRange{KeyRange: keyRange}
+		} else {
+			destination = key.DestinationShard(target.Shard)
+		}
+
+		execStart := time.Now()
+		sql = sqlannotation.AnnotateIfDML(sql, nil)
 		if e.normalize {
 			query, comments := sqlparser.SplitTrailingComments(sql)
 			stmt, err := sqlparser.Parse(query)
@@ -229,18 +249,11 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 			normalized := sqlparser.String(stmt)
 			sql = normalized + comments
 		}
-
+		logStats.PlanTime = execStart.Sub(logStats.StartTime)
 		logStats.SQL = sql
 		logStats.BindVariables = bindVars
-
-		execStart := time.Now()
-		logStats.PlanTime = execStart.Sub(logStats.StartTime)
-
-		result, err := e.shardExec(ctx, safeSession, sql, bindVars, target, logStats)
+		result, err := e.destinationExec(ctx, safeSession, sql, bindVars, target, destination, logStats)
 		logStats.ExecuteTime = time.Now().Sub(execStart)
-
-		logStats.ShardQueries = 1
-
 		return result, err
 	}
 
@@ -284,25 +297,8 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 	return qr, err
 }
 
-func (e *Executor) shardExec(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) destinationExec(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, destination key.Destination, logStats *LogStats) (*sqltypes.Result, error) {
 	f := func() ([]*srvtopo.ResolvedShard, error) {
-		return e.resolver.resolver.ResolveDestination(ctx, target.Keyspace, target.TabletType, key.DestinationShard(target.Shard))
-	}
-	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, safeSession.Session, f, false /* notInTransaction */, safeSession.Options, logStats)
-}
-
-func (e *Executor) handleDDL(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
-	if target.Keyspace == "" {
-		return nil, errNoKeyspace
-	}
-
-	f := func() ([]*srvtopo.ResolvedShard, error) {
-		var destination key.Destination
-		if target.Shard == "" {
-			destination = key.DestinationAllShards{}
-		} else {
-			destination = key.DestinationShard(target.Shard)
-		}
 		rss, err := e.resolver.resolver.ResolveDestination(ctx, target.Keyspace, target.TabletType, destination)
 		if err != nil {
 			return nil, err
@@ -310,10 +306,31 @@ func (e *Executor) handleDDL(ctx context.Context, safeSession *SafeSession, sql 
 		logStats.ShardQueries = uint32(len(rss))
 		return rss, nil
 	}
+	return e.resolver.Execute(ctx, sql, bindVars, target.TabletType, safeSession.Session, f, false /* notInTransaction */, safeSession.Options, logStats)
+}
+
+func (e *Executor) handleDDL(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+	if target.Keyspace == "" {
+		return nil, errNoKeyspace
+	}
+
+	keyRange, err := parseRange(safeSession.TargetString)
+	if err != nil {
+		return nil, errNoKeyspace
+	}
+
+	var destination key.Destination
+	if keyRange != nil {
+		destination = key.DestinationExactKeyRange{KeyRange: keyRange}
+	} else if target.Shard != "" {
+		destination = key.DestinationShard(target.Shard)
+	} else {
+		destination = key.DestinationAllShards{}
+	}
 
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-	result, err := e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, safeSession.Session, f, false /* notInTransaction */, safeSession.Options, logStats)
+	result, err := e.destinationExec(ctx, safeSession, sql, bindVars, target, destination, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
 }
@@ -708,6 +725,11 @@ func (e *Executor) handleUse(ctx context.Context, safeSession *SafeSession, sql 
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unrecognized USE statement: %v", sql)
 	}
 	target := e.ParseTarget(use.DBName.String())
+
+	if _, ok := e.VSchema().Keyspaces[target.Keyspace]; target.Keyspace != "" && !ok {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace provided: %s", target.Keyspace)
+	}
+
 	if safeSession.InTransaction() && target.TabletType != topodatapb.TabletType_MASTER {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot change to a non-master type in the middle of a transaction: %v", target.TabletType)
 	}
@@ -731,7 +753,7 @@ func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sq
 		target.Keyspace, target.Shard = rss[0].Target.Keyspace, rss[0].Target.Shard
 	}
 	execStart := time.Now()
-	result, err := e.shardExec(ctx, safeSession, sql, bindVars, target, logStats)
+	result, err := e.destinationExec(ctx, safeSession, sql, bindVars, target, key.DestinationShard(target.Shard), logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
 }
@@ -1064,6 +1086,11 @@ func (e *Executor) ParseTarget(targetString string) querypb.Target {
 		target.Shard = targetString[last+1:]
 		targetString = targetString[:last]
 	}
+	// Remove range query from string if present
+	last = strings.LastIndexAny(targetString, "[")
+	if last != -1 {
+		targetString = targetString[:last]
+	}
 	if targetString == "" && len(e.VSchema().Keyspaces) == 1 {
 		// Loop to extract the only keyspace name.
 		for k := range e.VSchema().Keyspaces {
@@ -1072,6 +1099,28 @@ func (e *Executor) ParseTarget(targetString string) querypb.Target {
 	}
 	target.Keyspace = targetString
 	return target
+}
+
+// parseRange parses range from target string.
+func parseRange(targetString string) (*topodatapb.KeyRange, error) {
+	last := strings.LastIndexAny(targetString, "[")
+	if last != -1 {
+		rangeEnd := strings.LastIndexAny(targetString, "]")
+		if rangeEnd == -1 {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid key range provided. Couldn't find range end ']'")
+
+		}
+		rangeString := targetString[last+1 : rangeEnd]
+		keyRange, err := key.ParseShardingSpec(rangeString)
+		if err != nil {
+			return nil, err
+		}
+		if len(keyRange) != 1 {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "single keyrange expected in %s", rangeString)
+		}
+		return keyRange[0], nil
+	}
+	return nil, nil
 }
 
 // getPlan computes the plan for the given query. If one is in

--- a/go/vt/vtgate/resolver.go
+++ b/go/vt/vtgate/resolver.go
@@ -85,7 +85,7 @@ func (res *Resolver) ExecuteKeyspaceIds(ctx context.Context, sql string, bindVar
 			tabletType,
 			key.DestinationKeyspaceIDs(keyspaceIds))
 	}
-	return res.Execute(ctx, sql, bindVariables, keyspace, tabletType, session, mapToShards, notInTransaction, options, nil /* LogStats */)
+	return res.Execute(ctx, sql, bindVariables, tabletType, session, mapToShards, notInTransaction, options, nil /* LogStats */)
 }
 
 // ExecuteKeyRanges executes a non-streaming query based on KeyRanges.
@@ -98,7 +98,7 @@ func (res *Resolver) ExecuteKeyRanges(ctx context.Context, sql string, bindVaria
 			tabletType,
 			key.DestinationKeyRanges(keyRanges))
 	}
-	return res.Execute(ctx, sql, bindVariables, keyspace, tabletType, session, mapToShards, notInTransaction, options, nil)
+	return res.Execute(ctx, sql, bindVariables, tabletType, session, mapToShards, notInTransaction, options, nil)
 }
 
 // Execute executes a non-streaming query based on shards resolved by given func.
@@ -107,7 +107,6 @@ func (res *Resolver) Execute(
 	ctx context.Context,
 	sql string,
 	bindVars map[string]*querypb.BindVariable,
-	keyspace string,
 	tabletType topodatapb.TabletType,
 	session *vtgatepb.Session,
 	mapToShards func() ([]*srvtopo.ResolvedShard, error),

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -407,7 +407,6 @@ func (vtg *VTGate) ExecuteShards(ctx context.Context, sql string, bindVariables 
 		ctx,
 		sql,
 		bindVariables,
-		keyspace,
 		tabletType,
 		session,
 		func() ([]*srvtopo.ResolvedShard, error) {


### PR DESCRIPTION
### Description

The following is the first iteration on [enhancing shard targeting](https://github.com/youtube/vitess/issues/3666). Per spec, it adds support to target a range using `keyspace[-20]` range syntax. 

### Implementation notes:

1) `e.resolver.Execute` was having a `keyspace` parameter and it was not being used. I took the opportunity to clean up this.
2) When targeting a single shard, there was no validation that a keyspace was being set. This validation was added.
3) `use` syntax didn't validate that you were providing a valid keyspace. I also added a validation for this.

### TODO for following PR's 
- Add support for this syntax in `FROM` clauses ( i.e ``select a from `keyspace[20-40]`.t``)
- Support for targeting a keyspace_id
- At the moment, targeting a single shard does not benefit from insta commit feature. I maintained this behavior for consistency. However, @demmer  and I were talking that we should do insta commit in these cases. If we decide to do this, I can do this in a different PR. 

