### PR TITLE
Adds read and write timeouts to MySQL server

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -162,7 +162,7 @@ func New(t *testing.T) *DB {
 	authServer := &mysql.AuthServerNone{}
 
 	// Start listening.
-	db.listener, err = mysql.NewListener("unix", socketFile, authServer, db)
+	db.listener, err = mysql.NewListener("unix", socketFile, authServer, db, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -43,7 +43,7 @@ func TestClearTextClientAuth(t *testing.T) {
 	}
 
 	// Create the listener.
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestSSLConnection(t *testing.T) {
 	}
 
 	// Create the listener, so we can get its host.
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}

--- a/go/mysql/query_benchmark_test.go
+++ b/go/mysql/query_benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkParallelShortQueries(b *testing.B) {
 
 	authServer := &AuthServerNone{}
 
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		b.Fatalf("NewListener failed: %v", err)
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -176,7 +176,7 @@ func TestConnectionFromListener(t *testing.T) {
 		t.Fatalf("net.Listener failed: %v", err)
 	}
 
-	l, err := NewFromListener(listener, authServer, th)
+	l, err := NewFromListener(listener, authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestConnectionWithoutSourceHost(t *testing.T) {
 		Password: "password1",
 		UserData: "userData1",
 	}}
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestConnectionWithSourceHost(t *testing.T) {
 		},
 	}
 
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestConnectionUseMysqlNativePasswordWithSourceHost(t *testing.T) {
 		},
 	}
 
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestConnectionUnixSocket(t *testing.T) {
 	}
 	os.Remove(unixSocket.Name())
 
-	l, err := NewListener("unix", unixSocket.Name(), authServer, th)
+	l, err := NewListener("unix", unixSocket.Name(), authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestClientFoundRows(t *testing.T) {
 		Password: "password1",
 		UserData: "userData1",
 	}}
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestServer(t *testing.T) {
 		Password: "password1",
 		UserData: "userData1",
 	}}
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -596,7 +596,7 @@ func TestClearTextServer(t *testing.T) {
 		UserData: "userData1",
 	}}
 	authServer.Method = MysqlClearPassword
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -681,7 +681,7 @@ func TestDialogServer(t *testing.T) {
 		UserData: "userData1",
 	}}
 	authServer.Method = MysqlDialog
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -728,7 +728,7 @@ func TestTLSServer(t *testing.T) {
 	// Below, we are enabling --ssl-verify-server-cert, which adds
 	// a check that the common name of the certificate matches the
 	// server host name we connect to.
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -807,7 +807,7 @@ func TestErrorCodes(t *testing.T) {
 		Password: "password1",
 		UserData: "userData1",
 	}}
-	l, err := NewListener("tcp", ":0", authServer, th)
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}

--- a/go/netutil/conn.go
+++ b/go/netutil/conn.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netutil
+
+import (
+	"net"
+	"time"
+)
+
+var _ net.Conn = (*ConnWithTimeouts)(nil)
+
+// A ConnWithTimeouts is a wrapper to net.Comm that allows to set a read and write timeouts.
+type ConnWithTimeouts struct {
+	net.Conn
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+// NewConnWithTimeouts wraps a net.Conn with read and write deadilnes.
+func NewConnWithTimeouts(conn net.Conn, readTimeout time.Duration, writeTimeout time.Duration) ConnWithTimeouts {
+	return ConnWithTimeouts{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout}
+}
+
+// Implementation of the Conn interface.
+
+// Read sets a read deadilne and delegates to conn.Read.
+func (c ConnWithTimeouts) Read(b []byte) (int, error) {
+	if c.readTimeout == 0 {
+		return c.Conn.Read(b)
+	}
+	if err := c.Conn.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+// Write sets a write deadline and delagates to conn.Write
+func (c ConnWithTimeouts) Write(b []byte) (int, error) {
+	if c.writeTimeout == 0 {
+		return c.Conn.Write(b)
+	}
+	if err := c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
+}
+
+// SetDeadline implements the Conn SetDeadline method.
+func (c ConnWithTimeouts) SetDeadline(t time.Time) error {
+	panic("can't call SetDeadline for ConnWithTimeouts")
+}
+
+// SetReadDeadline implements the Conn SetReadDeadline method.
+func (c ConnWithTimeouts) SetReadDeadline(t time.Time) error {
+	panic("can't call SetReadDeadline for ConnWithTimeouts")
+}
+
+// SetWriteDeadline implements the Conn SetWriteDeadline method.
+func (c ConnWithTimeouts) SetWriteDeadline(t time.Time) error {
+	panic("can't call SetWriteDeadline for ConnWithTimeouts")
+}

--- a/go/netutil/conn_test.go
+++ b/go/netutil/conn_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2018 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netutil
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func createSocketPair(t *testing.T) (net.Listener, net.Conn, net.Conn) {
+	// Create a listener.
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	addr := listener.Addr().String()
+
+	// Dial a client, Accept a server.
+	wg := sync.WaitGroup{}
+
+	var clientConn net.Conn
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		clientConn, err = net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatalf("Dial failed: %v", err)
+		}
+	}()
+
+	var serverConn net.Conn
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		serverConn, err = listener.Accept()
+		if err != nil {
+			t.Fatalf("Accept failed: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	return listener, serverConn, clientConn
+}
+
+func TestReadTimeout(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	cConnWithTimeout := NewConnWithTimeouts(cConn, 1*time.Millisecond, 1*time.Millisecond)
+
+	c := make(chan error, 1)
+	go func() {
+		_, err := cConnWithTimeout.Read(make([]byte, 10))
+		c <- err
+	}()
+
+	select {
+	case err := <-c:
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+
+		if !strings.HasSuffix(err.Error(), "i/o timeout") {
+			t.Errorf("Expected error timeout, got %s", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Errorf("Timeout did not happen")
+	}
+}
+
+func TestWriteTimeout(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	sConnWithTimeout := NewConnWithTimeouts(sConn, 1*time.Millisecond, 1*time.Millisecond)
+
+	c := make(chan error, 1)
+	go func() {
+		// The timeout will trigger when the buffer is full, so to test this we need to write multiple times.
+		for {
+			_, err := sConnWithTimeout.Write([]byte("payload"))
+			if err != nil {
+				c <- err
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-c:
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+
+		if !strings.HasSuffix(err.Error(), "i/o timeout") {
+			t.Errorf("Expected error timeout, got %s", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Errorf("Timeout did not happen")
+	}
+}
+
+func TestNoTimeouts(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	cConnWithTimeout := NewConnWithTimeouts(cConn, 0, 24*time.Hour)
+
+	c := make(chan error, 1)
+	go func() {
+		_, err := cConnWithTimeout.Read(make([]byte, 10))
+		c <- err
+	}()
+
+	select {
+	case <-c:
+		t.Fatalf("Connection timeout, without a timeout")
+	case <-time.After(100 * time.Millisecond):
+		// NOOP
+	}
+
+	c2 := make(chan error, 1)
+	sConnWithTimeout := NewConnWithTimeouts(sConn, 24*time.Hour, 0)
+	go func() {
+		// This should not fail as there is not timeout on write.
+		for {
+			_, err := sConnWithTimeout.Write([]byte("payload"))
+			if err != nil {
+				c2 <- err
+				return
+			}
+		}
+	}()
+	select {
+	case <-c2:
+		t.Fatalf("Connection timeout, without a timeout")
+	case <-time.After(100 * time.Millisecond):
+		// NOOP
+	}
+}


### PR DESCRIPTION
### Description

The following PR improves mysql server connection handling by adding read/write timeouts. We've seen that when hosts died abruptly on the client side, these connections stays open forever in vtgate. 

