### PR TITLE
Prometheus instrumentation for mysqlctld and mysqlctl

### DIFF
--- a/go/cmd/mysqlctl/plugin_prometheusbackend.go
+++ b/go/cmd/mysqlctl/plugin_prometheusbackend.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
+
+import (
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("mysqlctl")
+	})
+}

--- a/go/cmd/mysqlctld/plugin_prometheusbackend.go
+++ b/go/cmd/mysqlctld/plugin_prometheusbackend.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
+
+import (
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("mysqlctld")
+	})
+}


### PR DESCRIPTION
Add prometheus instrumentation for mysqlctld and mysqlctl. 
Issue: https://github.com/vitessio/vitess/issues/3963

Signed-off-by: Roland Rifandi Utama <roland.rutama@gmail.com>