### PR TITLE
partially revert commit 65fc9dffe

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -757,7 +757,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select id from user where 'targetString'",
+    "Query": "select id from user where database()",
     "FieldQuery": "select id from user where 1 != 1"
   }
 }

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1111,8 +1111,8 @@
       "Name": "main",
       "Sharded": false
     },
-    "Query": "select u1.a from unsharded as u1 join unsharded as u2 on 'targetString'",
-    "FieldQuery": "select u1.a from unsharded as u1 join unsharded as u2 on 'targetString' where 1 != 1"
+    "Query": "select u1.a from unsharded as u1 join unsharded as u2 on database()",
+    "FieldQuery": "select u1.a from unsharded as u1 join unsharded as u2 on database() where 1 != 1"
   }
 }
 

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -199,8 +199,8 @@
       "Name": "main",
       "Sharded": false
     },
-    "Query": "select 'targetString' from dual",
-    "FieldQuery": "select 'targetString' from dual where 1 != 1"
+    "Query": "select database() from dual",
+    "FieldQuery": "select database() from dual where 1 != 1"
   }
 }
 

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -126,8 +126,6 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (origin builder, pus
 				if rb, isRoute := pb.bldr.(*route); !isRoute || rb.ERoute.Keyspace.Sharded {
 					return false, errors.New("unsupported: LAST_INSERT_ID is only allowed for unsharded keyspaces")
 				}
-			case node.Name.EqualString("database"):
-				expr = sqlparser.ReplaceExpr(expr, node, sqlparser.NewStrVal([]byte(pb.vschema.TargetString())))
 			}
 			return true, nil
 		}


### PR DESCRIPTION
which added handling of the database() function to vtgates.

that commit was intended to fix a problem for Tirsen, but Sugu reports that it did not.
in the process, it broke an invocation of that function by liquibase here, which was not
expecting a full `...@master` target.

Signed-off-by: Alex Charis <acharis@hubspot.com>