### PR TITLE
Only log an error when it is related to the template.

### DIFF
--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -22,6 +22,7 @@ import (
 	"html"
 	"html/template"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -184,7 +185,9 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := statusTmpl.ExecuteTemplate(w, "status", data); err != nil {
-		log.Errorf("servenv: couldn't execute template: %v", err)
+		if _, ok := err.(net.Error); !ok {
+			log.Errorf("servenv: couldn't execute template: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
If the template cannot write due to a a connection problem we should ignore the error. For instance when a client has already closed the connection to the server.

Signed-off-by: Michael Pawliszyn <mpawliszyn@gmail.com>