### PR TITLE
Adds directive to set timeouts in SELECT queries

### DIFF
--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -43,6 +43,22 @@
   }
 }
 
+# select with timeout directive sets QueryTimeout in the route
+"select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user"
+{
+  "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user",
+    "FieldQuery": "select * from user where 1 != 1",
+    "QueryTimeout": 1000
+  }
+}
+
 # qualified '*' expression for simple route
 "select user.* from user"
 {

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -28,6 +28,8 @@ const (
 	DirectiveMultiShardAutocommit = "MULTI_SHARD_AUTOCOMMIT"
 	// DirectiveSkipQueryPlanCache skips query plan cache when set.
 	DirectiveSkipQueryPlanCache = "SKIP_QUERY_PLAN_CACHE"
+	// DirectiveQueryTimeout sets a query timeout in vtgate. Only supported for SELECTS.
+	DirectiveQueryTimeout = "QUERY_TIMEOUT_MS"
 )
 
 func isNonSpace(r rune) bool {
@@ -219,15 +221,15 @@ func ExtractCommentDirectives(comments Comments) CommentDirectives {
 			strVal := directive[sep+1:]
 			directive = directive[:sep]
 
-			boolVal, err := strconv.ParseBool(strVal)
-			if err == nil {
-				vals[directive] = boolVal
-				continue
-			}
-
 			intVal, err := strconv.Atoi(strVal)
 			if err == nil {
 				vals[directive] = intVal
+				continue
+			}
+
+			boolVal, err := strconv.ParseBool(strVal)
+			if err == nil {
+				vals[directive] = boolVal
 				continue
 			}
 
@@ -238,7 +240,7 @@ func ExtractCommentDirectives(comments Comments) CommentDirectives {
 }
 
 // IsSet checks the directive map for the named directive and returns
-// true iff the directive is set and has a true/false or 0/1 value
+// true if the directive is set and has a true/false or 0/1 value
 func (d CommentDirectives) IsSet(key string) bool {
 	if d == nil {
 		return false

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -42,7 +42,7 @@ func (t noopVCursor) Context() context.Context {
 	return context.Background()
 }
 
-func (t noopVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
+func (t noopVCursor) SetContextTimeout(timeout time.Duration) context.CancelFunc {
 	return func() {}
 }
 
@@ -94,7 +94,7 @@ type loggingVCursor struct {
 func (f *loggingVCursor) Context() context.Context {
 	return context.Background()
 }
-func (f *loggingVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
+func (f *loggingVCursor) SetContextTimeout(timeout time.Duration) context.CancelFunc {
 	return func() {}
 }
 

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -39,6 +40,11 @@ type noopVCursor struct {
 
 func (t noopVCursor) Context() context.Context {
 	return context.Background()
+}
+
+func (t noopVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
+	_, cancel := context.WithTimeout(t.Context(), (time.Duration(timeoutMilli) * time.Millisecond))
+	return cancel
 }
 
 func (t noopVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
@@ -88,6 +94,10 @@ type loggingVCursor struct {
 
 func (f *loggingVCursor) Context() context.Context {
 	return context.Background()
+}
+func (f *loggingVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
+	_, cancel := context.WithTimeout(f.Context(), (time.Duration(timeoutMilli) * time.Millisecond))
+	return cancel
 }
 
 func (f *loggingVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -43,8 +43,7 @@ func (t noopVCursor) Context() context.Context {
 }
 
 func (t noopVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
-	_, cancel := context.WithTimeout(t.Context(), (time.Duration(timeoutMilli) * time.Millisecond))
-	return cancel
+	return func() {}
 }
 
 func (t noopVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
@@ -96,8 +95,7 @@ func (f *loggingVCursor) Context() context.Context {
 	return context.Background()
 }
 func (f *loggingVCursor) SetContextTimeout(timeoutMilli int) context.CancelFunc {
-	_, cancel := context.WithTimeout(f.Context(), (time.Duration(timeoutMilli) * time.Millisecond))
-	return cancel
+	return func() {}
 }
 
 func (f *loggingVCursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -43,6 +43,9 @@ type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
 
+	// SetContextTimeout updates context and sets a timeout.
+	SetContextTimeout(timeoutMilli int) context.CancelFunc
+
 	// V3 functions.
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
 	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -44,7 +44,7 @@ type VCursor interface {
 	Context() context.Context
 
 	// SetContextTimeout updates the context and sets a timeout.
-	SetContextTimeout(timeoutMilli int) context.CancelFunc
+	SetContextTimeout(timeout time.Duration) context.CancelFunc
 
 	// V3 functions.
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -43,7 +43,7 @@ type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
 
-	// SetContextTimeout updates context and sets a timeout.
+	// SetContextTimeout updates the context and sets a timeout.
 	SetContextTimeout(timeoutMilli int) context.CancelFunc
 
 	// V3 functions.

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"vitess.io/vitess/go/jsonutil"
 	"vitess.io/vitess/go/sqltypes"
@@ -160,7 +161,7 @@ func (code RouteOpcode) MarshalJSON() ([]byte, error) {
 // Execute performs a non-streaming exec.
 func (route *Route) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	if route.QueryTimeout != 0 {
-		cancel := vcursor.SetContextTimeout(route.QueryTimeout)
+		cancel := vcursor.SetContextTimeout(time.Duration(route.QueryTimeout) * time.Millisecond)
 		defer cancel()
 	}
 	qr, err := route.execute(vcursor, bindVars, wantfields)
@@ -220,7 +221,7 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 	var bvs []map[string]*querypb.BindVariable
 	var err error
 	if route.QueryTimeout != 0 {
-		cancel := vcursor.SetContextTimeout(route.QueryTimeout)
+		cancel := vcursor.SetContextTimeout(time.Duration(route.QueryTimeout) * time.Millisecond)
 		defer cancel()
 	}
 	switch route.Opcode {

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -35,9 +35,7 @@ func buildSelectPlan(sel *sqlparser.Select, vschema ContextVSchema) (primitive e
 	}
 	if rb, ok := pb.bldr.(*route); ok {
 		directives := sqlparser.ExtractCommentDirectives(sel.Comments)
-		if isSet, timeout := queryTimeout(directives); isSet {
-			rb.ERoute.QueryTimeout = timeout
-		}
+		rb.ERoute.QueryTimeout = queryTimeout(directives)
 		if rb.ERoute.TargetDestination != nil {
 			return nil, errors.New("unsupported: SELECT with a target destination")
 		}
@@ -210,20 +208,20 @@ func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) 
 	return resultColumns, nil
 }
 
-// queryTimeout returns true/value if DirectiveQueryTimeout is set.
-func queryTimeout(d sqlparser.CommentDirectives) (bool, int) {
+// queryTimeout returns DirectiveQueryTimeout value if set, otherwise returns 0.
+func queryTimeout(d sqlparser.CommentDirectives) int {
 	if d == nil {
-		return false, 0
+		return 0
 	}
 
 	val, ok := d[sqlparser.DirectiveQueryTimeout]
 	if !ok {
-		return false, 0
+		return 0
 	}
 
 	intVal, ok := val.(int)
 	if ok {
-		return true, intVal
+		return intVal
 	}
-	return false, 0
+	return 0
 }

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -75,8 +75,8 @@ func (vc *vcursorImpl) Context() context.Context {
 }
 
 // SetContextTimeout updates context and sets a timeout.
-func (vc *vcursorImpl) SetContextTimeout(timeoutMilli int) context.CancelFunc {
-	ctx, cancel := context.WithTimeout(vc.ctx, (time.Duration(timeoutMilli) * time.Millisecond))
+func (vc *vcursorImpl) SetContextTimeout(timeout time.Duration) context.CancelFunc {
+	ctx, cancel := context.WithTimeout(vc.ctx, timeout)
 	vc.ctx = ctx
 	return cancel
 }

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -663,6 +663,14 @@ class TestVTGateFunctions(unittest.TestCase):
         ([(1, 'test 1')], 1L, 0,
          [('Id', self.int_type), ('Name', self.string_type)]))
 
+    # test directive timeout
+    try:
+      cursor.execute('SELECT /*vt+ QUERY_TIMEOUT_MS=1 */ SLEEP(5)', {})
+      self.fail('Execute went through')
+    except dbexceptions.DatabaseError as e:
+      s = str(e)
+      self.assertIn('DeadlineExceeded', s)
+
     # Test insert with no auto-inc
     vtgate_conn.begin()
     result = self.execute_on_master(

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -665,11 +665,19 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # test directive timeout
     try:
-      cursor.execute('SELECT /*vt+ QUERY_TIMEOUT_MS=1 */ SLEEP(5)', {})
+      cursor.execute('SELECT /*vt+ QUERY_TIMEOUT_MS=10 */ SLEEP(1)', {})
       self.fail('Execute went through')
     except dbexceptions.DatabaseError as e:
       s = str(e)
       self.assertIn('DeadlineExceeded', s)
+
+    # test directive timeout longer than the query time
+    cursor.execute('SELECT /*vt+ QUERY_TIMEOUT_MS=2000 */ SLEEP(1)', {})
+    self.assertEqual(
+        (cursor.fetchall(), cursor.rowcount, cursor.lastrowid,
+         cursor.description),
+        ([(0,)], 1L, 0,
+         [(u'SLEEP(1)', self.int_type)]))
 
     # Test insert with no auto-inc
     vtgate_conn.begin()
@@ -1082,7 +1090,7 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, ((1L, 'name0'), (2L, 'name1'), (3L, 'name2'), (5L, 'name4')))
     result = shard_1_master.mquery('vt_user', 'select id, name from vt_user2')
     self.assertEqual(result, ((4L, 'name3'),))
- 
+
     # Works when limit is set
     result = self.execute_on_master(
       vtgate_conn,


### PR DESCRIPTION
### Description

* Queries that include the QUERY_TIMEOUT_MS directive will timeout if execution time exceeds the value provided in the directive. 
* In this iteration, timeouts are only supported for selects. Once we do the
  refactor of removing sql.Preview from the engine, it should be really straight
  forward to refactor this code and support this feature for all statements.
* This feature can be used in the following way:
   ```
   select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from users
   ```
### Tests

* Added integration test and validated locally that it works as expected. 