### PR TITLE
tabletserver: Do not skip the hot row protection if the ExecuteBatch …

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -972,7 +972,7 @@ func (tsv *TabletServer) ExecuteBatch(ctx context.Context, target *querypb.Targe
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot start a new transaction in the scope of an existing one")
 	}
 
-	if tsv.enableHotRowProtection && asTransaction && len(queries) == 1 {
+	if tsv.enableHotRowProtection && asTransaction {
 		// Serialize transactions which target the same hot row range.
 		// NOTE: We put this intentionally at this place *before* tsv.startRequest()
 		// gets called below. Otherwise, the startRequest()/endRequest() section from


### PR DESCRIPTION
…RPC has more than one query.

In this case, we will only use the first query to determine which row is hot. This still helps if e.g. the RPC has multiple queries which target different tables. As long as the first query is always for the same table, serializing hot rows in that table will correctly serialize the whole RPC.

BUG=66906815

Signed-off-by: Michael Berlin <mberlin@google.com>