### PR TITLE
examples: Do not call "/bin/true" to ignore a failed command.

### DIFF
--- a/examples/local/etcd-up.sh
+++ b/examples/local/etcd-up.sh
@@ -39,12 +39,13 @@ echo "add /vitess/test"
 # And also add the CellInfo description for the 'test' cell.
 # If the node already exists, it's fine, means we used existing data.
 echo "add test CellInfo"
-
+set +e
 # shellcheck disable=SC2086
 "${VTROOT}"/bin/vtctl $TOPOLOGY_FLAGS AddCellInfo \
   -root /vitess/test \
   -server_address "${ETCD_SERVER}" \
-  test || /bin/true
+  test
+set -e
 
 echo "etcd start done..."
 

--- a/examples/local/zk-up.sh
+++ b/examples/local/zk-up.sh
@@ -52,9 +52,12 @@ echo "Started zk servers."
 
 # Add the CellInfo description for the 'test' cell.
 # If the node already exists, it's fine, means we used existing data.
+set +e
+# shellcheck disable=SC2086
 $VTROOT/bin/vtctl $TOPOLOGY_FLAGS AddCellInfo \
   -root /vitess/test \
   -server_address $ZK_SERVER \
-  test || /bin/true
+  test
+set -e
 
 echo "Configured zk servers."


### PR DESCRIPTION
The binary is available under /usr/bin/true on MacOS.

Instead of calling it, we just disable the error checking via "set +e". This is more explicit.

Fixes https://github.com/vitessio/vitess/issues/3907.

Signed-off-by: Michael Berlin <mberlin@google.com>