### PR TITLE
Add make release task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ _test/
 # Go vendored libs
 /vendor/*/
 
+# release folder
+releases
+
 # Angular2 Bower Libs
 /web/vtctld2/.bowerrc~
 /web/vtctld2/bower.json~

--- a/Makefile
+++ b/Makefile
@@ -242,10 +242,13 @@ docker_unit_test:
 rebalance_tests:
 	go run test.go -rebalance 5 -remote-stats http://enisoc.com:15123/travis/stats
 
-release:
-ifndef VERSION
-  $(error Set the env var VERSION with the release version)
-endif
+# Release a version.
+# This will generate a tar.gz file into the releases folder with the current source
+# as well as the vendored libs.
+release: docker_base
+	@if [ -z "$VERSION" ]; then \
+	  echo "Set the env var VERSION with the release version"; exit 1;\
+	fi
 	mkdir -p releases
 	docker build -f docker/Dockerfile.release -t vitess/release .
 	docker run -v ${PWD}/releases:/vt/releases --env VERSION=$(VERSION) vitess/release

--- a/Makefile
+++ b/Makefile
@@ -241,3 +241,15 @@ docker_unit_test:
 # then commit and push.
 rebalance_tests:
 	go run test.go -rebalance 5 -remote-stats http://enisoc.com:15123/travis/stats
+
+release:
+ifndef VERSION
+  $(error Set the env var VERSION with the release version)
+endif
+	mkdir -p releases
+	docker build -f docker/Dockerfile.release -t vitess/release .
+	docker run -v ${PWD}/releases:/vt/releases --env VERSION=$(VERSION) vitess/release
+	git tag -m Version\ $(VERSION) v$(VERSION)
+	echo "A git tag was created, you can push it with:"
+	echo "git push origin v$(VERSION)"
+	echo "Also, don't forget the upload releases/v$(VERSION).tar.gz file to GitHub releases"

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -3,6 +3,9 @@
 # vendor folder is up to data.
 FROM vitess/base
 
+# Clean local files, and keep vendorer libs
+RUN git clean -xdf --exclude="vendor"
+
 RUN mkdir /vt/releases
 
 CMD tar -czf /vt/releases/v$VERSION.tar.gz --exclude .git .

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,8 @@
+# We rely on the base image, as that will re-copy the local
+# working tree and build it. Because of so, we trust the local
+# vendor folder is up to data.
+FROM vitess/base
+
+RUN mkdir /vt/releases
+
+CMD tar -czf /vt/releases/v$VERSION.tar.gz --exclude .git .


### PR DESCRIPTION
This is a follow up on https://github.com/vitessio/vitess/pull/3678

This adds a `make release VERSION=2.2` command.
That will make sure all vendor libs are in place and compress a .tar.gz file for release.
It will also create a tag on git.

