### PR TITLE
Do not send to bin log init.db DDL's

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -5,6 +5,9 @@
 # Equivalent of mysql_secure_installation
 ##########################################
 
+# Changes during the init db should not make it to the binlog.
+# They could potentially create errant transactions on replicas.
+SET sql_log_bin = 0;
 # Remove anonymous users.
 DELETE FROM mysql.user WHERE User = '';
 


### PR DESCRIPTION
### Description

We recently discovered that there is a race where DDL's from this script could become errant transactions. I think we don't need these to end up in the bin log. We fixed by doing that. 
