### PR TITLE
trim non-letter from beginning of statement in preview

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -55,11 +55,10 @@ const (
 func Preview(sql string) int {
 	trimmed := StripLeadingComments(sql)
 
-	firstWord := trimmed
-	if end := strings.IndexFunc(trimmed, unicode.IsSpace); end != -1 {
-		firstWord = trimmed[:end]
+	firstWord := strings.TrimLeftFunc(trimmed, func(r rune) bool { return !unicode.IsLetter(r) })
+	if end := strings.IndexFunc(firstWord, unicode.IsSpace); end != -1 {
+		firstWord = firstWord[:end]
 	}
-
 	// Comparison is done in order of priority.
 	loweredFirstWord := strings.ToLower(firstWord)
 	switch loweredFirstWord {

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -55,10 +55,11 @@ const (
 func Preview(sql string) int {
 	trimmed := StripLeadingComments(sql)
 
-	firstWord := strings.TrimLeftFunc(trimmed, func(r rune) bool { return !unicode.IsLetter(r) })
-	if end := strings.IndexFunc(firstWord, unicode.IsSpace); end != -1 {
-		firstWord = firstWord[:end]
+	firstWord := trimmed
+	if end := strings.IndexFunc(trimmed, unicode.IsSpace); end != -1 {
+		firstWord = trimmed[:end]
 	}
+	firstWord = strings.TrimLeftFunc(firstWord, func(r rune) bool { return !unicode.IsLetter(r) })
 	// Comparison is done in order of priority.
 	loweredFirstWord := strings.ToLower(firstWord)
 	switch loweredFirstWord {

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -31,6 +31,7 @@ func TestPreview(t *testing.T) {
 	}{
 		{"select ...", StmtSelect},
 		{"    select ...", StmtSelect},
+		{"(select ...", StmtSelect},
 		{"insert ...", StmtInsert},
 		{"replace ....", StmtReplace},
 		{"   update ...", StmtUpdate},

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -70,6 +70,7 @@ func TestPreview(t *testing.T) {
 		{"unknown", StmtUnknown},
 
 		{"/* leading comment */ select ...", StmtSelect},
+		{"/* leading comment */ (select ...", StmtSelect},
 		{"/* leading comment */ /* leading comment 2 */ select ...", StmtSelect},
 		{"/*! MySQL-specific comment */", StmtComment},
 		{"/*!50708 MySQL-version comment */", StmtComment},


### PR DESCRIPTION
this allows us to analyze:
(select id from foo) union all (select id from bar) limit 10;

Signed-off-by: Alex Charis <acharis@hubspot.com>