### PR TITLE
Fixing a panic during vttablet shutdown.

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -578,6 +578,7 @@ func TestTabletServerTarget(t *testing.T) {
 		t.Errorf("err: %v, must contain %s", err, want)
 	}
 	err = tsv.Commit(ctx, &target1, 1)
+	want = "invalid tablet type: MASTER"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("err: %v, must contain %s", err, want)
 	}


### PR DESCRIPTION
The wait group that was setup to only be used during Begin was also used
during other transactional operations. So if a Commit came by as we are
shutting down and waiting on the wait group for begins to finish, it
would panic. Changing the behavior to only add / remove from the wait
group during real begins.

As a side effect, we don't catch the wrong tablet type on other
non-begin transactional statements. For instance, a commit fails a bit
later on a replica, not right away. I don't think it's a bit deal, it
will still fail.

This is this issue on GitHub:
https://github.com/vitessio/vitess/issues/3643

BUG=72882235

Signed-off-by: Alain Jobart <alainjobart@google.com>