### PR TITLE
vtbench: add initial version of a vitess benchmarking tool

### DIFF
--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"vitess.io/vitess/go/exit"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vtbench"
+
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
+)
+
+var (
+	// connection flags
+	host     = flag.String("host", "", "vtgate host(s) in the form 'host1,host2,...'")
+	port     = flag.Int("port", 0, "vtgate port")
+	protocol = flag.String("protocol", "mysql", "client protocol, either mysql (default) or grpc")
+	user     = flag.String("user", "", "username to connect using mysql (password comes from the db-credentials-file)")
+	db       = flag.String("db", "", "db name to use when connecting / running the queries (e.g. @replica, keyspace, keyspace/shard etc)")
+
+	// test flags
+	deadline = flag.Duration("deadline", 5*time.Minute, "maximum duration for the test run (default 5 minutes)")
+	sql      = flag.String("sql", "", "sql statement to execute")
+	threads  = flag.Int("threads", 2, "number of parallel threads to run")
+	count    = flag.Int("count", 1000, "number of queries per thread")
+)
+
+func main() {
+	logger := logutil.NewConsoleLogger()
+	flag.CommandLine.SetOutput(logutil.NewLoggerWriter(logger))
+
+	defer exit.Recover()
+
+	flag.Lookup("logtostderr").Value.Set("true")
+	flag.Parse()
+
+	clientProto := vtbench.MySQL
+	switch *protocol {
+	case "", "mysql":
+		clientProto = vtbench.MySQL
+	case "grpc-vtgate":
+		clientProto = vtbench.GRPCVtgate
+	case "grpc-vttablet":
+		clientProto = vtbench.GRPCVttablet
+	default:
+		log.Exitf("invalid client protocol %s", *protocol)
+	}
+
+	if *host == "" {
+		log.Exitf("must specify host(s)")
+	}
+
+	if *port == 0 {
+		log.Exitf("must specify port")
+	}
+
+	if *sql == "" {
+		log.Exitf("must specify sql")
+	}
+
+	var password string
+	if clientProto == vtbench.MySQL {
+		var err error
+		_, password, err = dbconfigs.GetCredentialsServer().GetUserAndPassword(*user)
+		if err != nil {
+			log.Exitf("error reading password for user %v from file: %v", *user, err)
+		}
+	}
+
+	connParams := vtbench.ConnParams{
+		Hosts:    strings.Split(*host, ","),
+		Port:     *port,
+		Protocol: clientProto,
+		DB:       *db,
+		Username: *user,
+		Password: password,
+	}
+
+	b := vtbench.NewBench(*threads, *count, connParams, *sql)
+
+	ctx, cancel := context.WithTimeout(context.Background(), *deadline)
+	defer cancel()
+
+	fmt.Printf("Initializing test with %s protocol / %d threads / %d iterations\n",
+		b.ConnParams.Protocol.String(), b.Threads, b.Count)
+	err := b.Run(ctx)
+	if err != nil {
+		log.Exitf("error in test: %v", err)
+	}
+
+	fmt.Printf("Average Rows Returned: %d\n", b.Rows.Get()/int64(b.Threads*b.Count))
+	fmt.Printf("Average Query Time: %v\n", time.Duration(b.Timings.Time()/b.Timings.Count()))
+	fmt.Printf("Total Test Time: %v\n", b.TotalTime)
+	fmt.Printf("QPS (Per Thread): %v\n", float64(b.Count)/b.TotalTime.Seconds())
+	fmt.Printf("QPS (Total): %v\n", float64(b.Count*b.Threads)/b.TotalTime.Seconds())
+
+	last := int64(0)
+
+	histograms := b.Timings.Histograms()
+	h := histograms["query"]
+	buckets := h.Buckets()
+	fmt.Printf("Query Timings:\n")
+	for i, bucket := range h.Cutoffs() {
+		count := buckets[i]
+		if count != 0 {
+			fmt.Printf("%v-%v: %v\n", time.Duration(last), time.Duration(bucket), count)
+		}
+		last = bucket
+	}
+
+}

--- a/go/cmd/vtbench/vtbench.go
+++ b/go/cmd/vtbench/vtbench.go
@@ -33,11 +33,54 @@ import (
 	_ "vitess.io/vitess/go/vt/vttablet/grpctabletconn"
 )
 
+/*
+
+  Vtbench is a simple load testing client to compare workloads in
+  Vitess across the various client/server protocols.
+
+  There are a number of command line options to control the behavior,
+  but as a basic example, the three supported client protocols are:
+
+  Mysql protocol to vtgate:
+  vtbench \
+        -protocol mysql \
+        -host vtgate-host.my.domain \
+        -port 15306 \
+        -user db_username \
+        -db-credentials-file ./vtbench_db_creds.json \
+        -db @replica \
+        -sql "select * from loadtest_table where id=123456789" \
+        -threads 10 \
+        -count 10
+
+  GRPC to vtgate:
+  vtbench \
+        -protocol grpc-vtgate \
+        -host vtgate-host.my.domain \
+        -port 15999 \
+        -db @replica  \
+        $VTTABLET_GRPC_ARGS \
+        -sql "select * from loadtest_table where id=123456789" \
+        -threads 10 \
+        -count 10
+
+  GRPC to vttablet:
+  vtbench \
+        -protocol grpc-vttablet \
+        -host tablet-loadtest-00-80.my.domain \
+        -port 15999 \
+        -db loadtest/00-80@replica  \
+        -sql "select * from loadtest_table where id=123456789" \
+        -threads 10 \
+        -count 10
+
+*/
+
 var (
 	// connection flags
 	host     = flag.String("host", "", "vtgate host(s) in the form 'host1,host2,...'")
 	port     = flag.Int("port", 0, "vtgate port")
-	protocol = flag.String("protocol", "mysql", "client protocol, either mysql (default) or grpc")
+	protocol = flag.String("protocol", "mysql", "client protocol, either mysql (default), grpc-vtgate, or grpc-vttablet")
 	user     = flag.String("user", "", "username to connect using mysql (password comes from the db-credentials-file)")
 	db       = flag.String("db", "", "db name to use when connecting / running the queries (e.g. @replica, keyspace, keyspace/shard etc)")
 
@@ -130,5 +173,4 @@ func main() {
 		}
 		last = bucket
 	}
-
 }

--- a/go/vtbench/client.go
+++ b/go/vtbench/client.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtbench
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+	"vitess.io/vitess/go/vt/vttablet/queryservice"
+	"vitess.io/vitess/go/vt/vttablet/tabletconn"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+type clientConn interface {
+	connect(ctx context.Context, cp ConnParams) error
+	execute(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error)
+}
+
+type mysqlClientConn struct {
+	conn *mysql.Conn
+}
+
+func (c *mysqlClientConn) connect(ctx context.Context, cp ConnParams) error {
+	conn, err := mysql.Connect(ctx, &mysql.ConnParams{
+		Host:   cp.Hosts[0],
+		Port:   cp.Port,
+		DbName: cp.DB,
+		Uname:  cp.Username,
+		Pass:   cp.Password,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+
+	return nil
+}
+
+func (c *mysqlClientConn) execute(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	if len(bindVars) != 0 {
+		panic("cannot have bind vars for mysql protocol")
+	}
+
+	return c.conn.ExecuteFetch(query, 10000 /* maxrows */, true /* wantfields*/)
+}
+
+// used to ensure grpc.WithBlock() is added once to the options
+var withBlockOnce sync.Once
+
+type grpcVtgateConn struct {
+	session *vtgateconn.VTGateSession
+}
+
+var vtgateConns = map[string]*vtgateconn.VTGateConn{}
+
+func (c *grpcVtgateConn) connect(ctx context.Context, cp ConnParams) error {
+	withBlockOnce.Do(func() {
+		grpcclient.RegisterGRPCDialOptions(func(opts []grpc.DialOption) ([]grpc.DialOption, error) {
+			return append(opts, grpc.WithBlock()), nil
+		})
+	})
+
+	address := fmt.Sprintf("%v:%v", cp.Hosts[0], cp.Port)
+
+	conn, ok := vtgateConns[address]
+	if !ok {
+		var err error
+		conn, err = vtgateconn.DialProtocol(ctx, "grpc", address)
+		if err != nil {
+			return err
+		}
+		vtgateConns[address] = conn
+	}
+
+	c.session = conn.Session(cp.DB, nil)
+
+	return nil
+}
+
+func (c *grpcVtgateConn) execute(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return c.session.Execute(ctx, query, bindVars)
+}
+
+type grpcVttabletConn struct {
+	qs     queryservice.QueryService
+	target querypb.Target
+}
+
+var vttabletConns = map[string]queryservice.QueryService{}
+
+func (c *grpcVttabletConn) connect(ctx context.Context, cp ConnParams) error {
+	withBlockOnce.Do(func() {
+		grpcclient.RegisterGRPCDialOptions(func(opts []grpc.DialOption) ([]grpc.DialOption, error) {
+			return append(opts, grpc.WithBlock()), nil
+		})
+	})
+
+	// parse the "db" into the keyspace/shard target
+	keyspace, tabletType, dest, err := topoproto.ParseDestination(cp.DB, topodatapb.TabletType_MASTER)
+	if err != nil {
+		return err
+	}
+
+	qs, ok := vttabletConns[cp.Hosts[0]]
+	if !ok {
+		tablet := topodatapb.Tablet{
+			Hostname: cp.Hosts[0],
+			PortMap:  map[string]int32{"grpc": int32(cp.Port)},
+			Keyspace: keyspace,
+		}
+		var err error
+		qs, err = tabletconn.GetDialer()(&tablet, true)
+		if err != nil {
+			return err
+		}
+		vttabletConns[cp.Hosts[0]] = qs
+	}
+
+	c.qs = qs
+
+	shard, ok := dest.(key.DestinationShard)
+	if !ok {
+		return fmt.Errorf("invalid destination shard")
+	}
+
+	c.target = querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      string(shard),
+		TabletType: tabletType,
+	}
+
+	return nil
+}
+
+func (c *grpcVttabletConn) execute(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return c.qs.Execute(ctx, &c.target, query, bindVars, 0, nil)
+}

--- a/go/vtbench/vtbench.go
+++ b/go/vtbench/vtbench.go
@@ -112,17 +112,18 @@ func NewBench(threads, count int, cp ConnParams, query string) *Bench {
 
 // Run executes the test
 func (b *Bench) Run(ctx context.Context) error {
-	err := b.createThreads(ctx)
+	err := b.createConns(ctx)
 	if err != nil {
 		return err
 	}
 
-	b.startThreads(ctx)
+	b.createThreads(ctx)
+	b.runTest(ctx)
 	return nil
 }
 
-func (b *Bench) createThreads(ctx context.Context) error {
-	log.V(10).Infof("creating %d client threads...", b.Threads)
+func (b *Bench) createConns(ctx context.Context) error {
+	log.V(10).Infof("creating %d client connections...", b.Threads)
 	start := time.Now()
 	reportInterval := 2 * time.Second
 	report := start.Add(reportInterval)
@@ -180,7 +181,7 @@ func (b *Bench) getQuery(i int) (string, map[string]*querypb.BindVariable) {
 	return query, bindVars
 }
 
-func (b *Bench) startThreads(ctx context.Context) error {
+func (b *Bench) createThreads(ctx context.Context) {
 	// Create a barrier so all the threads start at the same time
 	b.lock.Lock()
 
@@ -194,7 +195,9 @@ func (b *Bench) startThreads(ctx context.Context) error {
 	b.wg.Wait()
 
 	b.wg.Add(b.Threads)
+}
 
+func (b *Bench) runTest(ctx context.Context) error {
 	start := time.Now()
 	fmt.Printf("Starting test threads\n")
 	b.lock.Unlock()
@@ -232,21 +235,3 @@ func (bt *benchThread) clientLoop(ctx context.Context) {
 
 	b.wg.Done()
 }
-
-/*
-
-func run() {
-	for i := 0; i < *threads; ++i {
-		go run()
-	}
-
-
-func Connect(ctx context.Context, params *ConnParams) (*Conn, error) {
-
-func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (result *sqltypes.Result, err error) {
-	result, _, err = c.ExecuteFetchMulti(query, maxrows, wantfields)
-	return result, err
-}
-
-}
-*/

--- a/go/vtbench/vtbench.go
+++ b/go/vtbench/vtbench.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtbench
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/log"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// ClientProtocol indicates how to connect
+type ClientProtocol int
+
+const (
+	// MySQL uses the mysql wire protocol
+	MySQL ClientProtocol = iota
+
+	// GRPCVtgate uses the grpc wire protocol to vttablet
+	GRPCVtgate
+
+	// GRPCVttablet uses the grpc wire protocol to vttablet
+	GRPCVttablet
+)
+
+// ProtocolString returns a string representation of the protocol
+func (cp ClientProtocol) String() string {
+	switch cp {
+	case MySQL:
+		return "mysql"
+	case GRPCVtgate:
+		return "grpc-vtgate"
+	case GRPCVttablet:
+		return "grpc-vttablet"
+	default:
+		return fmt.Sprintf("unknown-protocol-%d", cp)
+	}
+}
+
+// ConnParams specifies how to connect to the vtgate(s)
+type ConnParams struct {
+	Hosts    []string
+	Port     int
+	DB       string
+	Username string
+	Password string
+	Protocol ClientProtocol
+}
+
+// Bench controls the test
+type Bench struct {
+	ConnParams ConnParams
+	Threads    int
+	Count      int
+	Query      string
+
+	threads []benchThread
+
+	// synchronization waitgroup for startup / completion
+	wg sync.WaitGroup
+
+	// starting gate used to block all threads on startup
+	lock sync.RWMutex
+
+	Rows    *stats.Counter
+	Bytes   *stats.Counter
+	Timings *stats.Timings
+
+	TotalTime time.Duration
+}
+
+type benchThread struct {
+	b        *Bench
+	i        int
+	conn     clientConn
+	query    string
+	bindVars map[string]*querypb.BindVariable
+}
+
+// NewBench creates a new bench test
+func NewBench(threads, count int, cp ConnParams, query string) *Bench {
+	bench := Bench{
+		Threads:    threads,
+		Count:      count,
+		ConnParams: cp,
+		Query:      query,
+		Rows:       stats.NewCounter("", ""),
+		Timings:    stats.NewTimings("", "", ""),
+	}
+	return &bench
+}
+
+// Run executes the test
+func (b *Bench) Run(ctx context.Context) error {
+	err := b.createThreads(ctx)
+	if err != nil {
+		return err
+	}
+
+	b.startThreads(ctx)
+	return nil
+}
+
+func (b *Bench) createThreads(ctx context.Context) error {
+	log.V(10).Infof("creating %d client threads...", b.Threads)
+	start := time.Now()
+	reportInterval := 2 * time.Second
+	report := start.Add(reportInterval)
+	for i := 0; i < b.Threads; i++ {
+		host := b.ConnParams.Hosts[i%len(b.ConnParams.Hosts)]
+		cp := b.ConnParams
+		cp.Hosts = []string{host}
+
+		var conn clientConn
+		var err error
+
+		switch b.ConnParams.Protocol {
+		case MySQL:
+			log.V(5).Infof("connecting to %s using mysql protocol...", host)
+			conn = &mysqlClientConn{}
+			err = conn.connect(ctx, cp)
+		case GRPCVtgate:
+			log.V(5).Infof("connecting to %s using grpc vtgate protocol...", host)
+			conn = &grpcVtgateConn{}
+			err = conn.connect(ctx, cp)
+		case GRPCVttablet:
+			log.V(5).Infof("connecting to %s using grpc vttablet protocol...", host)
+			conn = &grpcVttabletConn{}
+			err = conn.connect(ctx, cp)
+		default:
+			return fmt.Errorf("unimplemented connection protocol %s", b.ConnParams.Protocol.String())
+		}
+
+		if err != nil {
+			return fmt.Errorf("error connecting to %s using %v protocol: %v", host, cp.Protocol.String(), err)
+		}
+
+		// XXX handle normalization and per-thread query templating
+		query, bindVars := b.getQuery(i)
+		b.threads = append(b.threads, benchThread{
+			b:        b,
+			i:        i,
+			conn:     conn,
+			query:    query,
+			bindVars: bindVars,
+		})
+
+		if time.Now().After(report) {
+			fmt.Printf("Created %d/%d connections after %v\n", i, b.Threads, time.Since(start))
+			report = time.Now().Add(reportInterval)
+		}
+	}
+
+	return nil
+}
+
+func (b *Bench) getQuery(i int) (string, map[string]*querypb.BindVariable) {
+	query := strings.Replace(b.Query, ":thread", fmt.Sprintf("%d", i), -1)
+	bindVars := make(map[string]*querypb.BindVariable)
+	return query, bindVars
+}
+
+func (b *Bench) startThreads(ctx context.Context) error {
+	// Create a barrier so all the threads start at the same time
+	b.lock.Lock()
+
+	log.V(10).Infof("starting %d threads", b.Threads)
+	for i := 0; i < b.Threads; i++ {
+		b.wg.Add(1)
+		go b.threads[i].clientLoop(ctx)
+	}
+
+	log.V(10).Infof("waiting for %d threads to start", b.Threads)
+	b.wg.Wait()
+
+	b.wg.Add(b.Threads)
+
+	start := time.Now()
+	fmt.Printf("Starting test threads\n")
+	b.lock.Unlock()
+
+	// Then wait for them all to finish looping
+	log.V(10).Infof("waiting for %d threads to finish", b.Threads)
+	b.wg.Wait()
+	b.TotalTime = time.Since(start)
+
+	return nil
+}
+
+func (bt *benchThread) clientLoop(ctx context.Context) {
+	b := bt.b
+
+	// Declare that startup is finished and wait for
+	// the barrier
+	b.wg.Done()
+	log.V(10).Infof("thread %d waiting for startup barrier", bt.i)
+	b.lock.RLock()
+	log.V(10).Infof("thread %d starting loop", bt.i)
+
+	for i := 0; i < b.Count; i++ {
+		start := time.Now()
+		result, err := bt.conn.execute(ctx, bt.query, bt.bindVars)
+		b.Timings.Record("query", start)
+		if err != nil {
+			log.Errorf("query error: %v", err)
+			break
+		} else {
+			b.Rows.Add(int64(result.RowsAffected))
+		}
+
+	}
+
+	b.wg.Done()
+}
+
+/*
+
+func run() {
+	for i := 0; i < *threads; ++i {
+		go run()
+	}
+
+
+func Connect(ctx context.Context, params *ConnParams) (*Conn, error) {
+
+func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (result *sqltypes.Result, err error) {
+	result, _, err = c.ExecuteFetchMulti(query, maxrows, wantfields)
+	return result, err
+}
+
+}
+*/


### PR DESCRIPTION
## Description
Implement a simple benchmark tool that is capable of running queries using either mysql or grpc protocol to a vtgate, or by grpc straight to a vttablet.

## Motivation
Although plenty of off the shelf benchmarking tools existed, I wanted one where I was able to control the parallelism and make apples to apples comparisons between mysql / grpc vtgate / grpc vttablet.


