### PR TITLE
Fix workflow stop issue

### DIFF
--- a/go/vt/workflow/resharding/parallel_runner.go
+++ b/go/vt/workflow/resharding/parallel_runner.go
@@ -133,7 +133,9 @@ func (p *ParallelRunner) Run() error {
 		}
 		select {
 		case <-p.ctx.Done():
-			log.Info("Workflow is cancelled, will not run task: %v", task)
+			log.Infof("Workflow is cancelled, will not run task: %v", task)
+			// Break this run and return early. Do not try to to execute any subsequent tasks.
+			return nil
 		default:
 			wg.Add(1)
 			go func(t *workflowpb.Task) {

--- a/go/vt/workflow/resharding/parallel_runner_test.go
+++ b/go/vt/workflow/resharding/parallel_runner_test.go
@@ -136,7 +136,7 @@ func TestParallelRunnerStoppingWorkflowWithSequentialSteps(t *testing.T) {
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell")
 
-	m, uuid, wg, cancel, err := setupTestWorkflow(ctx, ts, true /* enableApprovals*/, false /* retry */, false /* sequential */)
+	m, uuid, wg, cancel, err := setupTestWorkflow(ctx, ts, true /* enableApprovals*/, false /* retry */, true /* sequential */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,6 @@ func TestParallelRunnerStoppingWorkflowWithSequentialSteps(t *testing.T) {
 	}
 	cancel()
 	wg.Wait()
-
 }
 
 func TestParallelRunnerApprovalFromFirstDone(t *testing.T) {


### PR DESCRIPTION
### Desc

This fixes a small but annoying where trying to `Stop` a workflow that was waiting approval for a `Sequential` step just hangs. 

This was due to not having enough semaphores in the running tasks loops. I fixed this by just returning the whole method early if the context is done.

