### PR TITLE
make vtexplain treat columns case-insensitively

### DIFF
--- a/data/test/vtexplain/multi-output/unsharded-output.txt
+++ b/data/test/vtexplain/multi-output/unsharded-output.txt
@@ -41,3 +41,8 @@ insert into t1 (id,intval,floatval) values (1,2,3.14) on duplicate key update in
 1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------
+select ID from t1
+
+1 ks_unsharded/-: select ID from t1 limit 10001
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/unsharded-queries.sql
+++ b/data/test/vtexplain/unsharded-queries.sql
@@ -4,3 +4,4 @@ update t1 set intval = 10;
 update t1 set floatval = 9.99;
 delete from t1 where id = 100;
 insert into t1 (id,intval,floatval) values (1,2,3.14) on duplicate key update intval=3, floatval=3.14;
+select ID from t1;

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -423,7 +423,7 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 		tableColumns[table] = make(map[string]querypb.Type)
 
 		for _, col := range ddl.TableSpec.Columns {
-			colName := col.Name.String()
+			colName := strings.ToLower(col.Name.String())
 			defaultVal := ""
 			if col.Type.Default != nil {
 				defaultVal = sqlparser.String(col.Type.Default)
@@ -518,7 +518,7 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 			case *sqlparser.AliasedExpr:
 				switch node := node.Expr.(type) {
 				case *sqlparser.ColName:
-					col := node.Name.String()
+					col := strings.ToLower(node.Name.String())
 					colType := colTypeMap[col]
 					if colType == querypb.Type_NULL_TYPE {
 						return fmt.Errorf("invalid column %s", col)


### PR DESCRIPTION
It works already in vtgate, just specific to vtexplain.
If you have a column name in all caps but code uses lowercase (or vice versa),
vtexplain will choke with something like:

  unknown error: invalid column UPPIE

Just strings.ToLower() the column name.

Signed-off-by: Scott Lanning <scott.lanning@booking.com>