### PR TITLE
Adds timeout to mysql queries.

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -174,7 +174,9 @@ func (l *Listener) Accept() {
 // handle is called in a go routine for each client connection.
 // FIXME(alainjobart) handle per-connection logs in a way that makes sense.
 func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Time) {
-	conn = netutil.NewConnWithTimeouts(conn, l.connReadTimeout, l.connWriteTimeout)
+	if l.connReadTimeout != 0 || l.connWriteTimeout != 0 {
+		conn = netutil.NewConnWithTimeouts(conn, l.connReadTimeout, l.connWriteTimeout)
+	}
 	c := newConn(conn)
 	c.ConnectionID = connectionID
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -174,9 +174,7 @@ func (l *Listener) Accept() {
 // handle is called in a go routine for each client connection.
 // FIXME(alainjobart) handle per-connection logs in a way that makes sense.
 func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Time) {
-	if l.connReadTimeout != 0 || l.connWriteTimeout != 0 {
-		conn = netutil.NewConnWithTimeouts(conn, l.connReadTimeout, l.connWriteTimeout)
-	}
+	conn = netutil.NewConnWithTimeouts(conn, l.connReadTimeout, l.connWriteTimeout)
 	c := newConn(conn)
 	c.ConnectionID = connectionID
 

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -19,7 +19,6 @@ package vtgate
 import (
 	"flag"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"sync/atomic"
@@ -40,7 +39,6 @@ import (
 )
 
 var (
-	infinity                      = time.Duration(math.MaxInt64)
 	mysqlServerPort               = flag.Int("mysql_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
 	mysqlServerBindAddress        = flag.String("mysql_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
 	mysqlServerSocketPath         = flag.String("mysql_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
@@ -55,9 +53,9 @@ var (
 
 	mysqlSlowConnectWarnThreshold = flag.Duration("mysql_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
 
-	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", infinity, "connection read timeout")
-	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", infinity, "connection write timeout")
-	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", infinity, "mysql query timeout")
+	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", 0, "connection read timeout")
+	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", 0, "connection write timeout")
+	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", 0, "mysql query timeout")
 
 	busyConnections int32
 )
@@ -80,8 +78,14 @@ func (vh *vtgateHandler) NewConnection(c *mysql.Conn) {
 
 func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 	// Rollback if there is an ongoing transaction. Ignore error.
-	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
-	defer cancel()
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if *mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 	session, _ := c.ClientData.(*vtgatepb.Session)
 	if session != nil {
 		if session.InTransaction {
@@ -92,8 +96,14 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
 func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
-	defer cancel()
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if *mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 
 	// Fill in the ImmediateCallerID with the UserData returned by
 	// the AuthServer plugin for that user. If nothing was

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -19,9 +19,11 @@ package vtqueryserver
 import (
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"syscall"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -37,6 +39,7 @@ import (
 )
 
 var (
+	infinity                      = time.Duration(math.MaxInt64)
 	mysqlServerPort               = flag.Int("mysqlproxy_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
 	mysqlServerBindAddress        = flag.String("mysqlproxy_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
 	mysqlServerSocketPath         = flag.String("mysqlproxy_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
@@ -49,8 +52,9 @@ var (
 
 	mysqlSlowConnectWarnThreshold = flag.Duration("mysqlproxy_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
 
-	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", 0, "connection read timeout")
-	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", 0, "connection write timeout")
+	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", infinity, "connection read timeout")
+	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", infinity, "connection write timeout")
+	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", infinity, "mysql query timeout")
 )
 
 // proxyHandler implements the Listener interface.
@@ -71,7 +75,8 @@ func (mh *proxyHandler) NewConnection(c *mysql.Conn) {
 
 func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 	// Rollback if there is an ongoing transaction. Ignore error.
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+	defer cancel()
 	session, _ := c.ClientData.(*mysqlproxy.ProxySession)
 	if session != nil && session.TransactionID != 0 {
 		_ = mh.mp.Rollback(ctx, session)
@@ -79,8 +84,8 @@ func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
 func (mh *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	// FIXME(alainjobart): Add some kind of timeout to the context.
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+	defer cancel()
 
 	// Fill in the ImmediateCallerID with the UserData returned by
 	// the AuthServer plugin for that user. If nothing was

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -19,11 +19,9 @@ package vtqueryserver
 import (
 	"flag"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"syscall"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -39,7 +37,6 @@ import (
 )
 
 var (
-	infinity                      = time.Duration(math.MaxInt64)
 	mysqlServerPort               = flag.Int("mysqlproxy_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
 	mysqlServerBindAddress        = flag.String("mysqlproxy_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
 	mysqlServerSocketPath         = flag.String("mysqlproxy_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
@@ -52,9 +49,9 @@ var (
 
 	mysqlSlowConnectWarnThreshold = flag.Duration("mysqlproxy_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
 
-	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", infinity, "connection read timeout")
-	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", infinity, "connection write timeout")
-	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", infinity, "mysql query timeout")
+	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", 0, "connection read timeout")
+	mysqlConnWriteTimeout = flag.Duration("mysql_server_write_timeout", 0, "connection write timeout")
+	mysqlQueryTimeout     = flag.Duration("mysql_server_query_timeout", 0, "mysql query timeout")
 )
 
 // proxyHandler implements the Listener interface.
@@ -75,8 +72,14 @@ func (mh *proxyHandler) NewConnection(c *mysql.Conn) {
 
 func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 	// Rollback if there is an ongoing transaction. Ignore error.
-	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
-	defer cancel()
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if *mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 	session, _ := c.ClientData.(*mysqlproxy.ProxySession)
 	if session != nil && session.TransactionID != 0 {
 		_ = mh.mp.Rollback(ctx, session)
@@ -84,9 +87,14 @@ func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
 func (mh *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), *mysqlQueryTimeout)
-	defer cancel()
-
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if *mysqlQueryTimeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 	// Fill in the ImmediateCallerID with the UserData returned by
 	// the AuthServer plugin for that user. If nothing was
 	// returned, use the User. This lets the plugin map a MySQL


### PR DESCRIPTION
### Description

*  Adds options to add a query timeout in mysql server plugin.
* ~Also, it refactors default value to use infinity instead of setting to 0. I've
  seeing this pattern in gRPC codebase and I think is more succint. We don't
  need to special case "0"~

### Tests

* Added integration test. 

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>