### PR TITLE
replication: don't auto-fix

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -38,8 +38,6 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
-	"os"
-	"path"
 	"regexp"
 	"sync"
 	"time"
@@ -67,12 +65,6 @@ import (
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-)
-
-const (
-	// slaveStoppedFile is the file name for the file whose existence informs
-	// vttablet to NOT try to repair replication.
-	slaveStoppedFile = "do_not_replicate"
 )
 
 var (
@@ -190,10 +182,6 @@ type ActionAgent struct {
 	// _ignoreHealthErrorExpr can be set by RPC to selectively disable certain
 	// healthcheck errors. It should only be accessed while holding actionMutex.
 	_ignoreHealthErrorExpr *regexp.Regexp
-
-	// _slaveStopped remembers if we've been told to stop replicating.
-	// If it's nil, we'll try to check for the slaveStoppedFile.
-	_slaveStopped *bool
 }
 
 // NewActionAgent creates a new ActionAgent and registers all the
@@ -459,48 +447,6 @@ func (agent *ActionAgent) EnableUpdateStream() bool {
 	agent.mutex.Lock()
 	defer agent.mutex.Unlock()
 	return agent._enableUpdateStream
-}
-
-func (agent *ActionAgent) slaveStopped() bool {
-	agent.mutex.Lock()
-	defer agent.mutex.Unlock()
-
-	// If we already know the value, don't bother checking the file.
-	if agent._slaveStopped != nil {
-		return *agent._slaveStopped
-	}
-
-	// If the marker file exists, we're stopped.
-	// Treat any read error as if the file doesn't exist.
-	_, err := os.Stat(path.Join(agent.MysqlDaemon.TabletDir(), slaveStoppedFile))
-	slaveStopped := err == nil
-	agent._slaveStopped = &slaveStopped
-	return slaveStopped
-}
-
-func (agent *ActionAgent) setSlaveStopped(slaveStopped bool) {
-	agent.mutex.Lock()
-	defer agent.mutex.Unlock()
-
-	agent._slaveStopped = &slaveStopped
-
-	// Make a best-effort attempt to persist the value across tablet restarts.
-	// We store a marker in the filesystem so it works regardless of whether
-	// mysqld is running, and so it's tied to this particular instance of the
-	// tablet data dir (the one that's paused at a known replication position).
-	tabletDir := agent.MysqlDaemon.TabletDir()
-	if tabletDir == "" {
-		return
-	}
-	markerFile := path.Join(tabletDir, slaveStoppedFile)
-	if slaveStopped {
-		file, err := os.Create(markerFile)
-		if err == nil {
-			file.Close()
-		}
-	} else {
-		os.Remove(markerFile)
-	}
 }
 
 func (agent *ActionAgent) setServicesDesiredState(disallowQueryService string, enableUpdateStream bool) {

--- a/go/vt/vttablet/tabletmanager/replication_reporter_test.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter_test.go
@@ -29,10 +29,9 @@ func TestBasicMySQLReplicationLag(t *testing.T) {
 	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(nil)
 	mysqld.Replicating = true
 	mysqld.SecondsBehindMaster = 10
-	slaveStopped := true
 
 	rep := &replicationReporter{
-		agent: &ActionAgent{MysqlDaemon: mysqld, _slaveStopped: &slaveStopped},
+		agent: &ActionAgent{MysqlDaemon: mysqld},
 		now:   time.Now,
 	}
 	dur, err := rep.Report(true, true)
@@ -44,10 +43,9 @@ func TestBasicMySQLReplicationLag(t *testing.T) {
 func TestNoKnownMySQLReplicationLag(t *testing.T) {
 	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(nil)
 	mysqld.Replicating = false
-	slaveStopped := true
 
 	rep := &replicationReporter{
-		agent: &ActionAgent{MysqlDaemon: mysqld, _slaveStopped: &slaveStopped},
+		agent: &ActionAgent{MysqlDaemon: mysqld},
 		now:   time.Now,
 	}
 	dur, err := rep.Report(true, true)
@@ -60,11 +58,10 @@ func TestExtrapolatedMySQLReplicationLag(t *testing.T) {
 	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(nil)
 	mysqld.Replicating = true
 	mysqld.SecondsBehindMaster = 10
-	slaveStopped := true
 
 	now := time.Now()
 	rep := &replicationReporter{
-		agent: &ActionAgent{MysqlDaemon: mysqld, _slaveStopped: &slaveStopped},
+		agent: &ActionAgent{MysqlDaemon: mysqld},
 		now:   func() time.Time { return now },
 	}
 
@@ -88,11 +85,10 @@ func TestNoExtrapolatedMySQLReplicationLag(t *testing.T) {
 	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(nil)
 	mysqld.Replicating = true
 	mysqld.SecondsBehindMaster = 10
-	slaveStopped := true
 
 	now := time.Now()
 	rep := &replicationReporter{
-		agent: &ActionAgent{MysqlDaemon: mysqld, _slaveStopped: &slaveStopped},
+		agent: &ActionAgent{MysqlDaemon: mysqld},
 		now:   func() time.Time { return now },
 	}
 

--- a/test/reparent.py
+++ b/test/reparent.py
@@ -195,7 +195,12 @@ class TestReparent(unittest.TestCase):
     # bring back the old master as a slave, check that it catches up
     tablet_62344.start_mysql().wait()
     tablet_62344.init_tablet('replica', 'test_keyspace', '0', start=True,
-                             wait_for_start=False)
+                             wait_for_start=True)
+    # Fix replication after mysqld restart.
+    utils.run_vtctl(['ReparentTablet',
+                     tablet_62344.tablet_alias], auto_log=True)
+    utils.run_vtctl(['StartSlave',
+                     tablet_62344.tablet_alias], auto_log=True)
     self._check_vt_insert_test(tablet_62344, 2)
 
     tablet.kill_tablets(


### PR DESCRIPTION
Autofixing replication during health check causes dangerous races
with the Orchestrator. Until we find a better workflow, it's better
to make this something that requires human intervention.

As reference, this is the PR that added the feature:
https://github.com/vitessio/vitess/commit/ebcb5b386eb947dfc8608baf5757ea73fddaf8ae

One possible behavioral change to note is the case of a mysqld restart.
In such cases, the replication reporter would have auto-fixed a
replica to point at the master. With this change, the restarter
script will have to do this explicitly.

The ReparentTablet command can be used to fix a stopped replication.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>