### PR TITLE
restore the deprecated user-specific "dbname" flags

### DIFF
--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -34,6 +34,10 @@ type ConnParams struct {
 	SslCert    string `json:"ssl_cert"`
 	SslKey     string `json:"ssl_key"`
 	ServerName string `json:"server_name"`
+
+	// The following is only set when the deprecated "dbname" flags are
+	// supplied and will be removed.
+	DeprecatedDBName string
 }
 
 // EnableSSL will set the right flag on the parameters.

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -125,7 +125,7 @@ func registerPerUserFlags(dbc *userConfig, userKey string) {
 	flag.StringVar(&dbc.param.SslCert, "db-config-"+userKey+"-ssl-cert", "", "deprecated: use db_ssl_cert")
 	flag.StringVar(&dbc.param.SslKey, "db-config-"+userKey+"-ssl-key", "", "deprecated: use db_ssl_key")
 
-	flag.StringVar(&dbc.param.DeprecatedDbName, "db-config-"+userKey+"-dbname", "", "deprecated: dbname does not need to be explicitly configured")
+	flag.StringVar(&dbc.param.DeprecatedDBName, "db-config-"+userKey+"-dbname", "", "deprecated: dbname does not need to be explicitly configured")
 
 }
 

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -124,6 +124,9 @@ func registerPerUserFlags(dbc *userConfig, userKey string) {
 	flag.StringVar(&dbc.param.SslCaPath, "db-config-"+userKey+"-ssl-ca-path", "", "deprecated: use db_ssl_ca_path")
 	flag.StringVar(&dbc.param.SslCert, "db-config-"+userKey+"-ssl-cert", "", "deprecated: use db_ssl_cert")
 	flag.StringVar(&dbc.param.SslKey, "db-config-"+userKey+"-ssl-key", "", "deprecated: use db_ssl_key")
+
+	flag.StringVar(&dbc.param.DeprecatedDbName, "db-config-"+userKey+"-dbname", "", "deprecated: dbname does not need to be explicitly configured")
+
 }
 
 // AppWithDB returns connection parameters for app with dbname set.


### PR DESCRIPTION
Fix a regression where the dbname flags were removed as part of the
earlier cleanup and refactor. This is against policy since we want
to keep the flags for now.

Unlike the other user-specific db connection flags, this one does
not actually do anything at runtime except set a "DeprecatedDBName"
field in the DBConfig.

Signed-off-by: Michael Demmer <mdemmer@slack-corp.com>