### PR TITLE
include the MultiShardAutocommit boolean in the plan json

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -921,6 +921,33 @@
   }
 }
 
+# insert with multiple rows - multi-shard autocommit
+"insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user(id) values (1), (2)"
+{
+  "Original": "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user(id) values (1), (2)",
+  "Instructions": {
+    "Opcode": "InsertSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user(id, Name, Costly) values (:_Id0, :_Name0, :_Costly0), (:_Id1, :_Name1, :_Costly1)",
+    "Values": [[[":__seq0",":__seq1"]],[[null,null]],[[null,null]]],
+    "Table": "user",
+    "Generate": {
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select next :n values from seq",
+      "Values": [1,2]
+    },
+    "Prefix": "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user(id, Name, Costly) values ",
+    "Mid": ["(:_Id0, :_Name0, :_Costly0)","(:_Id1, :_Name1, :_Costly1)"],
+    "MultiShardAutocommit": true
+  }
+}
+
 # simple replace unsharded
 "replace into unsharded values(1, 2)"
 {
@@ -1250,6 +1277,22 @@
     },
     "Query": "delete from user_extra where name = 'jose'",
     "Table": "user_extra"
+  }
+}
+
+# delete from with no index match - multi shard autocommit
+"delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where name = 'jose'"
+{
+  "Original": "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where name = 'jose'",
+  "Instructions": {
+    "Opcode": "DeleteScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where name = 'jose'",
+    "Table": "user_extra",
+    "MultiShardAutocommit": true
   }
 }
 

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -76,21 +76,23 @@ func (del *Delete) MarshalJSON() ([]byte, error) {
 		vindexName = del.Vindex.String()
 	}
 	marshalDelete := struct {
-		Opcode           DeleteOpcode
-		Keyspace         *vindexes.Keyspace   `json:",omitempty"`
-		Query            string               `json:",omitempty"`
-		Vindex           string               `json:",omitempty"`
-		Values           []sqltypes.PlanValue `json:",omitempty"`
-		Table            string               `json:",omitempty"`
-		OwnedVindexQuery string               `json:",omitempty"`
+		Opcode               DeleteOpcode
+		Keyspace             *vindexes.Keyspace   `json:",omitempty"`
+		Query                string               `json:",omitempty"`
+		Vindex               string               `json:",omitempty"`
+		Values               []sqltypes.PlanValue `json:",omitempty"`
+		Table                string               `json:",omitempty"`
+		OwnedVindexQuery     string               `json:",omitempty"`
+		MultiShardAutocommit bool                 `json:",omitempty"`
 	}{
-		Opcode:           del.Opcode,
-		Keyspace:         del.Keyspace,
-		Query:            del.Query,
-		Vindex:           vindexName,
-		Values:           del.Values,
-		Table:            tname,
-		OwnedVindexQuery: del.OwnedVindexQuery,
+		Opcode:               del.Opcode,
+		Keyspace:             del.Keyspace,
+		Query:                del.Query,
+		Vindex:               vindexName,
+		Values:               del.Values,
+		Table:                tname,
+		OwnedVindexQuery:     del.OwnedVindexQuery,
+		MultiShardAutocommit: del.MultiShardAutocommit,
 	}
 	return jsonutil.MarshalNoEscape(marshalDelete)
 }

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -86,25 +86,27 @@ func (ins *Insert) MarshalJSON() ([]byte, error) {
 		tname = ins.Table.Name.String()
 	}
 	marshalInsert := struct {
-		Opcode   InsertOpcode
-		Keyspace *vindexes.Keyspace   `json:",omitempty"`
-		Query    string               `json:",omitempty"`
-		Values   []sqltypes.PlanValue `json:",omitempty"`
-		Table    string               `json:",omitempty"`
-		Generate *Generate            `json:",omitempty"`
-		Prefix   string               `json:",omitempty"`
-		Mid      []string             `json:",omitempty"`
-		Suffix   string               `json:",omitempty"`
+		Opcode               InsertOpcode
+		Keyspace             *vindexes.Keyspace   `json:",omitempty"`
+		Query                string               `json:",omitempty"`
+		Values               []sqltypes.PlanValue `json:",omitempty"`
+		Table                string               `json:",omitempty"`
+		Generate             *Generate            `json:",omitempty"`
+		Prefix               string               `json:",omitempty"`
+		Mid                  []string             `json:",omitempty"`
+		Suffix               string               `json:",omitempty"`
+		MultiShardAutocommit bool                 `json:",omitempty"`
 	}{
-		Opcode:   ins.Opcode,
-		Keyspace: ins.Keyspace,
-		Query:    ins.Query,
-		Values:   ins.VindexValues,
-		Table:    tname,
-		Generate: ins.Generate,
-		Prefix:   ins.Prefix,
-		Mid:      ins.Mid,
-		Suffix:   ins.Suffix,
+		Opcode:               ins.Opcode,
+		Keyspace:             ins.Keyspace,
+		Query:                ins.Query,
+		Values:               ins.VindexValues,
+		Table:                tname,
+		Generate:             ins.Generate,
+		Prefix:               ins.Prefix,
+		Mid:                  ins.Mid,
+		Suffix:               ins.Suffix,
+		MultiShardAutocommit: ins.MultiShardAutocommit,
 	}
 	return jsonutil.MarshalNoEscape(marshalInsert)
 }


### PR DESCRIPTION
To help debugging whether or not the comment was parsed properly, include
the boolean for MultiShardAutocommit in the plan JSON.