### PR TITLE
Added Query Type for BigInteger to INT64

### DIFF
--- a/java/client/src/main/java/io/vitess/client/Proto.java
+++ b/java/client/src/main/java/io/vitess/client/Proto.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLInvalidAuthorizationSpecException;
@@ -299,7 +300,7 @@ public class Proto {
         this.type = Query.Type.VARBINARY;
         this.value = ByteString.copyFrom((byte[]) value);
       } else if (value instanceof Integer || value instanceof Long || value instanceof Short
-          || value instanceof Byte) {
+          || value instanceof Byte || value instanceof BigInteger) {
         // Int32, Int64, Short, Byte
         this.type = Query.Type.INT64;
         this.value = ByteString.copyFromUtf8(value.toString());

--- a/java/client/src/test/java/io/vitess/client/BindVarTest.java
+++ b/java/client/src/test/java/io/vitess/client/BindVarTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Test;
@@ -116,6 +117,9 @@ public class BindVarTest {
         {new BigDecimal("0.000000000123456789123456789"),
             BindVariable.newBuilder().setType(Query.Type.DECIMAL)
                 .setValue(ByteString.copyFromUtf8("0.000000000123456789123456789")).build()},
+        {new BigInteger("123456789123456789"),
+            BindVariable.newBuilder().setType(Query.Type.INT64)
+                .setValue(ByteString.copyFromUtf8("123456789123456789")).build()},
         // List of Int
         {Arrays.asList(1, 2, 3),
             BindVariable.newBuilder().setType(Query.Type.TUPLE)


### PR DESCRIPTION
This fixes the query type issue for recent addition of BigInteger type in Statement and PreparedStatement BindVariables.


```
java.lang.IllegalArgumentException: unsupported type for Query.Value proto: class java.math.BigInteger
    at io.vitess.client.Proto$TypedValue.<init>(Proto.java:329)
    at io.vitess.client.Proto.buildBindVariable(Proto.java:187)
    at io.vitess.client.Proto.bindQuery(Proto.java:209)
    at io.vitess.client.VTGateConnection.executeBatch(VTGateConnection.java:157)

```
Signed-off-by: Harshit Gangal <harshit.gangal@gmail.com>