### PR TITLE
Turn off repairReplication if other reparenting events are going on 

### DIFF
--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -126,6 +127,30 @@ func (orc *orcClient) EndMaintenance(tablet *topodatapb.Tablet) error {
 	}
 	_, err = orc.apiGet("end-maintenance", host, port)
 	return err
+}
+
+func (orc *orcClient) InActiveShardRecovery(tablet *topodatapb.Tablet) (bool, error) {
+	alias := fmt.Sprintf("%v.%v", tablet.GetKeyspace(), tablet.GetShard())
+
+	// TODO(zmagg): Replace this with simpler call to active-cluster-recovery
+	// when call with alias parameter is supported.
+	resp, err := orc.apiGet("audit-recovery", "alias", alias)
+
+	if err != nil {
+		return false, err
+	}
+
+	var r []map[string]interface{}
+
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return false, err
+	}
+
+	active, ok := r[0]["IsActive"].(bool)
+	if !ok {
+		return false, fmt.Errorf("Error parsing JSON response from Orchestrator")
+	}
+	return active, nil
 }
 
 func mysqlHostPort(tablet *topodatapb.Tablet) (host, port string, err error) {

--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -146,7 +146,12 @@ func (orc *orcClient) InActiveShardRecovery(tablet *topodatapb.Tablet) (bool, er
 		return false, err
 	}
 
+	if len(r) == 0 {
+		return false, fmt.Errorf("Orchestrator returned an empty audit-recovery response")
+	}
+
 	active, ok := r[0]["IsActive"].(bool)
+
 	if !ok {
 		return false, fmt.Errorf("Error parsing JSON response from Orchestrator")
 	}

--- a/go/vt/vttablet/tabletmanager/replication_reporter.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter.go
@@ -142,7 +142,7 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 		}
 	}
 
-	return agent.setMasterLocked(ctx, si.MasterAlias, 0, true)
+	return agent.setMasterRepairReplication(ctx, si.MasterAlias, 0, true)
 }
 
 func registerReplicationReporter(agent *ActionAgent) {

--- a/go/vt/vttablet/tabletmanager/replication_reporter.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter.go
@@ -138,6 +138,7 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 		// lock any other actions on this tablet by Orchestrator.
 		if err := agent.orc.BeginMaintenance(agent.Tablet(), "vttablet has been told to StopSlave"); err != nil {
 			log.Warningf("Orchestrator BeginMaintenance failed: %v", err)
+			return fmt.Errorf("Orchestrator BeginMaintenance failed :%v, skipping repairReplication", err)
 		}
 	}
 

--- a/go/vt/vttablet/tabletmanager/replication_reporter.go
+++ b/go/vt/vttablet/tabletmanager/replication_reporter.go
@@ -115,6 +115,7 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 
 	ts := agent.TopoServer
 	tablet := agent.Tablet()
+
 	si, err := ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
 	if err != nil {
 		return err
@@ -122,6 +123,24 @@ func repairReplication(ctx context.Context, agent *ActionAgent) error {
 	if !si.HasMaster() {
 		return fmt.Errorf("no master tablet for shard %v/%v", tablet.Keyspace, tablet.Shard)
 	}
+
+	// If Orchestrator is configured and if Orchestrator is actively reparenting, we should not repairReplication
+	if agent.orc != nil {
+		re, err := agent.orc.InActiveShardRecovery(tablet)
+		if err != nil {
+			return err
+		}
+		if re {
+			return fmt.Errorf("Orchestrator actively reparenting shard %v, skipping repairReplication", si)
+		}
+
+		// Before repairing replication, tell Orchestrator to enter maintenance mode for this tablet and to
+		// lock any other actions on this tablet by Orchestrator.
+		if err := agent.orc.BeginMaintenance(agent.Tablet(), "vttablet has been told to StopSlave"); err != nil {
+			log.Warningf("Orchestrator BeginMaintenance failed: %v", err)
+		}
+	}
+
 	return agent.setMasterLocked(ctx, si.MasterAlias, 0, true)
 }
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -404,7 +404,7 @@ func (agent *ActionAgent) SetMaster(ctx context.Context, parentAlias *topodatapb
 	return agent.setMasterLocked(ctx, parentAlias, timeCreatedNS, forceStartSlave)
 }
 
-func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, forceStartSlave bool) error {
+func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, forceStartSlave bool) (err error) {
 	parent, err := agent.TopoServer.GetTablet(ctx, parentAlias)
 	if err != nil {
 		return err
@@ -435,14 +435,15 @@ func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topo
 		shouldbeReplicating = true
 	}
 
-	// Lock the shard before doing any replication repair work.
-	ctx, unlock, lockErr := agent.TopoServer.LockShard(ctx, parent.Tablet.GetKeyspace(), parent.Tablet.GetShard(), fmt.Sprintf("repairReplication to %v as parent)", topoproto.TabletAliasString(parentAlias)))
-	if lockErr != nil {
-		return lockErr
+	if topo.CheckShardLocked(ctx, parent.Tablet.GetKeyspace(), parent.Tablet.GetShard()); err != nil {
+		// Lock the shard before doing any replication repair work if the shard is not already locked.
+		_, unlock, lockErr := agent.TopoServer.LockShard(ctx, parent.Tablet.GetKeyspace(), parent.Tablet.GetShard(), fmt.Sprintf("repairReplication to %v as parent)", topoproto.TabletAliasString(parentAlias)))
+		if lockErr != nil {
+			return lockErr
+		}
+
+		defer unlock(&err)
 	}
-
-	defer unlock(&err)
-
 	// If using semi-sync, we need to enable it before connecting to master.
 	if *enableSemiSync {
 		tt := agent.Tablet().Type

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -404,7 +404,7 @@ func (agent *ActionAgent) SetMaster(ctx context.Context, parentAlias *topodatapb
 	return agent.setMasterLocked(ctx, parentAlias, timeCreatedNS, forceStartSlave)
 }
 
-func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, forceStartSlave bool) (err error) {
+func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, forceStartSlave bool) error {
 	parent, err := agent.TopoServer.GetTablet(ctx, parentAlias)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Problem

Described more in detail in Slack, currently the tabletmanager's repairReplication races with Orchestrator's failover mechanisms, which results in a co-master situation in our topology during external reparenting events run by Orchestrator. The tabletmanager's repairReplication could also race with Vitess's internal reparenting actions. 

#### Solution

Add support for turning off repairReplication as part of the tablet health check if other reparenting events are going on. 

This implementation changes repairReplication to use the same shard lock in the topo as the PlannedReparent and EmergencyReparent operations do, eliminating the race condition between repairReplication and internal Vitess reparenting. 

To minimize the race between repairReplication and Orchestrator driven external reparenting, during repairReplication, check to see if Orchestrator is doing any reparenting actively, and if so, do not repairReplication. 

Before beginning any replication manipulation, use the _orchestrator_ side lock of
BeginMaintenance/EndMaintenance to indicate that Orchestrator should not begin any
reparenting. There's still a race if Orchestrator begins failover before it receives the BeginMaintenance event. Would love to hear suggestions for how to eliminate this race entirely.

As it turns out, PlannedReparenting and EmergencyReparenting *already* indicate to Orchestrator that they're manipulating the topology and call out to Orchestrator's `BeginMaintenance` before beginning topo manipulations. (i.e. https://github.com/vitessio/vitess/blob/master/go/vt/wrangler/reparent.go#L403) This helps reduce the risk of Orchestrator and Vitess-internal reparenting from interfering with each other. 

If we decide to go with this approach, there are a few other things I'd like to add as well:
[ ] add more metrics about how often repairReplication is called and ran
[ ] write unit tests 