### PR TITLE
vttablet: Remove import for github.com/golang/glog in test.

### DIFF
--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -27,13 +27,13 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"


### PR DESCRIPTION
We should not import glog directly anymore and instead use the new package vitess.io/vitess/go/vt/log which allows to override the usage of glog if wanted.

Signed-off-by: Michael Berlin <mberlin@google.com>