### PR TITLE
[VTQueryServer] Fix "set autocommit" handling

### DIFF
--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -143,7 +143,7 @@ func (mp *Proxy) doSet(ctx context.Context, session *ProxySession, sql string, b
 			case 0:
 				session.Autocommit = false
 			case 1:
-				if session.TransactionID != 0 {
+				if !session.Autocommit && session.TransactionID != 0 {
 					if err := mp.doCommit(ctx, session); err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
If autocommit is already 1, setting it again to 1 shouldn't mess with transaction state.

Signed-off-by: Daniel Tahara <tahara@dropbox.com>