### PR TITLE
callinfo: Switch to the new grpc.Method() function to find out the gRPC method of an RPC's context.

### DIFF
--- a/go/vt/callinfo/plugin_grpc.go
+++ b/go/vt/callinfo/plugin_grpc.go
@@ -23,18 +23,18 @@ import (
 	"html/template"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/transport"
+	"google.golang.org/grpc"
 )
 
 // GRPCCallInfo returns an augmented context with a CallInfo structure,
 // only for gRPC contexts.
 func GRPCCallInfo(ctx context.Context) context.Context {
-	stream, ok := transport.StreamFromContext(ctx)
+	method, ok := grpc.Method(ctx)
 	if !ok {
 		return ctx
 	}
 	return NewContext(ctx, &gRPCCallInfoImpl{
-		method: stream.Method(),
+		method: method,
 	})
 }
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,19 @@
+# govendor
+
+We manage the file `vendor.json` through the [govendor](https://github.com/kardianos/govendor) command.
+
+## Add a new dependency
+
+```sh
+govendor fetch <package_path>@<version>
+```
+
+If available, please always use a release version. If not, you can omit `@<version>`.
+
+## Update a dependency
+
+Example gRPC:
+
+```sh
+govendor fetch google.golang.org/grpc/...@v1.11.2
+```

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1129,14 +1129,6 @@
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
-			"revisionTime": "2017-10-25T22:03:47Z",
-			"version": "=v1.7.1",
-			"versionExact": "v1.7.1"
-		},
-		{
-			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
-			"path": "google.golang.org/grpc/grpclog",
 			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
 			"revisionTime": "2018-02-14T18:40:50Z",
 			"version": "v1.10.0",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1039,204 +1039,204 @@
 			"revisionTime": "2017-05-31T20:35:52Z"
 		},
 		{
-			"checksumSHA1": "lHOyCRQE8yw0+NfIjOmo8wS9VTU=",
+			"checksumSHA1": "Ts0J7j6y5Js06AhCzZj9XNJoB+g=",
 			"path": "google.golang.org/grpc",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "xBhmO0Vn4kzbmySioX+2gBImrkk=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "CPWX/IgaQSR3+78j4sPrvHNkW+U=",
 			"path": "google.golang.org/grpc/balancer/base",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "DJ1AtOk4Pu7bqtUMob95Hw8HPNw=",
 			"path": "google.golang.org/grpc/balancer/roundrobin",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "j8Qs+yfgwYYOtodB/1bSlbzV5rs=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "KthiDKNPHMeIu967enqtE4NaZzI=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "QbufP1o0bXrtd5XecqdRCK/Vl0M=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "mJTBJC0n9J2CV+tHX+dJosYOZmg=",
 			"path": "google.golang.org/grpc/encoding",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
 			"path": "google.golang.org/grpc/encoding/proto",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "QyasSHZlgle+PHSIQ2/p+fr+ihY=",
 			"path": "google.golang.org/grpc/grpclog/glogger",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "Qvf3zdmRCSsiM/VoBv0qB/naHtU=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "X1BGbIb3xaxiAG4O1Ot5YjPlh4g=",
+			"checksumSHA1": "RUgjR0iUFLCgdLAnNqiH+8jTzuk=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "5dwF592DPvhF2Wcex3m7iV6aGRQ=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "IKIaz1gx/CgosQ6U709XWiPPRXA=",
+			"checksumSHA1": "qbA3XLvX0RTvaqQefvFDtE9GaJs=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "WpWF+bDzObsHf+bjoGpb/abeFxo=",
 			"path": "google.golang.org/grpc/resolver/dns",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
 			"path": "google.golang.org/grpc/resolver/passthrough",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "G9lgXNi7qClo5sM2s6TbTHLFR3g=",
+			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "/7i6dC0tFTtGMxykj9VduLEfBCU=",
+			"checksumSHA1": "FXiovlBmrYdS4QT0Z4nV+x+v5HI=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "fgt81mMAzx0Zo0ZuI2Vv0/RYApA=",
+			"checksumSHA1": "sg7RY87LaWXaZMj0cuLQQaJJQYo=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "8e4536a86ab602859c20df5ebfd0bd4228d08655",
-			"revisionTime": "2018-02-14T18:40:50Z",
-			"version": "v1.10.0",
-			"versionExact": "v1.10.0"
+			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
+			"revisionTime": "2018-04-04T21:41:50Z",
+			"version": "v1.11.2",
+			"versionExact": "v1.11.2"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
The previous way was internal only and deprecreated.

Therefore, gRPC Go team provided this new Method() function for us.

It is available since gRPC Go 1.11.2: https://github.com/grpc/grpc-go/releases/tag/v1.11.2
(I upgraded the vendored package as part of this PR.)