### PR TITLE
Fix some flaky tests

### DIFF
--- a/config/mycnf/master_mysql56.cnf
+++ b/config/mycnf/master_mysql56.cnf
@@ -5,8 +5,11 @@ log_bin
 log_slave_updates
 enforce_gtid_consistency
 
-# Ignore relay logs on disk at startup.
-relay_log_recovery
+# Crash-safe replication settings.
+master_info_repository = TABLE
+relay_log_info_repository = TABLE
+relay_log_purge = 1
+relay_log_recovery = 1
 
 # Native AIO tends to run into aio-max-nr limit during test startup.
 innodb_use_native_aio = 0

--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -795,6 +795,12 @@ func TestWindow(t *testing.T) {
 	// (queue becomes not empty a second time).
 	flag.Set("buffer_window", "10m")
 
+	// This is a hack. The buffering semaphore gets released asynchronously.
+	// Sometimes the next issueRequest tries to acquire before that release
+	// and ends up failing. Waiting for the previous goroutines to exit ensures
+	// that the sema will get released.
+	b.waitForShutdown()
+
 	// This time the request does not go out of window and gets evicted by a third
 	// request instead.
 	t.Logf("second request does not exceed its window")

--- a/go/vt/vttablet/endtoend/compatibility_test.go
+++ b/go/vt/vttablet/endtoend/compatibility_test.go
@@ -63,7 +63,7 @@ func TestCharaterSet(t *testing.T) {
 				OrgTable:     "vitess_test",
 				Database:     "vttest",
 				OrgName:      "charval",
-				ColumnLength: 768,
+				ColumnLength: 30,
 				Charset:      33,
 			}, {
 				Name:         "binval",

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -117,7 +117,7 @@ func initTableACL() error {
 	return nil
 }
 
-var testSchema = `create table vitess_test(intval int default 0, floatval float default null, charval varchar(256) default null, binval varbinary(256) default null, primary key(intval));
+var testSchema = `create table vitess_test(intval int default 0, floatval float default null, charval varchar(10) default null, binval varbinary(256) default null, primary key(intval));
 create table vitess_test_debuguser(intval int default 0, floatval float default null, charval varchar(256) default null, binval varbinary(256) default null, primary key(intval));
 grant select, show databases, process on *.* to 'vt_appdebug'@'localhost';
 revoke select on *.* from 'vt_appdebug'@'localhost';


### PR DESCRIPTION
## mariadb flavor
The endtoend test was failing in mariadb because the error message
returned was different. The operation has now been changed
to something that returns the same message for all flavors.

## buffer_test
There was a race between releasing and acquiring a sema.

## vtgatev2_test
The test was flaky because frequent restarts of mysql were
causing the relay log to go corrupt. Changed the my.cnf settings
to be more crash-safe.

## update_stream
update_test was sometimes flaky if replicas were slow.
Changed some checks to accommodate this.