### PR TITLE
channel watcher maybe closed by etcd client, which may lead to a dead…

### DIFF
--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -19,13 +19,13 @@ package etcd2topo
 import (
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
-	"time"
 )
 
 // Watch is part of the topo.Conn interface.


### PR DESCRIPTION
channel watcher maybe closed by etcd client, which may lead to a dead loop and cpu usage increase 100%. add rewatch and backoff mechanism to avoid it.
