### PR TITLE
add option to disable the query consolidator

### DIFF
--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -157,6 +157,43 @@ func TestPoolSize(t *testing.T) {
 	}
 }
 
+func TestDisableConsolidator(t *testing.T) {
+	totalConsolidationsTag := "Waits/Histograms/Consolidations/inf"
+	initial := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
+		wg.Done()
+	}()
+	go func() {
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
+		wg.Done()
+	}()
+	wg.Wait()
+	afterOne := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
+	if initial+1 != afterOne {
+		t.Errorf("expected one consolidation, but got: before consolidation count: %v; after consolidation count: %v", initial, afterOne)
+	}
+	framework.Server.SetConsolidatorDisabled(true)
+	defer framework.Server.SetConsolidatorDisabled(false)
+	var wg2 sync.WaitGroup
+	wg2.Add(2)
+	go func() {
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
+		wg2.Done()
+	}()
+	go func() {
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
+		wg2.Done()
+	}()
+	wg2.Wait()
+	noNewConsolidations := framework.FetchInt(framework.DebugVars(), totalConsolidationsTag)
+	if afterOne != noNewConsolidations {
+		t.Errorf("expected no new consolidations, but got: before consolidation count: %v; after consolidation count: %v", afterOne, noNewConsolidations)
+	}
+}
+
 func TestQueryPlanCache(t *testing.T) {
 	defer framework.Server.SetQueryPlanCacheCap(framework.Server.QueryPlanCacheCap())
 	framework.Server.SetQueryPlanCacheCap(1)

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -175,8 +175,8 @@ func TestDisableConsolidator(t *testing.T) {
 	if initial+1 != afterOne {
 		t.Errorf("expected one consolidation, but got: before consolidation count: %v; after consolidation count: %v", initial, afterOne)
 	}
-	framework.Server.SetConsolidatorDisabled(true)
-	defer framework.Server.SetConsolidatorDisabled(false)
+	framework.Server.SetConsolidatorEnabled(false)
+	defer framework.Server.SetConsolidatorEnabled(true)
 	var wg2 sync.WaitGroup
 	wg2.Add(2)
 	go func() {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -162,6 +162,8 @@ type QueryEngine struct {
 
 	strictTransTables bool
 
+	disableConsolidator bool
+
 	// Loggers
 	accessCheckerLogger *logutil.ThrottledLogger
 }
@@ -196,7 +198,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)
-
+	qe.disableConsolidator = config.DisableConsolidator
 	qe.consolidator = sync2.NewConsolidator()
 	qe.txSerializer = txserializer.New(config.EnableHotRowProtectionDryRun,
 		config.HotRowProtectionMaxQueueSize,

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -162,7 +162,7 @@ type QueryEngine struct {
 
 	strictTransTables bool
 
-	disableConsolidator bool
+	enableConsolidator bool
 
 	// Loggers
 	accessCheckerLogger *logutil.ThrottledLogger
@@ -198,7 +198,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)
-	qe.disableConsolidator = config.DisableConsolidator
+	qe.enableConsolidator = config.EnableConsolidator
 	qe.consolidator = sync2.NewConsolidator()
 	qe.txSerializer = txserializer.New(config.EnableHotRowProtectionDryRun,
 		config.HotRowProtectionMaxQueueSize,

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -788,7 +788,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 	if err != nil {
 		return nil, err
 	}
-	if !qre.tsv.qe.disableConsolidator {
+	if qre.tsv.qe.enableConsolidator {
 		q, original := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 		if original {
 			defer q.Broadcast()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -48,6 +48,7 @@ import (
 
 // TODO(sougou): remove after affected parties have transitioned to new behavior.
 var legacyTableACL = flag.Bool("legacy-table-acl", false, "deprecated: this flag can be used to revert to the older table ACL behavior, which checked access for at most one table")
+var disableConsolidator = flag.Bool("disable-consolidator", false, "passing this flag turns off the query consolidator")
 
 // QueryExecutor is used for executing a query request.
 type QueryExecutor struct {
@@ -788,27 +789,39 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 	if err != nil {
 		return nil, err
 	}
-	q, ok := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
-	if ok {
-		defer q.Broadcast()
-		conn, err := qre.getConn()
+	if !*disableConsolidator {
+		q, original := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
+		if original {
+			defer q.Broadcast()
+			conn, err := qre.getConn()
 
-		if err != nil {
-			q.Err = err
+			if err != nil {
+				q.Err = err
+			} else {
+				defer conn.Recycle()
+				q.Result, q.Err = qre.execSQL(conn, sql, false)
+			}
 		} else {
-			defer conn.Recycle()
-			q.Result, q.Err = qre.execSQL(conn, sql, false)
+			logStats.QuerySources |= tabletenv.QuerySourceConsolidator
+			startTime := time.Now()
+			q.Wait()
+			tabletenv.WaitStats.Record("Consolidations", startTime)
 		}
-	} else {
-		logStats.QuerySources |= tabletenv.QuerySourceConsolidator
-		startTime := time.Now()
-		q.Wait()
-		tabletenv.WaitStats.Record("Consolidations", startTime)
+		if q.Err != nil {
+			return nil, q.Err
+		}
+		return q.Result.(*sqltypes.Result), nil
 	}
-	if q.Err != nil {
-		return nil, q.Err
+	conn, err := qre.getConn()
+	if err != nil {
+		return nil, err
 	}
-	return q.Result.(*sqltypes.Result), nil
+	defer conn.Recycle()
+	res, err := qre.execSQL(conn, sql, false)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // txFetch fetches from a TxConnection.

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -48,7 +48,6 @@ import (
 
 // TODO(sougou): remove after affected parties have transitioned to new behavior.
 var legacyTableACL = flag.Bool("legacy-table-acl", false, "deprecated: this flag can be used to revert to the older table ACL behavior, which checked access for at most one table")
-var disableConsolidator = flag.Bool("disable-consolidator", false, "passing this flag turns off the query consolidator")
 
 // QueryExecutor is used for executing a query request.
 type QueryExecutor struct {
@@ -789,7 +788,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 	if err != nil {
 		return nil, err
 	}
-	if !*disableConsolidator {
+	if !qre.tsv.qe.disableConsolidator {
 		q, original := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 		if original {
 			defer q.Broadcast()

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -99,7 +99,7 @@ func init() {
 	flag.DurationVar(&Config.HeartbeatInterval, "heartbeat_interval", DefaultQsConfig.HeartbeatInterval, "How frequently to read and write replication heartbeat.")
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
-	flag.BoolVar(&Config.DisableConsolidator, "disable-consolidator", DefaultQsConfig.DisableConsolidator, "Passing this flag turns off the query consolidator.")
+	flag.BoolVar(&Config.EnableConsolidator, "enable-consolidator", DefaultQsConfig.EnableConsolidator, "This option enables the query consolidator.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -170,7 +170,7 @@ type TabletConfig struct {
 	HeartbeatInterval time.Duration
 
 	EnforceStrictTransTables bool
-	DisableConsolidator      bool
+	EnableConsolidator       bool
 }
 
 // TransactionLimitConfig captures configuration of transaction pool slots
@@ -244,7 +244,7 @@ var DefaultQsConfig = TabletConfig{
 	HeartbeatInterval: 1 * time.Second,
 
 	EnforceStrictTransTables: true,
-	DisableConsolidator:      false,
+	EnableConsolidator:       true,
 }
 
 // defaultTxThrottlerConfig formats the default throttlerdata.Configuration

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -99,6 +99,7 @@ func init() {
 	flag.DurationVar(&Config.HeartbeatInterval, "heartbeat_interval", DefaultQsConfig.HeartbeatInterval, "How frequently to read and write replication heartbeat.")
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
+	flag.BoolVar(&Config.DisableConsolidator, "disable-consolidator", DefaultQsConfig.DisableConsolidator, "Passing this flag turns off the query consolidator.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -169,6 +170,7 @@ type TabletConfig struct {
 	HeartbeatInterval time.Duration
 
 	EnforceStrictTransTables bool
+	DisableConsolidator      bool
 }
 
 // TransactionLimitConfig captures configuration of transaction pool slots
@@ -242,6 +244,7 @@ var DefaultQsConfig = TabletConfig{
 	HeartbeatInterval: 1 * time.Second,
 
 	EnforceStrictTransTables: true,
+	DisableConsolidator:      false,
 }
 
 // defaultTxThrottlerConfig formats the default throttlerdata.Configuration

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2080,11 +2080,11 @@ func (tsv *TabletServer) GetTxPoolWaiterCap() int64 {
 	return tsv.te.txPool.waiterCap.Get()
 }
 
-// SetConsolidatorDisabled (true) will disable the query consolidator.
-// SetConsolidatorDisabled (false) will enable the query consolidator.
+// SetConsolidatorEnabled (true) will enable the query consolidator.
+// SetConsolidatorEnabled (false) will disable the query consolidator.
 // This function should only be used for testing.
-func (tsv *TabletServer) SetConsolidatorDisabled(disabled bool) {
-	tsv.qe.disableConsolidator = disabled
+func (tsv *TabletServer) SetConsolidatorEnabled(enabled bool) {
+	tsv.qe.enableConsolidator = enabled
 }
 
 // queryAsString returns a readable version of query+bind variables.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2080,6 +2080,13 @@ func (tsv *TabletServer) GetTxPoolWaiterCap() int64 {
 	return tsv.te.txPool.waiterCap.Get()
 }
 
+// SetConsolidatorDisabled (true) will disable the query consolidator.
+// SetConsolidatorDisabled (false) will enable the query consolidator.
+// This function should only be used for testing.
+func (tsv *TabletServer) SetConsolidatorDisabled(disabled bool) {
+	tsv.qe.disableConsolidator = disabled
+}
+
 // queryAsString returns a readable version of query+bind variables.
 func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable) string {
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
some of our engineers are concerned about stale reads and would like the consolidator turned off more or less globally, with the option to enable it for particular keyspaces, which this PR does for us by adding a flag to the vttablet.

Signed-off-by: Alex Charis <acharis@hubspot.com>