### PR TITLE
fix readme links to point to vitessio/vitess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.vitess/vitess-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.vitess/vitess-jdbc)
-[![Build Status](https://travis-ci.org/youtube/vitess.svg?branch=master)](https://travis-ci.org/youtube/vitess/builds)
+[![Build Status](https://travis-ci.org/vitessio/vitess.svg?branch=master)](https://travis-ci.org/vitessio/vitess/builds)
 [![codebeat badge](https://codebeat.co/badges/51c9a056-1103-4522-9a9c-dc623821ea87)](https://codebeat.co/projects/github-com-youtube-vitess)
-[![Go Report Card](https://goreportcard.com/badge/github.com/youtube/vitess)](https://goreportcard.com/report/github.com/youtube/vitess)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vitessio/vitess)](https://goreportcard.com/report/github.com/vitessio/vitess)
 
-# Vitess 
+# Vitess
 
 Vitess is a database clustering system for horizontal scaling of MySQL
 through generalized sharding.


### PR DESCRIPTION
fix readme links to point to vitessio/vitess

Signed-off-by: Michael Demmer <mdemmer@slack-corp.com>