### PR TITLE
test: Work-around Python exception when getting the hostname on my Macbook.

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -51,8 +51,17 @@ from vtproto import topodata_pb2
 
 options = None
 devnull = open('/dev/null', 'w')
-hostname = socket.getaddrinfo(
-    socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
+try:
+  hostname = socket.getaddrinfo(
+      socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
+except socket.gaierror:
+  # Fallback to 'localhost' if getfqdn() returns this value for "::1" and
+  # getaddrinfo() cannot resolve it and throws an exception.
+  # This error scenario was observed on mberlin@'s corp Macbook in 2018.
+  if socket.getfqdn() == '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa':  # pylint: disable=line-too-long
+    hostname = 'localhost'
+  else:
+    raise
 
 
 class TestError(Exception):


### PR DESCRIPTION
All Python tests fail on my Macbook without this:

> $ ./test/python_client_test.py
> Traceback (most recent call last):
>   File "./test/python_client_test.py", line 24, in <module>
>     import utils
>   File "/Users/mberlin/vitess/src/vitess.io/vitess/test/utils.py", line 55, in <module>
>     socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
> socket.gaierror: [Errno 8] nodename nor servname provided, or not known

Signed-off-by: Michael Berlin <mberlin@google.com>