### PR TITLE
docker: Add gRPC Python directory to PYTHONPATH.

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -43,7 +43,7 @@ ENV GOTOP $VTTOP/go
 ENV PYTOP $VTTOP/py
 ENV VTDATAROOT $VTROOT/vtdataroot
 ENV VTPORTSTART 15000
-ENV PYTHONPATH $VTROOT/dist/py-mock-1.0.1/lib/python2.7/site-packages:$VTROOT/py-vtdb:$VTROOT/dist/selenium/lib/python2.7/site-packages
+ENV PYTHONPATH $VTROOT/dist/grpc/usr/local/lib/python2.7/site-packages:$VTROOT/dist/py-mock-1.0.1/lib/python2.7/site-packages:$VTROOT/py-vtdb:$VTROOT/dist/selenium/lib/python2.7/site-packages
 ENV GOBIN $VTROOT/bin
 ENV GOPATH $VTROOT
 ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$VTROOT/dist/chromedriver:$PATH


### PR DESCRIPTION
Without it, all Python tests failed because the protobuf and gRPC
modules not be imported.

I forgot this change in: https://github.com/vitessio/vitess/pull/3810

Signed-off-by: Michael Berlin <mberlin@google.com>