### PR TITLE
dev.env: Fix that $GOPATH always had a trailing ":" if the Vitess directory is the only element in there.

### DIFF
--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -37,9 +37,24 @@ function goversion_min() {
 function prepend_path() {
   # $1 path variable
   # $2 path to add
-  if [ -d "$2" ] && [[ ":$1:" != *":$2:"* ]]; then
-    echo "$2:$1"
-  else
+  if [[ ! -d "$2" ]]; then
+    # To be added path does not exist. Ignore it and return the path variable unchanged.
     echo "$1"
+    return
   fi
+
+  if [[ -z "$1" ]]; then
+    # path variable is empty. Set its initial value to the path to add.
+    echo "$2"
+    return
+  fi
+
+  if [[ ":$1:" != *":$2:"* ]]; then
+    # path variable does not contain path to add yet. Prepend it.
+    echo "$2:$1"
+    return
+  fi
+
+  # Return path variable unchanged.
+  echo "$1"
 }


### PR DESCRIPTION
This was a regression which was introduced by https://github.com/vitessio/vitess/pull/3722.

Before this fix, the "go" binary always failed to run with the following error:

> go: GOPATH entry is relative; must be absolute path: "".
> For more details see: 'go help gopath'

Signed-off-by: Michael Berlin <mberlin@google.com>