### PR TITLE
Warning about mysqld_safe not being found is futile (2nd attempt)

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -228,7 +228,9 @@ func (mysqld *Mysqld) startNoWait(ctx context.Context, mysqldArgs ...string) err
 		}
 		name, err = binaryPath(dir, "mysqld_safe")
 		if err != nil {
-			log.Warningf("%v: trying to launch mysqld instead", err)
+			// The movement to use systemd means that mysqld_safe is not always provided.
+			// This should not be considered an issue do do not generate a warning.
+			log.Infof("%v: trying to launch mysqld instead", err)
 			name, err = binaryPath(dir, "mysqld")
 			// If this also fails, return an error.
 			if err != nil {


### PR DESCRIPTION
See: https://github.com/vitessio/vitess/issues/3979 but also https://github.com/vitessio/vitess/pull/3980.

The script is not provided now by the upstream vendor for later releases especially if the OS uses systemd. This patch removes the warning as it is not a concern.

Repushed patch with Sign-off as wasn't sure how to fix the original commit.