### PR TITLE
healthcheck: refactor to use less locking

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -528,8 +528,8 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, name string) {
 		// between the goroutine that sets it and the check for its value
 		// later.
 		timedout := sync2.NewAtomicBool(false)
+		serving := hcc.tabletStats.Serving
 		go func() {
-			serving := hcc.tabletStats.Serving
 			for {
 				select {
 				case serving = <-servingStatus:

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -204,6 +204,12 @@ func (e *TabletStats) DeepEqual(f *TabletStats) bool {
 			(e.LastError != nil && f.LastError != nil && e.LastError.Error() == f.LastError.Error()))
 }
 
+// Copy produces a copy of TabletStats.
+func (e *TabletStats) Copy() *TabletStats {
+	ts := *e
+	return &ts
+}
+
 // GetTabletHostPort formats a tablet host port address.
 func (e TabletStats) GetTabletHostPort() string {
 	vtPort := e.Tablet.PortMap["vt"]
@@ -294,22 +300,23 @@ type HealthCheck interface {
 // about a tablet.
 type healthCheckConn struct {
 	// set at construction time
-	ctx        context.Context
-	cancelFunc context.CancelFunc
-
-	// healthCheckTimeout specifies how long to wait for
-	// a health check update.
-	healthCheckTimeout time.Duration
+	ctx context.Context
 
 	// mu protects all the following fields.
 	// When locking both mutex from HealthCheck and healthCheckConn,
 	// HealthCheck.mu goes first.
 	// Note tabletStats.Tablet and tabletStats.Name are immutable.
-	mu                    sync.RWMutex
 	conn                  queryservice.QueryService
 	tabletStats           TabletStats
 	loggedServingState    bool
 	lastResponseTimestamp time.Time // timestamp of the last healthcheck response
+}
+
+// tabletHealth maintains the health status of a tablet fed by the health check connection.
+type tabletHealth struct {
+	cancelFunc  context.CancelFunc
+	conn        queryservice.QueryService
+	tabletStats TabletStats
 }
 
 // HealthCheckImpl performs health checking and notifies downstream components about any changes.
@@ -325,10 +332,10 @@ type HealthCheckImpl struct {
 	// mu protects all the following fields.
 	// When locking both mutex from HealthCheck and healthCheckConn,
 	// HealthCheck.mu goes first.
-	mu sync.RWMutex
+	mu sync.Mutex
 
-	// addrToConns maps from address to the healthCheckConn object.
-	addrToConns map[string]*healthCheckConn
+	// addrToHealth maps from address to tabletHealth.
+	addrToHealth map[string]*tabletHealth
 
 	// Wait group that's used to wait until all initial StatsUpdate() calls are made after the AddTablet() calls.
 	initialUpdatesWG sync.WaitGroup
@@ -350,7 +357,7 @@ func NewDefaultHealthCheck() HealthCheck {
 //   not healthy.
 func NewHealthCheck(retryDelay, healthCheckTimeout time.Duration) HealthCheck {
 	hc := &HealthCheckImpl{
-		addrToConns:        make(map[string]*healthCheckConn),
+		addrToHealth:       make(map[string]*tabletHealth),
 		retryDelay:         retryDelay,
 		healthCheckTimeout: healthCheckTimeout,
 	}
@@ -394,16 +401,13 @@ func (hc *HealthCheckImpl) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 // servingConnStats returns the number of serving tablets per keyspace/shard/tablet type.
 func (hc *HealthCheckImpl) servingConnStats() map[string]int64 {
 	res := make(map[string]int64)
-	hc.mu.RLock()
-	defer hc.mu.RUnlock()
-	for _, hcc := range hc.addrToConns {
-		hcc.mu.RLock()
-		if !hcc.tabletStats.Up || !hcc.tabletStats.Serving || hcc.tabletStats.LastError != nil {
-			hcc.mu.RUnlock()
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+	for _, th := range hc.addrToHealth {
+		if !th.tabletStats.Up || !th.tabletStats.Serving || th.tabletStats.LastError != nil {
 			continue
 		}
-		key := fmt.Sprintf("%s.%s.%s", hcc.tabletStats.Target.Keyspace, hcc.tabletStats.Target.Shard, topoproto.TabletTypeLString(hcc.tabletStats.Target.TabletType))
-		hcc.mu.RUnlock()
+		key := fmt.Sprintf("%s.%s.%s", th.tabletStats.Target.Keyspace, th.tabletStats.Target.Shard, topoproto.TabletTypeLString(th.tabletStats.Target.TabletType))
 		res[key]++
 	}
 	return res
@@ -431,29 +435,62 @@ func (hc *HealthCheckImpl) stateChecksum() int64 {
 	return int64(crc32.ChecksumIEEE(buf.Bytes()))
 }
 
+// updateHealth updates the tabletHealth record and transmits the tablet stats
+// to the listener.
+func (hc *HealthCheckImpl) updateHealth(ts *TabletStats, conn queryservice.QueryService) {
+	// Unconditionally send the received update at the end.
+	defer func() {
+		if hc.listener != nil {
+			hc.listener.StatsUpdate(ts)
+		}
+	}()
+
+	hc.mu.Lock()
+	th, ok := hc.addrToHealth[ts.Key]
+	if !ok {
+		// This can happen on delete because the entry is removed first.
+		hc.mu.Unlock()
+		return
+	}
+	oldts := th.tabletStats
+	th.tabletStats = *ts
+	th.conn = conn
+	hc.mu.Unlock()
+
+	// In the case where a tablet changes type (but not for the
+	// initial message), we want to log it, and maybe advertise it too.
+	if oldts.Target.TabletType != topodatapb.TabletType_UNKNOWN && oldts.Target.TabletType != ts.Target.TabletType {
+		// Log and maybe notify
+		log.Infof("HealthCheckUpdate(Type Change): %v, tablet: %s, target %+v => %+v, reparent time: %v",
+			oldts.Name, topotools.TabletIdent(oldts.Tablet), topotools.TargetIdent(oldts.Target), topotools.TargetIdent(ts.Target), ts.TabletExternallyReparentedTimestamp)
+		if hc.listener != nil && hc.sendDownEvents {
+			oldts.Up = false
+			hc.listener.StatsUpdate(&oldts)
+		}
+
+		// Track how often a tablet gets promoted to master. It is used for
+		// comparing against the variables in go/vtgate/buffer/variables.go.
+		if oldts.Target.TabletType != topodatapb.TabletType_MASTER && ts.Target.TabletType == topodatapb.TabletType_MASTER {
+			hcMasterPromotedCounters.Add([]string{ts.Target.Keyspace, ts.Target.Shard}, 1)
+		}
+	}
+}
+
 // finalizeConn closes the health checking connection and sends the final
 // notification about the tablet to downstream. To be called only on exit from
 // checkConn().
 func (hc *HealthCheckImpl) finalizeConn(hcc *healthCheckConn) {
-	hcc.mu.Lock()
-	hccConn := hcc.conn
-	hccCtx := hcc.ctx
-	hcc.conn = nil
+	if hcc.conn != nil {
+		// Don't use hcc.ctx because it's already closed.
+		hcc.conn.Close(context.Background())
+		hcc.conn = nil
+	}
 	hcc.tabletStats.Up = false
 	hcc.setServingState(false, "finalizeConn closing connection")
 	// Note: checkConn() exits only when hcc.ctx.Done() is closed. Thus it's
 	// safe to simply get Err() value here and assign to LastError.
 	hcc.tabletStats.LastError = hcc.ctx.Err()
-	ts := hcc.tabletStats
-	hcc.mu.Unlock()
-
-	if hccConn != nil {
-		hccConn.Close(hccCtx)
-	}
-
-	if hc.listener != nil {
-		hc.listener.StatsUpdate(&ts)
-	}
+	hc.updateHealth(hcc.tabletStats.Copy(), hcc.conn)
 }
 
 // checkConn performs health checking on the given tablet.
@@ -462,12 +499,7 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, name string) {
 	defer hc.finalizeConn(hcc)
 
 	// Initial notification for downstream about the tablet existence.
-	hcc.mu.Lock()
-	ts := hcc.tabletStats
-	hcc.mu.Unlock()
-	if hc.listener != nil {
-		hc.listener.StatsUpdate(&ts)
-	}
+	hc.updateHealth(hcc.tabletStats.Copy(), hcc.conn)
 	hc.initialUpdatesWG.Done()
 
 	retryDelay := hc.retryDelay
@@ -480,32 +512,25 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, name string) {
 		// servingStatus feeds into the serving var, which keeps track of the serving
 		// status transmitted by the tablet.
 		servingStatus := make(chan bool, 5)
-		serving := ts.Serving
+		serving := hcc.tabletStats.Serving
+		timedout := false
 		go func() {
 			for {
 				select {
 				case serving = <-servingStatus:
 					continue
-				case <-time.After(hcc.healthCheckTimeout):
+				case <-time.After(hc.healthCheckTimeout):
 					// Ignore if not serving.
 					if !serving {
 						continue
 					}
-					hcc.mu.Lock()
-					hcc.tabletStats.LastError = fmt.Errorf("healthcheck timed out (latest %v)", hcc.lastResponseTimestamp)
-					hcc.setServingState(false, hcc.tabletStats.LastError.Error())
-					hcc.mu.Unlock()
-					ts := hcc.tabletStats
-					if hc.listener != nil {
-						hc.listener.StatsUpdate(&ts)
-					}
-					hcErrorCounters.Add([]string{ts.Target.Keyspace, ts.Target.Shard, topoproto.TabletTypeLString(ts.Target.TabletType)}, 1)
+					timedout = true
 					streamCancel()
 					return
 				case <-streamCtx.Done():
-					// This is a failsafe code path. If a stream terminates when
-					// a tablet is in not serving state, this function will loop
-					// forever.
+					// If stream returns while serving is false, the function
+					// will get stuck in an infinite loop. This code path
+					// breaks the loop.
 					return
 				}
 			}
@@ -521,6 +546,16 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, name string) {
 
 		// streamCancel to make sure the watcher goroutine terminates.
 		streamCancel()
+
+		// If there was a timeout send an error. We do this after stream has returned.
+		// This will ensure that this update prevails over any previous message that
+		// stream could have sent.
+		if timedout {
+			hcc.tabletStats.LastError = fmt.Errorf("healthcheck timed out (latest %v)", hcc.lastResponseTimestamp)
+			hcc.setServingState(false, hcc.tabletStats.LastError.Error())
+			hc.updateHealth(hcc.tabletStats.Copy(), hcc.conn)
+			hcErrorCounters.Add([]string{hcc.tabletStats.Target.Keyspace, hcc.tabletStats.Target.Shard, topoproto.TabletTypeLString(hcc.tabletStats.Target.TabletType)}, 1)
+		}
 
 		// Streaming RPC failed e.g. because vttablet was restarted or took too long.
 		// Sleep until the next retry is up or the context is done/canceled.
@@ -562,41 +597,23 @@ func (hcc *healthCheckConn) setServingState(serving bool, reason string) {
 
 // stream streams healthcheck responses to callback.
 func (hcc *healthCheckConn) stream(ctx context.Context, hc *HealthCheckImpl, callback func(*querypb.StreamHealthResponse) error) {
-	hcc.mu.Lock()
-	conn := hcc.conn
-	hcc.mu.Unlock()
-
-	if conn == nil {
-		var err error
-		conn, err = tabletconn.GetDialer()(hcc.tabletStats.Tablet, grpcclient.FailFast(true))
+	if hcc.conn == nil {
+		conn, err := tabletconn.GetDialer()(hcc.tabletStats.Tablet, grpcclient.FailFast(true))
 		if err != nil {
-			hcc.mu.Lock()
 			hcc.tabletStats.LastError = err
-			hcc.mu.Unlock()
 			return
 		}
-
-		hcc.mu.Lock()
 		hcc.conn = conn
 		hcc.tabletStats.LastError = nil
-		hcc.mu.Unlock()
 	}
 
-	if err := conn.StreamHealth(ctx, callback); err != nil {
-		hcc.mu.Lock()
+	if err := hcc.conn.StreamHealth(ctx, callback); err != nil {
+		hcc.conn.Close(ctx)
 		hcc.conn = nil
 		hcc.setServingState(false, err.Error())
 		hcc.tabletStats.LastError = err
-		ts := hcc.tabletStats
-		hcc.mu.Unlock()
-		// notify downstream for serving status change
-		if hc.listener != nil {
-			hc.listener.StatsUpdate(&ts)
-		}
-		conn.Close(ctx)
-		return
+		hc.updateHealth(hcc.tabletStats.Copy(), hcc.conn)
 	}
-	return
 }
 
 // processResponse reads one health check response, and notifies HealthCheckStatsListener.
@@ -612,10 +629,6 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 		return fmt.Errorf("health stats is not valid: %v", shr)
 	}
 
-	hcc.mu.RLock()
-	oldTs := hcc.tabletStats
-	hcc.mu.RUnlock()
-
 	// an app-level error from tablet, force serving state.
 	var healthErr error
 	serving := shr.Serving
@@ -624,28 +637,10 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 		serving = false
 	}
 
-	// oldTs.Tablet.Alias.Uid may be 0 because the youtube internal mechanism uses a different
+	// hcc.TabletStats.Tablet.Alias.Uid may be 0 because the youtube internal mechanism uses a different
 	// code path to initialize this value. If so, we should skip this check.
-	if shr.TabletAlias != nil && oldTs.Tablet.Alias.Uid != 0 && !proto.Equal(shr.TabletAlias, oldTs.Tablet.Alias) {
-		return fmt.Errorf("health stats mismatch, tablet %+v alias does not match response alias %v", oldTs.Tablet, shr.TabletAlias)
-	}
-
-	// In the case where a tablet changes type (but not for the
-	// initial message), we want to log it, and maybe advertise it too.
-	if hcc.tabletStats.Target.TabletType != topodatapb.TabletType_UNKNOWN && hcc.tabletStats.Target.TabletType != shr.Target.TabletType {
-		// Log and maybe notify
-		log.Infof("HealthCheckUpdate(Type Change): %v, tablet: %s, target %+v => %+v, reparent time: %v",
-			oldTs.Name, topotools.TabletIdent(oldTs.Tablet), topotools.TargetIdent(oldTs.Target), topotools.TargetIdent(shr.Target), shr.TabletExternallyReparentedTimestamp)
-		if hc.listener != nil && hc.sendDownEvents {
-			oldTs.Up = false
-			hc.listener.StatsUpdate(&oldTs)
-		}
-
-		// Track how often a tablet gets promoted to master. It is used for
-		// comparing against the variables in go/vtgate/buffer/variables.go.
-		if oldTs.Target.TabletType != topodatapb.TabletType_MASTER && shr.Target.TabletType == topodatapb.TabletType_MASTER {
-			hcMasterPromotedCounters.Add([]string{shr.Target.Keyspace, shr.Target.Shard}, 1)
-		}
+	if shr.TabletAlias != nil && hcc.tabletStats.Tablet.Alias.Uid != 0 && !proto.Equal(shr.TabletAlias, hcc.tabletStats.Tablet.Alias) {
+		return fmt.Errorf("health stats mismatch, tablet %+v alias does not match response alias %v", hcc.tabletStats.Tablet, shr.TabletAlias)
 	}
 
 	// In this case where a new tablet is initialized or a tablet type changes, we want to
@@ -656,18 +651,6 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 
 	// Update our record, and notify downstream for tabletType and
 	// realtimeStats change.
-	ts := hcc.update(shr, serving, healthErr)
-	if hc.listener != nil {
-		hc.listener.StatsUpdate(&ts)
-	}
-	return nil
-}
-
-// update updates the stats of a healthCheckConn, and returns a copy
-// of its tabletStats.
-func (hcc *healthCheckConn) update(shr *querypb.StreamHealthResponse, serving bool, healthErr error) TabletStats {
-	hcc.mu.Lock()
-	defer hcc.mu.Unlock()
 	hcc.lastResponseTimestamp = time.Now()
 	hcc.tabletStats.Target = shr.Target
 	hcc.tabletStats.TabletExternallyReparentedTimestamp = shr.TabletExternallyReparentedTimestamp
@@ -678,7 +661,8 @@ func (hcc *healthCheckConn) update(shr *querypb.StreamHealthResponse, serving bo
 		reason = "healthCheck update error: " + healthErr.Error()
 	}
 	hcc.setServingState(serving, reason)
-	return hcc.tabletStats
+	hc.updateHealth(hcc.tabletStats.Copy(), hcc.conn)
+	return nil
 }
 
 func (hc *HealthCheckImpl) deleteConn(tablet *topodatapb.Tablet) {
@@ -686,16 +670,14 @@ func (hc *HealthCheckImpl) deleteConn(tablet *topodatapb.Tablet) {
 	defer hc.mu.Unlock()
 
 	key := TabletToMapKey(tablet)
-	hcc, ok := hc.addrToConns[key]
+	th, ok := hc.addrToHealth[key]
 	if !ok {
 		log.Warningf("deleting unknown tablet: %+v", tablet)
 		return
 	}
-	hcc.mu.Lock()
-	hcc.tabletStats.Up = false
-	hcc.mu.Unlock()
-	hcc.cancelFunc()
-	delete(hc.addrToConns, key)
+	th.tabletStats.Up = false
+	th.cancelFunc()
+	delete(hc.addrToHealth, key)
 }
 
 // SetListener sets the listener for healthcheck updates.
@@ -708,7 +690,7 @@ func (hc *HealthCheckImpl) SetListener(listener HealthCheckStatsListener, sendDo
 
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
-	if len(hc.addrToConns) > 0 {
+	if len(hc.addrToHealth) > 0 {
 		panic("must not call SetListener after tablets were added")
 	}
 
@@ -723,9 +705,7 @@ func (hc *HealthCheckImpl) AddTablet(tablet *topodatapb.Tablet, name string) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	key := TabletToMapKey(tablet)
 	hcc := &healthCheckConn{
-		ctx:                ctx,
-		cancelFunc:         cancelFunc,
-		healthCheckTimeout: hc.healthCheckTimeout,
+		ctx: ctx,
 		tabletStats: TabletStats{
 			Key:    key,
 			Tablet: tablet,
@@ -735,12 +715,15 @@ func (hc *HealthCheckImpl) AddTablet(tablet *topodatapb.Tablet, name string) {
 		},
 	}
 	hc.mu.Lock()
-	if _, ok := hc.addrToConns[key]; ok {
+	if _, ok := hc.addrToHealth[key]; ok {
 		hc.mu.Unlock()
 		log.Warningf("adding duplicate tablet %v for %v: %+v", name, tablet.Alias.Cell, tablet)
 		return
 	}
-	hc.addrToConns[key] = hcc
+	hc.addrToHealth[key] = &tabletHealth{
+		cancelFunc:  cancelFunc,
+		tabletStats: hcc.tabletStats,
+	}
 	hc.initialUpdatesWG.Add(1)
 	hc.mu.Unlock()
 
@@ -770,16 +753,14 @@ func (hc *HealthCheckImpl) WaitForInitialStatsUpdates() {
 
 // GetConnection returns the TabletConn of the given tablet.
 func (hc *HealthCheckImpl) GetConnection(key string) queryservice.QueryService {
-	hc.mu.RLock()
-	hcc := hc.addrToConns[key]
-	if hcc == nil {
-		hc.mu.RUnlock()
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+
+	th := hc.addrToHealth[key]
+	if th == nil {
 		return nil
 	}
-	hc.mu.RUnlock()
-	hcc.mu.RLock()
-	defer hcc.mu.RUnlock()
-	return hcc.conn
+	return th.conn
 }
 
 // TabletsCacheStatus is the current tablets for a cell/target.
@@ -879,22 +860,20 @@ func (hc *HealthCheckImpl) CacheStatus() TabletsCacheStatusList {
 
 func (hc *HealthCheckImpl) cacheStatusMap() map[string]*TabletsCacheStatus {
 	tcsMap := make(map[string]*TabletsCacheStatus)
-	hc.mu.RLock()
-	defer hc.mu.RUnlock()
-	for _, hcc := range hc.addrToConns {
-		hcc.mu.RLock()
-		key := fmt.Sprintf("%v.%v.%v.%v", hcc.tabletStats.Tablet.Alias.Cell, hcc.tabletStats.Target.Keyspace, hcc.tabletStats.Target.Shard, hcc.tabletStats.Target.TabletType.String())
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+	for _, th := range hc.addrToHealth {
+		key := fmt.Sprintf("%v.%v.%v.%v", th.tabletStats.Tablet.Alias.Cell, th.tabletStats.Target.Keyspace, th.tabletStats.Target.Shard, th.tabletStats.Target.TabletType.String())
 		var tcs *TabletsCacheStatus
 		var ok bool
 		if tcs, ok = tcsMap[key]; !ok {
 			tcs = &TabletsCacheStatus{
-				Cell:   hcc.tabletStats.Tablet.Alias.Cell,
-				Target: hcc.tabletStats.Target,
+				Cell:   th.tabletStats.Tablet.Alias.Cell,
+				Target: th.tabletStats.Target,
 			}
 			tcsMap[key] = tcs
 		}
-		stats := hcc.tabletStats
-		hcc.mu.RUnlock()
+		stats := th.tabletStats
 		tcs.TabletsStats = append(tcs.TabletsStats, &stats)
 	}
 	return tcsMap
@@ -905,10 +884,10 @@ func (hc *HealthCheckImpl) cacheStatusMap() map[string]*TabletsCacheStatus {
 // currently executing and won't be called again.
 func (hc *HealthCheckImpl) Close() error {
 	hc.mu.Lock()
-	for _, hcc := range hc.addrToConns {
-		hcc.cancelFunc()
+	for _, th := range hc.addrToHealth {
+		th.cancelFunc()
 	}
-	hc.addrToConns = make(map[string]*healthCheckConn)
+	hc.addrToHealth = make(map[string]*tabletHealth)
 	// Release the lock early or a pending checkHealthCheckTimeout
 	// cannot get a read lock on it.
 	hc.mu.Unlock()

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -1019,7 +1019,7 @@ func TestSplitCloneV2_NoMasterAvailable(t *testing.T) {
 
 			select {
 			case <-ctx.Done():
-				t.Fatalf("timed out waiting for vtworker to retry due to NoMasterAvailable: %v", ctx.Err())
+				panic(fmt.Errorf("timed out waiting for vtworker to retry due to NoMasterAvailable: %v", ctx.Err()))
 			case <-time.After(10 * time.Millisecond):
 				// Poll constantly.
 			}


### PR DESCRIPTION
This change gets rid of all locks in hcc. Instead we use the approach
of "sharing by communicating". Whenever there is a change in state,
hcc communicates the change to hc, which then performs the necessary
updates and handling.

Now that hc updates are trivial, the lock has been changed to
a simple Mutex, which is more efficient that RWMutex.

Also, instead of looping through every stream, this change
makes every stream goroutine perform its own timeout check.