### PR TITLE
parser: fix weird parser bug

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -118,6 +118,9 @@ var (
 	}, {
 		input: "select * from t1 join (select * from t2 union select * from t3) as t",
 	}, {
+		// Ensure this doesn't generate: ""select * from t1 join t2 on a = b join t3 on a = b".
+		input: "select * from t1 join t2 on a = b join t3",
+	}, {
 		input: "select * from t1 where col in (select 1 from dual union select 2 from dual)",
 	}, {
 		input: "select * from t1 where exists (select a from t2 union select b from t3)",

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -3969,6 +3969,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1549
 		{
+			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 280:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -3980,6 +3981,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1555
 		{
+			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 282:
 		yyDollar = yyS[yypt-2 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -1546,13 +1546,13 @@ join_condition:
 
 join_condition_opt:
 %prec JOIN
-  { }
+  { $$ = JoinCondition{} }
 | join_condition
   { $$ = $1 }
 
 on_expression_opt:
 %prec JOIN
-  { }
+  { $$ = JoinCondition{} }
 | ON expression
   { $$ = JoinCondition{On: $2} }
 


### PR DESCRIPTION
For some reason an empty { } doesn't get treated correctly in the
parser. A previously used value gets returned instead of a zero
value. Due to this, an input like this:
`select * from t1 join t2 on a = b join t3`
regenerated as:
`select * from t1 join t2 on a = b join t3 on a = b`

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>