### PR TITLE
vtexplain support partitions

### DIFF
--- a/data/test/vtexplain/test-schema.sql
+++ b/data/test/vtexplain/test-schema.sql
@@ -49,3 +49,21 @@ create table table_not_in_vschema (
 	id bigint,
 	primary key (id)
 ) Engine=InnoDB;
+
+/*
+ * This is not used by the tests themselves, but is used to verify
+ * that the vtexplain schema parsing logic can properly skip past
+ * the mysql comments used by partitioned tables.
+ */
+create table test_partitioned (
+	id bigint,
+	date_create int,
+	primary key(id)
+) Engine=InnoDB
+/*!50100 PARTITION BY RANGE (date_create)
+(PARTITION p2018_06_14 VALUES LESS THAN (1528959600) ENGINE = InnoDB,
+ PARTITION p2018_06_15 VALUES LESS THAN (1529046000) ENGINE = InnoDB,
+ PARTITION p2018_06_16 VALUES LESS THAN (1529132400) ENGINE = InnoDB,
+ PARTITION p2018_06_17 VALUES LESS THAN (1529218800) ENGINE = InnoDB)
+*/
+;

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -160,6 +160,28 @@ func hasCommentPrefix(sql string) bool {
 	return len(sql) > 1 && ((sql[0] == '/' && sql[1] == '*') || (sql[0] == '-' && sql[1] == '-'))
 }
 
+// StripComments removes all comments from the string regardless
+// of where they occur
+func StripComments(sql string) string {
+	sql = StripLeadingComments(sql) // handle -- or /* ... */ at the beginning
+
+	for {
+		start := strings.Index(sql, "/*")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(sql, "*/")
+		if end <= 1 {
+			break
+		}
+		sql = sql[:start] + sql[end+2:]
+	}
+
+	sql = strings.TrimFunc(sql, unicode.IsSpace)
+
+	return sql
+}
+
 // ExtractMysqlComment extracts the version and SQL from a comment-only query
 // such as /*!50708 sql here */
 func ExtractMysqlComment(sql string) (version string, innerSQL string) {

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -212,6 +212,85 @@ a`,
 	}
 }
 
+func TestRemoveComments(t *testing.T) {
+	var testCases = []struct {
+		input, outSQL string
+	}{{
+		input:  "/",
+		outSQL: "/",
+	}, {
+		input:  "*/",
+		outSQL: "*/",
+	}, {
+		input:  "/*/",
+		outSQL: "/*/",
+	}, {
+		input:  "/*a",
+		outSQL: "/*a",
+	}, {
+		input:  "/*a*",
+		outSQL: "/*a*",
+	}, {
+		input:  "/*a**",
+		outSQL: "/*a**",
+	}, {
+		input:  "/*b**a*/",
+		outSQL: "",
+	}, {
+		input:  "/*a*/",
+		outSQL: "",
+	}, {
+		input:  "/**/",
+		outSQL: "",
+	}, {
+		input:  "/*!*/",
+		outSQL: "",
+	}, {
+		input:  "/*!a*/",
+		outSQL: "",
+	}, {
+		input:  "/*b*/ /*a*/",
+		outSQL: "",
+	}, {
+		input: `/*b*/ --foo
+bar`,
+		outSQL: "bar",
+	}, {
+		input:  "foo /* bar */",
+		outSQL: "foo",
+	}, {
+		input:  "foo /* bar */ baz",
+		outSQL: "foo  baz",
+	}, {
+		input:  "/* foo */ bar",
+		outSQL: "bar",
+	}, {
+		input:  "-- /* foo */ bar",
+		outSQL: "",
+	}, {
+		input:  "foo -- bar */",
+		outSQL: "foo -- bar */",
+	}, {
+		input: `/*
+foo */ bar`,
+		outSQL: "bar",
+	}, {
+		input: `-- foo bar
+a`,
+		outSQL: "a",
+	}, {
+		input:  `-- foo bar`,
+		outSQL: "",
+	}}
+	for _, testCase := range testCases {
+		gotSQL := StripComments(testCase.input)
+
+		if gotSQL != testCase.outSQL {
+			t.Errorf("test input: '%s', got SQL\n%+v, want\n%+v", testCase.input, gotSQL, testCase.outSQL)
+		}
+	}
+}
+
 func TestExtractMysqlComment(t *testing.T) {
 	var testCases = []struct {
 		input, outSQL, outVersion string

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -35,6 +35,7 @@ func defaultTestOpts() *Options {
 		ReplicationMode: "ROW",
 		NumShards:       4,
 		Normalize:       true,
+		StrictDDL:       true,
 	}
 }
 

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -40,7 +40,7 @@ create table t3 (
 );
 `
 
-	ddls, err := parseSchema(testSchema)
+	ddls, err := parseSchema(testSchema, &Options{StrictDDL: true})
 	if err != nil {
 		t.Fatalf("parseSchema: %v", err)
 	}


### PR DESCRIPTION
## Description
Fix vtexplain's schema parser to ignore all comments so that it doesn't get confused by partitioned tables

## Details
In cases of partitioned tables, mysql will include version-specific comment directives in the output of a `show create table` command.

These were not properly parsed by vtexplain, so add a utility to just strip _all_ comments from the sql schema so this works again.
