### PR TITLE
vt/log: Do not use an alias when importing the "glog" package.

### DIFF
--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -5,9 +5,7 @@
 
 package log
 
-import (
-	glog "github.com/golang/glog"
-)
+import "github.com/golang/glog"
 
 // Level is used with V() to test log verbosity.
 type Level = glog.Level


### PR DESCRIPTION
The alias was "glog" as well and therefore redundant.

Signed-off-by: Michael Berlin <mberlin@google.com>