### PR TITLE
improve query logging efficiency by passing io.Writer along

### DIFF
--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -482,8 +483,9 @@ func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql 
 		return nil
 	}
 
-	log := streamlog.GetFormatter(QueryLogger)(nil, logStats)
-	fields := strings.Split(log, "\t")
+	var log bytes.Buffer
+	streamlog.GetFormatter(QueryLogger)(&log, nil, logStats)
+	fields := strings.Split(log.String(), "\t")
 
 	// fields[0] is the method
 	if method != fields[0] {

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -94,55 +94,6 @@ func (stats *LogStats) TotalTime() time.Duration {
 	return stats.EndTime.Sub(stats.StartTime)
 }
 
-// FmtBindVariables returns the map of bind variables as JSON. For
-// values that are strings or byte slices it only reports their type
-// and length.
-func (stats *LogStats) FmtBindVariables(full bool) string {
-	if *streamlog.RedactDebugUIQueries {
-		return "\"[REDACTED]\""
-	}
-
-	var out map[string]*querypb.BindVariable
-	if full {
-		out = stats.BindVariables
-	} else {
-		// NOTE(szopa): I am getting rid of potentially large bind
-		// variables.
-		out = make(map[string]*querypb.BindVariable)
-		for k, v := range stats.BindVariables {
-			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
-				out[k] = v
-			} else if v.Type == querypb.Type_TUPLE {
-				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v items", len(v.Values)))
-			} else {
-				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v bytes", len(v.Value)))
-			}
-		}
-	}
-
-	if *streamlog.QueryLogFormat == streamlog.QueryLogFormatJSON {
-		var buf bytes.Buffer
-		buf.WriteString("{")
-		first := true
-		for k, v := range out {
-			if !first {
-				buf.WriteString(", ")
-			} else {
-				first = false
-			}
-			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
-				fmt.Fprintf(&buf, "%q: {\"type\": %q, \"value\": %v}", k, v.Type, string(v.Value))
-			} else {
-				fmt.Fprintf(&buf, "%q: {\"type\": %q, \"value\": %q}", k, v.Type, string(v.Value))
-			}
-		}
-		buf.WriteString("}")
-		return buf.String()
-	}
-
-	return fmt.Sprintf("%v", out)
-}
-
 // ContextHTML returns the HTML version of the context that was used, or "".
 // This is a method on LogStats instead of a field so that it doesn't need
 // to be passed by value everywhere.
@@ -169,8 +120,15 @@ func (stats *LogStats) RemoteAddrUsername() (string, string) {
 
 // Format returns a tab separated list of logged fields.
 func (stats *LogStats) Format(params url.Values) string {
-	_, fullBindParams := params["full"]
-	formattedBindVars := stats.FmtBindVariables(fullBindParams)
+	formattedBindVars := "\"[REDACTED]\""
+	if !*streamlog.RedactDebugUIQueries {
+		_, fullBindParams := params["full"]
+		formattedBindVars = sqltypes.FormatBindVariables(
+			stats.BindVariables,
+			fullBindParams,
+			*streamlog.QueryLogFormat == streamlog.QueryLogFormatJSON,
+		)
+	}
 
 	// TODO: remove username here we fully enforce immediate caller id
 	remoteAddr, username := stats.RemoteAddrUsername()

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -33,6 +34,12 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
+func testFormat(stats *LogStats, params url.Values) string {
+	var b bytes.Buffer
+	stats.Logf(&b, params)
+	return b.String()
+}
+
 func TestLogStatsFormat(t *testing.T) {
 	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1)})
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
@@ -41,7 +48,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = false
 	*streamlog.QueryLogFormat = "text"
-	got := logStats.Format(url.Values(params))
+	got := testFormat(logStats, url.Values(params))
 	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[intVal:type:INT64 value:\"1\" ]\t0\t0\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
@@ -49,7 +56,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = true
 	*streamlog.QueryLogFormat = "text"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
@@ -57,7 +64,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = false
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	var parsed map[string]interface{}
 	err := json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
@@ -74,7 +81,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = true
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	err = json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
 		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
@@ -95,14 +102,14 @@ func TestLogStatsFormat(t *testing.T) {
 	logStats.BindVariables = map[string]*querypb.BindVariable{"strVal": sqltypes.StringBindVariable("abc")}
 
 	*streamlog.QueryLogFormat = "text"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[strVal:type:VARCHAR value:\"abc\" ]\t0\t0\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	err = json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
 		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -119,52 +119,6 @@ func TestLogStatsFormat(t *testing.T) {
 	*streamlog.QueryLogFormat = "text"
 }
 
-func TestLogStatsFormatBindVariables(t *testing.T) {
-	tupleBindVar, err := sqltypes.BuildBindVariable([]int64{1, 2})
-	if err != nil {
-		t.Fatalf("failed to create a tuple bind var: %v", err)
-	}
-
-	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{
-		"key_1": sqltypes.StringBindVariable("val_1"),
-		"key_2": sqltypes.Int64BindVariable(789),
-		"key_3": sqltypes.BytesBindVariable([]byte("val_3")),
-		"key_4": tupleBindVar,
-	})
-
-	formattedStr := logStats.FmtBindVariables(true)
-	if !strings.Contains(formattedStr, "key_1") ||
-		!strings.Contains(formattedStr, "val_1") {
-		t.Fatalf("bind variable 'key_1': 'val_1' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_2") ||
-		!strings.Contains(formattedStr, "789") {
-		t.Fatalf("bind variable 'key_2': '789' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "val_3") {
-		t.Fatalf("bind variable 'key_3': 'val_3' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_4") ||
-		!strings.Contains(formattedStr, "values:<type:INT64 value:\"1\" > values:<type:INT64 value:\"2\" >") {
-		t.Fatalf("bind variable 'key_4': (1, 2) is not formatted")
-	}
-
-	formattedStr = logStats.FmtBindVariables(false)
-	if !strings.Contains(formattedStr, "key_1") {
-		t.Fatalf("bind variable 'key_1' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_2") ||
-		!strings.Contains(formattedStr, "789") {
-		t.Fatalf("bind variable 'key_2': '789' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "5 bytes") {
-		t.Fatalf("bind variable 'key_3' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_4") || !strings.Contains(formattedStr, "2 items") {
-		t.Fatalf("bind variable 'key_4' is not formatted")
-	}
-}
-
 func TestLogStatsContextHTML(t *testing.T) {
 	html := "HtmlContext"
 	callInfo := &fakecallinfo.FakeCallInfo{

--- a/go/vt/vttablet/sysloglogger/sysloglogger.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger.go
@@ -18,6 +18,7 @@ limitations under the License.
 package sysloglogger
 
 import (
+	"bytes"
 	"flag"
 	"log/syslog"
 
@@ -73,7 +74,12 @@ func run() {
 			log.Errorf("Unexpected value in query logs: %#v (expecting value of type %T)", out, &tabletenv.LogStats{})
 			continue
 		}
-		if err := writer.Info(stats.Format(formatParams)); err != nil {
+		var b bytes.Buffer
+		if err := stats.Logf(&b, formatParams); err != nil {
+			log.Errorf("Error formatting logStats: %v", err)
+			continue
+		}
+		if err := writer.Info(b.String()); err != nil {
 			log.Errorf("Error writing to syslog: %v", err)
 			continue
 		}

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -146,53 +146,6 @@ func TestLogStatsFormat(t *testing.T) {
 	*streamlog.QueryLogFormat = "text"
 }
 
-func TestLogStatsFormatBindVariables(t *testing.T) {
-	tupleBindVar, err := sqltypes.BuildBindVariable([]int64{1, 2})
-	if err != nil {
-		t.Fatalf("failed to create a tuple bind var: %v", err)
-	}
-
-	logStats := NewLogStats(context.Background(), "test")
-	logStats.BindVariables = map[string]*querypb.BindVariable{
-		"key_1": sqltypes.StringBindVariable("val_1"),
-		"key_2": sqltypes.Int64BindVariable(789),
-		"key_3": sqltypes.BytesBindVariable([]byte("val_3")),
-		"key_4": tupleBindVar,
-	}
-
-	formattedStr := logStats.FmtBindVariables(true)
-	if !strings.Contains(formattedStr, "key_1") ||
-		!strings.Contains(formattedStr, "val_1") {
-		t.Fatalf("bind variable 'key_1': 'val_1' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_2") ||
-		!strings.Contains(formattedStr, "789") {
-		t.Fatalf("bind variable 'key_2': '789' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "val_3") {
-		t.Fatalf("bind variable 'key_3': 'val_3' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_4") ||
-		!strings.Contains(formattedStr, "values:<type:INT64 value:\"1\" > values:<type:INT64 value:\"2\" >") {
-		t.Fatalf("bind variable 'key_4': (1, 2) is not formatted")
-	}
-
-	formattedStr = logStats.FmtBindVariables(false)
-	if !strings.Contains(formattedStr, "key_1") {
-		t.Fatalf("bind variable 'key_1' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_2") ||
-		!strings.Contains(formattedStr, "789") {
-		t.Fatalf("bind variable 'key_2': '789' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_3") || !strings.Contains(formattedStr, "5 bytes") {
-		t.Fatalf("bind variable 'key_3' is not formatted")
-	}
-	if !strings.Contains(formattedStr, "key_4") || !strings.Contains(formattedStr, "2 items") {
-		t.Fatalf("bind variable 'key_4' is not formatted")
-	}
-}
-
 func TestLogStatsFormatQuerySources(t *testing.T) {
 	logStats := NewLogStats(context.Background(), "test")
 	if logStats.FmtQuerySources() != "none" {

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletenv
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -49,10 +50,12 @@ func TestLogStats(t *testing.T) {
 	if logStats.SizeOfResponse() <= 0 {
 		t.Fatalf("log stats has some rows, should have positive response size")
 	}
+}
 
-	params := map[string][]string{"full": {}}
-
-	logStats.Format(url.Values(params))
+func testFormat(stats *LogStats, params url.Values) string {
+	var b bytes.Buffer
+	stats.Logf(&b, params)
+	return b.String()
 }
 
 func TestLogStatsFormat(t *testing.T) {
@@ -68,7 +71,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = false
 	*streamlog.QueryLogFormat = "text"
-	got := logStats.Format(url.Values(params))
+	got := testFormat(logStats, url.Values(params))
 	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t\t\"sql\"\tmap[intVal:type:INT64 value:\"1\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
@@ -76,7 +79,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = true
 	*streamlog.QueryLogFormat = "text"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t\t\"sql\"\t\"[REDACTED]\"\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
@@ -84,7 +87,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = false
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	var parsed map[string]interface{}
 	err := json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
@@ -101,7 +104,7 @@ func TestLogStatsFormat(t *testing.T) {
 
 	*streamlog.RedactDebugUIQueries = true
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	err = json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
 		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
@@ -122,14 +125,14 @@ func TestLogStatsFormat(t *testing.T) {
 	logStats.BindVariables = map[string]*querypb.BindVariable{"strVal": sqltypes.StringBindVariable("abc")}
 
 	*streamlog.QueryLogFormat = "text"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t\t\"sql\"\tmap[strVal:type:VARCHAR value:\"abc\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
 	*streamlog.QueryLogFormat = "json"
-	got = logStats.Format(url.Values(params))
+	got = testFormat(logStats, url.Values(params))
 	err = json.Unmarshal([]byte(got), &parsed)
 	if err != nil {
 		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)


### PR DESCRIPTION
## Description
Change the internal interface for query logging so that it passes an io.Writer into the formatter function as opposed to producing a temporary string and calling io.WriteBytes.

This should reduce some GC pressure and enable more efficient buffer management under heavy workloads.

Along the way extract the common functionality for formatting bind variables out from both vtgate and vttablet's query logging modules into a sqltypes.FormatBindVariables helper.

## Testing
On a couple of quick before-and-after tests in our dev environment I couldn't discern any meaningful CPU performance impact, but I wasn't sure how to measure the GC impact. In principle I can't think of any reason why this would be _worse_, though it might not actually be meaningfully better.

If this looks reasonable then we (Slack) can try it out in a more systematic way to see if it has any measurable effect.