### PR TITLE
servenv port to listen

### DIFF
--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -34,7 +34,7 @@ var (
 // Run starts listening for RPC and HTTP requests,
 // and blocks until it the process gets a signal.
 func Run(port int) {
-	populateListeningURL()
+	populateListeningURL(int32(port))
 	createGRPCServer()
 	onRunHooks.Fire()
 	serveGRPC()

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -104,7 +104,7 @@ func Init() {
 	onInitHooks.Fire()
 }
 
-func populateListeningURL() {
+func populateListeningURL(port int32) {
 	host, err := netutil.FullyQualifiedHostname()
 	if err != nil {
 		host, err = os.Hostname()
@@ -114,7 +114,7 @@ func populateListeningURL() {
 	}
 	ListeningURL = url.URL{
 		Scheme: "http",
-		Host:   netutil.JoinHostPort(host, int32(*Port)),
+		Host:   netutil.JoinHostPort(host, port),
 		Path:   "/",
 	}
 }


### PR DESCRIPTION
I am creating a command, that calls Run with a custom port, however that
breaks at the populateListeningURL, as the method was reading the var coming
from the argument. Instead, we should just pass the port we got on the Run method


@sougou thoughts?