### PR TITLE
test: Fix broken vtctld_web_test when executed within Docker (and not on Travis).

### DIFF
--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -124,6 +124,11 @@ fi
 # Mirror permissions to "other" from the owning group (for which we assume it has at least rX permissions).
 chmod -R o=g .
 
+# This is required by the vtctld_web_test.py test.
+# Otherwise, /usr/bin/chromium will crash with the error:
+# "Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted"
+args="$args --cap-add=SYS_ADMIN"
+
 args="$args -v /dev/log:/dev/log"
 args="$args -v $PWD:/tmp/src"
 


### PR DESCRIPTION
This test was broken on newer Docker versions. According to https://serverfault.com/questions/824809/chrome-under-docker-cap-sys-admin-vs-privileged probably since Docker 1.12.

Note that Travis CI uses a different mechanism to run this test and
therefore the test always passed there.

However, project maintainers who followed
https://github.com/vitessio/vitess/tree/master/docker/bootstrap#for-vitess-project-maintainers
to update (and test!) the bootstrap images should have seen this error.

Note that I have extended test/environment.py. It now configures
webdriver to let chromedriver always log everything. If Chrome does not
start, the test will print the chromedriver log file. This is how I
found out why Chrome did not come up.

Also note that I saw some flaky test invocations. I hope that turning on
the logging in chromedriver does not result into timing issues and more
flaky tests. If so, we should consider to fix the tests and make them
more robust.

Signed-off-by: Michael Berlin <mberlin@google.com>