### PR TITLE
discovery: add a checksum and refresh lag metric

### DIFF
--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -81,7 +81,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
-	testChecksum(t, 3191378572, hc.stateChecksum())
+	testChecksum(t, 401258919, hc.stateChecksum())
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
@@ -128,7 +128,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(tcsl, tcslWant) {
 		t.Errorf("hc.CacheStatus() =\n%+v; want\n%+v", tcsl[0], tcslWant[0])
 	}
-	testChecksum(t, 1400791816, hc.stateChecksum())
+	testChecksum(t, 1562785705, hc.stateChecksum())
 
 	// TabletType changed, should get both old and new event
 	shr = &querypb.StreamHealthResponse{
@@ -169,7 +169,7 @@ func TestHealthCheck(t *testing.T) {
 	if err := checkErrorCounter("k", "s", topodatapb.TabletType_REPLICA, 0); err != nil {
 		t.Errorf("%v", err)
 	}
-	testChecksum(t, 3253721871, hc.stateChecksum())
+	testChecksum(t, 1906892404, hc.stateChecksum())
 
 	// Serving & RealtimeStats changed
 	shr = &querypb.StreamHealthResponse{
@@ -193,7 +193,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
-	testChecksum(t, 4287434095, hc.stateChecksum())
+	testChecksum(t, 1200695592, hc.stateChecksum())
 
 	// HealthError
 	shr = &querypb.StreamHealthResponse{
@@ -218,7 +218,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
-	testChecksum(t, 4287434095, hc.stateChecksum()) // unchanged
+	testChecksum(t, 1200695592, hc.stateChecksum()) // unchanged
 
 	// remove tablet
 	hc.deleteConn(tablet)

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -49,6 +49,13 @@ func init() {
 	connMap = make(map[string]*fakeConn)
 }
 
+func testChecksum(t *testing.T, want, got int64) {
+	t.Helper()
+	if want != got {
+		t.Errorf("want checksum %v, got %v", want, got)
+	}
+}
+
 func TestHealthCheck(t *testing.T) {
 	tablet := topo.NewTablet(0, "cell", "a")
 	tablet.PortMap["vt"] = 1
@@ -58,6 +65,7 @@ func TestHealthCheck(t *testing.T) {
 	l := newListener()
 	hc := NewHealthCheck(1*time.Millisecond, time.Hour).(*HealthCheckImpl)
 	hc.SetListener(l, true)
+	testChecksum(t, 0, hc.stateChecksum())
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
 
@@ -73,6 +81,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
+	testChecksum(t, 3191378572, hc.stateChecksum())
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
@@ -119,6 +128,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(tcsl, tcslWant) {
 		t.Errorf("hc.CacheStatus() =\n%+v; want\n%+v", tcsl[0], tcslWant[0])
 	}
+	testChecksum(t, 1400791816, hc.stateChecksum())
 
 	// TabletType changed, should get both old and new event
 	shr = &querypb.StreamHealthResponse{
@@ -159,6 +169,7 @@ func TestHealthCheck(t *testing.T) {
 	if err := checkErrorCounter("k", "s", topodatapb.TabletType_REPLICA, 0); err != nil {
 		t.Errorf("%v", err)
 	}
+	testChecksum(t, 3253721871, hc.stateChecksum())
 
 	// Serving & RealtimeStats changed
 	shr = &querypb.StreamHealthResponse{
@@ -182,6 +193,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
+	testChecksum(t, 4287434095, hc.stateChecksum())
 
 	// HealthError
 	shr = &querypb.StreamHealthResponse{
@@ -206,6 +218,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
+	testChecksum(t, 4287434095, hc.stateChecksum()) // unchanged
 
 	// remove tablet
 	hc.deleteConn(tablet)
@@ -224,6 +237,7 @@ func TestHealthCheck(t *testing.T) {
 	if !reflect.DeepEqual(res, want) {
 		t.Errorf("<-l.output:\n%+v; want\n%+v", res, want)
 	}
+	testChecksum(t, 0, hc.stateChecksum())
 
 	// close healthcheck
 	hc.Close()

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -17,7 +17,10 @@ limitations under the License.
 package discovery
 
 import (
+	"bytes"
 	"fmt"
+	"hash/crc32"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -119,8 +122,13 @@ type TopologyWatcher struct {
 	wg sync.WaitGroup
 
 	// mu protects all variables below
-	mu      sync.Mutex
+	mu sync.Mutex
+	// tablets contains a map of alias -> tabletInfo for all known tablets
 	tablets map[string]*tabletInfo
+	// topoChecksum stores a crc32 of the tablets map and is exported as a metric
+	topoChecksum uint32
+	// lastRefresh records the timestamp of the last topo refresh
+	lastRefresh time.Time
 	// firstLoadDone is true when first load of the topology data is done.
 	firstLoadDone bool
 	// firstLoadChan is closed when the initial loading of topology data is done.
@@ -181,10 +189,16 @@ func (tw *TopologyWatcher) loadTablets() {
 		return
 	}
 
+	// Accumulate a list of all known alias strings to use later
+	// when sorting
+	tabletAliasStrs := make([]string, 0, len(tabletAliases))
+
 	tw.mu.Lock()
 	for _, tAlias := range tabletAliases {
+		aliasStr := topoproto.TabletAliasString(tAlias)
+		tabletAliasStrs = append(tabletAliasStrs, aliasStr)
+
 		if !tw.refreshKnownTablets {
-			aliasStr := topoproto.TabletAliasString(tAlias)
 			if val, ok := tw.tablets[aliasStr]; ok {
 				newTablets[aliasStr] = val
 				continue
@@ -264,6 +278,19 @@ func (tw *TopologyWatcher) loadTablets() {
 		tw.firstLoadDone = true
 		close(tw.firstLoadChan)
 	}
+
+	// iterate through the tablets in a stable order and compute a
+	// checksum of the tablet map
+	sort.Strings(tabletAliasStrs)
+	var buf bytes.Buffer
+	for _, alias := range tabletAliasStrs {
+		tabletInfo := tw.tablets[alias]
+		buf.WriteString(alias)
+		buf.WriteString(tabletInfo.key)
+	}
+	tw.topoChecksum = crc32.ChecksumIEEE(buf.Bytes())
+	tw.lastRefresh = time.Now()
+
 	tw.mu.Unlock()
 }
 
@@ -284,6 +311,22 @@ func (tw *TopologyWatcher) Stop() {
 	tw.cancelFunc()
 	// wait for watch goroutine to finish.
 	tw.wg.Wait()
+}
+
+// RefreshLag returns the time since the last refresh
+func (tw *TopologyWatcher) RefreshLag() time.Duration {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	return time.Since(tw.lastRefresh)
+}
+
+// TopoChecksum returns the checksum of the current state of the topo
+func (tw *TopologyWatcher) TopoChecksum() uint32 {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	return tw.topoChecksum
 }
 
 // FilterByShard is a TabletRecorder filter that filters tablets by

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -284,9 +284,11 @@ func (tw *TopologyWatcher) loadTablets() {
 	sort.Strings(tabletAliasStrs)
 	var buf bytes.Buffer
 	for _, alias := range tabletAliasStrs {
-		tabletInfo := tw.tablets[alias]
-		buf.WriteString(alias)
-		buf.WriteString(tabletInfo.key)
+		tabletInfo, ok := tw.tablets[alias]
+		if ok {
+			buf.WriteString(alias)
+			buf.WriteString(tabletInfo.key)
+		}
 	}
 	tw.topoChecksum = crc32.ChecksumIEEE(buf.Bytes())
 	tw.lastRefresh = time.Now()

--- a/go/vt/vtgate/gateway/gateway.go
+++ b/go/vt/vtgate/gateway/gateway.go
@@ -64,6 +64,9 @@ type Gateway interface {
 	// - any other error: log.Fatalf out.
 	WaitForTablets(ctx context.Context, tabletTypesToWait []topodatapb.TabletType) error
 
+	// RegisterStats registers exported stats for the gateway
+	RegisterStats()
+
 	// CacheStatus returns a list of TabletCacheStatus per shard / tablet type.
 	CacheStatus() TabletCacheStatusList
 }

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -165,6 +165,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, ce
 	var l2vtgate *L2VTGate
 	if !*disableLocalGateway {
 		gw = gateway.GetCreator()(hc, serv, cell, retryCount)
+		gw.RegisterStats()
 		if err := gateway.WaitForTablets(gw, tabletTypesToWait); err != nil {
 			log.Fatalf("gateway.WaitForTablets failed: %v", err)
 		}


### PR DESCRIPTION
## Description
Add exported metrics to Discovery Gateway and Healthcheck to be able to validate that all vtgates have the same view of the topology.

## Details
In discovery, add a hook so that after each refresh loop, compute a crc32 of all the tablet alias and address/port maps, and export this as a metric.

Also export a metric of the time interval since the last time the topo was refreshed.

In healthcheck, add another metric function to compute this on demand when the metrics exporter is called, alongside the existing hook which counts the open connections to each shard.

## Testing
Added simple unit tests and verified in a dev environment.
