### PR TITLE
default helm vtgate maxReplicas to replicas

### DIFF
--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -138,7 +138,8 @@ spec:
       component: vtgate
       cell: {{ $cellClean }}
 
-{{ if gt .maxReplicas .replicas }}
+{{ $maxReplicas := .maxReplicas | default .replicas }}
+{{ if gt $maxReplicas .replicas }}
 ###################################
 # optional HPA for vtgate
 ###################################
@@ -153,7 +154,7 @@ spec:
     kind: Deployment
     name: vtgate-{{ $cellClean }}
   minReplicas: {{ .replicas }}
-  maxReplicas: {{ .maxReplicas }}
+  maxReplicas: {{ $maxReplicas }}
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
Using the Unsharded keyspace example from:
https://github.com/vitessio/vitess/tree/master/helm/vitess

Fails:
`Error: render error in "vitess/templates/vitess.yaml": template: vitess/templates/vitess.yaml:51:3: executing "vitess/templates/vitess.yaml" at <include "vtgate" (tu...>: error calling include: template: vitess/templates/_vtgate.tpl:141:6: executing "vtgate" at <gt .maxReplicas .rep...>: error calling gt: invalid type for comparison
`
On inspection it looks like .maxReplicas is undefined and so you can't compare it to an int. This fix assumes that maxReplicas isn't required, and defaults it to .replicas. Alternatively .maxReplicas could be required and the documentation should be updated instead. 

Cheers,
Geoff