### PR TITLE
Add .github/ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,65 @@
+---
+name: Bug Report
+about: You're experiencing an issue with Vitess that is different than the documented behavior.
+
+---
+
+When filing a bug, please include the following headings if
+possible. Any example text in this template can be deleted.
+
+#### Overview of the Issue
+
+A paragraph or two about the issue you're experiencing.
+
+#### Reproduction Steps
+
+Steps to reproduce this issue, example:
+
+1. Deploy the following `vschema`:
+
+    ```javascript
+    {
+      "sharded": true,
+      "vindexes": {
+        "hash": {
+          "type": "hash"
+        },
+      "tables": {
+        "user": {
+          "column_vindexes": [
+            {
+              "column": "user_id",
+              "name": "hash"
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+1. Deploy the following `schema`:
+
+    ```sql
+    create table user(user_id bigint, name varchar(128), primary key(user_id));
+    ```
+
+1. Run `SELECT...`
+1. View error
+
+#### Binary version
+Example:
+
+```sh
+giaquinti@workspace:~$ vtgate --version
+Version: a95cf5d (Git branch 'HEAD') built on Fri May 18 16:54:26 PDT 2018 by giaquinti@workspace using go1.10 linux/amd64
+```
+
+#### Operating system and Environment details
+
+OS, Architecture, and any other information you can provide
+about the environment.
+
+#### Log Fragments
+
+Include appropriate log fragments. If the log is longer than a few dozen lines, please
+include the URL to the [gist](https://gist.github.com/) of the log instead of posting it in the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: If you have something you think Vitess could improve or add support for.
+
+---
+
+Please search the existing issues for relevant feature requests, and use the [reaction feature](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to add upvotes to pre-existing requests.
+
+#### Feature Description
+
+A written overview of the feature.
+
+#### Use Case(s)
+
+Any relevant use-cases that you see.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: If you have a question, please check out our other community resources instead of opening an issue.
+
+---
+
+Issues on GitHub are intended to be related to bugs or feature requests, so we recommend using our other community resources instead of asking here.
+
+- [Vitess User Guide](https://vitess.io/user-guide/introduction/)
+- Any other questions can be asked in the community [Slack workspace](https://bit.ly/vitess-slack)


### PR DESCRIPTION
GitHub offers the nice functionality of custom [issue templates](https://help.github.com/articles/about-issue-and-pull-request-templates/#issue-templates). 

This PR adds 3 of them:
* bug report
* feature request
* question

I took inspiration for the templates from our friends at HashiCorp. You can see a preview when you try to open an issue in [my fork](https://github.com/guidoiaquinti/vitess/issues).
