### PR TITLE
topo: allow cross-cell master calls

### DIFF
--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -489,6 +489,14 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+	if target.TabletType == topodatapb.TabletType_MASTER {
+		if len(e.aggregates) == 0 {
+			return nil, topo.ErrNoNode
+		}
+		for _, agg := range e.aggregates {
+			return agg, nil
+		}
+	}
 	agg, ok := e.aggregates[target.Cell]
 	if !ok {
 		return nil, topo.ErrNoNode


### PR DESCRIPTION
VTGates are supposed to be able to go cross-cell for master traffic.
This ability was lost due to the recent refactor. This change
brings back this capability temporarily.

The more correct implementation will happen later when the ability
to go cross-cell gets implemented more generically for any serving
type.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>