### PR TITLE
Snappy gRPC compression

### DIFF
--- a/go/vt/grpcclient/snappy.go
+++ b/go/vt/grpcclient/snappy.go
@@ -1,0 +1,46 @@
+package grpcclient
+
+import (
+	"flag"
+	"io"
+
+	"github.com/golang/snappy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding"
+)
+
+var (
+	compression = flag.String("grpc_compression", "", "how to comrpess grpc, default: nothing, supported: snappy")
+)
+
+// SnappyCompressor is a gRPC compressor using the Snappy algorithm.
+type SnappyCompressor struct{}
+
+// Name is "snappy"
+func (s SnappyCompressor) Name() string {
+	return "snappy"
+}
+
+// Compress wraps with a SnappyReader
+func (s SnappyCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return snappy.NewBufferedWriter(w), nil
+}
+
+// Decompress wraps with a SnappyReader
+func (s SnappyCompressor) Decompress(r io.Reader) (io.Reader, error) {
+	return snappy.NewReader(r), nil
+}
+
+func appendCompression(opts []grpc.DialOption) ([]grpc.DialOption, error) {
+	if *compression == "snappy" {
+		compression := grpc.WithDefaultCallOptions(grpc.UseCompressor("snappy"))
+		opts = append(opts, compression)
+	}
+
+	return opts, nil
+}
+
+func init() {
+	encoding.RegisterCompressor(SnappyCompressor{})
+	RegisterGRPCDialOptions(appendCompression)
+}

--- a/go/vt/grpcclient/snappy.go
+++ b/go/vt/grpcclient/snappy.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	compression = flag.String("grpc_compression", "", "how to comrpess grpc, default: nothing, supported: snappy")
+	compression = flag.String("grpc_compression", "", "how to compress gRPC, default: nothing, supported: snappy")
 )
 
 // SnappyCompressor is a gRPC compressor using the Snappy algorithm.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -499,6 +499,12 @@
 			"revisionTime": "2017-08-08T02:16:21Z"
 		},
 		{
+			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
+			"path": "github.com/golang/snappy",
+			"revision": "553a641470496b2327abcac10b36396bd98e45c9",
+			"revisionTime": "2017-02-15T23:32:05Z"
+		},
+		{
 			"checksumSHA1": "V/53BpqgOkSDZCX6snQCAkdO2fM=",
 			"path": "github.com/googleapis/gax-go",
 			"revision": "da06d194a00e19ce00d9011a13931c3f6f6887c7",


### PR DESCRIPTION
Add support for gRPC compression using Snappy. We are bandwidth constrained on both our vtgate's and our vttablet's. Given neither of these use particularly large amounts of RAM or CPU we can decrease our hardware footprint dramatically by decreasing bandwidth usage and co-locating on the same physical hardware.