### PR TITLE
[MySQL] Fix EOFPacket handling for queries

### DIFF
--- a/go/mysql/endtoend/main_test.go
+++ b/go/mysql/endtoend/main_test.go
@@ -163,6 +163,14 @@ ssl-key=%v/server-key.pem
 			return 1
 		}
 
+		// For LargeQuery tests
+		cnf = "max_allowed_packet=100M\n"
+		maxPacketMyCnf := path.Join(root, "max_packet.cnf")
+		if err := ioutil.WriteFile(maxPacketMyCnf, []byte(cnf), os.ModePerm); err != nil {
+			fmt.Fprintf(os.Stderr, "ioutil.WriteFile(%v) failed: %v", maxPacketMyCnf, err)
+			return 1
+		}
+
 		// Launch MySQL.
 		// We need a Keyspace in the topology, so the DbName is set.
 		// We need a Shard too, so the database 'vttest' is created.
@@ -181,7 +189,7 @@ ssl-key=%v/server-key.pem
 				},
 			},
 			OnlyMySQL:  true,
-			ExtraMyCnf: []string{extraMyCnf},
+			ExtraMyCnf: []string{extraMyCnf, maxPacketMyCnf},
 		}
 		cluster := vttest.LocalCluster{
 			Config: cfg,

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -154,7 +154,7 @@ func (env *LocalTestEnv) MySQLManager(mycnf []string, snapshot string) (MySQLMan
 		InitFile:  path.Join(os.Getenv("VTTOP"), "config/init_db.sql"),
 		Directory: env.TmpPath,
 		Port:      env.PortForProtocol("mysql", ""),
-		MyCnf:     append(mycnf, env.DefaultMyCnf...),
+		MyCnf:     append(env.DefaultMyCnf, mycnf...),
 		Env:       env.EnvVars(),
 	}, nil
 }


### PR DESCRIPTION
Per https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html, an
EOF is only an EOF if it is < 9 bytes long. Otherwise it's a length
encoded integer (which typically precedes a length-encoded string:
https://dev.mysql.com/doc/internals/en/string.html#packet-Protocol::LengthEncodedString).

Resolves #3934 

Signed-off-by: Daniel Tahara <tahara@dropbox.com>