### PR TITLE
Also remove leading whitespace in SplitMarginComments.

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -1147,7 +1147,7 @@ options:PassthroughDMLs
   "FullQuery": "update d set foo = 'foo' where name in ('a', 'b') limit 1",
   "OuterQuery": "update d set foo = 'foo' where :#pk",
   "Subquery": "select name from d where name in ('a', 'b') limit 1 for update",
-  "WhereClause": " where name in ('a', 'b')"
+  "WhereClause": "where name in ('a', 'b')"
 }
 
 # update limit with pk
@@ -1302,7 +1302,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid + 1 = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid + 1 = 1"
+  "WhereClause": "where eid + 1 = 1"
 }
 
 # pk
@@ -1319,7 +1319,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1 and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "PKValues": [1, 1],
-  "WhereClause": " where eid = 1 and id = 1"
+  "WhereClause": "where eid = 1 and id = 1"
 }
 
 # partial pk
@@ -1336,7 +1336,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # bad pk
@@ -1353,7 +1353,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1.0 and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1.0 and id = 1"
+  "WhereClause": "where eid = 1.0 and id = 1"
 }
 
 # partial pk with limit
@@ -1370,7 +1370,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1 limit 10",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a where eid = 1 limit 10 for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # non-pk
@@ -1387,7 +1387,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1 and name = 'foo'",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update",
-  "WhereClause": " where eid = 1 and name = 'foo'"
+  "WhereClause": "where eid = 1 and name = 'foo'"
 }
 
 # no index
@@ -1420,7 +1420,7 @@ options:PassthroughDMLs
   "FullQuery":"update a set name = 'foo' where eid + 1 = 1 and id = 1",
   "OuterQuery":"update a set name = 'foo' where :#pk",
   "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid + 1 = 1 and id = 1"
+  "WhereClause": "where eid + 1 = 1 and id = 1"
 }
 
 # parenthesized expressions in where
@@ -1437,7 +1437,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where (eid = 1) and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "PKValues": [1, 1],
-  "WhereClause": " where (eid = 1) and id = 1"
+  "WhereClause": "where (eid = 1) and id = 1"
 }
 
 # in clause expression in where
@@ -1454,7 +1454,7 @@ options:PassthroughDMLs
   "FullQuery":"update a set name = 'foo' where eid in (1, 2) and id = 1",
   "OuterQuery":"update a set name = 'foo' where :#pk",
   "PKValues":[[1,2],1],
-  "WhereClause": " where eid in (1, 2) and id = 1"
+  "WhereClause": "where eid in (1, 2) and id = 1"
 }
 
 # double in clause
@@ -1471,7 +1471,7 @@ options:PassthroughDMLs
   "FullQuery":"update a set name = 'foo' where eid in (1, 2) and id in (1, 2)",
   "OuterQuery":"update a set name = 'foo' where :#pk",
   "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update",
-  "WhereClause": " where eid in (1, 2) and id in (1, 2)"
+  "WhereClause": "where eid in (1, 2) and id in (1, 2)"
 }
 
 # double use of pk
@@ -1488,7 +1488,7 @@ options:PassthroughDMLs
   "FullQuery":"update a set name = 'foo' where eid = 1 and eid = 2",
   "OuterQuery":"update a set name = 'foo' where :#pk",
   "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1 and eid = 2"
+  "WhereClause": "where eid = 1 and eid = 2"
 }
 
 # partial pk with order by
@@ -1505,7 +1505,7 @@ options:PassthroughDMLs
   "FullQuery": "update a set name = 'foo' where eid = 1 order by id desc",
   "OuterQuery": "update a set name = 'foo' where :#pk order by id desc",
   "Subquery": "select eid, id from a where eid = 1 order by id desc limit :#maxLimit for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # update with index hint
@@ -1523,7 +1523,7 @@ options:PassthroughDMLs
   "FullQuery": "update a use index (b) set name = 'foo' where eid = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
   "Subquery": "select eid, id from a use index (b) where eid = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # delete limit with pk
@@ -1540,7 +1540,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from d where name in ('a', 'b') limit 1",
   "OuterQuery": "delete from d where :#pk",
   "Subquery": "select name from d where name in ('a', 'b') limit 1 for update",
-  "WhereClause": " where name in ('a', 'b')"
+  "WhereClause": "where name in ('a', 'b')"
 }
 
 # delete limit with pk
@@ -1604,7 +1604,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid + 1 = 1",
   "OuterQuery": "delete from a where :#pk",
   "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid + 1 = 1"
+  "WhereClause": "where eid + 1 = 1"
 }
 
 # pk
@@ -1621,7 +1621,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid = 1 and id = 1",
   "OuterQuery": "delete from a where :#pk",
   "PKValues": [1, 1],
-  "WhereClause": " where eid = 1 and id = 1"
+  "WhereClause": "where eid = 1 and id = 1"
 }
 
 # pk
@@ -1653,7 +1653,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid = 1",
   "OuterQuery": "delete from a where :#pk",
   "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # partial pk with order by
@@ -1670,7 +1670,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid = 1 order by id desc",
   "OuterQuery": "delete from a where :#pk order by id desc",
   "Subquery": "select eid, id from a where eid = 1 order by id desc limit :#maxLimit for update",
-  "WhereClause": " where eid = 1"
+  "WhereClause": "where eid = 1"
 }
 
 # bad pk value delete
@@ -1687,7 +1687,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid = 1.0 and id = 1",
   "OuterQuery": "delete from a where :#pk",
   "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1.0 and id = 1"
+  "WhereClause": "where eid = 1.0 and id = 1"
 }
 
 # non-pk
@@ -1704,7 +1704,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where eid = 1 and name = 'foo'",
   "OuterQuery": "delete from a where :#pk",
   "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update",
-  "WhereClause": " where eid = 1 and name = 'foo'"
+  "WhereClause": "where eid = 1 and name = 'foo'"
 }
 
 # no index
@@ -1737,7 +1737,7 @@ options:PassthroughDMLs
   "FullQuery":"delete from a where eid + 1 = 1 and id = 1",
   "OuterQuery":"delete from a where :#pk",
   "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update",
-  "WhereClause": " where eid + 1 = 1 and id = 1"
+  "WhereClause": "where eid + 1 = 1 and id = 1"
 }
 
 # parenthesized expressions in where
@@ -1754,7 +1754,7 @@ options:PassthroughDMLs
   "FullQuery": "delete from a where (eid = 1) and id = 1",
   "OuterQuery": "delete from a where :#pk",
   "PKValues": [1, 1],
-  "WhereClause": " where (eid = 1) and id = 1"
+  "WhereClause": "where (eid = 1) and id = 1"
 }
 
 # delete in clause expression in where
@@ -1771,7 +1771,7 @@ options:PassthroughDMLs
   "FullQuery":"delete from a where eid in (1, 2) and id = 1",
   "OuterQuery":"delete from a where :#pk",
   "PKValues":[[1,2],1],
-  "WhereClause": " where eid in (1, 2) and id = 1"
+  "WhereClause": "where eid in (1, 2) and id = 1"
 }
 
 # delete double in clause
@@ -1788,7 +1788,7 @@ options:PassthroughDMLs
   "FullQuery":"delete from a where eid in (1, 2) and id in (1, 2)",
   "OuterQuery":"delete from a where :#pk",
   "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update",
-  "WhereClause": " where eid in (1, 2) and id in (1, 2)"
+  "WhereClause": "where eid in (1, 2) and id in (1, 2)"
 }
 
 # delete double use of pk
@@ -1805,7 +1805,7 @@ options:PassthroughDMLs
   "FullQuery":"delete from a where eid = 1 and eid = 2",
   "OuterQuery":"delete from a where :#pk",
   "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update",
-  "WhereClause": " where eid = 1 and eid = 2"
+  "WhereClause": "where eid = 1 and eid = 2"
 }
 
 # multi-table delete

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -111,7 +111,7 @@ func SplitMarginComments(sql string) (query string, comments MarginComments) {
 		Leading:  strings.TrimLeftFunc(sql[:leadingEnd], unicode.IsSpace),
 		Trailing: strings.TrimRightFunc(sql[trailingStart:], unicode.IsSpace),
 	}
-	return strings.TrimRightFunc(sql[leadingEnd:trailingStart], unicode.IsSpace), comments
+	return strings.TrimFunc(sql[leadingEnd:trailingStart], unicode.IsSpace), comments
 }
 
 // StripLeadingComments trims the SQL string and removes any leading comments

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -80,6 +80,11 @@ func TestSplitComments(t *testing.T) {
 		outLeadingComments:  "/* before */ ",
 		outTrailingComments: " /* bar */",
 	}, {
+		input:               "/* before1 */ /* before2 */ foo /* after1 */ /* after2 */",
+		outSQL:              "foo",
+		outLeadingComments:  "/* before1 */ /* before2 */ ",
+		outTrailingComments: " /* after1 */ /* after2 */",
+	}, {
 		input:               "/** before */ foo /** bar */",
 		outSQL:              "foo",
 		outLeadingComments:  "/** before */ ",
@@ -110,11 +115,8 @@ func TestSplitComments(t *testing.T) {
 		outLeadingComments:  "",
 		outTrailingComments: "",
 	}, {
-		input: " foo ",
-		// NOTE(dweitzman): Preserving leading whitespace because the WhereClause entries for 'update'
-		// in exec_cases.txt have leading whitespace and if we trim it here that will change. It may be
-		// safe to change, but changing query plans is not an intended effect of this diff.
-		outSQL:              " foo",
+		input:               " foo ",
+		outSQL:              "foo",
 		outLeadingComments:  "",
 		outTrailingComments: "",
 	}}


### PR DESCRIPTION
This was separated from the previous diff because it impacts query plans, although in seemingly-harmless way.

Side note: I don't claim that trimming leading whitespace is fundamentally better than leaving it alone, but it's at least consistent with what's done for trailing whitespace.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>