### PR TITLE
Fix obscure error messages

### DIFF
--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/topotools"
 )
 
 // TabletStatsCache is a HealthCheckStatsListener that keeps both the
@@ -484,14 +485,14 @@ func (tc *TabletStatsCache) Unsubscribe(i int) error {
 func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.AggregateStats, error) {
 	e := tc.getEntry(target.Keyspace, target.Shard, target.TabletType)
 	if e == nil {
-		return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
+		return nil, topo.NewError(topo.NoNode, topotools.TargetIdent(target))
 	}
 
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if target.TabletType == topodatapb.TabletType_MASTER {
 		if len(e.aggregates) == 0 {
-			return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
+			return nil, topo.NewError(topo.NoNode, topotools.TargetIdent(target))
 		}
 		for _, agg := range e.aggregates {
 			return agg, nil
@@ -499,7 +500,7 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 	}
 	agg, ok := e.aggregates[target.Cell]
 	if !ok {
-		return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
+		return nil, topo.NewError(topo.NoNode, topotools.TargetIdent(target))
 	}
 	return agg, nil
 }
@@ -508,7 +509,11 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 func (tc *TabletStatsCache) GetMasterCell(keyspace, shard string) (cell string, err error) {
 	e := tc.getEntry(keyspace, shard, topodatapb.TabletType_MASTER)
 	if e == nil {
-		return "", topo.NewError(topo.NoNode, keyspace+"/"+shard+"@"+topodatapb.TabletType_MASTER.String())
+		return "", topo.NewError(topo.NoNode, topotools.TargetIdent(&querypb.Target{
+			Keyspace:   keyspace,
+			Shard:      shard,
+			TabletType: topodatapb.TabletType_MASTER,
+		}))
 	}
 
 	e.mu.RLock()
@@ -516,7 +521,11 @@ func (tc *TabletStatsCache) GetMasterCell(keyspace, shard string) (cell string, 
 	for cell := range e.aggregates {
 		return cell, nil
 	}
-	return "", topo.NewError(topo.NoNode, keyspace+"/"+shard+"@"+topodatapb.TabletType_MASTER.String())
+	return "", topo.NewError(topo.NoNode, topotools.TargetIdent(&querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_MASTER,
+	}))
 }
 
 // Compile-time interface check.

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -484,14 +484,14 @@ func (tc *TabletStatsCache) Unsubscribe(i int) error {
 func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.AggregateStats, error) {
 	e := tc.getEntry(target.Keyspace, target.Shard, target.TabletType)
 	if e == nil {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
 	}
 
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if target.TabletType == topodatapb.TabletType_MASTER {
 		if len(e.aggregates) == 0 {
-			return nil, topo.ErrNoNode
+			return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
 		}
 		for _, agg := range e.aggregates {
 			return agg, nil
@@ -499,7 +499,7 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 	}
 	agg, ok := e.aggregates[target.Cell]
 	if !ok {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, target.Keyspace+"/"+target.Shard+"@"+target.TabletType.String())
 	}
 	return agg, nil
 }
@@ -508,7 +508,7 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 func (tc *TabletStatsCache) GetMasterCell(keyspace, shard string) (cell string, err error) {
 	e := tc.getEntry(keyspace, shard, topodatapb.TabletType_MASTER)
 	if e == nil {
-		return "", topo.ErrNoNode
+		return "", topo.NewError(topo.NoNode, keyspace+"/"+shard+"@"+topodatapb.TabletType_MASTER.String())
 	}
 
 	e.mu.RLock()
@@ -516,7 +516,7 @@ func (tc *TabletStatsCache) GetMasterCell(keyspace, shard string) (cell string, 
 	for cell := range e.aggregates {
 		return cell, nil
 	}
-	return "", topo.ErrNoNode
+	return "", topo.NewError(topo.NoNode, keyspace+"/"+shard+"@"+topodatapb.TabletType_MASTER.String())
 }
 
 // Compile-time interface check.

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -79,10 +79,10 @@ func NewCellTabletsWatcher(topoServer *topo.Server, tr TabletRecorder, cell stri
 func NewShardReplicationWatcher(topoServer *topo.Server, tr TabletRecorder, cell, keyspace, shard string, refreshInterval time.Duration, topoReadConcurrency int) *TopologyWatcher {
 	return NewTopologyWatcher(topoServer, tr, cell, refreshInterval, true /* refreshKnownTablets */, topoReadConcurrency, func(tw *TopologyWatcher) ([]*topodatapb.TabletAlias, error) {
 		sri, err := tw.topoServer.GetShardReplication(tw.ctx, tw.cell, keyspace, shard)
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			// we handle this case after this switch block
-		case topo.ErrNoNode:
+		case topo.IsErrType(err, topo.NoNode):
 			// this is not an error
 			return nil, nil
 		default:

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -170,7 +170,7 @@ func (mysqld *Mysqld) WaitMasterPos(ctx context.Context, targetPos mysql.Positio
 	}
 	result := qr.Rows[0][0]
 	if result.IsNull() {
-		return fmt.Errorf("WaitUntilPositionCommand(%v) failed: gtid_mode is OFF", query)
+		return fmt.Errorf("WaitUntilPositionCommand(%v) failed: replication is probably stopped", query)
 	}
 	if result.ToString() == "-1" {
 		return fmt.Errorf("timed out waiting for position %v", targetPos)

--- a/go/vt/srvtopo/discover.go
+++ b/go/vt/srvtopo/discover.go
@@ -50,7 +50,7 @@ func FindAllTargets(ctx context.Context, ts Server, cell string, tabletTypes []t
 			// Get SrvKeyspace for cell/keyspace.
 			ks, err := ts.GetSrvKeyspace(ctx, cell, keyspace)
 			if err != nil {
-				if err == topo.ErrNoNode {
+				if topo.IsErrType(err, topo.NoNode) {
 					// Possibly a race condition, or leftover
 					// crud in the topology service. Just log it.
 					log.Warningf("GetSrvKeyspace(%v, %v) returned ErrNoNode, skipping that SrvKeyspace", cell, keyspace)

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -439,7 +439,7 @@ func (server *ResilientServer) watchSrvKeyspace(callerCtx context.Context, entry
 		entry.lastErrorTime = time.Now()
 
 		// if the node disappears, delete the cached value
-		if current.Err == topo.ErrNoNode {
+		if topo.IsErrType(current.Err, topo.NoNode) {
 			entry.value = nil
 		}
 
@@ -483,7 +483,7 @@ func (server *ResilientServer) watchSrvKeyspace(callerCtx context.Context, entry
 			log.Errorf("%v", err)
 			server.counts.Add(errorCategory, 1)
 			entry.mutex.Lock()
-			if c.Err == topo.ErrNoNode {
+			if topo.IsErrType(c.Err, topo.NoNode) {
 				entry.value = nil
 			}
 			entry.watchState = watchStateIdle
@@ -529,7 +529,7 @@ func (server *ResilientServer) WatchSrvVSchema(ctx context.Context, cell string,
 			}
 			if current.Err != nil {
 				// Don't log if there is no VSchema to start with.
-				if current.Err != topo.ErrNoNode {
+				if !topo.IsErrType(current.Err, topo.NoNode) {
 					log.Warningf("Error watching vschema for cell %s (will wait 5s before retrying): %v", cell, current.Err)
 				}
 			} else {

--- a/go/vt/srvtopo/resilient_server_flaky_test.go
+++ b/go/vt/srvtopo/resilient_server_flaky_test.go
@@ -49,7 +49,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 
 	// Ask for a not-yet-created keyspace
 	_, err := rs.GetSrvKeyspace(context.Background(), "test_cell", "test_ks")
-	if err != topo.ErrNoNode {
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("GetSrvKeyspace(not created) got unexpected error: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 	expiry = time.Now().Add(5 * time.Second)
 	for {
 		got, err = rs.GetSrvKeyspace(context.Background(), "test_cell", "test_ks")
-		if err == topo.ErrNoNode {
+		if topo.IsErrType(err, topo.NoNode) {
 			break
 		}
 		if time.Now().After(expiry) {
@@ -377,10 +377,10 @@ func TestGetSrvKeyspaceCreated(t *testing.T) {
 	expiry := time.Now().Add(5 * time.Second)
 	for {
 		got, err := rs.GetSrvKeyspace(context.Background(), "test_cell", "test_ks")
-		switch err {
-		case topo.ErrNoNode:
+		switch {
+		case topo.IsErrType(err, topo.NoNode):
 			// keep trying
-		case nil:
+		case err == nil:
 			// we got a value, see if it's good
 			if proto.Equal(want, got) {
 				return
@@ -419,7 +419,7 @@ func TestWatchSrvVSchema(t *testing.T) {
 
 	// WatchSrvVSchema won't return until it gets the initial value,
 	// which is not there, so we should get watchErr=topo.ErrNoNode.
-	if _, err := get(); err != topo.ErrNoNode {
+	if _, err := get(); !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("WatchSrvVSchema didn't return topo.ErrNoNode at first, but got: %v", err)
 	}
 
@@ -469,7 +469,7 @@ func TestWatchSrvVSchema(t *testing.T) {
 	}
 	start = time.Now()
 	for {
-		if _, err := get(); err == topo.ErrNoNode {
+		if _, err := get(); topo.IsErrType(err, topo.NoNode) {
 			break
 		}
 		if time.Since(start) > 5*time.Second {

--- a/go/vt/topo/consultopo/directory.go
+++ b/go/vt/topo/consultopo/directory.go
@@ -46,7 +46,7 @@ func (s *Server) ListDir(ctx context.Context, dirPath string, full bool) ([]topo
 	if len(keys) == 0 {
 		// No key starts with this prefix, means the directory
 		// doesn't exist.
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, nodePath)
 	}
 
 	prefixLen := len(nodePath)

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -77,7 +77,7 @@ func (mp *consulMasterParticipation) WaitForMastership() (context.Context, error
 	// If Stop was already called, mp.done is closed, so we are interrupted.
 	select {
 	case <-mp.done:
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 	}
 

--- a/go/vt/topo/consultopo/error.go
+++ b/go/vt/topo/consultopo/error.go
@@ -37,12 +37,12 @@ var (
 
 // convertError converts a context error into a topo error. All errors
 // are either application-level errors, or context errors.
-func convertError(err error) error {
+func convertError(err error, nodePath string) error {
 	switch err {
 	case context.Canceled:
-		return topo.ErrInterrupted
+		return topo.NewError(topo.Interrupted, nodePath)
 	case context.DeadlineExceeded:
-		return topo.ErrTimeout
+		return topo.NewError(topo.Timeout, nodePath)
 	}
 	return err
 }

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -47,7 +47,7 @@ func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (
 	}
 	if !ok {
 		// Transaction was rolled back, means the node exists.
-		return nil, topo.ErrNodeExists
+		return nil, topo.NewError(topo.NodeExists, nodePath)
 	}
 	return ConsulVersion(resp.Results[0].ModifyIndex), nil
 }
@@ -77,7 +77,7 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 	if !ok {
 		// Transaction was rolled back, means the node has a
 		// bad version.
-		return nil, topo.ErrBadVersion
+		return nil, topo.NewError(topo.BadVersion, nodePath)
 	}
 	return ConsulVersion(resp.Results[0].ModifyIndex), nil
 }
@@ -91,7 +91,7 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 		return nil, nil, err
 	}
 	if pair == nil {
-		return nil, nil, topo.ErrNoNode
+		return nil, nil, topo.NewError(topo.NoNode, nodePath)
 	}
 
 	return pair.Value, ConsulVersion(pair.ModifyIndex), nil
@@ -134,10 +134,10 @@ func (s *Server) Delete(ctx context.Context, filePath string, version topo.Versi
 		switch resp.Errors[0].OpIndex {
 		case 0:
 			// Get failed (operation 0), the node didn't exist.
-			return topo.ErrNoNode
+			return topo.NewError(topo.NoNode, nodePath)
 		case 1:
 			// DeleteCAS failed (operation 1), means bad version.
-			return topo.ErrBadVersion
+			return topo.NewError(topo.BadVersion, nodePath)
 		default:
 			// very unexpected.
 			return ErrBadResponse

--- a/go/vt/topo/consultopo/lock.go
+++ b/go/vt/topo/consultopo/lock.go
@@ -43,7 +43,7 @@ func (s *Server) Lock(ctx context.Context, dirPath, contents string) (topo.LockD
 		// easiest way to do this is to return convertError(err).
 		// It may lose some of the context, if this is an issue,
 		// maybe logging the error would work here.
-		return nil, convertError(err)
+		return nil, convertError(err, dirPath)
 	}
 
 	lockPath := path.Join(s.root, dirPath, locksFilename)
@@ -66,7 +66,7 @@ func (s *Server) Lock(ctx context.Context, dirPath, contents string) (topo.LockD
 		s.mu.Unlock()
 		select {
 		case <-ctx.Done():
-			return nil, convertError(ctx.Err())
+			return nil, convertError(ctx.Err(), dirPath)
 		case <-li.done:
 		}
 

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -41,7 +41,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	}
 	if pair == nil {
 		// Node doesn't exist.
-		return &topo.WatchData{Err: topo.ErrNoNode}, nil, nil
+		return &topo.WatchData{Err: topo.NewError(topo.NoNode, nodePath)}, nil, nil
 	}
 
 	// Initial value to return.
@@ -80,7 +80,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			// If the node disappeared, pair is nil.
 			if pair == nil {
 				notifications <- &topo.WatchData{
-					Err: topo.ErrNoNode,
+					Err: topo.NewError(topo.NoNode, nodePath),
 				}
 				return
 			}
@@ -97,7 +97,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 			select {
 			case <-watchCtx.Done():
 				notifications <- &topo.WatchData{
-					Err: convertError(watchCtx.Err()),
+					Err: convertError(watchCtx.Err(), nodePath),
 				}
 				return
 			default:

--- a/go/vt/topo/errors.go
+++ b/go/vt/topo/errors.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import "fmt"
+
+// ErrorCode is the error code for topo errors.
+type ErrorCode int
+
+// The following is the list of error codes.
+const (
+	NodeExists = ErrorCode(iota)
+	NoNode
+	NodeNotEmpty
+	Timeout
+	Interrupted
+	BadVersion
+	PartialResult
+	NoUpdateNeeded
+)
+
+// Error represents a topo error.
+type Error struct {
+	code    ErrorCode
+	message string
+}
+
+// NewError creates a new topo error.
+func NewError(code ErrorCode, node string) error {
+	var message string
+	switch code {
+	case NodeExists:
+		message = fmt.Sprintf("node already exists: %s", node)
+	case NoNode:
+		message = fmt.Sprintf("node doesn't exist: %s", node)
+	case NodeNotEmpty:
+		message = fmt.Sprintf("node not empty: %s", node)
+	case Timeout:
+		message = fmt.Sprintf("deadline exceeded: %s", node)
+	case Interrupted:
+		message = fmt.Sprintf("interrupted: %s", node)
+	case BadVersion:
+		message = fmt.Sprintf("bad node version: %s", node)
+	case PartialResult:
+		message = fmt.Sprintf("partial result: %s", node)
+	case NoUpdateNeeded:
+		message = fmt.Sprintf("no update needed: %s", node)
+	default:
+		message = fmt.Sprintf("unknonw code: %s", node)
+	}
+	return Error{
+		code:    code,
+		message: message,
+	}
+}
+
+// Error satisfies error.
+func (e Error) Error() string {
+	return e.message
+}
+
+// IsErrType returns true if the error has the specified ErrorCode.
+func IsErrType(err error, code ErrorCode) bool {
+	if e, ok := err.(Error); ok {
+		return e.code == code
+	}
+	return false
+}

--- a/go/vt/topo/errors.go
+++ b/go/vt/topo/errors.go
@@ -60,7 +60,7 @@ func NewError(code ErrorCode, node string) error {
 	case NoUpdateNeeded:
 		message = fmt.Sprintf("no update needed: %s", node)
 	default:
-		message = fmt.Sprintf("unknonw code: %s", node)
+		message = fmt.Sprintf("unknown code: %s", node)
 	}
 	return Error{
 		code:    code,

--- a/go/vt/topo/etcd2topo/directory.go
+++ b/go/vt/topo/etcd2topo/directory.go
@@ -39,12 +39,12 @@ func (s *Server) ListDir(ctx context.Context, dirPath string, full bool) ([]topo
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
 		clientv3.WithKeysOnly())
 	if err != nil {
-		return nil, convertError(err)
+		return nil, convertError(err, dirPath)
 	}
 	if len(resp.Kvs) == 0 {
 		// No key starts with this prefix, means the directory
 		// doesn't exist.
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, nodePath)
 	}
 
 	prefixLen := len(nodePath)

--- a/go/vt/topo/etcd2topo/election.go
+++ b/go/vt/topo/etcd2topo/election.go
@@ -64,7 +64,7 @@ func (mp *etcdMasterParticipation) WaitForMastership() (context.Context, error) 
 	// If Stop was already called, mp.done is closed, so we are interrupted.
 	select {
 	case <-mp.done:
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 	}
 
@@ -116,7 +116,7 @@ func (mp *etcdMasterParticipation) GetCurrentMasterID(ctx context.Context) (stri
 		clientv3.WithSort(clientv3.SortByModRevision, clientv3.SortAscend),
 		clientv3.WithLimit(1))
 	if err != nil {
-		return "", convertError(err)
+		return "", convertError(err, electionPath)
 	}
 	if len(resp.Kvs) == 0 {
 		// No key starts with this prefix, means nobody is the master.

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -111,7 +111,7 @@ func (c *TeeConn) Create(ctx context.Context, filePath string, contents []byte) 
 	// This is critical enough that we want to fail. However, we support
 	// an unconditional update if the file already exists.
 	_, err = c.secondary.Create(ctx, filePath, contents)
-	if err == topo.ErrNodeExists {
+	if topo.IsErrType(err, topo.NodeExists) {
 		_, err = c.secondary.Update(ctx, filePath, contents, nil)
 	}
 	if err != nil {
@@ -149,7 +149,7 @@ func (c *TeeConn) Delete(ctx context.Context, filePath string, version topo.Vers
 	}
 
 	// Always do an unconditonal delete on secondary.
-	if err := c.secondary.Delete(ctx, filePath, nil); err != nil && err != topo.ErrNoNode {
+	if err := c.secondary.Delete(ctx, filePath, nil); err != nil && !topo.IsErrType(err, topo.NoNode) {
 		// Secondary didn't work, and the node wasn't gone already.
 		log.Warningf("secondary.Delete(%v) failed: %v", filePath, err)
 	}

--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -41,7 +41,7 @@ func (c *Conn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.D
 	// Get the node to list.
 	n := c.factory.nodeByPath(c.cell, dirPath)
 	if n == nil {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, dirPath)
 	}
 
 	// Check it's a directory.

--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -33,7 +33,7 @@ func (c *Conn) NewMasterParticipation(name, id string) (topo.MasterParticipation
 	// Make sure the global path exists.
 	electionPath := path.Join(electionsPath, name)
 	if n := c.factory.getOrCreatePath(c.cell, electionPath); n == nil {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, electionPath)
 	}
 
 	return &cMasterParticipation{
@@ -72,7 +72,7 @@ func (mp *cMasterParticipation) WaitForMastership() (context.Context, error) {
 	// If Stop was already called, mp.done is closed, so we are interrupted.
 	select {
 	case <-mp.done:
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 	}
 

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -47,7 +47,7 @@ func (c *Conn) Create(ctx context.Context, filePath string, contents []byte) (to
 
 	// Check the file doesn't already exist.
 	if _, ok := p.children[file]; ok {
-		return nil, topo.ErrNodeExists
+		return nil, topo.NewError(topo.NodeExists, file)
 	}
 
 	// Create the file.
@@ -75,7 +75,7 @@ func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, ver
 	if p == nil {
 		// Parent doesn't exist, let's create it if we need to.
 		if version != nil {
-			return nil, topo.ErrNoNode
+			return nil, topo.NewError(topo.NoNode, filePath)
 		}
 		p = c.factory.getOrCreatePath(c.cell, dir)
 		if p == nil {
@@ -88,7 +88,7 @@ func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, ver
 	if !ok {
 		// File doesn't exist, see if we need to create it.
 		if version != nil {
-			return nil, topo.ErrNoNode
+			return nil, topo.NewError(topo.NoNode, filePath)
 		}
 		n = c.factory.newFile(file, contents, p)
 		p.children[file] = n
@@ -102,7 +102,7 @@ func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, ver
 
 	// Check the version.
 	if version != nil && n.version != uint64(version.(NodeVersion)) {
-		return nil, topo.ErrBadVersion
+		return nil, topo.NewError(topo.BadVersion, filePath)
 	}
 
 	// Now we can update.
@@ -132,7 +132,7 @@ func (c *Conn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, 
 	// Get the node.
 	n := c.factory.nodeByPath(c.cell, filePath)
 	if n == nil {
-		return nil, nil, topo.ErrNoNode
+		return nil, nil, topo.NewError(topo.NoNode, filePath)
 	}
 	if n.contents == nil {
 		// it's a directory
@@ -154,13 +154,13 @@ func (c *Conn) Delete(ctx context.Context, filePath string, version topo.Version
 	dir, file := path.Split(filePath)
 	p := c.factory.nodeByPath(c.cell, dir)
 	if p == nil {
-		return topo.ErrNoNode
+		return topo.NewError(topo.NoNode, filePath)
 	}
 
 	// Get the existing file.
 	n, ok := p.children[file]
 	if !ok {
-		return topo.ErrNoNode
+		return topo.NewError(topo.NoNode, filePath)
 	}
 
 	// Check if it's a directory.
@@ -170,7 +170,7 @@ func (c *Conn) Delete(ctx context.Context, filePath string, version topo.Version
 
 	// Check the version.
 	if version != nil && n.version != uint64(version.(NodeVersion)) {
-		return topo.ErrBadVersion
+		return topo.NewError(topo.BadVersion, filePath)
 	}
 
 	// Now we can delete.
@@ -179,7 +179,7 @@ func (c *Conn) Delete(ctx context.Context, filePath string, version topo.Version
 	// Call the watches
 	for _, w := range n.watches {
 		w <- &topo.WatchData{
-			Err: topo.ErrNoNode,
+			Err: topo.NewError(topo.NoNode, filePath),
 		}
 		close(w)
 	}

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -76,7 +76,7 @@ func (f *Factory) Create(cell, serverAddr, root string) (topo.Conn, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if _, ok := f.cells[cell]; !ok {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, cell)
 	}
 	return &Conn{
 		factory: f,

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -35,7 +35,7 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 
 	n := c.factory.nodeByPath(c.cell, filePath)
 	if n == nil {
-		return &topo.WatchData{Err: topo.ErrNoNode}, nil, nil
+		return &topo.WatchData{Err: topo.NewError(topo.NoNode, filePath)}, nil, nil
 	}
 	if n.contents == nil {
 		// it's a directory
@@ -64,7 +64,7 @@ func (c *Conn) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-c
 
 		if w, ok := n.watches[watchIndex]; ok {
 			delete(n.watches, watchIndex)
-			w <- &topo.WatchData{Err: topo.ErrInterrupted}
+			w <- &topo.WatchData{Err: topo.NewError(topo.Interrupted, "watch")}
 			close(w)
 		}
 	}

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -43,7 +43,6 @@ There are two test sub-packages associated with this code:
 package topo
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"sync"
@@ -80,40 +79,6 @@ const (
 	KeyspacesPath = "keyspaces"
 	ShardsPath    = "shards"
 	TabletsPath   = "tablets"
-)
-
-var (
-	// ErrNodeExists is returned by functions to specify the
-	// requested resource already exists.
-	ErrNodeExists = errors.New("node already exists")
-
-	// ErrNoNode is returned by functions to specify the requested
-	// resource does not exist.
-	ErrNoNode = errors.New("node doesn't exist")
-
-	// ErrNotEmpty is returned by functions to specify a child of the
-	// resource is still present and prevents the action from completing.
-	ErrNotEmpty = errors.New("node not empty")
-
-	// ErrTimeout is returned by functions that wait for a result
-	// when the timeout value is reached.
-	ErrTimeout = errors.New("deadline exceeded")
-
-	// ErrInterrupted is returned by functions that wait for a result
-	// when they are interrupted.
-	ErrInterrupted = errors.New("interrupted")
-
-	// ErrBadVersion is returned by an update function that
-	// failed to update the data because the version was different
-	ErrBadVersion = errors.New("bad node version")
-
-	// ErrPartialResult is returned by a function that could only
-	// get a subset of its results
-	ErrPartialResult = errors.New("partial result")
-
-	// ErrNoUpdateNeeded can be returned by an 'UpdateFields' method
-	// to skip any update.
-	ErrNoUpdateNeeded = errors.New("no update needed")
 )
 
 // Factory is a factory interface to create Conn objects.
@@ -234,7 +199,7 @@ func NewWithFactory(factory Factory, serverAddress, root string) (*Server, error
 func OpenServer(implementation, serverAddress, root string) (*Server, error) {
 	factory, ok := factories[implementation]
 	if !ok {
-		return nil, ErrNoNode
+		return nil, NewError(NoNode, implementation)
 	}
 	return NewWithFactory(factory, serverAddress, root)
 }

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -237,12 +237,12 @@ func (ts *Server) UpdateShardFields(ctx context.Context, keyspace, shard string,
 			return nil, err
 		}
 		if err = update(si); err != nil {
-			if err == ErrNoUpdateNeeded {
+			if IsErrType(err, NoUpdateNeeded) {
 				return nil, nil
 			}
 			return nil, err
 		}
-		if err = ts.updateShard(ctx, si); err != ErrBadVersion {
+		if err = ts.updateShard(ctx, si); !IsErrType(err, BadVersion) {
 			return si, err
 		}
 	}
@@ -280,7 +280,7 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 		// if we are using range-based sharding, we don't want
 		// overlapping shards to all serve and confuse the clients.
 		sis, err := ts.FindAllShardsInKeyspace(ctx, keyspace)
-		if err != nil && err != ErrNoNode {
+		if err != nil && !IsErrType(err, NoNode) {
 			return err
 		}
 		for _, si := range sis {
@@ -323,17 +323,17 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 // already exist. Note the shard creation is protected by a keyspace Lock.
 func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard string) (si *ShardInfo, err error) {
 	si, err = ts.GetShard(ctx, keyspace, shard)
-	if err != ErrNoNode {
+	if !IsErrType(err, NoNode) {
 		return
 	}
 
 	// create the keyspace, maybe it already exists
-	if err = ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{}); err != nil && err != ErrNodeExists {
+	if err = ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{}); err != nil && !IsErrType(err, NodeExists) {
 		return nil, fmt.Errorf("CreateKeyspace(%v) failed: %v", keyspace, err)
 	}
 
 	// now try to create with the lock, may already exist
-	if err = ts.CreateShard(ctx, keyspace, shard); err != nil && err != ErrNodeExists {
+	if err = ts.CreateShard(ctx, keyspace, shard); err != nil && !IsErrType(err, NodeExists) {
 		return nil, fmt.Errorf("CreateShard(%v/%v) failed: %v", keyspace, shard, err)
 	}
 
@@ -656,7 +656,7 @@ func (ts *Server) FindAllTabletAliasesInShardByCell(ctx context.Context, keyspac
 	err = nil
 	if rec.HasErrors() {
 		log.Warningf("FindAllTabletAliasesInShard(%v,%v): got partial result: %v", keyspace, shard, rec.Error())
-		err = ErrPartialResult
+		err = NewError(PartialResult, shard)
 	}
 
 	result := make([]*topodatapb.TabletAlias, 0, len(resultAsMap))
@@ -684,7 +684,7 @@ func (ts *Server) GetTabletMapForShardByCell(ctx context.Context, keyspace, shar
 	// if we get a partial result, we keep going. It most likely means
 	// a cell is out of commission.
 	aliases, err := ts.FindAllTabletAliasesInShardByCell(ctx, keyspace, shard, cells)
-	if err != nil && err != ErrPartialResult {
+	if err != nil && !IsErrType(err, PartialResult) {
 		return nil, err
 	}
 

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -105,10 +105,10 @@ func (ts *Server) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]strin
 	}
 
 	children, err := conn.ListDir(ctx, KeyspacesPath, false /*full*/)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return DirEntriesToStringArray(children), nil
-	case ErrNoNode:
+	case IsErrType(err, NoNode):
 		return nil, nil
 	default:
 		return nil, err

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -290,12 +290,12 @@ func (ts *Server) UpdateTabletFields(ctx context.Context, alias *topodatapb.Tabl
 			return nil, err
 		}
 		if err = update(ti.Tablet); err != nil {
-			if err == ErrNoUpdateNeeded {
+			if IsErrType(err, NoUpdateNeeded) {
 				return nil, nil
 			}
 			return nil, err
 		}
-		if err = ts.UpdateTablet(ctx, ti); err != ErrBadVersion {
+		if err = ts.UpdateTablet(ctx, ti); !IsErrType(err, BadVersion) {
 			return ti.Tablet, err
 		}
 	}
@@ -338,7 +338,7 @@ func (ts *Server) CreateTablet(ctx context.Context, tablet *topodatapb.Tablet) e
 		return err
 	}
 	tabletPath := path.Join(TabletsPath, topoproto.TabletAliasString(tablet.Alias), TabletFile)
-	if _, err = conn.Create(ctx, tabletPath, data); err != nil && err != ErrNodeExists {
+	if _, err = conn.Create(ctx, tabletPath, data); err != nil && !IsErrType(err, NodeExists) {
 		return err
 	}
 
@@ -428,8 +428,8 @@ func (ts *Server) GetTabletMap(ctx context.Context, tabletAliases []*topodatapb.
 			if err != nil {
 				log.Warningf("%v: %v", tabletAlias, err)
 				// There can be data races removing nodes - ignore them for now.
-				if err != ErrNoNode {
-					someError = ErrPartialResult
+				if !IsErrType(err, NoNode) {
+					someError = NewError(PartialResult, "")
 				}
 			} else {
 				tabletMap[topoproto.TabletAliasString(tabletAlias)] = tabletInfo
@@ -454,7 +454,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cell string) ([]*topodat
 	// List the directory, and parse the aliases
 	children, err := conn.ListDir(ctx, TabletsPath, false /*full*/)
 	if err != nil {
-		if err == ErrNoNode {
+		if IsErrType(err, NoNode) {
 			// directory doesn't exist, empty list, no error.
 			return nil, nil
 		}

--- a/go/vt/topo/test/directory.go
+++ b/go/vt/topo/test/directory.go
@@ -57,12 +57,12 @@ func checkListDir(ctx context.Context, t *testing.T, conn topo.Conn, dirPath str
 
 	// Test with full=false.
 	entries, err := conn.ListDir(ctx, dirPath, false /*full*/)
-	switch err {
-	case topo.ErrNoNode:
+	switch {
+	case topo.IsErrType(err, topo.NoNode):
 		if len(se) != 0 {
 			t.Errorf("ListDir(%v, false) returned ErrNoNode but was expecting %v", dirPath, se)
 		}
-	case nil:
+	case err == nil:
 		if len(se) != 0 || len(entries) != 0 {
 			if !reflect.DeepEqual(entries, se) {
 				t.Errorf("ListDir(%v, false) returned %v but was expecting %v", dirPath, entries, se)
@@ -74,12 +74,12 @@ func checkListDir(ctx context.Context, t *testing.T, conn topo.Conn, dirPath str
 
 	// Test with full=true.
 	entries, err = conn.ListDir(ctx, dirPath, true /*full*/)
-	switch err {
-	case topo.ErrNoNode:
+	switch {
+	case topo.IsErrType(err, topo.NoNode):
 		if len(expected) != 0 {
 			t.Errorf("ListDir(%v, true) returned ErrNoNode but was expecting %v", dirPath, expected)
 		}
-	case nil:
+	case err == nil:
 		if len(expected) != 0 || len(entries) != 0 {
 			if !reflect.DeepEqual(entries, expected) {
 				t.Errorf("ListDir(%v, true) returned %v but was expecting %v", dirPath, entries, expected)

--- a/go/vt/topo/test/election.go
+++ b/go/vt/topo/test/election.go
@@ -143,7 +143,7 @@ func checkElection(t *testing.T, ts *topo.Server) {
 	// does, for instance. There is a go routine that runs
 	// WaitForMastership and needs to exit cleanly at the end.
 	_, err = mp2.WaitForMastership()
-	if err != topo.ErrInterrupted {
-		t.Errorf("wrong error returned by WaitForMastership, got %v expected %v", err, topo.ErrInterrupted)
+	if !topo.IsErrType(err, topo.Interrupted) {
+		t.Errorf("wrong error returned by WaitForMastership, got %v expected %v", err, topo.NewError(topo.Interrupted, ""))
 	}
 }

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -61,7 +61,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 
 	// Get with no file -> ErrNoNode.
 	contents, version, err := conn.Get(ctx, "/myfile")
-	if err != topo.ErrNoNode {
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("Get(non-existent) didn't return ErrNoNode but: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	}
 
 	// Try to update again with wrong version, should fail.
-	if _, err = conn.Update(ctx, "/myfile", []byte{'b'}, version); err != topo.ErrBadVersion {
+	if _, err = conn.Update(ctx, "/myfile", []byte{'b'}, version); !topo.IsErrType(err, topo.BadVersion) {
 		t.Errorf("Update(bad version) didn't return ErrBadVersion but: %v", err)
 	}
 
@@ -148,7 +148,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	}
 
 	// Try to delete with wrong version, should fail.
-	if err = conn.Delete(ctx, "/myfile", version); err != topo.ErrBadVersion {
+	if err = conn.Delete(ctx, "/myfile", version); !topo.IsErrType(err, topo.BadVersion) {
 		t.Errorf("Delete('/myfile', wrong version) returned bad error: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	checkListDir(ctx, t, conn, "/", expected)
 
 	// Try to delete again, should fail.
-	if err = conn.Delete(ctx, "/myfile", newVersion); err != topo.ErrNoNode {
+	if err = conn.Delete(ctx, "/myfile", newVersion); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("Delete(already gone) returned bad error: %v", err)
 	}
 

--- a/go/vt/topo/test/keyspace.go
+++ b/go/vt/topo/test/keyspace.go
@@ -39,7 +39,7 @@ func checkKeyspace(t *testing.T, ts *topo.Server) {
 	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); err != nil {
 		t.Errorf("CreateKeyspace: %v", err)
 	}
-	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); err != topo.ErrNodeExists {
+	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); !topo.IsErrType(err, topo.NodeExists) {
 		t.Errorf("CreateKeyspace(again) is not ErrNodeExists: %v", err)
 	}
 
@@ -47,7 +47,7 @@ func checkKeyspace(t *testing.T, ts *topo.Server) {
 	if err := ts.DeleteKeyspace(ctx, "test_keyspace"); err != nil {
 		t.Errorf("DeleteKeyspace: %v", err)
 	}
-	if err := ts.DeleteKeyspace(ctx, "test_keyspace"); err != topo.ErrNoNode {
+	if err := ts.DeleteKeyspace(ctx, "test_keyspace"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteKeyspace(again): %v", err)
 	}
 	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); err != nil {

--- a/go/vt/topo/test/lock.go
+++ b/go/vt/topo/test/lock.go
@@ -93,7 +93,7 @@ func checkLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 
 	// test we can't take the lock again
 	fastCtx, cancel := context.WithTimeout(ctx, timeUntilLockIsTaken)
-	if _, err := conn.Lock(fastCtx, keyspacePath, "again"); err != topo.ErrTimeout {
+	if _, err := conn.Lock(fastCtx, keyspacePath, "again"); !topo.IsErrType(err, topo.Timeout) {
 		t.Fatalf("Lock(again): %v", err)
 	}
 	cancel()
@@ -104,7 +104,7 @@ func checkLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 		time.Sleep(timeUntilLockIsTaken)
 		cancel()
 	}()
-	if _, err := conn.Lock(interruptCtx, keyspacePath, "interrupted"); err != topo.ErrInterrupted {
+	if _, err := conn.Lock(interruptCtx, keyspacePath, "interrupted"); !topo.IsErrType(err, topo.Interrupted) {
 		t.Fatalf("Lock(interrupted): %v", err)
 	}
 

--- a/go/vt/topo/test/replication.go
+++ b/go/vt/topo/test/replication.go
@@ -28,7 +28,7 @@ import (
 // checkShardReplication tests ShardReplication objects
 func checkShardReplication(t *testing.T, ts *topo.Server) {
 	ctx := context.Background()
-	if _, err := ts.GetShardReplication(ctx, LocalCellName, "test_keyspace", "-10"); err != topo.ErrNoNode {
+	if _, err := ts.GetShardReplication(ctx, LocalCellName, "test_keyspace", "-10"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetShardReplication(not there): %v", err)
 	}
 
@@ -43,7 +43,7 @@ func checkShardReplication(t *testing.T, ts *topo.Server) {
 		},
 	}
 	if err := ts.UpdateShardReplicationFields(ctx, LocalCellName, "test_keyspace", "-10", func(oldSr *topodatapb.ShardReplication) error {
-		return topo.ErrNoUpdateNeeded
+		return topo.NewError(topo.NoUpdateNeeded, LocalCellName)
 	}); err != nil {
 		t.Fatalf("UpdateShardReplicationFields() failed: %v", err)
 	}
@@ -91,16 +91,16 @@ func checkShardReplication(t *testing.T, ts *topo.Server) {
 	if err := ts.DeleteShardReplication(ctx, LocalCellName, "test_keyspace", "-10"); err != nil {
 		t.Errorf("DeleteShardReplication(existing) failed: %v", err)
 	}
-	if err := ts.DeleteShardReplication(ctx, LocalCellName, "test_keyspace", "-10"); err != topo.ErrNoNode {
+	if err := ts.DeleteShardReplication(ctx, LocalCellName, "test_keyspace", "-10"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteShardReplication(again) returned: %v", err)
 	}
 
 	// Some implementations may already remove the directory if not data is in there, so we ignore topo.ErrNoNode.
-	if err := ts.DeleteKeyspaceReplication(ctx, LocalCellName, "test_keyspace"); err != nil && err != topo.ErrNoNode {
+	if err := ts.DeleteKeyspaceReplication(ctx, LocalCellName, "test_keyspace"); err != nil && !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteKeyspaceReplication(existing) failed: %v", err)
 	}
 	// The second time though, it should be gone.
-	if err := ts.DeleteKeyspaceReplication(ctx, LocalCellName, "test_keyspace"); err != topo.ErrNoNode {
+	if err := ts.DeleteKeyspaceReplication(ctx, LocalCellName, "test_keyspace"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteKeyspaceReplication(again) returned: %v", err)
 	}
 }

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -63,7 +63,7 @@ func checkSrvKeyspace(t *testing.T, ts *topo.Server) {
 	if err := ts.UpdateSrvKeyspace(ctx, LocalCellName, "test_keyspace", srvKeyspace); err != nil {
 		t.Errorf("UpdateSrvKeyspace(1): %v", err)
 	}
-	if _, err := ts.GetSrvKeyspace(ctx, LocalCellName, "test_keyspace666"); err != topo.ErrNoNode {
+	if _, err := ts.GetSrvKeyspace(ctx, LocalCellName, "test_keyspace666"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetSrvKeyspace(invalid): %v", err)
 	}
 	if k, err := ts.GetSrvKeyspace(ctx, LocalCellName, "test_keyspace"); err != nil || !proto.Equal(srvKeyspace, k) {
@@ -85,7 +85,7 @@ func checkSrvKeyspace(t *testing.T, ts *topo.Server) {
 	if err := ts.DeleteSrvKeyspace(ctx, LocalCellName, "unknown_keyspace_so_far"); err != nil {
 		t.Fatalf("DeleteSrvKeyspace: %v", err)
 	}
-	if _, err := ts.GetSrvKeyspace(ctx, LocalCellName, "unknown_keyspace_so_far"); err != topo.ErrNoNode {
+	if _, err := ts.GetSrvKeyspace(ctx, LocalCellName, "unknown_keyspace_so_far"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetSrvKeyspace(deleted) got %v, want ErrNoNode", err)
 	}
 }
@@ -95,7 +95,7 @@ func checkSrvVSchema(t *testing.T, ts *topo.Server) {
 	ctx := context.Background()
 
 	// check GetSrvVSchema returns topo.ErrNoNode if no SrvVSchema
-	if _, err := ts.GetSrvVSchema(ctx, LocalCellName); err != topo.ErrNoNode {
+	if _, err := ts.GetSrvVSchema(ctx, LocalCellName); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetSrvVSchema(not set): %v", err)
 	}
 

--- a/go/vt/topo/test/shard.go
+++ b/go/vt/topo/test/shard.go
@@ -42,7 +42,7 @@ func checkShard(t *testing.T, ts *topo.Server) {
 	if err := ts.CreateShard(ctx, "test_keyspace", "b0-c0"); err != nil {
 		t.Fatalf("CreateShard: %v", err)
 	}
-	if err := ts.CreateShard(ctx, "test_keyspace", "b0-c0"); err != topo.ErrNodeExists {
+	if err := ts.CreateShard(ctx, "test_keyspace", "b0-c0"); !topo.IsErrType(err, topo.NodeExists) {
 		t.Errorf("CreateShard called second time, got: %v", err)
 	}
 
@@ -50,7 +50,7 @@ func checkShard(t *testing.T, ts *topo.Server) {
 	if err := ts.DeleteShard(ctx, "test_keyspace", "b0-c0"); err != nil {
 		t.Fatalf("DeleteShard: %v", err)
 	}
-	if err := ts.DeleteShard(ctx, "test_keyspace", "b0-c0"); err != topo.ErrNoNode {
+	if err := ts.DeleteShard(ctx, "test_keyspace", "b0-c0"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteShard(again): %v", err)
 	}
 	if err := ts.CreateShard(ctx, "test_keyspace", "b0-c0"); err != nil {
@@ -58,7 +58,7 @@ func checkShard(t *testing.T, ts *topo.Server) {
 	}
 
 	// Test getting an invalid shard returns ErrNoNode.
-	if _, err := ts.GetShard(ctx, "test_keyspace", "666"); err != topo.ErrNoNode {
+	if _, err := ts.GetShard(ctx, "test_keyspace", "666"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetShard(666): %v", err)
 	}
 
@@ -89,7 +89,7 @@ func checkShard(t *testing.T, ts *topo.Server) {
 		t.Errorf(`GetShardNames: want [ "b0-c0" ], got %v`, shards)
 	}
 
-	if _, err := ts.GetShardNames(ctx, "test_keyspace666"); err != topo.ErrNoNode {
+	if _, err := ts.GetShardNames(ctx, "test_keyspace666"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetShardNames(666): %v", err)
 	}
 }

--- a/go/vt/topo/test/tablet.go
+++ b/go/vt/topo/test/tablet.go
@@ -52,14 +52,14 @@ func checkTablet(t *testing.T, ts *topo.Server) {
 	if err := ts.CreateTablet(ctx, tablet); err != nil {
 		t.Fatalf("CreateTablet: %v", err)
 	}
-	if err := ts.CreateTablet(ctx, tablet); err != topo.ErrNodeExists {
+	if err := ts.CreateTablet(ctx, tablet); !topo.IsErrType(err, topo.NodeExists) {
 		t.Fatalf("CreateTablet(again): %v", err)
 	}
 
 	if _, err := ts.GetTablet(ctx, &topodatapb.TabletAlias{
 		Cell: LocalCellName,
 		Uid:  666,
-	}); err != topo.ErrNoNode {
+	}); !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("GetTablet(666): %v", err)
 	}
 
@@ -71,7 +71,7 @@ func checkTablet(t *testing.T, ts *topo.Server) {
 		t.Errorf("put and got tablets are not identical:\n%#v\n%#v", tablet, t)
 	}
 
-	if _, err := ts.GetTabletsByCell(ctx, "666"); err != topo.ErrNoNode {
+	if _, err := ts.GetTabletsByCell(ctx, "666"); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetTabletsByCell(666): %v", err)
 	}
 
@@ -117,7 +117,7 @@ func checkTablet(t *testing.T, ts *topo.Server) {
 
 	// test UpdateTabletFields that returns ErrNoUpdateNeeded works
 	if _, err := ts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
-		return topo.ErrNoUpdateNeeded
+		return topo.NewError(topo.NoUpdateNeeded, tablet.Alias.String())
 	}); err != nil {
 		t.Errorf("UpdateTabletFields: %v", err)
 	}
@@ -132,11 +132,11 @@ func checkTablet(t *testing.T, ts *topo.Server) {
 	if err := ts.DeleteTablet(ctx, tablet.Alias); err != nil {
 		t.Errorf("DeleteTablet: %v", err)
 	}
-	if err := ts.DeleteTablet(ctx, tablet.Alias); err != topo.ErrNoNode {
+	if err := ts.DeleteTablet(ctx, tablet.Alias); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("DeleteTablet(again): %v", err)
 	}
 
-	if _, err := ts.GetTablet(ctx, tablet.Alias); err != topo.ErrNoNode {
+	if _, err := ts.GetTablet(ctx, tablet.Alias); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("GetTablet: expected error, tablet was deleted: %v", err)
 	}
 

--- a/go/vt/topo/test/vschema.go
+++ b/go/vt/topo/test/vschema.go
@@ -40,7 +40,7 @@ func checkVSchema(t *testing.T, ts *topo.Server) {
 
 	got, err := ts.GetVSchema(ctx, "test_keyspace")
 	want := &vschemapb.Keyspace{}
-	if err != topo.ErrNoNode {
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Error(err)
 	}
 

--- a/go/vt/topo/test/watch.go
+++ b/go/vt/topo/test/watch.go
@@ -37,7 +37,7 @@ func waitForInitialValue(t *testing.T, conn topo.Conn, srvKeyspace *topodatapb.S
 	start := time.Now()
 	for {
 		current, changes, cancel = conn.Watch(ctx, "keyspaces/test_keyspace/SrvKeyspace")
-		if current.Err == topo.ErrNoNode {
+		if topo.IsErrType(current.Err, topo.NoNode) {
 			// hasn't appeared yet
 			if time.Now().Sub(start) > 10*time.Second {
 				t.Fatalf("time out waiting for file to appear")
@@ -73,7 +73,7 @@ func checkWatch(t *testing.T, ts *topo.Server) {
 
 	// start watching something that doesn't exist -> error
 	current, changes, cancel := conn.Watch(ctx, "keyspaces/test_keyspace/SrvKeyspace")
-	if current.Err != topo.ErrNoNode {
+	if !topo.IsErrType(current.Err, topo.NoNode) {
 		t.Errorf("watch on missing node didn't return ErrNoNode: %v %v", current, changes)
 	}
 
@@ -135,7 +135,7 @@ func checkWatch(t *testing.T, ts *topo.Server) {
 		if !ok {
 			t.Fatalf("watch channel unexpectedly closed")
 		}
-		if wd.Err == topo.ErrNoNode {
+		if topo.IsErrType(wd.Err, topo.NoNode) {
 			// good
 			break
 		}
@@ -188,7 +188,7 @@ func checkWatchInterrupt(t *testing.T, ts *topo.Server) {
 		if !ok {
 			t.Fatalf("watch channel unexpectedly closed")
 		}
-		if wd.Err == topo.ErrInterrupted {
+		if topo.IsErrType(wd.Err, topo.Interrupted) {
 			// good
 			break
 		}

--- a/go/vt/topo/topotests/cell_info_test.go
+++ b/go/vt/topo/topotests/cell_info_test.go
@@ -62,7 +62,7 @@ func TestCellInfo(t *testing.T) {
 	// Test update with no change.
 	if err := ts.UpdateCellInfoFields(ctx, cell, func(ci *topodatapb.CellInfo) error {
 		ci.ServerAddress = "bad address"
-		return topo.ErrNoUpdateNeeded
+		return topo.NewError(topo.NoUpdateNeeded, cell)
 	}); err != nil {
 		t.Fatalf("UpdateCellInfoFields failed: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestCellInfo(t *testing.T) {
 	if err := ts.DeleteCellInfo(ctx, newCell); err != nil {
 		t.Fatalf("DeleteCellInfo failed: %v", err)
 	}
-	if _, err := ts.GetCellInfo(ctx, newCell, true /*strongRead*/); err != topo.ErrNoNode {
+	if _, err := ts.GetCellInfo(ctx, newCell, true /*strongRead*/); !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("GetCellInfo(non-existing cell) failed: %v", err)
 	}
 }

--- a/go/vt/topo/topotests/tablet_test.go
+++ b/go/vt/topo/topotests/tablet_test.go
@@ -63,7 +63,7 @@ func TestCreateTablet(t *testing.T) {
 	}
 
 	// Create the same tablet again, make sure it fails with ErrNodeExists.
-	if err := ts.CreateTablet(ctx, tablet); err != topo.ErrNodeExists {
+	if err := ts.CreateTablet(ctx, tablet); !topo.IsErrType(err, topo.NodeExists) {
 		t.Fatalf("CreateTablet(again) returned: %v", err)
 	}
 
@@ -76,7 +76,7 @@ func TestCreateTablet(t *testing.T) {
 	if err != nil || len(sri.Nodes) != 0 {
 		t.Fatalf("Modifed ShardReplication doesn't match: %v %v", sri, err)
 	}
-	if err := ts.CreateTablet(ctx, tablet); err != topo.ErrNodeExists {
+	if err := ts.CreateTablet(ctx, tablet); !topo.IsErrType(err, topo.NodeExists) {
 		t.Fatalf("CreateTablet(again and again) returned: %v", err)
 	}
 	sri, err = ts.GetShardReplication(ctx, cell, keyspace, shard)

--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -90,10 +90,10 @@ func (ts *Server) ResolveShardWildcard(ctx context.Context, param string) ([]Key
 		if fileutil.HasWildcard(shard) {
 			// get all the shards for the keyspace
 			shardNames, err := ts.GetShardNames(ctx, matchedKeyspace)
-			switch err {
-			case nil:
+			switch {
+			case err == nil:
 				// got all the shards, we can keep going
-			case ErrNoNode:
+			case IsErrType(err, NoNode):
 				// keyspace doesn't exist
 				if keyspaceHasWildcards {
 					// that's the */* case when a keyspace has no shards
@@ -121,11 +121,11 @@ func (ts *Server) ResolveShardWildcard(ctx context.Context, param string) ([]Key
 			if keyspaceHasWildcards {
 				// keyspace was a wildcard, shard is not, just try it
 				_, err := ts.GetShard(ctx, matchedKeyspace, shard)
-				switch err {
-				case nil:
+				switch {
+				case err == nil:
 					// shard exists, add it
 					result = append(result, KeyspaceShard{matchedKeyspace, shard})
-				case ErrNoNode:
+				case IsErrType(err, NoNode):
 					// no shard, ignore
 				default:
 					// other error
@@ -205,7 +205,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 				// /keyspaces/aaa/* and
 				// /keyspaces/aaa doesn't exist
 				// -> return empty list, no error
-				if err == ErrNoNode {
+				if IsErrType(err, NoNode) {
 					return nil, nil
 				}
 				// otherwise we return the error
@@ -282,7 +282,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 	if err == nil {
 		// The path exists as a file, return it.
 		return []string{p}, nil
-	} else if err == ErrNoNode {
+	} else if IsErrType(err, NoNode) {
 		// The path doesn't exist, don't return anything.
 		return nil, nil
 	}

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -47,10 +47,10 @@ type WorkflowInfo struct {
 // workflows. They are sorted by uuid.
 func (ts *Server) GetWorkflowNames(ctx context.Context) ([]string, error) {
 	entries, err := ts.globalCell.ListDir(ctx, workflowsPath, false /*full*/)
-	switch err {
-	case ErrNoNode:
+	switch {
+	case IsErrType(err, NoNode):
 		return nil, nil
-	case nil:
+	case err == nil:
 		return DirEntriesToStringArray(entries), nil
 	default:
 		return nil, err

--- a/go/vt/topo/zk2topo/directory.go
+++ b/go/vt/topo/zk2topo/directory.go
@@ -36,7 +36,7 @@ func (zs *Server) ListDir(ctx context.Context, dirPath string, full bool) ([]top
 
 	children, _, err := zs.conn.Children(ctx, zkPath)
 	if err != nil {
-		return nil, convertError(err)
+		return nil, convertError(err, zkPath)
 	}
 	sort.Strings(children)
 

--- a/go/vt/topo/zk2topo/election.go
+++ b/go/vt/topo/zk2topo/election.go
@@ -40,7 +40,7 @@ func (zs *Server) NewMasterParticipation(name, id string) (topo.MasterParticipat
 	// Create the toplevel directory, OK if it exists already.
 	// We will create the parent directory as well, but not more.
 	if _, err := CreateRecursive(ctx, zs.conn, zkPath, nil, 0, zk.WorldACL(PermDirectory), 1); err != nil && err != zk.ErrNodeExists {
-		return nil, convertError(err)
+		return nil, convertError(err, zkPath)
 	}
 
 	result := &zkMasterParticipation{
@@ -85,7 +85,7 @@ func (mp *zkMasterParticipation) WaitForMastership() (context.Context, error) {
 	// If Stop was already called, mp.done is closed, so we are interrupted.
 	select {
 	case <-mp.done:
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 	}
 
@@ -96,7 +96,7 @@ func (mp *zkMasterParticipation) WaitForMastership() (context.Context, error) {
 	select {
 	case <-mp.stopCtx.Done():
 		close(mp.done)
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 	}
 
@@ -115,7 +115,7 @@ func (mp *zkMasterParticipation) WaitForMastership() (context.Context, error) {
 		break
 	case context.Canceled:
 		close(mp.done)
-		return nil, topo.ErrInterrupted
+		return nil, topo.NewError(topo.Interrupted, "mastership")
 	default:
 		// something else went wrong
 		return nil, err
@@ -174,7 +174,7 @@ func (mp *zkMasterParticipation) GetCurrentMasterID(ctx context.Context) (string
 	for {
 		children, _, err := mp.zs.conn.Children(ctx, zkPath)
 		if err != nil {
-			return "", convertError(err)
+			return "", convertError(err, zkPath)
 		}
 		if len(children) == 0 {
 			// no current master
@@ -190,7 +190,7 @@ func (mp *zkMasterParticipation) GetCurrentMasterID(ctx context.Context) (string
 				// try again
 				continue
 			}
-			return "", convertError(err)
+			return "", convertError(err, zkPath)
 		}
 
 		return string(data), nil

--- a/go/vt/topo/zk2topo/error.go
+++ b/go/vt/topo/zk2topo/error.go
@@ -24,22 +24,22 @@ import (
 )
 
 // Error codes returned by the zookeeper Go client:
-func convertError(err error) error {
+func convertError(err error, node string) error {
 	switch err {
 	case zk.ErrBadVersion:
-		return topo.ErrBadVersion
+		return topo.NewError(topo.BadVersion, node)
 	case zk.ErrNoNode:
-		return topo.ErrNoNode
+		return topo.NewError(topo.NoNode, node)
 	case zk.ErrNodeExists:
-		return topo.ErrNodeExists
+		return topo.NewError(topo.NodeExists, node)
 	case zk.ErrNotEmpty:
-		return topo.ErrNotEmpty
+		return topo.NewError(topo.NodeNotEmpty, node)
 	case zk.ErrSessionExpired:
-		return topo.ErrTimeout
+		return topo.NewError(topo.Timeout, node)
 	case context.Canceled:
-		return topo.ErrInterrupted
+		return topo.NewError(topo.Interrupted, node)
 	case context.DeadlineExceeded:
-		return topo.ErrTimeout
+		return topo.NewError(topo.Timeout, node)
 	}
 	return err
 }

--- a/go/vt/topo/zk2topo/watch.go
+++ b/go/vt/topo/zk2topo/watch.go
@@ -33,11 +33,11 @@ func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 	// Get the initial value, set the initial watch
 	data, stats, watch, err := zs.conn.GetW(ctx, zkPath)
 	if err != nil {
-		return &topo.WatchData{Err: convertError(err)}, nil, nil
+		return &topo.WatchData{Err: convertError(err, zkPath)}, nil, nil
 	}
 	if stats == nil {
 		// No stats --> node doesn't exist.
-		return &topo.WatchData{Err: topo.ErrNoNode}, nil, nil
+		return &topo.WatchData{Err: topo.NewError(topo.NoNode, zkPath)}, nil, nil
 	}
 	wd := &topo.WatchData{
 		Contents: data,
@@ -78,19 +78,19 @@ func (zs *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, 
 
 			case <-stop:
 				// user is not interested any more
-				c <- &topo.WatchData{Err: topo.ErrInterrupted}
+				c <- &topo.WatchData{Err: topo.NewError(topo.Interrupted, "watch")}
 				return
 			}
 
 			// Get the value again, and send it, or error.
 			data, stats, watch, err = zs.conn.GetW(ctx, zkPath)
 			if err != nil {
-				c <- &topo.WatchData{Err: convertError(err)}
+				c <- &topo.WatchData{Err: convertError(err, zkPath)}
 				return
 			}
 			if stats == nil {
 				// No data --> node doesn't exist
-				c <- &topo.WatchData{Err: topo.ErrNoNode}
+				c <- &topo.WatchData{Err: topo.NewError(topo.NoNode, zkPath)}
 				return
 			}
 			wd := &topo.WatchData{

--- a/go/vt/topotools/rebuild_vschema.go
+++ b/go/vt/topotools/rebuild_vschema.go
@@ -59,7 +59,7 @@ func RebuildVSchema(ctx context.Context, log logutil.Logger, ts *topo.Server, ce
 			defer wg.Done()
 
 			k, err := ts.GetVSchema(ctx, keyspace)
-			if err == topo.ErrNoNode {
+			if topo.IsErrType(err, topo.NoNode) {
 				err = nil
 				k = &vschemapb.Keyspace{}
 			}

--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -90,7 +90,7 @@ func CheckOwnership(oldTablet, newTablet *topodatapb.Tablet) error {
 func DeleteTablet(ctx context.Context, ts *topo.Server, tablet *topodatapb.Tablet) error {
 	// try to remove replication data, no fatal if we fail
 	if err := topo.DeleteTabletReplicationData(ctx, ts, tablet); err != nil {
-		if err == topo.ErrNoNode {
+		if topo.IsErrType(err, topo.NoNode) {
 			log.V(6).Infof("no ShardReplication object for cell %v", tablet.Alias.Cell)
 			err = nil
 		}

--- a/go/vt/topotools/utils.go
+++ b/go/vt/topotools/utils.go
@@ -37,7 +37,7 @@ func FindTabletByHostAndPort(tabletMap map[string]*topo.TabletInfo, addr, portNa
 			return ti.Alias, nil
 		}
 	}
-	return nil, topo.ErrNoNode
+	return nil, topo.NewError(topo.NoNode, addr+":"+portName)
 }
 
 // GetAllTablets returns a sorted list of tablets.
@@ -94,7 +94,7 @@ func GetAllTabletsAcrossCells(ctx context.Context, ts *topo.Server) ([]*topo.Tab
 		if errors[i] == nil {
 			allTablets = append(allTablets, results[i]...)
 		} else {
-			err = topo.ErrPartialResult
+			err = topo.NewError(topo.PartialResult, "")
 		}
 	}
 	return allTablets, err

--- a/go/vt/vtctl/cell_info.go
+++ b/go/vt/vtctl/cell_info.go
@@ -102,7 +102,7 @@ func commandUpdateCellInfo(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		if (*serverAddress == "" || ci.ServerAddress == *serverAddress) &&
 			(*root == "" || ci.Root == *root) &&
 			(*region == "" || ci.Region == *region) {
-			return topo.ErrNoUpdateNeeded
+			return topo.NewError(topo.NoUpdateNeeded, cell)
 		}
 		if *serverAddress != "" {
 			ci.ServerAddress = *serverAddress

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -81,7 +81,7 @@ func handleCollection(collection string, getFunc func(*http.Request) (interface{
 		// Get the requested object.
 		obj, err := getFunc(r)
 		if err != nil {
-			if err == topo.ErrNoNode {
+			if topo.IsErrType(err, topo.NoNode) {
 				http.NotFound(w, r)
 				return nil
 			}
@@ -276,13 +276,13 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 				}
 				if cell != "" {
 					result, err := ts.FindAllTabletAliasesInShardByCell(ctx, keyspace, shard, []string{cell})
-					if err != nil && err != topo.ErrPartialResult {
+					if err != nil && !topo.IsErrType(err, topo.PartialResult) {
 						return result, err
 					}
 					return result, nil
 				}
 				result, err := ts.FindAllTabletAliasesInShard(ctx, keyspace, shard)
-				if err != nil && err != topo.ErrPartialResult {
+				if err != nil && !topo.IsErrType(err, topo.PartialResult) {
 					return result, err
 				}
 				return result, nil

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -267,7 +267,7 @@ func TestAPI(t *testing.T) {
 		   "Output": "{\n  \"sharding_column_name\": \"shardcol\",\n  \"sharding_column_type\": 0,\n  \"served_froms\": [\n  ]\n}\n\n"
 		}`},
 		{"POST", "vtctl/", `["GetKeyspace","does_not_exist"]`, `{
-		   "Error": "node doesn't exist",
+			"Error": "node doesn't exist: keyspaces/does_not_exist/Keyspace",
 		   "Output": ""
 		}`},
 		{"POST", "vtctl/", `["Panic"]`, `uncaught panic: this command panics on purpose`},

--- a/go/vt/vtctld/explorer_test.go
+++ b/go/vt/vtctld/explorer_test.go
@@ -206,7 +206,7 @@ func TestHandlePathTablet(t *testing.T) {
 func TestHandleBadPath(t *testing.T) {
 	input := "/foo"
 	cells := []string{"cell1", "cell2", "cell3"}
-	want := "Invalid cell: node doesn't exist"
+	want := "Invalid cell: node doesn't exist: cells/foo/CellInfo"
 
 	ts := memorytopo.NewServer(cells...)
 	ex := newBackendExplorer(ts)

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -118,10 +118,10 @@ func runWorkflowManagerElection(ts *topo.Server) {
 		go func() {
 			for {
 				ctx, err := mp.WaitForMastership()
-				switch err {
-				case nil:
+				switch {
+				case err == nil:
 					vtctl.WorkflowManager.Run(ctx)
-				case topo.ErrInterrupted:
+				case topo.IsErrType(err, topo.Interrupted):
 					return
 				default:
 					log.Errorf("Got error while waiting for master, will retry in 5s: %v", err)

--- a/go/vt/vtgate/gateway/l2vtgateconn.go
+++ b/go/vt/vtgate/gateway/l2vtgateconn.go
@@ -174,12 +174,12 @@ func (c *L2VTGateConn) GetAggregateStats(target *querypb.Target) (*querypb.Aggre
 	defer c.mu.RUnlock()
 	e, ok := c.stats[key]
 	if !ok {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, target.String())
 	}
 
 	a, ok := e.aggregates[target.Cell]
 	if !ok {
-		return nil, topo.ErrNoNode
+		return nil, topo.NewError(topo.NoNode, target.String())
 	}
 	return a, nil
 }
@@ -195,13 +195,13 @@ func (c *L2VTGateConn) GetMasterCell(keyspace, shard string) (cell string, err e
 	defer c.mu.RUnlock()
 	e, ok := c.stats[key]
 	if !ok {
-		return "", topo.ErrNoNode
+		return "", topo.NewError(topo.NoNode, keyspace+"/"+shard)
 	}
 
 	for cell := range e.aggregates {
 		return cell, nil
 	}
-	return "", topo.ErrNoNode
+	return "", topo.NewError(topo.NoNode, keyspace+"/"+shard)
 }
 
 // CacheStatus returns a list of TabletCacheStatus per

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -60,10 +60,10 @@ func (vm *VSchemaManager) watchSrvVSchema(ctx context.Context, cell string) {
 		// we don't know the real value. In this case, we want
 		// to use the previous value if it was set, or an
 		// empty vschema if it wasn't.
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			// Good case, we can try to save that value.
-		case topo.ErrNoNode:
+		case topo.IsErrType(err, topo.NoNode):
 			// If the SrvVschema disappears, we need to clear our record.
 			// Otherwise, keep what we already had before.
 			v = nil

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -342,7 +342,7 @@ func TestVTGateExecuteWithKeyspaceShard(t *testing.T) {
 		"select id from none",
 		nil,
 	)
-	want = "vtgate: : target: TestUnsharded.noshard.master, no valid tablet: node doesn't exist"
+	want = "vtgate: : target: TestUnsharded.noshard.master, no valid tablet: node doesn't exist: TestUnsharded/noshard@MASTER"
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute: %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -342,7 +342,7 @@ func TestVTGateExecuteWithKeyspaceShard(t *testing.T) {
 		"select id from none",
 		nil,
 	)
-	want = "vtgate: : target: TestUnsharded.noshard.master, no valid tablet: node doesn't exist: TestUnsharded/noshard@MASTER"
+	want = "vtgate: : target: TestUnsharded.noshard.master, no valid tablet: node doesn't exist: TestUnsharded/noshard (MASTER)"
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute: %v, want %s", err, want)
 	}

--- a/go/vt/vttablet/customrule/topocustomrule/topocustomrule.go
+++ b/go/vt/vttablet/customrule/topocustomrule/topocustomrule.go
@@ -151,7 +151,7 @@ func (cr *topoCustomRule) oneWatch() error {
 		cancel()
 		for range wdChannel {
 		}
-		return topo.ErrInterrupted
+		return topo.NewError(topo.Interrupted, "watch")
 	}
 	cr.cancel = cancel
 	cr.mu.Unlock()

--- a/go/vt/vttablet/tabletmanager/initial_rebuild.go
+++ b/go/vt/vttablet/tabletmanager/initial_rebuild.go
@@ -29,12 +29,12 @@ import (
 // for the current cell only.
 func (agent *ActionAgent) maybeRebuildKeyspace(cell, keyspace string) {
 	_, err := agent.TopoServer.GetSrvKeyspace(agent.batchCtx, cell, keyspace)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		// SrvKeyspace exists, we're done
 		log.Infof("SrvKeyspace(%v,%v) exists, not building it", cell, keyspace)
 		return
-	case topo.ErrNoNode:
+	case topo.IsErrType(err, topo.NoNode):
 		log.Infof("SrvKeyspace(%v,%v) doesn't exist, rebuilding it", cell, keyspace)
 		// SrvKeyspace doesn't exist, we'll try to rebuild it
 	default:

--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
@@ -205,14 +205,14 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 		log.Infof("finalizeTabletExternallyReparented: updating global shard record if needed")
 		_, err = agent.TopoServer.UpdateShardFields(ctx, tablet.Keyspace, tablet.Shard, func(currentSi *topo.ShardInfo) error {
 			if topoproto.TabletAliasEqual(currentSi.MasterAlias, tablet.Alias) {
-				return topo.ErrNoUpdateNeeded
+				return topo.NewError(topo.NoUpdateNeeded, tablet.Alias.String())
 			}
 			if !topoproto.TabletAliasEqual(currentSi.MasterAlias, oldMasterAlias) {
 				log.Warningf("old master alias (%v) not found in the global Shard record i.e. it has changed in the meantime."+
 					" We're not overwriting the value with the new master (%v) because the current value is probably newer."+
 					" (initial Shard record = %#v, current Shard record = %#v)",
 					oldMasterAlias, tablet.Alias, si, currentSi)
-				return topo.ErrNoUpdateNeeded
+				return topo.NewError(topo.NoUpdateNeeded, oldMasterAlias.String())
 			}
 			currentSi.MasterAlias = tablet.Alias
 			return nil

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -461,7 +461,7 @@ func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topo
 			typeChanged = true
 			return nil
 		}
-		return topo.ErrNoUpdateNeeded
+		return topo.NewError(topo.NoUpdateNeeded, agent.TabletAlias.String())
 	})
 	if err != nil {
 		return err
@@ -500,7 +500,7 @@ func (agent *ActionAgent) SlaveWasRestarted(ctx context.Context, parent *topodat
 			typeChanged = true
 			return nil
 		}
-		return topo.ErrNoUpdateNeeded
+		return topo.NewError(topo.NoUpdateNeeded, agent.TabletAlias.String())
 	}); err != nil {
 		return err
 	}

--- a/go/vt/wrangler/cleaner.go
+++ b/go/vt/wrangler/cleaner.go
@@ -120,7 +120,7 @@ func (cleaner *Cleaner) RemoveActionByName(name, target string) error {
 			return nil
 		}
 	}
-	return topo.ErrNoNode
+	return topo.NewError(topo.NoNode, name+":"+target)
 }
 
 //

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -98,7 +98,12 @@ func (wr *Wrangler) ReloadSchemaShard(ctx context.Context, keyspace, shard, repl
 			defer wg.Done()
 			concurrency.Acquire()
 			defer concurrency.Release()
-			if err := wr.tmc.ReloadSchema(ctx, tablet, replicationPos); err != nil {
+			pos := replicationPos
+			// Master is always up-to-date. So, don't wait for position.
+			if tablet.Type == topodatapb.TabletType_MASTER {
+				pos = ""
+			}
+			if err := wr.tmc.ReloadSchema(ctx, tablet, pos); err != nil {
 				wr.logger.Warningf(
 					"Failed to reload schema on slave tablet %v in %v/%v (use vtctl ReloadSchema to try again): %v",
 					topoproto.TabletAliasString(tablet.Alias), keyspace, shard, err)

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -71,12 +71,12 @@ func (wr *Wrangler) ReloadSchema(ctx context.Context, tabletAlias *topodatapb.Ta
 // that fail to reload within the context deadline.
 func (wr *Wrangler) ReloadSchemaShard(ctx context.Context, keyspace, shard, replicationPos string, concurrency *sync2.Semaphore, includeMaster bool) {
 	tablets, err := wr.ts.GetTabletMapForShard(ctx, keyspace, shard)
-	switch err {
-	case topo.ErrPartialResult:
+	switch {
+	case topo.IsErrType(err, topo.PartialResult):
 		// We got a partial result. Do what we can, but warn
 		// that some may be missed.
 		wr.logger.Warningf("ReloadSchemaShard(%v/%v) got a partial tablet list. Some tablets may not have schema reloaded (use vtctl ReloadSchema to fix individual tablets)", keyspace, shard)
-	case nil:
+	case err == nil:
 		// Good case, keep going too.
 	default:
 		// This is best-effort, so just log it and move on.

--- a/go/vt/wrangler/testlib/reparent_external_test.go
+++ b/go/vt/wrangler/testlib/reparent_external_test.go
@@ -81,19 +81,19 @@ func TestTabletExternallyReparented(t *testing.T) {
 		t.Fatalf("FindTabletByHostAndPort(slave1) failed: %v %v", err, master)
 	}
 	slave2, err := topotools.FindTabletByHostAndPort(tabletMap, goodSlave2.Tablet.Hostname, "vt", goodSlave2.Tablet.PortMap["vt"])
-	if err != topo.ErrNoNode {
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("FindTabletByHostAndPort(slave2) worked: %v %v", err, slave2)
 	}
 
 	// Make sure the master is not exported in other cells
 	tabletMap, err = ts.GetTabletMapForShardByCell(ctx, "test_keyspace", "0", []string{"cell2"})
 	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
-	if err != topo.ErrNoNode {
+	if !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("FindTabletByHostAndPort(master) worked in cell2: %v %v", err, master)
 	}
 
 	tabletMap, err = ts.GetTabletMapForShard(ctx, "test_keyspace", "0")
-	if err != topo.ErrPartialResult {
+	if !topo.IsErrType(err, topo.PartialResult) {
 		t.Fatalf("GetTabletMapForShard should have returned ErrPartialResult but got: %v", err)
 	}
 	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])

--- a/go/vt/wrangler/testlib/shard_test.go
+++ b/go/vt/wrangler/testlib/shard_test.go
@@ -80,13 +80,13 @@ func TestDeleteShardCleanup(t *testing.T) {
 
 	// Make sure all tablets are gone.
 	for _, ft := range []*FakeTablet{master, slave, remoteSlave} {
-		if _, err := ts.GetTablet(ctx, ft.Tablet.Alias); err != topo.ErrNoNode {
+		if _, err := ts.GetTablet(ctx, ft.Tablet.Alias); !topo.IsErrType(err, topo.NoNode) {
 			t.Errorf("tablet %v is still in topo: %v", ft.Tablet.Alias, err)
 		}
 	}
 
 	// Make sure the shard is gone.
-	if _, err := ts.GetShard(ctx, master.Tablet.Keyspace, master.Tablet.Shard); err != topo.ErrNoNode {
+	if _, err := ts.GetShard(ctx, master.Tablet.Keyspace, master.Tablet.Shard); !topo.IsErrType(err, topo.NoNode) {
 		t.Errorf("shard %v/%v is still in topo: %v", master.Tablet.Keyspace, master.Tablet.Shard, err)
 	}
 }


### PR DESCRIPTION
Two fixes:
* `gtid_mode is OFF` was a misleading error message. It's been changed to `replication may not be running`.
* Topo errors were too obscure because they did not specify the node on which they were failing. The errors now carry a type code, which allows us to add more information to the error message.