### PR TITLE
Fix bug found in dev around repairReplication patch in PR #4024

### DIFF
--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -146,8 +146,9 @@ func (orc *orcClient) InActiveShardRecovery(tablet *topodatapb.Tablet) (bool, er
 		return false, err
 	}
 
+	// Orchestrator returns a 0-length response when it has no history of recovery on this cluster.
 	if len(r) == 0 {
-		return false, fmt.Errorf("Orchestrator returned an empty audit-recovery response")
+		return false, nil
 	}
 
 	active, ok := r[0]["IsActive"].(bool)


### PR DESCRIPTION
Fixes a bug introduced in the repairReplication #4024 where replica tablets _sometimes_ do not reconnect replication to the master tablet after restarting. This bug is triggered when Orchestrator has never recovered the shard the tablet is a member of.

This fixes the bug by allowing repairReplication to continue when `audit-recovery` returns an empty response, as an empty response indicates that Orchestrator is *not* actively recovering that shard, and has never recovered the shard before. Previously, #4024 assumed an empty response was an error and skipped repairReplication after getting an empty response back from Orchestrator's `audit-recovery` endpoint.