### PR TITLE
allow a vindex ddl statement to initialize a new keyspace

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -377,9 +377,18 @@ func (e *Executor) handleVindexDDL(ctx context.Context, safeSession *SafeSession
 		return errNoKeyspace
 	}
 
-	ks, ok := vschema.Keyspaces[ksName]
-	if !ok {
-		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "keyspace %s not defined in vschema", ksName)
+	ks, _ := vschema.Keyspaces[ksName]
+	if ks == nil {
+		ks = new(vschemapb.Keyspace)
+		vschema.Keyspaces[ksName] = ks
+	}
+
+	if ks.Tables == nil {
+		ks.Tables = map[string]*vschemapb.Table{}
+	}
+
+	if ks.Vindexes == nil {
+		ks.Vindexes = map[string]*vschemapb.Vindex{}
 	}
 
 	var tableName string

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1351,7 +1351,7 @@ func TestExecutorAddDropVindexDDL(t *testing.T) {
 
 	stmt = "alter table nowhere.nohow drop vindex test_lookup"
 	_, err = executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	wantErr = "keyspace nowhere not defined in vschema"
+	wantErr = "table nowhere.nohow not defined in vschema"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("got %v want err %s", err, wantErr)
 	}


### PR DESCRIPTION
Previously vtgate would crash when creating the first vindex in a
keyspace because the vschema data structures were nil.

This change enables bootstrapping a keyspace with the first vindex
by creating the various maps if they don't exist.

Signed-off-by: Michael Demmer <mdemmer@slack-corp.com>