### PR TITLE
vtgate: fix panic on 'analyze table'

### DIFF
--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -1803,6 +1803,20 @@ class TestVTGateFunctions(unittest.TestCase):
          [('id', self.varbinary_type),
           ('keyspace_id', self.varbinary_type)]))
 
+  def test_analyze_table(self):
+    vtgate_conn = get_connection()
+    self.execute_on_master(
+        vtgate_conn,
+        'use user',
+        {})
+    result = self.execute_on_master(
+        vtgate_conn,
+        'analyze table vt_user',
+        {})
+    self.assertEqual(
+        result[0],
+        [('vt_user.vt_user', 'analyze', 'status', 'OK')])
+
   def test_transaction_modes(self):
     vtgate_conn = get_connection()
     cursor = vtgate_conn.cursor(


### PR DESCRIPTION
analyze table was categorized as a DDL in order to store the table
name. However, vttablet code was not expecting fields to be returned
on DDL execution. This caused it to return a result with valid rows,
but empty fields, which caused vtgate to crash.

I've now changed DDL statements to also return fields. For good
measure, I've also changed DMLs to return fields, because there's
no harm.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>