### PR TITLE
Added libexec path to potential binary search paths

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -470,7 +470,7 @@ func execCmd(name string, args, env []string, dir string, input io.Reader) (cmd 
 // binaryPath does a limited path lookup for a command,
 // searching only within sbin and bin in the given root.
 func binaryPath(root, binary string) (string, error) {
-	subdirs := []string{"sbin", "bin"}
+	subdirs := []string{"sbin", "bin", "libexec"}
 	for _, subdir := range subdirs {
 		binPath := path.Join(root, subdir, binary)
 		if _, err := os.Stat(binPath); err == nil {


### PR DESCRIPTION
Some distributions of linux put the mysqld binary into `/usr/libexec`. This add libexec as a potential binary path to enable such distro's to work