### PR TITLE
Add a label to the tablet_name metric that attaches the human-readable state name

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -250,10 +250,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 		// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
 		// but exported with TabletStateName as a label for Prometheus, which doesn't support exporting strings as stat values.
 		stats.NewGaugesFuncWithMultiLabels("TabletServerState", "Tablet server state labeled by state name", []string{"name"}, func() map[string]int64 {
-			tsv.mu.Lock()
-			state := tsv.state
-			tsv.mu.Unlock()
-			return map[string]int64{stateName[state]: 1}
+			return map[string]int64{tsv.GetState: 1}
 		})
 		stats.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
 		stats.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -247,8 +247,8 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 		})
 		stats.Publish("TabletStateName", stats.StringFunc(tsv.GetState))
 
-		// This is the same information as the above two stats, but exported with TabletStateName as a label for Prometheus
-		// which doesn't support exporting strings as stat values.
+		// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
+		// but exported with TabletStateName as a label for Prometheus, which doesn't support exporting strings as stat values.
 		stats.NewGaugesFuncWithMultiLabels("TabletServerState", "Tablet server state labeled by state name", []string{"name"}, func() map[string]int64 {
 			tsv.mu.Lock()
 			state := tsv.state

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -239,11 +239,11 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	// So that vtcombo doesn't even call it once, on the first tablet.
 	// And we can remove the tsOnce variable.
 	tsOnce.Do(func() {
-		stats.NewGaugeFunc("TabletState", "Tablet server state", func() int64 {
+		stats.NewGaugesFuncWithMultiLabels("TabletState", "Tablet server state", []string{"TabletStateName"}, func() map[string]int64 {
 			tsv.mu.Lock()
 			state := tsv.state
 			tsv.mu.Unlock()
-			return state
+			return map[string]int64{stateName[state]: state}
 		})
 		stats.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
 		stats.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -250,7 +250,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 		// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
 		// but exported with TabletStateName as a label for Prometheus, which doesn't support exporting strings as stat values.
 		stats.NewGaugesFuncWithMultiLabels("TabletServerState", "Tablet server state labeled by state name", []string{"name"}, func() map[string]int64 {
-			return map[string]int64{tsv.GetState: 1}
+			return map[string]int64{tsv.GetState(): 1}
 		})
 		stats.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
 		stats.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)


### PR DESCRIPTION
We have an existing graph and alert, based on our old metrics setup, that checks how many tablets in each cluster are in the SERVING state. 

This is a bit of a hack to allow us to continue to graph one metric per state a shard is in. Even though the value is equivalent to the enum value of the state (aka. SERVING = 2), there's no way to compare against the value of a metric in PromQL, nor is there a way to export a String as a metric. Labeling the metric like this allows us to continue to have this graph/alert. We won't actually use the exported _value_, but we'll just match against occurrences of the labeled metric. 

Open to other suggestions for how to do this...

The outputted metric looks something like this for a SERVING tablet:

```
# TYPE vttablet_tablet_state gauge
vttablet_tablet_state{tablet_state_name="SERVING"} 2
```

The graph I'm trying to support is this one:
<img width="1760" alt="screen shot 2018-05-22 at 11 08 41 am" src="https://user-images.githubusercontent.com/1466845/40381450-8dd139ec-5db0-11e8-9634-3406e481ce96.png">
