### PR TITLE
mysql: ExecuteFetchMulti

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -785,6 +785,16 @@ func isEOFPacket(data []byte) bool {
 	return data[0] == EOFPacket && len(data) < 9
 }
 
+// parseEOFPacket returns true if there are more results to receive.
+func parseEOFPacket(data []byte) (bool, error) {
+	// The status flag is in position 4 & 5
+	statusFlags, _, ok := readUint16(data, 3)
+	if !ok {
+		return false, fmt.Errorf("invalid EOF packet statusFlags: %v", data)
+	}
+	return (statusFlags & ServerMoreResultsExists) != 0, nil
+}
+
 func parseOKPacket(data []byte) (uint64, uint64, uint16, uint16, error) {
 	// We already read the type.
 	pos := 1

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -47,7 +47,7 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 	}
 
 	// Get the result.
-	_, _, colNumber, err := c.readComQueryResponse()
+	_, _, colNumber, _, err := c.readComQueryResponse()
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -483,7 +483,7 @@ func TestQueryDeadline(t *testing.T) {
 		t.Errorf("Unexpected error code: %d, want %d", got, want)
 	}
 
-	_, err = conn.ReadQueryResult(1000, false)
+	_, _, err = conn.ReadQueryResult(1000, false)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}


### PR DESCRIPTION
Extend the client API to fetch multiple results. This extension
is needed to execute stored procedures that can return multiple
results.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>