### PR TITLE
Prometheus histogram improvements

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	// Metrics
-	timings    = stats.NewTimings("MysqlServerTimings", "MySQL server timings")
+	timings    = stats.NewTimings("MysqlServerTimings", "MySQL server timings", "operation")
 	connCount  = stats.NewGauge("MysqlServerConnCount", "Active MySQL server connections")
 	connAccept = stats.NewCounter("MysqlServerConnAccepted", "Connections accepted by MySQL server")
 	connSlow   = stats.NewCounter("MysqlServerConnSlow", "Connections that took more than the configured mysql_slow_connect_warn_threshold to establish")

--- a/go/stats/histogram.go
+++ b/go/stats/histogram.go
@@ -28,7 +28,6 @@ import (
 // using specified cutoffs.
 type Histogram struct {
 	help       string
-	labelName  string
 	cutoffs    []int64
 	labels     []string
 	countLabel string
@@ -167,9 +166,4 @@ func (h *Histogram) Buckets() []int64 {
 // Help returns the help string.
 func (h *Histogram) Help() string {
 	return h.help
-}
-
-// LabelName returns the label name.
-func (h *Histogram) LabelName() string {
-	return h.labelName
 }

--- a/go/stats/histogram.go
+++ b/go/stats/histogram.go
@@ -27,6 +27,8 @@ import (
 // splitting the counts under different buckets
 // using specified cutoffs.
 type Histogram struct {
+	help       string
+	labelName  string
 	cutoffs    []int64
 	labels     []string
 	countLabel string
@@ -41,24 +43,25 @@ type Histogram struct {
 // based on the cutoffs. The buckets are categorized using the
 // following criterion: cutoff[i-1] < value <= cutoff[i]. Anything
 // higher than the highest cutoff is labeled as "inf".
-func NewHistogram(name string, cutoffs []int64) *Histogram {
+func NewHistogram(name, help string, cutoffs []int64) *Histogram {
 	labels := make([]string, len(cutoffs)+1)
 	for i, v := range cutoffs {
 		labels[i] = fmt.Sprintf("%d", v)
 	}
 	labels[len(labels)-1] = "inf"
-	return NewGenericHistogram(name, cutoffs, labels, "Count", "Total")
+	return NewGenericHistogram(name, help, cutoffs, labels, "Count", "Total")
 }
 
 // NewGenericHistogram creates a histogram where all the labels are
 // supplied by the caller. The number of labels has to be one more than
 // the number of cutoffs because the last label captures everything that
 // exceeds the highest cutoff.
-func NewGenericHistogram(name string, cutoffs []int64, labels []string, countLabel, totalLabel string) *Histogram {
+func NewGenericHistogram(name, help string, cutoffs []int64, labels []string, countLabel, totalLabel string) *Histogram {
 	if len(cutoffs) != len(labels)-1 {
 		panic("mismatched cutoff and label lengths")
 	}
 	h := &Histogram{
+		help:       help,
 		cutoffs:    cutoffs,
 		labels:     labels,
 		countLabel: countLabel,
@@ -159,4 +162,14 @@ func (h *Histogram) Buckets() []int64 {
 		buckets[i] = h.buckets[i].Get()
 	}
 	return buckets
+}
+
+// Help returns the help string.
+func (h *Histogram) Help() string {
+	return h.help
+}
+
+// LabelName returns the label name.
+func (h *Histogram) LabelName() string {
+	return h.labelName
 }

--- a/go/stats/histogram_test.go
+++ b/go/stats/histogram_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestHistogram(t *testing.T) {
 	clear()
-	h := NewHistogram("hist1", []int64{1, 5})
+	h := NewHistogram("hist1", "desc1", []int64{1, 5})
 	for i := 0; i < 10; i++ {
 		h.Add(int64(i))
 	}
@@ -57,6 +57,7 @@ func TestGenericHistogram(t *testing.T) {
 	clear()
 	h := NewGenericHistogram(
 		"histgen",
+		"generic histogram",
 		[]int64{1, 5},
 		[]string{"one", "five", "max"},
 		"count",
@@ -78,7 +79,7 @@ func TestHistogramHook(t *testing.T) {
 	})
 
 	name := "hist2"
-	v := NewHistogram(name, []int64{1})
+	v := NewHistogram(name, "", []int64{1})
 	if gotname != name {
 		t.Errorf("got %v; want %v", gotname, name)
 	}

--- a/go/stats/histogram_test.go
+++ b/go/stats/histogram_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestHistogram(t *testing.T) {
 	clear()
-	h := NewHistogram("hist1", "desc1", []int64{1, 5})
+	h := NewHistogram("hist1", "help", []int64{1, 5})
 	for i := 0; i < 10; i++ {
 		h.Add(int64(i))
 	}
@@ -57,7 +57,7 @@ func TestGenericHistogram(t *testing.T) {
 	clear()
 	h := NewGenericHistogram(
 		"histgen",
-		"generic histogram",
+		"help",
 		[]int64{1, 5},
 		[]string{"one", "five", "max"},
 		"count",
@@ -79,7 +79,7 @@ func TestHistogramHook(t *testing.T) {
 	})
 
 	name := "hist2"
-	v := NewHistogram(name, "", []int64{1})
+	v := NewHistogram(name, "help", []int64{1})
 	if gotname != name {
 		t.Errorf("got %v; want %v", gotname, name)
 	}

--- a/go/stats/prometheusbackend/collectors.go
+++ b/go/stats/prometheusbackend/collectors.go
@@ -220,7 +220,7 @@ func newTimingsCollector(t *stats.Timings, name string) {
 		desc: prometheus.NewDesc(
 			name,
 			t.Help(),
-			[]string{t.LabelName()},
+			[]string{t.Label()},
 			nil),
 	}
 

--- a/go/stats/prometheusbackend/collectors.go
+++ b/go/stats/prometheusbackend/collectors.go
@@ -214,18 +214,19 @@ type timingsCollector struct {
 }
 
 func newTimingsCollector(t *stats.Timings, name string) {
+	cutoffs := make([]float64, len(t.Cutoffs()))
+	for i, val := range t.Cutoffs() {
+		cutoffs[i] = float64(val) / 1000000000
+	}
+
 	collector := &timingsCollector{
 		t:       t,
-		cutoffs: make([]float64, len(t.Cutoffs())),
+		cutoffs: cutoffs,
 		desc: prometheus.NewDesc(
 			name,
 			t.Help(),
 			[]string{t.Label()},
 			nil),
-	}
-
-	for i, val := range t.Cutoffs() {
-		collector.cutoffs[i] = float64(val) / 1000000000
 	}
 
 	prometheus.MustRegister(collector)
@@ -266,18 +267,19 @@ type multiTimingsCollector struct {
 }
 
 func newMultiTimingsCollector(mt *stats.MultiTimings, name string) {
+	cutoffs := make([]float64, len(mt.Cutoffs()))
+	for i, val := range mt.Cutoffs() {
+		cutoffs[i] = float64(val) / 1000000000
+	}
+
 	collector := &multiTimingsCollector{
 		mt:      mt,
-		cutoffs: make([]float64, len(mt.Cutoffs())),
+		cutoffs: cutoffs,
 		desc: prometheus.NewDesc(
 			name,
 			mt.Help(),
 			labelsToSnake(mt.Labels()),
 			nil),
-	}
-
-	for i, val := range mt.Cutoffs() {
-		collector.cutoffs[i] = float64(val) / 1000000000
 	}
 
 	prometheus.MustRegister(collector)
@@ -308,18 +310,19 @@ type histogramCollector struct {
 }
 
 func newHistogramCollector(h *stats.Histogram, name string) {
+	cutoffs := make([]float64, len(h.Cutoffs()))
+	for i, val := range h.Cutoffs() {
+		cutoffs[i] = float64(val)
+	}
+
 	collector := &histogramCollector{
 		h:       h,
-		cutoffs: make([]float64, len(h.Cutoffs())),
+		cutoffs: cutoffs,
 		desc: prometheus.NewDesc(
 			name,
 			h.Help(),
 			[]string{},
 			nil),
-	}
-
-	for i, val := range h.Cutoffs() {
-		collector.cutoffs[i] = float64(val)
 	}
 
 	prometheus.MustRegister(collector)

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -142,7 +142,7 @@ func (be *PromBackend) newTiming(t *stats.Timings, name string) {
 		desc: prometheus.NewDesc(
 			be.buildPromName(name),
 			t.Help(),
-			[]string{"Histograms"}, // hard coded label key
+			[]string{t.LabelName()},
 			nil),
 	}
 

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -34,157 +34,42 @@ func Init(namespace string) {
 func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 	switch st := v.(type) {
 	case *stats.Counter:
-		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return float64(st.Get()) })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.CounterValue, func() float64 { return float64(st.Get()) })
 	case *stats.CounterFunc:
-		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return float64(st.F()) })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.CounterValue, func() float64 { return float64(st.F()) })
 	case *stats.Gauge:
-		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return float64(st.Get()) })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.GaugeValue, func() float64 { return float64(st.Get()) })
 	case *stats.GaugeFunc:
-		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return float64(st.F()) })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.GaugeValue, func() float64 { return float64(st.F()) })
 	case *stats.CountersWithSingleLabel:
-		be.newCountersWithSingleLabel(st, name, st.Label(), prometheus.CounterValue)
+		newCountersWithSingleLabelCollector(st, be.buildPromName(name), st.Label(), prometheus.CounterValue)
 	case *stats.CountersWithMultiLabels:
-		be.newCountersWithMultiLabels(st, name)
+		newMetricWithMultiLabelsCollector(st, be.buildPromName(name))
 	case *stats.CountersFuncWithMultiLabels:
-		be.newMetricsFuncWithMultiLabels(st, name, prometheus.CounterValue)
+		newMetricsFuncWithMultiLabelsCollector(st, be.buildPromName(name), prometheus.CounterValue)
 	case *stats.GaugesFuncWithMultiLabels:
-		be.newMetricsFuncWithMultiLabels(&st.CountersFuncWithMultiLabels, name, prometheus.GaugeValue)
+		newMetricsFuncWithMultiLabelsCollector(&st.CountersFuncWithMultiLabels, be.buildPromName(name), prometheus.GaugeValue)
 	case *stats.GaugesWithSingleLabel:
-		be.newGaugesWithSingleLabel(st, name, st.Label(), prometheus.GaugeValue)
+		newGaugesWithSingleLabelCollector(st, be.buildPromName(name), st.Label(), prometheus.GaugeValue)
 	case *stats.GaugesWithMultiLabels:
-		be.newGaugesWithMultiLabels(st, name)
+		newGaugesWithMultiLabelsCollector(st, be.buildPromName(name))
 	case *stats.CounterDuration:
-		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return st.Get().Seconds() })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.CounterValue, func() float64 { return st.Get().Seconds() })
 	case *stats.CounterDurationFunc:
-		be.newMetric(st, name, prometheus.CounterValue, func() float64 { return st.F().Seconds() })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.CounterValue, func() float64 { return st.F().Seconds() })
 	case *stats.GaugeDuration:
-		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return st.Get().Seconds() })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.GaugeValue, func() float64 { return st.Get().Seconds() })
 	case *stats.GaugeDurationFunc:
-		be.newMetric(st, name, prometheus.GaugeValue, func() float64 { return st.F().Seconds() })
+		newMetricFuncCollector(st, be.buildPromName(name), prometheus.GaugeValue, func() float64 { return st.F().Seconds() })
 	case *stats.Timings:
-		be.newTiming(st, name)
+		newTimingsCollector(st, be.buildPromName(name))
 	case *stats.MultiTimings:
-		be.newMultiTiming(st, name)
+		newMultiTimingsCollector(st, be.buildPromName(name))
 	case *stats.Histogram:
 		newHistogramCollector(st, be.buildPromName(name))
 	default:
 		logUnsupported.Infof("Not exporting to Prometheus an unsupported metric type of %T: %s", st, name)
 	}
-}
-
-func (be *PromBackend) newCountersWithSingleLabel(c *stats.CountersWithSingleLabel, name string, labelName string, vt prometheus.ValueType) {
-	collector := &countersWithSingleLabelCollector{
-		counters: c,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			c.Help(),
-			[]string{labelName},
-			nil),
-		vt: vt}
-
-	prometheus.MustRegister(collector)
-}
-
-func (be *PromBackend) newGaugesWithSingleLabel(g *stats.GaugesWithSingleLabel, name string, labelName string, vt prometheus.ValueType) {
-	collector := &gaugesWithSingleLabelCollector{
-		gauges: g,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			g.Help(),
-			[]string{labelName},
-			nil),
-		vt: vt}
-
-	prometheus.MustRegister(collector)
-}
-
-func (be *PromBackend) newCountersWithMultiLabels(cml *stats.CountersWithMultiLabels, name string) {
-	c := &metricWithMultiLabelsCollector{
-		cml: cml,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			cml.Help(),
-			labelsToSnake(cml.Labels()),
-			nil),
-	}
-
-	prometheus.MustRegister(c)
-}
-
-func (be *PromBackend) newGaugesWithMultiLabels(gml *stats.GaugesWithMultiLabels, name string) {
-	c := &multiGaugesCollector{
-		gml: gml,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			gml.Help(),
-			labelsToSnake(gml.Labels()),
-			nil),
-	}
-
-	prometheus.MustRegister(c)
-}
-
-func (be *PromBackend) newMetricsFuncWithMultiLabels(cfml *stats.CountersFuncWithMultiLabels, name string, vt prometheus.ValueType) {
-	collector := &metricsFuncWithMultiLabelsCollector{
-		cfml: cfml,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			cfml.Help(),
-			labelsToSnake(cfml.Labels()),
-			nil),
-		vt: vt,
-	}
-
-	prometheus.MustRegister(collector)
-}
-
-func (be *PromBackend) newTiming(t *stats.Timings, name string) {
-	collector := &timingsCollector{
-		t:       t,
-		cutoffs: make([]float64, len(t.Cutoffs())),
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			t.Help(),
-			[]string{t.LabelName()},
-			nil),
-	}
-
-	for i, val := range t.Cutoffs() {
-		collector.cutoffs[i] = float64(val) / 1000000000
-	}
-
-	prometheus.MustRegister(collector)
-}
-
-func (be *PromBackend) newMultiTiming(mt *stats.MultiTimings, name string) {
-	collector := &multiTimingsCollector{
-		mt:      mt,
-		cutoffs: make([]float64, len(mt.Cutoffs())),
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			mt.Help(),
-			labelsToSnake(mt.Labels()),
-			nil),
-	}
-
-	for i, val := range mt.Cutoffs() {
-		collector.cutoffs[i] = float64(val) / 1000000000
-	}
-
-	prometheus.MustRegister(collector)
-}
-
-func (be *PromBackend) newMetric(v stats.Variable, name string, vt prometheus.ValueType, f func() float64) {
-	collector := &metricFuncCollector{
-		f: f,
-		desc: prometheus.NewDesc(
-			be.buildPromName(name),
-			v.Help(),
-			nil,
-			nil),
-		vt: vt}
-
-	prometheus.MustRegister(collector)
 }
 
 // buildPromName specifies the namespace as a prefix to the metric name

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -18,20 +18,20 @@ type PromBackend struct {
 }
 
 var (
-	be             *PromBackend
+	be             PromBackend
 	logUnsupported *logutil.ThrottledLogger
 )
 
 // Init initializes the Prometheus be with the given namespace.
 func Init(namespace string) {
 	http.Handle("/metrics", promhttp.Handler())
-	be := &PromBackend{namespace: namespace}
+	be.namespace = namespace
 	logUnsupported = logutil.NewThrottledLogger("PrometheusUnsupportedMetricType", 1*time.Minute)
 	stats.Register(be.publishPrometheusMetric)
 }
 
 // PublishPromMetric is used to publish the metric to Prometheus.
-func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
+func (be PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 	switch st := v.(type) {
 	case *stats.Counter:
 		newMetricFuncCollector(st, be.buildPromName(name), prometheus.CounterValue, func() float64 { return float64(st.Get()) })
@@ -73,7 +73,7 @@ func (be *PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 }
 
 // buildPromName specifies the namespace as a prefix to the metric name
-func (be *PromBackend) buildPromName(name string) string {
+func (be PromBackend) buildPromName(name string) string {
 	s := strings.TrimPrefix(normalizeMetric(name), be.namespace+"_")
 	return prometheus.BuildFQName("", be.namespace, s)
 }

--- a/go/stats/prometheusbackend/prometheusbackend_test.go
+++ b/go/stats/prometheusbackend/prometheusbackend_test.go
@@ -221,25 +221,25 @@ func checkHandlerForMetricWithMultiLabels(t *testing.T, metric string, labels []
 func TestPrometheusTimings(t *testing.T) {
 	name := "blah_timings"
 	cats := []string{"cat1", "cat2"}
-	timing := stats.NewTimings(name, "help", cats...)
+	timing := stats.NewTimings(name, "help", "category", cats...)
 	timing.Add("cat1", time.Duration(1000000000))
 
 	response := testMetricsHandler(t)
 	var s []string
 
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.0005\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.001\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.005\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.01\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.05\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.1\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"0.5\"} %d", namespace, name, cats[0], 0))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"1\"} %d", namespace, name, cats[0], 1))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"5\"} %d", namespace, name, cats[0], 1))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"10\"} %d", namespace, name, cats[0], 1))
-	s = append(s, fmt.Sprintf("%s_%s_bucket{Histograms=\"%s\",le=\"+Inf\"} %d", namespace, name, cats[0], 1))
-	s = append(s, fmt.Sprintf("%s_%s_sum{Histograms=\"%s\"} %d", namespace, name, cats[0], 1))
-	s = append(s, fmt.Sprintf("%s_%s_count{Histograms=\"%s\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.0005\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.001\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.005\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.01\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.05\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.1\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"0.5\"} %d", namespace, name, cats[0], 0))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"1\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"5\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"10\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_bucket{category=\"%s\",le=\"+Inf\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_sum{category=\"%s\"} %d", namespace, name, cats[0], 1))
+	s = append(s, fmt.Sprintf("%s_%s_count{category=\"%s\"} %d", namespace, name, cats[0], 1))
 
 	for _, line := range s {
 		if !strings.Contains(response.Body.String(), line) {

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -38,16 +38,18 @@ type Timings struct {
 	histograms map[string]*Histogram
 	hook       func(string, time.Duration)
 	help       string
+	labelName  string
 }
 
 // NewTimings creates a new Timings object, and publishes it if name is set.
 // categories is an optional list of categories to initialize to 0.
 // Categories that aren't initialized will be missing from the map until the
 // first time they are updated.
-func NewTimings(name string, help string, categories ...string) *Timings {
+func NewTimings(name, help, labelName string, categories ...string) *Timings {
 	t := &Timings{
 		histograms: make(map[string]*Histogram),
 		help:       help,
+		labelName:  labelName,
 	}
 	for _, cat := range categories {
 		t.histograms[cat] = NewGenericHistogram("", bucketCutoffs, bucketLabels, "Count", "Time")
@@ -158,6 +160,11 @@ func (t *Timings) Cutoffs() []int64 {
 // Help returns the help string.
 func (t *Timings) Help() string {
 	return t.help
+}
+
+// LabelName returns the label name.
+func (t *Timings) LabelName() string {
+	return t.labelName
 }
 
 var bucketCutoffs = []int64{5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 5e9, 1e10}

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -52,7 +52,7 @@ func NewTimings(name, help, labelName string, categories ...string) *Timings {
 		labelName:  labelName,
 	}
 	for _, cat := range categories {
-		t.histograms[cat] = NewGenericHistogram("", bucketCutoffs, bucketLabels, "Count", "Time")
+		t.histograms[cat] = NewGenericHistogram("", "", bucketCutoffs, bucketLabels, "Count", "Time")
 	}
 	if name != "" {
 		publish(name, t)
@@ -74,7 +74,7 @@ func (t *Timings) Add(name string, elapsed time.Duration) {
 		t.mu.Lock()
 		hist, ok = t.histograms[name]
 		if !ok {
-			hist = NewGenericHistogram("", bucketCutoffs, bucketLabels, "Count", "Time")
+			hist = NewGenericHistogram("", "", bucketCutoffs, bucketLabels, "Count", "Time")
 			t.histograms[name] = hist
 		}
 		t.mu.Unlock()

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -38,18 +38,18 @@ type Timings struct {
 	histograms map[string]*Histogram
 	hook       func(string, time.Duration)
 	help       string
-	labelName  string
+	label      string
 }
 
 // NewTimings creates a new Timings object, and publishes it if name is set.
 // categories is an optional list of categories to initialize to 0.
 // Categories that aren't initialized will be missing from the map until the
 // first time they are updated.
-func NewTimings(name, help, labelName string, categories ...string) *Timings {
+func NewTimings(name, help, label string, categories ...string) *Timings {
 	t := &Timings{
 		histograms: make(map[string]*Histogram),
 		help:       help,
-		labelName:  labelName,
+		label:      label,
 	}
 	for _, cat := range categories {
 		t.histograms[cat] = NewGenericHistogram("", "", bucketCutoffs, bucketLabels, "Count", "Time")
@@ -162,9 +162,9 @@ func (t *Timings) Help() string {
 	return t.help
 }
 
-// LabelName returns the label name.
-func (t *Timings) LabelName() string {
-	return t.labelName
+// Label returns the label name.
+func (t *Timings) Label() string {
+	return t.label
 }
 
 var bucketCutoffs = []int64{5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 5e9, 1e10}

--- a/go/stats/timings_test.go
+++ b/go/stats/timings_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestTimings(t *testing.T) {
 	clear()
-	tm := NewTimings("timings1", "help")
+	tm := NewTimings("timings1", "help", "category")
 	tm.Add("tag1", 500*time.Microsecond)
 	tm.Add("tag1", 1*time.Millisecond)
 	tm.Add("tag2", 1*time.Millisecond)
@@ -56,7 +56,7 @@ func TestTimingsHook(t *testing.T) {
 	})
 
 	name := "timings2"
-	v := NewTimings(name, "help")
+	v := NewTimings(name, "help", "")
 	if gotname != name {
 		t.Errorf("got %q, want %q", gotname, name)
 	}

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -88,7 +88,7 @@ func (bps *Stats) GetLastPosition() mysql.Position {
 // NewStats creates a new Stats structure
 func NewStats() *Stats {
 	bps := &Stats{}
-	bps.Timings = stats.NewTimings("", "")
+	bps.Timings = stats.NewTimings("", "", "")
 	bps.Rates = stats.NewRates("", bps.Timings, 15, 60e9)
 	return bps
 }

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -146,7 +146,7 @@ func NewFakeMysqlDaemon(db *fakesqldb.DB) *FakeMysqlDaemon {
 	}
 	if db != nil {
 		result.appPool = dbconnpool.NewConnectionPool("AppConnPool", 5, time.Minute)
-		result.appPool.Open(db.ConnParams(), stats.NewTimings("", ""))
+		result.appPool.Open(db.ConnParams(), stats.NewTimings("", "", ""))
 	}
 	return result
 }
@@ -410,12 +410,12 @@ func (fmd *FakeMysqlDaemon) GetAppConnection(ctx context.Context) (*dbconnpool.P
 
 // GetDbaConnection is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) GetDbaConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(fmd.db.ConnParams(), stats.NewTimings("", ""))
+	return dbconnpool.NewDBConnection(fmd.db.ConnParams(), stats.NewTimings("", "", ""))
 }
 
 // GetAllPrivsConnection is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) GetAllPrivsConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(fmd.db.ConnParams(), stats.NewTimings("", ""))
+	return dbconnpool.NewDBConnection(fmd.db.ConnParams(), stats.NewTimings("", "", ""))
 }
 
 // SetSemiSyncEnabled is part of the MysqlDaemon interface.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -73,9 +73,9 @@ var (
 	// masterConnectRetry is used in 'SET MASTER' commands
 	masterConnectRetry = flag.Duration("master_connect_retry", 10*time.Second, "how long to wait in between slave -> connection attempts. Only precise to the second.")
 
-	dbaMysqlStats      = stats.NewTimings("MysqlDba", "MySQL DBA stats")
-	allprivsMysqlStats = stats.NewTimings("MysqlAllPrivs", "MySQl Stats for all privs")
-	appMysqlStats      = stats.NewTimings("MysqlApp", "MySQL app stats")
+	dbaMysqlStats      = stats.NewTimings("MysqlDba", "MySQL DBA stats", "operation")
+	allprivsMysqlStats = stats.NewTimings("MysqlAllPrivs", "MySQl Stats for all privs", "operation")
+	appMysqlStats      = stats.NewTimings("MysqlApp", "MySQL app stats", "operation")
 )
 
 // Mysqld is the object that represents a mysqld daemon running on this server.

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -155,7 +155,7 @@ func (w *Writer) Close() {
 // and we also execute them with an isolated connection that turns off the binlog and
 // is closed at the end.
 func (w *Writer) initializeTables(cp *mysql.ConnParams) error {
-	conn, err := dbconnpool.NewDBConnection(cp, stats.NewTimings("", ""))
+	conn, err := dbconnpool.NewDBConnection(cp, stats.NewTimings("", "", ""))
 	if err != nil {
 		return fmt.Errorf("Failed to create connection for heartbeat: %v", err)
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
@@ -39,7 +39,7 @@ import (
 var (
 	finalizeReparentTimeout = flag.Duration("finalize_external_reparent_timeout", 30*time.Second, "Timeout for the finalize stage of a fast external reparent reconciliation.")
 
-	externalReparentStats = stats.NewTimings("ExternalReparents", "Stats from external reparentings", "NewMasterVisible", "FullRebuild")
+	externalReparentStats = stats.NewTimings("ExternalReparents", "External reparenting time", "stage", "NewMasterVisible", "FullRebuild")
 )
 
 // SetReparentFlags changes flag values. It should only be used in tests.

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -93,7 +93,9 @@ var (
 		"Total transaction latency for each CallerID",
 		[]string{"CallerID", "Conclusion"})
 	// ResultStats shows the histogram of number of rows returned.
-	ResultStats = stats.NewHistogram("Results", []int64{0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000})
+	ResultStats = stats.NewHistogram("Results",
+		"Distribution of rows returned",
+		[]int64{0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000})
 	// TableaclAllowed tracks the number allows.
 	TableaclAllowed = stats.NewCountersWithMultiLabels(
 		"TableACLAllowed",

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -34,13 +34,13 @@ import (
 
 var (
 	// MySQLStats shows the time histogram for operations spent on mysql side.
-	MySQLStats = stats.NewTimings("Mysql", "MySQl query time")
+	MySQLStats = stats.NewTimings("Mysql", "MySQl query time", "operation")
 	// QueryStats shows the time histogram for each type of queries.
-	QueryStats = stats.NewTimings("Queries", "MySQL query timings")
+	QueryStats = stats.NewTimings("Queries", "MySQL query timings", "plan_type")
 	// QPSRates shows the qps of QueryStats. Sample every 5 seconds and keep samples for up to 15 mins.
 	QPSRates = stats.NewRates("QPS", QueryStats, 15*60/5, 5*time.Second)
 	// WaitStats shows the time histogram for wait operations
-	WaitStats = stats.NewTimings("Waits", "Wait operations")
+	WaitStats = stats.NewTimings("Waits", "Wait operations", "type")
 	// KillStats shows number of connections being killed.
 	KillStats = stats.NewCountersWithSingleLabel("Kills", "Number of connections being killed", "query_type", "Transactions", "Queries")
 	// ErrorStats shows number of critial errors happened.

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -130,7 +130,7 @@ func NewTwoPC(readPool *connpool.Pool) *TwoPC {
 // are not present, they are created.
 func (tpc *TwoPC) Init(sidecarDBName string, dbaparams *mysql.ConnParams) error {
 	dbname := sqlescape.EscapeID(sidecarDBName)
-	conn, err := dbconnpool.NewDBConnection(dbaparams, stats.NewTimings("", ""))
+	conn, err := dbconnpool.NewDBConnection(dbaparams, stats.NewTimings("", "", ""))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -56,7 +56,7 @@ const txLogInterval = time.Duration(1 * time.Minute)
 
 var (
 	txOnce  sync.Once
-	txStats = stats.NewTimings("Transactions", "Transaction stats")
+	txStats = stats.NewTimings("Transactions", "Transaction stats", "operation")
 
 	txIsolations = map[querypb.ExecuteOptions_TransactionIsolation]string{
 		querypb.ExecuteOptions_REPEATABLE_READ:  "set transaction isolation level REPEATABLE READ",


### PR DESCRIPTION
Make a couple of improvements to the prometheus metrics:

1. Add a customizable label string for stats.NewTimings rather than a hard coded label of "Histograms".
2. Add prometheus export for stats.NewHistogram.
3. Reorganize the prometheus backend code to put the constructor definitions next to the structs themselves.
4. Change the PromBackend singleton from a pointer to a singleton struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vitessio/vitess/3879)
<!-- Reviewable:end -->
