### PR TITLE
v3: prep work for more primitives

### DIFF
--- a/go/vt/vtgate/planbuilder/doc.go
+++ b/go/vt/vtgate/planbuilder/doc.go
@@ -70,13 +70,6 @@ Every 'builder' primitive must satisfy the builder
 interface. This allows the planbuilder to outsource
 primitive-specific handling into those implementaions.
 
-Any primitive that computes or generates a new column
-must satisfy the 'columnOriginator' interface. When
-you search for a symbol, the symtab returns the
-columnOriginator that originates the symbol. Such
-primitives must also have a unique Order, which will
-allow the push-down algorithms to navigate to it.
-
 Variable naming: The AST, planbuilder and engine
 are three different worlds that use overloaded
 names that are contextually similar, but different.

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -79,7 +79,7 @@ func skipParenthesis(node sqlparser.Expr) sqlparser.Expr {
 //
 // If an expression has no references to the current query, then the left-most
 // origin is chosen as the default.
-func findOrigin(expr sqlparser.Expr, bldr builder) (origin columnOriginator, err error) {
+func findOrigin(expr sqlparser.Expr, bldr builder) (origin builder, err error) {
 	highestOrigin := bldr.Leftmost()
 	var subroutes []*route
 	err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -30,44 +30,35 @@ var _ builder = (*join)(nil)
 // operation.
 type join struct {
 	symtab        *symtab
+	order         int
 	resultColumns []*resultColumn
 
-	// leftMaxOrder and rightMaxOrder store the max order
-	// of the left node and right node. This is essentially
+	// leftOrder stores the order number of the left node. This is
 	// used for a b-tree style traversal towards the target route.
 	// Let us assume the following execution tree:
-	//      Ja
+	//      J9
 	//     /  \
 	//    /    \
-	//   Jb     Jc
+	//   J3     J8
 	//  / \    /  \
-	// R1  R2  Jd  R5
+	// R1  R2  J6  R7
 	//        / \
-	//        R3 R4
+	//        R4 R5
 	//
-	// R1-R5 are routes. Their numbers indicate execution
-	// order: R1 is executed first, then it's R2, which will
-	// be joined at Jb, etc.
+	// In the above trees, the suffix numbers indicate the
+	// execution order. The leftOrder for the joins will then
+	// be as follows:
+	// J3: 1
+	// J6: 4
+	// J8: 6
+	// J9: 3
 	//
-	// The values for left and right max order for the join
-	// nodes will be:
-	//     left right
-	// Jb: 1    2
-	// Jd: 3    4
-	// Jc: 4    5
-	// Ja: 2    5
-	// The route to R3 would be:
-	// Go right from Ja->Jc because Left(Ja)==2, which is <3.
-	// Go left from Jc->Jd because Left(Jc)==4, which is >=3.
-	// Go left from Jd->R3 because Left(Jd)==3, the destination.
-	//
-	// There are many use cases for these Orders. Look for 'isOnLeft'
-	// to see how these numbers are used. 'isOnLeft' is a convenience
-	// function to help with traversal.
-	// The MaxOrder for a join is the same as rightMaxOrder.
-	// A join can currently not be a destination. It therefore does
-	// not have its own Order.
-	leftMaxOrder, rightMaxOrder int
+	// The route to R4 would be:
+	// Go right from J9->J8 because Left(J9)==3, which is <4.
+	// Go left from J8->J6 because Left(J8)==6, which is >=4.
+	// Go left from J6->R4 because Left(J6)==4, the destination.
+	// Look for 'isOnLeft' to see how these numbers are used.
+	leftOrder int
 
 	// Left and Right are the nodes for the join.
 	Left, Right builder
@@ -84,27 +75,26 @@ func newJoin(lhs, rhs builder, ajoin *sqlparser.JoinTableExpr) (*join, error) {
 	// external references, and the FROM clause doesn't allow duplicates,
 	// it's safe to perform this conversion and still expect the same behavior.
 
-	err := lhs.Symtab().Merge(rhs.Symtab())
-	if err != nil {
-		return nil, err
-	}
-	rhs.SetOrder(lhs.MaxOrder())
+	rhs.Reorder(lhs.Order())
 	opcode := engine.NormalJoin
 	if ajoin != nil && ajoin.Join == sqlparser.LeftJoinStr {
 		opcode = engine.LeftJoin
 	}
 	jb := &join{
-		leftMaxOrder:  lhs.MaxOrder(),
-		rightMaxOrder: rhs.MaxOrder(),
-		Left:          lhs,
-		Right:         rhs,
-		symtab:        lhs.Symtab(),
+		order:     rhs.Order() + 1,
+		leftOrder: lhs.Order(),
+		Left:      lhs,
+		Right:     rhs,
+		symtab:    lhs.Symtab(),
 		ejoin: &engine.Join{
 			Opcode: opcode,
 			Left:   lhs.Primitive(),
 			Right:  rhs.Primitive(),
 			Vars:   make(map[string]int),
 		},
+	}
+	if err := lhs.Symtab().Merge(rhs.Symtab()); err != nil {
+		return nil, err
 	}
 	if ajoin == nil {
 		return jb, nil
@@ -114,14 +104,12 @@ func newJoin(lhs, rhs builder, ajoin *sqlparser.JoinTableExpr) (*join, error) {
 	}
 
 	if opcode == engine.LeftJoin {
-		err := pushFilter(ajoin.Condition.On, rhs, sqlparser.WhereStr)
-		if err != nil {
+		if err := pushFilter(ajoin.Condition.On, rhs, sqlparser.WhereStr); err != nil {
 			return nil, err
 		}
 		return jb, nil
 	}
-	err = pushFilter(ajoin.Condition.On, jb, sqlparser.WhereStr)
-	if err != nil {
+	if err := pushFilter(ajoin.Condition.On, jb, sqlparser.WhereStr); err != nil {
 		return nil, err
 	}
 	return jb, nil
@@ -132,17 +120,16 @@ func (jb *join) Symtab() *symtab {
 	return jb.symtab.Resolve()
 }
 
-// MaxOrder satisfies the builder interface.
-func (jb *join) MaxOrder() int {
-	return jb.rightMaxOrder
+// Order satisfies the builder interface.
+func (jb *join) Order() int {
+	return jb.order
 }
 
-// SetOrder satisfies the builder interface.
-func (jb *join) SetOrder(order int) {
-	jb.Left.SetOrder(order)
-	jb.leftMaxOrder = jb.Left.MaxOrder()
-	jb.Right.SetOrder(jb.leftMaxOrder)
-	jb.rightMaxOrder = jb.Right.MaxOrder()
+// Reorder satisfies the builder interface.
+func (jb *join) Reorder(order int) {
+	jb.Left.Reorder(order)
+	jb.leftOrder = jb.Left.Order()
+	jb.Right.Reorder(jb.leftOrder)
 }
 
 // Primitive satisfies the builder interface.
@@ -151,7 +138,7 @@ func (jb *join) Primitive() engine.Primitive {
 }
 
 // Leftmost satisfies the builder interface.
-func (jb *join) Leftmost() columnOriginator {
+func (jb *join) Leftmost() builder {
 	return jb.Left.Leftmost()
 }
 
@@ -161,7 +148,7 @@ func (jb *join) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (jb *join) PushFilter(filter sqlparser.Expr, whereType string, origin columnOriginator) error {
+func (jb *join) PushFilter(filter sqlparser.Expr, whereType string, origin builder) error {
 	if jb.isOnLeft(origin.Order()) {
 		return jb.Left.PushFilter(filter, whereType, origin)
 	}
@@ -172,7 +159,7 @@ func (jb *join) PushFilter(filter sqlparser.Expr, whereType string, origin colum
 }
 
 // PushSelect satisfies the builder interface.
-func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin columnOriginator) (rc *resultColumn, colnum int, err error) {
+func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
 	if jb.isOnLeft(origin.Order()) {
 		rc, colnum, err = jb.Left.PushSelect(expr, origin)
 		if err != nil {
@@ -282,5 +269,5 @@ func (jb *join) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int)
 // is on the left side of the join. If false, it means
 // the node is on the right.
 func (jb *join) isOnLeft(nodeNum int) bool {
-	return nodeNum <= jb.leftMaxOrder
+	return nodeNum <= jb.leftOrder
 }

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -28,7 +28,6 @@ import (
 )
 
 var _ builder = (*route)(nil)
-var _ columnOriginator = (*route)(nil)
 
 var errIntermixingUnsupported = errors.New("unsupported: intermixing of information_schema and regular tables")
 
@@ -92,18 +91,13 @@ func (rb *route) Symtab() *symtab {
 	return rb.symtab.Resolve()
 }
 
-// Order returns the order of the route.
+// Order satisfies the builder interface.
 func (rb *route) Order() int {
 	return rb.order
 }
 
-// MaxOrder satisfies the builder interface.
-func (rb *route) MaxOrder() int {
-	return rb.order
-}
-
-// SetOrder satisfies the builder interface.
-func (rb *route) SetOrder(order int) {
+// Reorder satisfies the builder interface.
+func (rb *route) Reorder(order int) {
 	rb.order = order + 1
 }
 
@@ -113,7 +107,7 @@ func (rb *route) Primitive() engine.Primitive {
 }
 
 // Leftmost satisfies the builder interface.
-func (rb *route) Leftmost() columnOriginator {
+func (rb *route) Leftmost() builder {
 	return rb
 }
 
@@ -247,7 +241,7 @@ func (rb *route) isSameRoute(rhs *route, filter sqlparser.Expr) bool {
 
 // PushFilter satisfies the builder interface.
 // The primitive will be updated if the new filter improves the plan.
-func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ columnOriginator) error {
+func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ builder) error {
 	sel := rb.Select.(*sqlparser.Select)
 	switch whereType {
 	case sqlparser.WhereStr:
@@ -374,7 +368,7 @@ func (rb *route) exprIsValue(expr sqlparser.Expr) bool {
 }
 
 // PushSelect satisfies the builder interface.
-func (rb *route) PushSelect(expr *sqlparser.AliasedExpr, _ columnOriginator) (rc *resultColumn, colnum int, err error) {
+func (rb *route) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
 	sel := rb.Select.(*sqlparser.Select)
 	sel.SelectExprs = append(sel.SelectExprs, expr)
 

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -45,6 +45,40 @@ func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive e
 }
 
 // processSelect builds a primitive tree for the given query or subquery.
+// The tree built by this function has the following general structure:
+//
+// The leaf nodes can be a route, vindexFunc or subquery. In the symtab,
+// the tables map has columns that point to these leaf nodes. A subquery
+// itself contains a builder tree, but it's opaque and is made to look
+// like a table for the analysis of the current tree.
+//
+// The leaf nodes are usually tied together by join nodes. While the join
+// nodes are built, they have ON clauses. Those are analyzed and pushed
+// down into the leaf nodes as the tree is formed. Join nodes are formed
+// during analysis of the FROM clause.
+//
+// During the WHERE clause analysis, the target leaf node is identified
+// for each part, and the PushFilter function is used to push the condition
+// down. The same strategy is used for the other clauses.
+//
+// So, a typical plan would either be a simple leaf node, or may consist
+// of leaf nodes tied together by join nodes.
+//
+// If a query has aggregates that cannot be pushed down, an aggregator
+// primitive is built. The current orderedAggregate primitive can only
+// be built on top of a route. The orderedAggregate expects the rows
+// to be ordered as they are returned. This work is performed by the
+// underlying route. This means that a compatible ORDER BY clause
+// can also be handled by this combination of primitives. In this case,
+// the tree would consist of an orderedAggregate whose input is a route.
+//
+// If a query has an ORDER BY, but the route is a scatter, then the
+// ordering is pushed down into the route itself. This results in a simple
+// route primitive.
+//
+// The LIMIT clause is the last construct of a query. If it cannot be
+// pushed into a route, then a primitve is created on top of any
+// of the above trees to make it discard unwanted rows.
 func processSelect(sel *sqlparser.Select, vschema ContextVSchema, outer builder) (builder, error) {
 	bldr, err := processTableExprs(sel.From, vschema)
 	if err != nil {


### PR DESCRIPTION
Simplified the code and added better comments to explain
how things work:
* Removed columnOriginator and merged its meaning with
  builder. This means that all builders need their own
  order number. They become potentially eligible to
  originate columns.
* Dropped some unnecessary fields in the 'column' type.
  Simplified comments.
* Documented the possible tree structures that can currently
  be built. Previously, there was this notion that
  anything is possible. But now, the limited list of
  possibilities makes it easier to follow the logic.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>