### PR TITLE
 vitess.io: Fix embedded presentations in HTTPS mode.

### DIFF
--- a/vitess.io/_config.yml
+++ b/vitess.io/_config.yml
@@ -6,9 +6,9 @@ logo: vitess_logo_with_border.svg
 icon: vitess_logo_icon_size.png
 teaser: 400x250.gif
 locale: en_US
-url: http://vitess.io
+url: https://vitess.io
 project-name: Vitess
-repo: https://github.com/youtube/vitess
+repo: https://github.com/vitessio/vitess
 
 # Jekyll configuration
 sass:
@@ -32,7 +32,7 @@ redcarpet:
 # Site owner
 owner:
   name: Vitess Team
-  web: https://github.com/youtube/vitess
+  web: https://github.com/vitessio/vitess
   email: 
   twitter: 
   bio: 

--- a/vitess.io/_config_dev.yml
+++ b/vitess.io/_config_dev.yml
@@ -8,7 +8,7 @@ teaser: 400x250.gif
 locale: en_US
 url: 
 project-name: Vitess
-repo: https://github.com/youtube/vitess
+repo: https://github.com/vitessio/vitess
 
 # Jekyll configuration
 sass:
@@ -29,7 +29,7 @@ redcarpet:
 # Site owner
 owner:
   name: Vitess Team
-  web: https://github.com/youtube/vitess
+  web: https://github.com/vitessio/vitess
   email: 
   twitter: 
   bio: 

--- a/vitess.io/_data/footer.yml
+++ b/vitess.io/_data/footer.yml
@@ -4,4 +4,4 @@
   url: /
 
 - title: GitHub
-  url: https://github.com/youtube/vitess
+  url: https://github.com/vitessio/vitess

--- a/vitess.io/_data/nav.yml
+++ b/vitess.io/_data/nav.yml
@@ -11,7 +11,7 @@
 #  image: 400x250.gif
 #
 #- title: GitHub
-#  url: https://github.com/youtube/vitess/
+#  url: https://github.com/vitessio/vitess/
 #  excerpt: "Download the code from GitHub."
 #  image: 400x250.gif
 

--- a/vitess.io/_includes/nav.html
+++ b/vitess.io/_includes/nav.html
@@ -20,13 +20,13 @@
         <li><a href="{% link user-guide/introduction.md %}">Guides</a></li>
         <li><a href="{% link reference/vitess-api.md %}">Reference</a></li>
         <li><a href="http://blog.vitess.io">Blog</a></li>
-        <li><a href="https://github.com/youtube/vitess"><i class="fa fa-github"></i> GitHub</a></li>
+        <li><a href="https://github.com/vitessio/vitess"><i class="fa fa-github"></i> GitHub</a></li>
         <!-- Hide link to blog unless we have actual posts -->
         <!-- <li><a href="/blog/" title="">Blog</a></li> -->
       </ul>
       <ul class="nav nav-stacked mobile-left-nav-menu" id="collapsed-left-menu">
         {% include left-nav-menu.html %}
-        <li><a href="https://github.com/youtube/vitess" id="collapsed-left-menu-repo-link"><i class="fa fa-github"></i> GitHub</a></li>
+        <li><a href="https://github.com/vitessio/vitess" id="collapsed-left-menu-repo-link"><i class="fa fa-github"></i> GitHub</a></li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->

--- a/vitess.io/resources/presentations.md
+++ b/vitess.io/resources/presentations.md
@@ -32,7 +32,7 @@ Vitess team member [Anthony Yeh](https://github.com/enisoc)'s talk at
 the [January 2016 CoreOS Meetup](http://www.meetup.com/coreos/events/228233948/)
 discussed challenges and techniques for running distributed databases
 within Kubernetes, followed by a deep dive into the design trade-offs
-of the [Vitess on Kubernetes](https://github.com/youtube/vitess/tree/master/examples/kubernetes)
+of the [Vitess on Kubernetes](https://github.com/vitessio/vitess/tree/master/examples/kubernetes)
 deployment templates.
 
 <iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/coreos-meetup-2016-01-27.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
@@ -59,7 +59,7 @@ of how Vitess has evolved to live in a containerized world with
 Kubernetes and Docker.
 
 <iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/percona-2015-vitess-and-kubernetes.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
-<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://github.com/youtube/vitess/blob/master/doc/slides/Percona2015.pptx?raw=true">download slides</a></div>
+<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://github.com/vitessio/vitess/blob/master/doc/slides/Percona2015.pptx?raw=true">download slides</a></div>
 
 
 ## Google I/O 2014 - Scaling with Go: YouTube's Vitess

--- a/vitess.io/resources/presentations.md
+++ b/vitess.io/resources/presentations.md
@@ -23,8 +23,8 @@ completely hidden from the application. They gave a live demo of
 which now knows nothing about shards, and explained how new features in VTGate
 make all of this possible.
 
-<iframe src="http://docs.google.com/gview?url=http://vitess.io/resources/percona-2016.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
-<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="http://vitess.io/resources/percona-2016.pdf">download slides</a></div>
+<iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/percona-2016.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
+<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://vitess.io/resources/percona-2016.pdf">download slides</a></div>
 
 ## CoreOS Meetup, January 2016
 
@@ -35,8 +35,8 @@ within Kubernetes, followed by a deep dive into the design trade-offs
 of the [Vitess on Kubernetes](https://github.com/youtube/vitess/tree/master/examples/kubernetes)
 deployment templates.
 
-<iframe src="http://docs.google.com/gview?url=http://vitess.io/resources/coreos-meetup-2016-01-27.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
-<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="http://vitess.io/resources/coreos-meetup-2016-01-27.pdf">download slides</a></div>
+<iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/coreos-meetup-2016-01-27.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
+<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://vitess.io/resources/coreos-meetup-2016-01-27.pdf">download slides</a></div>
 
 ## Oracle OpenWorld 2015
 
@@ -48,8 +48,8 @@ applied to MySQL in the cloud. The talk also included a deep dive into
 ({% link user-guide/sharding.md %}#resharding), one of the key
 features of Vitess that makes it well-adapted for a Cloud Native environment.
 
-<iframe src="http://docs.google.com/gview?url=http://vitess.io/resources/openworld-2015-vitess.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
-<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="http://vitess.io/resources/openworld-2015-vitess.pdf">download slides</a></div>
+<iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/openworld-2015-vitess.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
+<div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://vitess.io/resources/openworld-2015-vitess.pdf">download slides</a></div>
 
 ## Percona Live 2015
 
@@ -58,7 +58,7 @@ Percona Live 2015 provided an overview of Vitess as well as an explanation
 of how Vitess has evolved to live in a containerized world with
 Kubernetes and Docker.
 
-<iframe src="http://docs.google.com/gview?url=http://vitess.io/resources/percona-2015-vitess-and-kubernetes.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
+<iframe src="https://docs.google.com/gview?url=https://vitess.io/resources/percona-2015-vitess-and-kubernetes.pdf&embedded=true" style="width:643px; height:379px; margin-top: 20px;" frameborder="0"></iframe>
 <div style="text-align: right; width: 100%; margin-bottom:20px"><a href="https://github.com/youtube/vitess/blob/master/doc/slides/Percona2015.pptx?raw=true">download slides</a></div>
 
 

--- a/vitess.io/resources/roadmap.md
+++ b/vitess.io/resources/roadmap.md
@@ -25,7 +25,7 @@ internal release.
 
 ## Vitess 2.0 GA
 
-[Vitess 2.0 GA](https://github.com/youtube/vitess/releases/tag/v2.0.0) was
+[Vitess 2.0 GA](https://github.com/vitessio/vitess/releases/tag/v2.0.0) was
 created on July 11, 2016. It was the first major public release.
 
 It contains all the core features of the Vitess product:
@@ -91,7 +91,7 @@ following core features:
 
 We already cut
 the
-[2.1.0-alpha.1 release](https://github.com/youtube/vitess/releases/tag/v2.1.0-alpha.1),
+[2.1.0-alpha.1 release](https://github.com/vitessio/vitess/releases/tag/v2.1.0-alpha.1),
 and we are finalizing the last details at the moment. Release ETA is around
 beginning of 2017.
 


### PR DESCRIPTION
When viewing our site through HTTPS, the browser won't load iframes that aren't HTTPS by default.

Also update some links on the website for the new GitHub repo location.