### PR TITLE
Improve GetCellInfo failure message so caller can report more clearly

### DIFF
--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -270,7 +270,7 @@ func (ts *Server) ConnForCell(ctx context.Context, cell string) (Conn, error) {
 	// We can use the GlobalReadOnlyCell for this call.
 	ci, err := ts.GetCellInfo(ctx, cell, false /*strongRead*/)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetCellInfo failed for cell %v: %s", cell, err)
 	}
 
 	// Connect to the cell topo server, while holding the lock.


### PR DESCRIPTION
This improves the error message received "upstream" if there's a configuration error in the topology setup.

I recently saw something like this:
```
F0620 17:08:40.842678 56891 vttablet.go:130] NewActionAgent() failed: agent.InitTablet failed: CreateTablet failed: node doesn't exist
```

which is not very intuitive to a new user. Looks like the zookeeper configuration was configured incorrectly. This patch will at least expose the cell name to the caller which should catch typos or other types of issues and point a bit closer to the error.

Related to: https://github.com/vitessio/vitess/issues/4045.