### PR TITLE
jdbc: bump dep versions in order to pull in grpc 1.5.0 -> 1.11.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -60,7 +60,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
-    <grpc.version>1.5.0</grpc.version>
+    <grpc.version>1.11.0</grpc.version>
     <protobuf.java.version>3.0.0</protobuf.java.version>
   </properties>
 
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>19.0</version>
+        <version>20.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -122,14 +122,14 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.12.Final</version>
+        <version>4.1.22.Final</version>
       </dependency>
       <!-- TODO(mberlin): When we upgrade grpc, check if we can remove this. Without,
         grpc-client TLS tests fail with error "Jetty ALPN/NPN has not been properly configured.". -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.3.Final</version>
+        <version>2.0.7.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
we therefore now pull in:
 - guava 19.0 -> 20.0
 - netty-handler 4.1.12.Final -> 4.1.22.Final
 - netty-tcnative-boringssl-static 2.0.3.Final -> 2.0.7.Final

Signed-off-by: Alex Charis <acharis@hubspot.com>