### PR TITLE
remove the unused isDML boolean from the vcursor interface

### DIFF
--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -152,7 +152,7 @@ func (del *Delete) execDeleteUnsharded(vcursor VCursor, bindVars map[string]*que
 	if len(rss) != 1 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Keyspace does not have exactly one shard: %v", rss)
 	}
-	return execShard(vcursor, del.Query, bindVars, rss[0], true, true /* canAutocommit */)
+	return execShard(vcursor, del.Query, bindVars, rss[0], true /* canAutocommit */)
 }
 
 func (del *Delete) execDeleteEqual(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
@@ -174,11 +174,11 @@ func (del *Delete) execDeleteEqual(vcursor VCursor, bindVars map[string]*querypb
 		}
 	}
 	rewritten := sqlannotation.AddKeyspaceIDs(del.Query, [][]byte{ksid}, "")
-	return execShard(vcursor, rewritten, bindVars, rs, true /* isDML */, true /* canAutocommit */)
+	return execShard(vcursor, rewritten, bindVars, rs, true /* canAutocommit */)
 }
 
 func (del *Delete) deleteVindexEntries(vcursor VCursor, bindVars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard, ksid []byte) error {
-	result, err := execShard(vcursor, del.OwnedVindexQuery, bindVars, rs, false /* isDML */, false /* canAutocommit */)
+	result, err := execShard(vcursor, del.OwnedVindexQuery, bindVars, rs, false /* canAutocommit */)
 	if err != nil {
 		return err
 	}
@@ -215,5 +215,5 @@ func (del *Delete) execDeleteSharded(vcursor VCursor, bindVars map[string]*query
 			BindVariables: bindVars,
 		}
 	}
-	return vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, true /* canAutocommit */)
+	return vcursor.ExecuteMultiShard(rss, queries, true /* canAutocommit */)
 }

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -43,7 +43,7 @@ func TestDeleteUnsharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_delete {} true true`,
+		`ExecuteMultiShard ks.0: dummy_delete {} true`,
 	})
 
 	// Failure cases
@@ -76,7 +76,7 @@ func TestDeleteEqual(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
-		`ExecuteMultiShard ks.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard ks.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// Failure case
@@ -109,7 +109,7 @@ func TestDeleteEqualNoRoute(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		// This lookup query will return no rows. So, the DML will not be sent anywhere.
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 	})
 }
 
@@ -168,12 +168,12 @@ func TestDeleteOwnedVindex(t *testing.T) {
 		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// ResolveDestinations is hard-coded to return -20.
 		// It gets used to perform the subquery to fetch the changing column values.
-		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false`,
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
-		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
 		// Finally, the actual delete, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// No rows changing
@@ -188,9 +188,9 @@ func TestDeleteOwnedVindex(t *testing.T) {
 		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// ResolveDestinations is hard-coded to return -20.
 		// It gets used to perform the subquery to fetch the changing column values.
-		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false`,
 		// Subquery returns no rows. So, no vindexes are deleted. We still pass-through the original delete.
-		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// Delete can affect multiple rows
@@ -214,15 +214,15 @@ func TestDeleteOwnedVindex(t *testing.T) {
 		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// ResolveDestinations is hard-coded to return -20.
 		// It gets used to perform the subquery to fetch the changing column values.
-		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false`,
 		// Delete 4,5 and 7,8 from lkp2.
-		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"7" from2: type:INT64 value:"8" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"7" from2: type:INT64 value:"8" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
 		// Delete 6 and 8 from lkp1.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"9" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"9" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
 		// Send the DML.
-		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_delete /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 }
 
@@ -243,7 +243,7 @@ func TestDeleteSharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.-20: dummy_delete {} ks.20-: dummy_delete {} true true`,
+		`ExecuteMultiShard ks.-20: dummy_delete {} ks.20-: dummy_delete {} true`,
 	})
 
 	// Failure case

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -41,15 +41,15 @@ func (t noopVCursor) Context() context.Context {
 	return context.Background()
 }
 
-func (t noopVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (t noopVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 
-func (t noopVCursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (t noopVCursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 
-func (t noopVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
+func (t noopVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, canAutocommit bool) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 
@@ -86,13 +86,13 @@ func (f *loggingVCursor) Context() context.Context {
 	return context.Background()
 }
 
-func (f *loggingVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
-	f.log = append(f.log, fmt.Sprintf("Execute %s %v %v", query, printBindVars(bindvars), isDML))
+func (f *loggingVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	f.log = append(f.log, fmt.Sprintf("Execute %s %v", query, printBindVars(bindvars)))
 	return f.nextResult()
 }
 
-func (f *loggingVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
-	f.log = append(f.log, fmt.Sprintf("ExecuteMultiShard %v%v %v", printResolvedShardQueries(rss, queries), isDML, canAutocommit))
+func (f *loggingVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, canAutocommit bool) (*sqltypes.Result, error) {
+	f.log = append(f.log, fmt.Sprintf("ExecuteMultiShard %v%v", printResolvedShardQueries(rss, queries), canAutocommit))
 	return f.nextResult()
 }
 

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -178,7 +178,7 @@ func (ins *Insert) execInsertUnsharded(vcursor VCursor, bindVars map[string]*que
 	if len(rss) != 1 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Keyspace does not have exactly one shard: %v", rss)
 	}
-	result, err := execShard(vcursor, ins.Query, bindVars, rss[0], true, true /* canAutocommit */)
+	result, err := execShard(vcursor, ins.Query, bindVars, rss[0], true /* canAutocommit */)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "execInsertUnsharded")
 	}
@@ -203,7 +203,7 @@ func (ins *Insert) execInsertSharded(vcursor VCursor, bindVars map[string]*query
 		return nil, vterrors.Wrap(err, "execInsertSharded")
 	}
 
-	result, err := vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, true /* canAutocommit */)
+	result, err := vcursor.ExecuteMultiShard(rss, queries, true /* canAutocommit */)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "execInsertSharded")
 	}

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -49,7 +49,7 @@ func TestInsertUnsharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_insert {} true true`,
+		`ExecuteMultiShard ks.0: dummy_insert {} true`,
 	})
 	expectResult(t, "Execute", result, &sqltypes.Result{InsertID: 4})
 
@@ -112,7 +112,7 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 		`ExecuteStandalone dummy_generate n: type:INT64 value:"2"  ks2 0`,
 		// Fill those values into the insert.
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_insert {__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"4" __seq2: type:INT64 value:"2" __seq3: type:INT64 value:"5" __seq4: type:INT64 value:"3" } true true`,
+		`ExecuteMultiShard ks.0: dummy_insert {__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"4" __seq2: type:INT64 value:"2" __seq3: type:INT64 value:"5" __seq4: type:INT64 value:"3" } true`,
 	})
 
 	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerate.
@@ -183,7 +183,7 @@ func TestInsertShardedSimple(t *testing.T) {
 		`ExecuteMultiShard ` +
 			`sharded.20-: prefix mid1, mid3 suffix /* vtgate:: keyspace_id:166b40b44aba4bd6,4eb190c9a2fa169c */ {_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
 			`sharded.-20: prefix mid2 suffix /* vtgate:: keyspace_id:06e7ea22ce92708f */ {_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 }
 
@@ -338,7 +338,7 @@ func TestInsertShardedGenerate(t *testing.T) {
 			`sharded.-20: prefix mid2 suffix /* vtgate:: keyspace_id:06e7ea22ce92708f */ ` +
 			`{__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"2" __seq2: type:INT64 value:"2" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 
 	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerate.
@@ -463,10 +463,10 @@ func TestInsertShardedOwned(t *testing.T) {
 		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1), (:from12, :from22, :toc2) ` +
 			`from10: type:INT64 value:"4" from11: type:INT64 value:"5" from12: type:INT64 value:"6" ` +
 			`from20: type:INT64 value:"7" from21: type:INT64 value:"8" from22: type:INT64 value:"9" ` +
-			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234" `,
 		`Execute insert into lkp1(from, toc) values(:from0, :toc0), (:from1, :toc1), (:from2, :toc2) ` +
 			`from0: type:INT64 value:"10" from1: type:INT64 value:"11" from2: type:INT64 value:"12" ` +
-			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234" `,
 		// Based on shardForKsid, values returned will be 20-, -20, 20-.
 		`ResolveDestinations sharded [value:"0"  value:"1"  value:"2" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ` +
@@ -480,7 +480,7 @@ func TestInsertShardedOwned(t *testing.T) {
 			`_c20: type:INT64 value:"7" _c21: type:INT64 value:"8" _c22: type:INT64 value:"9" ` +
 			`_c30: type:INT64 value:"10" _c31: type:INT64 value:"11" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 }
 
@@ -711,26 +711,24 @@ func TestInsertShardedIgnoreOwned(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"1"  false`,
-		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"2"  false`,
-		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"3"  false`,
-		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"4"  false`,
+		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"1" `,
+		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"2" `,
+		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"3" `,
+		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"4" `,
 		`Execute insert ignore into lkp2(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1), (:from12, :from22, :toc2) ` +
 			`from10: type:INT64 value:"5" from11: type:INT64 value:"7" from12: type:INT64 value:"8" ` +
 			`from20: type:INT64 value:"9" from21: type:INT64 value:"11" from22: type:INT64 value:"12" ` +
-			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000" toc2: type:VARBINARY value:"\000"  ` +
-			`true`,
+			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000" toc2: type:VARBINARY value:"\000" `,
 		// row 2 is out because it didn't map to a ksid.
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"5" toc: type:VARBINARY value:"\000"  true`,
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"7" toc: type:VARBINARY value:"\000"  true`,
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"8" toc: type:VARBINARY value:"\000"  true`,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"5" toc: type:VARBINARY value:"\000" `,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"7" toc: type:VARBINARY value:"\000" `,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"8" toc: type:VARBINARY value:"\000" `,
 		`Execute insert ignore into lkp1(from, toc) values(:from0, :toc0), (:from1, :toc1) ` +
 			`from0: type:INT64 value:"13" from1: type:INT64 value:"16" ` +
-			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000"  ` +
-			`true`,
+			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000" `,
 		// row 3 is out because it failed Verify. Only two verifications from lkp1.
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"13" toc: type:VARBINARY value:"\000"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"16" toc: type:VARBINARY value:"\000"  true`,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"13" toc: type:VARBINARY value:"\000" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"16" toc: type:VARBINARY value:"\000" `,
 		`ResolveDestinations sharded [value:"0"  value:"3" ] Destinations:DestinationKeyspaceID(00),DestinationKeyspaceID(00)`,
 		// Bind vars for rows 2 & 3 may be missing because they were not sent.
 		`ExecuteMultiShard ` +
@@ -744,7 +742,7 @@ func TestInsertShardedIgnoreOwned(t *testing.T) {
 			`_c20: type:INT64 value:"9" _c22: type:INT64 value:"11" _c23: type:INT64 value:"12" ` +
 			`_c30: type:INT64 value:"13" _c33: type:INT64 value:"16" ` +
 			`_id0: type:INT64 value:"1" _id2: type:INT64 value:"3" _id3: type:INT64 value:"4" } ` +
-			`true true`,
+			`true`,
 	})
 }
 
@@ -952,12 +950,12 @@ func TestInsertShardedUnownedVerify(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		// Perform verification for each colvindex.
 		// Note that only first column of each colvindex is used.
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"4" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"5" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"6" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"10" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"11" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"12" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"4" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"5" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217" `,
+		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"6" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"10" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"11" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"12" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234" `,
 		// Based on shardForKsid, values returned will be 20-, -20, 20-.
 		`ResolveDestinations sharded [value:"0"  value:"1"  value:"2" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ` +
@@ -971,7 +969,7 @@ func TestInsertShardedUnownedVerify(t *testing.T) {
 			`_c20: type:INT64 value:"7" _c21: type:INT64 value:"8" _c22: type:INT64 value:"9" ` +
 			`_c30: type:INT64 value:"10" _c31: type:INT64 value:"11" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 }
 
@@ -1073,9 +1071,9 @@ func TestInsertShardedIgnoreUnownedVerify(t *testing.T) {
 	vc.ExpectLog(t, []string{
 		// Perform verification for each colvindex.
 		// Note that only first column of each colvindex is used.
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"10" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"11" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"12" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"10" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"11" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217" `,
+		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"12" toc: type:VARBINARY value:"N\261\220\311\242\372\026\234" `,
 		// Based on shardForKsid, values returned will be 20-, -20.
 		`ResolveDestinations sharded [value:"0"  value:"2" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ` +
@@ -1085,7 +1083,7 @@ func TestInsertShardedIgnoreUnownedVerify(t *testing.T) {
 			`sharded.-20: prefix mid3 suffix /* vtgate:: keyspace_id:4eb190c9a2fa169c */ ` +
 			`{_c30: type:INT64 value:"10" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 }
 
@@ -1297,7 +1295,7 @@ func TestInsertShardedUnownedReverseMap(t *testing.T) {
 			`_c20: _c21: _c22: ` +
 			`_c30: type:UINT64 value:"1" _c31: type:UINT64 value:"2" _c32: type:UINT64 value:"3" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true`,
 	})
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -44,11 +44,11 @@ type VCursor interface {
 	Context() context.Context
 
 	// V3 functions.
-	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
-	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	Execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
+	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
 
 	// Shard-level functions.
-	ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error)
+	ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, canAutocommit bool) (*sqltypes.Result, error)
 	ExecuteStandalone(query string, bindvars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard) (*sqltypes.Result, error)
 	StreamExecuteMulti(query string, rss []*srvtopo.ResolvedShard, bindVars []map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error
 

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -189,7 +189,7 @@ func (route *Route) execute(vcursor VCursor, bindVars map[string]*querypb.BindVa
 	}
 
 	queries := getQueries(route.Query, bvs)
-	result, err := vcursor.ExecuteMultiShard(rss, queries, false /* isDML */, false /* canAutocommit */)
+	result, err := vcursor.ExecuteMultiShard(rss, queries, false /* canAutocommit */)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (route *Route) GetFields(vcursor VCursor, bindVars map[string]*querypb.Bind
 		// This code is unreachable. It's just a sanity check.
 		return nil, fmt.Errorf("No shards for keyspace: %s", route.Keyspace.Name)
 	}
-	qr, err := execShard(vcursor, route.FieldQuery, bindVars, rss[0], false /* isDML */, false /* canAutocommit */)
+	qr, err := execShard(vcursor, route.FieldQuery, bindVars, rss[0], false /* canAutocommit */)
 	if err != nil {
 		return nil, err
 	}
@@ -395,13 +395,13 @@ func execAnyShard(vcursor VCursor, query string, bindVars map[string]*querypb.Bi
 	return vcursor.ExecuteStandalone(query, bindVars, rss[0])
 }
 
-func execShard(vcursor VCursor, query string, bindVars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard, isDML, canAutocommit bool) (*sqltypes.Result, error) {
+func execShard(vcursor VCursor, query string, bindVars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard, canAutocommit bool) (*sqltypes.Result, error) {
 	return vcursor.ExecuteMultiShard([]*srvtopo.ResolvedShard{rs}, []*querypb.BoundQuery{
 		{
 			Sql:           query,
 			BindVariables: bindVars,
 		},
-	}, isDML, canAutocommit)
+	}, canAutocommit)
 }
 
 func getQueries(query string, bvs []map[string]*querypb.BindVariable) []*querypb.BoundQuery {

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -55,7 +55,7 @@ func TestSelectUnsharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_select {} false false`,
+		`ExecuteMultiShard ks.0: dummy_select {} false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -92,7 +92,7 @@ func TestSelectScatter(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -132,7 +132,7 @@ func TestSelectEqualUnique(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
-		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -177,7 +177,7 @@ func TestSelectEqualUniqueScatter(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationKeyRange(-)`,
-		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -230,9 +230,9 @@ func TestSelectEqual(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationKeyspaceIDs(00,80)`,
-		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -242,7 +242,7 @@ func TestSelectEqual(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationKeyspaceIDs(00,80)`,
 		`StreamExecuteMulti dummy_select ks.-20: {} ks.20-: {} `,
 	})
@@ -273,7 +273,7 @@ func TestSelectEqualNoRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationNone()`,
 	})
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
@@ -284,7 +284,7 @@ func TestSelectEqualNoRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationNone()`,
 	})
 	expectResult(t, "sel.StreamExecute", result, nil)
@@ -326,7 +326,7 @@ func TestSelectINUnique(t *testing.T) {
 		`ExecuteMultiShard ` +
 			`ks.-20: dummy_select {__vals: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" > } ` +
 			`ks.20-: dummy_select {__vals: type:TUPLE values:<type:INT64 value:"4" > } ` +
-			`false false`,
+			`false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -399,14 +399,14 @@ func TestSelectINNonUnique(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"2"  false`,
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"4"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"2" `,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"4" `,
 		`ResolveDestinations ks [type:INT64 value:"1"  type:INT64 value:"2"  type:INT64 value:"4" ] Destinations:DestinationKeyspaceIDs(00,80),DestinationKeyspaceIDs(00),DestinationKeyspaceIDs(80)`,
 		`ExecuteMultiShard ` +
 			`ks.-20: dummy_select {__vals: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" > } ` +
 			`ks.20-: dummy_select {__vals: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"4" > } ` +
-			`false false`,
+			`false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -416,9 +416,9 @@ func TestSelectINNonUnique(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"2"  false`,
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"4"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"2" `,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"4" `,
 		`ResolveDestinations ks [type:INT64 value:"1"  type:INT64 value:"2"  type:INT64 value:"4" ] Destinations:DestinationKeyspaceIDs(00,80),DestinationKeyspaceIDs(00),DestinationKeyspaceIDs(80)`,
 		`StreamExecuteMulti dummy_select ks.-20: {__vals: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" > } ks.20-: {__vals: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"4" > } `,
 	})
@@ -509,10 +509,10 @@ func TestRouteGetFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationNone()`,
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteMultiShard ks.-20: dummy_select_field {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select_field {} false`,
 	})
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
 
@@ -522,10 +522,10 @@ func TestRouteGetFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 		`ResolveDestinations ks [type:INT64 value:"1" ] Destinations:DestinationNone()`,
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteMultiShard ks.-20: dummy_select_field {} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select_field {} false`,
 	})
 	expectResult(t, "sel.StreamExecute", result, &sqltypes.Result{})
 }
@@ -565,7 +565,7 @@ func TestRouteSort(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_select {} false false`,
+		`ExecuteMultiShard ks.0: dummy_select {} false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
@@ -651,7 +651,7 @@ func TestRouteSortTruncate(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_select {} false false`,
+		`ExecuteMultiShard ks.0: dummy_select {} false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
@@ -697,7 +697,7 @@ func TestRouteStreamTruncate(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_select {} false false`,
+		`ExecuteMultiShard ks.0: dummy_select {} false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -150,7 +150,7 @@ func (upd *Update) execUpdateUnsharded(vcursor VCursor, bindVars map[string]*que
 	if len(rss) != 1 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Keyspace does not have exactly one shard: %v", rss)
 	}
-	return execShard(vcursor, upd.Query, bindVars, rss[0], true, true /* canAutocommit */)
+	return execShard(vcursor, upd.Query, bindVars, rss[0], true /* canAutocommit */)
 }
 
 func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
@@ -171,7 +171,7 @@ func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb
 		}
 	}
 	rewritten := sqlannotation.AddKeyspaceIDs(upd.Query, [][]byte{ksid}, "")
-	return execShard(vcursor, rewritten, bindVars, rs, true /* isDML */, true /* canAutocommit */)
+	return execShard(vcursor, rewritten, bindVars, rs, true /* canAutocommit */)
 }
 
 // updateVindexEntries performs an update when a vindex is being modified
@@ -181,7 +181,7 @@ func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb
 // Note 2: While changes are being committed, the changing row could be
 // unreachable by either the new or old column values.
 func (upd *Update) updateVindexEntries(vcursor VCursor, query string, bindVars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard, ksid []byte) error {
-	subQueryResult, err := execShard(vcursor, upd.OwnedVindexQuery, bindVars, rs, false /* isDML */, false /* canAutocommit */)
+	subQueryResult, err := execShard(vcursor, upd.OwnedVindexQuery, bindVars, rs, false /* canAutocommit */)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -44,7 +44,7 @@ func TestUpdateUnsharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_update {} true true`,
+		`ExecuteMultiShard ks.0: dummy_update {} true`,
 	})
 
 	// Failure cases
@@ -77,7 +77,7 @@ func TestUpdateEqual(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
-		`ExecuteMultiShard ks.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard ks.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// Failure case
@@ -110,7 +110,7 @@ func TestUpdateEqualNoRoute(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		// This lookup query will return no rows. So, the DML will not be sent anywhere.
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select toc from lkp where from = :from from: type:INT64 value:"1" `,
 	})
 }
 
@@ -179,16 +179,16 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// ResolveDestinations is hard-coded to return -20.
 		// It gets used to perform the subquery to fetch the changing column values.
-		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false`,
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
-		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326" `,
 		// 6 has to be replaced by 3.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326" `,
+		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326" `,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
-		`ExecuteMultiShard sharded.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// No rows changing
@@ -203,9 +203,9 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		// ResolveDestinations is hard-coded to return -20.
 		// It gets used to perform the subquery to fetch the changing column values.
-		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false`,
 		// Subquery returns no rows. So, no vindexes are updated. We still pass-through the original update.
-		`ExecuteMultiShard sharded.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true true`,
+		`ExecuteMultiShard sharded.-20: dummy_update /* vtgate:: keyspace_id:166b40b44aba4bd6 */ {} true`,
 	})
 
 	// Failure case: multiple rows changing.

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -101,7 +101,7 @@ func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 }
 
 // Execute performs a V3 level execution of the query.
-func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	qr, err := vc.executor.Execute(vc.ctx, method, vc.safeSession, query+vc.trailingComments, BindVars)
 	if err == nil {
 		vc.hasPartialDML = true
@@ -110,7 +110,7 @@ func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]
 }
 
 // ExecuteAutocommit performs a V3 level execution of the query in a separate autocommit session.
-func (vc *vcursorImpl) ExecuteAutocommit(method string, query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (vc *vcursorImpl) ExecuteAutocommit(method string, query string, BindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	qr, err := vc.executor.Execute(vc.ctx, method, NewAutocommitSession(vc.safeSession.Session), query+vc.trailingComments, BindVars)
 	if err == nil {
 		vc.hasPartialDML = true
@@ -119,7 +119,7 @@ func (vc *vcursorImpl) ExecuteAutocommit(method string, query string, BindVars m
 }
 
 // ExecuteMultiShard is part of the engine.VCursor interface.
-func (vc *vcursorImpl) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
+func (vc *vcursorImpl) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, canAutocommit bool) (*sqltypes.Result, error) {
 	atomic.AddUint32(&vc.logStats.ShardQueries, uint32(len(queries)))
 	qr, err := vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, rss, commentedShardQueries(queries, vc.trailingComments), vc.target.TabletType, vc.safeSession, false, canAutocommit)
 	if err == nil {

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -68,9 +68,9 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value) ([]*sql
 		var err error
 		var result *sqltypes.Result
 		if lkp.Autocommit {
-			result, err = vcursor.ExecuteAutocommit("VindexLookup", lkp.sel, bindVars, false /* isDML */)
+			result, err = vcursor.ExecuteAutocommit("VindexLookup", lkp.sel, bindVars)
 		} else {
-			result, err = vcursor.Execute("VindexLookup", lkp.sel, bindVars, false /* isDML */)
+			result, err = vcursor.Execute("VindexLookup", lkp.sel, bindVars)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Map: %v", err)
@@ -91,9 +91,9 @@ func (lkp *lookupInternal) Verify(vcursor VCursor, ids, values []sqltypes.Value)
 		var err error
 		var result *sqltypes.Result
 		if lkp.Autocommit {
-			result, err = vcursor.ExecuteAutocommit("VindexVerify", lkp.ver, bindVars, true /* isDML */)
+			result, err = vcursor.ExecuteAutocommit("VindexVerify", lkp.ver, bindVars)
 		} else {
-			result, err = vcursor.Execute("VindexVerify", lkp.ver, bindVars, true /* isDML */)
+			result, err = vcursor.Execute("VindexVerify", lkp.ver, bindVars)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Verify: %v", err)
@@ -160,9 +160,9 @@ func (lkp *lookupInternal) Create(vcursor VCursor, rowsColValues [][]sqltypes.Va
 
 	var err error
 	if lkp.Autocommit {
-		_, err = vcursor.ExecuteAutocommit("VindexCreate", buf.String(), bindVars, true /* isDML */)
+		_, err = vcursor.ExecuteAutocommit("VindexCreate", buf.String(), bindVars)
 	} else {
-		_, err = vcursor.Execute("VindexCreate", buf.String(), bindVars, true /* isDML */)
+		_, err = vcursor.Execute("VindexCreate", buf.String(), bindVars)
 	}
 	if err != nil {
 		return fmt.Errorf("lookup.Create: %v", err)
@@ -205,7 +205,7 @@ func (lkp *lookupInternal) Delete(vcursor VCursor, rowsColValues [][]sqltypes.Va
 			bindVars[lkp.FromColumns[colIdx]] = sqltypes.ValueBindVariable(columnValue)
 		}
 		bindVars[lkp.To] = sqltypes.ValueBindVariable(value)
-		_, err := vcursor.Execute("VindexDelete", lkp.del, bindVars, true /* isDML */)
+		_, err := vcursor.Execute("VindexDelete", lkp.del, bindVars)
 		if err != nil {
 			return fmt.Errorf("lookup.Delete: %v", err)
 		}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -41,16 +41,16 @@ type vcursor struct {
 	autocommits int
 }
 
-func (vc *vcursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
-	return vc.execute(method, query, bindvars, isDML)
+func (vc *vcursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return vc.execute(method, query, bindvars)
 }
 
-func (vc *vcursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (vc *vcursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	vc.autocommits++
-	return vc.execute(method, query, bindvars, isDML)
+	return vc.execute(method, query, bindvars)
 }
 
-func (vc *vcursor) execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (vc *vcursor) execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	vc.queries = append(vc.queries, &querypb.BoundQuery{
 		Sql:           query,
 		BindVariables: bindvars,

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -31,8 +31,8 @@ import (
 // in the current context and session of a VTGate request. Vindexes
 // can use this interface to execute lookup queries.
 type VCursor interface {
-	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
-	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	Execute(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
+	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
 }
 
 // Vindex defines the interface required to register a vindex.


### PR DESCRIPTION
The isDML boolean was passed down through the vcursor API but isn't
actually needed by the scatter conn, so remove it from the various
interface methods.

Signed-off-by: Michael Demmer <mdemmer@slack-corp.com>