### PR TITLE
make dev.env work with posix (bourne) shell

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -1,4 +1,4 @@
-#!/bin/bash
+# No shebang line as this script is sourced from an external shell.
 
 # Copyright 2017 Google Inc.
 # 
@@ -13,6 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Plese ensure dev.env is written in a way which is POSIX (bourne)
+# shell compatible.
+# - Some build systems like rpm require the different scriptlets used
+#   to build a package to be run under a POSIX shell so non-POSIX
+#   syntax will break that as dev.env will not be sourced by bash..
 
 # Import prepend_path function.
 dir="$(dirname "${BASH_SOURCE[0]}")"
@@ -39,11 +45,16 @@ mkdir -p "$VTDATAROOT"
 export VTPORTSTART=15000
 
 # Add all site-packages or dist-packages directories below $VTROOT/dist to $PYTHONPATH.
-while IFS= read -r -d '' pypath; do
-  PYTHONPATH=$(prepend_path "$PYTHONPATH" "$pypath")
+BACKUP_IFS="$IFS"
+IFS="
+"
 # Note that the escaped ( ) around the -or expression are important.
-# Otherwise, the -print0 would match *all* files.
-done < <(find "$VTROOT/dist" \( -name site-packages -or -name dist-packages \) -print0)
+# Otherwise, the -print would match *all* files.
+for p in $(find "$VTROOT/dist" \( -name site-packages -or -name dist-packages \) -print); do
+  PYTHONPATH=$(prepend_path "$PYTHONPATH" "$pypath")
+done
+IFS="$BACKUP_IFS"
+
 PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTROOT/py-vtdb")
 PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTROOT/dist/selenium")
 PYTHONPATH=$(prepend_path "$PYTHONPATH" "$VTTOP/test")


### PR DESCRIPTION
dev.env is sourced from the shell and for some build environments like rpm the shell used for build "snippets" MUST be a posix shell, not bash.

So adjust one occurence where trying to build a vitess rpm from rpmbuild failed due to bashisms not recognised by the posix shell.

Also remove the shebang line as this script is not run in isolation but sourced from an existing shell.

Signed-off-by: Simon J Mudd <sjmudd@pobox.com>