### PR TITLE
No stdin for vttestserver

### DIFF
--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -205,12 +205,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Info("Local cluster started. Waiting for stdin input...")
+	log.Info("Local cluster started.")
 
-	_, err = fmt.Scanln()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Info("Shutting down cleanly")
+	select {}
 }


### PR DESCRIPTION
If we use stdin then the test server exits when running in docker.

Signed-off-by: Jon Tirsen <jontirsen@squareup.com>