### PR TITLE
docker/bootstrap: Add retries for APT GPG key retrieval.

### DIFF
--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -1,7 +1,7 @@
 FROM vitess/bootstrap:common
 
 # Install MySQL 5.6
-RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
+RUN for i in $(seq 1 10); do apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev && \

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -1,7 +1,7 @@
 FROM vitess/bootstrap:common
 
 # Install MySQL 5.7
-RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
+RUN for i in $(seq 1 10); do apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev && \

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -1,8 +1,7 @@
 FROM vitess/bootstrap:common
 
 # Install Percona 5.6
-RUN apt-key adv --keyserver keys.gnupg.net \
-        --recv-keys 8507EFA5 && \
+RUN for i in $(seq 1 10); do apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5 && break; done && \
     add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -1,8 +1,7 @@
 FROM vitess/bootstrap:common
 
 # Install Percona 5.7
-RUN apt-key adv --keyserver keys.gnupg.net \
-        --recv-keys 8507EFA5 && \
+RUN for i in $(seq 1 10); do apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5 && break; done && \
     add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \


### PR DESCRIPTION
Retrieving the key from the key server official is extremely flakely and
be usually solved by a retry.

Without this retry, "make docker_bootstrap" may fail in the middle and
we do not have a good way to skip building the images which were just
successfully built.

This retry (with 10 attempts in total) should work-around the transient
errors and make sure that a docker build always succeeds.

Signed-off-by: Michael Berlin <mberlin@google.com>