### PR TITLE
Add support for gRPC Prometheus monitoring

### DIFF
--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
+
 	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/vttls"
 
@@ -59,6 +61,12 @@ func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.Clie
 			log.Fatalf("There was an error initializing client grpc.DialOption: %v", err)
 		}
 	}
+
+	if *grpccommon.EnableGRPCPrometheus {
+		newopts = append(newopts, grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor))
+		newopts = append(newopts, grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor))
+	}
+
 	return grpc.Dial(target, newopts...)
 }
 

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -32,6 +32,9 @@ var (
 	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
 	// EnableTracing sets a flag to enable grpc client/server tracing.
 	EnableTracing = flag.Bool("grpc_enable_tracing", false, "Enable GRPC tracing")
+
+	// EnableGRPCPrometheus sets a flag to enable grpc client/server grpc monitoring.
+	EnableGRPCPrometheus = flag.Bool("grpc_prometheus", false, "Enable gRPC monitoring with Prometheus")
 )
 
 var enableTracing sync.Once

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -27,6 +27,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/keepalive"
 	"vitess.io/vitess/go/vt/grpccommon"
@@ -145,10 +147,18 @@ func createGRPCServer() {
 		opts = append(opts, grpc.UnaryInterceptor(unaryInterceptor))
 	}
 
+	if *grpccommon.EnableGRPCPrometheus {
+		opts = append(opts, grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor))
+		opts = append(opts, grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor))
+	}
+
 	GRPCServer = grpc.NewServer(opts...)
 }
 
 func serveGRPC() {
+	if *grpccommon.EnableGRPCPrometheus {
+		grpc_prometheus.Register(GRPCServer)
+	}
 	// skip if not registered
 	if GRPCPort == nil || *GRPCPort == 0 {
 		return

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -158,6 +158,7 @@ func createGRPCServer() {
 func serveGRPC() {
 	if *grpccommon.EnableGRPCPrometheus {
 		grpc_prometheus.Register(GRPCServer)
+		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 	// skip if not registered
 	if GRPCPort == nil || *GRPCPort == 0 {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -523,10 +523,10 @@
 			"revisionTime": "2016-09-12T15:30:41Z"
 		},
 		{
-			"checksumSHA1": "OJPSJ4GBgH/XOFtYu2VM1g7rtjk=",
+			"checksumSHA1": "9dP53doJ/haDqTJyD0iuv8g0XFs=",
 			"path": "github.com/grpc-ecosystem/go-grpc-prometheus",
-			"revision": "6b7015e65d366bf3f19b2b2a000a831940f0f7e0",
-			"revisionTime": "2016-09-10T22:24:44Z"
+			"revision": "39de4380c2e0353a115b80b1c730719c79bfb771",
+			"revisionTime": "2018-04-18T17:09:36Z"
 		},
 		{
 			"checksumSHA1": "LoEQ+t5UoMm4InaYVPVn0XqHPwA=",


### PR DESCRIPTION
Adds support for using the gRPC Prometheus metric Go library that exports client & server gRPC metrics to Prometheus. 

It looks like the package was added to the vendor file a while back, but code support for exporting these was never added. 