### PR TITLE
add a GetTopoServer method to srvtopo.Server

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -126,7 +126,7 @@ func main() {
 	vtgate.QueryLogHandler = "/debug/vtgate/querylog"
 	vtgate.QueryLogzHandler = "/debug/vtgate/querylogz"
 	vtgate.QueryzHandler = "/debug/vtgate/queryz"
-	vtgate.Init(context.Background(), healthCheck, ts, resilientServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
+	vtgate.Init(context.Background(), healthCheck, resilientServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
 
 	// vtctld configuration and init
 	vtctld.InitVtctld(ts)

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -84,7 +84,7 @@ func main() {
 		}
 	}
 
-	vtg := vtgate.Init(context.Background(), healthCheck, ts, resilientServer, *cell, *retryCount, tabletTypes)
+	vtg := vtgate.Init(context.Background(), healthCheck, resilientServer, *cell, *retryCount, tabletTypes)
 
 	servenv.OnRun(func() {
 		addStatusParts(vtg)

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -222,6 +222,11 @@ func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServe
 	}
 }
 
+// GetTopoServer returns the topo.Server that backs the resilient server.
+func (server *ResilientServer) GetTopoServer() *topo.Server {
+	return server.topoServer
+}
+
 // GetSrvKeyspaceNames returns all keyspace names for the given cell.
 func (server *ResilientServer) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]string, error) {
 	server.counts.Add(queryCategory, 1)

--- a/go/vt/srvtopo/server.go
+++ b/go/vt/srvtopo/server.go
@@ -25,12 +25,16 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/topo"
 )
 
 // Server is a subset of the topo.Server API that only contains
 // the serving graph read-only calls used by clients to resolve
 // serving addresses, and to get VSchema.
 type Server interface {
+	// GetTopoServer returns the full topo.Server instance
+	GetTopoServer() *topo.Server
+
 	// GetSrvKeyspaceNames returns the list of keyspaces served in
 	// the provided cell.
 	GetSrvKeyspaceNames(ctx context.Context, cell string) ([]string, error)

--- a/go/vt/vtexplain/vtexplain_topo.go
+++ b/go/vt/vtexplain/vtexplain_topo.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -51,6 +52,11 @@ func (et *ExplainTopo) getSrvVSchema() *vschemapb.SrvVSchema {
 	return &vschemapb.SrvVSchema{
 		Keyspaces: et.Keyspaces,
 	}
+}
+
+// GetTopoServer is part of the srvtopo.Server interface
+func (et *ExplainTopo) GetTopoServer() *topo.Server {
+	return nil
 }
 
 // GetSrvKeyspaceNames is part of the srvtopo.Server interface.

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -70,7 +70,7 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 }
 
 func newFakeResolver(opts *Options, hc discovery.HealthCheck, serv srvtopo.Server, cell string) *vtgate.Resolver {
-	gw := gateway.GetCreator()(hc, nil, serv, cell, 3)
+	gw := gateway.GetCreator()(hc, serv, cell, 3)
 	gw.WaitForTablets(context.Background(), []topodatapb.TabletType{topodatapb.TabletType_REPLICA})
 
 	txMode := vtgatepb.TransactionMode_MULTI

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -65,7 +65,6 @@ type discoveryGateway struct {
 	queryservice.QueryService
 	hc            discovery.HealthCheck
 	tsc           *discovery.TabletStatsCache
-	topoServer    *topo.Server
 	srvTopoServer srvtopo.Server
 	localCell     string
 	retryCount    int
@@ -92,7 +91,6 @@ func createDiscoveryGateway(hc discovery.HealthCheck, serv srvtopo.Server, cell 
 	dg := &discoveryGateway{
 		hc:                hc,
 		tsc:               discovery.NewTabletStatsCacheDoNotSetListener(topoServer, cell),
-		topoServer:        topoServer,
 		srvTopoServer:     serv,
 		localCell:         cell,
 		retryCount:        retryCount,
@@ -119,7 +117,7 @@ func createDiscoveryGateway(hc discovery.HealthCheck, serv srvtopo.Server, cell 
 			tr = fbs
 		}
 
-		ctw := discovery.NewCellTabletsWatcher(dg.topoServer, tr, c, *refreshInterval, *topoReadConcurrency)
+		ctw := discovery.NewCellTabletsWatcher(topoServer, tr, c, *refreshInterval, *topoReadConcurrency)
 		dg.tabletsWatchers = append(dg.tabletsWatchers, ctw)
 	}
 	dg.QueryService = queryservice.Wrap(nil, dg.withRetry)

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -84,7 +84,11 @@ type discoveryGateway struct {
 	buffer *buffer.Buffer
 }
 
-func createDiscoveryGateway(hc discovery.HealthCheck, topoServer *topo.Server, serv srvtopo.Server, cell string, retryCount int) Gateway {
+func createDiscoveryGateway(hc discovery.HealthCheck, serv srvtopo.Server, cell string, retryCount int) Gateway {
+	var topoServer *topo.Server
+	if serv != nil {
+		topoServer = serv.GetTopoServer()
+	}
 	dg := &discoveryGateway{
 		hc:                hc,
 		tsc:               discovery.NewTabletStatsCacheDoNotSetListener(topoServer, cell),

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -104,7 +104,7 @@ func TestDiscoveryGatewayGetTablets(t *testing.T) {
 	keyspace := "ks"
 	shard := "0"
 	hc := discovery.NewFakeHealthCheck()
-	dg := createDiscoveryGateway(hc, nil, nil, "local", 2).(*discoveryGateway)
+	dg := createDiscoveryGateway(hc, nil, "local", 2).(*discoveryGateway)
 
 	// replica should only use local ones
 	hc.Reset()
@@ -210,7 +210,7 @@ func TestDiscoveryGatewayGetTabletsWithRegion(t *testing.T) {
 	keyspace := "ks"
 	shard := "0"
 	hc := discovery.NewFakeHealthCheck()
-	dg := createDiscoveryGateway(hc, nil, nil, "local", 2).(*discoveryGateway)
+	dg := createDiscoveryGateway(hc, nil, "local", 2).(*discoveryGateway)
 	topo.UpdateCellsToRegionsForTests(map[string]string{
 		"local-west": "local",
 		"local-east": "local",
@@ -240,7 +240,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 		TabletType: tabletType,
 	}
 	hc := discovery.NewFakeHealthCheck()
-	dg := createDiscoveryGateway(hc, nil, nil, "cell", 2).(*discoveryGateway)
+	dg := createDiscoveryGateway(hc, nil, "cell", 2).(*discoveryGateway)
 
 	// no tablet
 	hc.Reset()
@@ -331,7 +331,7 @@ func testDiscoveryGatewayTransact(t *testing.T, streaming bool, f func(dg Gatewa
 		TabletType: tabletType,
 	}
 	hc := discovery.NewFakeHealthCheck()
-	dg := createDiscoveryGateway(hc, nil, nil, "cell", 2).(*discoveryGateway)
+	dg := createDiscoveryGateway(hc, nil, "cell", 2).(*discoveryGateway)
 
 	// retry error - no retry
 	hc.Reset()

--- a/go/vt/vtgate/gateway/gateway.go
+++ b/go/vt/vtgate/gateway/gateway.go
@@ -28,7 +28,6 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/srvtopo"
-	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -70,7 +69,7 @@ type Gateway interface {
 }
 
 // Creator is the factory method which can create the actual gateway object.
-type Creator func(hc discovery.HealthCheck, topoServer *topo.Server, serv srvtopo.Server, cell string, retryCount int) Gateway
+type Creator func(hc discovery.HealthCheck, serv srvtopo.Server, cell string, retryCount int) Gateway
 
 var creators = make(map[string]Creator)
 

--- a/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
+++ b/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
@@ -67,7 +67,7 @@ func TestGRPCDiscovery(t *testing.T) {
 	// Wait for the right tablets to be present.
 	hc := discovery.NewHealthCheck(10*time.Second, 2*time.Minute)
 	rs := srvtopo.NewResilientServer(ts, "TestGRPCDiscovery")
-	dg := gateway.GetCreator()(hc, ts, rs, cell, 2)
+	dg := gateway.GetCreator()(hc, rs, cell, 2)
 	hc.AddTablet(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: cell,
@@ -120,7 +120,7 @@ func TestL2VTGateDiscovery(t *testing.T) {
 	// Wait for the right tablets to be present.
 	hc := discovery.NewHealthCheck(10*time.Second, 2*time.Minute)
 	rs := srvtopo.NewResilientServer(ts, "TestL2VTGateDiscovery")
-	l2vtgate := vtgate.Init(context.Background(), hc, ts, rs, cell, 2, nil)
+	l2vtgate := vtgate.Init(context.Background(), hc, rs, cell, 2, nil)
 	hc.AddTablet(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: cell,

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/sandboxconn"
@@ -217,6 +218,11 @@ func createUnshardedKeyspace() (*topodatapb.SrvKeyspace, error) {
 
 // sandboxTopo satisfies the srvtopo.Server interface
 type sandboxTopo struct {
+}
+
+// GetTopoServer is part of the srvtopo.Server interface
+func (sct *sandboxTopo) GetTopoServer() *topo.Server {
+	return nil
 }
 
 // GetSrvKeyspaceNames is part of the srvtopo.Server interface.

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -580,7 +580,7 @@ func newTestScatterConn(hc discovery.HealthCheck, serv srvtopo.Server, cell stri
 	// The topo.Server is used to start watching the cells described
 	// in '-cells_to_watch' command line parameter, which is
 	// empty by default. So it's unused in this test, set to nil.
-	gw := gateway.GetCreator()(hc, nil /*topo.Server*/, serv, cell, 3)
+	gw := gateway.GetCreator()(hc, serv, cell, 3)
 	tc := NewTxConn(gw, vtgatepb.TransactionMode_TWOPC)
 	return NewScatterConn("", tc, gw, hc)
 }

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -148,7 +148,7 @@ type RegisterVTGate func(vtgateservice.VTGateService)
 var RegisterVTGates []RegisterVTGate
 
 // Init initializes VTGate server.
-func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server, serv srvtopo.Server, cell string, retryCount int, tabletTypesToWait []topodatapb.TabletType) *VTGate {
+func Init(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, cell string, retryCount int, tabletTypesToWait []topodatapb.TabletType) *VTGate {
 	if rpcVTGate != nil {
 		log.Fatalf("VTGate already initialized")
 	}
@@ -163,7 +163,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server
 	var gw gateway.Gateway
 	var l2vtgate *L2VTGate
 	if !*disableLocalGateway {
-		gw = gateway.GetCreator()(hc, topoServer, serv, cell, retryCount)
+		gw = gateway.GetCreator()(hc, serv, cell, retryCount)
 		if err := gateway.WaitForTablets(gw, tabletTypesToWait); err != nil {
 			log.Fatalf("gateway.WaitForTablets failed: %v", err)
 		}

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -67,7 +67,7 @@ func init() {
 	// The topo.Server is used to start watching the cells described
 	// in '-cells_to_watch' command line parameter, which is
 	// empty by default. So it's unused in this test, set to nil.
-	Init(context.Background(), hcVTGateTest, nil /*topo.Server*/, new(sandboxTopo), "aa", 10, nil)
+	Init(context.Background(), hcVTGateTest, new(sandboxTopo), "aa", 10, nil)
 
 	*mysqlServerPort = 0
 	*mysqlAuthServerImpl = "none"


### PR DESCRIPTION
Add a new `GetTopoServer()` method to the `srvtopo.Server` interface.

This way we can avoid passing around both a `srvtopo.Server` and the backing `topo.Server` throughout vtgate.
