### PR TITLE
Move PullApprove config to GitHub CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @alainjobart @bbeaudreault @demmer @enisoc @michael-berlin @sougou


### PR DESCRIPTION
This just defines a root rule. We can add owners for specific paths and file types over time.