### PR TITLE
Query comment multi shard autocommit

### DIFF
--- a/data/test/vtexplain/deletesharded-queries.sql
+++ b/data/test/vtexplain/deletesharded-queries.sql
@@ -11,3 +11,6 @@ delete from user where name='billy';
 
 /* multi-shard delete with autocommit is supported */
 delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc';
+
+/* multi-shard delete with limit and autocommit is supported using keyrange targeting */
+delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from `ks_sharded[-]`.music_extra where extra='abc' LIMIT 10;

--- a/data/test/vtexplain/deletesharded-queries.sql
+++ b/data/test/vtexplain/deletesharded-queries.sql
@@ -10,4 +10,4 @@ delete from user where name='billy';
 -- delete from music_extra where extra='abc';
 
 /* multi-shard delete with autocommit is supported */
-delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc';
+delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc';

--- a/data/test/vtexplain/deletesharded-queries.sql
+++ b/data/test/vtexplain/deletesharded-queries.sql
@@ -6,5 +6,8 @@ delete from user where id=1;
 /* with lookup index by other field */
 delete from user where name='billy';
 
-/* not supported - multi-shard delete */
---delete from user where pet='rover';
+/* multi-shard delete is supported but racy due to the commit ordering */
+-- delete from music_extra where extra='abc';
+
+/* multi-shard delete with autocommit is supported */
+delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc';

--- a/data/test/vtexplain/insertsharded-queries.sql
+++ b/data/test/vtexplain/insertsharded-queries.sql
@@ -24,4 +24,4 @@ insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 ma
 With the multi-shard autocommit option selected all inserts happen in one
 round trip so there is no race
 */
-insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c');
+insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c');

--- a/data/test/vtexplain/insertsharded-queries.sql
+++ b/data/test/vtexplain/insertsharded-queries.sql
@@ -19,3 +19,9 @@ insert ignore into user (id, name) values(2, 'bob'),(3, 'charlie');
 insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st')on duplicate key update nickname=values(nickname), address=values(address);
 
 */
+
+/*
+With the multi-shard autocommit option selected all inserts happen in one
+round trip so there is no race
+*/
+insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c');

--- a/data/test/vtexplain/multi-output/deletesharded-output.txt
+++ b/data/test/vtexplain/multi-output/deletesharded-output.txt
@@ -60,3 +60,23 @@ delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc'
 1 ks_sharded/c0-: commit
 
 ----------------------------------------------------------------------
+delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from `ks_sharded[-]`.music_extra where extra='abc' LIMIT 10
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: select id from music_extra where extra = 'abc' limit 10 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: commit
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: select id from music_extra where extra = 'abc' limit 10 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: commit
+1 ks_sharded/80-c0: begin
+1 ks_sharded/80-c0: select id from music_extra where extra = 'abc' limit 10 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: commit
+1 ks_sharded/c0-: begin
+1 ks_sharded/c0-: select id from music_extra where extra = 'abc' limit 10 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/deletesharded-output.txt
+++ b/data/test/vtexplain/multi-output/deletesharded-output.txt
@@ -40,23 +40,23 @@ delete from user where name='billy'
 7 ks_sharded/80-c0: commit
 
 ----------------------------------------------------------------------
-delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc'
+delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc'
 
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
-1 ks_sharded/-40: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
 1 ks_sharded/-40: commit
 1 ks_sharded/40-80: begin
 1 ks_sharded/40-80: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
-1 ks_sharded/40-80: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
 1 ks_sharded/40-80: commit
 1 ks_sharded/80-c0: begin
 1 ks_sharded/80-c0: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
-1 ks_sharded/80-c0: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
 1 ks_sharded/80-c0: commit
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
-1 ks_sharded/c0-: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
 1 ks_sharded/c0-: commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/deletesharded-output.txt
+++ b/data/test/vtexplain/multi-output/deletesharded-output.txt
@@ -40,3 +40,23 @@ delete from user where name='billy'
 7 ks_sharded/80-c0: commit
 
 ----------------------------------------------------------------------
+delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where extra='abc'
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: commit
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: commit
+1 ks_sharded/80-c0: begin
+1 ks_sharded/80-c0: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: commit
+1 ks_sharded/c0-: begin
+1 ks_sharded/c0-: select id from music_extra where extra = 'abc' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from music_extra where id in (1)/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/insertsharded-output.txt
+++ b/data/test/vtexplain/multi-output/insertsharded-output.txt
@@ -63,13 +63,13 @@ insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 ma
 5 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
-insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c')
+insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c')
 
 1 ks_sharded/-40: begin
-1 ks_sharded/-40: insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (1, 'a'), (2, 'b') /* vtgate:: keyspace_id:166b40b44aba4bd6,06e7ea22ce92708f */
+1 ks_sharded/-40: insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (1, 'a'), (2, 'b') /* vtgate:: keyspace_id:166b40b44aba4bd6,06e7ea22ce92708f */
 1 ks_sharded/-40: commit
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (3, 'c') /* vtgate:: keyspace_id:4eb190c9a2fa169c */
+1 ks_sharded/40-80: insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (3, 'c') /* vtgate:: keyspace_id:4eb190c9a2fa169c */
 1 ks_sharded/40-80: commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/insertsharded-output.txt
+++ b/data/test/vtexplain/multi-output/insertsharded-output.txt
@@ -63,3 +63,13 @@ insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 ma
 5 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
+insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra (id, extra) values (1, 'a'), (2, 'b'), (3, 'c')
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (1, 'a'), (2, 'b') /* vtgate:: keyspace_id:166b40b44aba4bd6,06e7ea22ce92708f */
+1 ks_sharded/-40: commit
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into music_extra(id, extra) values (3, 'c') /* vtgate:: keyspace_id:4eb190c9a2fa169c */
+1 ks_sharded/40-80: commit
+
+----------------------------------------------------------------------

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -163,7 +163,7 @@ func ExtractMysqlComment(sql string) (version string, innerSQL string) {
 	return version, innerSQL
 }
 
-const commentDirectivePreamble = "/*vt!"
+const commentDirectivePreamble = "/*vt+"
 
 // CommentDirectives is the parsed representation for execution directives
 // conveyed in query comments
@@ -172,7 +172,7 @@ type CommentDirectives map[string]interface{}
 // ExtractCommentDirectives parses the comment list for any execution directives
 // of the form:
 //
-//     /*vt! OPTION_ONE=1 OPTION_TWO OPTION_THREE=abcd */
+//     /*vt+ OPTION_ONE=1 OPTION_TWO OPTION_THREE=abcd */
 //
 // It returns the map of the directive values or nil if there aren't any.
 func ExtractCommentDirectives(comments Comments) CommentDirectives {

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -224,45 +224,45 @@ func TestExtractCommentDirectives(t *testing.T) {
 		input: "/* not a vt comment */",
 		vals:  nil,
 	}, {
-		input: "/*vt! */",
+		input: "/*vt+ */",
 		vals:  CommentDirectives{},
 	}, {
-		input: "/*vt! SINGLE_OPTION */",
+		input: "/*vt+ SINGLE_OPTION */",
 		vals: CommentDirectives{
 			"SINGLE_OPTION": true,
 		},
 	}, {
-		input: "/*vt! ONE_OPT TWO_OPT */",
+		input: "/*vt+ ONE_OPT TWO_OPT */",
 		vals: CommentDirectives{
 			"ONE_OPT": true,
 			"TWO_OPT": true,
 		},
 	}, {
-		input: "/*vt! ONE_OPT */ /* other comment */ /*vt! TWO_OPT */",
+		input: "/*vt+ ONE_OPT */ /* other comment */ /*vt+ TWO_OPT */",
 		vals: CommentDirectives{
 			"ONE_OPT": true,
 			"TWO_OPT": true,
 		},
 	}, {
-		input: "/*vt! ONE_OPT=abc TWO_OPT=def */",
+		input: "/*vt+ ONE_OPT=abc TWO_OPT=def */",
 		vals: CommentDirectives{
 			"ONE_OPT": "abc",
 			"TWO_OPT": "def",
 		},
 	}, {
-		input: "/*vt! ONE_OPT=true TWO_OPT=false */",
+		input: "/*vt+ ONE_OPT=true TWO_OPT=false */",
 		vals: CommentDirectives{
 			"ONE_OPT": true,
 			"TWO_OPT": false,
 		},
 	}, {
-		input: "/*vt! ONE_OPT=true TWO_OPT=\"false\" */",
+		input: "/*vt+ ONE_OPT=true TWO_OPT=\"false\" */",
 		vals: CommentDirectives{
 			"ONE_OPT": true,
 			"TWO_OPT": "\"false\"",
 		},
 	}, {
-		input: "/*vt! RANGE_OPT=[a:b] ANOTHER ANOTHER_WITH_VALEQ=val= AND_ONE_WITH_EQ== */",
+		input: "/*vt+ RANGE_OPT=[a:b] ANOTHER ANOTHER_WITH_VALEQ=val= AND_ONE_WITH_EQ== */",
 		vals: CommentDirectives{
 			"RANGE_OPT":          "[a:b]",
 			"ANOTHER":            true,

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -195,18 +195,18 @@ func TestAutocommitDeleteMultiShard(t *testing.T) {
 func TestAutocommitDeleteMultiShardAutoCommit(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 
-	if _, err := autocommitExec(executor, "delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)"); err != nil {
+	if _, err := autocommitExec(executor, "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)"); err != nil {
 		t.Fatal(err)
 	}
 	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
-		Sql:           "delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)/* vtgate:: filtered_replication_unfriendly */",
+		Sql:           "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)/* vtgate:: filtered_replication_unfriendly */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	})
 	testAsTransactionCount(t, "sbc1", sbc1, 1)
 	testCommitCount(t, "sbc1", sbc1, 0)
 
 	testBatchQuery(t, "sbc2", sbc2, &querypb.BoundQuery{
-		Sql:           "delete /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)/* vtgate:: filtered_replication_unfriendly */",
+		Sql:           "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id in (1, 2)/* vtgate:: filtered_replication_unfriendly */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	})
 	testAsTransactionCount(t, "sbc2", sbc2, 1)
@@ -268,11 +268,11 @@ func TestAutocommitInsertLookup(t *testing.T) {
 func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 
-	if _, err := autocommitExec(executor, "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)"); err != nil {
+	if _, err := autocommitExec(executor, "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)"); err != nil {
 		t.Fatal(err)
 	}
 	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
-		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id0, 2) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id0, 2) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id0": sqltypes.Int64BindVariable(1),
 			"_user_id1": sqltypes.Int64BindVariable(3),
@@ -282,7 +282,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	testCommitCount(t, "sbc1", sbc1, 0)
 
 	testBatchQuery(t, "sbc2", sbc2, &querypb.BoundQuery{
-		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id0": sqltypes.Int64BindVariable(1),
 			"_user_id1": sqltypes.Int64BindVariable(3),
@@ -294,7 +294,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	executor, sbc1, sbc2, _ = createExecutorEnv()
 	// Make the first shard fail - the second completes anyway
 	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
-	_, err := autocommitExec(executor, "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)")
+	_, err := autocommitExec(executor, "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)")
 	if err == nil || !strings.Contains(err.Error(), "INVALID_ARGUMENT") {
 		t.Errorf("expected invalid argument error, got %v", err)
 	}
@@ -305,7 +305,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	testCommitCount(t, "sbc1", sbc1, 0)
 
 	testBatchQuery(t, "sbc2", sbc2, &querypb.BoundQuery{
-		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id0": sqltypes.Int64BindVariable(1),
 			"_user_id1": sqltypes.Int64BindVariable(3),

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -25,6 +26,7 @@ import (
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 // This file contains tests for all the autocommit code paths
@@ -214,6 +216,58 @@ func TestAutocommitInsertLookup(t *testing.T) {
 	}})
 	testAsTransactionCount(t, "sbc1", sbc1, 0)
 	testCommitCount(t, "sbc1", sbc1, 1)
+}
+
+// TestAutocommitInsertShardAutoCommit: instant-commit.
+func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)"); err != nil {
+		t.Fatal(err)
+	}
+	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
+		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id0, 2) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+			"_user_id1": sqltypes.Int64BindVariable(3),
+		},
+	})
+	testAsTransactionCount(t, "sbc1", sbc1, 1)
+	testCommitCount(t, "sbc1", sbc1, 0)
+
+	testBatchQuery(t, "sbc2", sbc2, &querypb.BoundQuery{
+		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+			"_user_id1": sqltypes.Int64BindVariable(3),
+		},
+	})
+	testAsTransactionCount(t, "sbc2", sbc2, 1)
+	testCommitCount(t, "sbc2", sbc2, 0)
+
+	executor, sbc1, sbc2, _ = createExecutorEnv()
+	// Make the first shard fail - the second completes anyway
+	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
+	_, err := autocommitExec(executor, "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)")
+	if err == nil || !strings.Contains(err.Error(), "INVALID_ARGUMENT") {
+		t.Errorf("expected invalid argument error, got %v", err)
+	}
+	if len(sbc1.Queries) != 0 || len(sbc1.BatchQueries) != 0 {
+		t.Errorf("expected no queries")
+	}
+	testAsTransactionCount(t, "sbc1", sbc1, 1)
+	testCommitCount(t, "sbc1", sbc1, 0)
+
+	testBatchQuery(t, "sbc2", sbc2, &querypb.BoundQuery{
+		Sql: "insert /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+			"_user_id1": sqltypes.Int64BindVariable(3),
+		},
+	})
+	testAsTransactionCount(t, "sbc2", sbc2, 1)
+	testCommitCount(t, "sbc2", sbc2, 0)
+
 }
 
 func TestAutocommitInsertMultishard(t *testing.T) {

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -226,5 +226,6 @@ func (del *Delete) execDeleteByDestination(vcursor VCursor, bindVars map[string]
 			BindVariables: bindVars,
 		}
 	}
-	return vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, true /* canAutocommit */)
+	autocommit := len(rss) == 1 && vcursor.AutocommitApproval()
+	return vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, autocommit)
 }

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -59,6 +59,10 @@ type Delete struct {
 
 	// OwnedVindexQuery is used for deleting lookup vindex entries.
 	OwnedVindexQuery string
+
+	// Option to override the standard behavior and allow a multi-shard delete
+	// to use single round trip autocommit.
+	MultiShardAutocommit bool
 }
 
 // MarshalJSON serializes the Delete into a JSON representation.
@@ -226,6 +230,6 @@ func (del *Delete) execDeleteByDestination(vcursor VCursor, bindVars map[string]
 			BindVariables: bindVars,
 		}
 	}
-	autocommit := len(rss) == 1 && vcursor.AutocommitApproval()
+	autocommit := (len(rss) == 1 || del.MultiShardAutocommit) && vcursor.AutocommitApproval()
 	return vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, autocommit)
 }

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -243,7 +243,7 @@ func TestDeleteSharded(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.-20: dummy_delete {} ks.20-: dummy_delete {} true true`,
+		`ExecuteMultiShard ks.-20: dummy_delete {} ks.20-: dummy_delete {} true false`,
 	})
 
 	// Failure case

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -49,7 +49,11 @@ func (t noopVCursor) ExecuteAutocommit(method string, query string, bindvars map
 	panic("unimplemented")
 }
 
-func (t noopVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
+func (t noopVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, autocommit bool) (*sqltypes.Result, error) {
+	panic("unimplemented")
+}
+
+func (t noopVCursor) AutocommitApproval() bool {
 	panic("unimplemented")
 }
 
@@ -94,6 +98,10 @@ func (f *loggingVCursor) Execute(method string, query string, bindvars map[strin
 func (f *loggingVCursor) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
 	f.log = append(f.log, fmt.Sprintf("ExecuteMultiShard %v%v %v", printResolvedShardQueries(rss, queries), isDML, canAutocommit))
 	return f.nextResult()
+}
+
+func (f *loggingVCursor) AutocommitApproval() bool {
+	return true
 }
 
 func (f *loggingVCursor) ExecuteStandalone(query string, bindvars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -67,6 +67,15 @@ type Insert struct {
 	Prefix string
 	Mid    []string
 	Suffix string
+
+	// Option to override the standard behavior and allow a multi-shard insert
+	// to use single round trip autocommit.
+	//
+	// This is a clear violation of the SQL semantics since it means the statement
+	// is not atomic in the presence of PK conflicts on one shard and not another.
+	// However some application use cases would prefer that the statement partially
+	// succeed in order to get the performance benefits of autocommit.
+	MultiShardAutocommit bool
 }
 
 // MarshalJSON serializes the Insert into a JSON representation.
@@ -203,7 +212,7 @@ func (ins *Insert) execInsertSharded(vcursor VCursor, bindVars map[string]*query
 		return nil, vterrors.Wrap(err, "execInsertSharded")
 	}
 
-	autocommit := len(rss) == 1 && vcursor.AutocommitApproval()
+	autocommit := (len(rss) == 1 || ins.MultiShardAutocommit) && vcursor.AutocommitApproval()
 	result, err := vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, autocommit)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "execInsertSharded")

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -203,7 +203,8 @@ func (ins *Insert) execInsertSharded(vcursor VCursor, bindVars map[string]*query
 		return nil, vterrors.Wrap(err, "execInsertSharded")
 	}
 
-	result, err := vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, true /* canAutocommit */)
+	autocommit := len(rss) == 1 && vcursor.AutocommitApproval()
+	result, err := vcursor.ExecuteMultiShard(rss, queries, true /* isDML */, autocommit)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "execInsertSharded")
 	}

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -183,7 +183,7 @@ func TestInsertShardedSimple(t *testing.T) {
 		`ExecuteMultiShard ` +
 			`sharded.20-: prefix mid1, mid3 suffix /* vtgate:: keyspace_id:166b40b44aba4bd6,4eb190c9a2fa169c */ {_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
 			`sharded.-20: prefix mid2 suffix /* vtgate:: keyspace_id:06e7ea22ce92708f */ {_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 
@@ -338,7 +338,7 @@ func TestInsertShardedGenerate(t *testing.T) {
 			`sharded.-20: prefix mid2 suffix /* vtgate:: keyspace_id:06e7ea22ce92708f */ ` +
 			`{__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"2" __seq2: type:INT64 value:"2" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 
 	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerate.
@@ -480,7 +480,7 @@ func TestInsertShardedOwned(t *testing.T) {
 			`_c20: type:INT64 value:"7" _c21: type:INT64 value:"8" _c22: type:INT64 value:"9" ` +
 			`_c30: type:INT64 value:"10" _c31: type:INT64 value:"11" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 
@@ -744,7 +744,7 @@ func TestInsertShardedIgnoreOwned(t *testing.T) {
 			`_c20: type:INT64 value:"9" _c22: type:INT64 value:"11" _c23: type:INT64 value:"12" ` +
 			`_c30: type:INT64 value:"13" _c33: type:INT64 value:"16" ` +
 			`_id0: type:INT64 value:"1" _id2: type:INT64 value:"3" _id3: type:INT64 value:"4" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 
@@ -971,7 +971,7 @@ func TestInsertShardedUnownedVerify(t *testing.T) {
 			`_c20: type:INT64 value:"7" _c21: type:INT64 value:"8" _c22: type:INT64 value:"9" ` +
 			`_c30: type:INT64 value:"10" _c31: type:INT64 value:"11" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 
@@ -1085,7 +1085,7 @@ func TestInsertShardedIgnoreUnownedVerify(t *testing.T) {
 			`sharded.-20: prefix mid3 suffix /* vtgate:: keyspace_id:4eb190c9a2fa169c */ ` +
 			`{_c30: type:INT64 value:"10" _c32: type:INT64 value:"12" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 
@@ -1297,7 +1297,7 @@ func TestInsertShardedUnownedReverseMap(t *testing.T) {
 			`_c20: _c21: _c22: ` +
 			`_c30: type:UINT64 value:"1" _c31: type:UINT64 value:"2" _c32: type:UINT64 value:"3" ` +
 			`_id0: type:INT64 value:"1" _id1: type:INT64 value:"2" _id2: type:INT64 value:"3" } ` +
-			`true true`,
+			`true false`,
 	})
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -46,6 +46,7 @@ type VCursor interface {
 	// V3 functions.
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
 	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	AutocommitApproval() bool
 
 	// Shard-level functions.
 	ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -193,7 +193,7 @@ func (route *Route) execute(vcursor VCursor, bindVars map[string]*querypb.BindVa
 	}
 
 	queries := getQueries(route.Query, bvs)
-	result, err := vcursor.ExecuteMultiShard(rss, queries, false /* isDML */, false /* canAutocommit */)
+	result, err := vcursor.ExecuteMultiShard(rss, queries, false /* isDML */, false /* autocommit */)
 	if err != nil {
 		return nil, err
 	}
@@ -400,12 +400,13 @@ func execAnyShard(vcursor VCursor, query string, bindVars map[string]*querypb.Bi
 }
 
 func execShard(vcursor VCursor, query string, bindVars map[string]*querypb.BindVariable, rs *srvtopo.ResolvedShard, isDML, canAutocommit bool) (*sqltypes.Result, error) {
+	autocommit := canAutocommit && vcursor.AutocommitApproval()
 	return vcursor.ExecuteMultiShard([]*srvtopo.ResolvedShard{rs}, []*querypb.BoundQuery{
 		{
 			Sql:           query,
 			BindVariables: bindVars,
 		},
-	}, isDML, canAutocommit)
+	}, isDML, autocommit)
 }
 
 func getQueries(query string, bvs []map[string]*querypb.BindVariable) []*querypb.BoundQuery {

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -116,6 +116,12 @@ type ContextVSchema interface {
 	DefaultKeyspace() (*vindexes.Keyspace, error)
 }
 
+const (
+	// DirectiveMultiShardAutocommit is the query comment directive to allow
+	// single round trip autocommit with a multi-shard statement.
+	DirectiveMultiShardAutocommit = "MULTI_SHARD_AUTOCOMMIT"
+)
+
 // Build builds a plan for a query based on the specified vschema.
 // It's the main entry point for this package.
 func Build(query string, vschema ContextVSchema) (*engine.Plan, error) {

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -65,6 +65,12 @@ func buildDeletePlan(del *sqlparser.Delete, vschema ContextVSchema) (*engine.Del
 		return nil, err
 	}
 	edel.Table = table
+
+	directives := sqlparser.ExtractCommentDirectives(del.Comments)
+	if directives.IsSet(DirectiveMultiShardAutocommit) {
+		edel.MultiShardAutocommit = true
+	}
+
 	if destTarget != nil {
 		if destTabletType != topodatapb.TabletType_MASTER {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unsupported: DELETE statement with a replica target")
@@ -90,6 +96,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema ContextVSchema) (*engine.Del
 			return edel, errors.New("unsupported: multi shard delete with limit")
 		}
 	}
+
 	edel.OwnedVindexQuery = generateDeleteSubquery(del, edel.Table)
 	return edel, nil
 }

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -106,6 +106,12 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 	if len(ins.Columns) == 0 {
 		return nil, errors.New("no column list")
 	}
+
+	directives := sqlparser.ExtractCommentDirectives(ins.Comments)
+	if directives.IsSet(DirectiveMultiShardAutocommit) {
+		eins.MultiShardAutocommit = true
+	}
+
 	var rows sqlparser.Values
 	switch insertValues := ins.Rows.(type) {
 	case *sqlparser.Select, *sqlparser.Union:

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -166,14 +166,12 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	tabletType topodatapb.TabletType,
 	session *SafeSession,
 	notInTransaction bool,
-	canAutocommit bool,
+	autocommit bool,
 ) (*sqltypes.Result, error) {
 
 	// mu protects qr
 	var mu sync.Mutex
 	qr := new(sqltypes.Result)
-
-	canCommit := len(rss) == 1 && canAutocommit && session.AutocommitApproval()
 
 	err := stc.multiGoTransaction(
 		ctx,
@@ -193,7 +191,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 			}
 
 			switch {
-			case canCommit:
+			case autocommit:
 				innerqr, err = stc.executeAutocommit(ctx, rs, queries[i].Sql, queries[i].BindVariables, opts)
 			case shouldBegin:
 				innerqr, transactionID, err = rs.QueryService.BeginExecute(ctx, rs.Target, queries[i].Sql, queries[i].BindVariables, opts)


### PR DESCRIPTION
# Description
Add support for optional single round trip autocommit on multi-shard transactions, controlled by a query comment directive.

# Motivation
In order to maintain proper SQL atomicity constraints, a multi-shard DML statement is executed in two phases -- first it sends the statement to each shard, then if all statements succeed, it sends a commit to each in turn.

This way a failure on one shard is detectable and the transactions on the other shards can be rolled back. However, for certain application use cases it is actually preferable to have a best-effort multi-shard transaction which breaks the atomicity requirement and accepts the possibility of partial success to avoid the overhead of multiple round trips from the vtgate to the vttablets.

# Implementation
This PR adds support for vitess-specific comment directives, inspired by the mysql optimizer hints syntax:
https://dev.mysql.com/doc/refman/5.7/en/optimizer-hints.html

This adds an infrastructure so that comments of the form `/*vt! KEY_NAME=<value> */` that follow the statement can be parsed and inspected by the query planner for non-standard optimizations.

To address the above specific use case, this adds a multi-shard autocommit directive so that queries of this form:

`INSERT /*vt! MULTI_SHARD_AUTOCOMMIT=1 */ INTO mytable (c1, c2) VALUES (1,2), (3,4), (5,6)`

Are sent to potentially multiple shards, each in a single autocommit transaction.

# Checklist
- [x] Comment syntax and parsing hooks
- [x] Insert autocommit support
- [x] ~Update autocommit support~ (multi-shard updates aren't yet supported)
- [x] Delete autocommit support
- [x] End to end tests for success and partial failure
- [x] Vtexplain examples to show this in action
