### PR TITLE
stats: Simplify code for single-value stat variables.

### DIFF
--- a/go/stats/counter.go
+++ b/go/stats/counter.go
@@ -27,13 +27,15 @@ import (
 // logCounterNegative is for throttling adding a negative value to a counter messages in logs
 var logCounterNegative = logutil.NewThrottledLogger("StatsCounterNegative", 1*time.Minute)
 
-// Counter is expvar.Int+Get+hook
+// Counter tracks a cumulative count of a metric.
+// For a one-dimensional or multi-dimensional counter, please use
+// CountersWithSingleLabel or CountersWithMultiLabels instead.
 type Counter struct {
 	i    sync2.AtomicInt64
 	help string
 }
 
-// NewCounter returns a new Counter
+// NewCounter returns a new Counter.
 func NewCounter(name string, help string) *Counter {
 	v := &Counter{help: help}
 	if name != "" {
@@ -42,7 +44,7 @@ func NewCounter(name string, help string) *Counter {
 	return v
 }
 
-// Add adds the provided value to the Counter
+// Add adds the provided value to the Counter.
 func (v *Counter) Add(delta int64) {
 	if delta < 0 {
 		logCounterNegative.Warningf("Adding a negative value to a counter, %v should be a gauge instead", v)
@@ -50,22 +52,22 @@ func (v *Counter) Add(delta int64) {
 	v.i.Add(delta)
 }
 
-// Reset resets the counter value to 0
+// Reset resets the counter value to 0.
 func (v *Counter) Reset() {
 	v.i.Set(int64(0))
 }
 
-// Get returns the value
+// Get returns the value.
 func (v *Counter) Get() int64 {
 	return v.i.Get()
 }
 
-// String is the implementation of expvar.var
+// String implements the expvar.Var interface.
 func (v *Counter) String() string {
 	return strconv.FormatInt(v.i.Get(), 10)
 }
 
-// Help returns the help string
+// Help returns the help string.
 func (v *Counter) Help() string {
 	return v.help
 }
@@ -102,7 +104,10 @@ func (cf CounterFunc) String() string {
 	return strconv.FormatInt(cf.F(), 10)
 }
 
-// Gauge is an unlabeled metric whose values can go up/down.
+// Gauge tracks the current value of an integer metric.
+// The emphasis here is on *current* i.e. this is not a cumulative counter.
+// For a one-dimensional or multi-dimensional gauge, please use
+// GaugeWithSingleLabel or GaugesWithMultiLabels instead.
 type Gauge struct {
 	Counter
 }

--- a/go/stats/counter.go
+++ b/go/stats/counter.go
@@ -70,19 +70,19 @@ func (v *Counter) Help() string {
 	return v.help
 }
 
-// CounterFunc converts a function that returns
-// an int64 as an expvar.
+// CounterFunc allows to provide the counter value via a custom function.
 // For implementations that differentiate between Counters/Gauges,
-// CounterFunc's values only go up (or are reset to 0)
+// CounterFunc's values only go up (or are reset to 0).
 type CounterFunc struct {
-	Mf   MetricFunc
+	F    func() int64
 	help string
 }
 
-// NewCounterFunc creates a new CounterFunc instance and publishes it if name is set
-func NewCounterFunc(name string, help string, Mf MetricFunc) *CounterFunc {
+// NewCounterFunc creates a new CounterFunc instance and publishes it if name is
+// set.
+func NewCounterFunc(name string, help string, f func() int64) *CounterFunc {
 	c := &CounterFunc{
-		Mf:   Mf,
+		F:    f,
 		help: help,
 	}
 
@@ -92,33 +92,14 @@ func NewCounterFunc(name string, help string, Mf MetricFunc) *CounterFunc {
 	return c
 }
 
-// Help returns the help string
-func (cf *CounterFunc) Help() string {
+// Help returns the help string.
+func (cf CounterFunc) Help() string {
 	return cf.help
 }
 
-// String implements expvar.Var
-func (cf *CounterFunc) String() string {
-	return cf.Mf.String()
-}
-
-// MetricFunc defines an interface for things that can be exported with calls to stats.CounterFunc/stats.GaugeFunc
-type MetricFunc interface {
-	FloatVal() float64
-	String() string
-}
-
-// IntFunc converst a function that returns an int64 as both an expvar and a MetricFunc
-type IntFunc func() int64
-
-// FloatVal is the implementation of MetricFunc
-func (f IntFunc) FloatVal() float64 {
-	return float64(f())
-}
-
-// String is the implementation of expvar.var
-func (f IntFunc) String() string {
-	return strconv.FormatInt(f(), 10)
+// String implements expvar.Var.
+func (cf CounterFunc) String() string {
+	return strconv.FormatInt(cf.F(), 10)
 }
 
 // Gauge is an unlabeled metric whose values can go up/down.
@@ -126,7 +107,7 @@ type Gauge struct {
 	Counter
 }
 
-// NewGauge creates a new Gauge and publishes it if name is set
+// NewGauge creates a new Gauge and publishes it if name is set.
 func NewGauge(name string, help string) *Gauge {
 	v := &Gauge{Counter: Counter{help: help}}
 
@@ -136,28 +117,30 @@ func NewGauge(name string, help string) *Gauge {
 	return v
 }
 
-// Set sets the value
+// Set overwrites the current value.
 func (v *Gauge) Set(value int64) {
 	v.Counter.i.Set(value)
 }
 
-// Add adds the provided value to the Gauge
+// Add adds the provided value to the Gauge.
 func (v *Gauge) Add(delta int64) {
 	v.Counter.i.Add(delta)
 }
 
-// GaugeFunc converts a function that returns an int64 as an expvar.
-// It's a wrapper around CounterFunc for values that go up/down
-// for implementations (like Prometheus) that need to differ between Counters and Gauges.
+// GaugeFunc is the same as CounterFunc but meant for gauges.
+// It's a wrapper around CounterFunc for values that go up/down for
+// implementations (like Prometheus) that need to differ between Counters and
+// Gauges.
 type GaugeFunc struct {
 	CounterFunc
 }
 
-// NewGaugeFunc creates a new GaugeFunc instance and publishes it if name is set
-func NewGaugeFunc(name string, help string, Mf MetricFunc) *GaugeFunc {
+// NewGaugeFunc creates a new GaugeFunc instance and publishes it if name is
+// set.
+func NewGaugeFunc(name string, help string, f func() int64) *GaugeFunc {
 	i := &GaugeFunc{
 		CounterFunc: CounterFunc{
-			Mf:   Mf,
+			F:    f,
 			help: help,
 		}}
 

--- a/go/stats/counter.go
+++ b/go/stats/counter.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"strconv"
+	"time"
+
+	"vitess.io/vitess/go/sync2"
+	"vitess.io/vitess/go/vt/logutil"
+)
+
+// logCounterNegative is for throttling adding a negative value to a counter messages in logs
+var logCounterNegative = logutil.NewThrottledLogger("StatsCounterNegative", 1*time.Minute)
+
+// Counter is expvar.Int+Get+hook
+type Counter struct {
+	i    sync2.AtomicInt64
+	help string
+}
+
+// NewCounter returns a new Counter
+func NewCounter(name string, help string) *Counter {
+	v := &Counter{help: help}
+	if name != "" {
+		publish(name, v)
+	}
+	return v
+}
+
+// Add adds the provided value to the Counter
+func (v *Counter) Add(delta int64) {
+	if delta < 0 {
+		logCounterNegative.Warningf("Adding a negative value to a counter, %v should be a gauge instead", v)
+	}
+	v.i.Add(delta)
+}
+
+// Reset resets the counter value to 0
+func (v *Counter) Reset() {
+	v.i.Set(int64(0))
+}
+
+// Get returns the value
+func (v *Counter) Get() int64 {
+	return v.i.Get()
+}
+
+// String is the implementation of expvar.var
+func (v *Counter) String() string {
+	return strconv.FormatInt(v.i.Get(), 10)
+}
+
+// Help returns the help string
+func (v *Counter) Help() string {
+	return v.help
+}
+
+// CounterFunc converts a function that returns
+// an int64 as an expvar.
+// For implementations that differentiate between Counters/Gauges,
+// CounterFunc's values only go up (or are reset to 0)
+type CounterFunc struct {
+	Mf   MetricFunc
+	help string
+}
+
+// NewCounterFunc creates a new CounterFunc instance and publishes it if name is set
+func NewCounterFunc(name string, help string, Mf MetricFunc) *CounterFunc {
+	c := &CounterFunc{
+		Mf:   Mf,
+		help: help,
+	}
+
+	if name != "" {
+		publish(name, c)
+	}
+	return c
+}
+
+// Help returns the help string
+func (cf *CounterFunc) Help() string {
+	return cf.help
+}
+
+// String implements expvar.Var
+func (cf *CounterFunc) String() string {
+	return cf.Mf.String()
+}
+
+// MetricFunc defines an interface for things that can be exported with calls to stats.CounterFunc/stats.GaugeFunc
+type MetricFunc interface {
+	FloatVal() float64
+	String() string
+}
+
+// IntFunc converst a function that returns an int64 as both an expvar and a MetricFunc
+type IntFunc func() int64
+
+// FloatVal is the implementation of MetricFunc
+func (f IntFunc) FloatVal() float64 {
+	return float64(f())
+}
+
+// String is the implementation of expvar.var
+func (f IntFunc) String() string {
+	return strconv.FormatInt(f(), 10)
+}
+
+// Gauge is an unlabeled metric whose values can go up/down.
+type Gauge struct {
+	Counter
+}
+
+// NewGauge creates a new Gauge and publishes it if name is set
+func NewGauge(name string, help string) *Gauge {
+	v := &Gauge{Counter: Counter{help: help}}
+
+	if name != "" {
+		publish(name, v)
+	}
+	return v
+}
+
+// Set sets the value
+func (v *Gauge) Set(value int64) {
+	v.Counter.i.Set(value)
+}
+
+// Add adds the provided value to the Gauge
+func (v *Gauge) Add(delta int64) {
+	v.Counter.i.Add(delta)
+}
+
+// GaugeFunc converts a function that returns an int64 as an expvar.
+// It's a wrapper around CounterFunc for values that go up/down
+// for implementations (like Prometheus) that need to differ between Counters and Gauges.
+type GaugeFunc struct {
+	CounterFunc
+}
+
+// NewGaugeFunc creates a new GaugeFunc instance and publishes it if name is set
+func NewGaugeFunc(name string, help string, Mf MetricFunc) *GaugeFunc {
+	i := &GaugeFunc{
+		CounterFunc: CounterFunc{
+			Mf:   Mf,
+			help: help,
+		}}
+
+	if name != "" {
+		publish(name, i)
+	}
+	return i
+}

--- a/go/stats/counter_test.go
+++ b/go/stats/counter_test.go
@@ -61,13 +61,13 @@ func TestGaugeFunc(t *testing.T) {
 	v := NewGaugeFunc("name", "help", func() int64 {
 		return 1
 	})
-	if v.String() != "1" {
-		t.Errorf("want 1, got %v", v.String())
+	if gotname != "name" {
+		t.Errorf("want name, got %s", gotname)
 	}
 	if gotv != v {
 		t.Errorf("want %#v, got %#v", v, gotv)
 	}
-	if gotname != "name" {
-		t.Errorf("want name, got %s", gotname)
+	if v.String() != "1" {
+		t.Errorf("want 1, got %v", v.String())
 	}
 }

--- a/go/stats/counter_test.go
+++ b/go/stats/counter_test.go
@@ -58,9 +58,9 @@ func TestGaugeFunc(t *testing.T) {
 		gotv = v.(*GaugeFunc)
 	})
 
-	v := NewGaugeFunc("name", "help", IntFunc(func() int64 {
+	v := NewGaugeFunc("name", "help", func() int64 {
 		return 1
-	}))
+	})
 	if v.String() != "1" {
 		t.Errorf("want 1, got %f", v.String())
 	}

--- a/go/stats/counter_test.go
+++ b/go/stats/counter_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"expvar"
+	"testing"
+)
+
+func TestCounter(t *testing.T) {
+	var gotname string
+	var gotv *Counter
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*Counter)
+	})
+	v := NewCounter("Int", "help")
+	if gotname != "Int" {
+		t.Errorf("want Int, got %s", gotname)
+	}
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	v.Add(1)
+	if v.Get() != 1 {
+		t.Errorf("want 1, got %v", v.Get())
+	}
+	if v.String() != "1" {
+		t.Errorf("want 1, got %v", v.Get())
+	}
+	v.Reset()
+	if v.Get() != 0 {
+		t.Errorf("want 0, got %v", v.Get())
+	}
+}
+
+func TestGaugeFunc(t *testing.T) {
+	var gotname string
+	var gotv *GaugeFunc
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*GaugeFunc)
+	})
+
+	v := NewGaugeFunc("name", "help", IntFunc(func() int64 {
+		return 1
+	}))
+	if v.String() != "1" {
+		t.Errorf("want 1, got %f", v.String())
+	}
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	if gotname != "name" {
+		t.Errorf("want name, got %s", gotname)
+	}
+}

--- a/go/stats/counter_test.go
+++ b/go/stats/counter_test.go
@@ -62,7 +62,7 @@ func TestGaugeFunc(t *testing.T) {
 		return 1
 	})
 	if v.String() != "1" {
-		t.Errorf("want 1, got %f", v.String())
+		t.Errorf("want 1, got %v", v.String())
 	}
 	if gotv != v {
 		t.Errorf("want %#v, got %#v", v, gotv)

--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -19,86 +19,10 @@ package stats
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
-
-	"vitess.io/vitess/go/sync2"
-	"vitess.io/vitess/go/vt/logutil"
 )
-
-// logCounterNegative is for throttling adding a negative value to a counter messages in logs
-var logCounterNegative = logutil.NewThrottledLogger("StatsCounterNegative", 1*time.Minute)
-
-// Counter is expvar.Int+Get+hook
-type Counter struct {
-	i    sync2.AtomicInt64
-	help string
-}
-
-// NewCounter returns a new Counter
-func NewCounter(name string, help string) *Counter {
-	v := &Counter{help: help}
-	if name != "" {
-		publish(name, v)
-	}
-	return v
-}
-
-// Add adds the provided value to the Counter
-func (v *Counter) Add(delta int64) {
-	if delta < 0 {
-		logCounterNegative.Warningf("Adding a negative value to a counter, %v should be a gauge instead", v)
-	}
-	v.i.Add(delta)
-}
-
-// Reset resets the counter value to 0
-func (v *Counter) Reset() {
-	v.i.Set(int64(0))
-}
-
-// Get returns the value
-func (v *Counter) Get() int64 {
-	return v.i.Get()
-}
-
-// String is the implementation of expvar.var
-func (v *Counter) String() string {
-	return strconv.FormatInt(v.i.Get(), 10)
-}
-
-// Help returns the help string
-func (v *Counter) Help() string {
-	return v.help
-}
-
-// Gauge is an unlabeled metric whose values can go up/down.
-type Gauge struct {
-	Counter
-}
-
-// NewGauge creates a new Gauge and publishes it if name is set
-func NewGauge(name string, help string) *Gauge {
-	v := &Gauge{Counter: Counter{help: help}}
-
-	if name != "" {
-		publish(name, v)
-	}
-	return v
-}
-
-// Set sets the value
-func (v *Gauge) Set(value int64) {
-	v.Counter.i.Set(value)
-}
-
-// Add adds the provided value to the Gauge
-func (v *Gauge) Add(delta int64) {
-	v.Counter.i.Add(delta)
-}
 
 // counters is similar to expvar.Map, except that
 // it doesn't allow floats. It is used to build CountersWithLabels and GaugesWithLabels.
@@ -263,78 +187,6 @@ func (g *GaugesWithLabels) Set(name string, value int64) {
 func (g *GaugesWithLabels) Add(name string, value int64) {
 	a := g.getValueAddr(name)
 	atomic.AddInt64(a, value)
-}
-
-// CounterFunc converts a function that returns
-// an int64 as an expvar.
-// For implementations that differentiate between Counters/Gauges,
-// CounterFunc's values only go up (or are reset to 0)
-type CounterFunc struct {
-	Mf   MetricFunc
-	help string
-}
-
-// NewCounterFunc creates a new CounterFunc instance and publishes it if name is set
-func NewCounterFunc(name string, help string, Mf MetricFunc) *CounterFunc {
-	c := &CounterFunc{
-		Mf:   Mf,
-		help: help,
-	}
-
-	if name != "" {
-		publish(name, c)
-	}
-	return c
-}
-
-// Help returns the help string
-func (cf *CounterFunc) Help() string {
-	return cf.help
-}
-
-// String implements expvar.Var
-func (cf *CounterFunc) String() string {
-	return cf.Mf.String()
-}
-
-// MetricFunc defines an interface for things that can be exported with calls to stats.CounterFunc/stats.GaugeFunc
-type MetricFunc interface {
-	FloatVal() float64
-	String() string
-}
-
-// IntFunc converst a function that returns an int64 as both an expvar and a MetricFunc
-type IntFunc func() int64
-
-// FloatVal is the implementation of MetricFunc
-func (f IntFunc) FloatVal() float64 {
-	return float64(f())
-}
-
-// String is the implementation of expvar.var
-func (f IntFunc) String() string {
-	return strconv.FormatInt(f(), 10)
-}
-
-// GaugeFunc converts a function that returns an int64 as an expvar.
-// It's a wrapper around CounterFunc for values that go up/down
-// for implementations (like Prometheus) that need to differ between Counters and Gauges.
-type GaugeFunc struct {
-	CounterFunc
-}
-
-// NewGaugeFunc creates a new GaugeFunc instance and publishes it if name is set
-func NewGaugeFunc(name string, help string, Mf MetricFunc) *GaugeFunc {
-	i := &GaugeFunc{
-		CounterFunc: CounterFunc{
-			Mf:   Mf,
-			help: help,
-		}}
-
-	if name != "" {
-		publish(name, i)
-	}
-	return i
 }
 
 // CountersFunc converts a function that returns

--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -118,8 +118,8 @@ func (c *counters) Help() string {
 	return c.help
 }
 
-// CountersWithSingleLabel allows to publish related counters for a single
-// label (aka category).
+// CountersWithSingleLabel tracks multiple counter values for a single
+// dimension ("label").
 // It provides a Counts method which can be used for tracking rates.
 type CountersWithSingleLabel struct {
 	counters
@@ -194,9 +194,9 @@ func (f CountersFunc) String() string {
 	return b.String()
 }
 
-// CountersWithMultiLabels is a multidimensional counters implementation
-// where names of categories are compound names made with joining multiple
-// strings with '.'.
+// CountersWithMultiLabels is a multidimensional counters implementation.
+// Internally, each tuple of dimensions ("labels") is stored as a single
+// label value where all label values are joined with ".".
 type CountersWithMultiLabels struct {
 	counters
 	labels []string
@@ -291,7 +291,7 @@ func NewCountersFuncWithMultiLabels(name, help string, labels []string, f Counte
 }
 
 // GaugesWithSingleLabel is similar to CountersWithSingleLabel, except its
-// values can go up and down.
+// meant to track the current value and not a cumulative count.
 type GaugesWithSingleLabel struct {
 	CountersWithSingleLabel
 }

--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -118,25 +118,27 @@ func (c *counters) Help() string {
 	return c.help
 }
 
-// CountersWithSingleLabel provides a labelName for the tagged values in Counters
+// CountersWithSingleLabel allows to publish related counters for a single
+// label (aka category).
 // It provides a Counts method which can be used for tracking rates.
 type CountersWithSingleLabel struct {
 	counters
-	labelName string
+	label string
 }
 
 // NewCountersWithSingleLabel create a new Counters instance.
 // If name is set, the variable gets published.
 // The function also accepts an optional list of tags that pre-creates them
 // initialized to 0.
-// labelName is a category name used to organize the tags in Prometheus.
-func NewCountersWithSingleLabel(name string, help string, labelName string, tags ...string) *CountersWithSingleLabel {
+// label is a category name used to organize the tags. It is currently only
+// used by Prometheus, but not by the expvar package.
+func NewCountersWithSingleLabel(name, help, label string, tags ...string) *CountersWithSingleLabel {
 	c := &CountersWithSingleLabel{
 		counters: counters{
 			counts: make(map[string]*int64),
 			help:   help,
 		},
-		labelName: labelName,
+		label: label,
 	}
 
 	for _, tag := range tags {
@@ -148,9 +150,9 @@ func NewCountersWithSingleLabel(name string, help string, labelName string, tags
 	return c
 }
 
-// LabelName returns the label name.
-func (c *CountersWithSingleLabel) LabelName() string {
-	return c.labelName
+// Label returns the label name.
+func (c *CountersWithSingleLabel) Label() string {
+	return c.label
 }
 
 // Add adds a value to a named counter.
@@ -202,7 +204,7 @@ type CountersWithMultiLabels struct {
 
 // NewCountersWithMultiLabels creates a new CountersWithMultiLabels
 // instance, and publishes it if name is set.
-func NewCountersWithMultiLabels(name string, help string, labels []string) *CountersWithMultiLabels {
+func NewCountersWithMultiLabels(name, help string, labels []string) *CountersWithMultiLabels {
 	t := &CountersWithMultiLabels{
 		counters: counters{
 			counts: make(map[string]*int64),
@@ -251,7 +253,7 @@ func (mc *CountersWithMultiLabels) Counts() map[string]int64 {
 	return mc.counters.Counts()
 }
 
-// CountersFuncWithMultiLabels is a multidimensional CountersFunc implementation
+// CountersFuncWithMultiLabels is a multidimensional counters implementation
 // where names of categories are compound names made with joining
 // multiple strings with '.'.  Since the map is returned by the
 // function, we assume it's in the right format (meaning each key is
@@ -288,22 +290,23 @@ func NewCountersFuncWithMultiLabels(name string, labels []string, help string, f
 	return t
 }
 
-// GaugesWithSingleLabel is similar to CountersWithSingleLabel, except its values can
-// go up and down.
+// GaugesWithSingleLabel is similar to CountersWithSingleLabel, except its
+// values can go up and down.
 type GaugesWithSingleLabel struct {
 	CountersWithSingleLabel
 }
 
-// NewGaugesWithSingleLabel creates a new GaugesWithSingleLabel and publishes it if
-// the name is set.
-func NewGaugesWithSingleLabel(name string, help string, labelName string, tags ...string) *GaugesWithSingleLabel {
+// NewGaugesWithSingleLabel creates a new GaugesWithSingleLabel and
+// publishes it if the name is set.
+func NewGaugesWithSingleLabel(name, help, label string, tags ...string) *GaugesWithSingleLabel {
 	g := &GaugesWithSingleLabel{
 		CountersWithSingleLabel: CountersWithSingleLabel{
 			counters: counters{
 				counts: make(map[string]*int64),
 				help:   help,
 			},
-			labelName: labelName},
+			label: label,
+		},
 	}
 
 	for _, tag := range tags {
@@ -335,7 +338,7 @@ type GaugesWithMultiLabels struct {
 
 // NewGaugesWithMultiLabels creates a new GaugesWithMultiLabels instance,
 // and publishes it if name is set.
-func NewGaugesWithMultiLabels(name string, help string, labels []string) *GaugesWithMultiLabels {
+func NewGaugesWithMultiLabels(name, help string, labels []string) *GaugesWithMultiLabels {
 	t := &GaugesWithMultiLabels{
 		CountersWithMultiLabels: CountersWithMultiLabels{
 			counters: counters{

--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -261,27 +261,27 @@ func (mc *CountersWithMultiLabels) Counts() map[string]int64 {
 // Labels).
 type CountersFuncWithMultiLabels struct {
 	CountersFunc
-	labels []string
 	help   string
+	labels []string
 }
 
 // Labels returns the list of labels.
-func (mcf *CountersFuncWithMultiLabels) Labels() []string {
-	return mcf.labels
+func (c CountersFuncWithMultiLabels) Labels() []string {
+	return c.labels
 }
 
-// Help returns the help string
-func (mcf *CountersFuncWithMultiLabels) Help() string {
-	return mcf.help
+// Help returns the help string.
+func (c CountersFuncWithMultiLabels) Help() string {
+	return c.help
 }
 
 // NewCountersFuncWithMultiLabels creates a new CountersFuncWithMultiLabels
 // mapping to the provided function.
-func NewCountersFuncWithMultiLabels(name string, labels []string, help string, f CountersFunc) *CountersFuncWithMultiLabels {
+func NewCountersFuncWithMultiLabels(name, help string, labels []string, f CountersFunc) *CountersFuncWithMultiLabels {
 	t := &CountersFuncWithMultiLabels{
 		CountersFunc: f,
-		labels:       labels,
 		help:         help,
+		labels:       labels,
 	}
 	if name != "" {
 		publish(name, t)
@@ -383,12 +383,12 @@ type GaugesFuncWithMultiLabels struct {
 
 // NewGaugesFuncWithMultiLabels creates a new GaugesFuncWithMultiLabels
 // mapping to the provided function.
-func NewGaugesFuncWithMultiLabels(name string, labels []string, help string, f CountersFunc) *GaugesFuncWithMultiLabels {
+func NewGaugesFuncWithMultiLabels(name, help string, labels []string, f CountersFunc) *GaugesFuncWithMultiLabels {
 	t := &GaugesFuncWithMultiLabels{
 		CountersFuncWithMultiLabels: CountersFuncWithMultiLabels{
 			CountersFunc: f,
-			labels:       labels,
 			help:         help,
+			labels:       labels,
 		}}
 
 	if name != "" {

--- a/go/stats/counters_test.go
+++ b/go/stats/counters_test.go
@@ -89,7 +89,7 @@ func TestMultiCounters(t *testing.T) {
 	if counts["c2a.c2b"] != 2 {
 		t.Errorf("want 2, got %d", counts["c2a.c2b"])
 	}
-	f := NewCountersFuncWithMultiLabels("", []string{"aaa", "bbb"}, "help", func() map[string]int64 {
+	f := NewCountersFuncWithMultiLabels("", "help", []string{"aaa", "bbb"}, func() map[string]int64 {
 		return map[string]int64{
 			"c1a.c1b": 1,
 			"c2a.c2b": 2,

--- a/go/stats/counters_test.go
+++ b/go/stats/counters_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestCounters(t *testing.T) {
 	clear()
-	c := NewCountersWithLabels("counter1", "help", "type")
+	c := NewCountersWithSingleLabel("counter1", "help", "label")
 	c.Add("c1", 1)
 	c.Add("c2", 1)
 	c.Add("c2", 1)
@@ -56,14 +56,14 @@ func TestCounters(t *testing.T) {
 
 func TestCountersTags(t *testing.T) {
 	clear()
-	c := NewCountersWithLabels("counterTag1", "help", "label")
+	c := NewCountersWithSingleLabel("counterTag1", "help", "label")
 	want := map[string]int64{}
 	got := c.Counts()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("want %v, got %v", want, got)
 	}
 
-	c = NewCountersWithLabels("counterTag2", "help", "label", "tag1", "tag2")
+	c = NewCountersWithSingleLabel("counterTag2", "help", "label", "tag1", "tag2")
 	want = map[string]int64{"tag1": 0, "tag2": 0}
 	got = c.Counts()
 	if !reflect.DeepEqual(got, want) {
@@ -122,14 +122,14 @@ func TestMultiCountersDot(t *testing.T) {
 
 func TestCountersHook(t *testing.T) {
 	var gotname string
-	var gotv *CountersWithLabels
+	var gotv *CountersWithSingleLabel
 	clear()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
-		gotv = v.(*CountersWithLabels)
+		gotv = v.(*CountersWithSingleLabel)
 	})
 
-	v := NewCountersWithLabels("counter2", "help", "type")
+	v := NewCountersWithSingleLabel("counter2", "help", "label")
 	if gotname != "counter2" {
 		t.Errorf("want counter2, got %s", gotname)
 	}
@@ -138,7 +138,7 @@ func TestCountersHook(t *testing.T) {
 	}
 }
 
-var benchCounter = NewCountersWithLabels("bench", "help", "type")
+var benchCounter = NewCountersWithSingleLabel("bench", "help", "label")
 
 func BenchmarkCounters(b *testing.B) {
 	clear()

--- a/go/stats/duration.go
+++ b/go/stats/duration.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"strconv"
+	"time"
+
+	"vitess.io/vitess/go/sync2"
+)
+
+// Duration exports a time.Duration
+type Duration struct {
+	i sync2.AtomicDuration
+}
+
+// NewDuration returns a new Duration
+func NewDuration(name string) *Duration {
+	v := new(Duration)
+	publish(name, v)
+	return v
+}
+
+// Add adds the provided value to the Duration
+func (v *Duration) Add(delta time.Duration) {
+	v.i.Add(delta)
+}
+
+// Set sets the value
+func (v *Duration) Set(value time.Duration) {
+	v.i.Set(value)
+}
+
+// Get returns the value
+func (v *Duration) Get() time.Duration {
+	return v.i.Get()
+}
+
+// String is the implementation of expvar.var
+func (v *Duration) String() string {
+	return strconv.FormatInt(int64(v.i.Get()), 10)
+}
+
+// DurationFunc converts a function that returns
+// an time.Duration as an expvar.
+type DurationFunc func() time.Duration
+
+// String is the implementation of expvar.var
+func (f DurationFunc) String() string {
+	return strconv.FormatInt(int64(f()), 10)
+}
+
+// FloatVal is the implementation of MetricFunc
+func (f DurationFunc) FloatVal() float64 {
+	return f().Seconds()
+}

--- a/go/stats/duration_test.go
+++ b/go/stats/duration_test.go
@@ -30,7 +30,7 @@ func TestDuration(t *testing.T) {
 		gotname = name
 		gotv = v.(*Duration)
 	})
-	v := NewDuration("Duration")
+	v := NewDuration("Duration", "help")
 	if gotname != "Duration" {
 		t.Errorf("want Duration, got %s", gotname)
 	}
@@ -52,16 +52,16 @@ func TestDuration(t *testing.T) {
 
 func TestDurationFunc(t *testing.T) {
 	var gotname string
-	var gotv *CounterFunc
+	var gotv *DurationFunc
 	clear()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
-		gotv = v.(*CounterFunc)
+		gotv = v.(*DurationFunc)
 	})
 
-	v := NewCounterFunc("duration", "help", DurationFunc(func() time.Duration {
+	v := NewDurationFunc("duration", "help", func() time.Duration {
 		return time.Duration(1)
-	}))
+	})
 
 	if gotv != v {
 		t.Errorf("want %#v, got %#v", v, gotv)

--- a/go/stats/duration_test.go
+++ b/go/stats/duration_test.go
@@ -22,17 +22,67 @@ import (
 	"time"
 )
 
-func TestDuration(t *testing.T) {
+func TestCounterDuration(t *testing.T) {
 	var gotname string
-	var gotv *Duration
+	var gotv *CounterDuration
 	clear()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
-		gotv = v.(*Duration)
+		gotv = v.(*CounterDuration)
 	})
-	v := NewDuration("Duration", "help")
-	if gotname != "Duration" {
-		t.Errorf("want Duration, got %s", gotname)
+	v := NewCounterDuration("CounterDuration", "help")
+	if gotname != "CounterDuration" {
+		t.Errorf("want CounterDuration, got %s", gotname)
+	}
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	if v.Get() != 0 {
+		t.Errorf("want 0, got %v", v.Get())
+	}
+	v.Add(time.Duration(1))
+	if v.Get() != 1 {
+		t.Errorf("want 1, got %v", v.Get())
+	}
+	if v.String() != "1" {
+		t.Errorf("want 1, got %v", v.Get())
+	}
+}
+
+func TestCounterDurationFunc(t *testing.T) {
+	var gotname string
+	var gotv *CounterDurationFunc
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*CounterDurationFunc)
+	})
+
+	v := NewCounterDurationFunc("CounterDurationFunc", "help", func() time.Duration {
+		return time.Duration(1)
+	})
+	if gotname != "CounterDurationFunc" {
+		t.Errorf("want CounterDurationFunc, got %s", gotname)
+	}
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	if v.String() != "1" {
+		t.Errorf("want 1, got %v", v.String())
+	}
+}
+
+func TestGaugeDuration(t *testing.T) {
+	var gotname string
+	var gotv *GaugeDuration
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*GaugeDuration)
+	})
+	v := NewGaugeDuration("GaugeDuration", "help")
+	if gotname != "GaugeDuration" {
+		t.Errorf("want GaugeDuration, got %s", gotname)
 	}
 	if gotv != v {
 		t.Errorf("want %#v, got %#v", v, gotv)
@@ -50,26 +100,26 @@ func TestDuration(t *testing.T) {
 	}
 }
 
-func TestDurationFunc(t *testing.T) {
+func TestGaugeDurationFunc(t *testing.T) {
 	var gotname string
-	var gotv *DurationFunc
+	var gotv *GaugeDurationFunc
 	clear()
 	Register(func(name string, v expvar.Var) {
 		gotname = name
-		gotv = v.(*DurationFunc)
+		gotv = v.(*GaugeDurationFunc)
 	})
 
-	v := NewDurationFunc("duration", "help", func() time.Duration {
+	v := NewGaugeDurationFunc("GaugeDurationFunc", "help", func() time.Duration {
 		return time.Duration(1)
 	})
 
+	if gotname != "GaugeDurationFunc" {
+		t.Errorf("want GaugeDurationFunc, got %s", gotname)
+	}
 	if gotv != v {
 		t.Errorf("want %#v, got %#v", v, gotv)
 	}
 	if v.String() != "1" {
 		t.Errorf("want 1, got %v", v.String())
-	}
-	if gotname != "duration" {
-		t.Errorf("want duration, got %s", gotname)
 	}
 }

--- a/go/stats/duration_test.go
+++ b/go/stats/duration_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"expvar"
+	"testing"
+	"time"
+)
+
+func TestDuration(t *testing.T) {
+	var gotname string
+	var gotv *Duration
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*Duration)
+	})
+	v := NewDuration("Duration")
+	if gotname != "Duration" {
+		t.Errorf("want Duration, got %s", gotname)
+	}
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	v.Set(time.Duration(5))
+	if v.Get() != 5 {
+		t.Errorf("want 5, got %v", v.Get())
+	}
+	v.Add(time.Duration(1))
+	if v.Get() != 6 {
+		t.Errorf("want 6, got %v", v.Get())
+	}
+	if v.String() != "6" {
+		t.Errorf("want 6, got %v", v.Get())
+	}
+}
+
+func TestDurationFunc(t *testing.T) {
+	var gotname string
+	var gotv *CounterFunc
+	clear()
+	Register(func(name string, v expvar.Var) {
+		gotname = name
+		gotv = v.(*CounterFunc)
+	})
+
+	v := NewCounterFunc("duration", "help", DurationFunc(func() time.Duration {
+		return time.Duration(1)
+	}))
+
+	if gotv != v {
+		t.Errorf("want %#v, got %#v", v, gotv)
+	}
+	if v.String() != "1" {
+		t.Errorf("want 1, got %v", v.String())
+	}
+	if gotname != "duration" {
+		t.Errorf("want duration, got %s", gotname)
+	}
+}

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -36,7 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -194,52 +193,6 @@ type FloatFunc func() float64
 // String is the implementation of expvar.var
 func (f FloatFunc) String() string {
 	return strconv.FormatFloat(f(), 'g', -1, 64)
-}
-
-// Duration exports a time.Duration
-type Duration struct {
-	i sync2.AtomicDuration
-}
-
-// NewDuration returns a new Duration
-func NewDuration(name string) *Duration {
-	v := new(Duration)
-	publish(name, v)
-	return v
-}
-
-// Add adds the provided value to the Duration
-func (v *Duration) Add(delta time.Duration) {
-	v.i.Add(delta)
-}
-
-// Set sets the value
-func (v *Duration) Set(value time.Duration) {
-	v.i.Set(value)
-}
-
-// Get returns the value
-func (v *Duration) Get() time.Duration {
-	return v.i.Get()
-}
-
-// String is the implementation of expvar.var
-func (v *Duration) String() string {
-	return strconv.FormatInt(int64(v.i.Get()), 10)
-}
-
-// DurationFunc converts a function that returns
-// an time.Duration as an expvar.
-type DurationFunc func() time.Duration
-
-// String is the implementation of expvar.var
-func (f DurationFunc) String() string {
-	return strconv.FormatInt(int64(f()), 10)
-}
-
-// FloatVal is the implementation of MetricFunc
-func (f DurationFunc) FloatVal() float64 {
-	return f().Seconds()
 }
 
 // String is expvar.String+Get+hook

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -19,7 +19,6 @@ package stats
 import (
 	"expvar"
 	"testing"
-	"time"
 )
 
 func clear() {
@@ -68,111 +67,6 @@ func TestFloat(t *testing.T) {
 	})
 	if f.String() != "1.234" {
 		t.Errorf("want 1.234, got %v", f.String())
-	}
-}
-
-func TestCounter(t *testing.T) {
-	var gotname string
-	var gotv *Counter
-	clear()
-	Register(func(name string, v expvar.Var) {
-		gotname = name
-		gotv = v.(*Counter)
-	})
-	v := NewCounter("Int", "help")
-	if gotname != "Int" {
-		t.Errorf("want Int, got %s", gotname)
-	}
-	if gotv != v {
-		t.Errorf("want %#v, got %#v", v, gotv)
-	}
-	v.Add(1)
-	if v.Get() != 1 {
-		t.Errorf("want 1, got %v", v.Get())
-	}
-	if v.String() != "1" {
-		t.Errorf("want 1, got %v", v.Get())
-	}
-	v.Reset()
-	if v.Get() != 0 {
-		t.Errorf("want 0, got %v", v.Get())
-	}
-
-}
-
-func TestGaugeFunc(t *testing.T) {
-	var gotname string
-	var gotv *GaugeFunc
-	clear()
-	Register(func(name string, v expvar.Var) {
-		gotname = name
-		gotv = v.(*GaugeFunc)
-	})
-
-	v := NewGaugeFunc("name", "help", IntFunc(func() int64 {
-		return 1
-	}))
-	if v.String() != "1" {
-		t.Errorf("want 1, got %f", v.String())
-	}
-	if gotv != v {
-		t.Errorf("want %#v, got %#v", v, gotv)
-	}
-	if gotname != "name" {
-		t.Errorf("want name, got %s", gotname)
-	}
-}
-
-func TestDuration(t *testing.T) {
-	var gotname string
-	var gotv *Duration
-	clear()
-	Register(func(name string, v expvar.Var) {
-		gotname = name
-		gotv = v.(*Duration)
-	})
-	v := NewDuration("Duration")
-	if gotname != "Duration" {
-		t.Errorf("want Duration, got %s", gotname)
-	}
-	if gotv != v {
-		t.Errorf("want %#v, got %#v", v, gotv)
-	}
-	v.Set(time.Duration(5))
-	if v.Get() != 5 {
-		t.Errorf("want 5, got %v", v.Get())
-	}
-	v.Add(time.Duration(1))
-	if v.Get() != 6 {
-		t.Errorf("want 6, got %v", v.Get())
-	}
-	if v.String() != "6" {
-		t.Errorf("want 6, got %v", v.Get())
-	}
-
-}
-
-func TestDurationFunc(t *testing.T) {
-	var gotname string
-	var gotv *CounterFunc
-	clear()
-	Register(func(name string, v expvar.Var) {
-		gotname = name
-		gotv = v.(*CounterFunc)
-	})
-
-	v := NewCounterFunc("duration", "help", DurationFunc(func() time.Duration {
-		return time.Duration(1)
-	}))
-
-	if gotv != v {
-		t.Errorf("want %#v, got %#v", v, gotv)
-	}
-	if v.String() != "1" {
-		t.Errorf("want 1, got %v", v.String())
-	}
-	if gotname != "duration" {
-		t.Errorf("want duration, got %s", gotname)
 	}
 }
 

--- a/go/stats/multidimensional.go
+++ b/go/stats/multidimensional.go
@@ -34,19 +34,21 @@ type MultiTracker interface {
 func CounterForDimension(mt MultiTracker, dimension string) CountTracker {
 	for i, lab := range mt.Labels() {
 		if lab == dimension {
-			return CountersFunc(func() map[string]int64 {
-				result := make(map[string]int64)
-				for k, v := range mt.Counts() {
-					if k == "All" {
-						result[k] = v
-						continue
+			return wrappedCountTracker{
+				f: func() map[string]int64 {
+					result := make(map[string]int64)
+					for k, v := range mt.Counts() {
+						if k == "All" {
+							result[k] = v
+							continue
+						}
+						result[strings.Split(k, ".")[i]] += v
 					}
-					result[strings.Split(k, ".")[i]] += v
-				}
-				return result
-			})
+					return result
+				},
+			}
 		}
 	}
-	panic(fmt.Sprintf("label %v is not one of %v", dimension, mt.Labels()))
 
+	panic(fmt.Sprintf("label %v is not one of %v", dimension, mt.Labels()))
 }

--- a/go/stats/prometheusbackend/collectors.go
+++ b/go/stats/prometheusbackend/collectors.go
@@ -7,20 +7,21 @@ import (
 	"vitess.io/vitess/go/stats"
 )
 
-type metricCollector struct {
-	counter *stats.Counter
-	desc    *prometheus.Desc
-	vt      prometheus.ValueType
+type metricFuncCollector struct {
+	// f returns the floating point value of the metric.
+	f    func() float64
+	desc *prometheus.Desc
+	vt   prometheus.ValueType
 }
 
 // Describe implements Collector.
-func (c *metricCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.desc
+func (mc *metricFuncCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- mc.desc
 }
 
 // Collect implements Collector.
-func (c *metricCollector) Collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(c.desc, c.vt, float64(c.counter.Get()))
+func (mc *metricFuncCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(mc.desc, mc.vt, float64(mc.f()))
 }
 
 // countersWithLabelsCollector collects stats.CountersWithLabels
@@ -182,20 +183,4 @@ func (c *multiTimingsCollector) Collect(ch chan<- prometheus.Metric) {
 			makePromBucket(his.Cutoffs(), his.Buckets()),
 			labelValues...)
 	}
-}
-
-type metricFuncCollector struct {
-	cf   *stats.CounterFunc
-	desc *prometheus.Desc
-	vt   prometheus.ValueType
-}
-
-// Describe implements Collector.
-func (c *metricFuncCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.desc
-}
-
-// Collect implements Collector.
-func (c *metricFuncCollector) Collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(c.desc, c.vt, float64(c.cf.Mf.FloatVal()))
 }

--- a/go/stats/prometheusbackend/collectors.go
+++ b/go/stats/prometheusbackend/collectors.go
@@ -24,20 +24,20 @@ func (mc *metricFuncCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(mc.desc, mc.vt, float64(mc.f()))
 }
 
-// countersWithLabelsCollector collects stats.CountersWithLabels
-type countersWithLabelsCollector struct {
-	counters *stats.CountersWithLabels
+// countersWithSingleLabelCollector collects stats.CountersWithSingleLabel.
+type countersWithSingleLabelCollector struct {
+	counters *stats.CountersWithSingleLabel
 	desc     *prometheus.Desc
 	vt       prometheus.ValueType
 }
 
 // Describe implements Collector.
-func (c *countersWithLabelsCollector) Describe(ch chan<- *prometheus.Desc) {
+func (c *countersWithSingleLabelCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.desc
 }
 
 // Collect implements Collector.
-func (c *countersWithLabelsCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *countersWithSingleLabelCollector) Collect(ch chan<- prometheus.Metric) {
 	for tag, val := range c.counters.Counts() {
 		ch <- prometheus.MustNewConstMetric(
 			c.desc,
@@ -47,20 +47,20 @@ func (c *countersWithLabelsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-// gaugesWithLabelsCollector collects stats.GaugesWithLabels
-type gaugesWithLabelsCollector struct {
-	gauges *stats.GaugesWithLabels
+// gaugesWithSingleLabelCollector collects stats.GaugesWithSingleLabel.
+type gaugesWithSingleLabelCollector struct {
+	gauges *stats.GaugesWithSingleLabel
 	desc   *prometheus.Desc
 	vt     prometheus.ValueType
 }
 
 // Describe implements Collector.
-func (g *gaugesWithLabelsCollector) Describe(ch chan<- *prometheus.Desc) {
+func (g *gaugesWithSingleLabelCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- g.desc
 }
 
 // Collect implements Collector.
-func (g *gaugesWithLabelsCollector) Collect(ch chan<- prometheus.Metric) {
+func (g *gaugesWithSingleLabelCollector) Collect(ch chan<- prometheus.Metric) {
 	for tag, val := range g.gauges.Counts() {
 		ch <- prometheus.MustNewConstMetric(
 			g.desc,

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -42,7 +42,7 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 	case *stats.GaugeFunc:
 		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return float64(st.F()) })
 	case *stats.CountersWithSingleLabel:
-		be.newCountersWithSingleLabel(st, name, st.LabelName(), prometheus.CounterValue)
+		be.newCountersWithSingleLabel(st, name, st.Label(), prometheus.CounterValue)
 	case *stats.CountersWithMultiLabels:
 		be.newCountersWithMultiLabels(st, name)
 	case *stats.CountersFuncWithMultiLabels:
@@ -50,7 +50,7 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 	case *stats.GaugesFuncWithMultiLabels:
 		be.newMetricsFuncWithMultiLabels(&st.CountersFuncWithMultiLabels, name, prometheus.GaugeValue)
 	case *stats.GaugesWithSingleLabel:
-		be.newGaugesWithSingleLabel(st, name, st.LabelName(), prometheus.GaugeValue)
+		be.newGaugesWithSingleLabel(st, name, st.Label(), prometheus.GaugeValue)
 	case *stats.GaugesWithMultiLabels:
 		be.newGaugesWithMultiLabels(st, name)
 	case *stats.CounterDuration:

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -41,16 +41,16 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return float64(st.Get()) })
 	case *stats.GaugeFunc:
 		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return float64(st.F()) })
-	case *stats.CountersWithLabels:
-		be.newCountersWithLabels(st, name, st.LabelName(), prometheus.CounterValue)
+	case *stats.CountersWithSingleLabel:
+		be.newCountersWithSingleLabel(st, name, st.LabelName(), prometheus.CounterValue)
 	case *stats.CountersWithMultiLabels:
 		be.newCountersWithMultiLabels(st, name)
 	case *stats.CountersFuncWithMultiLabels:
 		be.newMetricsFuncWithMultiLabels(st, name, prometheus.CounterValue)
 	case *stats.GaugesFuncWithMultiLabels:
 		be.newMetricsFuncWithMultiLabels(&st.CountersFuncWithMultiLabels, name, prometheus.GaugeValue)
-	case *stats.GaugesWithLabels:
-		be.newGaugesWithLabels(st, name, st.LabelName(), prometheus.GaugeValue)
+	case *stats.GaugesWithSingleLabel:
+		be.newGaugesWithSingleLabel(st, name, st.LabelName(), prometheus.GaugeValue)
 	case *stats.GaugesWithMultiLabels:
 		be.newGaugesWithMultiLabels(st, name)
 	case *stats.CounterDuration:
@@ -70,8 +70,8 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 	}
 }
 
-func (be *PromBackend) newCountersWithLabels(c *stats.CountersWithLabels, name string, labelName string, vt prometheus.ValueType) {
-	collector := &countersWithLabelsCollector{
+func (be *PromBackend) newCountersWithSingleLabel(c *stats.CountersWithSingleLabel, name string, labelName string, vt prometheus.ValueType) {
+	collector := &countersWithSingleLabelCollector{
 		counters: c,
 		desc: prometheus.NewDesc(
 			be.buildPromName(name),
@@ -83,8 +83,8 @@ func (be *PromBackend) newCountersWithLabels(c *stats.CountersWithLabels, name s
 	prometheus.MustRegister(collector)
 }
 
-func (be *PromBackend) newGaugesWithLabels(g *stats.GaugesWithLabels, name string, labelName string, vt prometheus.ValueType) {
-	collector := &gaugesWithLabelsCollector{
+func (be *PromBackend) newGaugesWithSingleLabel(g *stats.GaugesWithSingleLabel, name string, labelName string, vt prometheus.ValueType) {
+	collector := &gaugesWithSingleLabelCollector{
 		gauges: g,
 		desc: prometheus.NewDesc(
 			be.buildPromName(name),

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -53,11 +53,13 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		be.newGaugesWithLabels(st, name, st.LabelName(), prometheus.GaugeValue)
 	case *stats.GaugesWithMultiLabels:
 		be.newGaugesWithMultiLabels(st, name)
-	case *stats.Duration:
-		// TODO(mberlin): For now, we only support duration as gauge value.
+	case *stats.CounterDuration:
+		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return st.Get().Seconds() })
+	case *stats.CounterDurationFunc:
+		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return st.F().Seconds() })
+	case *stats.GaugeDuration:
 		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return st.Get().Seconds() })
-	case *stats.DurationFunc:
-		// TODO(mberlin): For now, we only support duration as gauge value.
+	case *stats.GaugeDurationFunc:
 		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return st.F().Seconds() })
 	case *stats.Timings:
 		be.newTiming(st, name)

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -197,7 +197,7 @@ func TestPrometheusCountersFuncWithMultiLabels(t *testing.T) {
 	name := "blah_countersfuncwithmultilabels"
 	labels := []string{"label1", "label2"}
 
-	stats.NewCountersFuncWithMultiLabels(name, labels, "help", func() map[string]int64 {
+	stats.NewCountersFuncWithMultiLabels(name, "help", labels, func() map[string]int64 {
 		m := make(map[string]int64)
 		m["foo.bar"] = 1
 		m["bar.baz"] = 1

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -42,9 +42,9 @@ func TestPrometheusGauge(t *testing.T) {
 
 func TestPrometheusCounterFunc(t *testing.T) {
 	name := "blah_counterfunc"
-	stats.NewCounterFunc(name, "help", stats.IntFunc(func() int64 {
+	stats.NewCounterFunc(name, "help", func() int64 {
 		return 2
-	}))
+	})
 
 	checkHandlerForMetrics(t, name, 2)
 }
@@ -52,11 +52,28 @@ func TestPrometheusCounterFunc(t *testing.T) {
 func TestPrometheusGaugeFunc(t *testing.T) {
 	name := "blah_gaugefunc"
 
-	stats.NewGaugeFunc(name, "help", stats.IntFunc(func() int64 {
+	stats.NewGaugeFunc(name, "help", func() int64 {
 		return -3
-	}))
+	})
 
 	checkHandlerForMetrics(t, name, -3)
+}
+
+func TestPrometheusDuration(t *testing.T) {
+	name := "blah_duration"
+
+	d := stats.NewDuration(name, "help")
+	d.Set(1 * time.Second)
+
+	checkHandlerForMetrics(t, name, 1)
+}
+
+func TestPrometheusDurationFunc(t *testing.T) {
+	name := "blah_durationfunc"
+
+	stats.NewDurationFunc(name, "help", func() time.Duration { return 1 * time.Second })
+
+	checkHandlerForMetrics(t, name, 1)
 }
 
 func checkHandlerForMetrics(t *testing.T, metric string, value int) {

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -59,19 +59,36 @@ func TestPrometheusGaugeFunc(t *testing.T) {
 	checkHandlerForMetrics(t, name, -3)
 }
 
-func TestPrometheusDuration(t *testing.T) {
-	name := "blah_duration"
+func TestPrometheusCounterDuration(t *testing.T) {
+	name := "blah_counterduration"
 
-	d := stats.NewDuration(name, "help")
+	d := stats.NewCounterDuration(name, "help")
+	d.Add(1 * time.Second)
+
+	checkHandlerForMetrics(t, name, 1)
+}
+
+func TestPrometheusCounterDurationFunc(t *testing.T) {
+	name := "blah_counterdurationfunc"
+
+	stats.NewCounterDurationFunc(name, "help", func() time.Duration { return 1 * time.Second })
+
+	checkHandlerForMetrics(t, name, 1)
+}
+
+func TestPrometheusGaugeDuration(t *testing.T) {
+	name := "blah_gaugeduration"
+
+	d := stats.NewGaugeDuration(name, "help")
 	d.Set(1 * time.Second)
 
 	checkHandlerForMetrics(t, name, 1)
 }
 
-func TestPrometheusDurationFunc(t *testing.T) {
-	name := "blah_durationfunc"
+func TestPrometheusGaugeDurationFunc(t *testing.T) {
+	name := "blah_gaugedurationfunc"
 
-	stats.NewDurationFunc(name, "help", func() time.Duration { return 1 * time.Second })
+	stats.NewGaugeDurationFunc(name, "help", func() time.Duration { return 1 * time.Second })
 
 	checkHandlerForMetrics(t, name, 1)
 }

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -103,41 +103,41 @@ func checkHandlerForMetrics(t *testing.T, metric string, value int) {
 	}
 }
 
-func TestPrometheusCountersWithLabels(t *testing.T) {
-	name := "blah_counterswithlabels"
-	c := stats.NewCountersWithLabels(name, "help", "tag", "tag1", "tag2")
+func TestPrometheusCountersWithSingleLabel(t *testing.T) {
+	name := "blah_counterswithsinglelabel"
+	c := stats.NewCountersWithSingleLabel(name, "help", "label", "tag1", "tag2")
 	c.Add("tag1", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag2", 0)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", 1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag2", 0)
 	c.Add("tag2", 41)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag2", 41)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", 1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag2", 41)
 	c.Reset("tag2")
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag2", 0)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", 1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag2", 0)
 }
 
-func TestPrometheusGaugesWithLabels(t *testing.T) {
-	name := "blah_gaugeswithlabels"
-	c := stats.NewGaugesWithLabels(name, "help", "tag", "tag1", "tag2")
+func TestPrometheusGaugesWithSingleLabel(t *testing.T) {
+	name := "blah_gaugeswithsinglelabel"
+	c := stats.NewGaugesWithSingleLabel(name, "help", "label", "tag1", "tag2")
 	c.Add("tag1", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", 1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", 1)
 
 	c.Add("tag2", 1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag2", 1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag2", 1)
 
 	c.Set("tag1", -1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", -1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", -1)
 
 	c.Reset("tag2")
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag1", -1)
-	checkHandlerForMetricWithLabels(t, name, "tag", "tag2", 0)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag1", -1)
+	checkHandlerForMetricWithSingleLabel(t, name, "label", "tag2", 0)
 }
 
-func checkHandlerForMetricWithLabels(t *testing.T, metric string, tagName string, tagValue string, value int) {
+func checkHandlerForMetricWithSingleLabel(t *testing.T, metric, label, tag string, value int) {
 	response := testMetricsHandler(t)
 
-	expected := fmt.Sprintf("%s_%s{%s=\"%s\"} %d", namespace, metric, tagName, tagValue, value)
+	expected := fmt.Sprintf("%s_%s{%s=\"%s\"} %d", namespace, metric, label, tag, value)
 
 	if !strings.Contains(response.Body.String(), expected) {
 		t.Fatalf("Expected %s got %s", expected, response.Body.String())

--- a/go/stats/rates.go
+++ b/go/stats/rates.go
@@ -37,6 +37,15 @@ type CountTracker interface {
 	Counts() map[string]int64
 }
 
+// wrappedCountTracker implements the CountTracker interface.
+// It is used in multidimensional.go to publish specific, one-dimensional
+// counters.
+type wrappedCountTracker struct {
+	f func() map[string]int64
+}
+
+func (t wrappedCountTracker) Counts() map[string]int64 { return t.f() }
+
 // Rates is capable of reporting the rate (typically QPS)
 // for any variable that satisfies the CountTracker interface.
 type Rates struct {

--- a/go/stats/rates_test.go
+++ b/go/stats/rates_test.go
@@ -42,7 +42,7 @@ func TestRates(t *testing.T) {
 	}
 
 	clear()
-	c := NewCountersWithLabels("rcounter1", "rcounter help", "type")
+	c := NewCountersWithSingleLabel("rcounter1", "rcounter help", "label")
 	r := NewRates("rates1", c, 3, -1*time.Second)
 	r.snapshot()
 	now = now.Add(epsilon)
@@ -90,7 +90,7 @@ func TestRatesConsistency(t *testing.T) {
 	// covered by rates, the sum of the rates reported must be
 	// equal to the count reported by the counter.
 	clear()
-	c := NewCountersWithLabels("rcounter4", "rcounter4 help", "type")
+	c := NewCountersWithSingleLabel("rcounter4", "rcounter4 help", "label")
 	r := NewRates("rates4", c, 100, -1*time.Second)
 	r.snapshot()
 
@@ -123,7 +123,7 @@ func TestRatesConsistency(t *testing.T) {
 
 func TestRatesHook(t *testing.T) {
 	clear()
-	c := NewCountersWithLabels("rcounter2", "rcounter2 help", "type")
+	c := NewCountersWithSingleLabel("rcounter2", "rcounter2 help", "label")
 	var gotname string
 	var gotv *Rates
 	clear()

--- a/go/stats/variable_interface.go
+++ b/go/stats/variable_interface.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+// Variable is the minimal interface which each type in this "stats" package
+// must implement.
+// When integrating the Vitess stats types ("variables") with the different
+// monitoring systems, you can rely on this interface.
+type Variable interface {
+	// Help returns the description of the variable.
+	Help() string
+
+	// String must implement String() from the expvar.Var interface.
+	String() string
+}

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -40,7 +40,7 @@ var (
 	// QueryLogFormat controls the format of the query log (either text or json)
 	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
 
-	sendCount      = stats.NewCountersWithLabels("StreamlogSend", "stream log send count", "logger_names")
+	sendCount      = stats.NewCountersWithSingleLabel("StreamlogSend", "stream log send count", "logger_names")
 	deliveredCount = stats.NewCountersWithMultiLabels(
 		"StreamlogDelivered",
 		"Stream log delivered",

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	binlogStreamerErrors = stats.NewCountersWithLabels("BinlogStreamerErrors", "error count when streaming binlog", "state")
+	binlogStreamerErrors = stats.NewCountersWithSingleLabel("BinlogStreamerErrors", "error count when streaming binlog", "state")
 
 	// ErrClientEOF is returned by Streamer if the stream ended because the
 	// consumer of the stream indicated it doesn't want any more events.

--- a/go/vt/binlog/updatestreamctl.go
+++ b/go/vt/binlog/updatestreamctl.go
@@ -47,8 +47,8 @@ var usStateNames = map[int64]string{
 }
 
 var (
-	streamCount          = stats.NewCountersWithLabels("UpdateStreamStreamCount", "update stream count", "type")
-	updateStreamErrors   = stats.NewCountersWithLabels("UpdateStreamErrors", "update stream error count", "type")
+	streamCount          = stats.NewCountersWithSingleLabel("UpdateStreamStreamCount", "update stream count", "type")
+	updateStreamErrors   = stats.NewCountersWithSingleLabel("UpdateStreamErrors", "update stream error count", "type")
 	keyrangeStatements   = stats.NewCounter("UpdateStreamKeyRangeStatements", "update stream key range statement count")
 	keyrangeTransactions = stats.NewCounter("UpdateStreamKeyRangeTransactions", "update stream key range transaction count")
 	tablesStatements     = stats.NewCounter("UpdateStreamTablesStatements", "update stream table statement count")

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -71,8 +71,8 @@ func NewConnectionPool(name string, capacity int, idleTimeout time.Duration) *Co
 	stats.NewGaugeFunc(name+"InUse", "Connection pool in-use", cp.InUse)
 	stats.NewGaugeFunc(name+"MaxCap", "Connection pool max cap", cp.MaxCap)
 	stats.NewCounterFunc(name+"WaitCount", "Connection pool wait count", cp.WaitCount)
-	stats.NewDurationFunc(name+"WaitTime", "Connection pool wait time", cp.WaitTime)
-	stats.NewDurationFunc(name+"IdleTimeout", "Connection pool idle timeout", cp.IdleTimeout)
+	stats.NewCounterDurationFunc(name+"WaitTime", "Connection pool wait time", cp.WaitTime)
+	stats.NewGaugeDurationFunc(name+"IdleTimeout", "Connection pool idle timeout", cp.IdleTimeout)
 	stats.NewGaugeFunc(name+"IdleClosed", "Connection pool idle closed", cp.IdleClosed)
 	return cp
 }

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -65,15 +65,15 @@ func NewConnectionPool(name string, capacity int, idleTimeout time.Duration) *Co
 		return cp
 	}
 	usedNames[name] = true
-	stats.NewGaugeFunc(name+"Capacity", "Connection pool capacity", stats.IntFunc(cp.Capacity))
-	stats.NewGaugeFunc(name+"Available", "Connection pool available", stats.IntFunc(cp.Available))
-	stats.NewGaugeFunc(name+"Active", "Connection pool active", stats.IntFunc(cp.Active))
-	stats.NewGaugeFunc(name+"InUse", "Connection pool in-use", stats.IntFunc(cp.InUse))
-	stats.NewGaugeFunc(name+"MaxCap", "Connection pool max cap", stats.IntFunc(cp.MaxCap))
-	stats.NewCounterFunc(name+"WaitCount", "Connection pool wait count", stats.IntFunc(cp.WaitCount))
-	stats.NewCounterFunc(name+"WaitTime", "Connection pool wait time", stats.DurationFunc(cp.WaitTime))
-	stats.NewCounterFunc(name+"IdleTimeout", "Connection pool idle timeout", stats.DurationFunc(cp.IdleTimeout))
-	stats.NewGaugeFunc(name+"IdleClosed", "Connection pool idle closed", stats.IntFunc(cp.IdleClosed))
+	stats.NewGaugeFunc(name+"Capacity", "Connection pool capacity", cp.Capacity)
+	stats.NewGaugeFunc(name+"Available", "Connection pool available", cp.Available)
+	stats.NewGaugeFunc(name+"Active", "Connection pool active", cp.Active)
+	stats.NewGaugeFunc(name+"InUse", "Connection pool in-use", cp.InUse)
+	stats.NewGaugeFunc(name+"MaxCap", "Connection pool max cap", cp.MaxCap)
+	stats.NewCounterFunc(name+"WaitCount", "Connection pool wait count", cp.WaitCount)
+	stats.NewDurationFunc(name+"WaitTime", "Connection pool wait time", cp.WaitTime)
+	stats.NewDurationFunc(name+"IdleTimeout", "Connection pool idle timeout", cp.IdleTimeout)
+	stats.NewGaugeFunc(name+"IdleClosed", "Connection pool idle closed", cp.IdleClosed)
 	return cp
 }
 

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -388,8 +388,8 @@ func NewHealthCheck(retryDelay, healthCheckTimeout time.Duration) HealthCheck {
 func (hc *HealthCheckImpl) RegisterStats() {
 	stats.NewCountersFuncWithMultiLabels(
 		"HealthcheckConnections",
+		"the number of healthcheck connections registered",
 		[]string{"Keyspace", "ShardName", "TabletType"},
-		"the numb of healthcheck connections registered",
 		hc.servingConnStats)
 }
 

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -120,7 +120,7 @@ type ResilientServer struct {
 	topoServer   *topo.Server
 	cacheTTL     time.Duration
 	cacheRefresh time.Duration
-	counts       *stats.CountersWithLabels
+	counts       *stats.CountersWithSingleLabel
 
 	// mutex protects the cache map itself, not the individual
 	// values in the cache.
@@ -215,7 +215,7 @@ func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServe
 		topoServer:   base,
 		cacheTTL:     *srvTopoCacheTTL,
 		cacheRefresh: *srvTopoCacheRefresh,
-		counts:       stats.NewCountersWithLabels(counterPrefix+"Counts", "Resilient srvtopo server operations", "type"),
+		counts:       stats.NewCountersWithSingleLabel(counterPrefix+"Counts", "Resilient srvtopo server operations", "type"),
 
 		srvKeyspaceNamesCache: make(map[string]*srvKeyspaceNamesEntry),
 		srvKeyspaceCache:      make(map[string]*srvKeyspaceEntry),

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -104,10 +104,10 @@ func NewExecutor(ctx context.Context, serv srvtopo.Server, cell, statsName strin
 	e.vm.watchSrvVSchema(ctx, cell)
 
 	executorOnce.Do(func() {
-		stats.NewGaugeFunc("QueryPlanCacheLength", "Query plan cache length", stats.IntFunc(e.plans.Length))
-		stats.NewGaugeFunc("QueryPlanCacheSize", "Query plan cache size", stats.IntFunc(e.plans.Size))
-		stats.NewGaugeFunc("QueryPlanCacheCapacity", "Query plan cache capacity", stats.IntFunc(e.plans.Capacity))
-		stats.NewCounterFunc("QueryPlanCacheEvictions", "Query plan cache evictions", stats.IntFunc(e.plans.Evictions))
+		stats.NewGaugeFunc("QueryPlanCacheLength", "Query plan cache length", e.plans.Length)
+		stats.NewGaugeFunc("QueryPlanCacheSize", "Query plan cache size", e.plans.Size)
+		stats.NewGaugeFunc("QueryPlanCacheCapacity", "Query plan cache capacity", e.plans.Capacity)
+		stats.NewCounterFunc("QueryPlanCacheEvictions", "Query plan cache evictions", e.plans.Evictions)
 		stats.Publish("QueryPlanCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", e.plans.Oldest())
 		}))

--- a/go/vt/vtgate/gateway/hybridgateway.go
+++ b/go/vt/vtgate/gateway/hybridgateway.go
@@ -92,8 +92,8 @@ func (h *HybridGateway) WaitForTablets(ctx context.Context, tabletTypesToWait []
 func (h *HybridGateway) RegisterStats() {
 	stats.NewCountersFuncWithMultiLabels(
 		"L2VtgateConnections",
+		"number of l2vtgate connection",
 		[]string{"Keyspace", "ShardName", "TabletType"},
-		"The l2vtgate connection counts",
 		h.servingConnStats)
 }
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -89,7 +89,7 @@ var (
 	qpsByKeyspace  *stats.Rates
 	qpsByDbType    *stats.Rates
 
-	vschemaCounters *stats.CountersWithLabels
+	vschemaCounters *stats.CountersWithSingleLabel
 
 	errorsByOperation *stats.Rates
 	errorsByKeyspace  *stats.Rates
@@ -99,7 +99,7 @@ var (
 	// Error counters should be global so they can be set from anywhere
 	errorCounts *stats.CountersWithMultiLabels
 
-	warnings *stats.CountersWithLabels
+	warnings *stats.CountersWithSingleLabel
 )
 
 // VTGate is the rpc interface to vtgate. Only one instance
@@ -156,7 +156,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, ce
 
 	// vschemaCounters needs to be initialized before planner to
 	// catch the initial load stats.
-	vschemaCounters = stats.NewCountersWithLabels("VtgateVSchemaCounts", "Vtgate vschema counts", "changes")
+	vschemaCounters = stats.NewCountersWithSingleLabel("VtgateVSchemaCounts", "Vtgate vschema counts", "changes")
 
 	// Build objects from low to high level.
 	// Start with the gateway. If we can't reach the topology service,
@@ -239,7 +239,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, ce
 	errorsByDbType = stats.NewRates("ErrorsByDbType", stats.CounterForDimension(errorCounts, "DbType"), 15, 1*time.Minute)
 	errorsByCode = stats.NewRates("ErrorsByCode", stats.CounterForDimension(errorCounts, "Code"), 15, 1*time.Minute)
 
-	warnings = stats.NewCountersWithLabels("VtGateWarnings", "Vtgate warnings", "type", "IgnoredSet")
+	warnings = stats.NewCountersWithSingleLabel("VtGateWarnings", "Vtgate warnings", "type", "IgnoredSet")
 
 	servenv.OnRun(func() {
 		for _, f := range RegisterVTGates {

--- a/go/vt/vttablet/tabletmanager/binlog_players.go
+++ b/go/vt/vttablet/tabletmanager/binlog_players.go
@@ -421,19 +421,19 @@ func NewBinlogPlayerMap(ts *topo.Server, mysqld mysqlctl.MysqlDaemon, vtClientFa
 
 // RegisterBinlogPlayerMap registers the varz for the players.
 func RegisterBinlogPlayerMap(blm *BinlogPlayerMap) {
-	stats.NewGaugeFunc("BinlogPlayerMapSize", "Binlog player map size", stats.IntFunc(func() int64 {
+	stats.NewGaugeFunc("BinlogPlayerMapSize", "Binlog player map size", func() int64 {
 		blm.mu.Lock()
 		defer blm.mu.Unlock()
 		return int64(len(blm.players))
-	}))
+	})
 	stats.NewGaugeFunc(
 		"BinlogPlayerSecondsBehindMaster",
 		"Binlog player seconds behind master",
-		stats.IntFunc(func() int64 {
+		func() int64 {
 			blm.mu.Lock()
 			defer blm.mu.Unlock()
 			return blm.maxSecondsBehindMasterUNGUARDED()
-		}))
+		})
 	stats.Publish("BinlogPlayerSecondsBehindMasterMap", stats.CountersFunc(func() map[string]int64 {
 		blm.mu.Lock()
 		result := make(map[string]int64, len(blm.players))

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -88,8 +88,8 @@ func New(
 	stats.NewGaugeFunc(name+"InUse", "Tablet server conn pool in use", cp.InUse)
 	stats.NewGaugeFunc(name+"MaxCap", "Tablet server conn pool max cap", cp.MaxCap)
 	stats.NewCounterFunc(name+"WaitCount", "Tablet server conn pool wait count", cp.WaitCount)
-	stats.NewDurationFunc(name+"WaitTime", "Tablet server wait time", cp.WaitTime)
-	stats.NewDurationFunc(name+"IdleTimeout", "Tablet server idle timeout", cp.IdleTimeout)
+	stats.NewCounterDurationFunc(name+"WaitTime", "Tablet server wait time", cp.WaitTime)
+	stats.NewGaugeDurationFunc(name+"IdleTimeout", "Tablet server idle timeout", cp.IdleTimeout)
 	stats.NewCounterFunc(name+"IdleClosed", "Tablet server conn pool idle closed", cp.IdleClosed)
 	return cp
 }

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -82,15 +82,15 @@ func New(
 		return cp
 	}
 	usedNames[name] = true
-	stats.NewGaugeFunc(name+"Capacity", "Tablet server conn pool capacity", stats.IntFunc(cp.Capacity))
-	stats.NewGaugeFunc(name+"Available", "Tablet server conn pool available", stats.IntFunc(cp.Available))
-	stats.NewGaugeFunc(name+"Active", "Tablet server conn pool active", stats.IntFunc(cp.Active))
-	stats.NewGaugeFunc(name+"InUse", "Tablet server conn pool in use", stats.IntFunc(cp.InUse))
-	stats.NewGaugeFunc(name+"MaxCap", "Tablet server conn pool max cap", stats.IntFunc(cp.MaxCap))
-	stats.NewCounterFunc(name+"WaitCount", "Tablet server conn pool wait count", stats.IntFunc(cp.WaitCount))
-	stats.NewCounterFunc(name+"WaitTime", "Tablet server wait time", stats.DurationFunc(cp.WaitTime))
-	stats.NewCounterFunc(name+"IdleTimeout", "Tablet server idle timeout", stats.DurationFunc(cp.IdleTimeout))
-	stats.NewCounterFunc(name+"IdleClosed", "Tablet server conn pool idle closed", stats.IntFunc(cp.IdleClosed))
+	stats.NewGaugeFunc(name+"Capacity", "Tablet server conn pool capacity", cp.Capacity)
+	stats.NewGaugeFunc(name+"Available", "Tablet server conn pool available", cp.Available)
+	stats.NewGaugeFunc(name+"Active", "Tablet server conn pool active", cp.Active)
+	stats.NewGaugeFunc(name+"InUse", "Tablet server conn pool in use", cp.InUse)
+	stats.NewGaugeFunc(name+"MaxCap", "Tablet server conn pool max cap", cp.MaxCap)
+	stats.NewCounterFunc(name+"WaitCount", "Tablet server conn pool wait count", cp.WaitCount)
+	stats.NewDurationFunc(name+"WaitTime", "Tablet server wait time", cp.WaitTime)
+	stats.NewDurationFunc(name+"IdleTimeout", "Tablet server idle timeout", cp.IdleTimeout)
+	stats.NewCounterFunc(name+"IdleClosed", "Tablet server conn pool idle closed", cp.IdleClosed)
 	return cp
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -248,10 +248,10 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		stats.Publish("QueryCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", qe.plans.Oldest())
 		}))
-		_ = stats.NewCountersFuncWithMultiLabels("QueryCounts", []string{"Table", "Plan"}, "query counts", qe.getQueryCount)
-		_ = stats.NewCountersFuncWithMultiLabels("QueryTimesNs", []string{"Table", "Plan"}, "query times in ns", qe.getQueryTime)
-		_ = stats.NewCountersFuncWithMultiLabels("QueryRowCounts", []string{"Table", "Plan"}, "query row counts", qe.getQueryRowCount)
-		_ = stats.NewCountersFuncWithMultiLabels("QueryErrorCounts", []string{"Table", "Plan"}, "query error counts", qe.getQueryErrorCount)
+		_ = stats.NewCountersFuncWithMultiLabels("QueryCounts", "query counts", []string{"Table", "Plan"}, qe.getQueryCount)
+		_ = stats.NewCountersFuncWithMultiLabels("QueryTimesNs", "query times in ns", []string{"Table", "Plan"}, qe.getQueryTime)
+		_ = stats.NewCountersFuncWithMultiLabels("QueryRowCounts", "query row counts", []string{"Table", "Plan"}, qe.getQueryRowCount)
+		_ = stats.NewCountersFuncWithMultiLabels("QueryErrorCounts", "query error counts", []string{"Table", "Plan"}, qe.getQueryErrorCount)
 
 		http.Handle("/debug/hotrows", qe.txSerializer)
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -234,17 +234,17 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	qe.accessCheckerLogger = logutil.NewThrottledLogger("accessChecker", 1*time.Second)
 
 	qeOnce.Do(func() {
-		stats.NewGaugeFunc("MaxResultSize", "Query engine max result size", stats.IntFunc(qe.maxResultSize.Get))
-		stats.NewGaugeFunc("WarnResultSize", "Query engine warn result size", stats.IntFunc(qe.warnResultSize.Get))
-		stats.NewGaugeFunc("MaxDMLRows", "Query engine max DML rows", stats.IntFunc(qe.maxDMLRows.Get))
-		stats.NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", stats.IntFunc(qe.streamBufferSize.Get))
-		stats.NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", stats.IntFunc(qe.tableaclExemptCount.Get))
-		stats.NewGaugeFunc("QueryPoolWaiters", "Query engine query pool waiters", stats.IntFunc(qe.queryPoolWaiters.Get))
+		stats.NewGaugeFunc("MaxResultSize", "Query engine max result size", qe.maxResultSize.Get)
+		stats.NewGaugeFunc("WarnResultSize", "Query engine warn result size", qe.warnResultSize.Get)
+		stats.NewGaugeFunc("MaxDMLRows", "Query engine max DML rows", qe.maxDMLRows.Get)
+		stats.NewGaugeFunc("StreamBufferSize", "Query engine stream buffer size", qe.streamBufferSize.Get)
+		stats.NewCounterFunc("TableACLExemptCount", "Query engine table ACL exempt count", qe.tableaclExemptCount.Get)
+		stats.NewGaugeFunc("QueryPoolWaiters", "Query engine query pool waiters", qe.queryPoolWaiters.Get)
 
-		stats.NewGaugeFunc("QueryCacheLength", "Query engine query cache length", stats.IntFunc(qe.plans.Length))
-		stats.NewGaugeFunc("QueryCacheSize", "Query engine query cache size", stats.IntFunc(qe.plans.Size))
-		stats.NewGaugeFunc("QueryCacheCapacity", "Query engine query cache capacity", stats.IntFunc(qe.plans.Capacity))
-		stats.NewCounterFunc("QueryCacheEvictions", "Query engine query cache evictions", stats.IntFunc(qe.plans.Evictions))
+		stats.NewGaugeFunc("QueryCacheLength", "Query engine query cache length", qe.plans.Length)
+		stats.NewGaugeFunc("QueryCacheSize", "Query engine query cache size", qe.plans.Size)
+		stats.NewGaugeFunc("QueryCacheCapacity", "Query engine query cache capacity", qe.plans.Capacity)
+		stats.NewCounterFunc("QueryCacheEvictions", "Query engine query cache evictions", qe.plans.Evictions)
 		stats.Publish("QueryCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", qe.plans.Oldest())
 		}))

--- a/go/vt/vttablet/tabletserver/replication_watcher.go
+++ b/go/vt/vttablet/tabletserver/replication_watcher.go
@@ -71,12 +71,12 @@ func NewReplicationWatcher(se *schema.Engine, config tabletenv.TabletConfig) *Re
 		stats.NewGaugeFunc(
 			"EventTokenTimestamp",
 			"Replication watcher event token timestamp",
-			stats.IntFunc(func() int64 {
+			func() int64 {
 				if e := rpw.EventToken(); e != nil {
 					return e.Timestamp
 				}
 				return 0
-			}))
+			})
 	})
 	return rpw
 }

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -78,11 +78,11 @@ func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *En
 	}
 	schemaOnce.Do(func() {
 		_ = stats.NewGaugeDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
-		_ = stats.NewGaugesFuncWithMultiLabels("TableRows", []string{"Table"}, "table rows created in tabletserver", se.getTableRows)
-		_ = stats.NewGaugesFuncWithMultiLabels("DataLength", []string{"Table"}, "data length in tabletserver", se.getDataLength)
-		_ = stats.NewGaugesFuncWithMultiLabels("IndexLength", []string{"Table"}, "index length in tabletserver", se.getIndexLength)
-		_ = stats.NewGaugesFuncWithMultiLabels("DataFree", []string{"Table"}, "data free in tabletserver", se.getDataFree)
-		_ = stats.NewGaugesFuncWithMultiLabels("MaxDataLength", []string{"Table"}, "max data length in tabletserver", se.getMaxDataLength)
+		_ = stats.NewGaugesFuncWithMultiLabels("TableRows", "table rows created in tabletserver", []string{"Table"}, se.getTableRows)
+		_ = stats.NewGaugesFuncWithMultiLabels("DataLength", "data length in tabletserver", []string{"Table"}, se.getDataLength)
+		_ = stats.NewGaugesFuncWithMultiLabels("IndexLength", "index length in tabletserver", []string{"Table"}, se.getIndexLength)
+		_ = stats.NewGaugesFuncWithMultiLabels("DataFree", "data free in tabletserver", []string{"Table"}, se.getDataFree)
+		_ = stats.NewGaugesFuncWithMultiLabels("MaxDataLength", "max data length in tabletserver", []string{"Table"}, se.getMaxDataLength)
 
 		http.Handle("/debug/schema", se)
 		http.HandleFunc("/schemaz", func(w http.ResponseWriter, r *http.Request) {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -77,7 +77,7 @@ func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *En
 		reloadTime: reloadTime,
 	}
 	schemaOnce.Do(func() {
-		_ = stats.NewDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
+		_ = stats.NewGaugeDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
 		_ = stats.NewGaugesFuncWithMultiLabels("TableRows", []string{"Table"}, "table rows created in tabletserver", se.getTableRows)
 		_ = stats.NewGaugesFuncWithMultiLabels("DataLength", []string{"Table"}, "data length in tabletserver", se.getDataLength)
 		_ = stats.NewGaugesFuncWithMultiLabels("IndexLength", []string{"Table"}, "index length in tabletserver", se.getIndexLength)

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -77,7 +77,7 @@ func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *En
 		reloadTime: reloadTime,
 	}
 	schemaOnce.Do(func() {
-		_ = stats.NewGaugeFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", stats.DurationFunc(se.ticks.Interval))
+		_ = stats.NewDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
 		_ = stats.NewGaugesFuncWithMultiLabels("TableRows", []string{"Table"}, "table rows created in tabletserver", se.getTableRows)
 		_ = stats.NewGaugesFuncWithMultiLabels("DataLength", []string{"Table"}, "data length in tabletserver", se.getDataLength)
 		_ = stats.NewGaugesFuncWithMultiLabels("IndexLength", []string{"Table"}, "index length in tabletserver", se.getIndexLength)

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -42,9 +42,9 @@ var (
 	// WaitStats shows the time histogram for wait operations
 	WaitStats = stats.NewTimings("Waits", "Wait operations")
 	// KillStats shows number of connections being killed.
-	KillStats = stats.NewCountersWithLabels("Kills", "Number of connections being killed", "query_type", "Transactions", "Queries")
+	KillStats = stats.NewCountersWithSingleLabel("Kills", "Number of connections being killed", "query_type", "Transactions", "Queries")
 	// ErrorStats shows number of critial errors happened.
-	ErrorStats = stats.NewCountersWithLabels(
+	ErrorStats = stats.NewCountersWithSingleLabel(
 		"Errors",
 		"Critical errors",
 		"error_code",
@@ -67,11 +67,11 @@ var (
 		vtrpcpb.Code_DATA_LOSS.String(),
 	)
 	// InternalErrors shows number of errors from internal components.
-	InternalErrors = stats.NewCountersWithLabels("InternalErrors", "Internal component errors", "type", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages")
+	InternalErrors = stats.NewCountersWithSingleLabel("InternalErrors", "Internal component errors", "type", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages")
 	// Warnings shows number of warnings
-	Warnings = stats.NewCountersWithLabels("Warnings", "Warnings", "type", "ResultsExceeded")
+	Warnings = stats.NewCountersWithSingleLabel("Warnings", "Warnings", "type", "ResultsExceeded")
 	// Unresolved tracks unresolved items. For now it's just Prepares.
-	Unresolved = stats.NewGaugesWithLabels("Unresolved", "Unresolved items", "item_type", "Prepares")
+	Unresolved = stats.NewGaugesWithSingleLabel("Unresolved", "Unresolved items", "item_type", "Prepares")
 	// UserTableQueryCount shows number of queries received for each CallerID/table combination.
 	UserTableQueryCount = stats.NewCountersWithMultiLabels(
 		"UserTableQueryCount",

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -244,9 +244,9 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 			tsv.mu.Unlock()
 			return state
 		})
-		stats.NewDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
-		stats.NewDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)
-		stats.NewDurationFunc("BeginTimeout", "Tablet server begin timeout", tsv.BeginTimeout.Get)
+		stats.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
+		stats.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)
+		stats.NewGaugeDurationFunc("BeginTimeout", "Tablet server begin timeout", tsv.BeginTimeout.Get)
 		stats.Publish("TabletStateName", stats.StringFunc(tsv.GetState))
 	})
 	return tsv

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -238,15 +238,15 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	// So that vtcombo doesn't even call it once, on the first tablet.
 	// And we can remove the tsOnce variable.
 	tsOnce.Do(func() {
-		stats.NewGaugeFunc("TabletState", "Tablet server state", stats.IntFunc(func() int64 {
+		stats.NewGaugeFunc("TabletState", "Tablet server state", func() int64 {
 			tsv.mu.Lock()
 			state := tsv.state
 			tsv.mu.Unlock()
 			return state
-		}))
-		stats.NewGaugeFunc("QueryTimeout", "Tablet server query timeout", stats.DurationFunc(tsv.QueryTimeout.Get))
-		stats.NewGaugeFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", stats.DurationFunc(tsv.qe.connTimeout.Get))
-		stats.NewGaugeFunc("BeginTimeout", "Tablet server begin timeout", stats.DurationFunc(tsv.BeginTimeout.Get))
+		})
+		stats.NewDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
+		stats.NewDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)
+		stats.NewDurationFunc("BeginTimeout", "Tablet server begin timeout", tsv.BeginTimeout.Get)
 		stats.Publish("TabletStateName", stats.StringFunc(tsv.GetState))
 	})
 	return tsv

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -119,8 +119,8 @@ func NewTxPool(
 	txOnce.Do(func() {
 		// Careful: conns also exports name+"xxx" vars,
 		// but we know it doesn't export Timeout.
-		stats.NewGaugeFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", stats.DurationFunc(axp.timeout.Get))
-		stats.NewGaugeFunc(prefix+"TransactionPoolWaiters", "Transaction pool waiters", stats.IntFunc(axp.waiters.Get))
+		stats.NewDurationFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
+		stats.NewGaugeFunc(prefix+"TransactionPoolWaiters", "Transaction pool waiters", axp.waiters.Get)
 	})
 	return axp
 }

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -119,7 +119,7 @@ func NewTxPool(
 	txOnce.Do(func() {
 		// Careful: conns also exports name+"xxx" vars,
 		// but we know it doesn't export Timeout.
-		stats.NewDurationFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
+		stats.NewGaugeDurationFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
 		stats.NewGaugeFunc(prefix+"TransactionPoolWaiters", "Transaction pool waiters", axp.waiters.Get)
 	})
 	return axp

--- a/go/vt/vttablet/tabletserver/txlimiter/tx_limiter.go
+++ b/go/vt/vttablet/tabletserver/txlimiter/tx_limiter.go
@@ -31,8 +31,8 @@ import (
 const unknown string = "unknown"
 
 var (
-	rejections       = stats.NewCountersWithLabels("TxLimiterRejections", "rejections from TxLimiter", "user")
-	rejectionsDryRun = stats.NewCountersWithLabels("TxLimiterRejectionsDryRun", "rejections from TxLimiter in dry run", "user")
+	rejections       = stats.NewCountersWithSingleLabel("TxLimiterRejections", "rejections from TxLimiter", "user")
+	rejectionsDryRun = stats.NewCountersWithSingleLabel("TxLimiterRejectionsDryRun", "rejections from TxLimiter in dry run", "user")
 )
 
 // TxLimiter is the transaction limiter interface.

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -40,27 +40,27 @@ var (
 	// waits stores how many times a transaction was queued because another
 	// transaction was already in flight for the same row (range).
 	// The key of the map is the table name of the query.
-	waits = stats.NewCountersWithLabels(
+	waits = stats.NewCountersWithSingleLabel(
 		"TxSerializerWaits",
 		"Number of times a transaction was queued because another transaction was already in flight for the same row range",
 		"table_name")
 	// waitsDryRun is similar as "waits": In dry-run mode it records how many
 	// transactions would have been queued.
 	// The key of the map is the table name of the query.
-	waitsDryRun = stats.NewCountersWithLabels(
+	waitsDryRun = stats.NewCountersWithSingleLabel(
 		"TxSerializerWaitsDryRun",
 		"Dry run number of transactions that would've been queued",
 		"table_name")
 
 	// queueExceeded counts per table how many transactions were rejected because
 	// the max queue size per row (range) was exceeded.
-	queueExceeded = stats.NewCountersWithLabels(
+	queueExceeded = stats.NewCountersWithSingleLabel(
 		"TxSerializerQueueExceeded",
 		"Number of transactions that were rejected because the max queue size per row range was exceeded",
 		"table_name")
 	// queueExceededDryRun counts in dry-run mode how many transactions would have
 	// been rejected due to exceeding the max queue size per row (range).
-	queueExceededDryRun = stats.NewCountersWithLabels(
+	queueExceededDryRun = stats.NewCountersWithSingleLabel(
 		"TxSerializerQueueExceededDryRun",
 		"Dry-run Number of transactions that were rejcted because the max queue size was exceeded",
 		"table_name")

--- a/go/vt/worker/row_aggregator.go
+++ b/go/vt/worker/row_aggregator.go
@@ -48,9 +48,7 @@ type RowAggregator struct {
 	td            *tabletmanagerdatapb.TableDefinition
 	diffType      DiffType
 	builder       QueryBuilder
-	// statsCounters has a "diffType" specific stats.CountersWithLabels object to track how
-	// many rows were changed per table.
-	statsCounters *stats.CountersWithLabels
+	statsCounters *stats.CountersWithSingleLabel
 
 	buffer       bytes.Buffer
 	bufferedRows int
@@ -60,7 +58,7 @@ type RowAggregator struct {
 // The index of the elements in statCounters must match the elements
 // in "DiffTypes" i.e. the first counter is for inserts, second for updates
 // and the third for deletes.
-func NewRowAggregator(ctx context.Context, maxRows, maxSize int, insertChannel chan string, dbName string, td *tabletmanagerdatapb.TableDefinition, diffType DiffType, statsCounters *stats.CountersWithLabels) *RowAggregator {
+func NewRowAggregator(ctx context.Context, maxRows, maxSize int, insertChannel chan string, dbName string, td *tabletmanagerdatapb.TableDefinition, diffType DiffType, statsCounters *stats.CountersWithSingleLabel) *RowAggregator {
 	// Construct head and tail base commands for the reconciliation statement.
 	var builder QueryBuilder
 	switch diffType {

--- a/go/vt/worker/row_differ.go
+++ b/go/vt/worker/row_differ.go
@@ -74,7 +74,7 @@ type RowDiffer2 struct {
 	// aggregators are keyed by destination shard and DiffType.
 	aggregators [][]*RowAggregator
 	// equalRowsStatsCounters tracks per table how many rows are equal.
-	equalRowsStatsCounters *stats.CountersWithLabels
+	equalRowsStatsCounters *stats.CountersWithSingleLabel
 	// tableName is required to update "equalRowsStatsCounters".
 	tableName string
 }
@@ -89,7 +89,7 @@ func NewRowDiffer2(ctx context.Context, left, right ResultReader, td *tabletmana
 	// Parameters required by RowRouter.
 	destinationShards []*topo.ShardInfo, keyResolver keyspaceIDResolver,
 	// Parameters required by RowAggregator.
-	insertChannels []chan string, abort <-chan struct{}, dbNames []string, writeQueryMaxRows, writeQueryMaxSize int, statsCounters []*stats.CountersWithLabels) (*RowDiffer2, error) {
+	insertChannels []chan string, abort <-chan struct{}, dbNames []string, writeQueryMaxRows, writeQueryMaxSize int, statsCounters []*stats.CountersWithSingleLabel) (*RowDiffer2, error) {
 
 	if len(statsCounters) != len(DiffTypes) {
 		panic(fmt.Sprintf("statsCounter has the wrong number of elements. got = %v, want = %v", len(statsCounters), len(DiffTypes)))

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -826,14 +826,14 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 		}
 		firstSourceTablet = tablets[0].Tablet
 	}
-	var statsCounters []*stats.CountersWithLabels
+	var statsCounters []*stats.CountersWithSingleLabel
 	var tableStatusList *tableStatusList
 	switch state {
 	case WorkerStateCloneOnline:
-		statsCounters = []*stats.CountersWithLabels{statsOnlineInsertsCounters, statsOnlineUpdatesCounters, statsOnlineDeletesCounters, statsOnlineEqualRowsCounters}
+		statsCounters = []*stats.CountersWithSingleLabel{statsOnlineInsertsCounters, statsOnlineUpdatesCounters, statsOnlineDeletesCounters, statsOnlineEqualRowsCounters}
 		tableStatusList = scw.tableStatusListOnline
 	case WorkerStateCloneOffline:
-		statsCounters = []*stats.CountersWithLabels{statsOfflineInsertsCounters, statsOfflineUpdatesCounters, statsOfflineDeletesCounters, statsOfflineEqualRowsCounters}
+		statsCounters = []*stats.CountersWithSingleLabel{statsOfflineInsertsCounters, statsOfflineUpdatesCounters, statsOfflineDeletesCounters, statsOfflineEqualRowsCounters}
 		tableStatusList = scw.tableStatusListOffline
 	}
 

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -59,57 +59,57 @@ var (
 
 	statsState             = stats.NewString("WorkerState")
 	statsRetryCount        = stats.NewCounter("WorkerRetryCount", "Total number of times a query to a vttablet had to be retried")
-	statsRetryCounters     = stats.NewCountersWithLabels("WorkerRetryCounters", "Number of retries grouped by category e.g. TimeoutError or ReadOnly", "category")
+	statsRetryCounters     = stats.NewCountersWithSingleLabel("WorkerRetryCounters", "Number of retries grouped by category e.g. TimeoutError or ReadOnly", "category")
 	statsThrottledCounters = stats.NewCountersWithMultiLabels(
 		"WorkerThrottledCounters",
 		`Number of times a write has been throttled grouped by (keyspace, shard, threadID).
 		Mainly used for testing. If throttling is enabled this should always be non-zero for all threads`,
 		[]string{"Keyspace", "ShardName", "ThreadId"})
-	statsStateDurationsNs = stats.NewGaugesWithLabels("WorkerStateDurations", "How much time was spent in each state. Mainly used for testing.", "state")
+	statsStateDurationsNs = stats.NewGaugesWithSingleLabel("WorkerStateDurations", "How much time was spent in each state. Mainly used for testing.", "state")
 
-	statsOnlineInsertsCounters = stats.NewCountersWithLabels(
+	statsOnlineInsertsCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOnlineInsertsCounters",
 		"For every table how many rows were inserted during the online clone (reconciliation) phase",
 		"table")
-	statsOnlineUpdatesCounters = stats.NewCountersWithLabels(
+	statsOnlineUpdatesCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOnlineUpdatesCounters",
 		"For every table how many rows were updated",
 		"table")
-	statsOnlineDeletesCounters = stats.NewCountersWithLabels(
+	statsOnlineDeletesCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOnlineDeletesCounters",
 		"For every table how many rows were deleted",
 		"table")
-	statsOnlineEqualRowsCounters = stats.NewCountersWithLabels(
+	statsOnlineEqualRowsCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOnlineEqualRowsCounters",
 		"For every table how many rows were equal",
 		"table")
 
-	statsOfflineInsertsCounters = stats.NewCountersWithLabels(
+	statsOfflineInsertsCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOfflineInsertsCounters",
 		"For every table how many rows were inserted during the online clone (reconciliation) phase",
 		"table")
-	statsOfflineUpdatesCounters = stats.NewCountersWithLabels(
+	statsOfflineUpdatesCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOfflineUpdatesCounters",
 		"For every table how many rows were updated",
 		"table")
-	statsOfflineDeletesCounters = stats.NewCountersWithLabels(
+	statsOfflineDeletesCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOfflineDeletesCounters",
 		"For every table how many rows were deleted",
 		"table")
-	statsOfflineEqualRowsCounters = stats.NewCountersWithLabels(
+	statsOfflineEqualRowsCounters = stats.NewCountersWithSingleLabel(
 		"WorkerOfflineEqualRowsCounters",
 		"For every table how many rows were equal",
 		"table")
 
-	statsStreamingQueryCounters = stats.NewCountersWithLabels(
+	statsStreamingQueryCounters = stats.NewCountersWithSingleLabel(
 		"StreamingQueryCounters",
 		"For every tablet alias how often a streaming query was successfully established there",
 		"tablet_alias")
-	statsStreamingQueryErrorsCounters = stats.NewCountersWithLabels(
+	statsStreamingQueryErrorsCounters = stats.NewCountersWithSingleLabel(
 		"StreamingQueryErrorsCounters",
 		"For every tablet alias how often a (previously successfully established) streaming query did error",
 		"tablet_alias")
-	statsStreamingQueryRestartsSameTabletCounters = stats.NewCountersWithLabels(
+	statsStreamingQueryRestartsSameTabletCounters = stats.NewCountersWithSingleLabel(
 		"StreamingQueryRestartsSameTabletCounters",
 		`For every tablet alias how often we successfully restarted a streaming query on the first retry.
 		This kind of restart is usually necessary when our streaming query is idle and MySQL aborts it after a timeout.`,


### PR DESCRIPTION
Reviewer notes:
- You can ignore the first commit. It's just moving code around.

#3784 introduced two layers of code for "stats.Counter" (and the new type "stats.Gauge").

As a consequence, it was for example possible to create a "stats.Gauge" for a time.Duration value.

This approach did not work well with our internal usage of the stats package.

Therefore, I reversed this and simplified the code:

- MetricFunc() interface was removed. Instead, a CountFunc or a GaugeFunc requires a simple func() int64 as input.
- IntFunc() removed. Before #3784, it was used to implement the expvar.Var interface. But now, this is taken care of by the types itself e.g "stats.CounterFunc". Therefore, we do not need it anymore and users of the "stats" package can just pass a plain func() int64.
- Added types "Duration" and "DurationFunc" back.
- Added "Variable" interface. This allowed to simplify the Prometheus code which depends on the Help() method for each stats variable.
- Prometheus: Conversion to float64 values is now done in prometheusbackend.go and removed from the stats package.


@zmagg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitessio/vitess/3867)
<!-- Reviewable:end -->
