### PR TITLE
nomycnf: simplify db parameters

### DIFF
--- a/doc/SeparatingVttabletMysql.md
+++ b/doc/SeparatingVttabletMysql.md
@@ -20,9 +20,9 @@ The following adjustments need to be made to VTTablet command line parameters:
 
 * Do not use `-mycnf_socket_file`. There is no local MySQL unix socket file.
 
-* Specify the host and port of the MySQL daemon for the `-db-config-XXX-host`
-  and `-db-config-XXX-port` command line parameters. Do not specify
-  `-db-config-XXX-unixsocket` parameters.
+* Specify the host and port of the MySQL daemon for the `-db\_host`
+  and `-db\_port` command line parameters. Do not specify
+  `-db\_socket` parameters.
 
 * Disable restores / backups, by not passing any backup command line
   parameters. Specifically, `-restore_from_backup` and

--- a/doc/ServerConfiguration.md
+++ b/doc/ServerConfiguration.md
@@ -270,26 +270,31 @@ VTTablet requires multiple user credentials to perform its tasks. Since it's req
 
 * **db\_app\_user**: App username.
 * **db\_app\_password**: Password for the app username. If you need a more secure way of managing and supplying passwords, VTTablet does allow you to plug into a "password server" that can securely supply and refresh usernames and passwords. Please contact the Vitess team for help if you’d like to write such a custom plugin.
+* **db\_app\_use\_ssl**: Set this flag to false if you don't want to use SSL for this connection. This will allow you to turn off SSL for all users except for `repl`, which may have to be turned on for replication that goes over open networks.
 
 **appdebug** credentials are for the appdebug user:
 
 * **db\_appdebug\_user**
 * **db\_appdebug\_password**
+* **db\_appdebug\_use\_ssl**
 
 **dba** credentials will be used for housekeeping work like loading the schema or killing runaway queries:
 
 * **db\_dba\_user**
 * **db\_dba\_password**
+* **db\_dba\_use\_ssl**
 
 **repl** credentials are for managing replication.
 
 * **db\_repl\_user**
 * **db\_repl\_password**
+* **db\_repl\_use\_ssl**
 
 **filtered** credentials are for performing resharding:
 
 * **db\_filtered\_user**
 * **db\_filtered\_password**
+* **db\_filtered\_use\_ssl**
 
 ### Monitoring
 

--- a/doc/ServerConfiguration.md
+++ b/doc/ServerConfiguration.md
@@ -256,36 +256,40 @@ the binlogs in `/mnt/bin-logs`:
 
 VTTablet requires multiple user credentials to perform its tasks. Since it's required to run on the same machine as MySQL, it’s most beneficial to use the more efficient unix socket connections.
 
+**connection** parameters
+
+* **db\_socket**: The unix socket to connect on. If this is specifed, host and port will not be used.
+* **db\_host**: The host name for the tcp connection.
+* **db\_port**: The tcp port to be used with the db\_host.
+* **db\_charset**: Character set. Only utf8 or latin1 based character sets are supported.
+* **db\_flags**: Flag values as defined by MySQL.
+* **db\ssl\_ca, db\_ssl\_ca\_path, db\_ssl\_cert, db\_ssl\_key**: SSL flags.
+
+
 **app** credentials are for serving app queries:
 
-* **db-config-app-unixsocket**: MySQL socket name to connect to.
-* **db-config-app-uname**: App username.
-* **db-config-app-pass**: Password for the app username. If you need a more secure way of managing and supplying passwords, VTTablet does allow you to plug into a "password server" that can securely supply and refresh usernames and passwords. Please contact the Vitess team for help if you’d like to write such a custom plugin.
-* **db-config-app-charset**: The only supported character set is utf8. Vitess still works with latin1, but it’s getting deprecated.
+* **db\_app\_user**: App username.
+* **db\_app\_password**: Password for the app username. If you need a more secure way of managing and supplying passwords, VTTablet does allow you to plug into a "password server" that can securely supply and refresh usernames and passwords. Please contact the Vitess team for help if you’d like to write such a custom plugin.
+
+**appdebug** credentials are for the appdebug user:
+
+* **db\_appdebug\_user**
+* **db\_appdebug\_password**
 
 **dba** credentials will be used for housekeeping work like loading the schema or killing runaway queries:
 
-* **db-config-dba-unixsocket**
-* **db-config-dba-uname**
-* **db-config-dba-pass**
-* **db-config-dba-charset**
+* **db\_dba\_user**
+* **db\_dba\_password**
 
-**repl** credentials are for managing replication. Since repl connections can be used across machines, you can optionally turn on encryption:
+**repl** credentials are for managing replication.
 
-* **db-config-repl-uname**
-* **db-config-repl-pass**
-* **db-config-repl-charset**
-* **db-config-repl-flags**: If you want to enable SSL, this must be set to 2048.
-* **db-config-repl-ssl-ca**
-* **db-config-repl-ssl-cert**
-* **db-config-repl-ssl-key**
+* **db\_repl\_user**
+* **db\_repl\_password**
 
 **filtered** credentials are for performing resharding:
 
-* **db-config-filtered-unixsocket**
-* **db-config-filtered-uname**
-* **db-config-filtered-pass**
-* **db-config-filtered-charset**
+* **db\_filtered\_user**
+* **db\_filtered\_password**
 
 ### Monitoring
 

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -14,22 +14,6 @@ if [ "$uid" = "1" ]; then
     tablet_role='master'
 fi
 
-dbconfig_dba_flags="\
-    -db-config-dba-uname root \
-    -db-config-dba-charset utf8"
-
-dbconfig_flags="$dbconfig_dba_flags \
-    -db-config-app-uname root \
-    -db-config-app-charset utf8 \
-    -db-config-appdebug-uname root \
-    -db-config-appdebug-charset utf8 \
-    -db-config-allprivs-uname root \
-    -db-config-allprivs-charset utf8 \
-    -db-config-repl-uname root \
-    -db-config-repl-charset utf8 \
-    -db-config-filtered-uname root \
-    -db-config-filtered-charset utf8"
-
 init_db_sql_file="$VTROOT/init_db.sql"
 echo "GRANT ALL ON *.* TO 'root'@'%';" > $init_db_sql_file
 
@@ -52,7 +36,6 @@ fi
 $VTROOT/bin/mysqlctl \
   -log_dir $VTDATAROOT/tmp \
   -tablet_uid $uid \
-  $dbconfig_dba_flags \
   -mysql_port 3306 \
   $action &
 
@@ -78,5 +61,4 @@ exec $VTROOT/bin/vttablet \
   -grpc_port $GRPC_PORT \
   -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
   -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
-  -vtctld_addr http://vtctld:$WEB_PORT/ \
-  $dbconfig_flags
+  -vtctld_addr http://vtctld:$WEB_PORT/

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -61,4 +61,4 @@ exec $VTROOT/bin/vttablet \
   -grpc_port $GRPC_PORT \
   -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
   -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
-  -vtctld_addr http://vtctld:$WEB_PORT/
+  -vtctld_addr "http://vtctld:$WEB_PORT/"

--- a/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
+++ b/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
@@ -56,18 +56,6 @@ spec:
           -init_shard {{shard}}
           -init_tablet_type {{tablet_type}}
           -mysqlctl_socket $VTDATAROOT/mysqlctl.sock
-          -db-config-app-uname vt_app
-          -db-config-app-dbname vt_{{keyspace}}
-          -db-config-app-charset utf8
-          -db-config-dba-uname vt_dba
-          -db-config-dba-dbname vt_{{keyspace}}
-          -db-config-dba-charset utf8
-          -db-config-repl-uname vt_repl
-          -db-config-repl-dbname vt_{{keyspace}}
-          -db-config-repl-charset utf8
-          -db-config-filtered-uname vt_filtered
-          -db-config-filtered-dbname vt_{{keyspace}}
-          -db-config-filtered-charset utf8
           -queryserver-config-transaction-cap 300
           -queryserver-config-schema-reload-time 1
           -queryserver-config-pool-size 100
@@ -98,8 +86,6 @@ spec:
           -alsologtostderr
           -tablet_uid {{uid}}
           -socket_file $VTDATAROOT/mysqlctl.sock
-          -db-config-dba-uname vt_dba
-          -db-config-dba-charset utf8
           -init_db_sql_file $VTROOT/config/init_db.sql" vitess
       env:
         - name: EXTRA_MY_CNF

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -64,18 +64,6 @@ spec:
           -init_tablet_type {{tablet_type}}
           -health_check_interval 5s
           -mysqlctl_socket $VTDATAROOT/mysqlctl.sock
-          -db-config-app-uname vt_app
-          -db-config-app-dbname vt_{{keyspace}}
-          -db-config-app-charset utf8
-          -db-config-dba-uname vt_dba
-          -db-config-dba-dbname vt_{{keyspace}}
-          -db-config-dba-charset utf8
-          -db-config-repl-uname vt_repl
-          -db-config-repl-dbname vt_{{keyspace}}
-          -db-config-repl-charset utf8
-          -db-config-filtered-uname vt_filtered
-          -db-config-filtered-dbname vt_{{keyspace}}
-          -db-config-filtered-charset utf8
           -enable_semi_sync
           -enable_replication_reporter
           -orc_api_url http://orchestrator/api
@@ -107,8 +95,6 @@ spec:
           -alsologtostderr
           -tablet_uid {{uid}}
           -socket_file $VTDATAROOT/mysqlctl.sock
-          -db-config-dba-uname vt_dba
-          -db-config-dba-charset utf8
           -init_db_sql_file $VTROOT/config/init_db.sql" vitess
       env:
         - name: EXTRA_MY_CNF

--- a/examples/local/vttablet-down.sh
+++ b/examples/local/vttablet-down.sh
@@ -41,7 +41,6 @@ for uid_index in $uids; do
 
   echo "Stopping MySQL for tablet $alias..."
   $VTROOT/bin/mysqlctl \
-    -db-config-dba-uname vt_dba \
     -tablet_uid $uid \
     shutdown &
 done

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -36,25 +36,6 @@ fi
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-dbconfig_dba_flags="\
-    -db-config-dba-uname vt_dba \
-    -db-config-dba-charset utf8"
-dbconfig_flags="$dbconfig_dba_flags \
-    -db-config-app-uname vt_app \
-    -db-config-app-dbname vt_$keyspace \
-    -db-config-app-charset utf8 \
-    -db-config-appdebug-uname vt_appdebug \
-    -db-config-appdebug-dbname vt_$keyspace \
-    -db-config-appdebug-charset utf8 \
-    -db-config-allprivs-uname vt_allprivs \
-    -db-config-allprivs-dbname vt_$keyspace \
-    -db-config-allprivs-charset utf8 \
-    -db-config-repl-uname vt_repl \
-    -db-config-repl-dbname vt_$keyspace \
-    -db-config-repl-charset utf8 \
-    -db-config-filtered-uname vt_filtered \
-    -db-config-filtered-dbname vt_$keyspace \
-    -db-config-filtered-charset utf8"
 init_db_sql_file="$VTROOT/config/init_db.sql"
 
 case "$MYSQL_FLAVOR" in
@@ -142,7 +123,6 @@ for uid_index in $uids; do
     -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
     -vtctld_addr http://$hostname:$vtctld_web_port/ \
     $optional_auth_args \
-    $dbconfig_flags \
     > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
   echo "Access tablet $alias at http://$hostname:$port/debug/status"

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -74,7 +74,6 @@ for uid_index in $uids; do
   $VTROOT/bin/mysqlctl \
     -log_dir $VTDATAROOT/tmp \
     -tablet_uid $uid \
-    $dbconfig_dba_flags \
     -mysql_port $mysql_port \
     $action &
 done

--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -235,7 +235,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
-	dbconfigs.RegisterFlags(dbconfigs.DbaConfig)
+	dbconfigs.RegisterFlags(dbconfigs.Dba)
 	flag.Parse()
 
 	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))

--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -44,17 +44,11 @@ var (
 	tabletAddr string
 )
 
-const (
-	// dbconfigFlags is only set to DbaConfig, as mysqlctl only
-	// starts and stops mysqld, and that is only done with the dba user.
-	dbconfigFlags = dbconfigs.DbaConfig
-)
-
 func initConfigCmd(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, err := mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort), dbconfigFlags)
+	mysqld, err := mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
@@ -71,7 +65,7 @@ func initCmd(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 
 	// Generate my.cnf from scratch and use it to find mysqld.
-	mysqld, err := mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort), dbconfigFlags)
+	mysqld, err := mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
@@ -87,7 +81,7 @@ func initCmd(subFlags *flag.FlagSet, args []string) error {
 
 func reinitConfigCmd(subFlags *flag.FlagSet, args []string) error {
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID), dbconfigFlags)
+	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -104,7 +98,7 @@ func shutdownCmd(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID), dbconfigFlags)
+	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -125,7 +119,7 @@ func startCmd(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID), dbconfigFlags)
+	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -145,7 +139,7 @@ func teardownCmd(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 
 	// There ought to be an existing my.cnf, so use it to find mysqld.
-	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID), dbconfigFlags)
+	mysqld, err := mysqlctl.OpenMysqld(uint32(*tabletUID))
 	if err != nil {
 		return fmt.Errorf("failed to find mysql config: %v", err)
 	}
@@ -241,7 +235,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
-	dbconfigs.RegisterFlags(dbconfigFlags)
+	dbconfigs.RegisterFlags(dbconfigs.DbaConfig)
 	flag.Parse()
 
 	tabletAddr = netutil.JoinHostPort("localhost", int32(*port))

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -56,7 +56,7 @@ func main() {
 	defer logutil.Flush()
 
 	// mysqlctld only starts and stops mysql, only needs dba.
-	dbconfigs.RegisterFlags(dbconfigs.DbaConfig)
+	dbconfigs.RegisterFlags(dbconfigs.Dba)
 	servenv.ParseFlags("mysqlctld")
 
 	// We'll register this OnTerm handler before mysqld starts, so we get notified

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -56,8 +56,7 @@ func main() {
 	defer logutil.Flush()
 
 	// mysqlctld only starts and stops mysql, only needs dba.
-	dbconfigFlags := dbconfigs.DbaConfig
-	dbconfigs.RegisterFlags(dbconfigFlags)
+	dbconfigs.RegisterFlags(dbconfigs.DbaConfig)
 	servenv.ParseFlags("mysqlctld")
 
 	// We'll register this OnTerm handler before mysqld starts, so we get notified
@@ -75,7 +74,7 @@ func main() {
 		log.Infof("mycnf file (%s) doesn't exist, initializing", mycnfFile)
 
 		var err error
-		mysqld, err = mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort), dbconfigFlags)
+		mysqld, err = mysqlctl.CreateMysqld(uint32(*tabletUID), *mysqlSocket, int32(*mysqlPort))
 		if err != nil {
 			log.Errorf("failed to initialize mysql config: %v", err)
 			exit.Return(1)
@@ -91,7 +90,7 @@ func main() {
 		log.Infof("mycnf file (%s) already exists, starting without init", mycnfFile)
 
 		var err error
-		mysqld, err = mysqlctl.OpenMysqld(uint32(*tabletUID), dbconfigFlags)
+		mysqld, err = mysqlctl.OpenMysqld(uint32(*tabletUID))
 		if err != nil {
 			log.Errorf("failed to find mysql config: %v", err)
 			exit.Return(1)

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -63,9 +63,7 @@ func main() {
 	defer exit.Recover()
 
 	// flag parsing
-	dbconfigFlags := dbconfigs.AppConfig | dbconfigs.AllPrivsConfig | dbconfigs.DbaConfig |
-		dbconfigs.FilteredConfig | dbconfigs.ReplConfig
-	dbconfigs.RegisterFlags(dbconfigFlags)
+	dbconfigs.RegisterFlags(dbconfigs.All...)
 	mysqlctl.RegisterFlags()
 	servenv.ParseFlags("vtcombo")
 

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -102,15 +102,15 @@ func main() {
 		log.Errorf("mycnf read failed: %v", err)
 		exit.Return(1)
 	}
-	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile)
 	if err != nil {
 		log.Warning(err)
 	}
-	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs)
 	servenv.OnClose(mysqld.Close)
 
 	// tablets configuration and init
-	if err := vtcombo.InitTabletMap(ts, tpb, mysqld, *dbcfgs, *schemaDir, mycnf); err != nil {
+	if err := vtcombo.InitTabletMap(ts, tpb, mysqld, dbcfgs, *schemaDir, mycnf); err != nil {
 		log.Errorf("initTabletMapProto failed: %v", err)
 		exit.Return(1)
 	}

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -106,7 +106,7 @@ func main() {
 	if err != nil {
 		log.Warning(err)
 	}
-	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs)
+	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs)
 	servenv.OnClose(mysqld.Close)
 
 	// tablets configuration and init

--- a/go/cmd/vtqueryserver/vtqueryserver.go
+++ b/go/cmd/vtqueryserver/vtqueryserver.go
@@ -40,8 +40,7 @@ func init() {
 }
 
 func main() {
-	dbconfigFlags := dbconfigs.AppConfig | dbconfigs.AppDebugConfig
-	dbconfigs.RegisterFlags(dbconfigFlags)
+	dbconfigs.RegisterFlags(dbconfigs.App, dbconfigs.AppDebug)
 	flag.Parse()
 
 	if *servenv.Version {

--- a/go/cmd/vtqueryserver/vtqueryserver.go
+++ b/go/cmd/vtqueryserver/vtqueryserver.go
@@ -28,11 +28,15 @@ import (
 )
 
 var (
+	dbName          string
 	mysqlSocketFile = flag.String("mysql-socket-file", "", "path to unix socket file to connect to mysql")
 )
 
 func init() {
 	servenv.RegisterDefaultFlags()
+	// TODO(demmer): remove once migrated to using db_name
+	flag.StringVar(&dbName, "db-config-app-dbname", "", "db connection dbname")
+	flag.StringVar(&dbName, "db_name", "", "db connection dbname")
 }
 
 func main() {
@@ -61,8 +65,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	// DB name must be explicitly set.
+	dbcfgs.DBName.Set(dbName)
 
-	err = vtqueryserver.Init(&dbcfgs)
+	err = vtqueryserver.Init(dbcfgs)
 	if err != nil {
 		log.Exitf("error initializing proxy: %v", err)
 	}

--- a/go/cmd/vtqueryserver/vtqueryserver.go
+++ b/go/cmd/vtqueryserver/vtqueryserver.go
@@ -57,12 +57,12 @@ func main() {
 
 	servenv.Init()
 
-	dbcfgs, err := dbconfigs.Init(*mysqlSocketFile, dbconfigFlags)
+	dbcfgs, err := dbconfigs.Init(*mysqlSocketFile)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = vtqueryserver.Init(dbcfgs)
+	err = vtqueryserver.Init(&dbcfgs)
 	if err != nil {
 		log.Exitf("error initializing proxy: %v", err)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -75,7 +75,7 @@ func main() {
 		log.Exitf("mycnf read failed: %v", err)
 	}
 
-	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile)
 	if err != nil {
 		log.Warning(err)
 	}
@@ -117,7 +117,7 @@ func main() {
 	// Create mysqld and register the health reporter (needs to be done
 	// before initializing the agent, so the initial health check
 	// done by the agent has the right reporter)
-	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs)
 	servenv.OnClose(mysqld.Close)
 
 	// Depends on both query and updateStream.
@@ -125,7 +125,7 @@ func main() {
 	if servenv.GRPCPort != nil {
 		gRPCPort = int32(*servenv.GRPCPort)
 	}
-	agent, err = tabletmanager.NewActionAgent(context.Background(), ts, mysqld, qsc, tabletAlias, *dbcfgs, mycnf, int32(*servenv.Port), gRPCPort)
+	agent, err = tabletmanager.NewActionAgent(context.Background(), ts, mysqld, qsc, tabletAlias, dbcfgs, mycnf, int32(*servenv.Port), gRPCPort)
 	if err != nil {
 		log.Exitf("NewActionAgent() failed: %v", err)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -117,7 +117,7 @@ func main() {
 	// Create mysqld and register the health reporter (needs to be done
 	// before initializing the agent, so the initial health check
 	// done by the agent has the right reporter)
-	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs)
+	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs)
 	servenv.OnClose(mysqld.Close)
 
 	// Depends on both query and updateStream.

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -47,9 +47,7 @@ func init() {
 }
 
 func main() {
-	dbconfigFlags := dbconfigs.AppConfig | dbconfigs.AppDebugConfig | dbconfigs.AllPrivsConfig | dbconfigs.DbaConfig |
-		dbconfigs.FilteredConfig | dbconfigs.ReplConfig
-	dbconfigs.RegisterFlags(dbconfigFlags)
+	dbconfigs.RegisterFlags(dbconfigs.All...)
 	mysqlctl.RegisterFlags()
 
 	servenv.ParseFlags("vttablet")

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -53,7 +53,7 @@ func (dc *DBClient) Connect() error {
 		return err
 	}
 	ctx := context.Background()
-	dc.dbConn, err = mysql.Connect(ctx, &params)
+	dc.dbConn, err = mysql.Connect(ctx, params)
 	if err != nil {
 		return fmt.Errorf("error in connecting to mysql db, err %v", err)
 	}

--- a/go/vt/binlog/slave_connection.go
+++ b/go/vt/binlog/slave_connection.go
@@ -76,7 +76,7 @@ func connectForReplication(cp *mysql.ConnParams) (*mysql.Conn, error) {
 	}
 
 	ctx := context.Background()
-	conn, err := mysql.Connect(ctx, &params)
+	conn, err := mysql.Connect(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -110,7 +110,7 @@ func (fcs *FileCredentialsServer) GetUserAndPassword(user string) (string, strin
 
 // WithCredentials returns a copy of the provided ConnParams that we can use
 // to connect, after going through the CredentialsServer.
-func WithCredentials(cp *mysql.ConnParams) (mysql.ConnParams, error) {
+func WithCredentials(cp *mysql.ConnParams) (*mysql.ConnParams, error) {
 	result := *cp
 	user, passwd, err := GetCredentialsServer().GetUserAndPassword(cp.Uname)
 	switch err {
@@ -121,7 +121,7 @@ func WithCredentials(cp *mysql.ConnParams) (mysql.ConnParams, error) {
 		// we just use what we have, and will fail later anyway
 		err = nil
 	}
-	return result, err
+	return &result, err
 }
 
 func init() {

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -81,12 +81,12 @@ var All = []string{App, AppDebug, AllPrivs, Dba, Filtered, Repl}
 // RegisterFlags registers the flags for the given DBConfigFlag.
 // For instance, vttablet will register client, dba and repl.
 // Returns all registered flags.
-func RegisterFlags(names ...string) {
+func RegisterFlags(userKeys ...string) {
 	registerBaseFlags()
-	for _, name := range names {
+	for _, userKey := range userKeys {
 		uc := &userConfig{}
-		dbConfigs.userConfigs[name] = uc
-		registerUserFlags(uc, name)
+		dbConfigs.userConfigs[userKey] = uc
+		registerPerUserFlags(uc, userKey)
 	}
 }
 
@@ -104,26 +104,26 @@ func registerBaseFlags() {
 
 // The flags will change the global singleton
 // TODO(sougou): deprecate the legacy flags.
-func registerUserFlags(dbc *userConfig, name string) {
-	newUserFlag := "db_" + name + "_user"
-	flag.StringVar(&dbc.param.Uname, "db-config-"+name+"-uname", "vt_"+name, "deprecated: use "+newUserFlag)
-	flag.StringVar(&dbc.param.Uname, newUserFlag, "vt_"+name, "db "+name+" user name")
+func registerPerUserFlags(dbc *userConfig, userKey string) {
+	newUserFlag := "db_" + userKey + "_user"
+	flag.StringVar(&dbc.param.Uname, "db-config-"+userKey+"-uname", "vt_"+userKey, "deprecated: use "+newUserFlag)
+	flag.StringVar(&dbc.param.Uname, newUserFlag, "vt_"+userKey, "db "+userKey+" user userKey")
 
-	newPasswordFlag := "db_" + name + "_password"
-	flag.StringVar(&dbc.param.Pass, "db-config-"+name+"-pass", "", "db "+name+" deprecated: use "+newPasswordFlag)
-	flag.StringVar(&dbc.param.Pass, newPasswordFlag, "", "db "+name+" password")
+	newPasswordFlag := "db_" + userKey + "_password"
+	flag.StringVar(&dbc.param.Pass, "db-config-"+userKey+"-pass", "", "db "+userKey+" deprecated: use "+newPasswordFlag)
+	flag.StringVar(&dbc.param.Pass, newPasswordFlag, "", "db "+userKey+" password")
 
-	flag.BoolVar(&dbc.useSSL, "db_"+name+"_use_ssl", true, "Set this flag to false to make the "+name+" connection to not use ssl")
+	flag.BoolVar(&dbc.useSSL, "db_"+userKey+"_use_ssl", true, "Set this flag to false to make the "+userKey+" connection to not use ssl")
 
-	flag.StringVar(&dbc.param.Host, "db-config-"+name+"-host", "", "deprecated: use db_host")
-	flag.IntVar(&dbc.param.Port, "db-config-"+name+"-port", 0, "deprecated: use db_port")
-	flag.StringVar(&dbc.param.UnixSocket, "db-config-"+name+"-unixsocket", "", "deprecated: use db_socket")
-	flag.StringVar(&dbc.param.Charset, "db-config-"+name+"-charset", "utf8", "deprecated: use db_charset")
-	flag.Uint64Var(&dbc.param.Flags, "db-config-"+name+"-flags", 0, "deprecated: use db_flags")
-	flag.StringVar(&dbc.param.SslCa, "db-config-"+name+"-ssl-ca", "", "deprecated: use db_ssl_ca")
-	flag.StringVar(&dbc.param.SslCaPath, "db-config-"+name+"-ssl-ca-path", "", "deprecated: use db_ssl_ca_path")
-	flag.StringVar(&dbc.param.SslCert, "db-config-"+name+"-ssl-cert", "", "deprecated: use db_ssl_cert")
-	flag.StringVar(&dbc.param.SslKey, "db-config-"+name+"-ssl-key", "", "deprecated: use db_ssl_key")
+	flag.StringVar(&dbc.param.Host, "db-config-"+userKey+"-host", "", "deprecated: use db_host")
+	flag.IntVar(&dbc.param.Port, "db-config-"+userKey+"-port", 0, "deprecated: use db_port")
+	flag.StringVar(&dbc.param.UnixSocket, "db-config-"+userKey+"-unixsocket", "", "deprecated: use db_socket")
+	flag.StringVar(&dbc.param.Charset, "db-config-"+userKey+"-charset", "utf8", "deprecated: use db_charset")
+	flag.Uint64Var(&dbc.param.Flags, "db-config-"+userKey+"-flags", 0, "deprecated: use db_flags")
+	flag.StringVar(&dbc.param.SslCa, "db-config-"+userKey+"-ssl-ca", "", "deprecated: use db_ssl_ca")
+	flag.StringVar(&dbc.param.SslCaPath, "db-config-"+userKey+"-ssl-ca-path", "", "deprecated: use db_ssl_ca_path")
+	flag.StringVar(&dbc.param.SslCert, "db-config-"+userKey+"-ssl-cert", "", "deprecated: use db_ssl_cert")
+	flag.StringVar(&dbc.param.SslKey, "db-config-"+userKey+"-ssl-key", "", "deprecated: use db_ssl_key")
 }
 
 // AppWithDB returns connection parameters for app with dbname set.
@@ -162,8 +162,8 @@ func (dbcfgs *DBConfigs) Repl() *mysql.ConnParams {
 }
 
 // AppWithDB returns connection parameters for app with dbname set.
-func (dbcfgs *DBConfigs) makeParams(name string, withDB bool) *mysql.ConnParams {
-	orig := dbcfgs.userConfigs[name]
+func (dbcfgs *DBConfigs) makeParams(userKey string, withDB bool) *mysql.ConnParams {
+	orig := dbcfgs.userConfigs[userKey]
 	if orig == nil {
 		return &mysql.ConnParams{}
 	}

--- a/go/vt/dbconfigs/dbconfigs_test.go
+++ b/go/vt/dbconfigs/dbconfigs_test.go
@@ -17,40 +17,26 @@ limitations under the License.
 package dbconfigs
 
 import (
+	"reflect"
 	"testing"
 
 	"vitess.io/vitess/go/mysql"
 )
 
-func TestRegisterFlagsWithoutFlags(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("RegisterFlags should panic with empty db flags")
-		}
-	}()
-	dbConfigs = DBConfigs{}
-	RegisterFlags(EmptyConfig)
-}
-
 func TestRegisterFlagsWithSomeFlags(t *testing.T) {
-	saved := dbFlags
+	savedDBConfig := dbConfigs
+	savedBaseConfig := baseConfig
 	defer func() {
-		dbFlags = saved
+		dbConfigs = savedDBConfig
+		baseConfig = savedBaseConfig
 	}()
 
-	dbConfigs = DBConfigs{}
-	RegisterFlags(DbaConfig | ReplConfig)
-	if dbFlags&AppConfig != 0 {
-		t.Error("App connection params should not be registered.")
-	}
-	if dbFlags&DbaConfig == 0 {
-		t.Error("Dba connection params should be registered.")
-	}
-	if dbFlags&FilteredConfig != 0 {
-		t.Error("Filtered connection params should not be registered.")
-	}
-	if dbFlags&ReplConfig == 0 {
-		t.Error("Repl connection params should be registered.")
+	dbConfigs = DBConfigs{userConfigs: make(map[string]*userConfig)}
+	RegisterFlags(Dba, Repl)
+	for k := range dbConfigs.userConfigs {
+		if k != Dba && k != Repl {
+			t.Errorf("dbConfigs.params: %v, want dba or repl", k)
+		}
 	}
 }
 
@@ -63,56 +49,143 @@ func TestInit(t *testing.T) {
 	}()
 
 	dbConfigs = DBConfigs{
-		app: mysql.ConnParams{
-			UnixSocket: "socket",
-		},
-		dba: mysql.ConnParams{
-			Host: "host",
+		userConfigs: map[string]*userConfig{
+			App:      {param: mysql.ConnParams{UnixSocket: "socket"}},
+			AppDebug: {},
+			Dba:      {param: mysql.ConnParams{Host: "host"}},
 		},
 	}
 	dbc, err := Init("default")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := dbc.app.UnixSocket, "socket"; got != want {
+	if got, want := dbc.userConfigs[App].param.UnixSocket, "socket"; got != want {
 		t.Errorf("dbc.app.UnixSocket: %v, want %v", got, want)
 	}
-	if got, want := dbc.dba.Host, "host"; got != want {
+	if got, want := dbc.userConfigs[Dba].param.Host, "host"; got != want {
 		t.Errorf("dbc.app.Host: %v, want %v", got, want)
 	}
-	if got, want := dbc.appDebug.UnixSocket, "default"; got != want {
+	if got, want := dbc.userConfigs[AppDebug].param.UnixSocket, "default"; got != want {
 		t.Errorf("dbc.app.UnixSocket: %v, want %v", got, want)
 	}
 
 	baseConfig = mysql.ConnParams{
-		Host: "basehost",
+		Host:       "a",
+		Port:       1,
+		Uname:      "b",
+		Pass:       "c",
+		DbName:     "d",
+		UnixSocket: "e",
+		Charset:    "f",
+		Flags:      2,
+		SslCa:      "g",
+		SslCaPath:  "h",
+		SslCert:    "i",
+		SslKey:     "j",
+	}
+	dbConfigs = DBConfigs{
+		userConfigs: map[string]*userConfig{
+			App: {
+				param: mysql.ConnParams{
+					Uname:      "app",
+					Pass:       "apppass",
+					UnixSocket: "socket",
+				},
+			},
+			AppDebug: {
+				useSSL: true,
+			},
+			Dba: {
+				useSSL: true,
+				param: mysql.ConnParams{
+					Uname: "dba",
+					Pass:  "dbapass",
+					Host:  "host",
+				},
+			},
+		},
 	}
 	dbc, err = Init("default")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := dbc.app.UnixSocket, ""; got != want {
-		t.Errorf("dbc.app.UnixSocket: %v, want %v", got, want)
+	want := &DBConfigs{
+		userConfigs: map[string]*userConfig{
+			App: {
+				param: mysql.ConnParams{
+					Host:       "a",
+					Port:       1,
+					Uname:      "app",
+					Pass:       "apppass",
+					UnixSocket: "e",
+					Charset:    "f",
+					Flags:      2,
+				},
+			},
+			AppDebug: {
+				useSSL: true,
+				param: mysql.ConnParams{
+					Host:       "a",
+					Port:       1,
+					UnixSocket: "e",
+					Charset:    "f",
+					Flags:      2,
+					SslCa:      "g",
+					SslCaPath:  "h",
+					SslCert:    "i",
+					SslKey:     "j",
+				},
+			},
+			Dba: {
+				useSSL: true,
+				param: mysql.ConnParams{
+					Host:       "a",
+					Port:       1,
+					Uname:      "dba",
+					Pass:       "dbapass",
+					UnixSocket: "e",
+					Charset:    "f",
+					Flags:      2,
+					SslCa:      "g",
+					SslCaPath:  "h",
+					SslCert:    "i",
+					SslKey:     "j",
+				},
+			},
+		},
 	}
-	if got, want := dbc.dba.Host, "basehost"; got != want {
-		t.Errorf("dbc.app.Host: %v, want %v", got, want)
+	// Compare individually, otherwise the errors are not readable.
+	if !reflect.DeepEqual(dbc.userConfigs[App].param, want.userConfigs[App].param) {
+		t.Errorf("dbc: \n%#v, want \n%#v", dbc.userConfigs[App].param, want.userConfigs[App].param)
 	}
-	if got, want := dbc.appDebug.Host, "basehost"; got != want {
-		t.Errorf("dbc.app.Host: %v, want %v", got, want)
+	if !reflect.DeepEqual(dbc.userConfigs[AppDebug].param, want.userConfigs[AppDebug].param) {
+		t.Errorf("dbc: \n%#v, want \n%#v", dbc.userConfigs[AppDebug].param, want.userConfigs[AppDebug].param)
+	}
+	if !reflect.DeepEqual(dbc.userConfigs[Dba].param, want.userConfigs[Dba].param) {
+		t.Errorf("dbc: \n%#v, want \n%#v", dbc.userConfigs[Dba].param, want.userConfigs[Dba].param)
 	}
 }
 
 func TestAccessors(t *testing.T) {
-	dbc := &DBConfigs{}
+	dbc := &DBConfigs{
+		userConfigs: map[string]*userConfig{
+			App:      {},
+			AppDebug: {},
+			AllPrivs: {},
+			Dba:      {},
+			Filtered: {},
+			Repl:     {},
+		},
+	}
 	dbc.DBName.Set("db")
 	if got, want := dbc.AppWithDB().DbName, "db"; got != want {
 		t.Errorf("dbc.AppWithDB().DbName: %v, want %v", got, want)
 	}
-	if got, want := dbc.AppDebugWithDB().DbName, "db"; got != want {
-		t.Errorf("dbc.AppDebugWithDB().DbName: %v, want %v", got, want)
-	}
 	if got, want := dbc.AllPrivsWithDB().DbName, "db"; got != want {
 		t.Errorf("dbc.AllPrivsWithDB().DbName: %v, want %v", got, want)
+	}
+	if got, want := dbc.AppDebugWithDB().DbName, "db"; got != want {
+		t.Errorf("dbc.AppDebugWithDB().DbName: %v, want %v", got, want)
 	}
 	if got, want := dbc.Dba().DbName, ""; got != want {
 		t.Errorf("dbc.Dba().DbName: %v, want %v", got, want)
@@ -125,5 +198,22 @@ func TestAccessors(t *testing.T) {
 	}
 	if got, want := dbc.Repl().DbName, ""; got != want {
 		t.Errorf("dbc.Repl().DbName: %v, want %v", got, want)
+	}
+}
+
+func TestCopy(t *testing.T) {
+	want := &DBConfigs{
+		userConfigs: map[string]*userConfig{
+			App:      {param: mysql.ConnParams{UnixSocket: "aa"}},
+			AppDebug: {},
+			Repl:     {},
+		},
+	}
+	want.DBName.Set("db")
+	want.SidecarDBName.Set("_vt")
+
+	got := want.Copy()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DBConfig: %v, want %v", got, want)
 	}
 }

--- a/go/vt/dbconfigs/dbconfigs_test.go
+++ b/go/vt/dbconfigs/dbconfigs_test.go
@@ -29,18 +29,23 @@ func TestRegisterFlagsWithoutFlags(t *testing.T) {
 }
 
 func TestRegisterFlagsWithSomeFlags(t *testing.T) {
+	saved := dbFlags
+	defer func() {
+		dbFlags = saved
+	}()
+
 	dbConfigs = DBConfigs{}
-	registeredFlags := RegisterFlags(DbaConfig | ReplConfig)
-	if registeredFlags&AppConfig != 0 {
+	RegisterFlags(DbaConfig | ReplConfig)
+	if dbFlags&AppConfig != 0 {
 		t.Error("App connection params should not be registered.")
 	}
-	if registeredFlags&DbaConfig == 0 {
+	if dbFlags&DbaConfig == 0 {
 		t.Error("Dba connection params should be registered.")
 	}
-	if registeredFlags&FilteredConfig != 0 {
+	if dbFlags&FilteredConfig != 0 {
 		t.Error("Filtered connection params should not be registered.")
 	}
-	if registeredFlags&ReplConfig == 0 {
+	if dbFlags&ReplConfig == 0 {
 		t.Error("Repl connection params should be registered.")
 	}
 }
@@ -51,5 +56,5 @@ func TestInitWithEmptyFlags(t *testing.T) {
 			t.Error("Init should panic with empty db flags")
 		}
 	}()
-	Init("", EmptyConfig)
+	Init("")
 }

--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -124,7 +124,7 @@ func NewDBConnection(info *mysql.ConnParams, mysqlStats *stats.Timings) (*DBConn
 		return nil, err
 	}
 	ctx := context.Background()
-	c, err := mysql.Connect(ctx, &params)
+	c, err := mysql.Connect(ctx, params)
 	if err != nil {
 		mysqlStats.Record("ConnectError", start)
 	}

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -52,7 +52,7 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32) (*Mysql
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, &dbcfgs), nil
+	return NewMysqld(mycnf, dbcfgs), nil
 }
 
 // OpenMysqld returns a Mysqld object to use for working with a MySQL
@@ -70,5 +70,5 @@ func OpenMysqld(tabletUID uint32) (*Mysqld, error) {
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, &dbcfgs), nil
+	return NewMysqld(mycnf, dbcfgs), nil
 }

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -29,7 +29,7 @@ import (
 // CreateMysqld returns a Mysqld object to use for working with a MySQL
 // installation that hasn't been set up yet. This will generate a new my.cnf
 // from scratch and use that to call NewMysqld().
-func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
+func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32) (*Mysqld, error) {
 	mycnf := NewMycnf(tabletUID, mysqlPort)
 	// Choose a random MySQL server-id, since this is a fresh data dir.
 	// We don't want to use the tablet UID as the MySQL server-id,
@@ -47,28 +47,28 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfi
 		mycnf.SocketFile = mysqlSocket
 	}
 
-	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, dbcfgs, dbconfigFlags), nil
+	return NewMysqld(mycnf, &dbcfgs), nil
 }
 
 // OpenMysqld returns a Mysqld object to use for working with a MySQL
 // installation that already exists. This will look for an existing my.cnf file
 // and use that to call NewMysqld().
-func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
+func OpenMysqld(tabletUID uint32) (*Mysqld, error) {
 	// We pass a port of 0, this will be read and overwritten from the path on disk
 	mycnf, err := ReadMycnf(NewMycnf(tabletUID, 0))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read my.cnf file: %v", err)
 	}
 
-	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, dbcfgs, dbconfigFlags), nil
+	return NewMysqld(mycnf, &dbcfgs), nil
 }

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -216,7 +216,7 @@ func (mysqld *Mysqld) SetSlavePosition(ctx context.Context, pos mysql.Position) 
 // SetMaster makes the provided host / port the master. It optionally
 // stops replication before, and starts it after.
 func (mysqld *Mysqld) SetMaster(ctx context.Context, masterHost string, masterPort int, slaveStopBefore bool, slaveStartAfter bool) error {
-	params, err := dbconfigs.WithCredentials(&mysqld.dbcfgs.Repl)
+	params, err := dbconfigs.WithCredentials(mysqld.dbcfgs.Repl())
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (mysqld *Mysqld) SetMaster(ctx context.Context, masterHost string, masterPo
 	if slaveStopBefore {
 		cmds = append(cmds, conn.StopSlaveCommand())
 	}
-	smc := conn.SetMasterCommand(&params, masterHost, masterPort, int(masterConnectRetry.Seconds()))
+	smc := conn.SetMasterCommand(params, masterHost, masterPort, int(masterConnectRetry.Seconds()))
 	cmds = append(cmds, smc)
 	if slaveStartAfter {
 		cmds = append(cmds, conn.StartSlaveCommand())

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -37,12 +37,12 @@ var autoIncr = regexp.MustCompile(" AUTO_INCREMENT=\\d+")
 // executeSchemaCommands executes some SQL commands, using the mysql
 // command line tool. It uses the dba connection parameters, with credentials.
 func (mysqld *Mysqld) executeSchemaCommands(sql string) error {
-	params, err := dbconfigs.WithCredentials(&mysqld.dbcfgs.Dba)
+	params, err := dbconfigs.WithCredentials(mysqld.dbcfgs.Dba())
 	if err != nil {
 		return err
 	}
 
-	return mysqld.executeMysqlScript(&params, strings.NewReader(sql))
+	return mysqld.executeMysqlScript(params, strings.NewReader(sql))
 }
 
 // GetSchema returns the schema for database for tables listed in

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -73,7 +73,7 @@ var tabletMap map[uint32]*tablet
 
 // CreateTablet creates an individual tablet, with its agent, and adds
 // it to the map. If it's a master tablet, it also issues a TER.
-func CreateTablet(ctx context.Context, ts *topo.Server, cell string, uid uint32, keyspace, shard, dbname string, tabletType topodatapb.TabletType, mysqld mysqlctl.MysqlDaemon, dbcfgs dbconfigs.DBConfigs) error {
+func CreateTablet(ctx context.Context, ts *topo.Server, cell string, uid uint32, keyspace, shard, dbname string, tabletType topodatapb.TabletType, mysqld mysqlctl.MysqlDaemon, dbcfgs *dbconfigs.DBConfigs) error {
 	alias := &topodatapb.TabletAlias{
 		Cell: cell,
 		Uid:  uid,
@@ -106,7 +106,7 @@ func CreateTablet(ctx context.Context, ts *topo.Server, cell string, uid uint32,
 
 // InitTabletMap creates the action agents and associated data structures
 // for all tablets, based on the vttest proto parameter.
-func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlctl.MysqlDaemon, dbcfgs dbconfigs.DBConfigs, schemaDir string, mycnf *mysqlctl.Mycnf) error {
+func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlctl.MysqlDaemon, dbcfgs *dbconfigs.DBConfigs, schemaDir string, mycnf *mysqlctl.Mycnf) error {
 	tabletMap = make(map[uint32]*tablet)
 
 	ctx := context.Background()
@@ -165,8 +165,9 @@ func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 					if dbname == "" {
 						dbname = fmt.Sprintf("vt_%v_%v", keyspace, shard)
 					}
-					// Override SidecarDBName because there will be one for each db.
-					dbcfgs.SidecarDBName = "_" + dbname
+					// Copy dbcfgs and override SidecarDBName because there will be one for each db.
+					copydbcfgs := dbcfgs.Copy()
+					copydbcfgs.SidecarDBName.Set("_" + dbname)
 
 					replicas := int(kpb.ReplicaCount)
 					if replicas == 0 {
@@ -182,7 +183,7 @@ func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 						replicas--
 
 						// create the master
-						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_MASTER, mysqld, dbcfgs); err != nil {
+						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_MASTER, mysqld, copydbcfgs); err != nil {
 							return err
 						}
 						uid++
@@ -190,7 +191,7 @@ func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 
 					for i := 0; i < replicas; i++ {
 						// create a replica slave
-						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_REPLICA, mysqld, dbcfgs); err != nil {
+						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_REPLICA, mysqld, copydbcfgs); err != nil {
 							return err
 						}
 						uid++
@@ -198,7 +199,7 @@ func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 
 					for i := 0; i < rdonlys; i++ {
 						// create a rdonly slave
-						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_RDONLY, mysqld, dbcfgs); err != nil {
+						if err := CreateTablet(ctx, ts, cell, uid, keyspace, shard, dbname, topodatapb.TabletType_RDONLY, mysqld, copydbcfgs); err != nil {
 							return err
 						}
 						uid++

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -165,7 +165,6 @@ func InitTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 					if dbname == "" {
 						dbname = fmt.Sprintf("vt_%v_%v", keyspace, shard)
 					}
-					dbcfgs.App.DbName = dbname
 					// Override SidecarDBName because there will be one for each db.
 					dbcfgs.SidecarDBName = "_" + dbname
 

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -95,6 +95,7 @@ func newTablet(opts *Options, t *topodatapb.Tablet) *explainTablet {
 
 	dbcfgs := dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
+		Dba:           *db.ConnParams(),
 		SidecarDBName: "_vt",
 	}
 	cnf := mysqlctl.NewMycnf(22222, 6802)

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -93,11 +93,7 @@ func newTablet(opts *Options, t *topodatapb.Tablet) *explainTablet {
 		},
 	)
 
-	dbcfgs := dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
+	dbcfgs := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 	cnf := mysqlctl.NewMycnf(22222, 6802)
 	cnf.ServerID = 33333
 

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -107,6 +107,7 @@ func TestMain(m *testing.M) {
 		// Initialize the query service on top of the vttest MySQL database.
 		dbcfgs := dbconfigs.DBConfigs{
 			App: mysqlConnParams,
+			Dba: mysqlConnParams,
 		}
 		queryServer, err = initProxy(&dbcfgs)
 		if err != nil {

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -105,11 +105,8 @@ func TestMain(m *testing.M) {
 		defer func() { tabletenv.Config = tabletenv.DefaultQsConfig }()
 
 		// Initialize the query service on top of the vttest MySQL database.
-		dbcfgs := dbconfigs.DBConfigs{
-			App: mysqlConnParams,
-			Dba: mysqlConnParams,
-		}
-		queryServer, err = initProxy(&dbcfgs)
+		dbcfgs := dbconfigs.NewTestDBConfigs(mysqlConnParams, mysqlConnParams, cluster.DbName())
+		queryServer, err = initProxy(dbcfgs)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not start proxy: %v\n", err)
 			return 1

--- a/go/vt/vtqueryserver/vtqueryserver.go
+++ b/go/vt/vtqueryserver/vtqueryserver.go
@@ -58,7 +58,7 @@ func initProxy(dbcfgs *dbconfigs.DBConfigs) (*tabletserver.TabletServer, error) 
 	qs.SetAllowUnsafeDMLs(*allowUnsafeDMLs)
 	mysqlProxy = mysqlproxy.NewProxy(&target, qs, *normalizeQueries)
 
-	err := qs.StartService(target, *dbcfgs)
+	err := qs.StartService(target, dbcfgs)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -62,6 +62,7 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
 	dbcfgs := dbconfigs.DBConfigs{
 		App:           connParams,
 		AppDebug:      connAppDebugParams,
+		Dba:           connParams,
 		SidecarDBName: "_vt",
 	}
 

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -49,7 +49,7 @@ var (
 // StartServer starts the server and initializes
 // all the global variables. This function should only be called
 // once at the beginning of the test.
-func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
+func StartServer(connParams, connAppDebugParams mysql.ConnParams, dbName string) error {
 	// Setup a fake vtgate server.
 	protocol := "resolveTest"
 	*vtgateconn.VtgateProtocol = protocol
@@ -59,12 +59,7 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
 		}, nil
 	})
 
-	dbcfgs := dbconfigs.DBConfigs{
-		App:           connParams,
-		AppDebug:      connAppDebugParams,
-		Dba:           connParams,
-		SidecarDBName: "_vt",
-	}
+	dbcfgs := dbconfigs.NewTestDBConfigs(connParams, connAppDebugParams, dbName)
 
 	config := tabletenv.DefaultQsConfig
 	config.EnableAutoCommit = true

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -79,7 +79,7 @@ func TestMain(m *testing.M) {
 
 		connParams = cluster.MySQLConnParams()
 		connAppDebugParams = cluster.MySQLAppDebugConnParams()
-		err := framework.StartServer(connParams, connAppDebugParams)
+		err := framework.StartServer(connParams, connAppDebugParams, cluster.DbName())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)
 			return 1

--- a/go/vt/vttablet/heartbeat/reader_test.go
+++ b/go/vt/vttablet/heartbeat/reader_test.go
@@ -106,17 +106,13 @@ func newReader(db *fakesqldb.DB, nowFunc func() time.Time) *Reader {
 	config := tabletenv.DefaultQsConfig
 	config.HeartbeatEnable = true
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
-	dbc := dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
+	dbc := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 
 	tr := NewReader(&fakeMysqlChecker{}, config)
-	tr.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
+	tr.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
 	tr.keyspaceShard = "test:0"
 	tr.now = nowFunc
-	tr.pool.Open(&dbc.App, &dbc.Dba, &dbc.AppDebug)
+	tr.pool.Open(dbc.AppWithDB(), dbc.DbaWithDB(), dbc.AppDebugWithDB())
 
 	return tr
 }

--- a/go/vt/vttablet/heartbeat/writer_test.go
+++ b/go/vt/vttablet/heartbeat/writer_test.go
@@ -111,19 +111,15 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 	config.HeartbeatEnable = true
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
 
-	dbc := dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
+	dbc := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 
 	tw := NewWriter(&fakeMysqlChecker{},
 		topodatapb.TabletAlias{Cell: "test", Uid: 1111},
 		config)
-	tw.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
+	tw.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
 	tw.keyspaceShard = "test:0"
 	tw.now = nowFunc
-	tw.pool.Open(&dbc.App, &dbc.Dba, &dbc.AppDebug)
+	tw.pool.Open(dbc.AppWithDB(), dbc.DbaWithDB(), dbc.AppDebugWithDB())
 
 	return tw
 }

--- a/go/vt/vttablet/tabletmanager/init_tablet_test.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet_test.go
@@ -50,7 +50,7 @@ func TestInitTablet(t *testing.T) {
 		TopoServer:      ts,
 		TabletAlias:     tabletAlias,
 		MysqlDaemon:     mysqlDaemon,
-		DBConfigs:       dbconfigs.DBConfigs{},
+		DBConfigs:       &dbconfigs.DBConfigs{},
 		BinlogPlayerMap: nil,
 		batchCtx:        ctx,
 		History:         history.New(historyLength),

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -39,7 +39,7 @@ type Controller interface {
 	AddStatusPart()
 
 	// InitDBConfig sets up the db config vars.
-	InitDBConfig(querypb.Target, dbconfigs.DBConfigs) error
+	InitDBConfig(querypb.Target, *dbconfigs.DBConfigs) error
 
 	// SetServingType transitions the query service to the required serving type.
 	// Returns true if the state of QueryService or the tablet type changed.

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -47,7 +47,7 @@ type TabletService interface {
 
 // Engine is the engine for handling messages.
 type Engine struct {
-	dbconfigs dbconfigs.DBConfigs
+	dbconfigs *dbconfigs.DBConfigs
 
 	mu       sync.Mutex
 	isOpen   bool
@@ -76,7 +76,7 @@ func NewEngine(tsv TabletService, se *schema.Engine, config tabletenv.TabletConf
 }
 
 // InitDBConfig must be called before Open.
-func (me *Engine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+func (me *Engine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 	me.dbconfigs = dbcfgs
 }
 
@@ -85,7 +85,7 @@ func (me *Engine) Open() error {
 	if me.isOpen {
 		return nil
 	}
-	me.conns.Open(&me.dbconfigs.App, &me.dbconfigs.Dba, &me.dbconfigs.AppDebug)
+	me.conns.Open(me.dbconfigs.AppWithDB(), me.dbconfigs.DbaWithDB(), me.dbconfigs.AppDebugWithDB())
 	me.se.RegisterNotifier("messages", me.schemaChanged)
 	me.isOpen = true
 	return nil

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -261,11 +261,7 @@ func newTestEngine(db *fakesqldb.DB) *Engine {
 	tsv := newFakeTabletServer()
 	se := schema.NewEngine(tsv, config)
 	te := NewEngine(tsv, se, config)
-	te.InitDBConfig(dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	})
+	te.InitDBConfig(dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), ""))
 	te.Open()
 	return te
 }

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -263,6 +263,7 @@ func newTestEngine(db *fakesqldb.DB) *Engine {
 	te := NewEngine(tsv, se, config)
 	te.InitDBConfig(dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
+		Dba:           *db.ConnParams(),
 		SidecarDBName: "_vt",
 	})
 	te.Open()

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -785,11 +785,7 @@ func (fts *fakeTabletServer) PurgeMessages(ctx context.Context, target *querypb.
 
 func newMMConnPool(db *fakesqldb.DB) *connpool.Pool {
 	pool := connpool.New("", 20, time.Duration(10*time.Minute), newFakeTabletServer())
-	dbconfigs := dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
-	pool.Open(&dbconfigs.App, &dbconfigs.Dba, &dbconfigs.AppDebug)
+	dbconfigs := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
+	pool.Open(dbconfigs.AppWithDB(), dbconfigs.DbaWithDB(), dbconfigs.AppDebugWithDB())
 	return pool
 }

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -787,6 +787,7 @@ func newMMConnPool(db *fakesqldb.DB) *connpool.Pool {
 	pool := connpool.New("", 20, time.Duration(10*time.Minute), newFakeTabletServer())
 	dbconfigs := dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
+		Dba:           *db.ConnParams(),
 		SidecarDBName: "_vt",
 	}
 	pool.Open(&dbconfigs.App, &dbconfigs.Dba, &dbconfigs.AppDebug)

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -54,6 +54,7 @@ func TestStrictTransTables(t *testing.T) {
 	// config.EnforceStrictTransTable is true by default.
 	qe := NewQueryEngine(DummyChecker, schema.NewEngine(DummyChecker, config), config)
 	qe.InitDBConfig(dbcfgs)
+	qe.se.InitDBConfig(dbcfgs)
 	qe.se.Open()
 	if err := qe.Open(); err != nil {
 		t.Error(err)
@@ -291,7 +292,7 @@ func TestStatsURL(t *testing.T) {
 	qe.ServeHTTP(response, request)
 }
 
-func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, strict bool, dbcfgs dbconfigs.DBConfigs) *QueryEngine {
+func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, strict bool, dbcfgs *dbconfigs.DBConfigs) *QueryEngine {
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -35,7 +35,7 @@ import (
 func TestQueryzHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/schemaz", nil)
-	qe := newTestQueryEngine(100, 10*time.Second, true, dbconfigs.DBConfigs{})
+	qe := newTestQueryEngine(100, 10*time.Second, true, &dbconfigs.DBConfigs{})
 
 	plan1 := &TabletPlan{
 		Plan: &planbuilder.Plan{

--- a/go/vt/vttablet/tabletserver/replication_watcher.go
+++ b/go/vt/vttablet/tabletserver/replication_watcher.go
@@ -39,7 +39,7 @@ import (
 // replication stream. It can tell you the current event token,
 // and it will trigger schema reloads if a DDL is encountered.
 type ReplicationWatcher struct {
-	dbconfigs dbconfigs.DBConfigs
+	dbconfigs *dbconfigs.DBConfigs
 
 	// Life cycle management vars
 	isOpen bool
@@ -82,7 +82,7 @@ func NewReplicationWatcher(se *schema.Engine, config tabletenv.TabletConfig) *Re
 }
 
 // InitDBConfig must be called before Open.
-func (rpw *ReplicationWatcher) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+func (rpw *ReplicationWatcher) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 	rpw.dbconfigs = dbcfgs
 }
 
@@ -109,14 +109,14 @@ func (rpw *ReplicationWatcher) Close() {
 }
 
 // Process processes the replication stream.
-func (rpw *ReplicationWatcher) Process(ctx context.Context, dbconfigs dbconfigs.DBConfigs) {
+func (rpw *ReplicationWatcher) Process(ctx context.Context, dbconfigs *dbconfigs.DBConfigs) {
 	defer func() {
 		tabletenv.LogError()
 		rpw.wg.Done()
 	}()
 	for {
 		log.Infof("Starting a binlog Streamer from current replication position to monitor binlogs")
-		streamer := binlog.NewStreamer(&dbconfigs.Dba, rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
+		streamer := binlog.NewStreamer(dbconfigs.DbaWithDB(), rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
 			// Save the event token.
 			rpw.mu.Lock()
 			rpw.eventToken = eventToken

--- a/go/vt/vttablet/tabletserver/replication_watcher.go
+++ b/go/vt/vttablet/tabletserver/replication_watcher.go
@@ -116,9 +116,7 @@ func (rpw *ReplicationWatcher) Process(ctx context.Context, dbconfigs dbconfigs.
 	}()
 	for {
 		log.Infof("Starting a binlog Streamer from current replication position to monitor binlogs")
-		cp := dbconfigs.Dba
-		cp.DbName = dbconfigs.App.DbName
-		streamer := binlog.NewStreamer(&cp, rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
+		streamer := binlog.NewStreamer(&dbconfigs.Dba, rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
 			// Save the event token.
 			rpw.mu.Lock()
 			rpw.eventToken = eventToken

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -49,7 +49,7 @@ type notifier func(full map[string]*Table, created, altered, dropped []string)
 // Engine stores the schema info and performs operations that
 // keep itself up-to-date.
 type Engine struct {
-	dbconfigs dbconfigs.DBConfigs
+	dbconfigs *dbconfigs.DBConfigs
 
 	// mu protects the following fields.
 	mu         sync.Mutex
@@ -93,7 +93,7 @@ func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *En
 }
 
 // InitDBConfig must be called before Open.
-func (se *Engine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+func (se *Engine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 	se.dbconfigs = dbcfgs
 }
 
@@ -108,7 +108,7 @@ func (se *Engine) Open() error {
 	start := time.Now()
 	defer log.Infof("Time taken to load the schema: %v", time.Now().Sub(start))
 	ctx := tabletenv.LocalContext()
-	dbaParams := &se.dbconfigs.Dba
+	dbaParams := se.dbconfigs.DbaWithDB()
 	se.conns.Open(dbaParams, dbaParams, dbaParams)
 
 	conn, err := se.conns.Get(ctx)

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -433,10 +433,6 @@ func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout tim
 	return se
 }
 
-func newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {
-	return dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
+func newDBConfigs(db *fakesqldb.DB) *dbconfigs.DBConfigs {
+	return dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 }

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -336,13 +336,7 @@ func (tsv *TabletServer) InitDBConfig(target querypb.Target, dbcfgs dbconfigs.DB
 	}
 	tsv.target = target
 	tsv.dbconfigs = dbcfgs
-	// Massage Dba so that it inherits the
-	// App values but keeps the credentials.
-	tsv.dbconfigs.Dba = dbcfgs.App
-	if n, p := dbcfgs.Dba.Uname, dbcfgs.Dba.Pass; n != "" {
-		tsv.dbconfigs.Dba.Uname = n
-		tsv.dbconfigs.Dba.Pass = p
-	}
+	tsv.dbconfigs.SetDBName(dbcfgs.App.DbName, dbconfigs.AllConfig)
 
 	tsv.se.InitDBConfig(tsv.dbconfigs)
 	tsv.qe.InitDBConfig(tsv.dbconfigs)
@@ -1796,9 +1790,7 @@ func (tsv *TabletServer) UpdateStream(ctx context.Context, target *querypb.Targe
 	}
 	defer tsv.endRequest(false)
 
-	cp := tsv.dbconfigs.Dba
-	cp.DbName = tsv.dbconfigs.App.DbName
-	s := binlog.NewEventStreamer(&cp, tsv.se, p, timestamp, callback)
+	s := binlog.NewEventStreamer(&tsv.dbconfigs.Dba, tsv.se, p, timestamp, callback)
 
 	// Create a cancelable wrapping context.
 	streamCtx, streamCancel := context.WithCancel(ctx)

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -49,12 +49,8 @@ func (util *testUtils) checkEqual(t *testing.T, expected interface{}, result int
 	}
 }
 
-func (util *testUtils) newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {
-	return dbconfigs.DBConfigs{
-		App:           *db.ConnParams(),
-		Dba:           *db.ConnParams(),
-		SidecarDBName: "_vt",
-	}
+func (util *testUtils) newDBConfigs(db *fakesqldb.DB) *dbconfigs.DBConfigs {
+	return dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 }
 
 func (util *testUtils) newQueryServiceConfig() tabletenv.TabletConfig {

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -201,8 +201,8 @@ func (tpc *TwoPC) Init(sidecarDBName string, dbaparams *mysql.ConnParams) error 
 }
 
 // Open starts the TwoPC service.
-func (tpc *TwoPC) Open(dbconfigs dbconfigs.DBConfigs) {
-	tpc.readPool.Open(&dbconfigs.App, &dbconfigs.Dba, &dbconfigs.AppDebug)
+func (tpc *TwoPC) Open(dbconfigs *dbconfigs.DBConfigs) {
+	tpc.readPool.Open(dbconfigs.AppWithDB(), dbconfigs.DbaWithDB(), dbconfigs.DbaWithDB())
 }
 
 // Close closes the TwoPC service.

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -37,7 +37,7 @@ import (
 
 // TxEngine handles transactions.
 type TxEngine struct {
-	dbconfigs dbconfigs.DBConfigs
+	dbconfigs *dbconfigs.DBConfigs
 
 	isOpen, twopcEnabled bool
 	shutdownGracePeriod  time.Duration
@@ -107,7 +107,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 }
 
 // InitDBConfig must be called before Init.
-func (te *TxEngine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+func (te *TxEngine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
 	te.dbconfigs = dbcfgs
 }
 
@@ -115,7 +115,7 @@ func (te *TxEngine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
 // up the metadata tables.
 func (te *TxEngine) Init() error {
 	if te.twopcEnabled {
-		return te.twoPC.Init(te.dbconfigs.SidecarDBName, &te.dbconfigs.Dba)
+		return te.twoPC.Init(te.dbconfigs.SidecarDBName.Get(), te.dbconfigs.DbaWithDB())
 	}
 	return nil
 }
@@ -126,7 +126,7 @@ func (te *TxEngine) Open() {
 	if te.isOpen {
 		return
 	}
-	te.txPool.Open(&te.dbconfigs.App, &te.dbconfigs.Dba, &te.dbconfigs.AppDebug)
+	te.txPool.Open(te.dbconfigs.AppWithDB(), te.dbconfigs.DbaWithDB(), te.dbconfigs.AppDebugWithDB())
 	if !te.twopcEnabled {
 		te.isOpen = true
 		return

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -109,7 +109,7 @@ func (tqsc *Controller) AddStatusPart() {
 }
 
 // InitDBConfig is part of the tabletserver.Controller interface
-func (tqsc *Controller) InitDBConfig(target querypb.Target, dbcfgs dbconfigs.DBConfigs) error {
+func (tqsc *Controller) InitDBConfig(target querypb.Target, dbcfgs *dbconfigs.DBConfigs) error {
 	tqsc.mu.Lock()
 	defer tqsc.mu.Unlock()
 

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -60,8 +60,6 @@ func (ctl *Mysqlctl) Setup() error {
 		"-alsologtostderr",
 		"-tablet_uid", "1",
 		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
-		"-db-config-dba-charset", "utf8",
-		"-db-config-dba-uname", "vt_dba",
 		"init",
 		"-init_db_sql_file", ctl.InitFile,
 	)
@@ -86,8 +84,6 @@ func (ctl *Mysqlctl) TearDown() error {
 		"-alsologtostderr",
 		"-tablet_uid", "1",
 		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
-		"-db-config-dba-charset", "utf8",
-		"-db-config-dba-uname", "vt_dba",
 		"shutdown",
 	)
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -208,12 +208,11 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	}
 
 	vt.ExtraArgs = append(vt.ExtraArgs, []string{
-		"-db-config-app-charset", charset,
-		"-db-config-app-uname", user,
-		"-db-config-app-pass", pass,
-		"-db-config-dba-charset", charset,
-		"-db-config-dba-uname", user,
-		"-db-config-dba-pass", pass,
+		"-db_charset", charset,
+		"-db_app_user", user,
+		"-db_app_password", pass,
+		"-db_dba_user", user,
+		"-db_dba_password", pass,
 		"-proto_topo", proto.CompactTextString(args.Topology),
 		"-mycnf_server_id", "1",
 		"-mycnf_socket_file", socket,
@@ -235,18 +234,15 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 
 	if socket != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"-db-config-app-unixsocket", socket,
-			"-db-config-dba-unixsocket", socket,
+			"-db_socket", socket,
 		}...)
 	} else {
 		hostname, p := mysql.Address()
 		port := fmt.Sprintf("%d", p)
 
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"-db-config-app-host", hostname,
-			"-db-config-app-port", port,
-			"-db-config-dba-host", hostname,
-			"-db-config-dba-port", port,
+			"-db_host", hostname,
+			"-db_port", port,
 		}...)
 	}
 

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -402,18 +402,6 @@ spec:
         -init_tablet_type {{ $tablet.type | quote }}
         -health_check_interval "5s"
         -mysqlctl_socket "/vtdataroot/mysqlctl.sock"
-        -db-config-app-uname "vt_app"
-        -db-config-app-dbname "vt_{{$keyspace.name}}"
-        -db-config-app-charset "utf8"
-        -db-config-dba-uname "vt_dba"
-        -db-config-dba-dbname "vt_{{$keyspace.name}}"
-        -db-config-dba-charset "utf8"
-        -db-config-repl-uname "vt_repl"
-        -db-config-repl-dbname "vt_{{$keyspace.name}}"
-        -db-config-repl-charset "utf8"
-        -db-config-filtered-uname "vt_filtered"
-        -db-config-filtered-dbname "vt_{{$keyspace.name}}"
-        -db-config-filtered-charset "utf8"
         -enable_replication_reporter
 {{ if $defaultVttablet.enableSemisync }}
         -enable_semi_sync
@@ -485,8 +473,6 @@ spec:
         -tablet_dir "tabletdata"
         -tablet_uid "{{$uid}}"
         -socket_file "/vtdataroot/mysqlctl.sock"
-        -db-config-dba-uname "vt_dba"
-        -db-config-dba-charset "utf8"
         -init_db_sql_file "/vt/config/init_db.sql"
 
       END_OF_COMMAND

--- a/py/vttest/mysql_db_mysqlctl.py
+++ b/py/vttest/mysql_db_mysqlctl.py
@@ -38,8 +38,6 @@ class MySqlDBMysqlctl(mysql_db.MySqlDB):
         '-alsologtostderr',
         '-tablet_uid', '1',
         '-mysql_port', str(self._port),
-        '-db-config-dba-charset', 'utf8',
-        '-db-config-dba-uname', 'vt_dba',
         'init',
         '-init_db_sql_file',
         os.path.join(os.environ['VTTOP'], 'config/init_db.sql'),
@@ -60,8 +58,6 @@ class MySqlDBMysqlctl(mysql_db.MySqlDB):
         '-alsologtostderr',
         '-tablet_uid', '1',
         '-mysql_port', str(self._port),
-        '-db-config-dba-charset', 'utf8',
-        '-db-config-dba-uname', 'vt_dba',
         'shutdown',
     ]
     result = subprocess.call(cmd)

--- a/py/vttest/vt_processes.py
+++ b/py/vttest/vt_processes.py
@@ -141,12 +141,11 @@ class VtcomboProcess(VtProcess):
     VtProcess.__init__(self, 'vtcombo-%s' % os.environ['USER'], directory,
                        environment.vtcombo_binary, port_name='vtcombo')
     self.extraparams = [
-        '-db-config-app-charset', charset,
-        '-db-config-app-uname', mysql_db.username(),
-        '-db-config-app-pass', mysql_db.password(),
-        '-db-config-dba-charset', charset,
-        '-db-config-dba-uname', mysql_db.username(),
-        '-db-config-dba-pass', mysql_db.password(),
+        '-db_charset', charset,
+        '-db_app_user', mysql_db.username(),
+        '-db_app_password', mysql_db.password(),
+        '-db_dba_user', mysql_db.username(),
+        '-db_dba_password', mysql_db.password(),
         '-proto_topo', text_format.MessageToString(topology, as_one_line=True),
         '-mycnf_server_id', '1',
         '-mycnf_socket_file', mysql_db.unix_socket(),
@@ -159,15 +158,11 @@ class VtcomboProcess(VtProcess):
     if web_dir2:
       self.extraparams.extend(['-web_dir2', web_dir2])
     if mysql_db.unix_socket():
-      self.extraparams.extend(
-          ['-db-config-app-unixsocket', mysql_db.unix_socket(),
-           '-db-config-dba-unixsocket', mysql_db.unix_socket()])
+      self.extraparams.extend(['-db_socket', mysql_db.unix_socket()])
     else:
       self.extraparams.extend(
-          ['-db-config-app-host', mysql_db.hostname(),
-           '-db-config-app-port', str(mysql_db.port()),
-           '-db-config-dba-host', mysql_db.hostname(),
-           '-db-config-dba-port', str(mysql_db.port())])
+          ['-db_host', mysql_db.hostname(),
+           '-db_port', str(mysql_db.port())])
     self.vtcombo_mysql_port = environment.get_port('vtcombo_mysql_port')
     self.extraparams.extend(
         ['-mysql_auth_server_impl', 'none',

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -69,34 +69,6 @@ class Tablet(object):
   default_uid = 62344
   seq = 0
   tablets_running = 0
-  default_db_dba_config = {
-      'dba': {
-          'uname': 'vt_dba',
-          'charset': 'utf8'
-      },
-  }
-  default_db_config = {
-      'app': {
-          'uname': 'vt_app',
-          'charset': 'utf8'
-      },
-      'allprivs': {
-          'uname': 'vt_allprivs',
-          'charset': 'utf8'
-      },
-      'dba': {
-          'uname': 'vt_dba',
-          'charset': 'utf8'
-      },
-      'filtered': {
-          'uname': 'vt_filtered',
-          'charset': 'utf8'
-      },
-      'repl': {
-          'uname': 'vt_repl',
-          'charset': 'utf8'
-      }
-  }
 
   def __init__(self, tablet_uid=None, port=None, mysql_port=None, cell=None,
                use_mysqlctld=False, vt_dba_passwd=None):
@@ -158,7 +130,6 @@ class Tablet(object):
     if with_ports:
       args.extend(['-port', str(self.port),
                    '-mysql_port', str(self.mysql_port)])
-    self._add_dbconfigs(self.default_db_dba_config, args)
     if verbose:
       args.append('-alsologtostderr')
     if extra_args:
@@ -186,7 +157,6 @@ class Tablet(object):
         '-tablet_uid', str(self.tablet_uid),
         '-mysql_port', str(self.mysql_port),
         '-socket_file', os.path.join(self.tablet_dir, 'mysqlctl.sock')]
-    self._add_dbconfigs(self.default_db_dba_config, args)
     if verbose:
       args.append('-alsologtostderr')
     if extra_args:
@@ -587,8 +557,6 @@ class Tablet(object):
     args.extend(['-port', '%s' % (port or self.port),
                  '-log_dir', environment.vtlogroot])
 
-    self._add_dbconfigs(self.default_db_config, args, repl_extra_flags)
-
     if topocustomrule_path:
       args.extend(['-topocustomrule_path', topocustomrule_path])
 
@@ -687,22 +655,6 @@ class Tablet(object):
         return
       timeout = utils.wait_step('waiting for socket files: %s' % str(wait_for),
                                 timeout, sleep_time=2.0)
-
-  def _add_dbconfigs(self, cfg, args, repl_extra_flags=None):
-    """Helper method to generate and add --db-config-* flags to 'args'."""
-    if repl_extra_flags is None:
-      repl_extra_flags = {}
-    config = dict(cfg)
-    if self.keyspace:
-      if 'app' in config:
-        config['app']['dbname'] = self.dbname
-      if 'repl' in config:
-        config['repl']['dbname'] = self.dbname
-    if 'repl' in config:
-      config['repl'].update(repl_extra_flags)
-    for key1 in config:
-      for key2 in config[key1]:
-        args.extend(['-db-config-' + key1 + '-' + key2, config[key1][key2]])
 
   def get_status(self):
     return utils.get_status(self.port)

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# vim: tabstop=8 expandtab shiftwidth=2 softtabstop=2
 
 import json
 import logging
+import os
 import time
 import unittest
 import urllib
@@ -171,6 +173,25 @@ class TestTabletManager(unittest.TestCase):
   _populate_vt_select_test = [
       "insert into vt_select_test (msg) values ('test %s')" % x
       for x in xrange(4)]
+
+  # Test if a vttablet can be pointed at an existing mysql
+  # We point 62044 at 62344's mysql and try to read from it.
+  def test_command_line(self):
+    utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
+    tablet_62044.init_tablet('master', 'test_keyspace', '0')
+    tablet_62344.populate('vt_test_keyspace', self._create_vt_select_test,
+                          self._populate_vt_select_test)
+
+    # mycnf_server_id prevents vttablet from reading the mycnf
+    extra_args = [
+        '-mycnf_server_id', str(tablet_62044.tablet_uid),
+        '-db_socket', os.path.join(tablet_62344.tablet_dir, 'mysql.sock')]
+    # supports_backup=False prevents vttablet from trying to restore
+    tablet_62044.start_vttablet(extra_args=extra_args, supports_backups=False)
+    qr = tablet_62044.execute('select id, msg from vt_select_test')
+    self.assertEqual(len(qr['rows']), 4,
+                     'expected 4 rows in vt_select_test: %s' % str(qr))
+    tablet_62044.kill_vttablet()
 
   def test_actions_and_timeouts(self):
     # Start up a master mysql and vttablet


### PR DESCRIPTION
This is the first step towards vttablet not depending on mycnf. This PR makes the following changes:
* If host or socket file is specified in the command line, they supersede what's in mycnf.
* DB parameters have separated into two groups: connectivity parameters, and user credentials. Connectivity parameters are combined with user credentials to build the the mysql connection parameters.
* A new per-user `use_ssl` flag has been added that lets you choose which connections must use SSL. This allows you to selectively enable SSL for certain connections. The use case for this is the `repl` connection, because replication can go over open networks.
* New simpler flag names like `db_host`, etc. have now been introduced.
* Legacy flag names still work like before, but they will be deprecated soon.
* Reasonable defaults have been provided for all flags. One doesn't have to specify any connection parameters under normal circumstances, like the case where mysqlctl initialized the mysql.
* DBConfigs has been solidified. The app needs to specify whether it wants connectivity with or without the database. This greatly reduces ambiguity about whether we're connected to just the server or to a specific database.
* Examples have been simplified: all db config parameters have been removed.
* vtqueryserver has its own db_name flag. It's the only case where you need to specify a db name on the command line.
* A test has been added in tabletmanager.py to test and demonstrate the new flags.