### PR TITLE
jdbc: set type of BigInteger as VARCHAR

### DIFF
--- a/java/client/src/main/java/io/vitess/client/Proto.java
+++ b/java/client/src/main/java/io/vitess/client/Proto.java
@@ -300,9 +300,12 @@ public class Proto {
         this.type = Query.Type.VARBINARY;
         this.value = ByteString.copyFrom((byte[]) value);
       } else if (value instanceof Integer || value instanceof Long || value instanceof Short
-          || value instanceof Byte || value instanceof BigInteger) {
+          || value instanceof Byte ) {
         // Int32, Int64, Short, Byte
         this.type = Query.Type.INT64;
+        this.value = ByteString.copyFromUtf8(value.toString());
+      } else if (value instanceof BigInteger) {
+        this.type = Query.Type.UINT64;
         this.value = ByteString.copyFromUtf8(value.toString());
       } else if (value instanceof UnsignedLong) {
         // Uint64

--- a/java/client/src/main/java/io/vitess/client/Proto.java
+++ b/java/client/src/main/java/io/vitess/client/Proto.java
@@ -305,7 +305,7 @@ public class Proto {
         this.type = Query.Type.INT64;
         this.value = ByteString.copyFromUtf8(value.toString());
       } else if (value instanceof BigInteger) {
-        this.type = Query.Type.UINT64;
+        this.type = Query.Type.VARCHAR;
         this.value = ByteString.copyFromUtf8(value.toString());
       } else if (value instanceof UnsignedLong) {
         // Uint64

--- a/java/client/src/test/java/io/vitess/client/BindVarTest.java
+++ b/java/client/src/test/java/io/vitess/client/BindVarTest.java
@@ -118,7 +118,7 @@ public class BindVarTest {
             BindVariable.newBuilder().setType(Query.Type.DECIMAL)
                 .setValue(ByteString.copyFromUtf8("0.000000000123456789123456789")).build()},
         {new BigInteger("123456789123456789"),
-            BindVariable.newBuilder().setType(Query.Type.UINT64)
+            BindVariable.newBuilder().setType(Query.Type.VARCHAR)
                 .setValue(ByteString.copyFromUtf8("123456789123456789")).build()},
         // List of Int
         {Arrays.asList(1, 2, 3),

--- a/java/client/src/test/java/io/vitess/client/BindVarTest.java
+++ b/java/client/src/test/java/io/vitess/client/BindVarTest.java
@@ -118,7 +118,7 @@ public class BindVarTest {
             BindVariable.newBuilder().setType(Query.Type.DECIMAL)
                 .setValue(ByteString.copyFromUtf8("0.000000000123456789123456789")).build()},
         {new BigInteger("123456789123456789"),
-            BindVariable.newBuilder().setType(Query.Type.INT64)
+            BindVariable.newBuilder().setType(Query.Type.UINT64)
                 .setValue(ByteString.copyFromUtf8("123456789123456789")).build()},
         // List of Int
         {Arrays.asList(1, 2, 3),


### PR DESCRIPTION
Signed-off-by: Alex Charis <acharis@hubspot.com>