### PR TITLE
sqlparser: add option to skip special comments

### DIFF
--- a/go/vt/sqlparser/parse_next_test.go
+++ b/go/vt/sqlparser/parse_next_test.go
@@ -57,6 +57,27 @@ func TestParseNextValid(t *testing.T) {
 	}
 }
 
+func TestIgnoreSpecialComments(t *testing.T) {
+	input := `SELECT 1;/*! ALTER TABLE foo DISABLE KEYS */;SELECT 2;`
+
+	tokenizer := NewStringTokenizer(input)
+	tokenizer.SkipSpecialComments = true
+	one, err := ParseNextStrictDDL(tokenizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := ParseNextStrictDDL(tokenizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := String(one), "select 1 from dual"; got != want {
+		t.Fatalf("got %s want %s", got, want)
+	}
+	if got, want := String(two), "select 2 from dual"; got != want {
+		t.Fatalf("got %s want %s", got, want)
+	}
+}
+
 // TestParseNextErrors tests all the error cases, and ensures a valid
 // SQL statement can be passed afterwards.
 func TestParseNextErrors(t *testing.T) {

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -34,19 +34,20 @@ const (
 // Tokenizer is the struct used to generate SQL
 // tokens for the parser.
 type Tokenizer struct {
-	InStream       io.Reader
-	AllowComments  bool
-	ForceEOF       bool
-	lastChar       uint16
-	Position       int
-	lastToken      []byte
-	LastError      error
-	posVarIndex    int
-	ParseTree      Statement
-	partialDDL     *DDL
-	nesting        int
-	multi          bool
-	specialComment *Tokenizer
+	InStream            io.Reader
+	AllowComments       bool
+	SkipSpecialComments bool
+	ForceEOF            bool
+	lastChar            uint16
+	Position            int
+	lastToken           []byte
+	LastError           error
+	posVarIndex         int
+	ParseTree           Statement
+	partialDDL          *DDL
+	nesting             int
+	multi               bool
+	specialComment      *Tokenizer
 
 	buf     []byte
 	bufPos  int
@@ -535,12 +536,10 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 				return tkn.scanCommentType1("//")
 			case '*':
 				tkn.next()
-				switch tkn.lastChar {
-				case '!':
+				if tkn.lastChar == '!' && !tkn.SkipSpecialComments {
 					return tkn.scanMySQLSpecificComment()
-				default:
-					return tkn.scanCommentType2()
 				}
+				return tkn.scanCommentType2()
 			default:
 				return int(ch), nil
 			}


### PR DESCRIPTION
These are emitted by some tools like mysqldump containing syntaxes that may not yet be supported
which then surface as syntax errors. If a caller is not handling them, an option to simply ignore
them rather than try, and fail, to parse them avoids this issue.

Signed-off-by: David Taylor <tinystatemachine@gmail.com>