### PR TITLE
vtgate: subquery support

### DIFF
--- a/data/test/vtexplain/multi-output/selectsharded-output.txt
+++ b/data/test/vtexplain/multi-output/selectsharded-output.txt
@@ -88,33 +88,33 @@ select * from (select id from user) s /* scatter paren select */
 1 ks_sharded/c0-: select * from (select id from user) as s limit 10001 /* scatter paren select */
 
 ----------------------------------------------------------------------
-select name from user where id = (select id from t1) /* non-corelated subquery as value */
+select name from user where id = (select id from t1) /* non-correlated subquery as value */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery as value */
-2 ks_sharded/-40: select name from user where id = 1 limit 10001 /* non-corelated subquery as value */
-
-----------------------------------------------------------------------
-select name from user where id in (select id from t1) /* non-corelated subquery in IN clause */
-
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery in IN clause */
-2 ks_sharded/-40: select name from user where 1 = 1 and (id in (1)) limit 10001 /* non-corelated subquery in IN clause */
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery as value */
+2 ks_sharded/-40: select name from user where id = 1 limit 10001 /* non-correlated subquery as value */
 
 ----------------------------------------------------------------------
-select name from user where id not in (select id from t1) /* non-corelated subquery in NOT IN clause */
+select name from user where id in (select id from t1) /* non-correlated subquery in IN clause */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery in NOT IN clause */
-2 ks_sharded/-40: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
-2 ks_sharded/40-80: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
-2 ks_sharded/80-c0: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
-2 ks_sharded/c0-: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in IN clause */
+2 ks_sharded/-40: select name from user where 1 = 1 and (id in (1)) limit 10001 /* non-correlated subquery in IN clause */
 
 ----------------------------------------------------------------------
-select name from user where exists (select id from t1) /* non-corelated subquery as EXISTS */
+select name from user where id not in (select id from t1) /* non-correlated subquery in NOT IN clause */
 
-1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery as EXISTS */
-2 ks_sharded/-40: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
-2 ks_sharded/40-80: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
-2 ks_sharded/80-c0: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
-2 ks_sharded/c0-: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/-40: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/40-80: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/80-c0: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/c0-: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
+
+----------------------------------------------------------------------
+select name from user where exists (select id from t1) /* non-correlated subquery as EXISTS */
+
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/-40: select name from user where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/40-80: select name from user where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/80-c0: select name from user where 1 limit 10001 /* non-correlated subquery as EXISTS */
+2 ks_sharded/c0-: select name from user where 1 limit 10001 /* non-correlated subquery as EXISTS */
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/selectsharded-output.txt
+++ b/data/test/vtexplain/multi-output/selectsharded-output.txt
@@ -88,3 +88,33 @@ select * from (select id from user) s /* scatter paren select */
 1 ks_sharded/c0-: select * from (select id from user) as s limit 10001 /* scatter paren select */
 
 ----------------------------------------------------------------------
+select name from user where id = (select id from t1) /* non-corelated subquery as value */
+
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery as value */
+2 ks_sharded/-40: select name from user where id = 1 limit 10001 /* non-corelated subquery as value */
+
+----------------------------------------------------------------------
+select name from user where id in (select id from t1) /* non-corelated subquery in IN clause */
+
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery in IN clause */
+2 ks_sharded/-40: select name from user where 1 = 1 and (id in (1)) limit 10001 /* non-corelated subquery in IN clause */
+
+----------------------------------------------------------------------
+select name from user where id not in (select id from t1) /* non-corelated subquery in NOT IN clause */
+
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery in NOT IN clause */
+2 ks_sharded/-40: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
+2 ks_sharded/40-80: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
+2 ks_sharded/80-c0: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
+2 ks_sharded/c0-: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-corelated subquery in NOT IN clause */
+
+----------------------------------------------------------------------
+select name from user where exists (select id from t1) /* non-corelated subquery as EXISTS */
+
+1 ks_unsharded/-: select id from t1 limit 10001 /* non-corelated subquery as EXISTS */
+2 ks_sharded/-40: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
+2 ks_sharded/40-80: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
+2 ks_sharded/80-c0: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
+2 ks_sharded/c0-: select name from user where 1 limit 10001 /* non-corelated subquery as EXISTS */
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/selectsharded-queries.sql
+++ b/data/test/vtexplain/selectsharded-queries.sql
@@ -13,3 +13,8 @@ select name, count(*) from user group by name /* scatter aggregate */;
 
 select 1, "hello", 3.14 from user limit 10 /* select constant sql values */;
 select * from (select id from user) s /* scatter paren select */;
+
+select name from user where id = (select id from t1) /* non-corelated subquery as value */;
+select name from user where id in (select id from t1) /* non-corelated subquery in IN clause */;
+select name from user where id not in (select id from t1) /* non-corelated subquery in NOT IN clause */;
+select name from user where exists (select id from t1) /* non-corelated subquery as EXISTS */;

--- a/data/test/vtexplain/selectsharded-queries.sql
+++ b/data/test/vtexplain/selectsharded-queries.sql
@@ -14,7 +14,7 @@ select name, count(*) from user group by name /* scatter aggregate */;
 select 1, "hello", 3.14 from user limit 10 /* select constant sql values */;
 select * from (select id from user) s /* scatter paren select */;
 
-select name from user where id = (select id from t1) /* non-corelated subquery as value */;
-select name from user where id in (select id from t1) /* non-corelated subquery in IN clause */;
-select name from user where id not in (select id from t1) /* non-corelated subquery in NOT IN clause */;
-select name from user where exists (select id from t1) /* non-corelated subquery as EXISTS */;
+select name from user where id = (select id from t1) /* non-correlated subquery as value */;
+select name from user where id in (select id from t1) /* non-correlated subquery in IN clause */;
+select name from user where id not in (select id from t1) /* non-correlated subquery in NOT IN clause */;
+select name from user where exists (select id from t1) /* non-correlated subquery as EXISTS */;

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -730,6 +730,184 @@
   }
 }
 
+# cross-shard subquery in IN clause.
+# Note the improved Underlying plan as SelectIN.
+"select id from user where id in (select col from user)"
+{
+  "Original": "select id from user where id in (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectIN",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id from user where :__has_values1 and (id in ::__vals)",
+      "FieldQuery": "select id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [
+        "::__sq1"
+      ]
+    }
+  }
+}
+
+# cross-shard subquery in NOT IN clause.
+"select id from user where id not in (select col from user)"
+{
+  "Original": "select id from user where id not in (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutNotIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id from user where (:__is_empty1 or (id not in ::__sq1))",
+      "FieldQuery": "select id from user where 1 != 1"
+    }
+  }
+}
+
+# cross-shard subquery in EXISTS clause.
+"select id from user where exists (select col from user)"
+{
+  "Original": "select id from user where exists (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutExists",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id from user where :__sq1",
+      "FieldQuery": "select id from user where 1 != 1"
+    }
+  }
+}
+
+# cross-shard subquery as expression
+"select id from user where id = (select col from user)"
+{
+  "Original": "select id from user where id = (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id from user where id = :__sq1",
+      "FieldQuery": "select id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [
+        ":__sq1"
+      ]
+    }
+  }
+}
+
+# multi-level pullout
+"select id1 from user where id = (select id2 from user where id2 in (select id3 from user))"
+{
+  "Original": "select id1 from user where id = (select id2 from user where id2 in (select id3 from user))",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq2",
+    "HasValues": "__has_values2",
+    "IsEmpty": "__is_empty2",
+    "Subquery": {
+      "Opcode": "PulloutIn",
+      "SubqueryResult": "__sq1",
+      "HasValues": "__has_values1",
+      "IsEmpty": "__is_empty1",
+      "Subquery": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select id3 from user",
+        "FieldQuery": "select id3 from user where 1 != 1"
+      },
+      "Underlying": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select id2 from user where :__has_values1 and (id2 in ::__sq1)",
+        "FieldQuery": "select id2 from user where 1 != 1"
+      }
+    },
+    "Underlying": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id1 from user where id = :__sq2",
+      "FieldQuery": "select id1 from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [
+        ":__sq2"
+      ]
+    }
+  }
+}
+
 # Case preservation test
 "select user_extra.Id from user join user_extra on user.iD = user_extra.User_Id where user.Id = 5"
 {
@@ -766,4 +944,4 @@
 # but they refer to different things. The first reference is to the outermost query,
 # and the second reference is to the the innermost 'from' subquery.
 "select id2 from user uu where id in (select id from user where id = uu.id and user.col in (select col from (select id from user_extra where user_id = 5) uu where uu.user_id = uu.id))"
-"unsupported: UNION or subquery on different shards: vindex values are different"
+"unsupported: cross-shard correlated subquery"

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -739,7 +739,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -755,7 +754,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where :__has_values1 and (id in ::__vals)",
+      "Query": "select id from user where :__has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -773,7 +772,6 @@
     "Opcode": "PulloutNotIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -789,7 +787,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where (:__is_empty1 or (id not in ::__sq1))",
+      "Query": "select id from user where (:__has_values1 = 0 or (id not in ::__sq1))",
       "FieldQuery": "select id from user where 1 != 1"
     }
   }
@@ -803,7 +801,6 @@
     "Opcode": "PulloutExists",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -819,7 +816,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where :__sq1",
+      "Query": "select id from user where :__has_values1",
       "FieldQuery": "select id from user where 1 != 1"
     }
   }
@@ -833,7 +830,6 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -867,12 +863,10 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq2",
     "HasValues": "__has_values2",
-    "IsEmpty": "__is_empty2",
     "Subquery": {
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
       "HasValues": "__has_values1",
-      "IsEmpty": "__is_empty1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -888,7 +882,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select id2 from user where :__has_values1 and (id2 in ::__sq1)",
+        "Query": "select id2 from user where :__has_values1 = 1 and (id2 in ::__sq1)",
         "FieldQuery": "select id2 from user where 1 != 1"
       }
     },

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -738,7 +738,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -754,7 +754,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where :__has_values1 = 1 and (id in ::__vals)",
+      "Query": "select id from user where :__sq_has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -771,7 +771,7 @@
   "Instructions": {
     "Opcode": "PulloutNotIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -787,7 +787,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where (:__has_values1 = 0 or (id not in ::__sq1))",
+      "Query": "select id from user where (:__sq_has_values1 = 0 or (id not in ::__sq1))",
       "FieldQuery": "select id from user where 1 != 1"
     }
   }
@@ -800,7 +800,7 @@
   "Instructions": {
     "Opcode": "PulloutExists",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -816,7 +816,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where :__has_values1",
+      "Query": "select id from user where :__sq_has_values1",
       "FieldQuery": "select id from user where 1 != 1"
     }
   }
@@ -829,7 +829,7 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -862,11 +862,11 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq2",
-    "HasValues": "__has_values2",
+    "HasValues": "__sq_has_values2",
     "Subquery": {
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
-      "HasValues": "__has_values1",
+      "HasValues": "__sq_has_values1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -882,7 +882,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select id2 from user where :__has_values1 = 1 and (id2 in ::__sq1)",
+        "Query": "select id2 from user where :__sq_has_values1 = 1 and (id2 in ::__sq1)",
         "FieldQuery": "select id2 from user where 1 != 1"
       }
     },

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -999,6 +999,247 @@
   }
 }
 
+# subquery in ON clause, single route
+"select unsharded_a.col from unsharded_a join unsharded_b on (select col from user)"
+{
+  "Original": "select unsharded_a.col from unsharded_a join unsharded_b on (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on :__sq1",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on :__sq1 where 1 != 1"
+    }
+  }
+}
+
+# subquery in ON clause as sub-expression
+"select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col+(select col from user)"
+{
+  "Original": "select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col+(select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col + :__sq1",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col + :__sq1 where 1 != 1"
+    }
+  }
+}
+
+# IN subquery in ON clause, single route
+"select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col in (select col from user)"
+{
+  "Original": "select unsharded_a.col from unsharded_a join unsharded_b on unsharded_a.col in (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 and (unsharded_a.col in ::__sq1))",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 and (unsharded_a.col in ::__sq1)) where 1 != 1"
+    }
+  }
+}
+
+# subquery in ON clause, with join primitives
+"select unsharded.col from unsharded join user on user.col in (select col from user)"
+{
+  "Original": "select unsharded.col from unsharded join user on user.col in (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectUnsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "select unsharded.col from unsharded",
+        "FieldQuery": "select unsharded.col from unsharded where 1 != 1"
+      },
+      "Right": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+        "FieldQuery": "select 1 from user where 1 != 1"
+      },
+      "Cols": [
+        -1
+      ]
+    }
+  }
+}
+
+# subquery in ON clause, with left join primitives
+# The subquery is not pulled all the way out.
+"select unsharded.col from unsharded left join user on user.col in (select col from user)"
+{
+  "Original": "select unsharded.col from unsharded left join user on user.col in (select col from user)",
+  "Instructions": {
+    "Opcode": "LeftJoin",
+    "Left": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.col from unsharded",
+      "FieldQuery": "select unsharded.col from unsharded where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "PulloutIn",
+      "SubqueryResult": "__sq1",
+      "HasValues": "__has_values1",
+      "IsEmpty": "__is_empty1",
+      "Subquery": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col from user",
+        "FieldQuery": "select col from user where 1 != 1"
+      },
+      "Underlying": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+        "FieldQuery": "select 1 from user where 1 != 1"
+      }
+    },
+    "Cols": [
+      -1
+    ]
+  }
+}
+
+# subquery in ON clause, with join primitives, and join on top
+# The subquery is not pulled all the way out.
+"select unsharded.col from unsharded join user on user.col in (select col from user) join unsharded_a"
+{
+  "Original": "select unsharded.col from unsharded join user on user.col in (select col from user) join unsharded_a",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "PulloutIn",
+      "SubqueryResult": "__sq1",
+      "HasValues": "__has_values1",
+      "IsEmpty": "__is_empty1",
+      "Subquery": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col from user",
+        "FieldQuery": "select col from user where 1 != 1"
+      },
+      "Underlying": {
+        "Opcode": "Join",
+        "Left": {
+          "Opcode": "SelectUnsharded",
+          "Keyspace": {
+            "Name": "main",
+            "Sharded": false
+          },
+          "Query": "select unsharded.col from unsharded",
+          "FieldQuery": "select unsharded.col from unsharded where 1 != 1"
+        },
+        "Right": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+          "FieldQuery": "select 1 from user where 1 != 1"
+        },
+        "Cols": [
+          -1
+        ]
+      }
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select 1 from unsharded_a",
+      "FieldQuery": "select 1 from unsharded_a where 1 != 1"
+    },
+    "Cols": [
+      -1
+    ]
+  }
+}
 
 # keyspace-qualified queries
 "select user.user.col1, main.unsharded.col1 from user.user join main.unsharded where main.unsharded.col2 = user.user.col2"

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1006,7 +1006,7 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1035,7 +1035,7 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1064,7 +1064,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1080,8 +1080,8 @@
         "Name": "main",
         "Sharded": false
       },
-      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 = 1 and (unsharded_a.col in ::__sq1))",
-      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 = 1 and (unsharded_a.col in ::__sq1)) where 1 != 1"
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__sq_has_values1 = 1 and (unsharded_a.col in ::__sq1))",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__sq_has_values1 = 1 and (unsharded_a.col in ::__sq1)) where 1 != 1"
     }
   }
 }
@@ -1093,7 +1093,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1120,7 +1120,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
         "FieldQuery": "select 1 from user where 1 != 1"
       },
       "Cols": [
@@ -1149,7 +1149,7 @@
     "Right": {
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
-      "HasValues": "__has_values1",
+      "HasValues": "__sq_has_values1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -1165,7 +1165,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
         "FieldQuery": "select 1 from user where 1 != 1"
       }
     },
@@ -1185,7 +1185,7 @@
     "Left": {
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
-      "HasValues": "__has_values1",
+      "HasValues": "__sq_has_values1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -1212,7 +1212,7 @@
             "Name": "user",
             "Sharded": true
           },
-          "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
+          "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
           "FieldQuery": "select 1 from user where 1 != 1"
         },
         "Cols": [

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1007,7 +1007,6 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1037,7 +1036,6 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1067,7 +1065,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1083,8 +1080,8 @@
         "Name": "main",
         "Sharded": false
       },
-      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 and (unsharded_a.col in ::__sq1))",
-      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 and (unsharded_a.col in ::__sq1)) where 1 != 1"
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 = 1 and (unsharded_a.col in ::__sq1))",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__has_values1 = 1 and (unsharded_a.col in ::__sq1)) where 1 != 1"
     }
   }
 }
@@ -1097,7 +1094,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -1124,7 +1120,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
         "FieldQuery": "select 1 from user where 1 != 1"
       },
       "Cols": [
@@ -1154,7 +1150,6 @@
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
       "HasValues": "__has_values1",
-      "IsEmpty": "__is_empty1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -1170,7 +1165,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
         "FieldQuery": "select 1 from user where 1 != 1"
       }
     },
@@ -1191,7 +1186,6 @@
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
       "HasValues": "__has_values1",
-      "IsEmpty": "__is_empty1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -1218,7 +1212,7 @@
             "Name": "user",
             "Sharded": true
           },
-          "Query": "select 1 from user where :__has_values1 and (user.col in ::__sq1)",
+          "Query": "select 1 from user where :__has_values1 = 1 and (user.col in ::__sq1)",
           "FieldQuery": "select 1 from user where 1 != 1"
         },
         "Cols": [

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -80,6 +80,40 @@
   }
 }
 
+# HAVING uses subquery
+"select id from user having id in (select col from user)"
+{
+  "Original": "select id from user having id in (select col from user)",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectIN",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id from user having :__has_values1 and (id in ::__vals)",
+      "FieldQuery": "select id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [
+        "::__sq1"
+      ]
+    }
+  }
+}
+
 # ORDER BY, reference col from local table.
 "select col from user where id = 5 order by aa"
 {
@@ -248,6 +282,42 @@
   }
 }
 
+# ORDER BY after pull-out subquery
+"select col from user where col in (select col2 from user) order by col"
+{
+  "Original": "select col from user where col in (select col2 from user) order by col",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col2 from user",
+      "FieldQuery": "select col2 from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by col asc",
+      "FieldQuery": "select col from user where 1 != 1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
 # ORDER BY NULL for join
 "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by null"
 {
@@ -283,6 +353,36 @@
     ],
     "Vars": {
       "user_id": 2
+    }
+  }
+}
+
+# ORDER BY NULL after pull-out subquery
+"select col from user where col in (select col2 from user) order by null"
+{
+  "Original": "select col from user where col in (select col2 from user) order by null",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col2 from user",
+      "FieldQuery": "select col2 from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by null",
+      "FieldQuery": "select col from user where 1 != 1"
     }
   }
 }
@@ -337,6 +437,36 @@
     ],
     "Vars": {
       "user_id": 2
+    }
+  }
+}
+
+# ORDER BY RAND() after pull-out subquery
+"select col from user where col in (select col2 from user) order by rand()"
+{
+  "Original": "select col from user where col in (select col2 from user) order by rand()",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col2 from user",
+      "FieldQuery": "select col2 from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by rand()",
+      "FieldQuery": "select col from user where 1 != 1"
     }
   }
 }
@@ -636,6 +766,41 @@
       },
       "Query": "select * from user where id1 = 4 and name1 = 'abc' limit :__upper_limit",
       "FieldQuery": "select * from user where 1 != 1"
+    }
+  }
+}
+
+# scatter limit after pullout subquery
+"select col from user where col in (select col1 from user) limit 1"
+{
+  "Original": "select col from user where col in (select col1 from user) limit 1",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 1,
+    "Offset": null,
+    "Input": {
+      "Opcode": "PulloutIn",
+      "SubqueryResult": "__sq1",
+      "HasValues": "__has_values1",
+      "IsEmpty": "__is_empty1",
+      "Subquery": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col1 from user",
+        "FieldQuery": "select col1 from user where 1 != 1"
+      },
+      "Underlying": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col from user where :__has_values1 and (col in ::__sq1) limit :__upper_limit",
+        "FieldQuery": "select col from user where 1 != 1"
+      }
     }
   }
 }

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -88,7 +88,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -104,7 +103,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user having :__has_values1 and (id in ::__vals)",
+      "Query": "select id from user having :__has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -290,7 +289,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -306,7 +304,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by col asc",
+      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by col asc",
       "FieldQuery": "select col from user where 1 != 1",
       "OrderBy": [
         {
@@ -365,7 +363,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -381,7 +378,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by null",
+      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by null",
       "FieldQuery": "select col from user where 1 != 1"
     }
   }
@@ -449,7 +446,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -465,7 +461,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 and (col in ::__sq1) order by rand()",
+      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by rand()",
       "FieldQuery": "select col from user where 1 != 1"
     }
   }
@@ -782,7 +778,6 @@
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
       "HasValues": "__has_values1",
-      "IsEmpty": "__is_empty1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -798,7 +793,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select col from user where :__has_values1 and (col in ::__sq1) limit :__upper_limit",
+        "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) limit :__upper_limit",
         "FieldQuery": "select col from user where 1 != 1"
       }
     }

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -87,7 +87,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -103,7 +103,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user having :__has_values1 = 1 and (id in ::__vals)",
+      "Query": "select id from user having :__sq_has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -288,7 +288,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -304,7 +304,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by col asc",
+      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by col asc",
       "FieldQuery": "select col from user where 1 != 1",
       "OrderBy": [
         {
@@ -362,7 +362,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -378,7 +378,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by null",
+      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by null",
       "FieldQuery": "select col from user where 1 != 1"
     }
   }
@@ -445,7 +445,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -461,7 +461,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) order by rand()",
+      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by rand()",
       "FieldQuery": "select col from user where 1 != 1"
     }
   }
@@ -777,7 +777,7 @@
     "Input": {
       "Opcode": "PulloutIn",
       "SubqueryResult": "__sq1",
-      "HasValues": "__has_values1",
+      "HasValues": "__sq_has_values1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -793,7 +793,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select col from user where :__has_values1 = 1 and (col in ::__sq1) limit :__upper_limit",
+        "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) limit :__upper_limit",
         "FieldQuery": "select col from user where 1 != 1"
       }
     }

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -784,6 +784,66 @@
   }
 }
 
+# top level subquery in select
+"select a, (select col from user) from unsharded"
+{
+  "Original": "select a, (select col from user) from unsharded",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select a, :__sq1 from unsharded",
+      "FieldQuery": "select a, :__sq1 from unsharded where 1 != 1"
+    }
+  }
+}
+
+# sub-expression subquery in select
+"select a, 1+(select col from user) from unsharded"
+{
+  "Original": "select a, 1+(select col from user) from unsharded",
+  "Instructions": {
+    "Opcode": "PulloutValue",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user",
+      "FieldQuery": "select col from user where 1 != 1"
+    },
+    "Underlying": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select a, 1 + :__sq1 from unsharded",
+      "FieldQuery": "select a, 1 + :__sq1 from unsharded where 1 != 1"
+    }
+  }
+}
+
 # non-existent symbol in cross-shard subquery
 "select t.col from (select user.id from user join user_extra) as t"
 "symbol t.col is referencing a non-existent column of the subquery"

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -792,7 +792,6 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -822,7 +821,6 @@
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -791,7 +791,7 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -820,7 +820,7 @@
   "Instructions": {
     "Opcode": "PulloutValue",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "SelectScatter",
       "Keyspace": {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -35,10 +35,6 @@
 "select * from user where id in (select * from user union select * from user_extra)"
 "unsupported: UNION or subquery containing multi-shard queries"
 
-# subquery with join primitive (expressions)
-"select * from user where id in (select user.id from user join user_extra)"
-"unsupported: cross-shard query in subqueries"
-
 # TODO: Implement support for select with a target destination
 "select * from `user[-]`.user_metadata"
 "unsupported: SELECT with a target destination"
@@ -54,38 +50,6 @@
 # Unsupported DELETE statement with a replica target destination
 "DELETE FROM `user[-]@replica`.user_metadata limit 1"
 "unsupported: DELETE statement with a replica target"
-
-# subquery keyspace different from outer query
-"select * from user where id in (select m from unsharded)"
-"unsupported: subquery keyspace different from outer query"
-
-# scatter subquery
-"select * from user where id in (select id from user)"
-"unsupported: scatter subquery"
-
-# complex on clause on join
-"select c from user join user_extra on user.id in (select id from user)"
-"unsupported: scatter subquery"
-
-# complex on clause on left join
-"select c from user left join user_extra on user.id in (select id from user)"
-"unsupported: scatter subquery"
-
-# merging routes, but complex on clause
-"select user.id from user join user_extra on user_extra.user_id = user.id and user.id in (select id from user)"
-"unsupported: scatter subquery"
-
-# subquery does not depend on unique vindex of outer query
-"select id from user where id in (select user_id from user_extra where user_extra.user_id = user.col)"
-"unsupported: UNION or subquery containing multi-shard queries"
-
-# subquery does not depend on scatter outer query
-"select id from user where id in (select user_id from user_extra where user_extra.user_id = 4)"
-"unsupported: UNION or subquery containing multi-shard queries"
-
-# subquery depends on a cross-shard subquery
-"select id from (select user.id, user.col from user join user_extra) as t where id in (select t.col from user)"
-"unsupported: subquery cannot be merged with cross-shard subquery"
 
 # order by on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t order by id"
@@ -103,10 +67,6 @@
 "select id+1 from (select user.id, user.col from user join user_extra) as t"
 "unsupported: expression on results of a cross-shard subquery"
 
-# subquery and outer query route to different shards
-"select id from user where id = 5 and id in (select user_id from user_extra where user_extra.user_id = 4)"
-"unsupported: UNION or subquery on different shards: vindex values are different"
-
 # last_insert_id for sharded keyspace
 "select last_insert_id() from user"
 "unsupported: LAST_INSERT_ID is only allowed for unsharded keyspaces"
@@ -119,10 +79,6 @@
 "select foo from unsharded join information_schema.a"
 "unsupported: intermixing of information_schema and regular tables"
 
-# scatter subquery in select
-"select id, (select id from user) from user"
-"unsupported: scatter subquery"
-
 # natural join
 "select * from user natural join user_extra"
 "unsupported: natural join"
@@ -134,6 +90,10 @@
 # natural right join
 "select * from user natural right join user_extra"
 "unsupported: natural right join"
+
+# join with USING construct
+"select * from user join user_extra using(id)"
+"unsupported: join with USING(column_list) clause"
 
 # left join with expressions
 "select user.id, user_extra.col+1 from user left join user_extra on user.col = user_extra.col"
@@ -223,14 +183,6 @@
 "select id from user group by id, (select id from user_extra)"
 "unsupported: in group by: subqueries disallowed"
 
-# subquery of information_schema with normal table
-"select (select * from unsharded) from information_schema.a"
-"unsupported: intermixing of information_schema and regular tables"
-
-# subquery of normal table with information_schema
-"select (select * from information_schema.a) from unsharded"
-"unsupported: intermixing of information_schema and regular tables"
-
 # Order by uses cross-shard expression
 "select id from user order by id+1"
 "unsupported: in scatter query: complex order by expression: id + 1"
@@ -254,10 +206,6 @@
 # Order by has subqueries
 "select id from unsharded order by (select id from unsharded)"
 "unsupported: order by has subquery"
-
-# sequence in subquery
-"select col from unsharded where id in (select next value from seq)"
-"unsupported: use of sequence in subquery"
 
 # subqueries in update
 "update user set col = (select id from unsharded)"

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -446,6 +446,119 @@
   }
 }
 
+# Wire-up in subquery
+"select 1 from user where id in (select u.id, e.id from user u join user_extra e where e.id = u.col limit 10)"
+{
+  "Original": "select 1 from user where id in (select u.id, e.id from user u join user_extra e where e.id = u.col limit 10)",
+  "Instructions": {
+    "Opcode": "PulloutIn",
+    "SubqueryResult": "__sq1",
+    "HasValues": "__has_values1",
+    "IsEmpty": "__is_empty1",
+    "Subquery": {
+      "Opcode": "Limit",
+      "Count": 10,
+      "Offset": null,
+      "Input": {
+        "Opcode": "Join",
+        "Left": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select u.id, u.col from user as u",
+          "FieldQuery": "select u.id, u.col from user as u where 1 != 1"
+        },
+        "Right": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select e.id from user_extra as e where e.id = :u_col",
+          "FieldQuery": "select e.id from user_extra as e where 1 != 1"
+        },
+        "Cols": [
+          -1,
+          1
+        ],
+        "Vars": {
+          "u_col": 1
+        }
+      }
+    },
+    "Underlying": {
+      "Opcode": "SelectIN",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select 1 from user where :__has_values1 and (id in ::__vals)",
+      "FieldQuery": "select 1 from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [
+        "::__sq1"
+      ]
+    }
+  }
+}
+
+# Wire-up in in underlying primitive after pullout
+"select u.id, e.id, (select col from user) from user u join user_extra e where e.id = u.col limit 10"
+{
+  "Original": "select u.id, e.id, (select col from user) from user u join user_extra e where e.id = u.col limit 10",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 10,
+    "Offset": null,
+    "Input": {
+      "Opcode": "PulloutValue",
+      "SubqueryResult": "__sq1",
+      "HasValues": "__has_values1",
+      "IsEmpty": "__is_empty1",
+      "Subquery": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col from user",
+        "FieldQuery": "select col from user where 1 != 1"
+      },
+      "Underlying": {
+        "Opcode": "Join",
+        "Left": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select u.id, :__sq1, u.col from user as u",
+          "FieldQuery": "select u.id, :__sq1, u.col from user as u where 1 != 1"
+        },
+        "Right": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select e.id from user_extra as e where e.id = :u_col",
+          "FieldQuery": "select e.id from user_extra as e where 1 != 1"
+        },
+        "Cols": [
+          -1,
+          1,
+          -2
+        ],
+        "Vars": {
+          "u_col": 2
+        }
+      }
+    }
+  }
+}
+
 # Invalid value in IN clause
 "select id from user where id in (18446744073709551616, 1)"
 "strconv.ParseUint: parsing "18446744073709551616": value out of range"

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -454,7 +454,6 @@
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
     "HasValues": "__has_values1",
-    "IsEmpty": "__is_empty1",
     "Subquery": {
       "Opcode": "Limit",
       "Count": 10,
@@ -494,7 +493,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select 1 from user where :__has_values1 and (id in ::__vals)",
+      "Query": "select 1 from user where :__has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select 1 from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -516,7 +515,6 @@
       "Opcode": "PulloutValue",
       "SubqueryResult": "__sq1",
       "HasValues": "__has_values1",
-      "IsEmpty": "__is_empty1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -453,7 +453,7 @@
   "Instructions": {
     "Opcode": "PulloutIn",
     "SubqueryResult": "__sq1",
-    "HasValues": "__has_values1",
+    "HasValues": "__sq_has_values1",
     "Subquery": {
       "Opcode": "Limit",
       "Count": 10,
@@ -493,7 +493,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select 1 from user where :__has_values1 = 1 and (id in ::__vals)",
+      "Query": "select 1 from user where :__sq_has_values1 = 1 and (id in ::__vals)",
       "FieldQuery": "select 1 from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -514,7 +514,7 @@
     "Input": {
       "Opcode": "PulloutValue",
       "SubqueryResult": "__sq1",
-      "HasValues": "__has_values1",
+      "HasValues": "__sq_has_values1",
       "Subquery": {
         "Opcode": "SelectScatter",
         "Keyspace": {

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -39,6 +39,11 @@ type PulloutSubquery struct {
 	Underlying     Primitive
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (ps *PulloutSubquery) RouteType() string {
+	return ps.Opcode.String()
+}
+
 // Execute satisfies the Primtive interface.
 func (ps *PulloutSubquery) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	combinedVars, err := ps.execSubquery(vcursor, bindVars)

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+var _ Primitive = (*PulloutSubquery)(nil)
+
+// PulloutSubquery executes a "pulled out" subquery and stores
+// the results in a bind variable.
+type PulloutSubquery struct {
+	Opcode         PulloutOpcode
+	SubqueryResult string
+	HasValues      string
+	IsEmpty        string
+	Subquery       Primitive
+	Underlying     Primitive
+}
+
+// Execute satisfies the Primtive interface.
+func (ps *PulloutSubquery) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	combinedVars, err := ps.execSubquery(vcursor, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	return ps.Underlying.Execute(vcursor, combinedVars, wantfields)
+}
+
+// StreamExecute performs a streaming exec.
+func (ps *PulloutSubquery) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	combinedVars, err := ps.execSubquery(vcursor, bindVars)
+	if err != nil {
+		return err
+	}
+	return ps.Underlying.StreamExecute(vcursor, combinedVars, wantfields, callback)
+}
+
+// GetFields fetches the field info.
+func (ps *PulloutSubquery) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	combinedVars := make(map[string]*querypb.BindVariable, len(bindVars)+1)
+	for k, v := range bindVars {
+		combinedVars[k] = v
+	}
+	switch ps.Opcode {
+	case PulloutValue:
+		combinedVars[ps.SubqueryResult] = sqltypes.NullBindVariable
+	case PulloutIn, PulloutNotIn:
+		combinedVars[ps.HasValues] = sqltypes.Int64BindVariable(0)
+		combinedVars[ps.IsEmpty] = sqltypes.Int64BindVariable(1)
+		combinedVars[ps.SubqueryResult] = &querypb.BindVariable{
+			Type:   querypb.Type_TUPLE,
+			Values: []*querypb.Value{sqltypes.ValueToProto(sqltypes.NewInt64(0))},
+		}
+	case PulloutExists:
+		combinedVars[ps.SubqueryResult] = sqltypes.Int64BindVariable(0)
+	}
+	return ps.Underlying.GetFields(vcursor, combinedVars)
+}
+
+func (ps *PulloutSubquery) execSubquery(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (map[string]*querypb.BindVariable, error) {
+	result, err := ps.Subquery.Execute(vcursor, bindVars, false)
+	if err != nil {
+		return nil, err
+	}
+	combinedVars := make(map[string]*querypb.BindVariable, len(bindVars)+1)
+	for k, v := range bindVars {
+		combinedVars[k] = v
+	}
+	switch ps.Opcode {
+	case PulloutValue:
+		switch len(result.Rows) {
+		case 0:
+			combinedVars[ps.SubqueryResult] = sqltypes.NullBindVariable
+		case 1:
+			if len(result.Rows[0]) != 1 {
+				return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "subquery returned more than one column")
+			}
+			combinedVars[ps.SubqueryResult] = sqltypes.ValueBindVariable(result.Rows[0][0])
+		default:
+			return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "subquery returned more than one row")
+		}
+	case PulloutIn, PulloutNotIn:
+		switch len(result.Rows) {
+		case 0:
+			combinedVars[ps.HasValues] = sqltypes.Int64BindVariable(0)
+			combinedVars[ps.IsEmpty] = sqltypes.Int64BindVariable(1)
+			// Add a bogus value. It will not be checked.
+			combinedVars[ps.SubqueryResult] = &querypb.BindVariable{
+				Type:   querypb.Type_TUPLE,
+				Values: []*querypb.Value{sqltypes.ValueToProto(sqltypes.NewInt64(0))},
+			}
+		default:
+			if len(result.Rows[0]) != 1 {
+				return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "subquery returned more than one column")
+			}
+			combinedVars[ps.HasValues] = sqltypes.Int64BindVariable(1)
+			combinedVars[ps.IsEmpty] = sqltypes.Int64BindVariable(0)
+			values := &querypb.BindVariable{
+				Type:   querypb.Type_TUPLE,
+				Values: make([]*querypb.Value, len(result.Rows)),
+			}
+			for i, v := range result.Rows {
+				values.Values[i] = sqltypes.ValueToProto(v[0])
+			}
+			combinedVars[ps.SubqueryResult] = values
+		}
+	case PulloutExists:
+		switch len(result.Rows) {
+		case 0:
+			combinedVars[ps.SubqueryResult] = sqltypes.Int64BindVariable(0)
+		default:
+			combinedVars[ps.SubqueryResult] = sqltypes.Int64BindVariable(1)
+		}
+	}
+	return combinedVars, nil
+}
+
+// PulloutOpcode is a number representing the opcode
+// for the PulloutSubquery primitive.
+type PulloutOpcode int
+
+// This is the list of PulloutOpcode values.
+const (
+	PulloutValue = PulloutOpcode(iota)
+	PulloutIn
+	PulloutNotIn
+	PulloutExists
+)
+
+var pulloutName = map[PulloutOpcode]string{
+	PulloutValue:  "PulloutValue",
+	PulloutIn:     "PulloutIn",
+	PulloutNotIn:  "PulloutNotIn",
+	PulloutExists: "PulloutExists",
+}
+
+func (code PulloutOpcode) String() string {
+	return pulloutName[code]
+}
+
+// MarshalJSON serializes the PulloutOpcode as a JSON string.
+// It's used for testing and diagnostics.
+func (code PulloutOpcode) MarshalJSON() ([]byte, error) {
+	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
+}

--- a/go/vt/vtgate/engine/pullout_subquery_test.go
+++ b/go/vt/vtgate/engine/pullout_subquery_test.go
@@ -152,7 +152,6 @@ func TestPulloutSubqueryInNotinGood(t *testing.T) {
 		Opcode:         PulloutIn,
 		SubqueryResult: "sq",
 		HasValues:      "has_values",
-		IsEmpty:        "is_empty",
 		Subquery:       sfp,
 		Underlying:     ufp,
 	}
@@ -161,7 +160,7 @@ func TestPulloutSubqueryInNotinGood(t *testing.T) {
 		t.Error(err)
 	}
 	sfp.ExpectLog(t, []string{`Execute  false`})
-	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" is_empty: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
 
 	// Test the NOT IN case just once eventhough it's common code.
 	sfp.rewind()
@@ -171,7 +170,7 @@ func TestPulloutSubqueryInNotinGood(t *testing.T) {
 		t.Error(err)
 	}
 	sfp.ExpectLog(t, []string{`Execute  false`})
-	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" is_empty: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
 }
 
 func TestPulloutSubqueryInNone(t *testing.T) {
@@ -189,7 +188,6 @@ func TestPulloutSubqueryInNone(t *testing.T) {
 		Opcode:         PulloutIn,
 		SubqueryResult: "sq",
 		HasValues:      "has_values",
-		IsEmpty:        "is_empty",
 		Subquery:       sfp,
 		Underlying:     ufp,
 	}
@@ -198,7 +196,7 @@ func TestPulloutSubqueryInNone(t *testing.T) {
 		t.Error(err)
 	}
 	sfp.ExpectLog(t, []string{`Execute  false`})
-	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"0" >  false`})
 }
 
 func TestPulloutSubqueryInBadColumns(t *testing.T) {
@@ -235,17 +233,17 @@ func TestPulloutSubqueryExists(t *testing.T) {
 	}
 	ufp := &fakePrimitive{}
 	ps := &PulloutSubquery{
-		Opcode:         PulloutExists,
-		SubqueryResult: "sq",
-		Subquery:       sfp,
-		Underlying:     ufp,
+		Opcode:     PulloutExists,
+		HasValues:  "has_values",
+		Subquery:   sfp,
+		Underlying: ufp,
 	}
 
 	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
 		t.Error(err)
 	}
 	sfp.ExpectLog(t, []string{`Execute  false`})
-	ufp.ExpectLog(t, []string{`Execute sq: type:INT64 value:"1"  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1"  false`})
 }
 
 func TestPulloutSubqueryExistsNone(t *testing.T) {
@@ -260,17 +258,17 @@ func TestPulloutSubqueryExistsNone(t *testing.T) {
 	}
 	ufp := &fakePrimitive{}
 	ps := &PulloutSubquery{
-		Opcode:         PulloutExists,
-		SubqueryResult: "sq",
-		Subquery:       sfp,
-		Underlying:     ufp,
+		Opcode:     PulloutExists,
+		HasValues:  "has_values",
+		Subquery:   sfp,
+		Underlying: ufp,
 	}
 
 	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
 		t.Error(err)
 	}
 	sfp.ExpectLog(t, []string{`Execute  false`})
-	ufp.ExpectLog(t, []string{`Execute sq: type:INT64 value:"0"  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"0"  false`})
 }
 
 func TestPulloutSubqueryError(t *testing.T) {
@@ -336,7 +334,6 @@ func TestPulloutSubqueryGetFields(t *testing.T) {
 		Opcode:         PulloutValue,
 		SubqueryResult: "sq",
 		HasValues:      "has_values",
-		IsEmpty:        "is_empty",
 		Underlying:     ufp,
 	}
 
@@ -354,8 +351,8 @@ func TestPulloutSubqueryGetFields(t *testing.T) {
 		t.Error(err)
 	}
 	ufp.ExpectLog(t, []string{
-		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" > `,
-		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
+		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"0" > `,
+		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
 	})
 
 	ufp.rewind()
@@ -364,8 +361,8 @@ func TestPulloutSubqueryGetFields(t *testing.T) {
 		t.Error(err)
 	}
 	ufp.ExpectLog(t, []string{
-		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" > `,
-		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
+		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"0" > `,
+		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
 	})
 
 	ufp.rewind()
@@ -374,7 +371,7 @@ func TestPulloutSubqueryGetFields(t *testing.T) {
 		t.Error(err)
 	}
 	ufp.ExpectLog(t, []string{
-		`GetFields aa: type:INT64 value:"1" sq: type:INT64 value:"0" `,
-		`Execute aa: type:INT64 value:"1" sq: type:INT64 value:"0"  true`,
+		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" `,
+		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0"  true`,
 	})
 }

--- a/go/vt/vtgate/engine/pullout_subquery_test.go
+++ b/go/vt/vtgate/engine/pullout_subquery_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"testing"
+
+	"vitess.io/vitess/go/sqltypes"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func TestPulloutSubqueryValueGood(t *testing.T) {
+	// Test one case with actual bind vars.
+	bindVars := map[string]*querypb.BindVariable{
+		"aa": sqltypes.Int64BindVariable(1),
+	}
+
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+		"1",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	underlyingResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col",
+			"int64",
+		),
+		"0",
+	)
+	ufp := &fakePrimitive{
+		results: []*sqltypes.Result{underlyingResult},
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	result, err := ps.Execute(nil, bindVars, false)
+	if err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1"  false`})
+	ufp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1" sq: type:INT64 value:"1"  false`})
+	expectResult(t, "ps.Execute", result, underlyingResult)
+}
+
+func TestPulloutSubqueryValueNone(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute sq:  false`})
+}
+
+func TestPulloutSubqueryValueBadColumns(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1|col2",
+			"int64|int64",
+		),
+		"1|1",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+	}
+
+	_, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false)
+	expectError(t, "ps.Execute", err, "subquery returned more than one column")
+}
+
+func TestPulloutSubqueryValueBadRows(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+		"1",
+		"2",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+	}
+
+	_, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false)
+	expectError(t, "ps.Execute", err, "subquery returned more than one row")
+}
+
+func TestPulloutSubqueryInNotinGood(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+		"1",
+		"2",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutIn,
+		SubqueryResult: "sq",
+		HasValues:      "has_values",
+		IsEmpty:        "is_empty",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" is_empty: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
+
+	// Test the NOT IN case just once eventhough it's common code.
+	sfp.rewind()
+	ufp.rewind()
+	ps.Opcode = PulloutNotIn
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"1" is_empty: type:INT64 value:"0" sq: type:TUPLE values:<type:INT64 value:"1" > values:<type:INT64 value:"2" >  false`})
+}
+
+func TestPulloutSubqueryInNone(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutIn,
+		SubqueryResult: "sq",
+		HasValues:      "has_values",
+		IsEmpty:        "is_empty",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  false`})
+}
+
+func TestPulloutSubqueryInBadColumns(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1|col2",
+			"int64|int64",
+		),
+		"1|1",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutIn,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+	}
+
+	_, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false)
+	expectError(t, "ps.Execute", err, "subquery returned more than one column")
+}
+
+func TestPulloutSubqueryExists(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+		"1",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutExists,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute sq: type:INT64 value:"1"  false`})
+}
+
+func TestPulloutSubqueryExistsNone(t *testing.T) {
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutExists,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false); err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute  false`})
+	ufp.ExpectLog(t, []string{`Execute sq: type:INT64 value:"0"  false`})
+}
+
+func TestPulloutSubqueryError(t *testing.T) {
+	sfp := &fakePrimitive{
+		sendErr: errors.New("err"),
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutExists,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+	}
+
+	_, err := ps.Execute(nil, make(map[string]*querypb.BindVariable), false)
+	expectError(t, "ps.Execute", err, "err")
+}
+
+func TestPulloutSubqueryStream(t *testing.T) {
+	bindVars := map[string]*querypb.BindVariable{
+		"aa": sqltypes.Int64BindVariable(1),
+	}
+	sqResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1",
+			"int64",
+		),
+		"1",
+	)
+	sfp := &fakePrimitive{
+		results: []*sqltypes.Result{sqResult},
+	}
+	underlyingResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col",
+			"int64",
+		),
+		"0",
+	)
+	ufp := &fakePrimitive{
+		results: []*sqltypes.Result{underlyingResult},
+	}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		Subquery:       sfp,
+		Underlying:     ufp,
+	}
+
+	result, err := wrapStreamExecute(ps, nil, bindVars, false)
+	if err != nil {
+		t.Error(err)
+	}
+	sfp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1"  false`})
+	ufp.ExpectLog(t, []string{`StreamExecute aa: type:INT64 value:"1" sq: type:INT64 value:"1"  false`})
+	expectResult(t, "ps.StreamExecute", result, underlyingResult)
+}
+
+func TestPulloutSubqueryGetFields(t *testing.T) {
+	bindVars := map[string]*querypb.BindVariable{
+		"aa": sqltypes.Int64BindVariable(1),
+	}
+	ufp := &fakePrimitive{}
+	ps := &PulloutSubquery{
+		Opcode:         PulloutValue,
+		SubqueryResult: "sq",
+		HasValues:      "has_values",
+		IsEmpty:        "is_empty",
+		Underlying:     ufp,
+	}
+
+	if _, err := ps.GetFields(nil, bindVars); err != nil {
+		t.Error(err)
+	}
+	ufp.ExpectLog(t, []string{
+		`GetFields aa: type:INT64 value:"1" sq: `,
+		`Execute aa: type:INT64 value:"1" sq:  true`,
+	})
+
+	ufp.rewind()
+	ps.Opcode = PulloutIn
+	if _, err := ps.GetFields(nil, bindVars); err != nil {
+		t.Error(err)
+	}
+	ufp.ExpectLog(t, []string{
+		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" > `,
+		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
+	})
+
+	ufp.rewind()
+	ps.Opcode = PulloutNotIn
+	if _, err := ps.GetFields(nil, bindVars); err != nil {
+		t.Error(err)
+	}
+	ufp.ExpectLog(t, []string{
+		`GetFields aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" > `,
+		`Execute aa: type:INT64 value:"1" has_values: type:INT64 value:"0" is_empty: type:INT64 value:"1" sq: type:TUPLE values:<type:INT64 value:"0" >  true`,
+	})
+
+	ufp.rewind()
+	ps.Opcode = PulloutExists
+	if _, err := ps.GetFields(nil, bindVars); err != nil {
+		t.Error(err)
+	}
+	ufp.ExpectLog(t, []string{
+		`GetFields aa: type:INT64 value:"1" sq: type:INT64 value:"0" `,
+		`Execute aa: type:INT64 value:"1" sq: type:INT64 value:"0"  true`,
+	})
+}

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -177,45 +177,53 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 			return nil, nil, nil, errors.New("unsupported: cross-shard correlated subquery")
 		}
 
-		sqName, hasValues, isEmpty := pb.jt.GenerateSubqueryVars()
+		sqName, hasValues := pb.jt.GenerateSubqueryVars()
 		construct, ok := constructsMap[sqi.ast]
 		if !ok {
 			// (subquery) -> :_sq
 			expr = sqlparser.ReplaceExpr(expr, sqi.ast, sqlparser.NewValArg([]byte(":"+sqName)))
-			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutValue, sqName, hasValues, isEmpty, sqi.bldr))
+			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutValue, sqName, hasValues, sqi.bldr))
 			continue
 		}
 		switch construct := construct.(type) {
 		case *sqlparser.ComparisonExpr:
 			if construct.Operator == sqlparser.InStr {
-				// a in (subquery) -> (:__has_values and (a in ::__sq))
+				// a in (subquery) -> (:__has_values = 1 and (a in ::__sq))
 				newExpr := &sqlparser.ParenExpr{
 					Expr: &sqlparser.AndExpr{
-						Left: sqlparser.NewValArg([]byte(":" + hasValues)),
+						Left: &sqlparser.ComparisonExpr{
+							Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
+							Operator: sqlparser.EqualStr,
+							Right:    sqlparser.NewIntVal([]byte("1")),
+						},
 						Right: &sqlparser.ParenExpr{
 							Expr: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
 						},
 					},
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
-				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutIn, sqName, hasValues, isEmpty, sqi.bldr))
+				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutIn, sqName, hasValues, sqi.bldr))
 			} else {
-				// a not in (subquery) -> (:__is_empty or (a not in ::__sq))
+				// a not in (subquery) -> (:__has_values = 0 or (a not in ::__sq))
 				newExpr := &sqlparser.ParenExpr{
 					Expr: &sqlparser.OrExpr{
-						Left: sqlparser.NewValArg([]byte(":" + isEmpty)),
+						Left: &sqlparser.ComparisonExpr{
+							Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
+							Operator: sqlparser.EqualStr,
+							Right:    sqlparser.NewIntVal([]byte("0")),
+						},
 						Right: &sqlparser.ParenExpr{
 							Expr: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
 						},
 					},
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
-				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutNotIn, sqName, hasValues, isEmpty, sqi.bldr))
+				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutNotIn, sqName, hasValues, sqi.bldr))
 			}
 		case *sqlparser.ExistsExpr:
-			// exists (subquery) -> :_sq
-			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewValArg([]byte(":"+sqName)))
-			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutExists, sqName, hasValues, isEmpty, sqi.bldr))
+			// exists (subquery) -> :_has_values
+			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewValArg([]byte(":"+hasValues)))
+			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutExists, sqName, hasValues, sqi.bldr))
 		}
 	}
 	return pullouts, highestOrigin, expr, nil

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -188,7 +188,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 		switch construct := construct.(type) {
 		case *sqlparser.ComparisonExpr:
 			if construct.Operator == sqlparser.InStr {
-				// a in (subquery) -> (:__has_values = 1 and (a in ::__sq))
+				// a in (subquery) -> (:__sq_has_values = 1 and (a in ::__sq))
 				newExpr := &sqlparser.ParenExpr{
 					Expr: &sqlparser.AndExpr{
 						Left: &sqlparser.ComparisonExpr{
@@ -204,7 +204,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
 				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutIn, sqName, hasValues, sqi.bldr))
 			} else {
-				// a not in (subquery) -> (:__has_values = 0 or (a not in ::__sq))
+				// a not in (subquery) -> (:__sq_has_values = 0 or (a not in ::__sq))
 				newExpr := &sqlparser.ParenExpr{
 					Expr: &sqlparser.OrExpr{
 						Left: &sqlparser.ComparisonExpr{
@@ -221,7 +221,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutNotIn, sqName, hasValues, sqi.bldr))
 			}
 		case *sqlparser.ExistsExpr:
-			// exists (subquery) -> :_has_values
+			// exists (subquery) -> :__sq_has_values
 			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewValArg([]byte(":"+hasValues)))
 			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutExists, sqName, hasValues, sqi.bldr))
 		}

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -17,7 +17,6 @@ limitations under the License.
 package planbuilder
 
 import (
-	"errors"
 	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -235,20 +234,16 @@ func convertToLeftJoin(ajoin *sqlparser.JoinTableExpr) {
 }
 
 func (pb *primitiveBuilder) join(rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr) error {
-	if ajoin != nil && ajoin.Condition.Using != nil {
-		return errors.New("unsupported: join with USING(column_list) clause")
-	}
 	lRoute, leftIsRoute := pb.bldr.(*route)
 	rRoute, rightIsRoute := rpb.bldr.(*route)
 	if leftIsRoute && rightIsRoute {
 		// If both are routes, they have an opportunity
 		// to merge into one.
-		if lRoute.ERoute.Opcode == engine.SelectNext || rRoute.ERoute.Opcode == engine.SelectNext {
-			return errors.New("unsupported: sequence join with another table")
-		}
 		if lRoute.ERoute.Keyspace.Name != rRoute.ERoute.Keyspace.Name {
 			goto nomerge
 		}
+		// We don't have to check on SelectNext because the syntax
+		// doesn't allow joins.
 		switch lRoute.ERoute.Opcode {
 		case engine.SelectUnsharded:
 			if rRoute.ERoute.Opcode == engine.SelectUnsharded {
@@ -313,11 +308,12 @@ func (pb *primitiveBuilder) mergeRoutes(rpb *primitiveBuilder, ajoin *sqlparser.
 	if ajoin == nil {
 		return nil
 	}
-	_, expr, err := pb.findOrigin(ajoin.Condition.On)
+	pullouts, _, expr, err := pb.findOrigin(ajoin.Condition.On)
 	if err != nil {
 		return err
 	}
 	ajoin.Condition.On = expr
+	pb.addPullouts(pullouts)
 	for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
 		lRoute.UpdatePlan(pb, filter)
 	}

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -72,28 +72,27 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 // a subquery. It returns three names based on: __sq, __has_values,
 // __is_empty. The appropriate names can be used for substitution
 // depending on the scenario.
-func (jt *jointab) GenerateSubqueryVars() (sq, hasValues, isEmpty string) {
+func (jt *jointab) GenerateSubqueryVars() (sq, hasValues string) {
 	for {
 		jt.varIndex++
 		suffix := strconv.Itoa(jt.varIndex)
 		var1 := "__sq" + suffix
 		var2 := "__has_values" + suffix
-		var3 := "__is_empty" + suffix
-		if !jt.check(var1, var2, var3) {
+		if jt.containsAny(var1, var2) {
 			continue
 		}
-		return var1, var2, var3
+		return var1, var2
 	}
 }
 
-func (jt *jointab) check(names ...string) bool {
+func (jt *jointab) containsAny(names ...string) bool {
 	for _, name := range names {
 		if _, ok := jt.vars[name]; ok {
-			return false
+			return true
 		}
 		jt.vars[name] = struct{}{}
 	}
-	return true
+	return false
 }
 
 // Lookup returns the order of the route that supplies the column and

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -69,15 +69,15 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 }
 
 // GenerateSubqueryVars generates substitution variable names for
-// a subquery. It returns three names based on: __sq, __has_values,
-// __is_empty. The appropriate names can be used for substitution
+// a subquery. It returns two names based on: __sq, __sq_has_values.
+// The appropriate names can be used for substitution
 // depending on the scenario.
 func (jt *jointab) GenerateSubqueryVars() (sq, hasValues string) {
 	for {
 		jt.varIndex++
 		suffix := strconv.Itoa(jt.varIndex)
 		var1 := "__sq" + suffix
-		var2 := "__has_values" + suffix
+		var2 := "__sq_has_values" + suffix
 		if jt.containsAny(var1, var2) {
 			continue
 		}

--- a/go/vt/vtgate/planbuilder/jointab_test.go
+++ b/go/vt/vtgate/planbuilder/jointab_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateSubqueryVars(t *testing.T) {
+	jt := newJointab(map[string]struct{}{
+		"__sq1":         {},
+		"__has_values3": {},
+	})
+
+	v1, v2, v3 := jt.GenerateSubqueryVars()
+	combined := []string{v1, v2, v3}
+	want := []string{"__sq2", "__has_values2", "__is_empty2"}
+	if !reflect.DeepEqual(combined, want) {
+		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
+	}
+
+	v1, v2, v3 = jt.GenerateSubqueryVars()
+	combined = []string{v1, v2, v3}
+	want = []string{"__sq4", "__has_values4", "__is_empty4"}
+	if !reflect.DeepEqual(combined, want) {
+		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
+	}
+}

--- a/go/vt/vtgate/planbuilder/jointab_test.go
+++ b/go/vt/vtgate/planbuilder/jointab_test.go
@@ -27,16 +27,16 @@ func TestGenerateSubqueryVars(t *testing.T) {
 		"__has_values3": {},
 	})
 
-	v1, v2, v3 := jt.GenerateSubqueryVars()
-	combined := []string{v1, v2, v3}
-	want := []string{"__sq2", "__has_values2", "__is_empty2"}
+	v1, v2 := jt.GenerateSubqueryVars()
+	combined := []string{v1, v2}
+	want := []string{"__sq2", "__has_values2"}
 	if !reflect.DeepEqual(combined, want) {
 		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
 	}
 
-	v1, v2, v3 = jt.GenerateSubqueryVars()
-	combined = []string{v1, v2, v3}
-	want = []string{"__sq4", "__has_values4", "__is_empty4"}
+	v1, v2 = jt.GenerateSubqueryVars()
+	combined = []string{v1, v2}
+	want = []string{"__sq4", "__has_values4"}
 	if !reflect.DeepEqual(combined, want) {
 		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
 	}

--- a/go/vt/vtgate/planbuilder/jointab_test.go
+++ b/go/vt/vtgate/planbuilder/jointab_test.go
@@ -23,20 +23,20 @@ import (
 
 func TestGenerateSubqueryVars(t *testing.T) {
 	jt := newJointab(map[string]struct{}{
-		"__sq1":         {},
-		"__has_values3": {},
+		"__sq1":            {},
+		"__sq_has_values3": {},
 	})
 
 	v1, v2 := jt.GenerateSubqueryVars()
 	combined := []string{v1, v2}
-	want := []string{"__sq2", "__has_values2"}
+	want := []string{"__sq2", "__sq_has_values2"}
 	if !reflect.DeepEqual(combined, want) {
 		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
 	}
 
 	v1, v2 = jt.GenerateSubqueryVars()
 	combined = []string{v1, v2}
-	want = []string{"__sq4", "__has_values4"}
+	want = []string{"__sq4", "__sq_has_values4"}
 	if !reflect.DeepEqual(combined, want) {
 		t.Errorf("jt.GenerateSubqueryVars: %v, want %v", combined, want)
 	}

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+var _ builder = (*pulloutSubquery)(nil)
+
+// pulloutSubquery is the builder for engine.PulloutSubquery.
+// This gets built if a subquery is not correlated and can
+// therefore can be pulled out and executed upfront.
+type pulloutSubquery struct {
+	order      int
+	subquery   builder
+	underlying builder
+	eSubquery  *engine.PulloutSubquery
+}
+
+// newPulloutSubquery builds a new pulloutSubquery.
+func newPulloutSubquery(opcode engine.PulloutOpcode, sqName, hasValues, isEmpty string, subquery builder) *pulloutSubquery {
+	return &pulloutSubquery{
+		subquery: subquery,
+		eSubquery: &engine.PulloutSubquery{
+			Opcode:         opcode,
+			SubqueryResult: sqName,
+			HasValues:      hasValues,
+			IsEmpty:        isEmpty,
+		},
+	}
+}
+
+// setUnderlying sets the underlying primitive.
+func (ps *pulloutSubquery) setUnderlying(underlying builder) {
+	ps.underlying = underlying
+	ps.underlying.Reorder(ps.subquery.Order())
+	ps.order = ps.underlying.Order() + 1
+}
+
+// Order satisfies the builder interface.
+func (ps *pulloutSubquery) Order() int {
+	return ps.order
+}
+
+// Reorder satisfies the builder interface.
+func (ps *pulloutSubquery) Reorder(order int) {
+	ps.subquery.Reorder(order)
+	ps.underlying.Reorder(ps.subquery.Order())
+	ps.order = ps.underlying.Order() + 1
+}
+
+// Primitive satisfies the builder interface.
+func (ps *pulloutSubquery) Primitive() engine.Primitive {
+	ps.eSubquery.Subquery = ps.subquery.Primitive()
+	ps.eSubquery.Underlying = ps.underlying.Primitive()
+	return ps.eSubquery
+}
+
+// First satisfies the builder interface.
+func (ps *pulloutSubquery) First() builder {
+	return ps.underlying.First()
+}
+
+// ResultColumns satisfies the builder interface.
+func (ps *pulloutSubquery) ResultColumns() []*resultColumn {
+	return ps.underlying.ResultColumns()
+}
+
+// PushFilter satisfies the builder interface.
+func (ps *pulloutSubquery) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereType string, origin builder) error {
+	return ps.underlying.PushFilter(pb, filter, whereType, origin)
+}
+
+// PushSelect satisfies the builder interface.
+func (ps *pulloutSubquery) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+	return ps.underlying.PushSelect(expr, origin)
+}
+
+// PushOrderByNull satisfies the builder interface.
+func (ps *pulloutSubquery) PushOrderByNull() {
+	ps.underlying.PushOrderByNull()
+}
+
+// PushOrderByRand satisfies the builder interface.
+func (ps *pulloutSubquery) PushOrderByRand() {
+	ps.underlying.PushOrderByRand()
+}
+
+// SetUpperLimit satisfies the builder interface.
+// This is a no-op because we actually call SetLimit for this primitive.
+// In the future, we may have to honor this call for subqueries.
+func (ps *pulloutSubquery) SetUpperLimit(count *sqlparser.SQLVal) {
+	ps.underlying.SetUpperLimit(count)
+}
+
+// PushMisc satisfies the builder interface.
+func (ps *pulloutSubquery) PushMisc(sel *sqlparser.Select) {
+	ps.subquery.PushMisc(sel)
+	ps.underlying.PushMisc(sel)
+}
+
+// Wireup satisfies the builder interface.
+func (ps *pulloutSubquery) Wireup(bldr builder, jt *jointab) error {
+	if err := ps.underlying.Wireup(bldr, jt); err != nil {
+		return err
+	}
+	return ps.subquery.Wireup(bldr, jt)
+}
+
+// SupplyVar satisfies the builder interface.
+func (ps *pulloutSubquery) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	if from <= ps.subquery.Order() {
+		ps.subquery.SupplyVar(from, to, col, varname)
+		return
+	}
+	ps.underlying.SupplyVar(from, to, col, varname)
+}
+
+// SupplyCol satisfies the builder interface.
+func (ps *pulloutSubquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	panic("BUG: unreachable")
+}

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -34,14 +34,13 @@ type pulloutSubquery struct {
 }
 
 // newPulloutSubquery builds a new pulloutSubquery.
-func newPulloutSubquery(opcode engine.PulloutOpcode, sqName, hasValues, isEmpty string, subquery builder) *pulloutSubquery {
+func newPulloutSubquery(opcode engine.PulloutOpcode, sqName, hasValues string, subquery builder) *pulloutSubquery {
 	return &pulloutSubquery{
 		subquery: subquery,
 		eSubquery: &engine.PulloutSubquery{
 			Opcode:         opcode,
 			SubqueryResult: sqName,
 			HasValues:      hasValues,
-			IsEmpty:        isEmpty,
 		},
 	}
 }

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -1680,7 +1680,7 @@ class TestVTGateFunctions(unittest.TestCase):
         [(1, 1, 1, 1), (3, 3, 3, 0), (4, 4, 4, 0),
          (5, 5, 5, 5), (6, 6, 6, 6), (7, 7, 7, 7)])
 
-  def test_joins(self):
+  def test_joins_subqueries(self):
     vtgate_conn = get_connection()
     vtgate_conn.begin()
     self.execute_on_master(
@@ -1788,6 +1788,20 @@ class TestVTGateFunctions(unittest.TestCase):
          [('id', self.int_type),
           ('name', self.string_type),
           ('info', self.string_type)]))
+
+    # test a cross-shard subquery
+    result = self.execute_on_master(
+        vtgate_conn,
+        'select id, name from join_user '
+        'where id in (select user_id from join_user_extra)',
+        {})
+    self.assertEqual(
+        result,
+        ([(1L, 'name1')],
+         1,
+         0,
+         [('id', self.int_type),
+          ('name', self.string_type)]))
     vtgate_conn.begin()
     self.execute_on_master(
         vtgate_conn,


### PR DESCRIPTION
This implementation follows the design from doc/VTGateSubqueries.md.

A new PulloutSubquery primitive has been created. Its action is to
execute a subquery, save the resulting value(s) in a bind variable,
and pass that down to the underlying primitive.

The type of value set depends on whether the subquery occurred in
an IN clause, etc. In the case of IN and NOT IN clauses, if the
list returned is empty, a guard variable is set to work around
the inability for IN clauses to handle an empty list syntax.

Subqueries can only be pulled out if they are not correlated.
Correlated subqueries will be handled when we add the
ability to execute expressions in VTGate.