### PR TITLE
Using the configuration error string in this test.

### DIFF
--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -25,6 +25,7 @@ import urllib
 import environment
 import keyspace_util
 import utils
+from protocols_flavor import protocols_flavor
 
 from vtdb import dbexceptions
 from vtdb import vtgate_cursor
@@ -669,7 +670,7 @@ class TestVTGateFunctions(unittest.TestCase):
       self.fail('Execute went through')
     except dbexceptions.DatabaseError as e:
       s = str(e)
-      self.assertIn('DeadlineExceeded', s)
+      self.assertIn(protocols_flavor().rpc_timeout_message(), s)
 
     # test directive timeout longer than the query time
     cursor.execute('SELECT /*vt+ QUERY_TIMEOUT_MS=2000 */ SLEEP(1)', {})


### PR DESCRIPTION
So it works with other RPC implementations.

Signed-off-by: Alain Jobart <alainjobart@google.com>