### PR TITLE
Topology watcher refreshKnownTablets option

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -88,11 +88,20 @@ func (c *counters) Add(name string, value int64) {
 	atomic.AddInt64(a, value)
 }
 
-// ResetAll resets all counter values.
+// ResetAll resets all counter values and clears all keys.
 func (c *counters) ResetAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.counts = make(map[string]*int64)
+}
+
+// ZeroAll resets all counter values to zero
+func (c *counters) ZeroAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, a := range c.counts {
+		atomic.StoreInt64(a, int64(0))
+	}
 }
 
 // Reset resets a specific counter value to 0.

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -65,8 +65,8 @@ type TabletRecorder interface {
 
 // NewCellTabletsWatcher returns a TopologyWatcher that monitors all
 // the tablets in a cell, and starts refreshing.
-func NewCellTabletsWatcher(topoServer *topo.Server, tr TabletRecorder, cell string, refreshInterval time.Duration, topoReadConcurrency int) *TopologyWatcher {
-	return NewTopologyWatcher(topoServer, tr, cell, refreshInterval, topoReadConcurrency, func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error) {
+func NewCellTabletsWatcher(topoServer *topo.Server, tr TabletRecorder, cell string, refreshInterval time.Duration, refreshKnownTablets bool, topoReadConcurrency int) *TopologyWatcher {
+	return NewTopologyWatcher(topoServer, tr, cell, refreshInterval, refreshKnownTablets, topoReadConcurrency, func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error) {
 		return tw.topoServer.GetTabletsByCell(tw.ctx, tw.cell)
 	})
 }
@@ -74,7 +74,7 @@ func NewCellTabletsWatcher(topoServer *topo.Server, tr TabletRecorder, cell stri
 // NewShardReplicationWatcher returns a TopologyWatcher that
 // monitors the tablets in a cell/keyspace/shard, and starts refreshing.
 func NewShardReplicationWatcher(topoServer *topo.Server, tr TabletRecorder, cell, keyspace, shard string, refreshInterval time.Duration, topoReadConcurrency int) *TopologyWatcher {
-	return NewTopologyWatcher(topoServer, tr, cell, refreshInterval, topoReadConcurrency, func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error) {
+	return NewTopologyWatcher(topoServer, tr, cell, refreshInterval, true /* refreshKnownTablets */, topoReadConcurrency, func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error) {
 		sri, err := tw.topoServer.GetShardReplication(tw.ctx, tw.cell, keyspace, shard)
 		switch err {
 		case nil:
@@ -106,14 +106,15 @@ type tabletInfo struct {
 // the TabletRecorder AddTablet / RemoveTablet interface appropriately.
 type TopologyWatcher struct {
 	// set at construction time
-	topoServer      *topo.Server
-	tr              TabletRecorder
-	cell            string
-	refreshInterval time.Duration
-	getTablets      func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error)
-	sem             chan int
-	ctx             context.Context
-	cancelFunc      context.CancelFunc
+	topoServer          *topo.Server
+	tr                  TabletRecorder
+	cell                string
+	refreshInterval     time.Duration
+	refreshKnownTablets bool
+	getTablets          func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error)
+	sem                 chan int
+	ctx                 context.Context
+	cancelFunc          context.CancelFunc
 	// wg keeps track of all launched Go routines.
 	wg sync.WaitGroup
 
@@ -128,15 +129,16 @@ type TopologyWatcher struct {
 
 // NewTopologyWatcher returns a TopologyWatcher that monitors all
 // the tablets in a cell, and starts refreshing.
-func NewTopologyWatcher(topoServer *topo.Server, tr TabletRecorder, cell string, refreshInterval time.Duration, topoReadConcurrency int, getTablets func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error)) *TopologyWatcher {
+func NewTopologyWatcher(topoServer *topo.Server, tr TabletRecorder, cell string, refreshInterval time.Duration, refreshKnownTablets bool, topoReadConcurrency int, getTablets func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error)) *TopologyWatcher {
 	tw := &TopologyWatcher{
-		topoServer:      topoServer,
-		tr:              tr,
-		cell:            cell,
-		refreshInterval: refreshInterval,
-		getTablets:      getTablets,
-		sem:             make(chan int, topoReadConcurrency),
-		tablets:         make(map[string]*tabletInfo),
+		topoServer:          topoServer,
+		tr:                  tr,
+		cell:                cell,
+		refreshInterval:     refreshInterval,
+		refreshKnownTablets: refreshKnownTablets,
+		getTablets:          getTablets,
+		sem:                 make(chan int, topoReadConcurrency),
+		tablets:             make(map[string]*tabletInfo),
 	}
 	tw.firstLoadChan = make(chan struct{})
 	tw.ctx, tw.cancelFunc = context.WithCancel(context.Background())
@@ -178,7 +180,17 @@ func (tw *TopologyWatcher) loadTablets() {
 		log.Errorf("cannot get tablets for cell: %v: %v", tw.cell, err)
 		return
 	}
+
+	tw.mu.Lock()
 	for _, tAlias := range tabletAliases {
+		if !tw.refreshKnownTablets {
+			aliasStr := topoproto.TabletAliasString(tAlias)
+			if val, ok := tw.tablets[aliasStr]; ok {
+				newTablets[aliasStr] = val
+				continue
+			}
+		}
+
 		wg.Add(1)
 		go func(alias *topodatapb.TabletAlias) {
 			defer wg.Done()
@@ -207,6 +219,7 @@ func (tw *TopologyWatcher) loadTablets() {
 		}(tAlias)
 	}
 
+	tw.mu.Unlock()
 	wg.Wait()
 	tw.mu.Lock()
 

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -139,7 +139,7 @@ func checkWatcher(t *testing.T, cellTablets bool) {
 		t.Fatalf("UpdateTabletFields failed: %v", err)
 	}
 	tw.loadTablets()
-	counts = checkOpCounts(t, tw, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "AddTablet": 1, "RemoveTablet": 1})
+	counts = checkOpCounts(t, tw, counts, map[string]int64{"ListTablets": 1, "GetTablet": 2, "ReplaceTablet": 1})
 
 	allTablets = fhc.GetAllTablets()
 	key = TabletToMapKey(tablet)

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -46,6 +46,7 @@ var (
 	cellsToWatch        = flag.String("cells_to_watch", "", "comma-separated list of cells for watching tablets")
 	tabletFilters       flagutil.StringListValue
 	refreshInterval     = flag.Duration("tablet_refresh_interval", 1*time.Minute, "tablet refresh interval")
+	refreshKnownTablets = flag.Bool("tablet_refresh_known_tablets", true, "tablet refresh reloads the tablet address/port map from topo in case it changes")
 	topoReadConcurrency = flag.Int("topo_read_concurrency", 32, "concurrent topo reads")
 	allowedTabletTypes  []topodatapb.TabletType
 )
@@ -116,7 +117,7 @@ func createDiscoveryGateway(hc discovery.HealthCheck, serv srvtopo.Server, cell 
 			tr = fbs
 		}
 
-		ctw := discovery.NewCellTabletsWatcher(topoServer, tr, c, *refreshInterval, *topoReadConcurrency)
+		ctw := discovery.NewCellTabletsWatcher(topoServer, tr, c, *refreshInterval, *refreshKnownTablets, *topoReadConcurrency)
 		dg.tabletsWatchers = append(dg.tabletsWatchers, ctw)
 	}
 	dg.QueryService = queryservice.Wrap(nil, dg.withRetry)


### PR DESCRIPTION
# Overview
Adds an option to the topology watcher to reduce the topo k/v polling load in environments where the tablets never change their address/port information once launched.

# Motivation
The TopologyWatcher module in vtgate is responsible for periodically checking the topo service to find out whether new tablets have been provisioned so that HealthCheck can be notified.

To support environments in which the tablet may change address/port information, i.e. when the association between a tablet alias and the host/port map isn't stable over time, the default behavior gets a list of all the tablet aliases and then re-reads the topo k/v for each tablet.

This operation is by far the majority of the k/v polling load from a vtgate, and as the cluster grows, the rate of k/v requests is `NumVtgates * NumVttablets / PollingInterval`, which grows quickly as the cluster grows.

# Changes
To reduce this load, this PR adds a `refreshKnownTablets` option to the `TopologyWatcher` and a corresponding flag in discovery gateway. The default behavior is unchanged which means that each vtgate will periodically re-read the TabletInfo record for each tablet in case the address/port map changes.

However the new flag can disable these queries for environments in which the association between a tablet alias and the host/port map never changes. This greatly reduces the load on the topo service since most of the k/v requests are for refreshing the TabletInfo and there's no efficient way to watch for this data.

# Testing
I added extensive unit tests for this but have not (yet) verified in a real environment.
