### PR TITLE
add strict identical check; change Format method of DBDDL in style

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"strings"
 
@@ -633,13 +632,13 @@ type DBDDL struct {
 func (node *DBDDL) Format(buf *TrackedBuffer) {
 	switch node.Action {
 	case CreateStr:
-		buf.WriteString(fmt.Sprintf("%s database %s", node.Action, node.DBName))
+		buf.Myprintf("%s database %s", node.Action, node.DBName)
 	case DropStr:
 		exists := ""
 		if node.IfExists {
 			exists = " if exists"
 		}
-		buf.WriteString(fmt.Sprintf("%s database%s %v", node.Action, exists, node.DBName))
+		buf.Myprintf("%s database%s %s", node.Action, exists, node.DBName)
 	}
 }
 

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -104,6 +104,7 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 	keyspaceShard := subFlags.String("keyspace_shard", "", "keyspace/shard of the shard that needs to be reparented")
 	newMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
 	avoidMaster := subFlags.String("avoid_master", "", "alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master")
+	isStrictIdentical := subFlags.Bool("strict_identical", false, "check all instances in shard have the same replication position, i.e. reparent to any other tablet if this one is the master")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -135,6 +136,8 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 			return err
 		}
 	}
+
+	wr.SetStrictIdentical(*isStrictIdentical)
 	return wr.PlannedReparentShard(ctx, keyspace, shard, newMasterAlias, avoidMasterAlias, *waitSlaveTimeout)
 }
 

--- a/go/vt/wrangler/wrangler.go
+++ b/go/vt/wrangler/wrangler.go
@@ -38,9 +38,10 @@ var (
 // Multiple go routines can use the same Wrangler at the same time,
 // provided they want to share the same logger / topo server / lock timeout.
 type Wrangler struct {
-	logger logutil.Logger
-	ts     *topo.Server
-	tmc    tmclient.TabletManagerClient
+	strictIdentical bool
+	logger          logutil.Logger
+	ts              *topo.Server
+	tmc             tmclient.TabletManagerClient
 }
 
 // New creates a new Wrangler object.
@@ -72,4 +73,9 @@ func (wr *Wrangler) SetLogger(logger logutil.Logger) {
 // Logger returns the logger associated with this wrangler.
 func (wr *Wrangler) Logger() logutil.Logger {
 	return wr.logger
+}
+
+// SetStrictIdentical set strict identical model.
+func (wr *Wrangler) SetStrictIdentical(si bool) {
+	wr.strictIdentical = si
 }

--- a/web/vtctld2/src/app/shared/flags/shard.flags.ts
+++ b/web/vtctld2/src/app/shared/flags/shard.flags.ts
@@ -59,6 +59,8 @@ export class EmergencyRepShardFlags {
     this.flags['shard_ref']['positional'] = true;
     this.flags['tablet_alias'] = new TabletSelectFlag(1, 'tablet_alias', '', tablets);
     this.flags['tablet_alias']['positional'] = true;
+    this.flags['strict_identical'] = new IdenticalModelSelectFlag(2, 'strict_identical');
+    this.flags['strict_identical']['positional'] = true;
   }
 }
 
@@ -153,6 +155,14 @@ export class TabletSelectFlag extends DropDownFlag {
     tablets.forEach(tablet => {
       options.push({label: tablet.label, value: tablet.alias});
     });
+    this.setOptions(options);
+  }
+}
+
+export class IdenticalModelSelectFlag extends DropDownFlag {
+  constructor(position: number, id: string, value= '') {
+    super(position, id, 'Select strict model', 'Strict model check if all tablet binlog positions are identical.', value);
+    let options = [{label: 'Strict identical', value: 'true'}, {label: 'Lose identical', value: 'false'}];
     this.setOptions(options);
   }
 }


### PR DESCRIPTION
## Background
DBA use PlanReparent function online daily,  they need check all the binlog locations of instances in shard are identical, for reasons of security.

## Motivation
+ Reduce manual operations;
+ Provide more powerful PlanReparent function.

## Implementation
When execute plan reparent, we add check "strict identical" option. if it's is true, before reparent try three times to check if all instance binlog positions are identical; if it's false, it act as raw PlanReparent.

## Todo
we try to build web, but failed. If build web success, we can add select option on PlanReparent page.