### PR TITLE
v3: revamp: simplify some relationships

### DIFF
--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -106,7 +106,8 @@ func (route *Route) MarshalJSON() ([]byte, error) {
 }
 
 // RouteOpcode is a number representing the opcode
-// for the Route primitve.
+// for the Route primitve. Adding new opcodes here
+// will require review of the join code in planbuilder.
 type RouteOpcode int
 
 // This is the list of RouteOpcode values.

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -57,7 +57,7 @@ type builder interface {
 
 	// PushFilter pushes a WHERE or HAVING clause expression
 	// to the specified origin.
-	PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, origin builder) error
+	PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereType string, origin builder) error
 
 	// PushSelect pushes the select expression to the specified
 	// originator. If successful, the originator must create

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -31,10 +31,6 @@ import (
 // builder defines the interface that a primitive must
 // satisfy.
 type builder interface {
-	// Symtab returns the associated symtab.
-	// Please copy code from an existing primitive to define this function.
-	Symtab() *symtab
-
 	// Order is the execution order of the primitve. If there are subprimitves,
 	// the order is one above the order of the subprimitives.
 	// This is because the primitive executes its subprimitives first and
@@ -55,12 +51,13 @@ type builder interface {
 	// Primitve returns the underlying primitive.
 	Primitive() engine.Primitive
 
-	// Leftmost returns the leftmost builder.
-	Leftmost() builder
+	// First returns the first builder of the tree,
+	// which is usually the left most.
+	First() builder
 
 	// PushFilter pushes a WHERE or HAVING clause expression
 	// to the specified origin.
-	PushFilter(filter sqlparser.Expr, whereType string, origin builder) error
+	PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, origin builder) error
 
 	// PushSelect pushes the select expression to the specified
 	// originator. If successful, the originator must create

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -33,7 +33,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema ContextVSchema) (*engine.Del
 	edel := &engine.Delete{
 		Query: generateQuery(del),
 	}
-	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(del)))
+	pb := newPrimitiveBuilder(vschema, newJointab(sqlparser.GetBindvars(del)))
 	if err := pb.processTableExprs(del.TableExprs); err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -33,31 +33,31 @@ func buildDeletePlan(del *sqlparser.Delete, vschema ContextVSchema) (*engine.Del
 	edel := &engine.Delete{
 		Query: generateQuery(del),
 	}
-	bldr, err := processTableExprs(del.TableExprs, vschema)
-	if err != nil {
+	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(del)))
+	if err := pb.processTableExprs(del.TableExprs); err != nil {
 		return nil, err
 	}
-	rb, ok := bldr.(*route)
+	rb, ok := pb.bldr.(*route)
 	if !ok {
 		return nil, errors.New("unsupported: multi-table delete statement in sharded keyspace")
 	}
 	edel.Keyspace = rb.ERoute.Keyspace
 	if !edel.Keyspace.Sharded {
 		// We only validate non-table subexpressions because the previous analysis has already validated them.
-		if !validateSubquerySamePlan(rb.ERoute.Keyspace.Name, rb, vschema, del.Targets, del.Where, del.OrderBy, del.Limit) {
+		if !pb.validateSubquerySamePlan(del.Targets, del.Where, del.OrderBy, del.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		edel.Opcode = engine.DeleteUnsharded
 		return edel, nil
 	}
-	if del.Targets != nil || len(rb.Symtab().tables) != 1 {
+	if del.Targets != nil || len(pb.st.tables) != 1 {
 		return nil, errors.New("unsupported: multi-table delete statement in sharded keyspace")
 	}
 	if hasSubquery(del) {
 		return nil, errors.New("unsupported: subqueries in sharded DML")
 	}
 	var tableName sqlparser.TableName
-	for t := range rb.Symtab().tables {
+	for t := range pb.st.tables {
 		tableName = t
 	}
 	table, _, destTabletType, destTarget, err := vschema.FindTable(tableName)

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -79,7 +79,7 @@ func skipParenthesis(node sqlparser.Expr) sqlparser.Expr {
 //
 // If an expression has no references to the current query, then the left-most
 // origin is chosen as the default.
-func (pb *planBuilder) findOrigin(expr sqlparser.Expr) (origin builder, err error) {
+func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (origin builder, err error) {
 	highestOrigin := pb.bldr.First()
 	var subroutes []*route
 	err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
@@ -93,7 +93,7 @@ func (pb *planBuilder) findOrigin(expr sqlparser.Expr) (origin builder, err erro
 				highestOrigin = newOrigin
 			}
 		case *sqlparser.Subquery:
-			spb := newPlanBuilder(pb.vschema, pb.jt)
+			spb := newPrimitiveBuilder(pb.vschema, pb.jt)
 			switch stmt := node.Select.(type) {
 			case *sqlparser.Select:
 				if err := spb.processSelect(stmt, pb.st); err != nil {
@@ -158,7 +158,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 	return has
 }
 
-func (pb *planBuilder) validateSubquerySamePlan(nodes ...sqlparser.SQLNode) bool {
+func (pb *primitiveBuilder) validateSubquerySamePlan(nodes ...sqlparser.SQLNode) bool {
 	var keyspace string
 	if rb, ok := pb.bldr.(*route); ok {
 		keyspace = rb.ERoute.Keyspace.Name
@@ -176,7 +176,7 @@ func (pb *planBuilder) validateSubquerySamePlan(nodes ...sqlparser.SQLNode) bool
 				if !inSubQuery {
 					return true, nil
 				}
-				spb := newPlanBuilder(pb.vschema, pb.jt)
+				spb := newPrimitiveBuilder(pb.vschema, pb.jt)
 				if err := spb.processSelect(nodeType, pb.st); err != nil {
 					samePlan = false
 					return false, err
@@ -194,7 +194,7 @@ func (pb *planBuilder) validateSubquerySamePlan(nodes ...sqlparser.SQLNode) bool
 				if !inSubQuery {
 					return true, nil
 				}
-				spb := newPlanBuilder(pb.vschema, pb.jt)
+				spb := newPrimitiveBuilder(pb.vschema, pb.jt)
 				if err := spb.processUnion(nodeType, pb.st); err != nil {
 					samePlan = false
 					return false, err

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -79,13 +79,13 @@ func skipParenthesis(node sqlparser.Expr) sqlparser.Expr {
 //
 // If an expression has no references to the current query, then the left-most
 // origin is chosen as the default.
-func findOrigin(expr sqlparser.Expr, bldr builder) (origin builder, err error) {
-	highestOrigin := bldr.Leftmost()
+func (pb *planBuilder) findOrigin(expr sqlparser.Expr) (origin builder, err error) {
+	highestOrigin := pb.bldr.First()
 	var subroutes []*route
 	err = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
-			newOrigin, isLocal, err := bldr.Symtab().Find(node)
+			newOrigin, isLocal, err := pb.st.Find(node)
 			if err != nil {
 				return false, err
 			}
@@ -93,25 +93,26 @@ func findOrigin(expr sqlparser.Expr, bldr builder) (origin builder, err error) {
 				highestOrigin = newOrigin
 			}
 		case *sqlparser.Subquery:
-			var subplan builder
+			spb := newPlanBuilder(pb.vschema, pb.jt)
 			switch stmt := node.Select.(type) {
 			case *sqlparser.Select:
-				subplan, err = processSelect(stmt, bldr.Symtab().VSchema, bldr)
+				if err := spb.processSelect(stmt, pb.st); err != nil {
+					return false, err
+				}
 			case *sqlparser.Union:
-				subplan, err = processUnion(stmt, bldr.Symtab().VSchema, bldr)
+				if err := spb.processUnion(stmt, pb.st); err != nil {
+					return false, err
+				}
 			default:
 				panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", node))
 			}
-			if err != nil {
-				return false, err
-			}
-			subroute, isRoute := subplan.(*route)
+			subroute, isRoute := spb.bldr.(*route)
 			if !isRoute {
 				return false, errors.New("unsupported: cross-shard query in subqueries")
 			}
-			for _, extern := range subroute.Symtab().Externs {
+			for _, extern := range spb.st.Externs {
 				// No error expected. These are resolved externs.
-				newOrigin, isLocal, _ := bldr.Symtab().Find(extern)
+				newOrigin, isLocal, _ := pb.st.Find(extern)
 				if isLocal && newOrigin.Order() > highestOrigin.Order() {
 					highestOrigin = newOrigin
 				}
@@ -123,7 +124,7 @@ func findOrigin(expr sqlparser.Expr, bldr builder) (origin builder, err error) {
 			if !node.Name.EqualString("last_insert_id") {
 				return true, nil
 			}
-			if rb, isRoute := bldr.(*route); !isRoute || rb.ERoute.Keyspace.Sharded {
+			if rb, isRoute := pb.bldr.(*route); !isRoute || rb.ERoute.Keyspace.Sharded {
 				return false, errors.New("unsupported: LAST_INSERT_ID is only allowed for unsharded keyspaces")
 			}
 		}
@@ -137,7 +138,7 @@ func findOrigin(expr sqlparser.Expr, bldr builder) (origin builder, err error) {
 		return nil, errors.New("unsupported: subquery cannot be merged with cross-shard subquery")
 	}
 	for _, subroute := range subroutes {
-		if err := highestRoute.SubqueryCanMerge(subroute); err != nil {
+		if err := highestRoute.SubqueryCanMerge(pb, subroute); err != nil {
 			return nil, err
 		}
 		subroute.Redirect = highestRoute
@@ -157,7 +158,11 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 	return has
 }
 
-func validateSubquerySamePlan(keyspace string, bldr builder, vschema ContextVSchema, nodes ...sqlparser.SQLNode) bool {
+func (pb *planBuilder) validateSubquerySamePlan(nodes ...sqlparser.SQLNode) bool {
+	var keyspace string
+	if rb, ok := pb.bldr.(*route); ok {
+		keyspace = rb.ERoute.Keyspace.Name
+	}
 	samePlan := true
 
 	for _, node := range nodes {
@@ -171,12 +176,12 @@ func validateSubquerySamePlan(keyspace string, bldr builder, vschema ContextVSch
 				if !inSubQuery {
 					return true, nil
 				}
-				bldr, err := processSelect(nodeType, vschema, bldr)
-				if err != nil {
+				spb := newPlanBuilder(pb.vschema, pb.jt)
+				if err := spb.processSelect(nodeType, pb.st); err != nil {
 					samePlan = false
 					return false, err
 				}
-				innerRoute, ok := bldr.(*route)
+				innerRoute, ok := spb.bldr.(*route)
 				if !ok {
 					samePlan = false
 					return false, errors.New("dummy")
@@ -189,12 +194,12 @@ func validateSubquerySamePlan(keyspace string, bldr builder, vschema ContextVSch
 				if !inSubQuery {
 					return true, nil
 				}
-				bldr, err := processUnion(nodeType, vschema, nil)
-				if err != nil {
+				spb := newPlanBuilder(pb.vschema, pb.jt)
+				if err := spb.processUnion(nodeType, pb.st); err != nil {
 					samePlan = false
 					return false, err
 				}
-				innerRoute, ok := bldr.(*route)
+				innerRoute, ok := spb.bldr.(*route)
 				if !ok {
 					samePlan = false
 					return false, errors.New("dummy")

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planbuilder
 
 import (
+	"errors"
 	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -29,39 +30,38 @@ import (
 
 // processTableExprs analyzes the FROM clause. It produces a builder
 // with all the routes identified.
-func processTableExprs(tableExprs sqlparser.TableExprs, vschema ContextVSchema) (builder, error) {
+func (pb *planBuilder) processTableExprs(tableExprs sqlparser.TableExprs) error {
 	if len(tableExprs) == 1 {
-		return processTableExpr(tableExprs[0], vschema)
+		return pb.processTableExpr(tableExprs[0])
 	}
 
-	lplan, err := processTableExpr(tableExprs[0], vschema)
-	if err != nil {
-		return nil, err
+	if err := pb.processTableExpr(tableExprs[0]); err != nil {
+		return err
 	}
-	rplan, err := processTableExprs(tableExprs[1:], vschema)
-	if err != nil {
-		return nil, err
+	rpb := newPlanBuilder(pb.vschema, pb.jt)
+	if err := rpb.processTableExprs(tableExprs[1:]); err != nil {
+		return err
 	}
-	return joinBuilders(lplan, rplan, nil)
+	return pb.join(rpb, nil)
 }
 
 // processTableExpr produces a builder subtree for the given TableExpr.
-func processTableExpr(tableExpr sqlparser.TableExpr, vschema ContextVSchema) (builder, error) {
+func (pb *planBuilder) processTableExpr(tableExpr sqlparser.TableExpr) error {
 	switch tableExpr := tableExpr.(type) {
 	case *sqlparser.AliasedTableExpr:
-		return processAliasedTable(tableExpr, vschema)
+		return pb.processAliasedTable(tableExpr)
 	case *sqlparser.ParenTableExpr:
-		bldr, err := processTableExprs(tableExpr.Exprs, vschema)
+		err := pb.processTableExprs(tableExpr.Exprs)
 		// If it's a route, preserve the parenthesis so things
 		// don't associate differently when more things are pushed
 		// into it. FROM a, (b, c) should not become FROM a, b, c.
-		if rb, ok := bldr.(*route); ok {
+		if rb, ok := pb.bldr.(*route); ok {
 			sel := rb.Select.(*sqlparser.Select)
 			sel.From = sqlparser.TableExprs{&sqlparser.ParenTableExpr{Exprs: sel.From}}
 		}
-		return bldr, err
+		return err
 	case *sqlparser.JoinTableExpr:
-		return processJoin(tableExpr, vschema)
+		return pb.processJoin(tableExpr)
 	}
 	panic(fmt.Sprintf("BUG: unexpected table expression type: %T", tableExpr))
 }
@@ -73,28 +73,29 @@ func processTableExpr(tableExpr sqlparser.TableExpr, vschema ContextVSchema) (bu
 // versatile than a subquery. If a subquery becomes a route, then any result
 // columns that represent underlying vindex columns are also exposed as
 // vindex columns.
-func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema ContextVSchema) (builder, error) {
+func (pb *planBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTableExpr) error {
 	switch expr := tableExpr.Expr.(type) {
 	case sqlparser.TableName:
-		return buildTablePrimitive(tableExpr, expr, vschema)
+		return pb.buildTablePrimitive(tableExpr, expr)
 	case *sqlparser.Subquery:
-		var err error
-		var subplan builder
+		spb := newPlanBuilder(pb.vschema, pb.jt)
 		switch stmt := expr.Select.(type) {
 		case *sqlparser.Select:
-			subplan, err = processSelect(stmt, vschema, nil)
+			if err := spb.processSelect(stmt, nil); err != nil {
+				return err
+			}
 		case *sqlparser.Union:
-			subplan, err = processUnion(stmt, vschema, nil)
+			if err := spb.processUnion(stmt, nil); err != nil {
+				return err
+			}
 		default:
 			panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", stmt))
 		}
-		if err != nil {
-			return nil, err
-		}
 
-		subroute, ok := subplan.(*route)
+		subroute, ok := spb.bldr.(*route)
 		if !ok {
-			return newSubquery(tableExpr.As, subplan, vschema), nil
+			pb.bldr, pb.st = newSubquery(tableExpr.As, spb.bldr)
+			return nil
 		}
 
 		// Since a route is more versatile than a subquery, we
@@ -112,7 +113,7 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema ContextV
 			// Dups are not allowed in subqueries in this situation.
 			for _, colVindex := range table.ColumnVindexes {
 				if colVindex.Columns[0].Equal(rc.alias) {
-					return nil, fmt.Errorf("duplicate column aliases: %v", rc.alias)
+					return fmt.Errorf("duplicate column aliases: %v", rc.alias)
 				}
 			}
 			table.ColumnVindexes = append(table.ColumnVindexes, &vindexes.ColumnVindex{
@@ -120,60 +121,62 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema ContextV
 				Vindex:  rc.column.Vindex,
 			})
 		}
-		rb := newRoute(
+		rb, st := newRoute(
 			&sqlparser.Select{From: sqlparser.TableExprs([]sqlparser.TableExpr{tableExpr})},
 			subroute.ERoute,
 			subroute.condition,
-			vschema,
 		)
 		// AddVindexTable can never fail because symtab is empty.
-		_ = rb.symtab.AddVindexTable(sqlparser.TableName{Name: tableExpr.As}, table, rb)
+		_ = st.AddVindexTable(sqlparser.TableName{Name: tableExpr.As}, table, rb)
 		subroute.Redirect = rb
-		return rb, nil
+		pb.bldr, pb.st = rb, st
+		return nil
 	}
 	panic(fmt.Sprintf("BUG: unexpected table expression type: %T", tableExpr.Expr))
 }
 
 // buildTablePrimitive builds a primitive based on the table name.
-func buildTablePrimitive(tableExpr *sqlparser.AliasedTableExpr, tableName sqlparser.TableName, vschema ContextVSchema) (builder, error) {
+func (pb *planBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTableExpr, tableName sqlparser.TableName) error {
 	alias := tableName
 	if !tableExpr.As.IsEmpty() {
 		alias = sqlparser.TableName{Name: tableExpr.As}
 	}
-	rb := newRoute(
-		&sqlparser.Select{From: sqlparser.TableExprs([]sqlparser.TableExpr{tableExpr})},
-		nil,
-		nil,
-		vschema,
-	)
+	sel := &sqlparser.Select{From: sqlparser.TableExprs([]sqlparser.TableExpr{tableExpr})}
+
 	if systemTable(tableName.Qualifier.String()) {
-		ks, err := vschema.DefaultKeyspace()
+		ks, err := pb.vschema.DefaultKeyspace()
 		if err != nil {
-			return nil, err
+			return err
 		}
+		rb, st := newRoute(sel, nil, nil)
 		rb.ERoute = &engine.Route{
 			Opcode:   engine.SelectDBA,
 			Keyspace: ks,
 		}
-		return rb, nil
+		pb.bldr, pb.st = rb, st
+		return nil
 	}
 
-	table, vindex, _, _, destTarget, err := vschema.FindTableOrVindex(tableName)
+	table, vindex, _, _, destTarget, err := pb.vschema.FindTableOrVindex(tableName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if vindex != nil {
-		return newVindexFunc(alias, vindex, vschema), nil
+		pb.bldr, pb.st = newVindexFunc(alias, vindex)
+		return nil
 	}
+
+	rb, st := newRoute(sel, nil, nil)
+	pb.bldr, pb.st = rb, st
 	// AddVindexTable can never fail because symtab is empty.
-	_ = rb.symtab.AddVindexTable(alias, table, rb)
+	_ = st.AddVindexTable(alias, table, rb)
 
 	if !table.Keyspace.Sharded {
 		rb.ERoute = &engine.Route{
 			Opcode:   engine.SelectUnsharded,
 			Keyspace: table.Keyspace,
 		}
-		return rb, nil
+		return nil
 	}
 	if table.Pinned == nil {
 		rb.ERoute = &engine.Route{
@@ -181,41 +184,40 @@ func buildTablePrimitive(tableExpr *sqlparser.AliasedTableExpr, tableName sqlpar
 			Keyspace:          table.Keyspace,
 			TargetDestination: destTarget,
 		}
-		return rb, nil
+		return nil
 	}
 	// Pinned tables have their keyspace ids already assigned.
 	// Use the Binary vindex, which is the identity function
 	// for keyspace id. Currently only dual tables are pinned.
-	route := &engine.Route{
+	eRoute := &engine.Route{
 		Opcode:   engine.SelectEqualUnique,
 		Keyspace: table.Keyspace,
 	}
-	route.Vindex, _ = vindexes.NewBinary("binary", nil)
-	route.Values = []sqltypes.PlanValue{{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, table.Pinned)}}
-	rb.ERoute = route
-	return rb, nil
+	eRoute.Vindex, _ = vindexes.NewBinary("binary", nil)
+	eRoute.Values = []sqltypes.PlanValue{{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, table.Pinned)}}
+	rb.ERoute = eRoute
+	return nil
 }
 
 // processJoin produces a builder subtree for the given Join.
 // If the left and right nodes can be part of the same route,
 // then it's a route. Otherwise, it's a join.
-func processJoin(ajoin *sqlparser.JoinTableExpr, vschema ContextVSchema) (builder, error) {
+func (pb *planBuilder) processJoin(ajoin *sqlparser.JoinTableExpr) error {
 	switch ajoin.Join {
 	case sqlparser.JoinStr, sqlparser.StraightJoinStr, sqlparser.LeftJoinStr:
 	case sqlparser.RightJoinStr:
 		convertToLeftJoin(ajoin)
 	default:
-		return nil, fmt.Errorf("unsupported: %s", ajoin.Join)
+		return fmt.Errorf("unsupported: %s", ajoin.Join)
 	}
-	lplan, err := processTableExpr(ajoin.LeftExpr, vschema)
-	if err != nil {
-		return nil, err
+	if err := pb.processTableExpr(ajoin.LeftExpr); err != nil {
+		return err
 	}
-	rplan, err := processTableExpr(ajoin.RightExpr, vschema)
-	if err != nil {
-		return nil, err
+	rpb := newPlanBuilder(pb.vschema, pb.jt)
+	if err := rpb.processTableExpr(ajoin.RightExpr); err != nil {
+		return err
 	}
-	return joinBuilders(lplan, rplan, ajoin)
+	return pb.join(rpb, ajoin)
 }
 
 // convertToLeftJoin converts a right join into a left join.
@@ -232,16 +234,130 @@ func convertToLeftJoin(ajoin *sqlparser.JoinTableExpr) {
 	ajoin.Join = sqlparser.LeftJoinStr
 }
 
-func joinBuilders(left, right builder, ajoin *sqlparser.JoinTableExpr) (builder, error) {
-	lRoute, leftIsRoute := left.(*route)
-	rRoute, rightIsRoute := right.(*route)
+func (pb *planBuilder) join(rpb *planBuilder, ajoin *sqlparser.JoinTableExpr) error {
+	if ajoin != nil && ajoin.Condition.Using != nil {
+		return errors.New("unsupported: join with USING(column_list) clause")
+	}
+	lRoute, leftIsRoute := pb.bldr.(*route)
+	rRoute, rightIsRoute := rpb.bldr.(*route)
 	if leftIsRoute && rightIsRoute {
 		// If both are routes, they have an opportunity
-		// to merge into one. route.Join performs this work.
-		return lRoute.Join(rRoute, ajoin)
+		// to merge into one.
+		if lRoute.ERoute.Opcode == engine.SelectNext || rRoute.ERoute.Opcode == engine.SelectNext {
+			return errors.New("unsupported: sequence join with another table")
+		}
+		if lRoute.ERoute.Keyspace.Name != rRoute.ERoute.Keyspace.Name {
+			goto nomerge
+		}
+		switch lRoute.ERoute.Opcode {
+		case engine.SelectUnsharded:
+			if rRoute.ERoute.Opcode == engine.SelectUnsharded {
+				return pb.mergeRoutes(rpb, ajoin)
+			}
+			return errIntermixingUnsupported
+		case engine.SelectDBA:
+			if rRoute.ERoute.Opcode == engine.SelectDBA {
+				return pb.mergeRoutes(rpb, ajoin)
+			}
+			return errIntermixingUnsupported
+		}
+
+		// Both route are sharded routes. For ',' joins (ajoin==nil), don't
+		// analyze mergeability.
+		if ajoin == nil {
+			goto nomerge
+		}
+
+		// Both route are sharded routes. Analyze join condition for merging.
+		for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
+			if pb.isSameRoute(rpb, filter) {
+				return pb.mergeRoutes(rpb, ajoin)
+			}
+		}
+
+		// Both l & r routes point to the same shard.
+		if lRoute.ERoute.Opcode == engine.SelectEqualUnique && rRoute.ERoute.Opcode == engine.SelectEqualUnique {
+			if valEqual(lRoute.condition, rRoute.condition) {
+				return pb.mergeRoutes(rpb, ajoin)
+			}
+		}
 	}
 
-	// If any of them is not a route, we have to build
-	// a new join primitve.
-	return newJoin(left, right, ajoin)
+nomerge:
+	return newJoin(pb, rpb, ajoin)
+}
+
+// mergeRoutes merges the two routes. The ON clause is also analyzed to
+// see if the primitive can be improved. The operation can fail if
+// the expression contains a non-pushable subquery. ajoin can be nil
+// if the join is on a ',' operator.
+func (pb *planBuilder) mergeRoutes(rpb *planBuilder, ajoin *sqlparser.JoinTableExpr) error {
+	lRoute := pb.bldr.(*route)
+	rRoute := rpb.bldr.(*route)
+	sel := lRoute.Select.(*sqlparser.Select)
+
+	if ajoin == nil {
+		rhsSel := rRoute.Select.(*sqlparser.Select)
+		sel.From = append(sel.From, rhsSel.From...)
+	} else {
+		sel.From = sqlparser.TableExprs{ajoin}
+		if ajoin.Join == sqlparser.LeftJoinStr {
+			rpb.st.ClearVindexes()
+		}
+	}
+	// Redirect before merging the symtabs. Merge will use Redirect
+	// to check if rRoute matches lRoute.
+	rRoute.Redirect = lRoute
+	err := pb.st.Merge(rpb.st)
+	if err != nil {
+		return err
+	}
+	if ajoin == nil {
+		return nil
+	}
+	for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
+		// If VTGate evolves, this section should be rewritten
+		// to use processExpr.
+		_, err = pb.findOrigin(filter)
+		if err != nil {
+			return err
+		}
+		lRoute.UpdatePlan(pb, filter)
+	}
+	return nil
+}
+
+// isSameRoute returns true if the join constraint makes the routes
+// mergeable by unique vindex. The constraint has to be an equality
+// like a.id = b.id where both columns have the same unique vindex.
+func (pb *planBuilder) isSameRoute(rpb *planBuilder, filter sqlparser.Expr) bool {
+	lRoute := pb.bldr.(*route)
+	rRoute := rpb.bldr.(*route)
+
+	filter = skipParenthesis(filter)
+	comparison, ok := filter.(*sqlparser.ComparisonExpr)
+	if !ok {
+		return false
+	}
+	if comparison.Operator != sqlparser.EqualStr {
+		return false
+	}
+	left := comparison.Left
+	right := comparison.Right
+	lVindex := pb.st.Vindex(left, lRoute)
+	if lVindex == nil {
+		left, right = right, left
+		lVindex = pb.st.Vindex(left, lRoute)
+	}
+	if lVindex == nil || !lVindex.IsUnique() {
+		return false
+	}
+	rVindex := rpb.st.Vindex(right, rRoute)
+	if rVindex == nil {
+		return false
+	}
+	if rVindex != lVindex {
+		return false
+	}
+	return true
 }

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -29,14 +29,24 @@ import (
 
 // buildInsertPlan builds the route for an INSERT statement.
 func buildInsertPlan(ins *sqlparser.Insert, vschema ContextVSchema) (*engine.Insert, error) {
-	table, _, _, destTarget, err := vschema.FindTable(ins.Table)
-	if err != nil {
+	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(ins)))
+	aliased := &sqlparser.AliasedTableExpr{Expr: ins.Table}
+	if err := pb.processAliasedTable(aliased); err != nil {
 		return nil, err
 	}
-	if destTarget != nil {
+	// route is guaranteed because of simple table expr.
+	rb := pb.bldr.(*route)
+	if rb.ERoute.TargetDestination != nil {
 		return nil, errors.New("unsupported: INSERT with a target destination")
 	}
+	var table *vindexes.Table
+	for _, tval := range pb.st.tables {
+		table = tval.vindexTable
+	}
 	if !table.Keyspace.Sharded {
+		if !pb.validateSubquerySamePlan(ins) {
+			return nil, errors.New("unsupported: sharded subquery in insert values")
+		}
 		return buildInsertUnshardedPlan(ins, table, vschema)
 	}
 	if ins.Action == sqlparser.ReplaceStr {
@@ -50,9 +60,6 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		Opcode:   engine.InsertUnsharded,
 		Table:    table,
 		Keyspace: table.Keyspace,
-	}
-	if !validateSubquerySamePlan(eins.Keyspace.Name, nil, vschema, ins) {
-		return nil, errors.New("unsupported: sharded subquery in insert values")
 	}
 	var rows sqlparser.Values
 	switch insertValues := ins.Rows.(type) {

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -29,7 +29,7 @@ import (
 
 // buildInsertPlan builds the route for an INSERT statement.
 func buildInsertPlan(ins *sqlparser.Insert, vschema ContextVSchema) (*engine.Insert, error) {
-	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(ins)))
+	pb := newPrimitiveBuilder(vschema, newJointab(sqlparser.GetBindvars(ins)))
 	aliased := &sqlparser.AliasedTableExpr{Expr: ins.Table}
 	if err := pb.processAliasedTable(aliased); err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -68,7 +68,7 @@ type join struct {
 // newJoin makes a new join using the two planBuilder. ajoin can be nil
 // if the join is on a ',' operator. lpb will contain the resulting join.
 // rpb will be discarded.
-func newJoin(lpb, rpb *planBuilder, ajoin *sqlparser.JoinTableExpr) error {
+func newJoin(lpb, rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr) error {
 	// This function converts ON clauses to WHERE clauses. The WHERE clause
 	// scope can see all tables, whereas the ON clause can only see the
 	// participants of the JOIN. However, since the ON clause doesn't allow
@@ -148,7 +148,7 @@ func (jb *join) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (jb *join) PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, origin builder) error {
+func (jb *join) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereType string, origin builder) error {
 	if jb.isOnLeft(origin.Order()) {
 		return jb.Left.PushFilter(pb, filter, whereType, origin)
 	}

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -29,7 +29,6 @@ var _ builder = (*join)(nil)
 // It's used to build a normal join or a left join
 // operation.
 type join struct {
-	symtab        *symtab
 	order         int
 	resultColumns []*resultColumn
 
@@ -66,58 +65,58 @@ type join struct {
 	ejoin *engine.Join
 }
 
-// newJoin makes a new joinBuilder using the two nodes. ajoin can be nil
-// if the join is on a ',' operator.
-func newJoin(lhs, rhs builder, ajoin *sqlparser.JoinTableExpr) (*join, error) {
+// newJoin makes a new join using the two planBuilder. ajoin can be nil
+// if the join is on a ',' operator. lpb will contain the resulting join.
+// rpb will be discarded.
+func newJoin(lpb, rpb *planBuilder, ajoin *sqlparser.JoinTableExpr) error {
 	// This function converts ON clauses to WHERE clauses. The WHERE clause
 	// scope can see all tables, whereas the ON clause can only see the
 	// participants of the JOIN. However, since the ON clause doesn't allow
 	// external references, and the FROM clause doesn't allow duplicates,
 	// it's safe to perform this conversion and still expect the same behavior.
 
-	if err := lhs.Symtab().Merge(rhs.Symtab()); err != nil {
-		return nil, err
-	}
 	opcode := engine.NormalJoin
-	if ajoin != nil && ajoin.Join == sqlparser.LeftJoinStr {
-		opcode = engine.LeftJoin
+	if ajoin != nil {
+		switch {
+		case ajoin.Join == sqlparser.LeftJoinStr:
+			opcode = engine.LeftJoin
+
+			// For left joins, we have to push the ON clause into the RHS.
+			// We do this before creating the join primitive.
+			// However, variables of LHS need to be visible. To allow this,
+			// we mark the LHS symtab as outer scope to the RHS, just like
+			// a subquery. This make the RHS treat the LHS symbols as external.
+			// This will prevent constructs from escaping out of the rpb scope.
+			rpb.st.Outer = lpb.st
+			if err := rpb.pushFilter(ajoin.Condition.On, sqlparser.WhereStr); err != nil {
+				return err
+			}
+		case ajoin.Condition.Using != nil:
+			return errors.New("unsupported: join with USING(column_list) clause")
+		}
 	}
-	jb := &join{
-		order:     rhs.Order() + 1,
-		leftOrder: lhs.Order(),
-		Left:      lhs,
-		Right:     rhs,
-		symtab:    lhs.Symtab(),
+	// Merge the symbol tables. In the case of a left join, we have to
+	// ideally create new symbols that originate from the join primitive.
+	// However, this is not worth it for now, because the Push functions
+	// verify that only valid constructs are passed through in case of left join.
+	if err := lpb.st.Merge(rpb.st); err != nil {
+		return err
+	}
+	lpb.bldr = &join{
+		Left:  lpb.bldr,
+		Right: rpb.bldr,
 		ejoin: &engine.Join{
 			Opcode: opcode,
-			Left:   lhs.Primitive(),
-			Right:  rhs.Primitive(),
+			Left:   lpb.bldr.Primitive(),
+			Right:  rpb.bldr.Primitive(),
 			Vars:   make(map[string]int),
 		},
 	}
-	jb.Reorder(0)
-	if ajoin == nil {
-		return jb, nil
+	lpb.bldr.Reorder(0)
+	if ajoin == nil || opcode == engine.LeftJoin {
+		return nil
 	}
-	if ajoin.Condition.Using != nil {
-		return nil, errors.New("unsupported: join with USING(column_list) clause")
-	}
-
-	if opcode == engine.LeftJoin {
-		if err := pushFilter(ajoin.Condition.On, rhs, sqlparser.WhereStr); err != nil {
-			return nil, err
-		}
-		return jb, nil
-	}
-	if err := pushFilter(ajoin.Condition.On, jb, sqlparser.WhereStr); err != nil {
-		return nil, err
-	}
-	return jb, nil
-}
-
-// Symtab satisfies the builder interface.
-func (jb *join) Symtab() *symtab {
-	return jb.symtab.Resolve()
+	return lpb.pushFilter(ajoin.Condition.On, sqlparser.WhereStr)
 }
 
 // Order satisfies the builder interface.
@@ -138,9 +137,9 @@ func (jb *join) Primitive() engine.Primitive {
 	return jb.ejoin
 }
 
-// Leftmost satisfies the builder interface.
-func (jb *join) Leftmost() builder {
-	return jb.Left.Leftmost()
+// First satisfies the builder interface.
+func (jb *join) First() builder {
+	return jb.Left.First()
 }
 
 // ResultColumns satisfies the builder interface.
@@ -149,14 +148,14 @@ func (jb *join) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (jb *join) PushFilter(filter sqlparser.Expr, whereType string, origin builder) error {
+func (jb *join) PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, origin builder) error {
 	if jb.isOnLeft(origin.Order()) {
-		return jb.Left.PushFilter(filter, whereType, origin)
+		return jb.Left.PushFilter(pb, filter, whereType, origin)
 	}
 	if jb.ejoin.Opcode == engine.LeftJoin {
 		return errors.New("unsupported: cross-shard left join and where clause")
 	}
-	return jb.Right.PushFilter(filter, whereType, origin)
+	return jb.Right.PushFilter(pb, filter, whereType, origin)
 }
 
 // PushSelect satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -73,7 +73,7 @@ func (l *limit) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (l *limit) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
+func (l *limit) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	panic("BUG: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -29,7 +29,6 @@ import (
 // operation. Since a limit is the final operation
 // of a SELECT, most pushes are not applicable.
 type limit struct {
-	symtab        *symtab
 	order         int
 	resultColumns []*resultColumn
 	input         builder
@@ -39,17 +38,11 @@ type limit struct {
 // newLimit builds a new limit.
 func newLimit(bldr builder) *limit {
 	return &limit{
-		symtab:        bldr.Symtab(),
 		order:         bldr.Order() + 1,
 		resultColumns: bldr.ResultColumns(),
 		input:         bldr,
 		elimit:        &engine.Limit{},
 	}
-}
-
-// Symtab satisfies the builder interface.
-func (l *limit) Symtab() *symtab {
-	return l.symtab.Resolve()
 }
 
 // Order satisfies the builder interface.
@@ -69,9 +62,9 @@ func (l *limit) Primitive() engine.Primitive {
 	return l.elimit
 }
 
-// Leftmost satisfies the builder interface.
-func (l *limit) Leftmost() builder {
-	return l.input.Leftmost()
+// First satisfies the builder interface.
+func (l *limit) First() builder {
+	return l.input.First()
 }
 
 // ResultColumns satisfies the builder interface.
@@ -80,7 +73,7 @@ func (l *limit) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (l *limit) PushFilter(_ sqlparser.Expr, whereType string, _ builder) error {
+func (l *limit) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	panic("BUG: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -54,7 +54,6 @@ var _ builder = (*orderedAggregate)(nil)
 //      Input: (Scatter Route with the order by request),
 //    }
 type orderedAggregate struct {
-	symtab        *symtab
 	resultColumns []*resultColumn
 	order         int
 	input         *route
@@ -63,11 +62,12 @@ type orderedAggregate struct {
 
 // checkAggregates analyzes the select expression for aggregates. If it determines
 // that a primitive is needed to handle the aggregation, it builds an orderedAggregate
-// primitive and returns it.
-func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
-	rb, isRoute := bldr.(*route)
+// primitive and returns it. It returns a groupByHandler if there is aggregation it
+// can handle.
+func (pb *planBuilder) checkAggregates(sel *sqlparser.Select) (groupByHandler, error) {
+	rb, isRoute := pb.bldr.(*route)
 	if isRoute && rb.IsSingle() {
-		return bldr, nil
+		return rb, nil
 	}
 
 	// Check if we can allow aggregates.
@@ -81,7 +81,7 @@ func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
 		hasAggregates = true
 	}
 	if !hasAggregates {
-		return bldr, nil
+		return rb, nil
 	}
 
 	// The query has aggregates. We can proceed only
@@ -89,7 +89,7 @@ func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
 	// we need the ability to push down group by and
 	// order by clauses.
 	if !isRoute {
-		return bldr, errors.New("unsupported: cross-shard query with aggregates")
+		return nil, errors.New("unsupported: cross-shard query with aggregates")
 	}
 
 	// If there is a distinct clause, we can check the select list
@@ -105,9 +105,9 @@ func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
 		for _, selectExpr := range sel.SelectExprs {
 			switch selectExpr := selectExpr.(type) {
 			case *sqlparser.AliasedExpr:
-				vindex := bldr.Symtab().Vindex(selectExpr.Expr, rb)
+				vindex := pb.st.Vindex(selectExpr.Expr, rb)
 				if vindex != nil && vindex.IsUnique() {
-					return bldr, nil
+					return rb, nil
 				}
 			}
 		}
@@ -120,17 +120,18 @@ func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
 	// the grouping can be done at the shard level, which allows the entire query
 	// to be pushed down. In order to perform this analysis, we're going to look
 	// ahead at the group by clause to see if it references a unique vindex.
-	if groupByHasUniqueVindex(sel, bldr, rb) {
-		return bldr, nil
+	if pb.groupByHasUniqueVindex(sel, rb) {
+		return rb, nil
 	}
 
 	// We need an aggregator primitive.
-	return &orderedAggregate{
-		symtab: rb.Symtab(),
-		order:  rb.Order() + 1,
-		input:  rb,
-		eaggr:  &engine.OrderedAggregate{},
-	}, nil
+	oa := &orderedAggregate{
+		order: rb.Order() + 1,
+		input: rb,
+		eaggr: &engine.OrderedAggregate{},
+	}
+	pb.bldr = oa
+	return oa, nil
 }
 
 func nodeHasAggregates(node sqlparser.SQLNode) bool {
@@ -174,7 +175,7 @@ func nodeHasAggregates(node sqlparser.SQLNode) bool {
 // we don't search the ResultColumns because they're not created yet. Also,
 // error conditions are treated as no match for simplicity; They will be
 // subsequently caught downstream.
-func groupByHasUniqueVindex(sel *sqlparser.Select, bldr builder, rb *route) bool {
+func (pb *planBuilder) groupByHasUniqueVindex(sel *sqlparser.Select, rb *route) bool {
 	for _, expr := range sel.GroupBy {
 		var matchedExpr sqlparser.Expr
 		switch node := expr.(type) {
@@ -203,7 +204,7 @@ func groupByHasUniqueVindex(sel *sqlparser.Select, bldr builder, rb *route) bool
 		default:
 			continue
 		}
-		vindex := bldr.Symtab().Vindex(matchedExpr, rb)
+		vindex := pb.st.Vindex(matchedExpr, rb)
 		if vindex != nil && vindex.IsUnique() {
 			return true
 		}
@@ -229,11 +230,6 @@ func findAlias(colname *sqlparser.ColName, selects sqlparser.SelectExprs) sqlpar
 	return nil
 }
 
-// Symtab satisfies the builder interface.
-func (oa *orderedAggregate) Symtab() *symtab {
-	return oa.symtab.Resolve()
-}
-
 // Order satisfies the builder interface.
 func (oa *orderedAggregate) Order() int {
 	return oa.order
@@ -251,9 +247,9 @@ func (oa *orderedAggregate) Primitive() engine.Primitive {
 	return oa.eaggr
 }
 
-// Leftmost satisfies the builder interface.
-func (oa *orderedAggregate) Leftmost() builder {
-	return oa.input.Leftmost()
+// First satisfies the builder interface.
+func (oa *orderedAggregate) First() builder {
+	return oa.input.First()
 }
 
 // ResultColumns satisfies the builder interface.
@@ -262,7 +258,7 @@ func (oa *orderedAggregate) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (oa *orderedAggregate) PushFilter(_ sqlparser.Expr, whereType string, _ builder) error {
+func (oa *orderedAggregate) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	return errors.New("unsupported: filtering on results of aggregates")
 }
 
@@ -368,7 +364,7 @@ func (oa *orderedAggregate) SetGroupBy(groupBy sqlparser.GroupBy) error {
 // 'select a, b, count(*) from t group by a, b order by b'
 // The following construct is not allowed:
 // 'select a, count(*) from t group by a order by count(*)'
-func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) error {
+func (oa *orderedAggregate) PushOrderBy(pb *planBuilder, orderBy sqlparser.OrderBy) error {
 	// Treat order by null as nil order by.
 	if len(orderBy) == 1 {
 		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {
@@ -389,7 +385,7 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) error {
 			}
 			orderByCol = oa.input.ResultColumns()[num].column
 		case *sqlparser.ColName:
-			_, _, err := oa.Symtab().Find(expr)
+			_, _, err := pb.st.Find(expr)
 			if err != nil {
 				return fmt.Errorf("invalid order by: %v", err)
 			}

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -64,7 +64,7 @@ type orderedAggregate struct {
 // that a primitive is needed to handle the aggregation, it builds an orderedAggregate
 // primitive and returns it. It returns a groupByHandler if there is aggregation it
 // can handle.
-func (pb *planBuilder) checkAggregates(sel *sqlparser.Select) (groupByHandler, error) {
+func (pb *primitiveBuilder) checkAggregates(sel *sqlparser.Select) (groupByHandler, error) {
 	rb, isRoute := pb.bldr.(*route)
 	if isRoute && rb.IsSingle() {
 		return rb, nil
@@ -175,7 +175,7 @@ func nodeHasAggregates(node sqlparser.SQLNode) bool {
 // we don't search the ResultColumns because they're not created yet. Also,
 // error conditions are treated as no match for simplicity; They will be
 // subsequently caught downstream.
-func (pb *planBuilder) groupByHasUniqueVindex(sel *sqlparser.Select, rb *route) bool {
+func (pb *primitiveBuilder) groupByHasUniqueVindex(sel *sqlparser.Select, rb *route) bool {
 	for _, expr := range sel.GroupBy {
 		var matchedExpr sqlparser.Expr
 		switch node := expr.(type) {
@@ -258,7 +258,7 @@ func (oa *orderedAggregate) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (oa *orderedAggregate) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
+func (oa *orderedAggregate) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	return errors.New("unsupported: filtering on results of aggregates")
 }
 
@@ -364,7 +364,7 @@ func (oa *orderedAggregate) SetGroupBy(groupBy sqlparser.GroupBy) error {
 // 'select a, b, count(*) from t group by a, b order by b'
 // The following construct is not allowed:
 // 'select a, count(*) from t group by a order by count(*)'
-func (oa *orderedAggregate) PushOrderBy(pb *planBuilder, orderBy sqlparser.OrderBy) error {
+func (oa *orderedAggregate) PushOrderBy(pb *primitiveBuilder, orderBy sqlparser.OrderBy) error {
 	// Treat order by null as nil order by.
 	if len(orderBy) == 1 {
 		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {

--- a/go/vt/vtgate/planbuilder/planbuilder.go
+++ b/go/vt/vtgate/planbuilder/planbuilder.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+// planBuilder is the top level type for building plans.
+// It contains the current builder tree, the symtab and
+// the jointab. It can create transient planBuilders due
+// to the recursive nature of SQL.
+type planBuilder struct {
+	vschema ContextVSchema
+	jt      *jointab
+	bldr    builder
+	st      *symtab
+}
+
+func newPlanBuilder(vschema ContextVSchema, jt *jointab) *planBuilder {
+	return &planBuilder{
+		vschema: vschema,
+		jt:      jt,
+	}
+}

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -39,7 +39,7 @@ type groupByHandler interface {
 
 // pushGroupBy processes the group by clause. It resolves all symbols,
 // and ensures that there are no subqueries.
-func (pb *planBuilder) pushGroupBy(sel *sqlparser.Select, grouper groupByHandler) error {
+func (pb *primitiveBuilder) pushGroupBy(sel *sqlparser.Select, grouper groupByHandler) error {
 	if sel.Distinct != "" {
 		// We can be here only if the builder could handle a group by.
 		if err := grouper.MakeDistinct(); err != nil {
@@ -62,7 +62,7 @@ func (pb *planBuilder) pushGroupBy(sel *sqlparser.Select, grouper groupByHandler
 // In the case of a join, it's only possible to push down if the
 // order by references columns of the left-most route. Otherwise, the
 // function returns an unsupported error.
-func (pb *planBuilder) pushOrderBy(orderBy sqlparser.OrderBy) error {
+func (pb *primitiveBuilder) pushOrderBy(orderBy sqlparser.OrderBy) error {
 	if oa, ok := pb.bldr.(*orderedAggregate); ok {
 		return oa.PushOrderBy(pb, orderBy)
 	}
@@ -130,7 +130,7 @@ func (pb *planBuilder) pushOrderBy(orderBy sqlparser.OrderBy) error {
 	return nil
 }
 
-func (pb *planBuilder) pushLimit(limit *sqlparser.Limit) error {
+func (pb *primitiveBuilder) pushLimit(limit *sqlparser.Limit) error {
 	if limit == nil {
 		return nil
 	}

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -39,10 +39,10 @@ type groupByHandler interface {
 
 // pushGroupBy processes the group by clause. It resolves all symbols,
 // and ensures that there are no subqueries.
-func pushGroupBy(sel *sqlparser.Select, bldr builder) error {
+func (pb *planBuilder) pushGroupBy(sel *sqlparser.Select, grouper groupByHandler) error {
 	if sel.Distinct != "" {
 		// We can be here only if the builder could handle a group by.
-		if err := bldr.(groupByHandler).MakeDistinct(); err != nil {
+		if err := grouper.MakeDistinct(); err != nil {
 			return err
 		}
 	}
@@ -50,21 +50,21 @@ func pushGroupBy(sel *sqlparser.Select, bldr builder) error {
 	if len(sel.GroupBy) == 0 {
 		return nil
 	}
-	if err := bldr.Symtab().ResolveSymbols(sel.GroupBy); err != nil {
+	if err := pb.st.ResolveSymbols(sel.GroupBy); err != nil {
 		return fmt.Errorf("unsupported: in group by: %v", err)
 	}
 
 	// We can be here only if the builder could handle a group by.
-	return bldr.(groupByHandler).SetGroupBy(sel.GroupBy)
+	return grouper.SetGroupBy(sel.GroupBy)
 }
 
 // pushOrderBy pushes the order by clause to the appropriate route.
 // In the case of a join, it's only possible to push down if the
 // order by references columns of the left-most route. Otherwise, the
 // function returns an unsupported error.
-func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
-	if oa, ok := bldr.(*orderedAggregate); ok {
-		return oa.PushOrderBy(orderBy)
+func (pb *planBuilder) pushOrderBy(orderBy sqlparser.OrderBy) error {
+	if oa, ok := pb.bldr.(*orderedAggregate); ok {
+		return oa.PushOrderBy(pb, orderBy)
 	}
 
 	switch len(orderBy) {
@@ -73,17 +73,17 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 	case 1:
 		// Special handling for ORDER BY NULL. Push it everywhere.
 		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {
-			bldr.PushOrderByNull()
+			pb.bldr.PushOrderByNull()
 			return nil
 		} else if f, ok := orderBy[0].Expr.(*sqlparser.FuncExpr); ok {
 			if f.Name.Lowered() == "rand" {
-				bldr.PushOrderByRand()
+				pb.bldr.PushOrderByRand()
 				return nil
 			}
 		}
 	}
 
-	leftmostRB, ok := bldr.Leftmost().(*route)
+	firstRB, ok := pb.bldr.First().(*route)
 	if !ok {
 		return errors.New("unsupported: cannot order by on a cross-shard subquery")
 	}
@@ -91,12 +91,12 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		if node, ok := order.Expr.(*sqlparser.SQLVal); ok {
 			// This block handles constructs that use ordinals for 'ORDER BY'. For example:
 			// SELECT a, b, c FROM t1, t2 ORDER BY 1, 2, 3.
-			num, err := ResultFromNumber(bldr.Symtab().ResultColumns, node)
+			num, err := ResultFromNumber(pb.st.ResultColumns, node)
 			if err != nil {
 				return err
 			}
-			target := bldr.Symtab().ResultColumns[num].column.Origin()
-			if target != leftmostRB {
+			target := pb.st.ResultColumns[num].column.Origin()
+			if target != firstRB {
 				return errors.New("unsupported: order by spans across shards")
 			}
 		} else {
@@ -105,11 +105,11 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 			err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 				switch node := node.(type) {
 				case *sqlparser.ColName:
-					target, _, err := bldr.Symtab().Find(node)
+					target, _, err := pb.st.Find(node)
 					if err != nil {
 						return false, err
 					}
-					if target != leftmostRB {
+					if target != firstRB {
 						return false, errors.New("unsupported: order by spans across shards")
 					}
 				case *sqlparser.Subquery:
@@ -123,25 +123,26 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		}
 
 		// There were no errors. We can push the order by to the left-most route.
-		if err := leftmostRB.PushOrderBy(order); err != nil {
+		if err := firstRB.PushOrderBy(order); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func pushLimit(limit *sqlparser.Limit, bldr builder) (builder, error) {
+func (pb *planBuilder) pushLimit(limit *sqlparser.Limit) error {
 	if limit == nil {
-		return bldr, nil
+		return nil
 	}
-	rb, ok := bldr.(*route)
+	rb, ok := pb.bldr.(*route)
 	if ok && rb.IsSingle() {
 		rb.SetLimit(limit)
-		return bldr, nil
+		return nil
 	}
-	lb := newLimit(bldr)
+	lb := newLimit(pb.bldr)
 	if err := lb.SetLimit(limit); err != nil {
-		return nil, err
+		return err
 	}
-	return lb, nil
+	pb.bldr = lb
+	return nil
 }

--- a/go/vt/vtgate/planbuilder/primitive_builder.go
+++ b/go/vt/vtgate/planbuilder/primitive_builder.go
@@ -16,19 +16,19 @@ limitations under the License.
 
 package planbuilder
 
-// planBuilder is the top level type for building plans.
+// primitiveBuilder is the top level type for building plans.
 // It contains the current builder tree, the symtab and
 // the jointab. It can create transient planBuilders due
 // to the recursive nature of SQL.
-type planBuilder struct {
+type primitiveBuilder struct {
 	vschema ContextVSchema
 	jt      *jointab
 	bldr    builder
 	st      *symtab
 }
 
-func newPlanBuilder(vschema ContextVSchema, jt *jointab) *planBuilder {
-	return &planBuilder{
+func newPrimitiveBuilder(vschema ContextVSchema, jt *jointab) *primitiveBuilder {
+	return &primitiveBuilder{
 		vschema: vschema,
 		jt:      jt,
 	}

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -37,8 +37,7 @@ var errIntermixingUnsupported = errors.New("unsupported: intermixing of informat
 // are moved into this node, which will be used to build
 // the final SQL for this route.
 type route struct {
-	symtab *symtab
-	order  int
+	order int
 
 	// Redirect may point to another route if this route
 	// was merged with it. The Resolve function chases
@@ -65,7 +64,7 @@ type route struct {
 	ERoute *engine.Route
 }
 
-func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, condition sqlparser.Expr, vschema ContextVSchema) *route {
+func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, condition sqlparser.Expr) (*route, *symtab) {
 	rb := &route{
 		Select:        stmt,
 		order:         1,
@@ -73,8 +72,7 @@ func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, condition sq
 		weightStrings: make(map[*resultColumn]int),
 		ERoute:        eroute,
 	}
-	rb.symtab = newSymtabWithRoute(vschema, rb)
-	return rb
+	return rb, newSymtabWithRoute(rb)
 }
 
 // Resolve resolves redirects, and returns the last
@@ -84,11 +82,6 @@ func (rb *route) Resolve() *route {
 		rb = rb.Redirect
 	}
 	return rb
-}
-
-// Symtab satisfies the builder interface.
-func (rb *route) Symtab() *symtab {
-	return rb.symtab.Resolve()
 }
 
 // Order satisfies the builder interface.
@@ -106,8 +99,8 @@ func (rb *route) Primitive() engine.Primitive {
 	return rb.ERoute
 }
 
-// Leftmost satisfies the builder interface.
-func (rb *route) Leftmost() builder {
+// First satisfies the builder interface.
+func (rb *route) First() builder {
 	return rb
 }
 
@@ -116,132 +109,9 @@ func (rb *route) ResultColumns() []*resultColumn {
 	return rb.resultColumns
 }
 
-// Join joins with the RHS. This could produce a merged route
-// or a new join node.
-func (rb *route) Join(rRoute *route, ajoin *sqlparser.JoinTableExpr) (builder, error) {
-	if rb.ERoute.Opcode == engine.SelectNext {
-		return nil, errors.New("unsupported: sequence join with another table")
-	}
-	if rRoute.ERoute.Opcode == engine.SelectNext {
-		return nil, errors.New("unsupported: sequence join with another table")
-	}
-	if ajoin != nil && ajoin.Condition.Using != nil {
-		return nil, errors.New("unsupported: join with USING(column_list) clause")
-	}
-	if rb.ERoute.Keyspace.Name != rRoute.ERoute.Keyspace.Name {
-		return newJoin(rb, rRoute, ajoin)
-	}
-	switch rb.ERoute.Opcode {
-	case engine.SelectUnsharded:
-		if rRoute.ERoute.Opcode == engine.SelectUnsharded {
-			return rb.merge(rRoute, ajoin)
-		}
-		return nil, errIntermixingUnsupported
-	case engine.SelectDBA:
-		if rRoute.ERoute.Opcode == engine.SelectDBA {
-			return rb.merge(rRoute, ajoin)
-		}
-		return nil, errIntermixingUnsupported
-	}
-
-	// Both route are sharded routes. For ',' joins (ajoin==nil), don't
-	// analyze mergeability.
-	if ajoin == nil {
-		return newJoin(rb, rRoute, nil)
-	}
-
-	// Both route are sharded routes. Analyze join condition for merging.
-	for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
-		if rb.isSameRoute(rRoute, filter) {
-			return rb.merge(rRoute, ajoin)
-		}
-	}
-
-	// Both l & r routes point to the same shard.
-	if rb.ERoute.Opcode == engine.SelectEqualUnique && rRoute.ERoute.Opcode == engine.SelectEqualUnique {
-		if valEqual(rb.condition, rRoute.condition) {
-			return rb.merge(rRoute, ajoin)
-		}
-	}
-
-	return newJoin(rb, rRoute, ajoin)
-}
-
-// merge merges the two routes. The ON clause is also analyzed to
-// see if the primitive can be improved. The operation can fail if
-// the expression contains a non-pushable subquery. ajoin can be nil
-// if the join is on a ',' operator.
-func (rb *route) merge(rhs *route, ajoin *sqlparser.JoinTableExpr) (builder, error) {
-	sel := rb.Select.(*sqlparser.Select)
-	if ajoin == nil {
-		rhsSel := rhs.Select.(*sqlparser.Select)
-		sel.From = append(sel.From, rhsSel.From...)
-	} else {
-		sel.From = sqlparser.TableExprs{ajoin}
-		if ajoin.Join == sqlparser.LeftJoinStr {
-			rhs.Symtab().ClearVindexes()
-		}
-	}
-	// Redirect before merging the symtabs. Merge will use Redirect
-	// to check if rhs route matches lhs.
-	rhs.Redirect = rb
-	err := rb.Symtab().Merge(rhs.Symtab())
-	if err != nil {
-		return nil, err
-	}
-	if ajoin == nil {
-		return rb, nil
-	}
-	if ajoin.Condition.Using != nil {
-		return nil, errors.New("unsupported: join with USING(column_list) clause")
-	}
-	for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
-		// If VTGate evolves, this section should be rewritten
-		// to use processExpr.
-		_, err = findOrigin(filter, rb)
-		if err != nil {
-			return nil, err
-		}
-		rb.UpdatePlan(filter)
-	}
-	return rb, nil
-}
-
-// isSameRoute returns true if the join constraint makes the routes
-// mergeable by unique vindex. The constraint has to be an equality
-// like a.id = b.id where both columns have the same unique vindex.
-func (rb *route) isSameRoute(rhs *route, filter sqlparser.Expr) bool {
-	filter = skipParenthesis(filter)
-	comparison, ok := filter.(*sqlparser.ComparisonExpr)
-	if !ok {
-		return false
-	}
-	if comparison.Operator != sqlparser.EqualStr {
-		return false
-	}
-	left := comparison.Left
-	right := comparison.Right
-	lVindex := rb.Symtab().Vindex(left, rb)
-	if lVindex == nil {
-		left, right = right, left
-		lVindex = rb.Symtab().Vindex(left, rb)
-	}
-	if lVindex == nil || !lVindex.IsUnique() {
-		return false
-	}
-	rVindex := rhs.Symtab().Vindex(right, rhs)
-	if rVindex == nil {
-		return false
-	}
-	if rVindex != lVindex {
-		return false
-	}
-	return true
-}
-
 // PushFilter satisfies the builder interface.
 // The primitive will be updated if the new filter improves the plan.
-func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ builder) error {
+func (rb *route) PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, _ builder) error {
 	sel := rb.Select.(*sqlparser.Select)
 	switch whereType {
 	case sqlparser.WhereStr:
@@ -249,7 +119,7 @@ func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ builder) 
 	case sqlparser.HavingStr:
 		sel.AddHaving(filter)
 	}
-	rb.UpdatePlan(filter)
+	rb.UpdatePlan(pb, filter)
 	return nil
 }
 
@@ -259,8 +129,8 @@ func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ builder) 
 // the route. This function should only be used when merging
 // routes, where the ON clause gets implicitly pushed into
 // the merged route.
-func (rb *route) UpdatePlan(filter sqlparser.Expr) {
-	opcode, vindex, values := rb.computePlan(filter)
+func (rb *route) UpdatePlan(pb *planBuilder, filter sqlparser.Expr) {
+	opcode, vindex, values := rb.computePlan(pb, filter)
 	if opcode == engine.SelectScatter {
 		return
 	}
@@ -302,29 +172,29 @@ func (rb *route) updateRoute(opcode engine.RouteOpcode, vindex vindexes.Vindex, 
 }
 
 // computePlan computes the plan for the specified filter.
-func (rb *route) computePlan(filter sqlparser.Expr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
+func (rb *route) computePlan(pb *planBuilder, filter sqlparser.Expr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
 	switch node := filter.(type) {
 	case *sqlparser.ComparisonExpr:
 		switch node.Operator {
 		case sqlparser.EqualStr:
-			return rb.computeEqualPlan(node)
+			return rb.computeEqualPlan(pb, node)
 		case sqlparser.InStr:
-			return rb.computeINPlan(node)
+			return rb.computeINPlan(pb, node)
 		}
 	case *sqlparser.ParenExpr:
-		return rb.computePlan(node.Expr)
+		return rb.computePlan(pb, node.Expr)
 	}
 	return engine.SelectScatter, nil, nil
 }
 
 // computeEqualPlan computes the plan for an equality constraint.
-func (rb *route) computeEqualPlan(comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
+func (rb *route) computeEqualPlan(pb *planBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
 	left := comparison.Left
 	right := comparison.Right
-	vindex = rb.Symtab().Vindex(left, rb)
+	vindex = pb.st.Vindex(left, rb)
 	if vindex == nil {
 		left, right = right, left
-		vindex = rb.Symtab().Vindex(left, rb)
+		vindex = pb.st.Vindex(left, rb)
 		if vindex == nil {
 			return engine.SelectScatter, nil, nil
 		}
@@ -339,8 +209,8 @@ func (rb *route) computeEqualPlan(comparison *sqlparser.ComparisonExpr) (opcode 
 }
 
 // computeINPlan computes the plan for an IN constraint.
-func (rb *route) computeINPlan(comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
-	vindex = rb.Symtab().Vindex(comparison.Left, rb)
+func (rb *route) computeINPlan(pb *planBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.Vindex, condition sqlparser.Expr) {
+	vindex = pb.st.Vindex(comparison.Left, rb)
 	if vindex == nil {
 		return engine.SelectScatter, nil, nil
 	}
@@ -372,7 +242,7 @@ func (rb *route) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resultC
 	sel := rb.Select.(*sqlparser.Select)
 	sel.SelectExprs = append(sel.SelectExprs, expr)
 
-	rc = rb.Symtab().NewResultColumn(expr, rb)
+	rc = newResultColumn(expr, rb)
 	rb.resultColumns = append(rb.resultColumns, rc)
 
 	return rc, len(rb.resultColumns) - 1, nil
@@ -720,7 +590,7 @@ func (rb *route) IsSingle() bool {
 // SubqueryCanMerge returns nil if the supplied route that represents
 // a subquery can be merged with the outer route. If not, it
 // returns an appropriate error.
-func (rb *route) SubqueryCanMerge(inner *route) error {
+func (rb *route) SubqueryCanMerge(pb *planBuilder, inner *route) error {
 	if rb.ERoute.Keyspace.Name != inner.ERoute.Keyspace.Name {
 		return errors.New("unsupported: subquery keyspace different from outer query")
 	}
@@ -745,7 +615,7 @@ func (rb *route) SubqueryCanMerge(inner *route) error {
 		// query: the subquery can merge with the outer query.
 		switch vals := inner.condition.(type) {
 		case *sqlparser.ColName:
-			if rb.Symtab().Vindex(vals, rb) == inner.ERoute.Vindex {
+			if pb.st.Vindex(vals, rb) == inner.ERoute.Vindex {
 				return nil
 			}
 		}

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -26,7 +26,7 @@ import (
 
 // buildSelectPlan is the new function to build a Select plan.
 func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive engine.Primitive, err error) {
-	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(sel)))
+	pb := newPrimitiveBuilder(vschema, newJointab(sqlparser.GetBindvars(sel)))
 	if err := pb.processSelect(sel, nil); err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive e
 // The LIMIT clause is the last construct of a query. If it cannot be
 // pushed into a route, then a primitve is created on top of any
 // of the above trees to make it discard unwanted rows.
-func (pb *planBuilder) processSelect(sel *sqlparser.Select, outer *symtab) error {
+func (pb *primitiveBuilder) processSelect(sel *sqlparser.Select, outer *symtab) error {
 	if err := pb.processTableExprs(sel.From); err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (pb *planBuilder) processSelect(sel *sqlparser.Select, outer *symtab) error
 // pushFilter identifies the target route for the specified bool expr,
 // pushes it down, and updates the route info if the new constraint improves
 // the primitive. This function can push to a WHERE or HAVING clause.
-func (pb *planBuilder) pushFilter(boolExpr sqlparser.Expr, whereType string) error {
+func (pb *primitiveBuilder) pushFilter(boolExpr sqlparser.Expr, whereType string) error {
 	filters := splitAndExpression(nil, boolExpr)
 	reorderBySubquery(filters)
 	for _, filter := range filters {
@@ -150,7 +150,7 @@ func reorderBySubquery(filters []sqlparser.Expr) {
 
 // pushSelectExprs identifies the target route for the
 // select expressions and pushes them down.
-func (pb *planBuilder) pushSelectExprs(sel *sqlparser.Select, grouper groupByHandler) error {
+func (pb *primitiveBuilder) pushSelectExprs(sel *sqlparser.Select, grouper groupByHandler) error {
 	resultColumns, err := pb.pushSelectRoutes(sel.SelectExprs)
 	if err != nil {
 		return err
@@ -161,7 +161,7 @@ func (pb *planBuilder) pushSelectExprs(sel *sqlparser.Select, grouper groupByHan
 
 // pusheSelectRoutes is a convenience function that pushes all the select
 // expressions and returns the list of resultColumns generated for it.
-func (pb *planBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) ([]*resultColumn, error) {
+func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) ([]*resultColumn, error) {
 	resultColumns := make([]*resultColumn, len(selectExprs))
 	for i, node := range selectExprs {
 		switch node := node.(type) {

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -24,24 +24,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
-// planBuilder is the top level type for building plans.
-// It contains the current builder tree, the symtab and
-// the jointab. It can create transient planBuilders due
-// to the recursive nature of SQL.
-type planBuilder struct {
-	vschema ContextVSchema
-	jt      *jointab
-	bldr    builder
-	st      *symtab
-}
-
-func newPlanBuilder(vschema ContextVSchema, jt *jointab) *planBuilder {
-	return &planBuilder{
-		vschema: vschema,
-		jt:      jt,
-	}
-}
-
 // buildSelectPlan is the new function to build a Select plan.
 func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive engine.Primitive, err error) {
 	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(sel)))

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -24,24 +24,39 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+// planBuilder is the top level type for building plans.
+// It contains the current builder tree, the symtab and
+// the jointab. It can create transient planBuilders due
+// to the recursive nature of SQL.
+type planBuilder struct {
+	vschema ContextVSchema
+	jt      *jointab
+	bldr    builder
+	st      *symtab
+}
+
+func newPlanBuilder(vschema ContextVSchema, jt *jointab) *planBuilder {
+	return &planBuilder{
+		vschema: vschema,
+		jt:      jt,
+	}
+}
+
 // buildSelectPlan is the new function to build a Select plan.
 func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive engine.Primitive, err error) {
-	bindvars := sqlparser.GetBindvars(sel)
-	builder, err := processSelect(sel, vschema, nil)
-	if err != nil {
+	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(sel)))
+	if err := pb.processSelect(sel, nil); err != nil {
 		return nil, err
 	}
-	jt := newJointab(bindvars)
-	err = builder.Wireup(builder, jt)
-	if err != nil {
+	if err := pb.bldr.Wireup(pb.bldr, pb.jt); err != nil {
 		return nil, err
 	}
-	if rb, ok := builder.(*route); ok {
+	if rb, ok := pb.bldr.(*route); ok {
 		if rb.ERoute.TargetDestination != nil {
 			return nil, errors.New("unsupported: SELECT with a target destination")
 		}
 	}
-	return builder.Primitive(), nil
+	return pb.bldr.Primitive(), nil
 }
 
 // processSelect builds a primitive tree for the given query or subquery.
@@ -79,58 +94,52 @@ func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive e
 // The LIMIT clause is the last construct of a query. If it cannot be
 // pushed into a route, then a primitve is created on top of any
 // of the above trees to make it discard unwanted rows.
-func processSelect(sel *sqlparser.Select, vschema ContextVSchema, outer builder) (builder, error) {
-	bldr, err := processTableExprs(sel.From, vschema)
-	if err != nil {
-		return nil, err
+func (pb *planBuilder) processSelect(sel *sqlparser.Select, outer *symtab) error {
+	if err := pb.processTableExprs(sel.From); err != nil {
+		return err
 	}
-	if outer != nil {
-		bldr.Symtab().Outer = outer.Symtab()
-	}
+	// Set the outer symtab after processing of FROM clause.
+	// This is because correlation is not allowed there.
+	pb.st.Outer = outer
 	if sel.Where != nil {
-		err = pushFilter(sel.Where.Expr, bldr, sqlparser.WhereStr)
-		if err != nil {
-			return nil, err
+		if err := pb.pushFilter(sel.Where.Expr, sqlparser.WhereStr); err != nil {
+			return err
 		}
 	}
-	bldr, err = checkAggregates(sel, bldr)
+	grouper, err := pb.checkAggregates(sel)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	bldr, err = pushSelectExprs(sel, bldr)
-	if err != nil {
-		return nil, err
+	if err := pb.pushSelectExprs(sel, grouper); err != nil {
+		return err
 	}
 	if sel.Having != nil {
-		err = pushFilter(sel.Having.Expr, bldr, sqlparser.HavingStr)
-		if err != nil {
-			return nil, err
+		if err := pb.pushFilter(sel.Having.Expr, sqlparser.HavingStr); err != nil {
+			return err
 		}
 	}
-	err = pushOrderBy(sel.OrderBy, bldr)
-	if err != nil {
-		return nil, err
+	if err := pb.pushOrderBy(sel.OrderBy); err != nil {
+		return err
 	}
-	bldr, err = pushLimit(sel.Limit, bldr)
-	if err != nil {
-		return nil, err
+	if err := pb.pushLimit(sel.Limit); err != nil {
+		return err
 	}
-	bldr.PushMisc(sel)
-	return bldr, nil
+	pb.bldr.PushMisc(sel)
+	return nil
 }
 
 // pushFilter identifies the target route for the specified bool expr,
 // pushes it down, and updates the route info if the new constraint improves
 // the primitive. This function can push to a WHERE or HAVING clause.
-func pushFilter(boolExpr sqlparser.Expr, bldr builder, whereType string) error {
+func (pb *planBuilder) pushFilter(boolExpr sqlparser.Expr, whereType string) error {
 	filters := splitAndExpression(nil, boolExpr)
 	reorderBySubquery(filters)
 	for _, filter := range filters {
-		origin, err := findOrigin(filter, bldr)
+		origin, err := pb.findOrigin(filter)
 		if err != nil {
 			return err
 		}
-		if err := bldr.PushFilter(filter, whereType, origin); err != nil {
+		if err := pb.bldr.PushFilter(pb, filter, whereType, origin); err != nil {
 			return err
 		}
 	}
@@ -159,37 +168,33 @@ func reorderBySubquery(filters []sqlparser.Expr) {
 
 // pushSelectExprs identifies the target route for the
 // select expressions and pushes them down.
-func pushSelectExprs(sel *sqlparser.Select, bldr builder) (builder, error) {
-	resultColumns, err := pushSelectRoutes(sel.SelectExprs, bldr)
+func (pb *planBuilder) pushSelectExprs(sel *sqlparser.Select, grouper groupByHandler) error {
+	resultColumns, err := pb.pushSelectRoutes(sel.SelectExprs)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	bldr.Symtab().ResultColumns = resultColumns
-
-	if err := pushGroupBy(sel, bldr); err != nil {
-		return nil, err
-	}
-	return bldr, nil
+	pb.st.SetResultColumns(resultColumns)
+	return pb.pushGroupBy(sel, grouper)
 }
 
 // pusheSelectRoutes is a convenience function that pushes all the select
 // expressions and returns the list of resultColumns generated for it.
-func pushSelectRoutes(selectExprs sqlparser.SelectExprs, bldr builder) ([]*resultColumn, error) {
+func (pb *planBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) ([]*resultColumn, error) {
 	resultColumns := make([]*resultColumn, len(selectExprs))
 	for i, node := range selectExprs {
 		switch node := node.(type) {
 		case *sqlparser.AliasedExpr:
-			origin, err := findOrigin(node.Expr, bldr)
+			origin, err := pb.findOrigin(node.Expr)
 			if err != nil {
 				return nil, err
 			}
-			resultColumns[i], _, err = bldr.PushSelect(node, origin)
+			resultColumns[i], _, err = pb.bldr.PushSelect(node, origin)
 			if err != nil {
 				return nil, err
 			}
 		case *sqlparser.StarExpr:
 			// We'll allow select * for simple routes.
-			rb, ok := bldr.(*route)
+			rb, ok := pb.bldr.(*route)
 			if !ok {
 				return nil, errors.New("unsupported: '*' expression in cross-shard query")
 			}
@@ -203,7 +208,7 @@ func pushSelectRoutes(selectExprs sqlparser.SelectExprs, bldr builder) ([]*resul
 			}
 			resultColumns[i] = rb.PushAnonymous(node)
 		case sqlparser.Nextval:
-			rb, ok := bldr.(*route)
+			rb, ok := pb.bldr.(*route)
 			if !ok {
 				// This code is unreachable because the parser doesn't allow joins for next val statements.
 				return nil, errors.New("unsupported: SELECT NEXT query in cross-shard query")

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -36,18 +36,16 @@ var _ builder = (*subquery)(nil)
 // a subquery.
 type subquery struct {
 	order         int
-	symtab        *symtab
 	resultColumns []*resultColumn
 	input         builder
 	esubquery     *engine.Subquery
 }
 
 // newSubquery builds a new subquery.
-func newSubquery(alias sqlparser.TableIdent, bldr builder, vschema ContextVSchema) *subquery {
+func newSubquery(alias sqlparser.TableIdent, bldr builder) (*subquery, *symtab) {
 	sq := &subquery{
 		order:     bldr.Order() + 1,
 		input:     bldr,
-		symtab:    newSymtab(vschema),
 		esubquery: &engine.Subquery{},
 	}
 
@@ -68,14 +66,10 @@ func newSubquery(alias sqlparser.TableIdent, bldr builder, vschema ContextVSchem
 
 	// Populate the table with those columns and add it to symtab.
 	t.columns = cols
+	st := newSymtab()
 	// AddTable will not fail because symtab is empty.
-	_ = sq.symtab.AddTable(t)
-	return sq
-}
-
-// Symtab satisfies the builder interface.
-func (sq *subquery) Symtab() *symtab {
-	return sq.symtab.Resolve()
+	_ = st.AddTable(t)
+	return sq, st
 }
 
 // Order satisfies the builder interface.
@@ -95,8 +89,8 @@ func (sq *subquery) Primitive() engine.Primitive {
 	return sq.esubquery
 }
 
-// Leftmost satisfies the builder interface.
-func (sq *subquery) Leftmost() builder {
+// First satisfies the builder interface.
+func (sq *subquery) First() builder {
 	return sq
 }
 
@@ -106,7 +100,7 @@ func (sq *subquery) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (sq *subquery) PushFilter(_ sqlparser.Expr, whereType string, _ builder) error {
+func (sq *subquery) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	return errors.New("unsupported: filtering on results of cross-shard subquery")
 }
 
@@ -122,7 +116,7 @@ func (sq *subquery) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resu
 	sq.esubquery.Cols = append(sq.esubquery.Cols, inner)
 
 	// Build a new column reference to represent the result column.
-	rc = sq.Symtab().NewResultColumn(expr, sq)
+	rc = newResultColumn(expr, sq)
 	sq.resultColumns = append(sq.resultColumns, rc)
 
 	return rc, len(sq.resultColumns) - 1, nil

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -100,7 +100,7 @@ func (sq *subquery) ResultColumns() []*resultColumn {
 }
 
 // PushFilter satisfies the builder interface.
-func (sq *subquery) PushFilter(_ *planBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
+func (sq *subquery) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
 	return errors.New("unsupported: filtering on results of cross-shard subquery")
 }
 

--- a/go/vt/vtgate/planbuilder/symtab_test.go
+++ b/go/vt/vtgate/planbuilder/symtab_test.go
@@ -118,7 +118,7 @@ func TestSymtabAddVindexTable(t *testing.T) {
 	}}
 
 	for _, tcase := range tcases {
-		st := newSymtab(nil)
+		st := newSymtab()
 		err := st.AddVindexTable(tname, tcase.in, rb)
 		if err != nil {
 			t.Error(err)

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -26,7 +26,7 @@ import (
 
 func buildUnionPlan(union *sqlparser.Union, vschema ContextVSchema) (primitive engine.Primitive, err error) {
 	// For unions, create a pb with anonymous scope.
-	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(union)))
+	pb := newPrimitiveBuilder(vschema, newJointab(sqlparser.GetBindvars(union)))
 	if err := pb.processUnion(union, nil); err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func buildUnionPlan(union *sqlparser.Union, vschema ContextVSchema) (primitive e
 	return pb.bldr.Primitive(), nil
 }
 
-func (pb *planBuilder) processUnion(union *sqlparser.Union, outer *symtab) error {
-	lpb := newPlanBuilder(pb.vschema, pb.jt)
+func (pb *primitiveBuilder) processUnion(union *sqlparser.Union, outer *symtab) error {
+	lpb := newPrimitiveBuilder(pb.vschema, pb.jt)
 	if err := lpb.processPart(union.Left, outer); err != nil {
 		return err
 	}
-	rpb := newPlanBuilder(pb.vschema, pb.jt)
+	rpb := newPrimitiveBuilder(pb.vschema, pb.jt)
 	if err := rpb.processPart(union.Right, outer); err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (pb *planBuilder) processUnion(union *sqlparser.Union, outer *symtab) error
 	return pb.pushLimit(union.Limit)
 }
 
-func (pb *planBuilder) processPart(part sqlparser.SelectStatement, outer *symtab) error {
+func (pb *primitiveBuilder) processPart(part sqlparser.SelectStatement, outer *symtab) error {
 	switch part := part.(type) {
 	case *sqlparser.Union:
 		return pb.processUnion(part, outer)

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -25,84 +25,70 @@ import (
 )
 
 func buildUnionPlan(union *sqlparser.Union, vschema ContextVSchema) (primitive engine.Primitive, err error) {
-	bindvars := sqlparser.GetBindvars(union)
-	bldr, err := processUnion(union, vschema, nil)
-	if err != nil {
+	// For unions, create a pb with anonymous scope.
+	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(union)))
+	if err := pb.processUnion(union, nil); err != nil {
 		return nil, err
 	}
-	jt := newJointab(bindvars)
-	err = bldr.Wireup(bldr, jt)
-	if err != nil {
+	if err := pb.bldr.Wireup(pb.bldr, pb.jt); err != nil {
 		return nil, err
 	}
-	return bldr.Primitive(), nil
+	return pb.bldr.Primitive(), nil
 }
 
-func processUnion(union *sqlparser.Union, vschema ContextVSchema, outer builder) (builder, error) {
-	lbldr, err := processPart(union.Left, vschema, outer)
-	if err != nil {
-		return nil, err
+func (pb *planBuilder) processUnion(union *sqlparser.Union, outer *symtab) error {
+	lpb := newPlanBuilder(pb.vschema, pb.jt)
+	if err := lpb.processPart(union.Left, outer); err != nil {
+		return err
 	}
-	rbldr, err := processPart(union.Right, vschema, outer)
-	if err != nil {
-		return nil, err
+	rpb := newPlanBuilder(pb.vschema, pb.jt)
+	if err := rpb.processPart(union.Right, outer); err != nil {
+		return err
 	}
-	bldr, err := unionRouteMerge(union, lbldr, rbldr, vschema)
-	if err != nil {
-		return nil, err
-	}
-	if outer != nil {
-		bldr.Symtab().Outer = outer.Symtab()
-	}
-	err = pushOrderBy(union.OrderBy, bldr)
-	if err != nil {
-		return nil, err
-	}
-	bldr, err = pushLimit(union.Limit, bldr)
-	if err != nil {
-		return nil, err
-	}
-	return bldr, nil
-}
 
-func processPart(part sqlparser.SelectStatement, vschema ContextVSchema, outer builder) (builder, error) {
 	var err error
-	var bldr builder
+	pb.bldr, pb.st, err = unionRouteMerge(union, lpb.bldr, rpb.bldr)
+	if err != nil {
+		return err
+	}
+	pb.st.Outer = outer
+
+	if err := pb.pushOrderBy(union.OrderBy); err != nil {
+		return err
+	}
+	return pb.pushLimit(union.Limit)
+}
+
+func (pb *planBuilder) processPart(part sqlparser.SelectStatement, outer *symtab) error {
 	switch part := part.(type) {
 	case *sqlparser.Union:
-		bldr, err = processUnion(part, vschema, outer)
+		return pb.processUnion(part, outer)
 	case *sqlparser.Select:
-		bldr, err = processSelect(part, vschema, outer)
+		return pb.processSelect(part, outer)
 	case *sqlparser.ParenSelect:
-		bldr, err = processPart(part.Select, vschema, outer)
-	default:
-		panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", part))
+		return pb.processPart(part.Select, outer)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return bldr, nil
+	panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", part))
 }
 
-func unionRouteMerge(union *sqlparser.Union, left, right builder, vschema ContextVSchema) (builder, error) {
+func unionRouteMerge(union *sqlparser.Union, left, right builder) (builder, *symtab, error) {
 	lroute, ok := left.(*route)
 	if !ok {
-		return nil, errors.New("unsupported construct: SELECT of UNION is non-trivial")
+		return nil, nil, errors.New("unsupported construct: SELECT of UNION is non-trivial")
 	}
 	rroute, ok := right.(*route)
 	if !ok {
-		return nil, errors.New("unsupported construct: SELECT of UNION is non-trivial")
+		return nil, nil, errors.New("unsupported construct: SELECT of UNION is non-trivial")
 	}
 	if err := lroute.UnionCanMerge(rroute); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	rb := newRoute(
+	rb, st := newRoute(
 		&sqlparser.Union{Type: union.Type, Left: union.Left, Right: union.Right, Lock: union.Lock},
 		lroute.ERoute,
 		lroute.condition,
-		vschema,
 	)
 	lroute.Redirect = rb
 	rroute.Redirect = rb
-	return rb, nil
+	return rb, st, nil
 }

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -34,7 +34,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema ContextVSchema) (*engine.Upd
 		Query:               generateQuery(upd),
 		ChangedVindexValues: make(map[string][]sqltypes.PlanValue),
 	}
-	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(upd)))
+	pb := newPrimitiveBuilder(vschema, newJointab(sqlparser.GetBindvars(upd)))
 	if err := pb.processTableExprs(upd.TableExprs); err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -34,11 +34,11 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema ContextVSchema) (*engine.Upd
 		Query:               generateQuery(upd),
 		ChangedVindexValues: make(map[string][]sqltypes.PlanValue),
 	}
-	bldr, err := processTableExprs(upd.TableExprs, vschema)
-	if err != nil {
+	pb := newPlanBuilder(vschema, newJointab(sqlparser.GetBindvars(upd)))
+	if err := pb.processTableExprs(upd.TableExprs); err != nil {
 		return nil, err
 	}
-	rb, ok := bldr.(*route)
+	rb, ok := pb.bldr.(*route)
 	if !ok {
 		return nil, errors.New("unsupported: multi-table update statement in sharded keyspace")
 	}
@@ -48,7 +48,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema ContextVSchema) (*engine.Upd
 	eupd.Keyspace = rb.ERoute.Keyspace
 	if !eupd.Keyspace.Sharded {
 		// We only validate non-table subexpressions because the previous analysis has already validated them.
-		if !validateSubquerySamePlan(rb.ERoute.Keyspace.Name, rb, vschema, upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
+		if !pb.validateSubquerySamePlan(upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		eupd.Opcode = engine.UpdateUnsharded
@@ -58,18 +58,19 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema ContextVSchema) (*engine.Upd
 	if hasSubquery(upd) {
 		return nil, errors.New("unsupported: subqueries in sharded DML")
 	}
-	if len(rb.Symtab().tables) != 1 {
+	if len(pb.st.tables) != 1 {
 		return nil, errors.New("unsupported: multi-table update statement in sharded keyspace")
 	}
 
 	var vindexTable *vindexes.Table
-	for _, tval := range rb.Symtab().tables {
+	for _, tval := range pb.st.tables {
 		vindexTable = tval.vindexTable
 	}
 	eupd.Table = vindexTable
 	if eupd.Table == nil {
 		return nil, errors.New("internal error: table.vindexTable is mysteriously nil")
 	}
+	var err error
 	eupd.Vindex, eupd.Values, err = getDMLRouting(upd.Where, eupd.Table)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -31,8 +31,7 @@ var _ builder = (*vindexFunc)(nil)
 
 // vindexFunc is used to build a VindexFunc primitive.
 type vindexFunc struct {
-	order  int
-	symtab *symtab
+	order int
 
 	// resultColumns represent the columns returned by this route.
 	resultColumns []*resultColumn
@@ -41,10 +40,9 @@ type vindexFunc struct {
 	eVindexFunc *engine.VindexFunc
 }
 
-func newVindexFunc(alias sqlparser.TableName, vindex vindexes.Vindex, vschema ContextVSchema) *vindexFunc {
+func newVindexFunc(alias sqlparser.TableName, vindex vindexes.Vindex) (*vindexFunc, *symtab) {
 	vf := &vindexFunc{
-		symtab: newSymtab(vschema),
-		order:  1,
+		order: 1,
 		eVindexFunc: &engine.VindexFunc{
 			Vindex: vindex,
 		},
@@ -68,14 +66,10 @@ func newVindexFunc(alias sqlparser.TableName, vindex vindexes.Vindex, vschema Co
 		},
 	}
 
+	st := newSymtab()
 	// AddTable will not fail because symtab is empty.
-	_ = vf.symtab.AddTable(t)
-	return vf
-}
-
-// Symtab satisfies the builder interface.
-func (vf *vindexFunc) Symtab() *symtab {
-	return vf.symtab.Resolve()
+	_ = st.AddTable(t)
+	return vf, st
 }
 
 // Order satisfies the builder interface.
@@ -93,8 +87,8 @@ func (vf *vindexFunc) Primitive() engine.Primitive {
 	return vf.eVindexFunc
 }
 
-// Leftmost satisfies the builder interface.
-func (vf *vindexFunc) Leftmost() builder {
+// First satisfies the builder interface.
+func (vf *vindexFunc) First() builder {
 	return vf
 }
 
@@ -105,7 +99,7 @@ func (vf *vindexFunc) ResultColumns() []*resultColumn {
 
 // PushFilter satisfies the builder interface.
 // Only some where clauses are allowed.
-func (vf *vindexFunc) PushFilter(filter sqlparser.Expr, whereType string, _ builder) error {
+func (vf *vindexFunc) PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, _ builder) error {
 	if vf.eVindexFunc.Opcode != engine.VindexNone {
 		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (multiple filters)")
 	}
@@ -151,7 +145,7 @@ func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *re
 	if !ok {
 		return nil, 0, errors.New("unsupported: expression on results of a vindex function")
 	}
-	rc = vf.symtab.NewResultColumn(expr, vf)
+	rc = newResultColumn(expr, vf)
 	vf.resultColumns = append(vf.resultColumns, rc)
 	vf.eVindexFunc.Fields = append(vf.eVindexFunc.Fields, &querypb.Field{
 		Name: rc.alias.String(),

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -99,7 +99,7 @@ func (vf *vindexFunc) ResultColumns() []*resultColumn {
 
 // PushFilter satisfies the builder interface.
 // Only some where clauses are allowed.
-func (vf *vindexFunc) PushFilter(pb *planBuilder, filter sqlparser.Expr, whereType string, _ builder) error {
+func (vf *vindexFunc) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereType string, _ builder) error {
 	if vf.eVindexFunc.Opcode != engine.VindexNone {
 		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (multiple filters)")
 	}


### PR DESCRIPTION
This is a fundamental change in the relationships
of some core data structures.

Previously, every primitive was required to point at
the symatb it was part of. At the same time,
a symtab pointed at various primitives through
the symbols it was holding. This was problematic when
symtabs merged, which required the old symtabs to 'redirect'
to the new ones. There was no clarity on when those redirects
were applicable. There were places where it was not used.

In this new code, the primitive->symtab relationship has
been removed. A new top level planBuilder object now holds
the symtab, along with other 'global' things like vschema,
and the jointab. Most functions that needed the symtab
have been made members of planBuilder. There are a few
stray cases (members of the builder primitives) that still
need it. In those cases, the symtab is passed in. But these
are far and few.

This has led to an overall simplification because this has
caused most function signatures to shrink. There is also
no ambiguity about the exact symtab being referenced.

The route merge functionality had to be refactored. Some
of those functions have moved to planBuilder. Also,
newJoin was affected. Also, the code in newJoin was
conceptually incorrect when handling left join. This
has now been fixed to better represent the meaning
of the functionality.

In builder, LeftMost has been renamed to First, which
is a more appropriate name.

Also, while handling group by expressions, there were
some risky type-casts. That has now been cleaned. If
a group by is possible, then the analyzer returns
an explicit object that can handle them.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>