### PR TITLE
v3: misc fixes

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -32,14 +32,6 @@
   }
 }
 
-# Aggregate detection (distinct)
-"select distinct user.a from user join user_extra"
-"unsupported: cross-shard query with aggregates"
-
-# Aggregate detection (function)
-"select count(*) from user join user_extra"
-"unsupported: cross-shard query with aggregates"
-
 # Aggregate detection (non-aggregate function)
 "select fun(1), col from user"
 {
@@ -54,14 +46,6 @@
     "FieldQuery": "select fun(1), col from user where 1 != 1"
   }
 }
-
-# Aggregate detection (group_concat)
-"select group_concat(user.a) from user join user_extra"
-"unsupported: cross-shard query with aggregates"
-
-# Aggregate detection (group by)
-"select user.a from user join user_extra group by user.a"
-"unsupported: cross-shard query with aggregates"
 
 # select distinct with unique vindex for scatter route.
 "select distinct col1, id from user"
@@ -688,14 +672,6 @@
 "select col from user group by 2"
 "column number out of range: 2"
 
-# scatter aggregate group by invalid column number
-"select col from user group by col+1"
-"unsupported: in scatter query: only simple references allowed"
-
-# scatter aggregate with ambiguous column names
-"select col1, col2 as col1 from user group by col1"
-"unsupported: in group by: ambiguous symbol reference: col1"
-
 # scatter aggregate order by null
 "select count(*) from user order by null"
 {
@@ -723,10 +699,6 @@
 # scatter aggregate with complex select list (can't build order by)
 "select distinct a+1 from user"
 "generating order by clause: cannot reference a complex expression"
-
-# scatter aggregate with ambiguous aliases
-"select distinct a, b as a from user"
-"generating order by clause: ambiguous symbol reference: a"
 
 # scatter aggregate with numbered order by columns
 "select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1, 2, 3"
@@ -947,10 +919,6 @@
     }
   }
 }
-
-# Scatter order by is complex
-"select col, count(*) from user group by col order by col+1"
-"unsupported: in scatter query: complex order by expression: col + 1"
 
 # invalid order by column numner for scatter
 "select col, count(*) from user group by col order by 5 limit 10"

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -175,10 +175,6 @@
   }
 }
 
-# update with unsupported multi-shard where clause with parens
-"update user set val = 1 where (name = 'foo' or id = 1)"
-"unsupported: multi-shard where clause in DML"
-
 # update by primary keyspace id, changing one vindex column
 "update user_metadata set email = 'juan@vitess.io' where user_id = 1"
 {

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1135,15 +1135,3 @@
 # non-existent table on right of join
 "select c from user join t"
 "table t not found"
-
-# complex on clause on join
-"select c from user join user_extra on user.id in (select id from user)"
-"unsupported: scatter subquery"
-
-# complex on clause on left join
-"select c from user left join user_extra on user.id in (select id from user)"
-"unsupported: scatter subquery"
-
-# merging routes, but complex on clause
-"select user.id from user join user_extra on user_extra.user_id = user.id and user.id in (select id from user)"
-"unsupported: scatter subquery"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -47,6 +47,18 @@
 "select * from user where id in (select id from user)"
 "unsupported: scatter subquery"
 
+# complex on clause on join
+"select c from user join user_extra on user.id in (select id from user)"
+"unsupported: scatter subquery"
+
+# complex on clause on left join
+"select c from user left join user_extra on user.id in (select id from user)"
+"unsupported: scatter subquery"
+
+# merging routes, but complex on clause
+"select user.id from user join user_extra on user_extra.user_id = user.id and user.id in (select id from user)"
+"unsupported: scatter subquery"
+
 # subquery does not depend on unique vindex of outer query
 "select id from user where id in (select user_id from user_extra where user_extra.user_id = user.col)"
 "unsupported: subquery does not depend on scatter outer query"
@@ -155,9 +167,17 @@
 "select id, b as id, count(*) from user order by id"
 "invalid order by: ambiguous symbol reference: id"
 
+# scatter aggregate with ambiguous aliases
+"select distinct a, b as a from user"
+"generating order by clause: ambiguous symbol reference: a"
+
 # scatter aggregate complex order by
 "select id from user group by id order by id+1"
 "unsupported: in scatter query: complex order by expression: id + 1"
+
+# Scatter order by is complex with aggregates in select
+"select col, count(*) from user group by col order by col+1"
+"unsupported: in scatter query: complex order by expression: col + 1"
 
 # scatter aggregate order by does not reference group by
 "select a, b, count(*) from user group by a order by b"
@@ -167,8 +187,16 @@
 "select count(*) from user join user_extra"
 "unsupported: cross-shard query with aggregates"
 
-# group by and joins
-"select user.id from user join user_extra group by id"
+# Aggregate detection (distinct)
+"select distinct user.a from user join user_extra"
+"unsupported: cross-shard query with aggregates"
+
+# Aggregate detection (group_concat)
+"select group_concat(user.a) from user join user_extra"
+"unsupported: cross-shard query with aggregates"
+
+# Aggregate detection (group by)
+"select user.a from user join user_extra group by user.a"
 "unsupported: cross-shard query with aggregates"
 
 # group by and ',' joins
@@ -269,6 +297,10 @@
 
 # update by lookup with IN clause
 "update music set val = 1 where id in (1, 2)"
+"unsupported: multi-shard where clause in DML"
+
+# update with where clause with parens
+"update user set val = 1 where (name = 'foo' or id = 1)"
 "unsupported: multi-shard where clause in DML"
 
 # delete with multi-table targets

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -1,7 +1,3 @@
-# outer and inner subquery match different types
-"select id from user where id = 1 and user.col in (select user_extra.col from user_extra where user_extra.user_id = :a)"
-"unsupported: subquery and parent route to different shards"
-
 # join on having clause
 "select e.col, u.id uid, e.id eid from user u join user_extra e having uid = eid"
 {

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -386,6 +386,13 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
 	}
 	vc.mustFail = false
+
+	// Test column mismatch.
+	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
+	want = "lookup.Create: column vindex count does not match the columns in the lookup: 2 vs [fromc]"
+	if err == nil || err.Error() != want {
+		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
+	}
 }
 
 func TestLookupNonUniqueCreateAutocommit(t *testing.T) {
@@ -467,6 +474,13 @@ func TestLookupNonUniqueDelete(t *testing.T) {
 		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
 	}
 	vc.mustFail = false
+
+	// Test column count fail.
+	err = lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	want = "lookup.Delete: column vindex count does not match the columns in the lookup: 2 vs [fromc]"
+	if err == nil || err.Error() != want {
+		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
+	}
 }
 
 func TestLookupNonUniqueDeleteAutocommit(t *testing.T) {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -230,15 +230,15 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 					owned = true
 				}
 				var columns []sqlparser.ColIdent
-				if ind.Column != "" && len(ind.Columns) > 0 {
-					return fmt.Errorf("Can't use column and columns at the same time in vindex (%s) and table (%s)", ind.Name, tname)
-				}
-				if owned && len(columns) > 1 {
-					return fmt.Errorf("Can't have a multicolumn unowned vindex (%s) and table (%s)", ind.Name, tname)
-				}
 				if ind.Column != "" {
+					if len(ind.Columns) > 0 {
+						return fmt.Errorf("can't use column and columns at the same time in vindex (%s) and table (%s)", ind.Name, tname)
+					}
 					columns = []sqlparser.ColIdent{sqlparser.NewColIdent(ind.Column)}
 				} else {
+					if len(ind.Columns) == 0 {
+						return fmt.Errorf("must specify at least one column for vindex (%s) and table (%s)", ind.Name, tname)
+					}
 					for _, indCol := range ind.Columns {
 						columns = append(columns, sqlparser.NewColIdent(indCol))
 					}


### PR DESCRIPTION
Added some safety checks to lookup vindexes:
* Ensure at least one vindex column is specified.
* Ensure number of vindex columns matches the ones
  expected by the lookup vindex.
* Remove incorrect multi-column unowned vindex
  check. The condition was impossible. Also,
  the check will become unnecessary when we
  implement multi-column Map functions.

Some unsupported cases were present outside
unsupported_cases.txt.