### PR TITLE
Run diff on largest table first

### DIFF
--- a/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
+++ b/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
@@ -52,6 +53,16 @@ func NewStreamHealthQueryService(target querypb.Target) *StreamHealthQueryServic
 		healthResponses: make(chan *querypb.StreamHealthResponse, 1000),
 		target:          target,
 	}
+}
+
+// Begin implemented as a no op
+func (q *StreamHealthQueryService) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, error) {
+	return 0, nil
+}
+
+// Execute implemented as a no op
+func (q *StreamHealthQueryService) Execute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
+	return &sqltypes.Result{}, nil
 }
 
 // StreamHealth implements the QueryService interface.


### PR DESCRIPTION
This should speed up diff if there are large differences in table size
by ensuring we don't start diff a large table late in the process.