### PR TITLE
Adding better timeouts to mysqladmin shutdown.

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -401,6 +401,9 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, waitForMysqld bool) error {
 		defer os.Remove(cnf)
 		args := []string{
 			"--defaults-extra-file=" + cnf,
+			"--shutdown-timeout=300",
+			"--connect-timeout=30",
+			"--wait=10",
 			"shutdown",
 		}
 		env := []string{


### PR DESCRIPTION
The defaults of connect-timeout=43200 and shutdown-timeout=3600 are too
high here, especially for tests.