### PR TITLE
Makefile: Reduce number of concurrent tests from 4 to 2 for "make docker_bootstrap_test".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ docker_bootstrap:
 	for i in $(DOCKER_IMAGES); do echo "building bootstrap image: $$i"; docker/bootstrap/build.sh $$i || exit 1; done
 
 docker_bootstrap_test:
-	flavors='$(DOCKER_IMAGES_FOR_TEST)' && ./test.go -pull=false -parallel=4 -flavor=$${flavors// /,}
+	flavors='$(DOCKER_IMAGES_FOR_TEST)' && ./test.go -pull=false -parallel=2 -flavor=$${flavors// /,}
 
 docker_bootstrap_push:
 	for i in $(DOCKER_IMAGES); do echo "pushing boostrap image: $$i"; docker push vitess/bootstrap:$$i || exit 1; done


### PR DESCRIPTION
4 tests concurrently is killing my workstation :)

Signed-off-by: Michael Berlin <mberlin@google.com>