### PR TITLE
Removed explicit one hour timeout from vtctlclient_wrapper

### DIFF
--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -51,9 +51,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), *actionTimeout)
+	defer cancel()
+
 	err := vtctlclient.RunCommandAndWait(
-		context.Background(), *server, flag.Args(),
-		*actionTimeout,
+		ctx, *server, flag.Args(),
 		func(e *logutilpb.Event) {
 			logutil.LogEvent(logger, e)
 		})

--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -19,7 +19,6 @@ package automation
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/log"
@@ -44,8 +43,6 @@ func ExecuteVtctl(ctx context.Context, server string, args []string) (string, er
 
 	err := vtctlclient.RunCommandAndWait(
 		ctx, server, args,
-		// TODO(mberlin): Should this value be configurable as flags?
-		time.Hour, // actionTimeout
 		loggerToBufferFunc)
 
 	endMsg := fmt.Sprintf("Executed remote vtctl command: %v server: %v err: %v", args, server, err)

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 
 	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/vttls"


### PR DESCRIPTION
Removal of hard coded one hour timeout into vtctlclient_wrapper commands. Plumbed through the `context` to provide a timeout when it exists. If no timeout is given in the context the system will default to a one hour timeout. 

