### PR TITLE
mysqlctl and binlog fixes

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -119,6 +119,9 @@ type BinlogEvent interface {
 	// checksum stripped off, if any. If there is no checksum, it returns
 	// the same event and a nil checksum.
 	StripChecksum(BinlogFormat) (ev BinlogEvent, checksum []byte, err error)
+
+	// IsPseudo is for custom implemetations of GTID.
+	IsPseudo() bool
 }
 
 // BinlogFormat contains relevant data from the FORMAT_DESCRIPTION_EVENT.

--- a/go/mysql/binlog_event_common.go
+++ b/go/mysql/binlog_event_common.go
@@ -161,6 +161,11 @@ func (ev binlogEvent) IsDeleteRows() bool {
 		ev.Type() == eDeleteRowsEventV2
 }
 
+// IsPseudo is always false for a native binlogEvent.
+func (ev binlogEvent) IsPseudo() bool {
+	return false
+}
+
 // Format implements BinlogEvent.Format().
 //
 // Expected format (L = total length of event data):

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -42,6 +42,12 @@ type flavor interface {
 	// masterGTIDSet returns the current GTIDSet of a server.
 	masterGTIDSet(c *Conn) (GTIDSet, error)
 
+	// startSlave returns the command to start the slave.
+	startSlaveCommand() string
+
+	// stopSlave returns the command to stop the slave.
+	stopSlaveCommand() string
+
 	// sendBinlogDumpCommand sends the packet required to start
 	// dumping binlogs from the specified location.
 	sendBinlogDumpCommand(c *Conn, slaveID uint32, startPos Position) error
@@ -135,6 +141,16 @@ func (c *Conn) MasterPosition() (Position, error) {
 	return Position{
 		GTIDSet: gtidSet,
 	}, nil
+}
+
+// StartSlaveCommand returns the command to start the slave.
+func (c *Conn) StartSlaveCommand() string {
+	return c.flavor.startSlaveCommand()
+}
+
+// StopSlaveCommand returns the command to stop the slave.
+func (c *Conn) StopSlaveCommand() string {
+	return c.flavor.stopSlaveCommand()
 }
 
 // SendBinlogDumpCommand sends the flavor-specific version of

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -40,6 +40,14 @@ func (mariadbFlavor) masterGTIDSet(c *Conn) (GTIDSet, error) {
 	return parseMariadbGTIDSet(qr.Rows[0][0].ToString())
 }
 
+func (mariadbFlavor) startSlaveCommand() string {
+	return "START SLAVE"
+}
+
+func (mariadbFlavor) stopSlaveCommand() string {
+	return "STOP SLAVE"
+}
+
 // sendBinlogDumpCommand is part of the Flavor interface.
 func (mariadbFlavor) sendBinlogDumpCommand(c *Conn, slaveID uint32, startPos Position) error {
 	// Tell the server that we understand GTIDs by setting our slave

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -19,6 +19,7 @@ package mysql
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"golang.org/x/net/context"
@@ -156,7 +157,17 @@ func (mariadbFlavor) waitUntilPositionCommand(ctx context.Context, pos Position)
 	return fmt.Sprintf("SELECT MASTER_GTID_WAIT('%s')", pos), nil
 }
 
-// makeBinlogEvent is part of the Flavor interface.
-func (mariadbFlavor) makeBinlogEvent(buf []byte) BinlogEvent {
-	return NewMariadbBinlogEvent(buf)
+// readBinlogEvent is part of the Flavor interface.
+func (mariadbFlavor) readBinlogEvent(c *Conn) (BinlogEvent, error) {
+	result, err := c.ReadPacket()
+	if err != nil {
+		return nil, err
+	}
+	switch result[0] {
+	case EOFPacket:
+		return nil, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", io.EOF)
+	case ErrPacket:
+		return nil, ParseErrorPacket(result)
+	}
+	return NewMariadbBinlogEvent(result[1:]), nil
 }

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -38,6 +38,14 @@ func (mysqlFlavor) masterGTIDSet(c *Conn) (GTIDSet, error) {
 	return parseMysql56GTIDSet(qr.Rows[0][0].ToString())
 }
 
+func (mysqlFlavor) startSlaveCommand() string {
+	return "START SLAVE"
+}
+
+func (mysqlFlavor) stopSlaveCommand() string {
+	return "STOP SLAVE"
+}
+
 // sendBinlogDumpCommand is part of the Flavor interface.
 func (mysqlFlavor) sendBinlogDumpCommand(c *Conn, slaveID uint32, startPos Position) error {
 	gtidSet, ok := startPos.GTIDSet.(Mysql56GTIDSet)

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -299,7 +299,7 @@ func backup(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger, bh b
 			return false, fmt.Errorf("can't get master position: %v", err)
 		}
 	} else {
-		if err = StopSlave(mysqld, hookExtraEnv); err != nil {
+		if err = mysqld.StopSlave(hookExtraEnv); err != nil {
 			return false, fmt.Errorf("can't stop slave: %v", err)
 		}
 		var slaveStatus mysql.SlaveStatus
@@ -345,7 +345,7 @@ func backup(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger, bh b
 	}
 	if slaveStartRequired {
 		logger.Infof("restarting mysql replication")
-		if err := StartSlave(mysqld, hookExtraEnv); err != nil {
+		if err := mysqld.StartSlave(hookExtraEnv); err != nil {
 			return usable, fmt.Errorf("cannot restart slave: %v", err)
 		}
 

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -245,6 +245,20 @@ func (fmd *FakeMysqlDaemon) SetReadOnly(on bool) error {
 	return nil
 }
 
+// StartSlave is part of the MysqlDaemon interface.
+func (fmd *FakeMysqlDaemon) StartSlave(hookExtraEnv map[string]string) error {
+	return fmd.ExecuteSuperQueryList(context.Background(), []string{
+		"START SLAVE",
+	})
+}
+
+// StopSlave is part of the MysqlDaemon interface.
+func (fmd *FakeMysqlDaemon) StopSlave(hookExtraEnv map[string]string) error {
+	return fmd.ExecuteSuperQueryList(context.Background(), []string{
+		"STOP SLAVE",
+	})
+}
+
 // SetSlavePosition is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) SetSlavePosition(ctx context.Context, pos mysql.Position) error {
 	if !reflect.DeepEqual(fmd.SetSlavePositionPos, pos) {
@@ -263,11 +277,11 @@ func (fmd *FakeMysqlDaemon) SetMaster(ctx context.Context, masterHost string, ma
 	}
 	cmds := []string{}
 	if slaveStopBefore {
-		cmds = append(cmds, mysqlctl.SQLStopSlave)
+		cmds = append(cmds, "STOP SLAVE")
 	}
 	cmds = append(cmds, "FAKE SET MASTER")
 	if slaveStartAfter {
-		cmds = append(cmds, mysqlctl.SQLStartSlave)
+		cmds = append(cmds, "START SLAVE")
 	}
 	return fmd.ExecuteSuperQueryList(ctx, cmds)
 }
@@ -320,9 +334,9 @@ func (fmd *FakeMysqlDaemon) ExecuteSuperQueryList(ctx context.Context, queryList
 
 		// intercept some queries to update our status
 		switch query {
-		case mysqlctl.SQLStartSlave:
+		case "START SLAVE":
 			fmd.Replicating = true
-		case mysqlctl.SQLStopSlave:
+		case "STOP SLAVE":
 			fmd.Replicating = false
 		}
 	}

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -46,6 +46,8 @@ type MysqlDaemon interface {
 	GetMysqlPort() (int32, error)
 
 	// replication related methods
+	StartSlave(hookExtraEnv map[string]string) error
+	StopSlave(hookExtraEnv map[string]string) error
 	SlaveStatus() (mysql.SlaveStatus, error)
 	SetSemiSyncEnabled(master, slave bool) error
 	SemiSyncEnabled() (master, slave bool)

--- a/go/vt/vttablet/tabletmanager/binlog_players_test.go
+++ b/go/vt/vttablet/tabletmanager/binlog_players_test.go
@@ -370,9 +370,9 @@ func TestBinlogPlayerMapHorizontalSplit(t *testing.T) {
 		sql[0] != "SELECT pos, flags FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 		sql[1] != "SELECT max_tps, max_replication_lag FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 		sql[2] != "BEGIN" ||
-		!strings.HasPrefix(sql[3], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
-		!strings.HasSuffix(sql[3], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
-		sql[4] != "INSERT INTO tablet VALUES(1)" ||
+		sql[3] != "INSERT INTO tablet VALUES(1)" ||
+		!strings.HasPrefix(sql[4], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
+		!strings.HasSuffix(sql[4], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
 		sql[5] != "COMMIT" {
 		t.Errorf("Got wrong SQL: %#v", sql)
 	}
@@ -570,9 +570,9 @@ func TestBinlogPlayerMapHorizontalSplitStopStartUntil(t *testing.T) {
 			sql[2] != "SELECT pos, flags FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 			sql[3] != "SELECT max_tps, max_replication_lag FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 			sql[4] != "BEGIN" ||
-			!strings.HasPrefix(sql[5], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
-			!strings.HasSuffix(sql[5], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
-			sql[6] != "INSERT INTO tablet VALUES(1)" ||
+			sql[5] != "INSERT INTO tablet VALUES(1)" ||
+			!strings.HasPrefix(sql[6], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
+			!strings.HasSuffix(sql[6], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
 			sql[7] != "COMMIT" {
 			t.Errorf("Got wrong SQL: %#v", sql)
 		}
@@ -756,9 +756,9 @@ func TestBinlogPlayerMapVerticalSplit(t *testing.T) {
 		sql[0] != "SELECT pos, flags FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 		sql[1] != "SELECT max_tps, max_replication_lag FROM _vt.blp_checkpoint WHERE source_shard_uid=1" ||
 		sql[2] != "BEGIN" ||
-		!strings.HasPrefix(sql[3], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
-		!strings.HasSuffix(sql[3], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
-		sql[4] != "INSERT INTO tablet VALUES(1)" ||
+		sql[3] != "INSERT INTO tablet VALUES(1)" ||
+		!strings.HasPrefix(sql[4], "UPDATE _vt.blp_checkpoint SET pos='MariaDB/0-1-1235', time_updated=") ||
+		!strings.HasSuffix(sql[4], ", transaction_timestamp=72 WHERE source_shard_uid=1") ||
 		sql[5] != "COMMIT" {
 		t.Errorf("Got wrong SQL: %#v", sql)
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -84,7 +84,7 @@ func (agent *ActionAgent) stopSlaveLocked(ctx context.Context) error {
 		}
 	}()
 
-	return mysqlctl.StopSlave(agent.MysqlDaemon, agent.hookExtraEnv())
+	return agent.MysqlDaemon.StopSlave(agent.hookExtraEnv())
 }
 
 // StopSlaveMinimum will stop the slave after it reaches at least the
@@ -139,7 +139,7 @@ func (agent *ActionAgent) StartSlave(ctx context.Context) error {
 	if err := agent.fixSemiSync(agent.Tablet().Type); err != nil {
 		return err
 	}
-	return mysqlctl.StartSlave(agent.MysqlDaemon, agent.hookExtraEnv())
+	return agent.MysqlDaemon.StartSlave(agent.hookExtraEnv())
 }
 
 // GetSlaves returns the address of all the slaves
@@ -644,10 +644,10 @@ func (agent *ActionAgent) fixSemiSyncAndReplication(tabletType topodatapb.Tablet
 
 	// We need to restart replication
 	log.Infof("Restarting replication for semi-sync flag change to take effect from %v to %v", acking, shouldAck)
-	if err := mysqlctl.StopSlave(agent.MysqlDaemon, agent.hookExtraEnv()); err != nil {
+	if err := agent.MysqlDaemon.StopSlave(agent.hookExtraEnv()); err != nil {
 		return fmt.Errorf("failed to StopSlave: %v", err)
 	}
-	if err := mysqlctl.StartSlave(agent.MysqlDaemon, agent.hookExtraEnv()); err != nil {
+	if err := agent.MysqlDaemon.StartSlave(agent.hookExtraEnv()); err != nil {
 		return fmt.Errorf("failed to StartSlave: %v", err)
 	}
 	return nil


### PR DESCRIPTION
The purpose of these changes is to be more versatile about supporting various mysql instances. There are many new requests coming in: RDS, CloudSQL, XtraDB, pseudo-GTID. This requires us to tighten the abstractions. This is the first step. More may be on the way.

Part 1: improved flavor abstraction

START and STOP SLAVE commands are not applicable to all
flavors of mysql. In RDS, these are achieved through stored
procedure calls. So, it's better to make these flavor-specific.

The change also required me to move the global StartSlave and
StopSlave functions into mysqld.

Part 2: improved SlaveConnection

Code in SlaveConnection has been simplified by changing how
it interacts with the underlying connection and flavors.
The logic that handles read packet is combined with the logic
that builds the binlog event.

Also refactored StartBinlogDumpFromBinlogBeforeTimestamp to
be more robust and readable, and it reuses the event loop
of the other functions.

This change will also be better for integrating with other
systems like RDS where we need to keep track of file position.

Part 3: Misc blp fixes
* Recovery position must be updated only after successful write.
  Otherwise, the internal blp.position which makes things inconsistent.
* If processTransaction fails, log the statements to help with
  troubleshooting.
* getPoolReconnect had a code path where it would lose a connection
  without returning it, which would cause it to eternally hang on
  shutdown.

Part 4: Pseudo GTID handling

Not all systems support GTID. For those that don't we need a way
to emulate it. For such cases, we create the pseudo gtid code path.