### PR TITLE
Fix s3 backups of tables > 50gb

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -402,7 +402,7 @@ func backupFiles(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger,
 	}
 
 	// open the MANIFEST
-	wc, err := bh.AddFile(ctx, backupManifest)
+	wc, err := bh.AddFile(ctx, backupManifest, 0)
 	if err != nil {
 		return fmt.Errorf("cannot add %v to backup: %v", backupManifest, err)
 	}
@@ -440,8 +440,13 @@ func backupFile(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger, 
 	}
 	defer source.Close()
 
+	fi, err := source.Stat()
+	if err != nil {
+		return err
+	}
+
 	// Open the destination file for writing, and a buffer.
-	wc, err := bh.AddFile(ctx, name)
+	wc, err := bh.AddFile(ctx, name, fi.Size())
 	if err != nil {
 		return fmt.Errorf("cannot add file: %v", err)
 	}

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -49,7 +49,7 @@ type BackupHandle interface {
 	// multiple go routines once a backup has been started.
 	// The context is valid for the duration of the writes, until the
 	// WriteCloser is closed.
-	AddFile(ctx context.Context, filename string) (io.WriteCloser, error)
+	AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error)
 
 	// EndBackup stops and closes a backup. The contents should be kept.
 	// Only works for read-write backups (created by StartBackup).

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -73,7 +73,7 @@ func (bh *CephBackupHandle) Name() string {
 }
 
 // AddFile implements BackupHandle.
-func (bh *CephBackupHandle) AddFile(ctx context.Context, filename string) (io.WriteCloser, error) {
+func (bh *CephBackupHandle) AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error) {
 	if bh.readOnly {
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -56,7 +56,7 @@ func (fbh *FileBackupHandle) Name() string {
 }
 
 // AddFile is part of the BackupHandle interface
-func (fbh *FileBackupHandle) AddFile(ctx context.Context, filename string) (io.WriteCloser, error) {
+func (fbh *FileBackupHandle) AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error) {
 	if fbh.readOnly {
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}

--- a/go/vt/mysqlctl/filebackupstorage/file_test.go
+++ b/go/vt/mysqlctl/filebackupstorage/file_test.go
@@ -140,7 +140,7 @@ func TestListBackups(t *testing.T) {
 	}
 
 	// check we cannot chaneg a backup we listed
-	if _, err := bhs[0].AddFile(ctx, "test"); err == nil {
+	if _, err := bhs[0].AddFile(ctx, "test", 0); err == nil {
 		t.Fatalf("was able to AddFile to read-only backup")
 	}
 	if err := bhs[0].EndBackup(ctx); err == nil {
@@ -166,7 +166,7 @@ func TestFileContents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fbs.StartBackup failed: %v", err)
 	}
-	wc, err := bh.AddFile(ctx, filename1)
+	wc, err := bh.AddFile(ctx, filename1, 0)
 	if err != nil {
 		t.Fatalf("bh.AddFile failed: %v", err)
 	}

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -66,7 +66,7 @@ func (bh *GCSBackupHandle) Name() string {
 }
 
 // AddFile implements BackupHandle.
-func (bh *GCSBackupHandle) AddFile(ctx context.Context, filename string) (io.WriteCloser, error) {
+func (bh *GCSBackupHandle) AddFile(ctx context.Context, filename string, filesize int64) (io.WriteCloser, error) {
 	if bh.readOnly {
 		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
 	}


### PR DESCRIPTION
By default the s3uploader has a max of 10000 parts with a default part size of 5mb, meaning the largest file it can upload successfully is 50gb. 
Any table with data greater than 50gb will fail a backup with:
```
E0417 14:54:36.546921   50578 main.go:58] E0417 14:54:36.546467 vtctl.go:1042] E0417 14:54:36.545616 backup.go:243] backup is not usable, aborting it: cannot copy data: MultipartUpload: upload multipart failed
    upload id: crmzwJ5gN7OhgpKuwrre4lNl9QDpudJeaiOdSvvKj04NZho_NRogaIoOFE62iqpghEEpawgEkZmk2NYDifXUYoTCOApvV7nUn7trb3HE4KaWt_bAbeV3uAxdqnMlI_11
caused by: TotalPartsExceeded: exceeded total allowed configured MaxUploadParts (10000). Adjust PartSize to fit in this limit
E0417 14:54:37.454383   50578 main.go:61] Remote error: rpc error: code = Unknown desc = TabletManager.Backup on prod-0368789102 error: cannot copy data: MultipartUpload: upload multipart failed
    upload id: crmzwJ5gN7OhgpKuwrre4lNl9QDpudJeaiOdSvvKj04NZho_NRogaIoOFE62iqpghEEpawgEkZmk2NYDifXUYoTCOApvV7nUn7trb3HE4KaWt_bAbeV3uAxdqnMlI_11
caused by: TotalPartsExceeded: exceeded total allowed configured MaxUploadParts (10000). Adjust PartSize to fit in this limit
```

This PR dynamically adjusts the uploader partsize based on the filesize of the source file by doing filesize/max parts and then rounding that up to the nearest mb. I tested this successfully on a db with a 120gb table.