### PR TITLE
Fix issue with tablet_template_url in HealthCheck

### DIFF
--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -86,6 +86,7 @@ func main() {
 	vtg := vtgate.Init(context.Background(), healthCheck, resilientServer, *cell, *retryCount, tabletTypes)
 
 	servenv.OnRun(func() {
+		discovery.LoadHealthCheckTabletURLTemplate()
 		addStatusParts(vtg)
 	})
 	servenv.RunDefault()

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -86,7 +86,8 @@ func main() {
 	vtg := vtgate.Init(context.Background(), healthCheck, resilientServer, *cell, *retryCount, tabletTypes)
 
 	servenv.OnRun(func() {
-		discovery.LoadHealthCheckTabletURLTemplate()
+		// Flags are parsed now. Parse the template using the actual flag value and overwrite the current template.
+		discovery.ParseTabletURLTemplateFromFlag()
 		addStatusParts(vtg)
 	})
 	servenv.RunDefault()

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -120,12 +120,11 @@ const (
 )
 
 func init() {
-	loadTabletURLTemplate()
+	LoadHealthCheckTabletURLTemplate()
 }
 
-// loadTabletURLTemplate loads or reloads the URL template.
-// Should only be used independently for testing.
-func loadTabletURLTemplate() {
+// LoadHealthCheckTabletURLTemplate loads or reloads the URL template.
+func LoadHealthCheckTabletURLTemplate() {
 	tabletURLTemplate = template.New("")
 	_, err := tabletURLTemplate.Parse(*tabletURLTemplateString)
 	if err != nil {

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -120,11 +120,12 @@ const (
 )
 
 func init() {
-	LoadHealthCheckTabletURLTemplate()
+	// Flags are not parsed at this point and the default value of the flag (just the hostname) will be used.
+	ParseTabletURLTemplateFromFlag()
 }
 
-// LoadHealthCheckTabletURLTemplate loads or reloads the URL template.
-func LoadHealthCheckTabletURLTemplate() {
+// ParseTabletURLTemplateFromFlag loads or reloads the URL template.
+func ParseTabletURLTemplateFromFlag() {
 	tabletURLTemplate = template.New("")
 	_, err := tabletURLTemplate.Parse(*tabletURLTemplateString)
 	if err != nil {

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -574,7 +574,7 @@ func TestTemplate(t *testing.T) {
 
 func TestDebugURLFormatting(t *testing.T) {
 	flag.Set("tablet_url_template", "https://{{.GetHostNameLevel 0}}.bastion.{{.Tablet.Alias.Cell}}.corp")
-	LoadHealthCheckTabletURLTemplate()
+	ParseTabletURLTemplateFromFlag()
 
 	tablet := topo.NewTablet(0, "cell", "host.dc.domain")
 	ts := []*TabletStats{

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -574,7 +574,7 @@ func TestTemplate(t *testing.T) {
 
 func TestDebugURLFormatting(t *testing.T) {
 	flag.Set("tablet_url_template", "https://{{.GetHostNameLevel 0}}.bastion.{{.Tablet.Alias.Cell}}.corp")
-	loadTabletURLTemplate()
+	LoadHealthCheckTabletURLTemplate()
 
 	tablet := topo.NewTablet(0, "cell", "host.dc.domain")
 	ts := []*TabletStats{


### PR DESCRIPTION
### Description 
* We were trying to use feature https://github.com/vitessio/vitess/pull/3842, but noticed that it was always using the default template. I think it's because flag is not parsed yet when `init()` is called. 
* The following makes template loader public so it can be called when starting vtgate.

### Tests

* Tested locally. 