### PR TITLE
Replace "." with "_" in multi-counter and multi-timings label values.

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -19,7 +19,6 @@ package stats
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -212,7 +211,7 @@ func (mc *CountersWithMultiLabels) Add(names []string, value int64) {
 		logCounterNegative.Warningf("Adding a negative value to a counter, %v should be a gauge instead", mc)
 	}
 
-	mc.counters.Add(mapKey(names), value)
+	mc.counters.Add(safeJoinLabels(names), value)
 }
 
 // Reset resets the value of a named counter back to 0.
@@ -222,7 +221,7 @@ func (mc *CountersWithMultiLabels) Reset(names []string) {
 		panic("CountersWithMultiLabels: wrong number of values in Reset")
 	}
 
-	mc.counters.Reset(mapKey(names))
+	mc.counters.Reset(safeJoinLabels(names))
 }
 
 // Counts returns a copy of the Counters' map.
@@ -371,7 +370,7 @@ func (mg *GaugesWithMultiLabels) Set(names []string, value int64) {
 	if len(names) != len(mg.CountersWithMultiLabels.labels) {
 		panic("GaugesWithMultiLabels: wrong number of values in Set")
 	}
-	a := mg.getValueAddr(mapKey(names))
+	a := mg.getValueAddr(safeJoinLabels(names))
 	atomic.StoreInt64(a, value)
 }
 
@@ -382,7 +381,7 @@ func (mg *GaugesWithMultiLabels) Add(names []string, value int64) {
 		panic("CountersWithMultiLabels: wrong number of values in Add")
 	}
 
-	mg.counters.Add(mapKey(names), value)
+	mg.counters.Add(safeJoinLabels(names), value)
 }
 
 // GaugesFuncWithMultiLabels is a wrapper around CountersFuncWithMultiLabels
@@ -407,14 +406,4 @@ func NewGaugesFuncWithMultiLabels(name, help string, labels []string, f func() m
 	}
 
 	return t
-}
-
-var escaper = strings.NewReplacer(".", "\\.", "\\", "\\\\")
-
-func mapKey(ss []string) string {
-	esc := make([]string, len(ss))
-	for i, f := range ss {
-		esc[i] = escaper.Replace(f)
-	}
-	return strings.Join(esc, ".")
 }

--- a/go/stats/counters_test.go
+++ b/go/stats/counters_test.go
@@ -97,17 +97,17 @@ func TestMultiCountersDot(t *testing.T) {
 	c.Add([]string{"c1.a", "c1b"}, 1)
 	c.Add([]string{"c2a", "c2.b"}, 1)
 	c.Add([]string{"c2a", "c2.b"}, 1)
-	want1 := `{"c1\\.a.c1b": 1, "c2a.c2\\.b": 2}`
-	want2 := `{"c2a.c2\\.b": 2, "c1\\.a.c1b": 1}`
+	want1 := `{"c1_a.c1b": 1, "c2a.c2_b": 2}`
+	want2 := `{"c2a.c2_b": 2, "c1_a.c1b": 1}`
 	if s := c.String(); s != want1 && s != want2 {
 		t.Errorf("want %s or %s, got %s", want1, want2, s)
 	}
 	counts := c.Counts()
-	if counts["c1\\.a.c1b"] != 1 {
-		t.Errorf("want 1, got %d", counts["c1\\.a.c1b"])
+	if counts["c1_a.c1b"] != 1 {
+		t.Errorf("want 1, got %d", counts["c1_a.c1b"])
 	}
-	if counts["c2a.c2\\.b"] != 2 {
-		t.Errorf("want 2, got %d", counts["c2a.c2\\.b"])
+	if counts["c2a.c2_b"] != 2 {
+		t.Errorf("want 2, got %d", counts["c2a.c2_b"])
 	}
 }
 

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -208,12 +208,22 @@ func (mt *MultiTimings) Labels() []string {
 	return mt.labels
 }
 
+// safeJoinLabels joins the label values with ".", but first replaces any existing
+// "." characters in the labels with "_" to avoid issues parsing them apart later.
+func safeJoinLabels(labels []string) string {
+	sanitizedLabels := make([]string, len(labels), len(labels))
+	for idx, label := range labels {
+		sanitizedLabels[idx] = strings.Replace(label, ".", "_", -1)
+	}
+	return strings.Join(sanitizedLabels, ".")
+}
+
 // Add will add a new value to the named histogram.
 func (mt *MultiTimings) Add(names []string, elapsed time.Duration) {
 	if len(names) != len(mt.labels) {
 		panic("MultiTimings: wrong number of values in Add")
 	}
-	mt.Timings.Add(strings.Join(names, "."), elapsed)
+	mt.Timings.Add(safeJoinLabels(names), elapsed)
 }
 
 // Record is a convenience function that records completion
@@ -222,7 +232,7 @@ func (mt *MultiTimings) Record(names []string, startTime time.Time) {
 	if len(names) != len(mt.labels) {
 		panic("MultiTimings: wrong number of values in Record")
 	}
-	mt.Timings.Record(strings.Join(names, "."), startTime)
+	mt.Timings.Record(safeJoinLabels(names), startTime)
 }
 
 // Cutoffs returns the cutoffs used in the component histograms.

--- a/go/stats/timings_test.go
+++ b/go/stats/timings_test.go
@@ -46,6 +46,16 @@ func TestMultiTimings(t *testing.T) {
 	}
 }
 
+func TestMultiTimingsDot(t *testing.T) {
+	clear()
+	mtm := NewMultiTimings("maptimings2", "help", []string{"label"})
+	mtm.Add([]string{"value.dot"}, 500*time.Microsecond)
+	want := `{"TotalCount":1,"TotalTime":500000,"Histograms":{"value_dot":{"500000":1,"1000000":1,"5000000":1,"10000000":1,"50000000":1,"100000000":1,"500000000":1,"1000000000":1,"5000000000":1,"10000000000":1,"inf":1,"Count":1,"Time":500000}}}`
+	if got := mtm.String(); got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
 func TestTimingsHook(t *testing.T) {
 	var gotname string
 	var gotv *Timings


### PR DESCRIPTION
This ensures that the number of labels at parse time equals the number of labels at join time.

Without this, some metrics exporters can get confused and panic().

Signed-off-by: David Weitzman <dweitzman@pinterest.com>

This is a fix for https://github.com/vitessio/vitess/issues/4015