### PR TITLE
Support cross-compilation by providing a pure alternative to cgzip.

### DIFF
--- a/go/cgzip/adler32.go
+++ b/go/cgzip/adler32.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 /*
 Copyright 2017 Google Inc.
 
@@ -74,14 +76,4 @@ func (a *adler32Hash) BlockSize() int {
 // hash.Hash32 interface
 func (a *adler32Hash) Sum32() uint32 {
 	return uint32(a.adler)
-}
-
-// Adler32Combine method for partial checksums. From the zlib.h header:
-//
-// Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
-// and seq2 with lengths len1 and len2, Adler-32 checksums were calculated for
-// each, adler1 and adler2.  adler32_combine() returns the Adler-32 checksum of
-// seq1 and seq2 concatenated, requiring only adler1, adler2, and len2.
-func Adler32Combine(adler1, adler2 uint32, len2 int) uint32 {
-	return uint32(C.adler32_combine(C.uLong(adler1), C.uLong(adler2), C.z_off_t(len2)))
 }

--- a/go/cgzip/cgzip_test.go
+++ b/go/cgzip/cgzip_test.go
@@ -141,35 +141,6 @@ func testChecksums(t *testing.T, data []byte) {
 		t.Errorf("go and cgzip adler32 mismatch")
 	}
 
-	// now test partial checksuming also works with adler32
-	cutoff := len(data) / 3
-	toChecksum = bytes.NewBuffer(data[0:cutoff])
-	cgzipAdler32.Reset()
-	_, err = io.Copy(cgzipAdler32, toChecksum)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-	adler1 := cgzipAdler32.Sum32()
-	t.Log("   a1   :", adler1)
-	t.Log("   len1 :", cutoff)
-
-	toChecksum = bytes.NewBuffer(data[cutoff:])
-	cgzipAdler32.Reset()
-	_, err = io.Copy(cgzipAdler32, toChecksum)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-	adler2 := cgzipAdler32.Sum32()
-	t.Log("   a2   :", adler2)
-	t.Log("   len2 :", len(data)-cutoff)
-
-	adlerCombined := Adler32Combine(adler1, adler2, len(data)-cutoff)
-	t.Log("   comb :", adlerCombined)
-
-	if cgzipResult != adlerCombined {
-		t.Errorf("full and combined adler32 mismatch")
-	}
-
 	// crc32 with go library
 	goCrc32 := crc32.New(crc32.MakeTable(crc32.IEEE))
 	toChecksum = bytes.NewBuffer(data)
@@ -197,34 +168,6 @@ func testChecksums(t *testing.T, data []byte) {
 	// test both results are the same
 	if goResult != cgzipResult {
 		t.Errorf("go and cgzip crc32 mismatch")
-	}
-
-	// now test partial checksuming also works with crc32
-	toChecksum = bytes.NewBuffer(data[0:cutoff])
-	cgzipCrc32.Reset()
-	_, err = io.Copy(cgzipCrc32, toChecksum)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-	crc1 := cgzipCrc32.Sum32()
-	t.Log("   crc1 :", crc1)
-	t.Log("   len1 :", cutoff)
-
-	toChecksum = bytes.NewBuffer(data[cutoff:])
-	cgzipCrc32.Reset()
-	_, err = io.Copy(cgzipCrc32, toChecksum)
-	if err != nil {
-		t.Errorf("Copy failed: %v", err)
-	}
-	crc2 := cgzipCrc32.Sum32()
-	t.Log("   crc2 :", crc2)
-	t.Log("   len2 :", len(data)-cutoff)
-
-	crcCombined := Crc32Combine(crc1, crc2, len(data)-cutoff)
-	t.Log("   comb :", crcCombined)
-
-	if cgzipResult != crcCombined {
-		t.Errorf("full and combined crc32 mismatch")
 	}
 }
 

--- a/go/cgzip/crc32.go
+++ b/go/cgzip/crc32.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 /*
 Copyright 2017 Google Inc.
 
@@ -74,14 +76,4 @@ func (a *crc32Hash) BlockSize() int {
 // hash.Hash32 interface
 func (a *crc32Hash) Sum32() uint32 {
 	return uint32(a.crc)
-}
-
-// Crc32Combine helper method for partial checksums. From the zlib.h header:
-//
-// Combine two CRC-32 checksums into one.  For two sequences of bytes, seq1
-// and seq2 with lengths len1 and len2, CRC-32 checksums were calculated for
-// each, crc1 and crc2.  crc32_combine() returns the CRC-32 checksum of
-// seq1 and seq2 concatenated, requiring only crc1, crc2, and len2.
-func Crc32Combine(crc1, crc2 uint32, len2 int) uint32 {
-	return uint32(C.crc32_combine(C.uLong(crc1), C.uLong(crc2), C.z_off_t(len2)))
 }

--- a/go/cgzip/pure.go
+++ b/go/cgzip/pure.go
@@ -1,0 +1,22 @@
+// +build !cgo
+
+// A slower, pure go alternative to cgzip to allow for cross compilation.
+
+package cgzip
+
+import (
+	"compress/gzip"
+	"hash/adler32"
+	"hash/crc32"
+)
+
+// Writer is an io.WriteCloser. Writes to a Writer are compressed.
+type Writer = gzip.Writer
+
+var (
+	Z_BEST_SPEED   = gzip.BestSpeed
+	NewWriterLevel = gzip.NewWriterLevel
+	NewReader      = gzip.NewReader
+	NewCrc32       = crc32.NewIEEE
+	NewAdler32     = adler32.New
+)

--- a/go/cgzip/reader.go
+++ b/go/cgzip/reader.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 /*
 Copyright 2017 Google Inc.
 

--- a/go/cgzip/writer.go
+++ b/go/cgzip/writer.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 /*
 Copyright 2017 Google Inc.
 

--- a/go/cgzip/zstream.go
+++ b/go/cgzip/zstream.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 /*
 Copyright 2017 Google Inc.
 


### PR DESCRIPTION
Command to run the unit test in pure go mode (which would really be testing golang gzip instead of cgzip):

CGO_ENABLED=0 go test vitess.io/vitess/go/cgzip/...

Signed-off-by: David Weitzman <dweitzman@pinterest.com>

Disclaimer: I don't have any urgent need for cross-compilation, but I've learned that this is possible as an alternative to deleting cgzip entirely (https://github.com/vitessio/vitess/pull/3786).