### PR TITLE
Some tweaks to avoid spamming the logs

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -197,7 +197,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	// so we don't buffer the TLS negotiation packets.
 	response, err := c.readPacketDirect()
 	if err != nil {
-		log.Errorf("Cannot read client handshake response from %s: %v", c, err)
+		// Don't log EOF errors. They cause too much spam, same as main read loop.
+		if err != io.EOF {
+			log.Errorf("Cannot read client handshake response from %s: %v", c, err)
+		}
 		return
 	}
 	user, authMethod, authResponse, err := l.parseClientHandshakePacket(c, true, response)


### PR DESCRIPTION
### Description

This a small but yet very fulfilling change (at least for me :D ) - For a very long time I've been wanting to fix an issue where our logs get spammed with EOF errors. Today I took the time to read a bit `server.go` and I think I found what the problem was. 

There is already precedence ignoring these kind of errors. This is being handled in the main read loop. However, this is not done during the initial handshake. 

This PR does the following:

* Treat EOF errors when reading handshake the same way it is done in the main
  read loop.
* There is this note in the existent code:
  ```
	// Note io.ReadFull will return two different types of errors:
	// 1. if the socket is already closed, and the go runtime knows it,
	//   then ReadFull will return an error (different than EOF),
	//   someting like 'read: connection reset by peer'.
	// 2. if the socket is not closed while we start the read,
	//   but gets closed after the read is started, we'll get io.EOF.
  ``` 
  I propose we treat connection reset by peer as EOF error. Otherwise, in our case this kind of error also creates too much spam. 

### Tests

I tested this in one of our development clusters and seems to be working 👌 