### PR TITLE
tabletserver: dmls: like is not equality

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -1457,6 +1457,23 @@ options:PassthroughDMLs
   "WhereClause": "where eid in (1, 2) and id = 1"
 }
 
+# 'like' expression in where
+"update d set foo='foo' where name like 'a%'"
+{
+  "PlanID": "DML_SUBQUERY",
+  "TableName": "d",
+  "Permissions": [
+    {
+      "TableName": "d",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update d set foo = 'foo' where name like 'a%'",
+  "OuterQuery": "update d set foo = 'foo' where :#pk",
+  "Subquery": "select name from d where name like 'a%' limit :#maxLimit for update",
+  "WhereClause": "where name like 'a%'"
+}
+
 # double in clause
 "update a set name='foo' where eid in (1, 2) and id in (1, 2)"
 {
@@ -1671,6 +1688,23 @@ options:PassthroughDMLs
   "OuterQuery": "delete from a where :#pk order by id desc",
   "Subquery": "select eid, id from a where eid = 1 order by id desc limit :#maxLimit for update",
   "WhereClause": "where eid = 1"
+}
+
+# 'like' expression
+"delete from d where name like 'a%'"
+{
+  "PlanID": "DML_SUBQUERY",
+  "TableName": "d",
+  "Permissions": [
+    {
+      "TableName": "d",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "delete from d where name like 'a%'",
+  "OuterQuery": "delete from d where :#pk",
+  "Subquery": "select name from d where name like 'a%' limit :#maxLimit for update",
+  "WhereClause": "where name like 'a%'"
 }
 
 # bad pk value delete

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -254,17 +254,6 @@ func NewPlanValue(node Expr) (sqltypes.PlanValue, error) {
 	return sqltypes.PlanValue{}, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "expression is too complex '%v'", String(node))
 }
 
-// StringIn is a convenience function that returns
-// true if str matches any of the values.
-func StringIn(str string, values ...string) bool {
-	for _, val := range values {
-		if str == val {
-			return true
-		}
-	}
-	return false
-}
-
 // SetKey is the extracted key from one SetExpr
 type SetKey struct {
 	Key   string

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -339,27 +339,6 @@ func TestNewPlanValue(t *testing.T) {
 	}
 }
 
-func TestStringIn(t *testing.T) {
-	testcases := []struct {
-		in1 string
-		in2 []string
-		out bool
-	}{{
-		in1: "v1",
-		in2: []string{"v1", "v2"},
-		out: true,
-	}, {
-		in1: "v0",
-		in2: []string{"v1", "v2"},
-	}}
-	for _, tc := range testcases {
-		out := StringIn(tc.in1, tc.in2...)
-		if out != tc.out {
-			t.Errorf("StringIn(%v,%v): %#v, want %#v", tc.in1, tc.in2, out, tc.out)
-		}
-	}
-}
-
 func TestExtractSetValues(t *testing.T) {
 	testcases := []struct {
 		sql   string

--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -248,10 +248,7 @@ func analyzeBoolean(node sqlparser.Expr) (conditions []*sqlparser.ComparisonExpr
 		return analyzeBoolean(node.Expr)
 	case *sqlparser.ComparisonExpr:
 		switch {
-		case sqlparser.StringIn(
-			node.Operator,
-			sqlparser.EqualStr,
-			sqlparser.LikeStr):
+		case node.Operator == sqlparser.EqualStr:
 			if sqlparser.IsColName(node.Left) && sqlparser.IsValue(node.Right) {
 				return []*sqlparser.ComparisonExpr{node}
 			}


### PR DESCRIPTION
Fixes #4007
Tabletserver was treating 'like' expressions as equality.
a like 'a%' is not the same as a = 'a%'.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>