### PR TITLE
grpc: rework the window size settings to apply on the server

### DIFF
--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -34,10 +34,8 @@ import (
 )
 
 var (
-	keepaliveTime         = flag.Duration("grpc_keepalive_time", 0, "After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive.")
-	keepaliveTimeout      = flag.Duration("grpc_keepalive_timeout", 0, "After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.")
-	initialConnWindowSize = flag.Int("grpc_initial_conn_window_size", 0, "grpc initial connection window size")
-	initialWindowSize     = flag.Int("grpc_initial_window_size", 0, "grpc initial window size")
+	keepaliveTime    = flag.Duration("grpc_keepalive_time", 0, "After a duration of this time if the client doesn't see any activity it pings the server to see if the transport is still alive.")
+	keepaliveTimeout = flag.Duration("grpc_keepalive_timeout", 0, "After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed.")
 )
 
 // FailFast is a self-documenting type for the grpc.FailFast.
@@ -76,12 +74,12 @@ func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.Clie
 		newopts = append(newopts, grpc.WithKeepaliveParams(kp))
 	}
 
-	if *initialConnWindowSize != 0 {
-		newopts = append(newopts, grpc.WithInitialConnWindowSize(int32(*initialConnWindowSize)))
+	if *grpccommon.InitialConnWindowSize != 0 {
+		newopts = append(newopts, grpc.WithInitialConnWindowSize(int32(*grpccommon.InitialConnWindowSize)))
 	}
 
-	if *initialWindowSize != 0 {
-		newopts = append(newopts, grpc.WithInitialWindowSize(int32(*initialWindowSize)))
+	if *grpccommon.InitialWindowSize != 0 {
+		newopts = append(newopts, grpc.WithInitialWindowSize(int32(*grpccommon.InitialWindowSize)))
 	}
 
 	newopts = append(newopts, opts...)

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -35,6 +35,12 @@ var (
 
 	// EnableGRPCPrometheus sets a flag to enable grpc client/server grpc monitoring.
 	EnableGRPCPrometheus = flag.Bool("grpc_prometheus", false, "Enable gRPC monitoring with Prometheus")
+
+	// InitialConnWindowSize sets the initial connection window size
+	InitialConnWindowSize = flag.Int("grpc_initial_conn_window_size", 0, "grpc initial connection window size")
+
+	// InitialWindowSize sets the initial stream window size
+	InitialWindowSize = flag.Int("grpc_initial_window_size", 0, "grpc initial window size")
 )
 
 var enableTracing sync.Once

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -125,6 +125,14 @@ func createGRPCServer() {
 	opts = append(opts, grpc.MaxRecvMsgSize(*grpccommon.MaxMessageSize))
 	opts = append(opts, grpc.MaxSendMsgSize(*grpccommon.MaxMessageSize))
 
+	if *grpccommon.InitialConnWindowSize != 0 {
+		opts = append(opts, grpc.InitialConnWindowSize(int32(*grpccommon.InitialConnWindowSize)))
+	}
+
+	if *grpccommon.InitialWindowSize != 0 {
+		opts = append(opts, grpc.InitialWindowSize(int32(*grpccommon.InitialWindowSize)))
+	}
+
 	if GRPCMaxConnectionAge != nil {
 		ka := keepalive.ServerParameters{
 			MaxConnectionAge: *GRPCMaxConnectionAge,


### PR DESCRIPTION
In addition to setting the initial conn window / initial window size settings on the grpc client side, also set the corresponding options for the server side.

I noticed when using wireshark to inspect the traffic going back and forth, that the GRPC settings need to be applied on both the client and server side so that the flow control is applied to accepted connections as well as those initiated outbound.


