### PR TITLE
Remove RefreshConfig() from backups

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -322,11 +322,6 @@ func backup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.
 	usable := backupErr == nil
 
 	// Try to restart mysqld
-	err = mysqld.RefreshConfig(ctx, cnf)
-	if err != nil {
-		return usable, fmt.Errorf("can't refresh mysqld config: %v", err)
-	}
-
 	err = mysqld.Start(ctx, cnf)
 	if err != nil {
 		return usable, fmt.Errorf("can't restart mysqld: %v", err)

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -34,7 +34,6 @@ type MysqlDaemon interface {
 	Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bool) error
 	RunMysqlUpgrade() error
 	ReinitConfig(ctx context.Context, cnf *Mycnf) error
-	RefreshConfig(ctx context.Context, cnf *Mycnf) error
 	Wait(ctx context.Context, cnf *Mycnf) error
 
 	// GetMysqlPort returns the current port mysql is listening on.


### PR DESCRIPTION
### Description

* Currently this is not having the intended behavior. Removing while adding a
  proper fix for this. This effectively reverts:  https://github.com/vitessio/vitess/pull/3063
* Conversation about this bug can be found in: https://vitess.slack.com/archives/C0PQY0PTK/p1532042506000063 