### PR TITLE
Add Vagrantfile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ releases
 /web/vtctld2/bower.json~
 /web/vtctld2/public/bower_components/
 
+
+# Vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,56 @@
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.hostname = 'vitess'
+
+  config.vm.network "private_network", type: "dhcp"
+
+  # vtctld
+  config.vm.network "forwarded_port", guest: 8000, host: 8000 # http
+  config.vm.network "forwarded_port", guest: 15000, host: 15000 # http
+  config.vm.network "forwarded_port", guest: 15999, host: 15999 # grpc
+
+  # vtgate
+  config.vm.network "forwarded_port", guest: 15001, host: 15001 # http
+  config.vm.network "forwarded_port", guest: 15991, host: 15991 # grpc
+  config.vm.network "forwarded_port", guest: 15306, host: 15306 # mysql
+
+  # vttablet 1
+  config.vm.network "forwarded_port", guest: 15100, host: 15100 # http
+  config.vm.network "forwarded_port", guest: 16100, host: 16100 # grpc
+
+  # vttablet 2
+  config.vm.network "forwarded_port", guest: 15101, host: 15101 # http
+  config.vm.network "forwarded_port", guest: 16101, host: 16101 # grpc
+
+  # vttablet 3
+  config.vm.network "forwarded_port", guest: 15102, host: 15102 # http
+  config.vm.network "forwarded_port", guest: 16102, host: 16102 # grpc
+
+  # vttablet 4
+  config.vm.network "forwarded_port", guest: 15103, host: 15103 # http
+  config.vm.network "forwarded_port", guest: 16103, host: 16103 # grpc
+
+  # vttablet 5
+  config.vm.network "forwarded_port", guest: 15104, host: 15104 # http
+  config.vm.network "forwarded_port", guest: 16104, host: 16104 # grpc
+
+  # Demo Appp
+  config.vm.network "forwarded_port", guest: 8000, host: 8000 # http
+
+  # If possible, use nfs, this gives a good boost to IO operations in the VM.
+  # if you run into with nfs, just remove this from the synced folder
+
+  config.vm.synced_folder ".", "/vagrant/src/vitess.io/vitess", type: "nfs"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.name = "vitess"
+    vb.customize ["modifyvm", :id, "--ioapic", "on"]
+    vb.customize ["modifyvm", :id, "--cpuexecutioncap", "85"]
+    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+    vb.memory = 12888
+    vb.cpus = 4
+  end
+  config.vm.provision "shell", path: "./vagrant-scripts/bootstrap_vm.sh"
+end

--- a/vagrant-scripts/bootstrap_vm.sh
+++ b/vagrant-scripts/bootstrap_vm.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# See http://vitess.io/getting-started/local-instance.html#manual-build
+# for more info
+#
+set -ex
+
+TMP_DIR="$(mktemp -d)"
+SEED_FILE='/root/.provisioning_done'
+
+if [ -f $SEED_FILE ];
+then
+    printf "\nVM provisioning already completed\n"
+    exit 0
+fi
+
+# Install pre-requisites
+add-apt-repository -y ppa:openjdk-r/ppa
+apt-get update
+apt-get install -y make \
+                   automake \
+                   libtool \
+                   python-dev \
+                   python-virtualenv \
+                   python-mysqldb \
+                   libssl-dev \
+                   g++ \
+                   mercurial \
+                   git \
+                   pkg-config \
+                   bison \
+                   curl \
+                   openjdk-7-jre \
+                   zip \
+                   unzip
+
+# Install golang
+GO_VER='1.9.1'
+GO_DOWNLOAD_URL='https://storage.googleapis.com/golang'
+GO_FILENAME="go${GO_VER}.linux-amd64.tar.gz"
+wget "${GO_DOWNLOAD_URL}/${GO_FILENAME}" -O "${TMP_DIR}/${GO_FILENAME}"
+tar xzf "${TMP_DIR}/${GO_FILENAME}" -C "/usr/local"
+
+# Install MySQL Percona 5.7 (via APT)
+PERCONA_APT="https://repo.percona.com/apt/percona-release_0.1-4.$(lsb_release -sc)_all.deb"
+PERCONA_APT_FILENAME='percona-server.tar'
+wget "${PERCONA_APT}" -O "${TMP_DIR}/${PERCONA_APT_FILENAME}"
+dpkg -i "${TMP_DIR}/${PERCONA_APT_FILENAME}"
+apt-get update
+export DEBIAN_FRONTEND="noninteractive"
+apt-get install -y percona-server-server-5.7 libmysqlclient-dev
+echo "CREATE USER 'mysql_user'@'%' IDENTIFIED BY 'mysql_password'; GRANT ALL PRIVILEGES ON *.* TO 'mysql_user'@'%'; FLUSH PRIVILEGES;" | mysql -u root
+
+# System tweaks
+printf "\nSetting /etc/environment\n"
+{
+  GOROOT='/usr/local/go'
+  GOPATH='/vagrant'
+  echo "GOROOT=${GOROOT}"
+  echo "GOPATH=${GOPATH}"
+  echo "PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin"
+  echo "VITESS_WORKSPACE=/vagrant/src/vitess.io/vitess"
+} >> /etc/environment
+# shellcheck disable=SC2013
+# shellcheck disable=SC2163
+for line in $( cat /etc/environment ) ; do export "$line" ; done # source environment file
+
+printf "\nSetting higher limit for max number of open files\n"
+echo "fs.file-max = 10000" >> /etc/sysctl.conf
+sysctl -p
+
+# Provisioning completed
+touch $SEED_FILE
+printf "\nProvisioning completed!\n\n"

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -12,12 +12,13 @@ export VT_MYSQL_ROOT=/usr
 printf "\nBuilding Vitess...\n"
 
 # This is just to make sure the vm can write into these directories
-sudo chown `whoami`:`whoami` /vagrant
-sudo chown `whoami`:`whoami` /vagrant/src
+sudo chown $(whoami):$(whoami) /vagrant
+sudo chown $(whoami):$(whoami) /vagrant/src
 cd "$VITESS_WORKSPACE"
 ./bootstrap.sh
 # shellcheck disable=SC1091
 source dev.env
+# shellcheck disable=SC1091
 source /vagrant/dist/grpc/usr/local/bin/activate
 pip install mysqlclient
 make build

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# See http://vitess.io/getting-started/local-instance.html#manual-build
+# for more info
+#
+set -ex
+
+ulimit -n 10000
+export MYSQL_FLAVOR=MySQL56
+export VT_MYSQL_ROOT=/usr
+
+printf "\nBuilding Vitess...\n"
+
+# This is just to make sure the vm can write into these directories
+sudo chown `whoami`:`whoami` /vagrant
+sudo chown `whoami`:`whoami` /vagrant/src
+cd "$VITESS_WORKSPACE"
+./bootstrap.sh
+# shellcheck disable=SC1091
+source dev.env
+make build
+
+printf "\Build completed\n\n."

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -18,6 +18,8 @@ cd "$VITESS_WORKSPACE"
 ./bootstrap.sh
 # shellcheck disable=SC1091
 source dev.env
+source /vagrant/dist/grpc/usr/local/bin/activate
+pip install mysqlclient
 make build
 
 printf "\Build completed\n\n."

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -12,8 +12,8 @@ export VT_MYSQL_ROOT=/usr
 printf "\nBuilding Vitess...\n"
 
 # This is just to make sure the vm can write into these directories
-sudo chown $(whoami):$(whoami) /vagrant
-sudo chown $(whoami):$(whoami) /vagrant/src
+sudo chown "$(whoami)":"$(whoami)" /vagrant
+sudo chown "$(whoami)":"$(whoami)" /vagrant/src
 cd "$VITESS_WORKSPACE"
 ./bootstrap.sh
 # shellcheck disable=SC1091

--- a/vagrant-scripts/vitess/start.sh
+++ b/vagrant-scripts/vitess/start.sh
@@ -7,7 +7,7 @@ printf "\nStarting Vitess cluster\n"
 export VTROOT=/vagrant
 export VTDATAROOT=/tmp/vtdata-dev
 export MYSQL_FLAVOR=MySQL56
-cd $VITESS_WORKSPACE/examples/local
+cd "$VITESS_WORKSPACE"/examples/local
 export SHARD="-"
 ./zk-up.sh
 ./vtctld-up.sh --enable-grpc-static-auth

--- a/vagrant-scripts/vitess/start.sh
+++ b/vagrant-scripts/vitess/start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+printf "\nStarting Vitess cluster\n"
+
+export VTROOT=/vagrant
+export VTDATAROOT=/tmp/vtdata-dev
+export MYSQL_FLAVOR=MySQL56
+cd $VITESS_WORKSPACE/examples/local
+export SHARD="-"
+./zk-up.sh
+./vtctld-up.sh --enable-grpc-static-auth
+./vttablet-up.sh --enable-grpc-static-auth
+./vtgate-up.sh --enable-grpc-static-auth
+sleep 3
+./lvtctl.sh InitShardMaster -force test_keyspace/- test-100
+./lvtctl.sh ApplySchema -sql "$(cat create_test_table.sql)" test_keyspace
+./lvtctl.sh ApplyVSchema -vschema_file vschema.json test_keyspace
+./lvtctl.sh RebuildVSchemaGraph
+
+printf "\nVitess cluster started successfully.\n\n"

--- a/vagrant-scripts/vitess/stop.sh
+++ b/vagrant-scripts/vitess/stop.sh
@@ -7,7 +7,7 @@ printf "\nStopping Vitess cluster\n"
 export VTROOT=/vagrant
 export VTDATAROOT=/tmp/vtdata-dev
 export MYSQL_FLAVOR=MySQL56
-cd $VITESS_WORKSPACE/examples/local
+cd "$VITESS_WORKSPACE"/examples/local
 
 ./vtgate-down.sh
 ./vttablet-down.sh

--- a/vagrant-scripts/vitess/stop.sh
+++ b/vagrant-scripts/vitess/stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+printf "\nStopping Vitess cluster\n"
+
+export VTROOT=/vagrant
+export VTDATAROOT=/tmp/vtdata-dev
+export MYSQL_FLAVOR=MySQL56
+cd $VITESS_WORKSPACE/examples/local
+
+./vtgate-down.sh
+./vttablet-down.sh
+./vtctld-down.sh
+./zk-down.sh
+
+rm -rf $VTDATAROOT
+
+printf "\nVitess cluster stopped successfully.\n\n"

--- a/vagrant-scripts/vitess/test.sh
+++ b/vagrant-scripts/vitess/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+#
+set -ex
+
+ulimit -n 10000
+export VT_GO_PARALLEL_VALUE=4
+export VTDATAROOT=/tmp/vtdata
+export VTROOT=/vagrant
+export PYTHONROOT=$VTROOT/dist/grpc/usr/local/lib/python2.7/site-packages
+
+printf "\nStarting Vitess test suite...\n"
+
+cd "$VITESS_WORKSPACE"
+# shellcheck disable=SC1091
+source dev.env
+make site_test
+rm -rf "$VTDATAROOT"
+
+printf "\nVitess test suite completed.\n\n"

--- a/vagrant-scripts/vitess/test.sh
+++ b/vagrant-scripts/vitess/test.sh
@@ -14,6 +14,7 @@ printf "\nStarting Vitess test suite...\n"
 cd "$VITESS_WORKSPACE"
 # shellcheck disable=SC1091
 source dev.env
+source /vagrant/dist/grpc/usr/local/bin/activate
 make site_test
 rm -rf "$VTDATAROOT"
 

--- a/vagrant-scripts/vitess/test.sh
+++ b/vagrant-scripts/vitess/test.sh
@@ -14,6 +14,7 @@ printf "\nStarting Vitess test suite...\n"
 cd "$VITESS_WORKSPACE"
 # shellcheck disable=SC1091
 source dev.env
+# shellcheck disable=SC1091
 source /vagrant/dist/grpc/usr/local/bin/activate
 make site_test
 rm -rf "$VTDATAROOT"


### PR DESCRIPTION
###  Desc

Long overdue promise of having a [Vagrantfile](https://www.vagrantup.com/) for Vitess project. The following allows people to quickly set up a Vitess development environment. 

@sougou  - If you think this is good to merge, I can follow up with other PR's to add this to the docs.

I tested this Vagrantfile in a ubuntu machine and in Mac OS. VirtualBox seems to work better in mac OS (the VM runs more smoothly  there and tests/building run faster, but the setup works in both cases).

cc: @dweitzman 

### Usage

1) Install vagrant and vmware/VirtualBox in your system.
2) In the vitess project do:
  ```
  $ vagrant up
  ```
3) Connect to the VM:
  ```
  $ vagrant ssh
  ```
4) Build the project:
  ```
  $ cd $VITESS_WORKSPACE
  $ ./vagrant-scripts/vitess/build.sh 
  ```
5) Run the tests:
  ```
  $ ./vagrant-scripts/vitess/test.sh
  ```

There are also scripts to start/stop a Vitess clusters that have port forwarding setup to the local machine. 