### PR TITLE
planbuilder: set table name in plan even in passthrough dml mode

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -337,6 +337,7 @@ options:PassthroughDMLs
 "insert into b.a (eid, id) values (1, :a)"
 {
   "PlanID": "PASS_DML",
+  "Reason": "TABLE",
   "TableName": "",
   "Permissions": [
     {
@@ -368,7 +369,7 @@ options:PassthroughDMLs
 "insert into a (eid, id) values (1, :a)"
 {
   "PlanID": "PASS_DML",
-  "TableName": "",
+  "TableName": "a",
   "Permissions": [
     {
       "TableName": "a",
@@ -560,7 +561,7 @@ options:PassthroughDMLs
 "insert into a (eid, id) values (1, 2) on duplicate key update name = func(a)"
 {
   "PlanID": "PASS_DML",
-  "TableName": "",
+  "TableName": "a",
   "Permissions": [
     {
       "TableName": "a",
@@ -1070,6 +1071,7 @@ options:PassthroughDMLs
 "replace into b (eid, id) values (1, 2), (3, 4)"
 {
   "PlanID": "PASS_DML",
+  "Reason": "REPLACE",
   "TableName": "",
   "Permissions": [
     {
@@ -1155,7 +1157,7 @@ options:PassthroughDMLs
 "update d set foo='foo' where name in ('a', 'b') limit 1"
 {
   "PlanID": "PASS_DML",
-  "TableName": "",
+  "TableName": "d",
   "Permissions": [
     {
       "TableName": "d",
@@ -1185,6 +1187,7 @@ options:PassthroughDMLs
 "update b.a set name='foo' where eid=1 and id=1"
 {
   "PlanID": "PASS_DML",
+  "Reason": "TABLE",
   "TableName": "",
   "Permissions": [
     {
@@ -1193,6 +1196,25 @@ options:PassthroughDMLs
     }
   ],
   "FullQuery": "update b.a set name = 'foo' where eid = 1 and id = 1"
+}
+
+# update unknown table
+"update bogus set name='foo' where id=1"
+"table bogus not found in schema"
+
+# update unknown table
+options:PassthroughDMLs
+"update bogus set name='foo' where id=1"
+{
+  "PlanID": "PASS_DML",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "bogus",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update bogus set name = 'foo' where id = 1"
 }
 
 # multi-table update
@@ -1215,6 +1237,26 @@ options:PassthroughDMLs
 }
 
 # multi-table update
+"update a, b set a.name = 'foo' where a.id = b.id and b.var = 'test'"
+{
+  "PlanID": "PASS_DML",
+  "Reason": "MULTI_TABLE",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    },
+    {
+      "TableName": "b",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update a, b set a.name = 'foo' where a.id = b.id and b.var = 'test'"
+}
+
+# multi-table update
+options:PassthroughDMLs
 "update a join b on a.id = b.id set a.name = 'foo' where b.var = 'test'"
 {
   "PlanID": "PASS_DML",
@@ -1269,6 +1311,21 @@ options:PassthroughDMLs
   ],
   "FullQuery": "update b set eid = foo()",
   "WhereClause": ""
+}
+
+# complex pk change
+options:PassthroughDMLs
+"update b set eid=foo()"
+{
+  "PlanID": "PASS_DML",
+  "TableName": "b",
+  "Permissions": [
+    {
+      "TableName": "b",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update b set eid = foo()"
 }
 
 # update subquery
@@ -1565,7 +1622,7 @@ options:PassthroughDMLs
 "delete from d where name in ('a', 'b') limit 1"
 {
   "PlanID": "PASS_DML",
-  "TableName": "",
+  "TableName": "d",
   "Permissions": [
     {
       "TableName": "d",
@@ -1646,7 +1703,7 @@ options:PassthroughDMLs
 "delete from a where eid=1 and id=1"
 {
   "PlanID": "PASS_DML",
-  "TableName": "",
+  "TableName": "a",
   "Permissions": [
     {
       "TableName": "a",

--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -32,10 +32,6 @@ func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan
 		FullQuery: GenerateFullQuery(upd),
 	}
 
-	if PassthroughDMLs {
-		return plan, nil
-	}
-
 	if len(upd.TableExprs) > 1 {
 		plan.Reason = ReasonMultiTable
 		return plan, nil
@@ -52,9 +48,16 @@ func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan
 		plan.Reason = ReasonTable
 		return plan, nil
 	}
-	table, err := plan.setTable(tableName, tables)
-	if err != nil {
-		return nil, err
+	table, tableErr := plan.setTable(tableName, tables)
+
+	// In passthrough dml mode, allow the operation even if the
+	// table is unknown in the schema.
+	if PassthroughDMLs {
+		return plan, nil
+	}
+
+	if tableErr != nil {
+		return nil, tableErr
 	}
 
 	// Store the WHERE clause as string for the hot row protection (txserializer).
@@ -99,10 +102,6 @@ func analyzeDelete(del *sqlparser.Delete, tables map[string]*schema.Table) (plan
 		FullQuery: GenerateFullQuery(del),
 	}
 
-	if PassthroughDMLs {
-		return plan, nil
-	}
-
 	if len(del.TableExprs) > 1 {
 		plan.Reason = ReasonMultiTable
 		return plan, nil
@@ -117,9 +116,16 @@ func analyzeDelete(del *sqlparser.Delete, tables map[string]*schema.Table) (plan
 		plan.Reason = ReasonTable
 		return plan, nil
 	}
-	table, err := plan.setTable(tableName, tables)
-	if err != nil {
-		return nil, err
+	table, tableErr := plan.setTable(tableName, tables)
+
+	// In passthrough dml mode, allow the operation even if the
+	// table is unknown in the schema.
+	if PassthroughDMLs {
+		return plan, nil
+	}
+
+	if tableErr != nil {
+		return nil, tableErr
 	}
 
 	// Store the WHERE clause as string for the hot row protection (txserializer).
@@ -297,9 +303,6 @@ func analyzeInsert(ins *sqlparser.Insert, tables map[string]*schema.Table) (plan
 		PlanID:    PlanPassDML,
 		FullQuery: GenerateFullQuery(ins),
 	}
-	if PassthroughDMLs {
-		return plan, nil
-	}
 
 	if ins.Action == sqlparser.ReplaceStr {
 		plan.Reason = ReasonReplace
@@ -310,9 +313,16 @@ func analyzeInsert(ins *sqlparser.Insert, tables map[string]*schema.Table) (plan
 		plan.Reason = ReasonTable
 		return plan, nil
 	}
-	table, err := plan.setTable(tableName, tables)
-	if err != nil {
-		return nil, err
+	table, tableErr := plan.setTable(tableName, tables)
+
+	// In passthrough dml mode, allow the operation even if the
+	// table is unknown in the schema.
+	if PassthroughDMLs {
+		return plan, nil
+	}
+
+	if tableErr != nil {
+		return nil, tableErr
 	}
 
 	if !table.HasPrimary() {


### PR DESCRIPTION
Rework the implementation of passthrough DML mode so that it tries to set the Table in the plan before returning.

This fixes an annoyance in which the per-table metrics don't properly include DMLs in passthrough mode because they are generated dynamically based on the table name in the plan stats.
