### PR TITLE
vttablet mysql conn improvements

### DIFF
--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -117,11 +117,16 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 // NewDBConnection returns a new DBConnection based on the ConnParams
 // and will use the provided stats to collect timing.
 func NewDBConnection(info *mysql.ConnParams, mysqlStats *stats.Timings) (*DBConnection, error) {
+	start := time.Now()
+	defer mysqlStats.Record("Connect", start)
 	params, err := dbconfigs.WithCredentials(info)
 	if err != nil {
 		return nil, err
 	}
 	ctx := context.Background()
 	c, err := mysql.Connect(ctx, &params)
+	if err != nil {
+		mysqlStats.Record("ConnectError", start)
+	}
 	return &DBConnection{c, mysqlStats}, err
 }

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -148,12 +148,12 @@ func testFetch(t *testing.T, conn *mysql.Conn, sql string, expectedRows int) *sq
 func testDML(t *testing.T, conn *mysql.Conn, sql string, expectedNumQueries int64, expectedRowsAffected uint64) {
 	t.Helper()
 
-	numQueries := tabletenv.MySQLStats.Count()
+	numQueries := tabletenv.MySQLStats.Counts()["Exec"]
 	result, err := conn.ExecuteFetch(sql, 1000, false)
 	if err != nil {
 		t.Errorf("error: %v", err)
 	}
-	numQueries = tabletenv.MySQLStats.Count() - numQueries
+	numQueries = tabletenv.MySQLStats.Counts()["Exec"] - numQueries
 
 	if numQueries != expectedNumQueries {
 		t.Errorf("expected %d mysql queries but got %d", expectedNumQueries, numQueries)

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -132,6 +132,16 @@ func (dbc *DBConn) execOnce(ctx context.Context, query string, maxrows int, want
 	dbc.current.Set(query)
 	defer dbc.current.Set("")
 
+	// Check if the context is already past its deadline before
+	// trying to execute the query.
+	if ctx.Done() != nil {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("%v before execution started", ctx.Err())
+		default:
+		}
+	}
+
 	done, wg := dbc.setDeadline(ctx)
 	if done != nil {
 		defer func() {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -134,12 +134,10 @@ func (dbc *DBConn) execOnce(ctx context.Context, query string, maxrows int, want
 
 	// Check if the context is already past its deadline before
 	// trying to execute the query.
-	if ctx.Done() != nil {
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("%v before execution started", ctx.Err())
-		default:
-		}
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("%v before execution started", ctx.Err())
+	default:
 	}
 
 	done, wg := dbc.setDeadline(ctx)

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -31,11 +31,23 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
+
+func compareTimingCounts(t *testing.T, op string, delta int64, before, after map[string]int64) {
+	t.Helper()
+	countBefore := before[op]
+	countAfter := after[op]
+	if countAfter-countBefore != delta {
+		t.Errorf("Expected %s to increase by %d, got %d (%d => %d)", op, delta, countAfter-countBefore, countBefore, countAfter)
+	}
+}
 
 func TestDBConnExec(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
+	startCounts := tabletenv.MySQLStats.Counts()
+
 	sql := "select * from test_table limit 1000"
 	expectedResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -66,7 +78,13 @@ func TestDBConnExec(t *testing.T) {
 	if !reflect.DeepEqual(expectedResult, result) {
 		t.Errorf("Exec: %v, want %v", expectedResult, result)
 	}
-	// Exec fail
+
+	compareTimingCounts(t, "Connect", 1, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "Exec", 1, startCounts, tabletenv.MySQLStats.Counts())
+
+	startCounts = tabletenv.MySQLStats.Counts()
+
+	// Exec fail due to client side error
 	db.AddRejectedQuery(sql, &mysql.SQLError{
 		Num:     2012,
 		Message: "connection fail",
@@ -77,6 +95,26 @@ func TestDBConnExec(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Exec: %v, want %s", err, want)
 	}
+
+	// The client side error triggers a retry in exec.
+	compareTimingCounts(t, "Connect", 1, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "Exec", 2, startCounts, tabletenv.MySQLStats.Counts())
+
+	startCounts = tabletenv.MySQLStats.Counts()
+
+	// Set the connection fail flag and and try again.
+	// This time the initial query fails as does the reconnect attempt.
+	db.EnableConnFail()
+	_, err = dbConn.Exec(ctx, sql, 1, false)
+	want = "packet read failed"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Exec: %v, want %s", err, want)
+	}
+	db.DisableConnFail()
+
+	compareTimingCounts(t, "Connect", 1, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "ConnectError", 1, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "Exec", 1, startCounts, tabletenv.MySQLStats.Counts())
 }
 
 func TestDBConnKill(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -175,6 +175,22 @@ func TestDBConnDeadline(t *testing.T) {
 	compareTimingCounts(t, "ConnectError", 0, startCounts, tabletenv.MySQLStats.Counts())
 	compareTimingCounts(t, "Exec", 1, startCounts, tabletenv.MySQLStats.Counts())
 
+	startCounts = tabletenv.MySQLStats.Counts()
+
+	// Test with just the background context (with no deadline)
+	result, err = dbConn.Exec(context.Background(), sql, 1, false)
+	if err != nil {
+		t.Fatalf("should not get an error, err: %v", err)
+	}
+	expectedResult.Fields = nil
+	if !reflect.DeepEqual(expectedResult, result) {
+		t.Errorf("Exec: %v, want %v", expectedResult, result)
+	}
+
+	compareTimingCounts(t, "Connect", 0, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "ConnectError", 0, startCounts, tabletenv.MySQLStats.Counts())
+	compareTimingCounts(t, "Exec", 1, startCounts, tabletenv.MySQLStats.Counts())
+
 }
 
 func TestDBConnKill(t *testing.T) {


### PR DESCRIPTION
Add a couple of changes to improve visibility and robustness on the vttablet => mysql connection handling.

1. Add timing stats for successful / failed calls to Connect to mysql.

In order to better monitor how many times the tablet creates a new mysql connection and how long these attempts take, add another call to measure the timings of each Connect operation in the dbconn wrapper.

Additionally record the timings and associated counts for any times
when the connection to mysql fails to execute the handshake.

2. Check that the context deadline hasn't expired before running a query

If the context deadline expires before the query has a chance to execute, the query killer will terminate the connection immediately after sending the query to mysql.

Instead, add a check at the start of dbConn.execOnce and fail the query immediately if the context is already past the deadline.