### PR TITLE
fix vtexplain when there's a BIT column with a DEFAULT value

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -507,7 +507,7 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 		}
 
 		colTypeMap := tableColumns[table.String()]
-		if colTypeMap == nil {
+		if colTypeMap == nil && table.String() != "dual" {
 			return fmt.Errorf("unable to resolve table name %s", table.String())
 		}
 

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -34,6 +34,10 @@ create table t1 (
 create table t2 (
 	val text default "default2"
 );
+
+create table t3 (
+    b bit(1) default B'0'
+);
 `
 
 	ddls, err := parseSchema(testSchema)


### PR DESCRIPTION
This error would happen when the schema given to vtexplain
has a BIT column with a DEFAULT value of B'0':

  engine.go:163] Engine.Open: failed to load table foo: unknown error: unable to resolve table name dual (errno 1105) (sqlstate HY000) during query: select B'0'

When LoadTable does fetchColumns, it has special handling for Type_BIT
where it does a "select B'0'" to get the binary value of the BIT column's DEFAULT.
vtexplain only knows tables from the "create table"s mentioned in the schema file/SQL
you tell it, so I suppose I could add a dual table there, but this seemed to work.

Signed-off-by: Scott Lanning <scott.lanning@booking.com>