### PR TITLE
Do not update replication data if sanity check fails

### DIFF
--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -338,15 +338,10 @@ func (ts *Server) CreateTablet(ctx context.Context, tablet *topodatapb.Tablet) e
 		return err
 	}
 	tabletPath := path.Join(TabletsPath, topoproto.TabletAliasString(tablet.Alias), TabletFile)
-	if _, err = conn.Create(ctx, tabletPath, data); err != nil && !IsErrType(err, NodeExists) {
+	if _, err = conn.Create(ctx, tabletPath, data); err != nil {
 		return err
 	}
 
-	// Update ShardReplication in any case, to be sure.  This is
-	// meant to fix the case when a Tablet record was created, but
-	// then the ShardReplication record was not (because for
-	// instance of a startup timeout). Upon running this code
-	// again, we want to fix ShardReplication.
 	if updateErr := UpdateTabletReplicationData(ctx, ts, tablet); updateErr != nil {
 		return updateErr
 	}

--- a/go/vt/topo/topotests/tablet_test.go
+++ b/go/vt/topo/topotests/tablet_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
-	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -58,28 +57,6 @@ func TestCreateTablet(t *testing.T) {
 		t.Fatalf("Created Tablet doesn't match: %v %v", ti, err)
 	}
 	sri, err := ts.GetShardReplication(ctx, cell, keyspace, shard)
-	if err != nil || len(sri.Nodes) != 1 || !proto.Equal(sri.Nodes[0].TabletAlias, alias) {
-		t.Fatalf("Created ShardReplication doesn't match: %v %v", sri, err)
-	}
-
-	// Create the same tablet again, make sure it fails with ErrNodeExists.
-	if err := ts.CreateTablet(ctx, tablet); !topo.IsErrType(err, topo.NodeExists) {
-		t.Fatalf("CreateTablet(again) returned: %v", err)
-	}
-
-	// Remove the ShardReplication record, try to create the
-	// tablets again, make sure it's fixed.
-	if err := topo.RemoveShardReplicationRecord(ctx, ts, cell, keyspace, shard, alias); err != nil {
-		t.Fatalf("RemoveShardReplicationRecord failed: %v", err)
-	}
-	sri, err = ts.GetShardReplication(ctx, cell, keyspace, shard)
-	if err != nil || len(sri.Nodes) != 0 {
-		t.Fatalf("Modifed ShardReplication doesn't match: %v %v", sri, err)
-	}
-	if err := ts.CreateTablet(ctx, tablet); !topo.IsErrType(err, topo.NodeExists) {
-		t.Fatalf("CreateTablet(again and again) returned: %v", err)
-	}
-	sri, err = ts.GetShardReplication(ctx, cell, keyspace, shard)
 	if err != nil || len(sri.Nodes) != 1 || !proto.Equal(sri.Nodes[0].TabletAlias, alias) {
 		t.Fatalf("Created ShardReplication doesn't match: %v %v", sri, err)
 	}


### PR DESCRIPTION
### Description

* We discovered this error the hard way. Unfortunately, we had a tablet uid collision in  our provisioning process and a tablet what spun up with this id. `CreateTablet` and `init_tablet` fails correctly, but it has the side effect of registering this newly created tablet (in a different shard) in the data replication topology. This is really dangerous, as now this tablet is shown in two shards (potentially in different keyspaces).
* The following is a fix to do the same sanity check that init_tablet does before trying to `UpdateTabletReplicationData`. 
* This PR also adds a test to avoid future regressions. 
