### PR TITLE
Fix bug in where timeout condition is checked

### DIFF
--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -59,6 +59,52 @@
   }
 }
 
+# select aggregation with timeout directive sets QueryTimeout in the route
+"select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user"
+{
+  "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user",
+      "FieldQuery": "select count(*) from user where 1 != 1",
+      "QueryTimeout": 1000
+    }
+  }
+}
+
+# select limit with timeout directive sets QueryTimeout in the route
+"select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user limit 10"
+{
+  "Original": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user limit 10",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 10,
+    "Offset": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user limit :__upper_limit",
+      "FieldQuery": "select * from user where 1 != 1",
+      "QueryTimeout": 1000
+    }
+  }
+}
+
 # qualified '*' expression for simple route
 "select user.* from user"
 {


### PR DESCRIPTION
The following fixes a bug where timeouts where not being properly propagated
when using limit or count clauses.

This needs to be done before the full route is wireup. Otherwise the type
pattern matching won't work.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>