### PR TITLE
Don't fail on PATHs with embedded whitespace

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -36,12 +36,12 @@ export VTPORTSTART=15000
 
 for pypath in $(find $VTROOT/dist -name site-packages -or -name dist-packages | grep -v src/python/grpcio/.tox/py27/lib/python2.7/site-packages)
 do
-  export PYTHONPATH=$(prepend_path $PYTHONPATH $pypath)
+  export PYTHONPATH=$(prepend_path "$PYTHONPATH" "$pypath")
 done
 
-export PYTHONPATH=$(prepend_path $PYTHONPATH $VTROOT/py-vtdb)
-export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test)
-export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test/cluster/sandbox)
+export PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTROOT/py-vtdb")
+export PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTTOP/test")
+export PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTTOP/test/cluster/sandbox")
 
 # Ensure bootstrap and install_grpc use python2 on systems which default to python3
 command -v python2 >/dev/null && PYTHON=python2 || PYTHON=python
@@ -52,26 +52,26 @@ command -v virtualenv2 >/dev/null && VIRTUALENV=virtualenv2 || VIRTUALENV=virtua
 export VIRTUALENV
 
 selenium_dist=$VTROOT/dist/selenium
-export PYTHONPATH=$(prepend_path $PYTHONPATH $selenium_dist)
+export PYTHONPATH=$(prepend_path "$PYTHONPATH" "$selenium_dist")
 
 # Add the current GOBIN
 if [ "$GOBIN" ]; then
-  export PATH=$(prepend_path $PATH $GOBIN)
+  export PATH=$(prepend_path "$PATH" "$GOBIN")
 fi
 
 # Many tests rely on "go install" and assume GOBIN is really $VTROOT/bin.
 # Make sure these take precedence.
 export GOBIN=$VTROOT/bin
-export PATH=$(prepend_path $PATH $GOBIN)
+export PATH=$(prepend_path "$PATH" "$GOBIN")
 
 # If we have a custom built mysql, prefer it over the default installation.
-export PATH=$(prepend_path $PATH $VTROOT/dist/mysql/bin)
+export PATH=$(prepend_path "$PATH" "$VTROOT/dist/mysql/bin")
 
 # Add chromedriver to path for selenium tests
-export PATH=$(prepend_path $PATH $VTROOT/dist/chromedriver)
+export PATH=$(prepend_path "$PATH" "$VTROOT/dist/chromedriver")
 
 # Node path
-export PATH=$(prepend_path $PATH $VTROOT/dist/node/bin)
+export PATH=$(prepend_path "$PATH" "$VTROOT/dist/node/bin")
 
 # GOROOT sanity
 go_bin=`which go`
@@ -103,15 +103,15 @@ fi
 if [ -z "$MYSQL_FLAVOR" ]; then
   export MYSQL_FLAVOR=MariaDB
 fi
-export PKG_CONFIG_PATH=$(prepend_path $PKG_CONFIG_PATH $VTROOT/lib)
+export PKG_CONFIG_PATH=$(prepend_path "$PKG_CONFIG_PATH" "$VTROOT/lib")
 
 # needed to correctly import grpc if it's not installed globally
 grpc_dist=$VTROOT/dist/grpc
 if [ -f $grpc_dist/.build_finished ]; then
-  export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $grpc_dist/usr/local/lib)
+  export LD_LIBRARY_PATH=$(prepend_path "$LD_LIBRARY_PATH" "$grpc_dist/usr/local/lib")
 fi
 
-export GOPATH=$(prepend_path $GOPATH $VTROOT)
+export GOPATH=$(prepend_path "$GOPATH" "$VTROOT")
 
 # Useful aliases. Remove if inconvenient.
 alias gt="cd $GOTOP"


### PR DESCRIPTION
`prepend_path` will incorrectly collect arguments if there is an embedded whitespace character, which isn't uncommon on macOS where some applications will append their `/Applications/…` subdirectories to PATH.