### PR TITLE
fix data race in vtexplain implementation of ExecuteBatch

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -224,12 +224,11 @@ func (t *explainTablet) ExecuteBatch(ctx context.Context, target *querypb.Target
 	// Since the query is simulated being "sent" over the wire we need to
 	// copy the bindVars into the executor to avoid a data race.
 	for _, query := range queries {
-		bindVariables := sqltypes.CopyBindVariables(query.BindVariables)
-		query.BindVariables = bindVariables
+		query.BindVariables = sqltypes.CopyBindVariables(query.BindVariables)
 		t.tabletQueries = append(t.tabletQueries, &TabletQuery{
 			Time:     t.currentTime,
 			SQL:      query.Sql,
-			BindVars: bindVariables,
+			BindVars: query.BindVariables,
 		})
 	}
 	t.mu.Unlock()

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -225,6 +225,7 @@ func (t *explainTablet) ExecuteBatch(ctx context.Context, target *querypb.Target
 	// copy the bindVars into the executor to avoid a data race.
 	for _, query := range queries {
 		bindVariables := sqltypes.CopyBindVariables(query.BindVariables)
+		query.BindVariables = bindVariables
 		t.tabletQueries = append(t.tabletQueries, &TabletQuery{
 			Time:     t.currentTime,
 			SQL:      query.Sql,


### PR DESCRIPTION
To prevent concurrent access to the BindVariables map, vtexplain
needs to copy the map when simulating RPCs from the vtgate to the
vttablet.

Fix a bug where the ExecuteBatch implementation didn't do this
quite right which caused a data race.
