### PR TITLE
Fixed Hibernate use case (SHOW VARIABLES after connection)

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -740,6 +740,17 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 	defer func() { logStats.ExecuteTime = time.Since(execStart) }()
 
 	switch show.Type {
+	case sqlparser.KeywordString(sqlparser.VARIABLES):
+		if destKeyspace == "" {
+			keyspaces, err := e.resolver.resolver.GetAllKeyspaces(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if len(keyspaces) == 0 {
+				return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspaces available")
+			}
+			return e.handleOther(ctx, safeSession, sql, bindVars, dest, keyspaces[0], destTabletType, logStats)
+		}
 	case sqlparser.KeywordString(sqlparser.TABLES):
 		if show.ShowTablesOpt != nil && show.ShowTablesOpt.DbName != "" {
 			show.ShowTablesOpt.DbName = "vt_" + destKeyspace

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -603,7 +603,10 @@ func TestExecutorShow(t *testing.T) {
 			t.Errorf("show databases:\n%+v, want\n%+v", qr, wantqr)
 		}
 	}
-
+	_, err := executor.Execute(context.Background(), "TestExecute", session, "show variables", nil)
+	if err != nil {
+		t.Error(err)
+	}
 	qr, err := executor.Execute(context.Background(), "TestExecute", session, "show vitess_shards", nil)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
While testing Vitess with Java Hibernate I found that, during the connection stage, Hibernate is sending a **SHOW VARIABLE** statement without specifying the DBNAME.
Right now Vitess is failing because is unable to propagate the query to the right keyspace.

In order to fix this use case I just changed the code to forward the SHOW VARIABLE statement to the first keyspace if not specified.
