### PR TITLE
Make Workflow SplitDiff task parallel across Shards

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -62,6 +62,9 @@ func (agent *ActionAgent) ChangeType(ctx context.Context, tabletType topodatapb.
 	}
 	defer agent.unlock()
 
+	// We don't want to allow multiple callers to claim a tablet as drained. There is a race that could happen during
+	// horizontal resharding where two vtworkers will try to DRAIN the same tablet. This check prevents that race from
+	// causing errors.
 	if tabletType == topodatapb.TabletType_DRAINED && agent.Tablet().Type == topodatapb.TabletType_DRAINED {
 		return fmt.Errorf("Tablet: %v, is already drained", agent.TabletAlias)
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -62,6 +62,9 @@ func (agent *ActionAgent) ChangeType(ctx context.Context, tabletType topodatapb.
 	}
 	defer agent.unlock()
 
+	if tabletType == topodatapb.TabletType_DRAINED && agent.Tablet().Type == topodatapb.TabletType_DRAINED {
+		return fmt.Errorf("Tablet: %v, is already drained", agent.TabletAlias)
+	}
 	// change our type in the topology
 	_, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, tabletType)
 	if err != nil {

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -241,9 +241,9 @@ func (sdw *SplitDiffWorker) findTargets(ctx context.Context) error {
 		if ss.Uid == sdw.sourceUID {
 			// During an horizontal shard split, multiple workers could race to get
 			// a RDONLY tablet in the source shard. When this happen, one of the workers
-			// will fail to drain the tablet and FindWorkerTablet will fail.
-			// The following works in an optimistic way, but it fails,
-			// it retries as long the context does not timeouts.
+			// will fail to drain the tablet and FindWorkerTablet will return an error.
+			// The following works in an optimistic way, but in the case of a failure,
+			// it will retry as long the context does not timeout.
 			shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 			for {
 				select {

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -239,11 +239,11 @@ func (sdw *SplitDiffWorker) findTargets(ctx context.Context) error {
 	// find an appropriate tablet in the source shard
 	for _, ss := range sdw.shardInfo.SourceShards {
 		if ss.Uid == sdw.sourceUID {
-			// During an horizontal shard split, multiple workers could race to get
-			// a RDONLY tablet in the source shard. When this happen, one of the workers
-			// will fail to drain the tablet and FindWorkerTablet will return an error.
-			// The following works in an optimistic way, but in the case of a failure,
-			// it will retry as long the context does not timeout.
+			// During an horizontal shard split, multiple workers will race to get
+			// a RDONLY tablet in the source shard. When this happen, concurrent calls
+			// to FindWorkerTablet could attempt to set to DRAIN state the same tablet. Only
+			// one of these calls to FindWorkerTablet will succeed and the rest will fail.
+			// The following, makes sures we keep trying to find a worker tablet when this error occur.
 			shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 			for {
 				select {

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -127,8 +127,6 @@ func FindWorkerTablet(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrang
 		return nil, err
 	}
 
-	// We add the tag before calling ChangeSlaveType, so the destination
-	// vttablet reloads the worker URL when it reloads the tablet.
 	ourURL := servenv.ListeningURL.String()
 	wr.Logger().Infof("Adding tag[worker]=%v to tablet %v", ourURL, topoproto.TabletAliasString(tabletAlias))
 	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
@@ -150,8 +148,17 @@ func FindWorkerTablet(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrang
 	defer wrangler.RecordTabletTagAction(cleaner, tabletAlias, "worker", "")
 	defer wrangler.RecordTabletTagAction(cleaner, tabletAlias, "drain_reason", "")
 
-	// Record a clean-up action to take the tablet back to rdonly.
-	wrangler.RecordChangeSlaveTypeAction(cleaner, tabletAlias, topodatapb.TabletType_DRAINED, topodatapb.TabletType_RDONLY)
+	// Record a clean-up action to take the tablet back to tabletAlias.
+	wrangler.RecordChangeSlaveTypeAction(cleaner, tabletAlias, topodatapb.TabletType_DRAINED, tabletType)
+
+	// We refresh the destination vttablet reloads the worker URL when it reloads the tablet.
+	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
+	wr.RefreshTabletState(shortCtx, tabletAlias)
+	if err != nil {
+		return nil, err
+	}
+	cancel()
+
 	return tabletAlias, nil
 }
 

--- a/go/vt/workflow/resharding/horizontal_resharding_workflow.go
+++ b/go/vt/workflow/resharding/horizontal_resharding_workflow.go
@@ -252,8 +252,9 @@ func initCheckpointFromShards(keyspace string, vtworkers, sourceShards, destinat
 		return nil, fmt.Errorf("there are %v vtworkers, %v destination shards: the number should be same", len(vtworkers), len(destinationShards))
 	}
 
-	if minHealthyRdonlyTabletsVal, err := strconv.Atoi(minHealthyRdonlyTablets); err != nil || minHealthyRdonlyTabletsVal < 2 {
-		return nil, fmt.Errorf("there are not enough rdonly tablets in source shards. You need at least 2, it got: %v", minHealthyRdonlyTablets)
+	splitRatio := len(destinationShards) / len(sourceShards)
+	if minHealthyRdonlyTabletsVal, err := strconv.Atoi(minHealthyRdonlyTablets); err != nil || minHealthyRdonlyTabletsVal < splitRatio {
+		return nil, fmt.Errorf("there are not enough rdonly tablets in source shards. You need at least %v, it got: %v", splitRatio, minHealthyRdonlyTablets)
 	}
 
 	tasks := make(map[string]*workflowpb.Task)
@@ -284,7 +285,7 @@ func initCheckpointFromShards(keyspace string, vtworkers, sourceShards, destinat
 			"keyspace":          keyspace,
 			"destination_shard": shard,
 			"dest_tablet_type":  splitDiffDestTabletType,
-			"vtworker":          vtworkers[0],
+			"vtworker":          vtworkers[i],
 		}
 	})
 	initTasks(tasks, phaseMigrateRdonly, sourceShards, func(i int, shard string) map[string]string {

--- a/go/vt/workflow/resharding/horizontal_resharding_workflow.go
+++ b/go/vt/workflow/resharding/horizontal_resharding_workflow.go
@@ -248,8 +248,12 @@ func findSourceAndDestinationShards(ts *topo.Server, keyspace string) ([]string,
 }
 
 func initCheckpointFromShards(keyspace string, vtworkers, sourceShards, destinationShards []string, minHealthyRdonlyTablets, splitCmd, splitDiffDestTabletType string) (*workflowpb.WorkflowCheckpoint, error) {
-	if len(vtworkers) != len(sourceShards) {
-		return nil, fmt.Errorf("there are %v vtworkers, %v source shards: the number should be same", len(vtworkers), len(sourceShards))
+	if len(vtworkers) != len(destinationShards) {
+		return nil, fmt.Errorf("there are %v vtworkers, %v destination shards: the number should be same", len(vtworkers), len(destinationShards))
+	}
+
+	if minHealthyRdonlyTabletsVal, err := strconv.Atoi(minHealthyRdonlyTablets); err != nil || minHealthyRdonlyTabletsVal < 2 {
+		return nil, fmt.Errorf("there are not enough rdonly tablets in source shards. You need at least 2, it got: %v", minHealthyRdonlyTablets)
 	}
 
 	tasks := make(map[string]*workflowpb.Task)
@@ -382,7 +386,7 @@ func (hw *HorizontalReshardingWorkflow) runWorkflow() error {
 	}
 
 	diffTasks := hw.GetTasks(phaseDiff)
-	diffRunner := NewParallelRunner(hw.ctx, hw.rootUINode, hw.checkpointWriter, diffTasks, hw.runSplitDiff, Sequential, hw.enableApprovals)
+	diffRunner := NewParallelRunner(hw.ctx, hw.rootUINode, hw.checkpointWriter, diffTasks, hw.runSplitDiff, Parallel, hw.enableApprovals)
 	if err := diffRunner.Run(); err != nil {
 		return err
 	}

--- a/go/vt/workflow/resharding/horizontal_resharding_workflow_test.go
+++ b/go/vt/workflow/resharding/horizontal_resharding_workflow_test.go
@@ -66,7 +66,8 @@ func TestHorizontalResharding(t *testing.T) {
 	// Run the manager in the background.
 	wg, _, cancel := startManager(m)
 	// Create the workflow.
-	uuid, err := m.Create(ctx, horizontalReshardingFactoryName, []string{"-keyspace=" + testKeyspace, "-vtworkers=" + testVtworkers, "-enable_approvals=false"})
+	vtworkersParameter := testVtworkers + "," + testVtworkers
+	uuid, err := m.Create(ctx, horizontalReshardingFactoryName, []string{"-keyspace=" + testKeyspace, "-vtworkers=" + vtworkersParameter, "-enable_approvals=false", "-min_healthy_rdonly_tablets=2"})
 	if err != nil {
 		t.Fatalf("cannot create resharding workflow: %v", err)
 	}
@@ -101,7 +102,7 @@ func setupFakeVtworker(keyspace, vtworkers string) *fakevtworkerclient.FakeVtwor
 	flag.Set("vtworker_client_protocol", "fake")
 	fakeVtworkerClient := fakevtworkerclient.NewFakeVtworkerClient()
 	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"Reset"}, "", nil)
-	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"SplitClone", "--min_healthy_rdonly_tablets=1", keyspace + "/0"}, "", nil)
+	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"SplitClone", "--min_healthy_rdonly_tablets=2", keyspace + "/0"}, "", nil)
 	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"Reset"}, "", nil)
 	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"SplitDiff", "--min_healthy_rdonly_tablets=1", "--dest_tablet_type=RDONLY", keyspace + "/-80"}, "", nil)
 	fakeVtworkerClient.RegisterResultForAddr(vtworkers, []string{"Reset"}, "", nil)

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -161,6 +161,18 @@ func (wr *Wrangler) ChangeSlaveType(ctx context.Context, tabletAlias *topodatapb
 	return wr.tmc.ChangeType(ctx, ti.Tablet, tabletType)
 }
 
+// RefreshTabletState refreshes tablet state
+func (wr *Wrangler) RefreshTabletState(ctx context.Context, tabletAlias *topodatapb.TabletAlias) error {
+	// Load tablet to find endpoint, and keyspace and shard assignment.
+	ti, err := wr.ts.GetTablet(ctx, tabletAlias)
+	if err != nil {
+		return err
+	}
+
+	// and ask the tablet to refresh itself
+	return wr.tmc.RefreshState(ctx, ti.Tablet)
+}
+
 // ExecuteFetchAsDba executes a query remotely using the DBA pool
 func (wr *Wrangler) ExecuteFetchAsDba(ctx context.Context, tabletAlias *topodatapb.TabletAlias, query string, maxRows int, disableBinlogs bool, reloadSchema bool) (*querypb.QueryResult, error) {
 	ti, err := wr.ts.GetTablet(ctx, tabletAlias)

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -507,6 +507,12 @@ class TestTabletManager(unittest.TestCase):
     # implementation.)  The tablet will stay healthy, and the
     # query service is still running.
     utils.run_vtctl(['ChangeSlaveType', tablet_62044.tablet_alias, 'drained'])
+    # Trying to drain the same tablet again, should error
+    try:
+      utils.run_vtctl(['ChangeSlaveType', tablet_62044.tablet_alias, 'drained'])
+    except Exception as e:
+      s = str(e)
+      self.assertIn("already drained", s)
     utils.run_vtctl(['StopSlave', tablet_62044.tablet_alias])
     # Trigger healthcheck explicitly to avoid waiting for the next interval.
     utils.run_vtctl(['RunHealthCheck', tablet_62044.tablet_alias])


### PR DESCRIPTION
### Description

* The following PR changes `SplitDiff` tasks in a workflow to be `Parallel`. The change is for the most part straightforward, but it required some sort of coordination between the workers to not race when trying to choose a `RDONLY` tablet in the source shards. I addressed this by doing some optimistic locking and making `ChangeType` fail if a tablet is already drained. If the worker gets this error, it will try to find another `RDONLY` tablet.
* @demmer / @sougou  - We discussed that a better high level approach for this is to refactor `SplitDiff` to not require a destination shard as parameter, but rather work more like `SplitClone` and figure out by itself what to do. I think we should do that and I'll be opening an issue for that, but for now I think this is a good compromise and we get us unblock with parallel `SplitDiff` tasks in Workflows.

### Tests

* I added an integration test for the `ChangeType` change and updated some of the unit tests for Workflows to reflect the new validations.
* I verified this change in my local environment. 