### PR TITLE
Fix a memory leak in opentsdb reporting

### DIFF
--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -39,8 +39,12 @@ func sendDataPoints(data []dataPoint) error {
 		return err
 	}
 
-	_, err = http.Post(*openTsdbURI, "application/json", bytes.NewReader(json))
-	return err
+	resp, err := http.Post(*openTsdbURI, "application/json", bytes.NewReader(json))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // openTSDBBackend implements stats.PushBackend

--- a/test.go
+++ b/test.go
@@ -700,6 +700,7 @@ func reshardTests(config *Config, numShards int) error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 		if data, err = ioutil.ReadAll(resp.Body); err != nil {
 			return err
 		}


### PR DESCRIPTION
Responses from http.* methods must be explicitly closed.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>

"go vet" can tell you if you try to close a response body before checking the error code, but sadly it does not tell you if you've completely failed to close the body at all (https://github.com/golang/go/blob/master/src/cmd/vet/testdata/httpresponse.go).