### PR TITLE
Bug fix: bump grpc version to v1.10.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,7 @@ ln -snf $consul_dist/consul $VTROOT/bin/consul
 # Install gRPC proto compilers. There is no download for grpc_python_plugin.
 # So, we need to build it.
 export grpc_dist=$VTROOT/dist/grpc
-export grpc_ver="v1.7.0"
+export grpc_ver="v1.10.0"
 if [ $SKIP_ROOT_INSTALLS == "True" ]; then
   echo "skipping grpc build, as root version was already installed."
 elif [[ -f $grpc_dist/.build_finished && "$(cat $grpc_dist/.build_finished)" == "$grpc_ver" ]]; then

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -60,7 +60,7 @@ fi
 
 # Install gRPC python libraries from PyPI.
 # Dependencies like protobuf python will be installed automatically.
-grpcio_ver=1.7.0
+grpcio_ver=1.10.0
 $PIP install --upgrade grpcio==$grpcio_ver
 
 # now install grpc_python_plugin, which also builds the protoc compiler.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1033,60 +1033,92 @@
 			"revisionTime": "2017-05-31T20:35:52Z"
 		},
 		{
-			"checksumSHA1": "y6h+XSUljIi7QBgKWGNl9cRtdZA=",
+			"checksumSHA1": "lHOyCRQE8yw0+NfIjOmo8wS9VTU=",
 			"path": "google.golang.org/grpc",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "OCBWpefHJ05ZkENccs7COJjWIvk=",
+			"checksumSHA1": "xBhmO0Vn4kzbmySioX+2gBImrkk=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "Dkjgw1HasWvqct0IuiZdjbD7O0c=",
+			"checksumSHA1": "CPWX/IgaQSR3+78j4sPrvHNkW+U=",
+			"path": "google.golang.org/grpc/balancer/base",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "DJ1AtOk4Pu7bqtUMob95Hw8HPNw=",
+			"path": "google.golang.org/grpc/balancer/roundrobin",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "j8Qs+yfgwYYOtodB/1bSlbzV5rs=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "5ylThBvJnIcyWhL17AC9+Sdbw2E=",
+			"checksumSHA1": "KthiDKNPHMeIu967enqtE4NaZzI=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "QbufP1o0bXrtd5XecqdRCK/Vl0M=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "WxP3QV0Y4fIx5NsT0dwBp6JsrJE=",
+			"checksumSHA1": "mJTBJC0n9J2CV+tHX+dJosYOZmg=",
+			"path": "google.golang.org/grpc/encoding",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
+			"path": "google.golang.org/grpc/encoding/proto",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
@@ -1099,96 +1131,114 @@
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "QyasSHZlgle+PHSIQ2/p+fr+ihY=",
 			"path": "google.golang.org/grpc/grpclog/glogger",
-			"revision": "08a45354194cd00490a5d926825670fb928b5f76",
-			"revisionTime": "2017-11-01T20:14:29Z"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "U9vDe05/tQrvFBojOQX8Xk12W9I=",
+			"checksumSHA1": "Qvf3zdmRCSsiM/VoBv0qB/naHtU=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "KeUmTZV+2X46C49cKyjp+xM7fvw=",
+			"checksumSHA1": "X1BGbIb3xaxiAG4O1Ot5YjPlh4g=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "556Vl75S7EVxgScPckfELwn6+xo=",
+			"checksumSHA1": "5dwF592DPvhF2Wcex3m7iV6aGRQ=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "ifLyU1wZH521mt8htJZpGB/XVgQ=",
+			"checksumSHA1": "IKIaz1gx/CgosQ6U709XWiPPRXA=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "WpWF+bDzObsHf+bjoGpb/abeFxo=",
+			"path": "google.golang.org/grpc/resolver/dns",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
+		},
+		{
+			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
+			"path": "google.golang.org/grpc/resolver/passthrough",
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "G9lgXNi7qClo5sM2s6TbTHLFR3g=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "3Dwz4RLstDHMPyDA7BUsYe+JP4w=",
+			"checksumSHA1": "/7i6dC0tFTtGMxykj9VduLEfBCU=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
-			"checksumSHA1": "Bxregh/v5pH6fVa1rIo2zLCb5NI=",
+			"checksumSHA1": "fgt81mMAzx0Zo0ZuI2Vv0/RYApA=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
+			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
+			"revisionTime": "2018-02-14T18:40:50Z",
+			"version": "v1.10.0",
+			"versionExact": "v1.10.0"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
This PR rev's the GRPC version to v1.10.0. 

This came about when digging into a vtgate memory leak that we found after upgrading our internal vitess version. I found that grpc v1.7.1 was never closing connections, which was a regression since grpc 1.6. Each connection has a 32k read buffer and a 32k write buffer, which eventually leads to us running OOM on our vtgate kubernetes pods. I've upgraded grpc to v1.10.0 and am running a few test vtgates which show stable behavior in both connections and memory usage.

Thanks for taking a look!