### PR TITLE
remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @alainjobart @bbeaudreault @demmer @enisoc @michael-berlin @sougou


### PR DESCRIPTION
Remove the CODEOWNERS file to stop auto-assigning reviewers.
