### PR TITLE
Add git hook to check for DCO signoff.

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -241,7 +241,7 @@ echo "creating git hooks"
 mkdir -p $VTTOP/.git/hooks
 ln -sf $VTTOP/misc/git/pre-commit $VTTOP/.git/hooks/pre-commit
 ln -sf $VTTOP/misc/git/prepare-commit-msg.bugnumber $VTTOP/.git/hooks/prepare-commit-msg
-ln -sf $VTTOP/misc/git/commit-msg.bugnumber $VTTOP/.git/hooks/commit-msg
+ln -sf $VTTOP/misc/git/commit-msg $VTTOP/.git/hooks/commit-msg
 (cd $VTTOP && git config core.hooksPath $VTTOP/.git/hooks)
 
 # Download chromedriver

--- a/misc/git/commit-msg
+++ b/misc/git/commit-msg
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Runs any hooks in misc/git/hooks, and exits if any of them fail.
+# Runs any hooks in misc/git/commit-msg.*, and exits if any of them fail.
 set -e
 
 # This is necessary because the Emacs extensions don't set GIT_DIR.
@@ -15,6 +15,6 @@ if [ -z "$GOPATH" ]; then
   export GOPATH
 fi
 
-for hook in $GIT_DIR/../misc/git/hooks/*; do
-  $hook
+for hook in $GIT_DIR/../misc/git/commit-msg.*; do
+  $hook $@
 done

--- a/misc/git/commit-msg.signoff
+++ b/misc/git/commit-msg.signoff
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script is run during "git commit" after the commit message was entered.
+#
+# If it does not find a Signed-off-by: line in this commit,
+# it prints a message about using the -s flag and a link
+# to an explanation of the DCO.
+
+msg_file="$1"
+
+git_email="$(git config --get user.email)"
+signoff="$(grep -E --max-count=1 "^Signed-off-by: " "$msg_file")"
+
+if [[ "$signoff" =~ \<(.*)\> ]]; then
+  if [[ "${BASH_REMATCH[1]}" == "${git_email}" ]]; then
+    # Everything checks out!
+    exit 0
+  fi
+fi
+
+# No signoff found, or the email doesn't match. Print some instructions.
+echo
+echo "No 'Signed-off-by:' line was found, or the email didn't match"
+echo "the commit author (${git_email})."
+echo
+echo "This project uses a Developer Certificate of Origin"
+echo "instead of a Contributor License Agreement."
+echo "For more information, see: https://wiki.linuxfoundation.org/dco"
+echo
+echo "Please certify this contribution meets the requirements in the"
+echo "'DCO' file in the root of this repository by committing with"
+echo "the --signoff flag:"
+echo
+echo "    git commit --signoff"
+exit 1


### PR DESCRIPTION
This will only take effect after devs re-run `bootstrap.sh`, which they should do anyway after moving the repo to the new directory structure.