### PR TITLE
[Guestbook App] - Adding GRPC libs.

### DIFF
--- a/examples/kubernetes/guestbook/extract.sh
+++ b/examples/kubernetes/guestbook/extract.sh
@@ -22,5 +22,3 @@ cp -R $VTTOP/py/* /out/pkg/py-vtdb/
 cp -R /usr/local/lib/python2.7/dist-packages /out/pkg/
 cp -R /vt/dist/py-* /out/pkg/
 
-# We also need the grpc libraries.
-cp /usr/local/lib/libgrpc.so /out/lib/

--- a/examples/kubernetes/guestbook/requirements.txt
+++ b/examples/kubernetes/guestbook/requirements.txt
@@ -1,1 +1,3 @@
 Flask==0.10
+grpcio==1.12.0
+grpcio-tools==1.12.0


### PR DESCRIPTION
When running through the 'Getting Started' guide, the Guestbook app was not launching correctly because of the missing gRPC libraries:

```
Traceback (most recent call last):
  File "main.py", line 27, in <module>
    from vtdb import grpc_vtgate_client  # pylint: disable=unused-import
  File "/app/pkg/py-vtdb/vtdb/grpc_vtgate_client.py", line 24, in <module>
    import grpc
ImportError: No module named grpc
```

This PR modifies the Docker build process to include the gRPC libraries.