### PR TITLE
v3: refactor join vars

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -254,10 +254,7 @@
         "Sharded": true
       },
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col",
-      "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-      "JoinVars": {
-        "user_col": {}
-      }
+      "FieldQuery": "select user_extra.id from user_extra where 1 != 1"
     },
     "Cols": [
       1
@@ -294,10 +291,7 @@
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = 5",
       "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
       "Vindex": "user_index",
-      "Values": [5],
-      "JoinVars": {
-        "user_col": {}
-      }
+      "Values": [5]
     },
     "Cols": [
       1
@@ -332,10 +326,7 @@
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = :user_col",
       "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
       "Vindex": "user_index",
-      "Values": [":user_col"],
-      "JoinVars": {
-        "user_col": {}
-      }
+      "Values": [":user_col"]
     },
     "Cols": [
       1
@@ -368,10 +359,7 @@
         "Sharded": true
       },
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col",
-      "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-      "JoinVars": {
-        "user_col": {}
-      }
+      "FieldQuery": "select user_extra.id from user_extra where 1 != 1"
     },
     "Cols": [
       1
@@ -525,10 +513,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.id from unsharded where unsharded.id = :user_id",
-      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-      "JoinVars": {
-        "user_id": {}
-      }
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
     },
     "Cols": [
       1
@@ -544,7 +529,7 @@
 {
   "Original": "select * from information_schema.a where id in (select * from information_schema.b)",
   "Instructions": {
-    "Opcode": "ExecDBA",
+    "Opcode": "SelectDBA",
     "Keyspace": {
       "Name": "main",
       "Sharded": false
@@ -580,10 +565,7 @@
       "Vindex": "user_index",
       "Values": [
         [":user_extra_col", 1]
-      ],
-      "JoinVars": {
-        "user_extra_col": {}
-      }
+      ]
     },
     "Cols": [
       1
@@ -652,10 +634,7 @@
       "Vindex": "user_index",
       "Values": [
         [":user_extra_col", 1]
-      ],
-      "JoinVars": {
-        "user_extra_col": {}
-      }
+      ]
     },
     "Cols": [
       1

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -33,7 +33,7 @@
 {
   "Original": "select col from information_schema.foo",
   "Instructions": {
-    "Opcode": "ExecDBA",
+    "Opcode": "SelectDBA",
     "Keyspace": {
       "Name": "main",
       "Sharded": false
@@ -138,7 +138,7 @@
 {
   "Original": "select * from information_schema.a, information_schema.b",
   "Instructions": {
-    "Opcode": "ExecDBA",
+    "Opcode": "SelectDBA",
     "Keyspace": {
       "Name": "main",
       "Sharded": false
@@ -200,10 +200,7 @@
         "Sharded": false
       },
       "Query": "select 1 from unsharded as m where m.b = :u_a",
-      "FieldQuery": "select 1 from unsharded as m where 1 != 1",
-      "JoinVars": {
-        "u_a": {}
-      }
+      "FieldQuery": "select 1 from unsharded as m where 1 != 1"
     },
     "Cols": [
       -1
@@ -238,10 +235,7 @@
           "Sharded": false
         },
         "Query": "select m1.col from unsharded as m1 where m1.co = :user_col",
-        "FieldQuery": "select m1.col from unsharded as m1 where 1 != 1",
-        "JoinVars": {
-          "user_col": {}
-        }
+        "FieldQuery": "select m1.col from unsharded as m1 where 1 != 1"
       },
       "Cols": [
         -1,
@@ -258,10 +252,7 @@
         "Sharded": false
       },
       "Query": "select 1 from unsharded as m2 where m2.col = :m1_col",
-      "FieldQuery": "select 1 from unsharded as m2 where 1 != 1",
-      "JoinVars": {
-        "m1_col": {}
-      }
+      "FieldQuery": "select 1 from unsharded as m2 where 1 != 1"
     },
     "Cols": [
       -1
@@ -296,10 +287,7 @@
           "Sharded": true
         },
         "Query": "select e.col from user_extra as e where e.col = :user_col",
-        "FieldQuery": "select e.col from user_extra as e where 1 != 1",
-        "JoinVars": {
-          "user_col": {}
-        }
+        "FieldQuery": "select e.col from user_extra as e where 1 != 1"
       },
       "Right": {
         "Opcode": "SelectUnsharded",
@@ -308,10 +296,7 @@
           "Sharded": false
         },
         "Query": "select 1 from unsharded as m1 where m1.col = :e_col",
-        "FieldQuery": "select 1 from unsharded as m1 where 1 != 1",
-        "JoinVars": {
-          "e_col": {}
-        }
+        "FieldQuery": "select 1 from unsharded as m1 where 1 != 1"
       },
       "Vars": {
         "e_col": 0
@@ -602,10 +587,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user_extra where :user_id \u003c user_extra.user_id",
-      "FieldQuery": "select 1 from user_extra where 1 != 1",
-      "JoinVars": {
-        "user_id": {}
-      }
+      "FieldQuery": "select 1 from user_extra where 1 != 1"
     },
     "Cols": [
       -1
@@ -702,10 +684,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user_extra where user_extra.col = :user_id",
-      "FieldQuery": "select 1 from user_extra where 1 != 1",
-      "JoinVars": {
-        "user_id": {}
-      }
+      "FieldQuery": "select 1 from user_extra where 1 != 1"
     },
     "Cols": [
       -1
@@ -740,10 +719,7 @@
       "Query": "select user.col from user where user.name = :user_extra_user_id",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "name_user_map",
-      "Values": [":user_extra_user_id"],
-      "JoinVars": {
-        "user_extra_user_id": {}
-      }
+      "Values": [":user_extra_user_id"]
     },
     "Cols": [
       1
@@ -848,10 +824,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user_extra where user_extra.col = :t_id",
-      "FieldQuery": "select 1 from user_extra where 1 != 1",
-      "JoinVars": {
-        "t_id": {}
-      }
+      "FieldQuery": "select 1 from user_extra where 1 != 1"
     },
     "Cols": [
       -1
@@ -923,11 +896,7 @@
         "Sharded": false
       },
       "Query": "select 1 from unsharded where unsharded.col1 = :t_col1 and unsharded.id = :t_id",
-      "FieldQuery": "select 1 from unsharded where 1 != 1",
-      "JoinVars": {
-        "t_col1": {},
-        "t_id": {}
-      }
+      "FieldQuery": "select 1 from unsharded where 1 != 1"
     },
     "Cols": [
       -1
@@ -965,10 +934,7 @@
           "Sharded": true
         },
         "Query": "select 1 from user_extra where user_extra.col = :user_col",
-        "FieldQuery": "select 1 from user_extra where 1 != 1",
-        "JoinVars": {
-          "user_col": {}
-        }
+        "FieldQuery": "select 1 from user_extra where 1 != 1"
       },
       "Cols": [
         -1,
@@ -1056,10 +1022,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.col1 from unsharded where unsharded.col2 = :user_col2",
-      "FieldQuery": "select unsharded.col1 from unsharded where 1 != 1",
-      "JoinVars": {
-        "user_col2": {}
-      }
+      "FieldQuery": "select unsharded.col1 from unsharded where 1 != 1"
     },
     "Cols": [
       -1,

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -274,10 +274,7 @@
       "Query": "select music.col3 from music where music.id = :user_id order by null",
       "FieldQuery": "select music.col3 from music where 1 != 1",
       "Vindex": "music_user_map",
-      "Values": [":user_id"],
-      "JoinVars": {
-        "user_id": {}
-      }
+      "Values": [":user_id"]
     },
     "Cols": [
       -1,
@@ -331,10 +328,7 @@
       "Query": "select music.col3 from music where music.id = :user_id order by rand()",
       "FieldQuery": "select music.col3 from music where 1 != 1",
       "Vindex": "music_user_map",
-      "Values": [":user_id"],
-      "JoinVars": {
-        "user_id": {}
-      }
+      "Values": [":user_id"]
     },
     "Cols": [
       -1,
@@ -420,10 +414,7 @@
         "Sharded": true
       },
       "Query": "select e.id from user_extra as e where e.col = :u_col",
-      "FieldQuery": "select e.id from user_extra as e where 1 != 1",
-      "JoinVars": {
-        "u_col": {}
-      }
+      "FieldQuery": "select e.id from user_extra as e where 1 != 1"
     },
     "Cols": [
       -1,

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -399,10 +399,7 @@
         "Sharded": false
       },
       "Query": "select (select :user_id + outm.m + unsharded.m from unsharded) from unsharded as outm",
-      "FieldQuery": "select (select :user_id + outm.m + unsharded.m from unsharded where 1 != 1) from unsharded as outm where 1 != 1",
-      "JoinVars": {
-        "user_id": {}
-      }
+      "FieldQuery": "select (select :user_id + outm.m + unsharded.m from unsharded where 1 != 1) from unsharded as outm where 1 != 1"
     },
     "Cols": [
       -1,
@@ -592,7 +589,7 @@
 {
   "Original": "select * from information_schema.a union select * from information_schema.b",
   "Instructions": {
-    "Opcode": "ExecDBA",
+    "Opcode": "SelectDBA",
     "Keyspace": {
       "Name": "main",
       "Sharded": false

--- a/data/test/vtgate/symtab_cases.txt
+++ b/data/test/vtgate/symtab_cases.txt
@@ -22,10 +22,7 @@
         "Sharded": false
       },
       "Query": "select predef3 from unsharded where predef3 = :predef2",
-      "FieldQuery": "select predef3 from unsharded where 1 != 1",
-      "JoinVars": {
-        "predef2": {}
-      }
+      "FieldQuery": "select predef3 from unsharded where 1 != 1"
     },
     "Cols": [
       -1,

--- a/data/test/vtgate/vindex_func_cases.txt
+++ b/data/test/vtgate/vindex_func_cases.txt
@@ -193,10 +193,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id",
-      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-      "JoinVars": {
-        "user_index_id": {}
-      }
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
     },
     "Cols": [
       -1,
@@ -241,10 +238,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id",
-      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-      "JoinVars": {
-        "user_index_id": {}
-      }
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
     },
     "Cols": [
       -1,
@@ -288,10 +282,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.id from unsharded where unsharded.id = :ui_id",
-      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
-      "JoinVars": {
-        "ui_id": {}
-      }
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
     },
     "Cols": [
       -1,

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -24,10 +24,7 @@
         "Sharded": true
       },
       "Query": "select e.col, e.id as eid from user_extra as e having eid = :uid",
-      "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1",
-      "JoinVars": {
-        "uid": {}
-      }
+      "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1"
     },
     "Cols": [
       1,
@@ -62,10 +59,7 @@
         "Sharded": true
       },
       "Query": "select e.col, e.id as eid from user_extra as e having eid = :uid1 and e.col = :uid",
-      "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1",
-      "JoinVars": {
-        "uid1": {}
-      }
+      "FieldQuery": "select e.col, e.id as eid from user_extra as e where 1 != 1"
     },
     "Cols": [
       1,
@@ -116,10 +110,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user as u3 where u3.col = :u1_col",
-      "FieldQuery": "select 1 from user as u3 where 1 != 1",
-      "JoinVars": {
-        "u1_col": {}
-      }
+      "FieldQuery": "select 1 from user as u3 where 1 != 1"
     },
     "Cols": [
       -1
@@ -168,10 +159,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user as u3 where u3.col = :u2_col",
-      "FieldQuery": "select 1 from user as u3 where 1 != 1",
-      "JoinVars": {
-        "u2_col": {}
-      }
+      "FieldQuery": "select 1 from user as u3 where 1 != 1"
     },
     "Cols": [
       -1
@@ -206,10 +194,7 @@
           "Sharded": true
         },
         "Query": "select 1 from user as u2 where u2.col = :u1_col",
-        "FieldQuery": "select 1 from user as u2 where 1 != 1",
-        "JoinVars": {
-          "u1_col": {}
-        }
+        "FieldQuery": "select 1 from user as u2 where 1 != 1"
       },
       "Cols": [
         -1,
@@ -226,10 +211,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user as u3 where u3.col = :u1_col",
-      "FieldQuery": "select 1 from user as u3 where 1 != 1",
-      "JoinVars": {
-        "u1_col": {}
-      }
+      "FieldQuery": "select 1 from user as u3 where 1 != 1"
     },
     "Cols": [
       -1
@@ -285,10 +267,7 @@
         "Query": "select 1 from user as u3 where u3.id = :u1_col",
         "FieldQuery": "select 1 from user as u3 where 1 != 1",
         "Vindex": "user_index",
-        "Values": [":u1_col"],
-        "JoinVars": {
-          "u1_col": {}
-        }
+        "Values": [":u1_col"]
       },
       "Cols": [
         -1,
@@ -305,10 +284,7 @@
         "Sharded": true
       },
       "Query": "select 1 from user as u4 where u4.col = :u1_col",
-      "FieldQuery": "select 1 from user as u4 where 1 != 1",
-      "JoinVars": {
-        "u1_col": {}
-      }
+      "FieldQuery": "select 1 from user as u4 where 1 != 1"
     },
     "Cols": [
       -1
@@ -345,10 +321,7 @@
         "Query": "select 1 from user as u2 where u2.id = :u1_col",
         "FieldQuery": "select 1 from user as u2 where 1 != 1",
         "Vindex": "user_index",
-        "Values": [":u1_col"],
-        "JoinVars": {
-          "u1_col": {}
-        }
+        "Values": [":u1_col"]
       },
       "Right": {
         "Opcode": "SelectEqualUnique",
@@ -359,10 +332,7 @@
         "Query": "select 1 from user as u3 where u3.id = :u1_col",
         "FieldQuery": "select 1 from user as u3 where 1 != 1",
         "Vindex": "user_index",
-        "Values": [":u1_col"],
-        "JoinVars": {
-          "u1_col": {}
-        }
+        "Values": [":u1_col"]
       }
     },
     "Cols": [
@@ -396,10 +366,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.b from unsharded where unsharded.id = :weird_name_a_b_c",
-      "FieldQuery": "select unsharded.b from unsharded where 1 != 1",
-      "JoinVars": {
-        "weird_name_a_b_c": {}
-      }
+      "FieldQuery": "select unsharded.b from unsharded where 1 != 1"
     },
     "Cols": [
       -1,
@@ -433,10 +400,7 @@
         "Sharded": false
       },
       "Query": "select unsharded.b from unsharded where unsharded.id = :weird_name_a_b_c",
-      "FieldQuery": "select unsharded.b from unsharded where 1 != 1",
-      "JoinVars": {
-        "weird_name_a_b_c": {}
-      }
+      "FieldQuery": "select unsharded.b from unsharded where 1 != 1"
     },
     "Cols": [
       1
@@ -472,10 +436,7 @@
           "Sharded": true
         },
         "Query": "select e.id from user_extra as e where e.id = :u_col",
-        "FieldQuery": "select e.id from user_extra as e where 1 != 1",
-        "JoinVars": {
-          "u_col": {}
-        }
+        "FieldQuery": "select e.id from user_extra as e where 1 != 1"
       },
       "Cols": [
         -1,

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -118,7 +118,7 @@ func (code DeleteOpcode) MarshalJSON() ([]byte, error) {
 }
 
 // Execute performs a non-streaming exec.
-func (del *Delete) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+func (del *Delete) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch del.Opcode {
 	case DeleteUnsharded:
 		return del.execDeleteUnsharded(vcursor, bindVars)
@@ -133,12 +133,12 @@ func (del *Delete) Execute(vcursor VCursor, bindVars, joinVars map[string]*query
 }
 
 // StreamExecute performs a streaming exec.
-func (del *Delete) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+func (del *Delete) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	return fmt.Errorf("query %q cannot be used for streaming", del.Query)
 }
 
 // GetFields fetches the field info.
-func (del *Delete) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (del *Delete) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, fmt.Errorf("BUG: unreachable code for %q", del.Query)
 }
 

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -37,7 +37,7 @@ func TestDeleteUnsharded(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,11 +48,11 @@ func TestDeleteUnsharded(t *testing.T) {
 
 	// Failure cases
 	vc = &loggingVCursor{shardErr: errors.New("shard_error")}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execDeleteUnsharded: shard_error")
 
 	vc = &loggingVCursor{}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "Keyspace does not have exactly one shard: []")
 }
 
@@ -70,7 +70,7 @@ func TestDeleteEqual(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"-20", "20-"}}
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -82,7 +82,7 @@ func TestDeleteEqual(t *testing.T) {
 
 	// Failure case
 	del.Values = []sqltypes.PlanValue{{Key: "aa"}}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execDeleteEqual: missing bind var aa")
 }
 
@@ -104,7 +104,7 @@ func TestDeleteEqualNoRoute(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func TestDeleteEqualNoScatter(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execDeleteEqual: vindex could not map the value to a unique keyspace id")
 }
 
@@ -162,7 +162,7 @@ func TestDeleteOwnedVindex(t *testing.T) {
 		results: results,
 	}
 
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -184,7 +184,7 @@ func TestDeleteOwnedVindex(t *testing.T) {
 	vc = &loggingVCursor{
 		shards: []string{"-20", "20-"},
 	}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -212,7 +212,7 @@ func TestDeleteOwnedVindex(t *testing.T) {
 		shards:  []string{"-20", "20-"},
 		results: results,
 	}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -245,7 +245,7 @@ func TestDeleteSharded(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"-20", "20-"}}
-	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -256,12 +256,12 @@ func TestDeleteSharded(t *testing.T) {
 
 	// Failure case
 	vc = &loggingVCursor{shardErr: errors.New("shard_error")}
-	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = del.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execDeleteSharded: shard_error")
 }
 
 func TestDeleteNoStream(t *testing.T) {
 	del := &Delete{}
-	err := del.StreamExecute(nil, nil, nil, false, nil)
+	err := del.StreamExecute(nil, nil, false, nil)
 	expectError(t, "StreamExecute", err, `query "" cannot be used for streaming`)
 }

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -36,7 +36,7 @@ func (tp *fakePrimitive) rewind() {
 	tp.curResult = 0
 }
 
-func (tp *fakePrimitive) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+func (tp *fakePrimitive) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	if tp.results == nil {
 		return nil, tp.sendErr
 	}
@@ -49,7 +49,7 @@ func (tp *fakePrimitive) Execute(vcursor VCursor, bindVars, joinVars map[string]
 	return r, nil
 }
 
-func (tp *fakePrimitive) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error {
+func (tp *fakePrimitive) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error {
 	if tp.results == nil {
 		return tp.sendErr
 	}
@@ -81,6 +81,6 @@ func (tp *fakePrimitive) StreamExecute(vcursor VCursor, bindVars, joinVars map[s
 	return nil
 }
 
-func (tp *fakePrimitive) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	return tp.Execute(vcursor, bindVars, joinVars, false /* wantfields */)
+func (tp *fakePrimitive) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return tp.Execute(vcursor, bindVars, false /* wantfields */)
 }

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -141,7 +141,7 @@ func (code InsertOpcode) MarshalJSON() ([]byte, error) {
 }
 
 // Execute performs a non-streaming exec.
-func (ins *Insert) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+func (ins *Insert) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch ins.Opcode {
 	case InsertUnsharded:
 		return ins.execInsertUnsharded(vcursor, bindVars)
@@ -154,12 +154,12 @@ func (ins *Insert) Execute(vcursor VCursor, bindVars, joinVars map[string]*query
 }
 
 // StreamExecute performs a streaming exec.
-func (ins *Insert) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+func (ins *Insert) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	return fmt.Errorf("query %q cannot be used for streaming", ins.Query)
 }
 
 // GetFields fetches the field info.
-func (ins *Insert) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (ins *Insert) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: unreachable code for %q", ins.Query)
 }
 

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -43,7 +43,7 @@ func TestInsertUnsharded(t *testing.T) {
 			InsertID: 4,
 		}},
 	}
-	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -55,11 +55,11 @@ func TestInsertUnsharded(t *testing.T) {
 
 	// Failure cases
 	vc = &loggingVCursor{shardErr: errors.New("shard_error")}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertUnsharded: shard_error")
 
 	vc = &loggingVCursor{}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "Keyspace does not have exactly one shard: []")
 }
 
@@ -102,7 +102,7 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 			{InsertID: 1},
 		},
 	}
-	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -172,7 +172,7 @@ func TestInsertShardedSimple(t *testing.T) {
 		shards:       []string{"-20", "20-"},
 		shardForKsid: []string{"20-", "-20", "20-"},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -242,7 +242,7 @@ func TestInsertShardedFail(t *testing.T) {
 	vc := &loggingVCursor{}
 
 	// The lookup will fail to map to a keyspace id.
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertSharded: getInsertShardedRoute: could not map INT64(1) to a keyspace id")
 }
 
@@ -323,7 +323,7 @@ func TestInsertShardedGenerate(t *testing.T) {
 			{InsertID: 1},
 		},
 	}
-	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -459,7 +459,7 @@ func TestInsertShardedOwned(t *testing.T) {
 		shards:       []string{"-20", "20-"},
 		shardForKsid: []string{"20-", "-20", "20-"},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -560,7 +560,7 @@ func TestInsertShardedOwnedFail(t *testing.T) {
 		shards: []string{"-20", "20-"},
 	}
 	// No reverse map available for lookup. So, it will fail.
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertSharded: getInsertShardedRoute: value must be supplied for column c3")
 }
 
@@ -713,7 +713,7 @@ func TestInsertShardedIgnoreOwned(t *testing.T) {
 			ksid0,
 		},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -825,7 +825,7 @@ func TestInsertShardedIgnoreOwnedFail(t *testing.T) {
 	vc := &loggingVCursor{
 		shards: []string{"-20", "20-"},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertSharded: getInsertShardedRoute: value must be supplied for column [c3]")
 }
 
@@ -954,7 +954,7 @@ func TestInsertShardedUnownedVerify(t *testing.T) {
 			nonemptyResult,
 		},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1078,7 +1078,7 @@ func TestInsertShardedIgnoreUnownedVerify(t *testing.T) {
 			nonemptyResult,
 		},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1170,7 +1170,7 @@ func TestInsertShardedIgnoreUnownedVerifyFail(t *testing.T) {
 	vc := &loggingVCursor{
 		shards: []string{"-20", "20-"},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertSharded: getInsertShardedRoute: values [[INT64(2)]] for column [c3] does not map to keyspace ids")
 }
 
@@ -1294,7 +1294,7 @@ func TestInsertShardedUnownedReverseMap(t *testing.T) {
 			nonemptyResult,
 		},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1385,6 +1385,6 @@ func TestInsertShardedUnownedReverseMapFail(t *testing.T) {
 	vc := &loggingVCursor{
 		shards: []string{"-20", "20-"},
 	}
-	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execInsertSharded: getInsertShardedRoute: value must be supplied for column [c3]")
 }

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -51,13 +51,13 @@ func (l *Limit) MarshalJSON() ([]byte, error) {
 }
 
 // Execute satisfies the Primtive interface.
-func (l *Limit) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	count, err := l.fetchCount(bindVars, joinVars)
+func (l *Limit) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	count, err := l.fetchCount(bindVars)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := l.Input.Execute(vcursor, bindVars, joinVars, wantfields)
+	result, err := l.Input.Execute(vcursor, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
@@ -70,13 +70,13 @@ func (l *Limit) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.
 }
 
 // StreamExecute satisfies the Primtive interface.
-func (l *Limit) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
-	count, err := l.fetchCount(bindVars, joinVars)
+func (l *Limit) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	count, err := l.fetchCount(bindVars)
 	if err != nil {
 		return err
 	}
 
-	err = l.Input.StreamExecute(vcursor, bindVars, joinVars, wantfields, func(qr *sqltypes.Result) error {
+	err = l.Input.StreamExecute(vcursor, bindVars, wantfields, func(qr *sqltypes.Result) error {
 		if len(qr.Fields) != 0 {
 			if err := callback(&sqltypes.Result{Fields: qr.Fields}); err != nil {
 				return err
@@ -117,15 +117,11 @@ func (l *Limit) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*qu
 }
 
 // GetFields satisfies the Primtive interface.
-func (l *Limit) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	return l.Input.GetFields(vcursor, bindVars, joinVars)
+func (l *Limit) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return l.Input.GetFields(vcursor, bindVars)
 }
 
-func (l *Limit) fetchCount(bindVars, joinVars map[string]*querypb.BindVariable) (int, error) {
-	// TODO(sougou): to avoid duplication, check if this can be done
-	// by the supplier of joinVars instead.
-	bindVars = combineVars(bindVars, joinVars)
-
+func (l *Limit) fetchCount(bindVars map[string]*querypb.BindVariable) (int, error) {
 	resolved, err := l.Count.ResolveValue(bindVars)
 	if err != nil {
 		return 0, err

--- a/go/vt/vtgate/engine/limit_test.go
+++ b/go/vt/vtgate/engine/limit_test.go
@@ -46,7 +46,7 @@ func TestLimitExecute(t *testing.T) {
 	}
 
 	// Test with limit smaller than input.
-	result, err := l.Execute(nil, nil, nil, false)
+	result, err := l.Execute(nil, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -62,7 +62,7 @@ func TestLimitExecute(t *testing.T) {
 	// Test with limit equal to input.
 	tp.rewind()
 	l.Count = int64PlanValue(3)
-	result, err = l.Execute(nil, nil, nil, false)
+	result, err = l.Execute(nil, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -73,7 +73,7 @@ func TestLimitExecute(t *testing.T) {
 	// Test with limit higher than input.
 	tp.rewind()
 	l.Count = int64PlanValue(4)
-	result, err = l.Execute(nil, nil, nil, false)
+	result, err = l.Execute(nil, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -84,7 +84,7 @@ func TestLimitExecute(t *testing.T) {
 	// Test with bind vars.
 	tp.rewind()
 	l.Count = sqltypes.PlanValue{Key: "l"}
-	result, err = l.Execute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, nil, false)
+	result, err = l.Execute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -115,7 +115,7 @@ func TestLimitStreamExecute(t *testing.T) {
 
 	// Test with limit smaller than input.
 	var results []*sqltypes.Result
-	err := l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err := l.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -135,7 +135,7 @@ func TestLimitStreamExecute(t *testing.T) {
 	tp.rewind()
 	l.Count = sqltypes.PlanValue{Key: "l"}
 	results = nil
-	err = l.StreamExecute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, nil, false, func(qr *sqltypes.Result) error {
+	err = l.StreamExecute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -150,7 +150,7 @@ func TestLimitStreamExecute(t *testing.T) {
 	tp.rewind()
 	l.Count = int64PlanValue(3)
 	results = nil
-	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err = l.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -172,7 +172,7 @@ func TestLimitStreamExecute(t *testing.T) {
 	tp.rewind()
 	l.Count = int64PlanValue(4)
 	results = nil
-	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err = l.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -196,7 +196,7 @@ func TestLimitGetFields(t *testing.T) {
 
 	l := &Limit{Input: tp}
 
-	got, err := l.GetFields(nil, nil, nil)
+	got, err := l.GetFields(nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -211,18 +211,18 @@ func TestLimitInputFail(t *testing.T) {
 	l := &Limit{Count: int64PlanValue(1), Input: tp}
 
 	want := "input fail"
-	if _, err := l.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+	if _, err := l.Execute(nil, nil, false); err == nil || err.Error() != want {
 		t.Errorf("l.Execute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	err := l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil })
+	err := l.StreamExecute(nil, nil, false, func(_ *sqltypes.Result) error { return nil })
 	if err == nil || err.Error() != want {
 		t.Errorf("l.StreamExecute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	if _, err := l.GetFields(nil, nil, nil); err == nil || err.Error() != want {
+	if _, err := l.GetFields(nil, nil); err == nil || err.Error() != want {
 		t.Errorf("l.GetFields(): %v, want %s", err, want)
 	}
 }
@@ -231,33 +231,33 @@ func TestLimitInvalidCount(t *testing.T) {
 	l := &Limit{
 		Count: sqltypes.PlanValue{Key: "l"},
 	}
-	_, err := l.fetchCount(nil, nil)
+	_, err := l.fetchCount(nil)
 	want := "missing bind var l"
 	if err == nil || err.Error() != want {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
 	l.Count = sqltypes.PlanValue{Value: sqltypes.NewFloat64(1.2)}
-	_, err = l.fetchCount(nil, nil)
+	_, err = l.fetchCount(nil)
 	want = "could not parse value: '1.2'"
 	if err == nil || err.Error() != want {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
 	l.Count = sqltypes.PlanValue{Value: sqltypes.NewUint64(18446744073709551615)}
-	_, err = l.fetchCount(nil, nil)
+	_, err = l.fetchCount(nil)
 	want = "requested limit is out of range: 18446744073709551615"
 	if err == nil || err.Error() != want {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
 	// When going through the API, it should return the same error.
-	_, err = l.Execute(nil, nil, nil, false)
+	_, err = l.Execute(nil, nil, false)
 	if err == nil || err.Error() != want {
 		t.Errorf("l.Execute: %v, want %s", err, want)
 	}
 
-	err = l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil })
+	err = l.StreamExecute(nil, nil, false, func(_ *sqltypes.Result) error { return nil })
 	if err == nil || err.Error() != want {
 		t.Errorf("l.Execute: %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -92,16 +92,16 @@ func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
 }
 
 // Execute is a Primitive function.
-func (oa *OrderedAggregate) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	qr, err := oa.execute(vcursor, bindVars, joinVars, wantfields)
+func (oa *OrderedAggregate) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	qr, err := oa.execute(vcursor, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
 	return qr.Truncate(oa.TruncateColumnCount), nil
 }
 
-func (oa *OrderedAggregate) execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	result, err := oa.Input.Execute(vcursor, bindVars, joinVars, wantfields)
+func (oa *OrderedAggregate) execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	result, err := oa.Input.Execute(vcursor, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (oa *OrderedAggregate) execute(vcursor VCursor, bindVars, joinVars map[stri
 }
 
 // StreamExecute is a Primitive function.
-func (oa *OrderedAggregate) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+func (oa *OrderedAggregate) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	var current []sqltypes.Value
 	var fields []*querypb.Field
 
@@ -149,7 +149,7 @@ func (oa *OrderedAggregate) StreamExecute(vcursor VCursor, bindVars, joinVars ma
 		return callback(qr.Truncate(oa.TruncateColumnCount))
 	}
 
-	err := oa.Input.StreamExecute(vcursor, bindVars, joinVars, wantfields, func(qr *sqltypes.Result) error {
+	err := oa.Input.StreamExecute(vcursor, bindVars, wantfields, func(qr *sqltypes.Result) error {
 		if len(qr.Fields) != 0 {
 			fields = qr.Fields
 			if err := cb(&sqltypes.Result{Fields: fields}); err != nil {
@@ -195,8 +195,8 @@ func (oa *OrderedAggregate) StreamExecute(vcursor VCursor, bindVars, joinVars ma
 }
 
 // GetFields is a Primitive function.
-func (oa *OrderedAggregate) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	qr, err := oa.Input.GetFields(vcursor, bindVars, joinVars)
+func (oa *OrderedAggregate) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	qr, err := oa.Input.GetFields(vcursor, bindVars)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -49,7 +49,7 @@ func TestOrderedAggregateExecute(t *testing.T) {
 		Input: tp,
 	}
 
-	result, err := oa.Execute(nil, nil, nil, false)
+	result, err := oa.Execute(nil, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,7 +90,7 @@ func TestOrderedAggregateExecuteTruncate(t *testing.T) {
 		Input:               tp,
 	}
 
-	result, err := oa.Execute(nil, nil, nil, false)
+	result, err := oa.Execute(nil, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,7 +135,7 @@ func TestOrderedAggregateStreamExecute(t *testing.T) {
 	}
 
 	var results []*sqltypes.Result
-	err := oa.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err := oa.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -182,7 +182,7 @@ func TestOrderedAggregateStreamExecuteTruncate(t *testing.T) {
 	}
 
 	var results []*sqltypes.Result
-	err := oa.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err := oa.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -217,7 +217,7 @@ func TestOrderedAggregateGetFields(t *testing.T) {
 
 	oa := &OrderedAggregate{Input: tp}
 
-	got, err := oa.GetFields(nil, nil, nil)
+	got, err := oa.GetFields(nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -240,7 +240,7 @@ func TestOrderedAggregateGetFieldsTruncate(t *testing.T) {
 		Input:               tp,
 	}
 
-	got, err := oa.GetFields(nil, nil, nil)
+	got, err := oa.GetFields(nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -261,17 +261,17 @@ func TestOrderedAggregateInputFail(t *testing.T) {
 	oa := &OrderedAggregate{Input: tp}
 
 	want := "input fail"
-	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+	if _, err := oa.Execute(nil, nil, false); err == nil || err.Error() != want {
 		t.Errorf("oa.Execute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+	if err := oa.StreamExecute(nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
 		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	if _, err := oa.GetFields(nil, nil, nil); err == nil || err.Error() != want {
+	if _, err := oa.GetFields(nil, nil); err == nil || err.Error() != want {
 		t.Errorf("oa.GetFields(): %v, want %s", err, want)
 	}
 }
@@ -299,12 +299,12 @@ func TestOrderedAggregateKeysFail(t *testing.T) {
 	}
 
 	want := "types are not comparable: VARCHAR vs VARCHAR"
-	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+	if _, err := oa.Execute(nil, nil, false); err == nil || err.Error() != want {
 		t.Errorf("oa.Execute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+	if err := oa.StreamExecute(nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
 		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
 	}
 }
@@ -332,12 +332,12 @@ func TestOrderedAggregateMergeFail(t *testing.T) {
 	}
 
 	want := "could not parse value: 'b'"
-	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+	if _, err := oa.Execute(nil, nil, false); err == nil || err.Error() != want {
 		t.Errorf("oa.Execute(): %v, want %s", err, want)
 	}
 
 	tp.rewind()
-	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+	if err := oa.StreamExecute(nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
 		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
 	}
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -116,7 +116,7 @@ func (p *Plan) Size() int {
 // Primitive is the interface that needs to be satisfied by
 // all primitives of a plan.
 type Primitive interface {
-	Execute(vcursor VCursor, bindVars, joinvars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error)
-	StreamExecute(vcursor VCursor, bindVars, joinvars map[string]*querypb.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error
-	GetFields(vcursor VCursor, bindVars, joinvars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
+	Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error)
+	StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error
+	GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
 }

--- a/go/vt/vtgate/engine/subquery.go
+++ b/go/vt/vtgate/engine/subquery.go
@@ -32,8 +32,8 @@ type Subquery struct {
 }
 
 // Execute performs a non-streaming exec.
-func (sq *Subquery) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	inner, err := sq.Subquery.Execute(vcursor, bindVars, joinVars, wantfields)
+func (sq *Subquery) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	inner, err := sq.Subquery.Execute(vcursor, bindVars, wantfields)
 	if err != nil {
 		return nil, err
 	}
@@ -41,15 +41,15 @@ func (sq *Subquery) Execute(vcursor VCursor, bindVars, joinVars map[string]*quer
 }
 
 // StreamExecute performs a streaming exec.
-func (sq *Subquery) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
-	return sq.Subquery.StreamExecute(vcursor, bindVars, joinVars, wantfields, func(inner *sqltypes.Result) error {
+func (sq *Subquery) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	return sq.Subquery.StreamExecute(vcursor, bindVars, wantfields, func(inner *sqltypes.Result) error {
 		return callback(sq.buildResult(inner))
 	})
 }
 
 // GetFields fetches the field info.
-func (sq *Subquery) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	inner, err := sq.Subquery.GetFields(vcursor, bindVars, joinVars)
+func (sq *Subquery) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	inner, err := sq.Subquery.GetFields(vcursor, bindVars)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -118,7 +118,7 @@ func (code UpdateOpcode) MarshalJSON() ([]byte, error) {
 }
 
 // Execute performs a non-streaming exec.
-func (upd *Update) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+func (upd *Update) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch upd.Opcode {
 	case UpdateUnsharded:
 		return upd.execUpdateUnsharded(vcursor, bindVars)
@@ -131,12 +131,12 @@ func (upd *Update) Execute(vcursor VCursor, bindVars, joinVars map[string]*query
 }
 
 // StreamExecute performs a streaming exec.
-func (upd *Update) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+func (upd *Update) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	return fmt.Errorf("query %q cannot be used for streaming", upd.Query)
 }
 
 // GetFields fetches the field info.
-func (upd *Update) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (upd *Update) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return nil, fmt.Errorf("BUG: unreachable code for %q", upd.Query)
 }
 

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -38,7 +38,7 @@ func TestUpdateUnsharded(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,11 +49,11 @@ func TestUpdateUnsharded(t *testing.T) {
 
 	// Failure cases
 	vc = &loggingVCursor{shardErr: errors.New("shard_error")}
-	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execUpdateUnsharded: shard_error")
 
 	vc = &loggingVCursor{}
-	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "Keyspace does not have exactly one shard: []")
 }
 
@@ -71,7 +71,7 @@ func TestUpdateEqual(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"-20", "20-"}}
-	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -83,7 +83,7 @@ func TestUpdateEqual(t *testing.T) {
 
 	// Failure case
 	upd.Values = []sqltypes.PlanValue{{Key: "aa"}}
-	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execUpdateEqual: missing bind var aa")
 }
 
@@ -105,7 +105,7 @@ func TestUpdateEqualNoRoute(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,7 +135,7 @@ func TestUpdateEqualNoScatter(t *testing.T) {
 	}
 
 	vc := &loggingVCursor{shards: []string{"0"}}
-	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execUpdateEqual: vindex could not map the value to a unique keyspace id")
 }
 
@@ -173,7 +173,7 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		results: results,
 	}
 
-	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err := upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -199,7 +199,7 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 	vc = &loggingVCursor{
 		shards: []string{"-20", "20-"},
 	}
-	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -227,13 +227,13 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		shards:  []string{"-20", "20-"},
 		results: results,
 	}
-	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, nil, false)
+	_, err = upd.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	expectError(t, "Execute", err, "execUpdateEqual: unsupported: update changes multiple rows in the vindex")
 }
 
 func TestUpdateNoStream(t *testing.T) {
 	upd := &Update{}
-	err := upd.StreamExecute(nil, nil, nil, false, nil)
+	err := upd.StreamExecute(nil, nil, false, nil)
 	expectError(t, "StreamExecute", err, `query "" cannot be used for streaming`)
 }
 

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -79,13 +79,13 @@ func (code VindexOpcode) MarshalJSON() ([]byte, error) {
 }
 
 // Execute performs a non-streaming exec.
-func (vf *VindexFunc) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
-	return vf.mapVindex(vcursor, bindVars, joinVars)
+func (vf *VindexFunc) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	return vf.mapVindex(vcursor, bindVars)
 }
 
 // StreamExecute performs a streaming exec.
-func (vf *VindexFunc) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
-	r, err := vf.mapVindex(vcursor, bindVars, joinVars)
+func (vf *VindexFunc) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	r, err := vf.mapVindex(vcursor, bindVars)
 	if err != nil {
 		return err
 	}
@@ -96,12 +96,11 @@ func (vf *VindexFunc) StreamExecute(vcursor VCursor, bindVars, joinVars map[stri
 }
 
 // GetFields fetches the field info.
-func (vf *VindexFunc) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (vf *VindexFunc) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return &sqltypes.Result{Fields: vf.Fields}, nil
 }
 
-func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	bindVars = combineVars(bindVars, joinVars)
+func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	key, err := vf.Value.ResolveValue(bindVars)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/engine/vindex_func_test.go
+++ b/go/vt/vtgate/engine/vindex_func_test.go
@@ -84,7 +84,7 @@ func (v *nvindex) Map(vindexes.VCursor, []sqltypes.Value) ([]vindexes.Ksids, err
 func TestVindexFuncMap(t *testing.T) {
 	// Unique Vindex returning 0 rows.
 	vf := testVindexFunc(&uvindex{})
-	got, err := vf.Execute(nil, nil, nil, false)
+	got, err := vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestVindexFuncMap(t *testing.T) {
 
 	// Unique Vindex returning 1 row.
 	vf = testVindexFunc(&uvindex{matchid: true})
-	got, err = vf.Execute(nil, nil, nil, false)
+	got, err = vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestVindexFuncMap(t *testing.T) {
 
 	// Unique Vindex returning keyrange.
 	vf = testVindexFunc(&uvindex{matchkr: true})
-	got, err = vf.Execute(nil, nil, nil, false)
+	got, err = vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestVindexFuncMap(t *testing.T) {
 
 	// NonUnique Vindex returning 0 rows.
 	vf = testVindexFunc(&nvindex{})
-	got, err = vf.Execute(nil, nil, nil, false)
+	got, err = vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestVindexFuncMap(t *testing.T) {
 
 	// NonUnique Vindex returning 2 rows.
 	vf = testVindexFunc(&nvindex{matchid: true})
-	got, err = vf.Execute(nil, nil, nil, false)
+	got, err = vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestVindexFuncMap(t *testing.T) {
 
 	// NonUnique Vindex returning keyrange
 	vf = testVindexFunc(&nvindex{matchkr: true})
-	got, err = vf.Execute(nil, nil, nil, false)
+	got, err = vf.Execute(nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestVindexFuncStreamExecute(t *testing.T) {
 		}},
 	}}
 	i := 0
-	err := vf.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+	err := vf.StreamExecute(nil, nil, false, func(qr *sqltypes.Result) error {
 		if !reflect.DeepEqual(qr, want[i]) {
 			t.Errorf("callback(%d):\n%v, want\n%v", i, qr, want[i])
 		}
@@ -209,7 +209,7 @@ func TestVindexFuncStreamExecute(t *testing.T) {
 
 func TestVindexFuncGetFields(t *testing.T) {
 	vf := testVindexFunc(&uvindex{matchid: true})
-	got, err := vf.GetFields(nil, nil, nil)
+	got, err := vf.GetFields(nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestFieldOrder(t *testing.T) {
 	vf := testVindexFunc(&nvindex{matchid: true})
 	vf.Fields = sqltypes.MakeTestFields("keyspace_id|id|keyspace_id", "varbinary|varbinary|varbinary")
 	vf.Cols = []int{1, 0, 1}
-	got, err := vf.Execute(nil, nil, nil, true)
+	got, err := vf.Execute(nil, nil, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -262,7 +262,7 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 		return nil, err
 	}
 
-	qr, err := plan.Instructions.Execute(vcursor, bindVars, make(map[string]*querypb.BindVariable), true)
+	qr, err := plan.Instructions.Execute(vcursor, bindVars, true)
 	logStats.ExecuteTime = time.Since(execStart)
 	var errCount uint64
 	if err != nil {
@@ -779,7 +779,7 @@ func (e *Executor) StreamExecute(ctx context.Context, method string, safeSession
 	// dictated by stream_buffer_size.
 	result := &sqltypes.Result{}
 	byteCount := 0
-	err = plan.Instructions.StreamExecute(vcursor, bindVars, make(map[string]*querypb.BindVariable), true, func(qr *sqltypes.Result) error {
+	err = plan.Instructions.StreamExecute(vcursor, bindVars, true, func(qr *sqltypes.Result) error {
 		// If the row has field info, send it separately.
 		// TODO(sougou): this behavior is for handling tests because
 		// the framework currently sends all results as one packet.

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -53,13 +53,13 @@ func TestSelectNext(t *testing.T) {
 	}
 }
 
-func TestExecDBA(t *testing.T) {
+func TestSelectDBA(t *testing.T) {
 	executor, sbc1, _, _ := createExecutorEnv()
 
 	query := "select * from INFORMATION_SCHEMA.foo"
 	_, err := executor.Execute(
 		context.Background(),
-		"TestExecDBA",
+		"TestSelectDBA",
 		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
 		query,
 		map[string]*querypb.BindVariable{},

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -151,7 +151,7 @@ func buildTablePrimitive(tableExpr *sqlparser.AliasedTableExpr, tableName sqlpar
 		if err != nil {
 			return nil, err
 		}
-		rb.ERoute = engine.NewRoute(engine.ExecDBA, ks)
+		rb.ERoute = engine.NewRoute(engine.SelectDBA, ks)
 		return rb, nil
 	}
 


### PR DESCRIPTION
Join Vars don't really need to be part of the Primitive API.
Anyone that supplies join vars can pre-combine them into the
bind vars.

Also, ExecDBA->SelectDBA

As for renaming Route to Select. It leads to issues because
'select' is a go keyword, which doesn't fit the v3 naming
nomenclature. So, for now, I'll leave it as Route.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>