### PR TITLE
Add: vtaclcheck command to allow validating table ACLs

### DIFF
--- a/go/cmd/vtaclcheck/tableacl1.json
+++ b/go/cmd/vtaclcheck/tableacl1.json
@@ -1,0 +1,14 @@
+{
+  "table_groups": [
+    {
+        "name": "group1",
+        "table_names_or_prefixes": ["table1"],
+        "readers": ["web_app"]
+    },
+    {
+        "name": "group2",
+        "table_names_or_prefixes": ["*"],
+        "admins": ["cron_app"]
+    }
+  ]
+}

--- a/go/cmd/vtaclcheck/tableacl2.json
+++ b/go/cmd/vtaclcheck/tableacl2.json
@@ -1,0 +1,121 @@
+{
+  "table_groups": [
+    {
+      "name": "mysql",
+      "table_names_or_prefixes": [""],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_cached",
+      "table_names_or_prefixes": ["vitess_nocache", "vitess_cached%"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_renamed",
+      "table_names_or_prefixes": ["vitess_renamed%"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_part",
+      "table_names_or_prefixes": ["vitess_part%"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess",
+      "table_names_or_prefixes": ["vitess_a", "vitess_b", "vitess_c", "dual", "vitess_d", "vitess_temp", "vitess_e", "vitess_f", "vitess_mixed_case", "upsert_test", "vitess_strings", "vitess_fracts", "vitess_ints", "vitess_misc", "vitess_bit_default", "vitess_big", "vitess_view", "vitess_json", "vitess_bool", "vitess_autoinc_seq"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_test",
+      "table_names_or_prefixes": ["vitess_test"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_seq",
+      "table_names_or_prefixes": ["vitess_seq"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_reset_seq",
+      "table_names_or_prefixes": ["vitess_reset_seq"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_message",
+      "table_names_or_prefixes": ["vitess_message"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_message3",
+      "table_names_or_prefixes": ["vitess_message3"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_message_auto",
+      "table_names_or_prefixes": ["vitess_message_auto"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_acl_unmatched",
+      "table_names_or_prefixes": ["vitess_acl_unmatched"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_acl_no_access",
+      "table_names_or_prefixes": ["vitess_acl_no_access"]
+    },
+    {
+      "name": "vitess_acl_read_only",
+      "table_names_or_prefixes": ["vitess_acl_read_only"],
+      "readers": ["dev"]
+    },
+    {
+      "name": "vitess_acl_read_write",
+      "table_names_or_prefixes": ["vitess_acl_read_write"],
+      "readers": ["dev"],
+      "writers": ["dev"]
+    },
+    {
+      "name": "vitess_acl_admin",
+      "table_names_or_prefixes": ["vitess_acl_admin"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_acl_all_user_read_only",
+      "table_names_or_prefixes": ["vitess_acl_all_user_read_only"],
+      "readers": ["dev"]
+    },
+    {
+      "name": "vitess_acl_appdebug",
+      "table_names_or_prefixes": ["vitess_test_debuguser"],
+      "readers": ["dev", "vt_appdebug"],
+      "writers": ["dev", "vt_appdebug"]
+    }
+  ]
+}

--- a/go/cmd/vtaclcheck/tableacl_bad.json
+++ b/go/cmd/vtaclcheck/tableacl_bad.json
@@ -1,0 +1,14 @@
+{
+  "xxxxxxxxxxxx": [
+    {
+        "name": "group1",
+        "table_names_or_prefixes": ["table1"],
+        "readers": ["web_app"]
+    },
+    {
+        "name": "group2",
+        "table_names_or_prefixes": ["*"],
+        "admins": ["cron_app"]
+    }
+  ]
+}

--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vtaclcheck"
+)
+
+var (
+	aclFileFlag = flag.String("acl_file", "", "Identifies the JSON ACL file to check")
+
+	// vtaclcheckFlags lists all the flags that should show in usage
+	vtaclcheckFlags = []string{
+		"acl_file",
+	}
+)
+
+func usage() {
+	fmt.Printf("usage of vtaclcheck:\n")
+	for _, name := range vtaclcheckFlags {
+		f := flag.Lookup(name)
+		if f == nil {
+			panic("unkown flag " + name)
+		}
+		flagUsage(f)
+	}
+}
+
+// Cloned from the source to print out the usage for a given flag
+func flagUsage(f *flag.Flag) {
+	s := fmt.Sprintf("  -%s", f.Name) // Two spaces before -; see next two comments.
+	name, usage := flag.UnquoteUsage(f)
+	if len(name) > 0 {
+		s += " " + name
+	}
+	// Boolean flags of one ASCII letter are so common we
+	// treat them specially, putting their usage on the same line.
+	if len(s) <= 4 { // space, space, '-', 'x'.
+		s += "\t"
+	} else {
+		// Four spaces before the tab triggers good alignment
+		// for both 4- and 8-space tab stops.
+		s += "\n    \t"
+	}
+	s += usage
+	if name == "string" {
+		// put quotes on the value
+		s += fmt.Sprintf(" (default %q)", f.DefValue)
+	} else {
+		s += fmt.Sprintf(" (default %v)", f.DefValue)
+	}
+	fmt.Printf(s + "\n")
+}
+
+func init() {
+	logger := logutil.NewConsoleLogger()
+	flag.CommandLine.SetOutput(logutil.NewLoggerWriter(logger))
+	flag.Usage = usage
+}
+
+func main() {
+	defer exit.RecoverAll()
+	defer logutil.Flush()
+
+	servenv.ParseFlags("vtaclcheck")
+
+	err := parseAndRun()
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		exit.Return(1)
+	}
+}
+
+func parseAndRun() error {
+	if aclFileFlag == nil {
+		return fmt.Errorf("-acl_file <filename> option not provided")
+	}
+
+	opts := &vtaclcheck.Options{
+		ACLFile: *aclFileFlag,
+	}
+
+	log.V(100).Infof("acl_file %s\n", *aclFileFlag)
+
+	if err := vtaclcheck.Init(opts); err != nil {
+		return err
+	}
+
+	if err := vtaclcheck.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -107,9 +107,5 @@ func parseAndRun() error {
 		return err
 	}
 
-	if err := vtaclcheck.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return vtaclcheck.Run()
 }

--- a/go/vt/vtaclcheck/vtaclcheck.go
+++ b/go/vt/vtaclcheck/vtaclcheck.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vtaclcheck analyzes a set of sql statements and returns the
+// corresponding vtgate and vttablet query plans that will be executed
+// on the given statements
+package vtaclcheck
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/vt/tableacl"
+	"vitess.io/vitess/go/vt/tableacl/simpleacl"
+)
+
+// Options to control the explain process
+type Options struct {
+	// AclFile is the file with the JSON acl configuration
+	ACLFile string
+}
+
+var options *Options
+
+// Init sets up the fake execution environment
+func Init(opts *Options) error {
+	// verify opts is defined
+	if opts == nil {
+		return fmt.Errorf("vtaclcheck.Init: opts is NULL")
+	}
+	// Verify options
+	if len(opts.ACLFile) == 0 {
+		return fmt.Errorf("-acl_file <filename> provided but len(filename) is zero")
+	}
+
+	options = opts
+
+	return nil
+}
+
+// Run the check on the given file
+func Run() error {
+	filename := options.ACLFile
+
+	tableacl.Register("simpleacl", &simpleacl.Factory{})
+	err := tableacl.Init(
+		filename,
+		func() {},
+	)
+	if err != nil {
+		return fmt.Errorf("Fail to initialize Table ACL: %v", err)
+	}
+
+	fmt.Printf("JSON ACL file %s looks good\n", filename)
+
+	return nil
+}


### PR DESCRIPTION
Usage: `vtaclcheck -acl_file <path_to_file>`

Will indicate if the table ACL is valid or not.
A couple of good and one bad json acl file is provided for reference.

I was not sure how to verify the JSON tableacls prior to pushing them to a vttablet and this seemed like an easier way to do it.  Having said that error reporting if the content is bad is not very helpful. I was not sure how to resolve that.