### PR TITLE
Describe tuples more accurately in streaming short logs

### DIFF
--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -112,6 +112,8 @@ func (stats *LogStats) FmtBindVariables(full bool) string {
 		for k, v := range stats.BindVariables {
 			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
 				out[k] = v
+			} else if v.Type == querypb.Type_TUPLE {
+				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v items", len(v.Values)))
 			} else {
 				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v bytes", len(v.Value)))
 			}

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -120,9 +120,16 @@ func TestLogStatsFormat(t *testing.T) {
 }
 
 func TestLogStatsFormatBindVariables(t *testing.T) {
+	tupleBindVar, err := sqltypes.BuildBindVariable([]int64{1, 2})
+	if err != nil {
+		t.Fatalf("failed to create a tuple bind var: %v", err)
+	}
+
 	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{
 		"key_1": sqltypes.StringBindVariable("val_1"),
 		"key_2": sqltypes.Int64BindVariable(789),
+		"key_3": sqltypes.BytesBindVariable([]byte("val_3")),
+		"key_4": tupleBindVar,
 	})
 
 	formattedStr := logStats.FmtBindVariables(true)
@@ -134,8 +141,14 @@ func TestLogStatsFormatBindVariables(t *testing.T) {
 		!strings.Contains(formattedStr, "789") {
 		t.Fatalf("bind variable 'key_2': '789' is not formatted")
 	}
+	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "val_3") {
+		t.Fatalf("bind variable 'key_3': 'val_3' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_4") ||
+		!strings.Contains(formattedStr, "values:<type:INT64 value:\"1\" > values:<type:INT64 value:\"2\" >") {
+		t.Fatalf("bind variable 'key_4': (1, 2) is not formatted")
+	}
 
-	logStats.BindVariables["key_3"] = sqltypes.BytesBindVariable([]byte("val_3"))
 	formattedStr = logStats.FmtBindVariables(false)
 	if !strings.Contains(formattedStr, "key_1") {
 		t.Fatalf("bind variable 'key_1' is not formatted")
@@ -144,8 +157,11 @@ func TestLogStatsFormatBindVariables(t *testing.T) {
 		!strings.Contains(formattedStr, "789") {
 		t.Fatalf("bind variable 'key_2': '789' is not formatted")
 	}
-	if !strings.Contains(formattedStr, "key_3") {
+	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "5 bytes") {
 		t.Fatalf("bind variable 'key_3' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_4") || !strings.Contains(formattedStr, "2 items") {
+		t.Fatalf("bind variable 'key_4' is not formatted")
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -154,6 +154,8 @@ func (stats *LogStats) FmtBindVariables(full bool) string {
 		for k, v := range stats.BindVariables {
 			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
 				out[k] = v
+			} else if v.Type == querypb.Type_TUPLE {
+				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v items", len(v.Values)))
 			} else {
 				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v bytes", len(v.Value)))
 			}


### PR DESCRIPTION
Currently tuples are described as "0 bytes", which is misleading and can make you worry that a tuple is empty when it's not.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>