### PR TITLE
v3: improved handling of parenthesis

### DIFF
--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -621,9 +621,9 @@
 }
 
 # cross-shard expression in parenthesis with limit
-"select * from user where (id = 4 AND name ='abc') limit 5"
+"select * from user where (id1 = 4 AND name1 ='abc') limit 5"
 {
-  "Original": "select * from user where (id = 4 AND name ='abc') limit 5",
+  "Original": "select * from user where (id1 = 4 AND name1 ='abc') limit 5",
   "Instructions": {
     "Opcode": "Limit",
     "Count": 5,
@@ -634,7 +634,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select * from user where (id = 4 and name = 'abc') limit :__upper_limit",
+      "Query": "select * from user where id1 = 4 and name1 = 'abc' limit :__upper_limit",
       "FieldQuery": "select * from user where 1 != 1"
     }
   }

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -520,6 +520,25 @@
   }
 }
 
+# Multiple parenthesized expressions
+"select * from user where (id = 4 and name ='abc') limit 5"
+{
+  "Original": "select * from user where (id = 4 and name ='abc') limit 5",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select * from user where id = 4 and name = 'abc' limit 5",
+    "FieldQuery": "select * from user where 1 != 1",
+    "Vindex": "user_index",
+    "Values": [
+      4
+    ]
+  }
+}
+
 # Column Aliasing with Table.Column
 "select user0_.col as col0_ from user user0_ where id = 1 order by user0_.col desc limit 2"
 {

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -31,9 +31,16 @@ func splitAndExpression(filters []sqlparser.Expr, node sqlparser.Expr) []sqlpars
 	if node == nil {
 		return filters
 	}
-	if node, ok := node.(*sqlparser.AndExpr); ok {
+	switch node := node.(type) {
+	case *sqlparser.AndExpr:
 		filters = splitAndExpression(filters, node.Left)
 		return splitAndExpression(filters, node.Right)
+	case *sqlparser.ParenExpr:
+		// If the inner expression is AndExpr, then we can remove
+		// the parenthesis because they are unnecessary.
+		if node, ok := node.Expr.(*sqlparser.AndExpr); ok {
+			return splitAndExpression(filters, node)
+		}
 	}
 	return append(filters, node)
 }


### PR DESCRIPTION
When splitting AND expressions, we can drop parenthesis if the
inner expression is also AND. This is because they are the same
precedence.

In fact, we could drop the parenthesis for anything that is not
an OR expression. However, this change does it only for AND
expressions so the original construct can be preserved to the
extent possible.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>