### PR TITLE
Disallow GET_LOCK() calls in vttablet.

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -2151,3 +2151,7 @@ options:PassthroughDMLs
 # syntax error
 "syntax error"
 "syntax error at position 7 near 'syntax'"
+
+# named locks are unsafe with server-side connection pooling
+"select get_lock('foo') from dual"
+"get_lock() not allowed"

--- a/data/test/tabletserver/stream_cases.txt
+++ b/data/test/tabletserver/stream_cases.txt
@@ -52,3 +52,7 @@
 # syntax error
 "syntax error"
 "syntax error at position 7 near 'syntax'"
+
+# named locks are unsafe with server-side connection pooling
+"select get_lock('foo') from dual"
+"get_lock() not allowed"


### PR DESCRIPTION
Named locks are unsafe with server-side connection pool.

See https://github.com/vitessio/vitess/issues/3631 for background.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>