### PR TITLE
v3: support database() function

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -747,6 +747,21 @@
   }
 }
 
+# database() call in where clause.
+"select id from user where database()"
+{
+  "Original": "select id from user where database()",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id from user where 'targetString'",
+    "FieldQuery": "select id from user where 1 != 1"
+  }
+}
+
 # outer and inner subquery route reference the same "uu.id" name
 # but they refer to different things. The first reference is to the outermost query,
 # and the second reference is to the the innermost 'from' subquery.

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1100,6 +1100,22 @@
   }
 }
 
+# database call in ON clause.
+# The on clause is weird because the substitution must even for root expressions.
+"select u1.a from unsharded u1 join unsharded u2 on database()"
+{
+  "Original": "select u1.a from unsharded u1 join unsharded u2 on database()",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select u1.a from unsharded as u1 join unsharded as u2 on 'targetString'",
+    "FieldQuery": "select u1.a from unsharded as u1 join unsharded as u2 on 'targetString' where 1 != 1"
+  }
+}
+
 # verify ',' vs JOIN precedence
 "select u1.a from unsharded u1, unsharded u2 join unsharded u3 on u1.a = u2.a"
 "symbol u1.a not found"

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -143,6 +143,22 @@
   }
 }
 
+# database calls should be substituted
+"select database() from dual"
+{
+  "Original": "select database() from dual",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select 'targetString' from dual",
+    "FieldQuery": "select 'targetString' from dual where 1 != 1"
+  }
+}
+
+
 # nextval for simple route
 "select next value from user"
 "NEXT used on a sharded table"

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -111,6 +111,7 @@ type ContextVSchema interface {
 	FindTable(tablename sqlparser.TableName) (*vindexes.Table, string, topodatapb.TabletType, key.Destination, error)
 	FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, string, topodatapb.TabletType, key.Destination, error)
 	DefaultKeyspace() (*vindexes.Keyspace, error)
+	TargetString() string
 }
 
 // Build builds a plan for a query based on the specified vschema.

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -315,13 +315,12 @@ func (pb *primitiveBuilder) mergeRoutes(rpb *primitiveBuilder, ajoin *sqlparser.
 	if ajoin == nil {
 		return nil
 	}
+	_, expr, err := pb.findOrigin(ajoin.Condition.On)
+	if err != nil {
+		return err
+	}
+	ajoin.Condition.On = expr
 	for _, filter := range splitAndExpression(nil, ajoin.Condition.On) {
-		// If VTGate evolves, this section should be rewritten
-		// to use processExpr.
-		_, err = pb.findOrigin(filter)
-		if err != nil {
-			return err
-		}
 		lRoute.UpdatePlan(pb, filter)
 	}
 	return nil

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -210,6 +210,10 @@ func (vw *vschemaWrapper) DefaultKeyspace() (*vindexes.Keyspace, error) {
 	return vw.v.Keyspaces["main"].Keyspace, nil
 }
 
+func (vw *vschemaWrapper) TargetString() string {
+	return "targetString"
+}
+
 // For the purposes of this set of tests, just compare the actual plan
 // and ignore all the metrics.
 type testPlan struct {

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -119,11 +119,11 @@ func (pb *primitiveBuilder) pushFilter(boolExpr sqlparser.Expr, whereType string
 	filters := splitAndExpression(nil, boolExpr)
 	reorderBySubquery(filters)
 	for _, filter := range filters {
-		origin, err := pb.findOrigin(filter)
+		origin, expr, err := pb.findOrigin(filter)
 		if err != nil {
 			return err
 		}
-		if err := pb.bldr.PushFilter(pb, filter, whereType, origin); err != nil {
+		if err := pb.bldr.PushFilter(pb, expr, whereType, origin); err != nil {
 			return err
 		}
 	}
@@ -168,10 +168,11 @@ func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) 
 	for i, node := range selectExprs {
 		switch node := node.(type) {
 		case *sqlparser.AliasedExpr:
-			origin, err := pb.findOrigin(node.Expr)
+			origin, expr, err := pb.findOrigin(node.Expr)
 			if err != nil {
 				return nil, err
 			}
+			node.Expr = expr
 			resultColumns[i], _, err = pb.bldr.PushSelect(node, origin)
 			if err != nil {
 				return nil, err

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -128,6 +128,11 @@ func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 	return ks.Keyspace, nil
 }
 
+// TargetString returns the current TargetString of the session.
+func (vc *vcursorImpl) TargetString() string {
+	return vc.safeSession.TargetString
+}
+
 // Execute performs a V3 level execution of the query.
 func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
 	qr, err := vc.executor.Execute(vc.ctx, method, vc.safeSession, vc.marginComments.Leading+query+vc.marginComments.Trailing, BindVars)


### PR DESCRIPTION
Fixes #3954
This is an alternate PR to #3962. The implementation is less
efficient, but more correct. This allows you to use the
database() call anywherei in the sql, and v3 will substitute
it to the actual target string.

If necessary, we can add an optimization that won't send the
query to the vttablets.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>