### PR TITLE
Updating tests for new consul version.

### DIFF
--- a/go/testfiles/ports.go
+++ b/go/testfiles/ports.go
@@ -44,7 +44,7 @@ var (
 	GoVtTopoZk2topoPort = GoVtTopoEtcd2topoPort + 2
 
 	// GoVtTopoConsultopoPort is used by the go/vt/topo/consultopo package.
-	// Takes five ports.
+	// Takes four ports.
 	GoVtTopoConsultopoPort = GoVtTopoZk2topoPort + 3
 )
 

--- a/test/topo_flavor/consul.py
+++ b/test/topo_flavor/consul.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ class ConsulTopoServer(server.TopoServer):
     import environment  # pylint: disable=g-import-not-at-top
     import utils  # pylint: disable=g-import-not-at-top
 
-    self.port_base = environment.reserve_ports(5)
+    self.port_base = environment.reserve_ports(4)
     self.server_addr = 'localhost:%d' % (self.port_base + 1)
 
     # Write our config file.
@@ -38,9 +38,8 @@ class ConsulTopoServer(server.TopoServer):
         'ports': {
             'dns': self.port_base,
             'http': self.port_base + 1,
-            'rpc': self.port_base + 2,
-            'serf_lan': self.port_base + 3,
-            'serf_wan': self.port_base + 4,
+            'serf_lan': self.port_base + 2,
+            'serf_wan': self.port_base + 3,
         },
     }
     with open(self.config_file, 'w') as fd:


### PR DESCRIPTION
Version 1.0.6 (now installed by bootsrap) doesn't understand the 'rpc'
port. Also, its config file name has to end in '.json'.