### PR TITLE
Queryserver conn pool timeout take 2

### DIFF
--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -41,9 +41,6 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 		return NewSQLError(CRCommandsOutOfSync, SSUnknownSQLState, "streaming query already in progress")
 	}
 
-	// This is a new command, need to reset the sequence.
-	c.sequence = 0
-
 	// Send the query as a COM_QUERY packet.
 	if err := c.WriteComQuery(query); err != nil {
 		return err

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -45,7 +45,7 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 	c.sequence = 0
 
 	// Send the query as a COM_QUERY packet.
-	if err := c.writeComQuery(query); err != nil {
+	if err := c.WriteComQuery(query); err != nil {
 		return err
 	}
 

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -399,11 +399,11 @@ func TestQueryDeadline(t *testing.T) {
 	// Now send another query to tie up the connection, followed up by
 	// a query that should fail due to not getting the conn from the
 	// conn pool
-	err = conn.WriteComQuery("select sleep(0.5) from dual")
+	err = conn.WriteComQuery("select sleep(1.75) from dual")
 	if err != nil {
 		t.Errorf("unexpected error sending query: %v", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	_, err = conn2.ExecuteFetch("select 1 from dual", 1000, false)
 	wantErr = "query pool wait time exceeded"

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -185,6 +185,8 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)
+	qe.connTimeout.Set(time.Duration(config.QueryPoolTimeout * 1e9))
+
 	qe.streamConns = connpool.New(
 		config.PoolNamePrefix+"StreamConnPool",
 		config.StreamPoolSize,

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -768,7 +768,7 @@ func (qre *QueryExecutor) getConn() (*connpool.DBConn, error) {
 
 func (qre *QueryExecutor) getStreamConn() (*connpool.DBConn, error) {
 	span := trace.NewSpanFromContext(qre.ctx)
-	span.StartLocal("QueryExecutor.getConn")
+	span.StartLocal("QueryExecutor.getStreamConn")
 	defer span.Finish()
 
 	start := time.Now()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -150,7 +150,7 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		case planbuilder.PlanSet:
 			return qre.execSet()
 		case planbuilder.PlanOtherRead:
-			conn, connErr := qre.getConn(qre.tsv.qe.conns)
+			conn, connErr := qre.getConn()
 			if connErr != nil {
 				return nil, connErr
 			}
@@ -201,7 +201,7 @@ func (qre *QueryExecutor) Stream(callback func(*sqltypes.Result) error) error {
 		return err
 	}
 
-	conn, err := qre.getConn(qre.tsv.qe.streamConns)
+	conn, err := qre.getStreamConn()
 	if err != nil {
 		return err
 	}
@@ -509,7 +509,7 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		newResult.Fields = qre.plan.Fields
 		return &newResult, nil
 	}
-	conn, err := qre.getConn(qre.tsv.qe.conns)
+	conn, err := qre.getConn()
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.Par
 }
 
 func (qre *QueryExecutor) execSet() (*sqltypes.Result, error) {
-	conn, err := qre.getConn(qre.tsv.qe.conns)
+	conn, err := qre.getConn()
 	if err != nil {
 		return nil, err
 	}
@@ -749,13 +749,30 @@ func (qre *QueryExecutor) execSet() (*sqltypes.Result, error) {
 	return qre.dbConnFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false)
 }
 
-func (qre *QueryExecutor) getConn(pool *connpool.Pool) (*connpool.DBConn, error) {
+func (qre *QueryExecutor) getConn() (*connpool.DBConn, error) {
 	span := trace.NewSpanFromContext(qre.ctx)
 	span.StartLocal("QueryExecutor.getConn")
 	defer span.Finish()
 
 	start := time.Now()
-	conn, err := pool.Get(qre.ctx)
+	conn, err := qre.tsv.qe.getQueryConn(qre.ctx)
+	switch err {
+	case nil:
+		qre.logStats.WaitingForConnection += time.Now().Sub(start)
+		return conn, nil
+	case connpool.ErrConnPoolClosed:
+		return nil, err
+	}
+	return nil, err
+}
+
+func (qre *QueryExecutor) getStreamConn() (*connpool.DBConn, error) {
+	span := trace.NewSpanFromContext(qre.ctx)
+	span.StartLocal("QueryExecutor.getConn")
+	defer span.Finish()
+
+	start := time.Now()
+	conn, err := qre.tsv.qe.streamConns.Get(qre.ctx)
 	switch err {
 	case nil:
 		qre.logStats.WaitingForConnection += time.Now().Sub(start)
@@ -774,9 +791,8 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 	q, ok := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 	if ok {
 		defer q.Broadcast()
-		waitingForConnectionStart := time.Now()
-		conn, err := qre.tsv.qe.getQueryConn(qre.ctx)
-		logStats.WaitingForConnection += time.Now().Sub(waitingForConnectionStart)
+		conn, err := qre.getConn()
+
 		if err != nil {
 			q.Err = err
 		} else {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1583,7 +1583,7 @@ func newSplitQuerySQLExecuter(
 		queryExecutor: queryExecutor,
 	}
 	var err error
-	result.conn, err = queryExecutor.getConn(queryExecutor.tsv.qe.conns)
+	result.conn, err = queryExecutor.getConn()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As it turns out, PR #3717 wasn't sufficient to actually implement the desired functionality for a couple reasons:

1. Due to some refactoring I had done during that change, I accidentally omitted the one line needed to actually set QueryEngine.connPoolTimeout from the tablet server Config. This wasn't caught from the unit tests because the tests use a hook to override the configured timeout.

2. I missed some calls to conns.Get due to the fact that some (but not all) QueryExecutor functions used a `getConn` wrapper that took the pool as a parameter so it could be reused for stream connections as well. To fix this I refactored the call sites so that all of them should now use the timeout if configured.

This PR fixes both of  those and _should_ implement the desired timeout functionality for all queries.

Note that to test this I also refactored the mysql query code so that the sending of a query and blocking to get the result are exposed as separate public functions.
