### PR TITLE
[Sqlparser] SET TRANSACTION has special semantics

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -275,13 +275,14 @@ func ExtractSetValues(sql string) (keyValues map[SetKey]interface{}, scope strin
 	}
 	result := make(map[SetKey]interface{})
 	for _, expr := range setStmt.Exprs {
-		scope := SessionStr
+		scope := ImplicitStr
 		key := expr.Name.Lowered()
 		switch {
 		case strings.HasPrefix(key, "@@global."):
 			scope = GlobalStr
 			key = strings.TrimPrefix(key, "@@global.")
 		case strings.HasPrefix(key, "@@session."):
+			scope = SessionStr
 			key = strings.TrimPrefix(key, "@@session.")
 		case strings.HasPrefix(key, "@@"):
 			key = strings.TrimPrefix(key, "@@")

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -356,107 +356,120 @@ func TestExtractSetValues(t *testing.T) {
 		err: "invalid syntax: 1 + 1",
 	}, {
 		sql: "set transaction_mode='single'",
-		out: map[SetKey]interface{}{{Key: "transaction_mode", Scope: "session"}: "single"},
+		out: map[SetKey]interface{}{{Key: "transaction_mode", Scope: ImplicitStr}: "single"},
 	}, {
 		sql: "set autocommit=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: int64(1)},
 	}, {
 		sql: "set autocommit=true",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: int64(1)},
 	}, {
 		sql: "set autocommit=false",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(0)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: int64(0)},
 	}, {
 		sql: "set autocommit=on",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: "on"},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: "on"},
 	}, {
 		sql: "set autocommit=off",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: "off"},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: "off"},
 	}, {
 		sql: "set @@global.autocommit=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "global"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: GlobalStr}: int64(1)},
 	}, {
 		sql: "set @@global.autocommit=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "global"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: GlobalStr}: int64(1)},
 	}, {
 		sql: "set @@session.autocommit=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set @@session.`autocommit`=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set @@session.'autocommit'=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set @@session.\"autocommit\"=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set @@session.'\"autocommit'=1",
-		out: map[SetKey]interface{}{{Key: "\"autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "\"autocommit", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set @@session.`autocommit'`=1",
-		out: map[SetKey]interface{}{{Key: "autocommit'", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit'", Scope: SessionStr}: int64(1)},
 	}, {
 		sql: "set AUTOCOMMIT=1",
-		out: map[SetKey]interface{}{{Key: "autocommit", Scope: "session"}: int64(1)},
+		out: map[SetKey]interface{}{{Key: "autocommit", Scope: ImplicitStr}: int64(1)},
 	}, {
 		sql: "SET character_set_results = NULL",
-		out: map[SetKey]interface{}{{Key: "character_set_results", Scope: "session"}: nil},
+		out: map[SetKey]interface{}{{Key: "character_set_results", Scope: ImplicitStr}: nil},
 	}, {
 		sql: "SET foo = 0x1234",
 		err: "invalid value type: 0x1234",
 	}, {
 		sql: "SET names utf8",
-		out: map[SetKey]interface{}{{Key: "names", Scope: "session"}: "utf8"},
+		out: map[SetKey]interface{}{{Key: "names", Scope: ImplicitStr}: "utf8"},
 	}, {
 		sql: "SET names ascii collate ascii_bin",
-		out: map[SetKey]interface{}{{Key: "names", Scope: "session"}: "ascii"},
+		out: map[SetKey]interface{}{{Key: "names", Scope: ImplicitStr}: "ascii"},
 	}, {
 		sql: "SET charset default",
-		out: map[SetKey]interface{}{{Key: "charset", Scope: "session"}: "default"},
+		out: map[SetKey]interface{}{{Key: "charset", Scope: ImplicitStr}: "default"},
 	}, {
 		sql: "SET character set ascii",
-		out: map[SetKey]interface{}{{Key: "charset", Scope: "session"}: "ascii"},
+		out: map[SetKey]interface{}{{Key: "charset", Scope: ImplicitStr}: "ascii"},
 	}, {
 		sql:   "SET SESSION wait_timeout = 3600",
-		out:   map[SetKey]interface{}{{Key: "wait_timeout", Scope: "session"}: int64(3600)},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: "wait_timeout", Scope: ImplicitStr}: int64(3600)},
+		scope: SessionStr,
 	}, {
 		sql:   "SET GLOBAL wait_timeout = 3600",
-		out:   map[SetKey]interface{}{{Key: "wait_timeout", Scope: "session"}: int64(3600)},
-		scope: "global",
+		out:   map[SetKey]interface{}{{Key: "wait_timeout", Scope: ImplicitStr}: int64(3600)},
+		scope: GlobalStr,
 	}, {
 		sql:   "set session transaction isolation level repeatable read",
-		out:   map[SetKey]interface{}{{Key: "tx_isolation", Scope: "session"}: "repeatable read"},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: IsolationLevelRepeatableRead},
+		scope: SessionStr,
 	}, {
 		sql:   "set session transaction isolation level read committed",
-		out:   map[SetKey]interface{}{{Key: "tx_isolation", Scope: "session"}: "read committed"},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: IsolationLevelReadCommitted},
+		scope: SessionStr,
 	}, {
 		sql:   "set session transaction isolation level read uncommitted",
-		out:   map[SetKey]interface{}{{Key: "tx_isolation", Scope: "session"}: "read uncommitted"},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: IsolationLevelReadUncommitted},
+		scope: SessionStr,
 	}, {
 		sql:   "set session transaction isolation level serializable",
-		out:   map[SetKey]interface{}{{Key: "tx_isolation", Scope: "session"}: "serializable"},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: IsolationLevelSerializable},
+		scope: SessionStr,
+	}, {
+		sql: "set transaction isolation level serializable",
+		out: map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: IsolationLevelSerializable},
+	}, {
+		sql: "set transaction read only",
+		out: map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: TxReadOnly},
+	}, {
+		sql: "set transaction read write",
+		out: map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: TxReadWrite},
+	}, {
+		sql:   "set session transaction read write",
+		out:   map[SetKey]interface{}{{Key: TransactionStr, Scope: ImplicitStr}: TxReadWrite},
+		scope: SessionStr,
 	}, {
 		sql:   "set session tx_read_only = 0",
-		out:   map[SetKey]interface{}{{Key: "tx_read_only", Scope: "session"}: int64(0)},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: "tx_read_only", Scope: ImplicitStr}: int64(0)},
+		scope: SessionStr,
 	}, {
 		sql:   "set session tx_read_only = 1",
-		out:   map[SetKey]interface{}{{Key: "tx_read_only", Scope: "session"}: int64(1)},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: "tx_read_only", Scope: ImplicitStr}: int64(1)},
+		scope: SessionStr,
 	}, {
 		sql:   "set session sql_safe_updates = 0",
-		out:   map[SetKey]interface{}{{Key: "sql_safe_updates", Scope: "session"}: int64(0)},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: "sql_safe_updates", Scope: ImplicitStr}: int64(0)},
+		scope: SessionStr,
 	}, {
 		sql:   "set session sql_safe_updates = 1",
-		out:   map[SetKey]interface{}{{Key: "sql_safe_updates", Scope: "session"}: int64(1)},
-		scope: "session",
+		out:   map[SetKey]interface{}{{Key: "sql_safe_updates", Scope: ImplicitStr}: int64(1)},
+		scope: SessionStr,
 	}}
 	for _, tcase := range testcases {
 		out, _, err := ExtractSetValues(tcase.sql)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -619,8 +619,9 @@ type Set struct {
 
 // Set.Scope or Show.Scope
 const (
-	SessionStr = "session"
-	GlobalStr  = "global"
+	SessionStr  = "session"
+	GlobalStr   = "global"
+	ImplicitStr = ""
 )
 
 // Format formats the node.
@@ -3329,11 +3330,28 @@ type SetExpr struct {
 	Expr Expr
 }
 
+// SetExpr.Expr, for SET TRANSACTION ... or START TRANSACTION
+const (
+	// TransactionStr is the Name for a SET TRANSACTION statement
+	TransactionStr = "transaction"
+
+	IsolationLevelReadUncommitted = "isolation level read uncommitted"
+	IsolationLevelReadCommitted   = "isolation level read committed"
+	IsolationLevelRepeatableRead  = "isolation level repeatable read"
+	IsolationLevelSerializable    = "isolation level serializable"
+
+	TxReadOnly  = "read only"
+	TxReadWrite = "read write"
+)
+
 // Format formats the node.
 func (node *SetExpr) Format(buf *TrackedBuffer) {
 	// We don't have to backtick set variable names.
 	if node.Name.EqualString("charset") || node.Name.EqualString("names") {
 		buf.Myprintf("%s %v", node.Name.String(), node.Expr)
+	} else if node.Name.EqualString(TransactionStr) {
+		sqlVal := node.Expr.(*SQLVal)
+		buf.Myprintf("%s %s", node.Name.String(), strings.ToLower(string(sqlVal.Val)))
 	} else {
 		buf.Myprintf("%s = %v", node.Name.String(), node.Expr)
 	}

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -715,29 +715,23 @@ var (
 	}, {
 		input: "set /* mixed list */ a = 3, names 'utf8', charset 'ascii', b = 4",
 	}, {
-		input:  "set session transaction isolation level repeatable read",
-		output: "set session tx_isolation = 'repeatable read'",
+		input: "set session transaction isolation level repeatable read",
 	}, {
-		input:  "set global transaction isolation level repeatable read",
-		output: "set global tx_isolation = 'repeatable read'",
+		input: "set transaction isolation level repeatable read",
 	}, {
-		input:  "set transaction isolation level repeatable read",
-		output: "set tx_isolation = 'repeatable read'",
+		input: "set global transaction isolation level repeatable read",
 	}, {
-		input:  "set transaction isolation level read committed",
-		output: "set tx_isolation = 'read committed'",
+		input: "set transaction isolation level repeatable read",
 	}, {
-		input:  "set transaction isolation level read uncommitted",
-		output: "set tx_isolation = 'read uncommitted'",
+		input: "set transaction isolation level read committed",
 	}, {
-		input:  "set transaction isolation level serializable",
-		output: "set tx_isolation = 'serializable'",
+		input: "set transaction isolation level read uncommitted",
 	}, {
-		input:  "set transaction read write",
-		output: "set tx_read_only = 0",
+		input: "set transaction isolation level serializable",
 	}, {
-		input:  "set transaction read only",
-		output: "set tx_read_only = 1",
+		input: "set transaction read write",
+	}, {
+		input: "set transaction read only",
 	}, {
 		input: "set tx_read_only = 1",
 	}, {
@@ -1639,6 +1633,9 @@ func TestConvert(t *testing.T) {
 	}, {
 		input:  "/* a comment */",
 		output: "empty statement",
+	}, {
+		input:  "set transaction isolation level 12345",
+		output: "syntax error at position 38 near '12345'",
 	}}
 
 	for _, tcase := range invalidSQL {

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -2783,35 +2783,35 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:308
+		//line sql.y:309
 		{
 			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:313
+		//line sql.y:314
 		{
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:314
+		//line sql.y:315
 		{
 		}
 	case 4:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:318
+		//line sql.y:319
 		{
 			yyVAL.statement = yyDollar[1].selStmt
 		}
 	case 22:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:339
+		//line sql.y:340
 		{
 			setParseTree(yylex, nil)
 		}
 	case 23:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:345
+		//line sql.y:346
 		{
 			sel := yyDollar[1].selStmt.(*Select)
 			sel.OrderBy = yyDollar[2].orderBy
@@ -2821,55 +2821,55 @@ yydefault:
 		}
 	case 24:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:353
+		//line sql.y:354
 		{
 			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt, OrderBy: yyDollar[4].orderBy, Limit: yyDollar[5].limit, Lock: yyDollar[6].str}
 		}
 	case 25:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:357
+		//line sql.y:358
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, SelectExprs: SelectExprs{Nextval{Expr: yyDollar[5].expr}}, From: TableExprs{&AliasedTableExpr{Expr: yyDollar[7].tableName}}}
 		}
 	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:363
+		//line sql.y:364
 		{
 			yyVAL.statement = &Stream{Comments: Comments(yyDollar[2].bytes2), SelectExpr: yyDollar[3].selectExpr, Table: yyDollar[5].tableName}
 		}
 	case 27:
 		yyDollar = yyS[yypt-10 : yypt+1]
-		//line sql.y:370
+		//line sql.y:371
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, Distinct: yyDollar[4].str, Hints: yyDollar[5].str, SelectExprs: yyDollar[6].selectExprs, From: yyDollar[7].tableExprs, Where: NewWhere(WhereStr, yyDollar[8].expr), GroupBy: GroupBy(yyDollar[9].exprs), Having: NewWhere(HavingStr, yyDollar[10].expr)}
 		}
 	case 28:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:376
+		//line sql.y:377
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 29:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:380
+		//line sql.y:381
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:386
+		//line sql.y:387
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:390
+		//line sql.y:391
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 32:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:397
+		//line sql.y:398
 		{
 			// insert_data returns a *Insert pre-filled with Columns & Values
 			ins := yyDollar[6].ins
@@ -2883,7 +2883,7 @@ yydefault:
 		}
 	case 33:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:409
+		//line sql.y:410
 		{
 			cols := make(Columns, 0, len(yyDollar[7].updateExprs))
 			vals := make(ValTuple, 0, len(yyDollar[8].updateExprs))
@@ -2895,174 +2895,174 @@ yydefault:
 		}
 	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:421
+		//line sql.y:422
 		{
 			yyVAL.str = InsertStr
 		}
 	case 35:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:425
+		//line sql.y:426
 		{
 			yyVAL.str = ReplaceStr
 		}
 	case 36:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:431
+		//line sql.y:432
 		{
 			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), TableExprs: yyDollar[3].tableExprs, Exprs: yyDollar[5].updateExprs, Where: NewWhere(WhereStr, yyDollar[6].expr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 37:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:437
+		//line sql.y:438
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), TableExprs: TableExprs{&AliasedTableExpr{Expr: yyDollar[4].tableName}}, Partitions: yyDollar[5].partitions, Where: NewWhere(WhereStr, yyDollar[6].expr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 38:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:441
+		//line sql.y:442
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[4].tableNames, TableExprs: yyDollar[6].tableExprs, Where: NewWhere(WhereStr, yyDollar[7].expr)}
 		}
 	case 39:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:445
+		//line sql.y:446
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[3].tableNames, TableExprs: yyDollar[5].tableExprs, Where: NewWhere(WhereStr, yyDollar[6].expr)}
 		}
 	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:450
+		//line sql.y:451
 		{
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:451
+		//line sql.y:452
 		{
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:455
+		//line sql.y:456
 		{
 			yyVAL.tableNames = TableNames{yyDollar[1].tableName}
 		}
 	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:459
+		//line sql.y:460
 		{
 			yyVAL.tableNames = append(yyVAL.tableNames, yyDollar[3].tableName)
 		}
 	case 44:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:464
+		//line sql.y:465
 		{
 			yyVAL.partitions = nil
 		}
 	case 45:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:468
+		//line sql.y:469
 		{
 			yyVAL.partitions = yyDollar[3].partitions
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:474
+		//line sql.y:475
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].setExprs}
 		}
 	case 47:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:478
+		//line sql.y:479
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Scope: yyDollar[3].str, Exprs: yyDollar[4].setExprs}
 		}
 	case 48:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:482
+		//line sql.y:483
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Scope: yyDollar[3].str, Exprs: yyDollar[5].setExprs}
 		}
 	case 49:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:486
+		//line sql.y:487
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[4].setExprs}
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:492
+		//line sql.y:493
 		{
 			yyVAL.setExprs = SetExprs{yyDollar[1].setExpr}
 		}
 	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:496
+		//line sql.y:497
 		{
 			yyVAL.setExprs = append(yyVAL.setExprs, yyDollar[3].setExpr)
 		}
 	case 52:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:502
+		//line sql.y:503
 		{
-			yyVAL.setExpr = yyDollar[3].setExpr
+			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(yyDollar[3].str))}
 		}
 	case 53:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:506
+		//line sql.y:507
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_read_only"), Expr: NewIntVal([]byte("0"))}
+			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadWrite))}
 		}
 	case 54:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:510
+		//line sql.y:511
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_read_only"), Expr: NewIntVal([]byte("1"))}
+			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadOnly))}
 		}
 	case 55:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:516
+		//line sql.y:517
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("repeatable read"))}
+			yyVAL.str = IsolationLevelRepeatableRead
 		}
 	case 56:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:520
+		//line sql.y:521
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("read committed"))}
+			yyVAL.str = IsolationLevelReadCommitted
 		}
 	case 57:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:524
+		//line sql.y:525
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("read uncommitted"))}
+			yyVAL.str = IsolationLevelReadUncommitted
 		}
 	case 58:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:528
+		//line sql.y:529
 		{
-			yyVAL.setExpr = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("serializable"))}
+			yyVAL.str = IsolationLevelSerializable
 		}
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:534
+		//line sql.y:535
 		{
 			yyVAL.str = SessionStr
 		}
 	case 60:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:538
+		//line sql.y:539
 		{
 			yyVAL.str = GlobalStr
 		}
 	case 61:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:544
+		//line sql.y:545
 		{
 			yyDollar[1].ddl.TableSpec = yyDollar[2].TableSpec
 			yyVAL.statement = yyDollar[1].ddl
 		}
 	case 62:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:549
+		//line sql.y:550
 		{
 			// Create table [name] like [name]
 			yyDollar[1].ddl.OptLike = yyDollar[2].optLike
@@ -3070,26 +3070,26 @@ yydefault:
 		}
 	case 63:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:555
+		//line sql.y:556
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[7].tableName, NewName: yyDollar[7].tableName}
 		}
 	case 64:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:560
+		//line sql.y:561
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, NewName: yyDollar[3].tableName.ToViewName()}
 		}
 	case 65:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:564
+		//line sql.y:565
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, NewName: yyDollar[5].tableName.ToViewName()}
 		}
 	case 66:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:568
+		//line sql.y:569
 		{
 			yyVAL.statement = &DDL{Action: CreateVindexStr, VindexSpec: &VindexSpec{
 				Name:   yyDollar[3].colIdent,
@@ -3099,120 +3099,120 @@ yydefault:
 		}
 	case 67:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:576
+		//line sql.y:577
 		{
 			yyVAL.statement = &DBDDL{Action: CreateStr, DBName: string(yyDollar[4].bytes)}
 		}
 	case 68:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:580
+		//line sql.y:581
 		{
 			yyVAL.statement = &DBDDL{Action: CreateStr, DBName: string(yyDollar[4].bytes)}
 		}
 	case 69:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:585
+		//line sql.y:586
 		{
 			yyVAL.colIdent = NewColIdent("")
 		}
 	case 70:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:589
+		//line sql.y:590
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 71:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:595
+		//line sql.y:596
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 72:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:600
+		//line sql.y:601
 		{
 			var v []VindexParam
 			yyVAL.vindexParams = v
 		}
 	case 73:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:605
+		//line sql.y:606
 		{
 			yyVAL.vindexParams = yyDollar[2].vindexParams
 		}
 	case 74:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:611
+		//line sql.y:612
 		{
 			yyVAL.vindexParams = make([]VindexParam, 0, 4)
 			yyVAL.vindexParams = append(yyVAL.vindexParams, yyDollar[1].vindexParam)
 		}
 	case 75:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:616
+		//line sql.y:617
 		{
 			yyVAL.vindexParams = append(yyVAL.vindexParams, yyDollar[3].vindexParam)
 		}
 	case 76:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:622
+		//line sql.y:623
 		{
 			yyVAL.vindexParam = VindexParam{Key: yyDollar[1].colIdent, Val: yyDollar[3].str}
 		}
 	case 77:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:628
+		//line sql.y:629
 		{
 			yyVAL.ddl = &DDL{Action: CreateStr, NewName: yyDollar[4].tableName}
 			setDDL(yylex, yyVAL.ddl)
 		}
 	case 78:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:635
+		//line sql.y:636
 		{
 			yyVAL.TableSpec = yyDollar[2].TableSpec
 			yyVAL.TableSpec.Options = yyDollar[4].str
 		}
 	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:642
+		//line sql.y:643
 		{
 			yyVAL.optLike = &OptLike{LikeTable: yyDollar[2].tableName}
 		}
 	case 80:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:646
+		//line sql.y:647
 		{
 			yyVAL.optLike = &OptLike{LikeTable: yyDollar[3].tableName}
 		}
 	case 81:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:652
+		//line sql.y:653
 		{
 			yyVAL.TableSpec = &TableSpec{}
 			yyVAL.TableSpec.AddColumn(yyDollar[1].columnDefinition)
 		}
 	case 82:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:657
+		//line sql.y:658
 		{
 			yyVAL.TableSpec.AddColumn(yyDollar[3].columnDefinition)
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:661
+		//line sql.y:662
 		{
 			yyVAL.TableSpec.AddIndex(yyDollar[3].indexDefinition)
 		}
 	case 84:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:665
+		//line sql.y:666
 		{
 			yyVAL.TableSpec.AddConstraint(yyDollar[3].constraintDefinition)
 		}
 	case 85:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:671
+		//line sql.y:672
 		{
 			yyDollar[2].columnType.NotNull = yyDollar[3].boolVal
 			yyDollar[2].columnType.Default = yyDollar[4].optVal
@@ -3224,7 +3224,7 @@ yydefault:
 		}
 	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:682
+		//line sql.y:683
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 			yyVAL.columnType.Unsigned = yyDollar[2].boolVal
@@ -3232,62 +3232,62 @@ yydefault:
 		}
 	case 90:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:693
+		//line sql.y:694
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 			yyVAL.columnType.Length = yyDollar[2].optVal
 		}
 	case 91:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:698
+		//line sql.y:699
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 		}
 	case 92:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:704
+		//line sql.y:705
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 93:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:708
+		//line sql.y:709
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 94:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:712
+		//line sql.y:713
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 95:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:716
+		//line sql.y:717
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 96:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:720
+		//line sql.y:721
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 97:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:724
+		//line sql.y:725
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 98:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:728
+		//line sql.y:729
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 99:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:734
+		//line sql.y:735
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -3295,7 +3295,7 @@ yydefault:
 		}
 	case 100:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:740
+		//line sql.y:741
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -3303,7 +3303,7 @@ yydefault:
 		}
 	case 101:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:746
+		//line sql.y:747
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -3311,7 +3311,7 @@ yydefault:
 		}
 	case 102:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:752
+		//line sql.y:753
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -3319,7 +3319,7 @@ yydefault:
 		}
 	case 103:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:758
+		//line sql.y:759
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -3327,206 +3327,206 @@ yydefault:
 		}
 	case 104:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:766
+		//line sql.y:767
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 105:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:770
+		//line sql.y:771
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 106:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:774
+		//line sql.y:775
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 107:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:778
+		//line sql.y:779
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 108:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:782
+		//line sql.y:783
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 109:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:788
+		//line sql.y:789
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal, Charset: yyDollar[3].str, Collate: yyDollar[4].str}
 		}
 	case 110:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:792
+		//line sql.y:793
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal, Charset: yyDollar[3].str, Collate: yyDollar[4].str}
 		}
 	case 111:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:796
+		//line sql.y:797
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 112:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:800
+		//line sql.y:801
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 113:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:804
+		//line sql.y:805
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 114:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:808
+		//line sql.y:809
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 115:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:812
+		//line sql.y:813
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 116:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:816
+		//line sql.y:817
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 117:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:820
+		//line sql.y:821
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 118:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:824
+		//line sql.y:825
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 119:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:828
+		//line sql.y:829
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 120:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:832
+		//line sql.y:833
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 121:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:836
+		//line sql.y:837
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 122:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:840
+		//line sql.y:841
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, Collate: yyDollar[6].str}
 		}
 	case 123:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:845
+		//line sql.y:846
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, Collate: yyDollar[6].str}
 		}
 	case 124:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:851
+		//line sql.y:852
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 125:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:855
+		//line sql.y:856
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 126:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:859
+		//line sql.y:860
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 127:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:863
+		//line sql.y:864
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 128:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:867
+		//line sql.y:868
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 129:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:871
+		//line sql.y:872
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 130:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:875
+		//line sql.y:876
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 131:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:879
+		//line sql.y:880
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 132:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:885
+		//line sql.y:886
 		{
 			yyVAL.strs = make([]string, 0, 4)
 			yyVAL.strs = append(yyVAL.strs, "'"+string(yyDollar[1].bytes)+"'")
 		}
 	case 133:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:890
+		//line sql.y:891
 		{
 			yyVAL.strs = append(yyDollar[1].strs, "'"+string(yyDollar[3].bytes)+"'")
 		}
 	case 134:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:895
+		//line sql.y:896
 		{
 			yyVAL.optVal = nil
 		}
 	case 135:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:899
+		//line sql.y:900
 		{
 			yyVAL.optVal = NewIntVal(yyDollar[2].bytes)
 		}
 	case 136:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:904
+		//line sql.y:905
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{}
 		}
 	case 137:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:908
+		//line sql.y:909
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -3535,13 +3535,13 @@ yydefault:
 		}
 	case 138:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:916
+		//line sql.y:917
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{}
 		}
 	case 139:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:920
+		//line sql.y:921
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -3549,7 +3549,7 @@ yydefault:
 		}
 	case 140:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:926
+		//line sql.y:927
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -3558,398 +3558,398 @@ yydefault:
 		}
 	case 141:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:934
+		//line sql.y:935
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 142:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:938
+		//line sql.y:939
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 143:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:943
+		//line sql.y:944
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 144:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:947
+		//line sql.y:948
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 145:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:953
+		//line sql.y:954
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 146:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:957
+		//line sql.y:958
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 147:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:961
+		//line sql.y:962
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 148:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:966
+		//line sql.y:967
 		{
 			yyVAL.optVal = nil
 		}
 	case 149:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:970
+		//line sql.y:971
 		{
 			yyVAL.optVal = NewStrVal(yyDollar[2].bytes)
 		}
 	case 150:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:974
+		//line sql.y:975
 		{
 			yyVAL.optVal = NewIntVal(yyDollar[2].bytes)
 		}
 	case 151:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:978
+		//line sql.y:979
 		{
 			yyVAL.optVal = NewFloatVal(yyDollar[2].bytes)
 		}
 	case 152:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:982
+		//line sql.y:983
 		{
 			yyVAL.optVal = NewValArg(yyDollar[2].bytes)
 		}
 	case 153:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:986
+		//line sql.y:987
 		{
 			yyVAL.optVal = NewValArg(yyDollar[2].bytes)
 		}
 	case 154:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:990
+		//line sql.y:991
 		{
 			yyVAL.optVal = NewBitVal(yyDollar[2].bytes)
 		}
 	case 155:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:995
+		//line sql.y:996
 		{
 			yyVAL.optVal = nil
 		}
 	case 156:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:999
+		//line sql.y:1000
 		{
 			yyVAL.optVal = NewValArg(yyDollar[3].bytes)
 		}
 	case 157:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1004
+		//line sql.y:1005
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 158:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1008
+		//line sql.y:1009
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 159:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1013
+		//line sql.y:1014
 		{
 			yyVAL.str = ""
 		}
 	case 160:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1017
+		//line sql.y:1018
 		{
 			yyVAL.str = string(yyDollar[3].bytes)
 		}
 	case 161:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1021
+		//line sql.y:1022
 		{
 			yyVAL.str = string(yyDollar[3].bytes)
 		}
 	case 162:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1026
+		//line sql.y:1027
 		{
 			yyVAL.str = ""
 		}
 	case 163:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1030
+		//line sql.y:1031
 		{
 			yyVAL.str = string(yyDollar[2].bytes)
 		}
 	case 164:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1034
+		//line sql.y:1035
 		{
 			yyVAL.str = string(yyDollar[2].bytes)
 		}
 	case 165:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1039
+		//line sql.y:1040
 		{
 			yyVAL.colKeyOpt = colKeyNone
 		}
 	case 166:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1043
+		//line sql.y:1044
 		{
 			yyVAL.colKeyOpt = colKeyPrimary
 		}
 	case 167:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1047
+		//line sql.y:1048
 		{
 			yyVAL.colKeyOpt = colKey
 		}
 	case 168:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1051
+		//line sql.y:1052
 		{
 			yyVAL.colKeyOpt = colKeyUniqueKey
 		}
 	case 169:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1055
+		//line sql.y:1056
 		{
 			yyVAL.colKeyOpt = colKeyUnique
 		}
 	case 170:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1060
+		//line sql.y:1061
 		{
 			yyVAL.optVal = nil
 		}
 	case 171:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1064
+		//line sql.y:1065
 		{
 			yyVAL.optVal = NewStrVal(yyDollar[2].bytes)
 		}
 	case 172:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1070
+		//line sql.y:1071
 		{
 			yyVAL.indexDefinition = &IndexDefinition{Info: yyDollar[1].indexInfo, Columns: yyDollar[3].indexColumns, Options: yyDollar[5].indexOptions}
 		}
 	case 173:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1074
+		//line sql.y:1075
 		{
 			yyVAL.indexDefinition = &IndexDefinition{Info: yyDollar[1].indexInfo, Columns: yyDollar[3].indexColumns}
 		}
 	case 174:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1080
+		//line sql.y:1081
 		{
 			yyVAL.indexOptions = []*IndexOption{yyDollar[1].indexOption}
 		}
 	case 175:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1084
+		//line sql.y:1085
 		{
 			yyVAL.indexOptions = append(yyVAL.indexOptions, yyDollar[2].indexOption)
 		}
 	case 176:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1090
+		//line sql.y:1091
 		{
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Using: string(yyDollar[2].bytes)}
 		}
 	case 177:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1094
+		//line sql.y:1095
 		{
 			// should not be string
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Value: NewIntVal(yyDollar[3].bytes)}
 		}
 	case 178:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1099
+		//line sql.y:1100
 		{
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Value: NewStrVal(yyDollar[2].bytes)}
 		}
 	case 179:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1105
+		//line sql.y:1106
 		{
 			yyVAL.str = ""
 		}
 	case 180:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1109
+		//line sql.y:1110
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 181:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1115
+		//line sql.y:1116
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].bytes), Name: NewColIdent("PRIMARY"), Primary: true, Unique: true}
 		}
 	case 182:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1119
+		//line sql.y:1120
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].str), Name: NewColIdent(string(yyDollar[3].bytes)), Spatial: true, Unique: false}
 		}
 	case 183:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1123
+		//line sql.y:1124
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].str), Name: NewColIdent(string(yyDollar[3].bytes)), Unique: true}
 		}
 	case 184:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1127
+		//line sql.y:1128
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes), Name: NewColIdent(string(yyDollar[2].bytes)), Unique: true}
 		}
 	case 185:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1131
+		//line sql.y:1132
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].str), Name: NewColIdent(string(yyDollar[2].bytes)), Unique: false}
 		}
 	case 186:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1137
+		//line sql.y:1138
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 187:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1141
+		//line sql.y:1142
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 188:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1147
+		//line sql.y:1148
 		{
 			yyVAL.indexColumns = []*IndexColumn{yyDollar[1].indexColumn}
 		}
 	case 189:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1151
+		//line sql.y:1152
 		{
 			yyVAL.indexColumns = append(yyVAL.indexColumns, yyDollar[3].indexColumn)
 		}
 	case 190:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1157
+		//line sql.y:1158
 		{
 			yyVAL.indexColumn = &IndexColumn{Column: yyDollar[1].colIdent, Length: yyDollar[2].optVal}
 		}
 	case 191:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1163
+		//line sql.y:1164
 		{
 			yyVAL.constraintDefinition = &ConstraintDefinition{Name: string(yyDollar[2].bytes), Details: yyDollar[3].constraintInfo}
 		}
 	case 192:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1167
+		//line sql.y:1168
 		{
 			yyVAL.constraintDefinition = &ConstraintDefinition{Details: yyDollar[1].constraintInfo}
 		}
 	case 193:
 		yyDollar = yyS[yypt-10 : yypt+1]
-		//line sql.y:1174
+		//line sql.y:1175
 		{
 			yyVAL.constraintInfo = &ForeignKeyDefinition{Source: yyDollar[4].columns, ReferencedTable: yyDollar[7].tableName, ReferencedColumns: yyDollar[9].columns}
 		}
 	case 194:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1179
+		//line sql.y:1180
 		{
 			yyVAL.str = ""
 		}
 	case 195:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1183
+		//line sql.y:1184
 		{
 			yyVAL.str = " " + string(yyDollar[1].str)
 		}
 	case 196:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1187
+		//line sql.y:1188
 		{
 			yyVAL.str = string(yyDollar[1].str) + ", " + string(yyDollar[3].str)
 		}
 	case 197:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1195
+		//line sql.y:1196
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 198:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1199
+		//line sql.y:1200
 		{
 			yyVAL.str = yyDollar[1].str + " " + yyDollar[2].str
 		}
 	case 199:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1203
+		//line sql.y:1204
 		{
 			yyVAL.str = yyDollar[1].str + "=" + yyDollar[3].str
 		}
 	case 200:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1209
+		//line sql.y:1210
 		{
 			yyVAL.str = yyDollar[1].colIdent.String()
 		}
 	case 201:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1213
+		//line sql.y:1214
 		{
 			yyVAL.str = "'" + string(yyDollar[1].bytes) + "'"
 		}
 	case 202:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1217
+		//line sql.y:1218
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 203:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:1223
+		//line sql.y:1224
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 204:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1227
+		//line sql.y:1228
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 205:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1231
+		//line sql.y:1232
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 206:
 		yyDollar = yyS[yypt-12 : yypt+1]
-		//line sql.y:1235
+		//line sql.y:1236
 		{
 			yyVAL.statement = &DDL{
 				Action: AddColVindexStr,
@@ -3964,7 +3964,7 @@ yydefault:
 		}
 	case 207:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1248
+		//line sql.y:1249
 		{
 			yyVAL.statement = &DDL{
 				Action: DropColVindexStr,
@@ -3976,69 +3976,69 @@ yydefault:
 		}
 	case 208:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1258
+		//line sql.y:1259
 		{
 			// Change this to a rename statement
 			yyVAL.statement = &DDL{Action: RenameStr, Table: yyDollar[4].tableName, NewName: yyDollar[7].tableName}
 		}
 	case 209:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1263
+		//line sql.y:1264
 		{
 			// Rename an index can just be an alter
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 210:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1268
+		//line sql.y:1269
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[3].tableName.ToViewName(), NewName: yyDollar[3].tableName.ToViewName()}
 		}
 	case 211:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1272
+		//line sql.y:1273
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, PartitionSpec: yyDollar[5].partSpec}
 		}
 	case 223:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1291
+		//line sql.y:1292
 		{
 			yyVAL.partSpec = &PartitionSpec{Action: ReorganizeStr, Name: yyDollar[3].colIdent, Definitions: yyDollar[6].partDefs}
 		}
 	case 224:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1297
+		//line sql.y:1298
 		{
 			yyVAL.partDefs = []*PartitionDefinition{yyDollar[1].partDef}
 		}
 	case 225:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1301
+		//line sql.y:1302
 		{
 			yyVAL.partDefs = append(yyDollar[1].partDefs, yyDollar[3].partDef)
 		}
 	case 226:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:1307
+		//line sql.y:1308
 		{
 			yyVAL.partDef = &PartitionDefinition{Name: yyDollar[2].colIdent, Limit: yyDollar[7].expr}
 		}
 	case 227:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:1311
+		//line sql.y:1312
 		{
 			yyVAL.partDef = &PartitionDefinition{Name: yyDollar[2].colIdent, Maxvalue: true}
 		}
 	case 228:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1317
+		//line sql.y:1318
 		{
 			yyVAL.statement = &DDL{Action: RenameStr, Table: yyDollar[3].tableName, NewName: yyDollar[5].tableName}
 		}
 	case 229:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1323
+		//line sql.y:1324
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -4048,14 +4048,14 @@ yydefault:
 		}
 	case 230:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:1331
+		//line sql.y:1332
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[5].tableName, NewName: yyDollar[5].tableName}
 		}
 	case 231:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1336
+		//line sql.y:1337
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -4065,128 +4065,128 @@ yydefault:
 		}
 	case 232:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1344
+		//line sql.y:1345
 		{
 			yyVAL.statement = &DBDDL{Action: DropStr, DBName: string(yyDollar[4].bytes)}
 		}
 	case 233:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1348
+		//line sql.y:1349
 		{
 			yyVAL.statement = &DBDDL{Action: DropStr, DBName: string(yyDollar[4].bytes)}
 		}
 	case 234:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1354
+		//line sql.y:1355
 		{
 			yyVAL.statement = &DDL{Action: TruncateStr, Table: yyDollar[3].tableName}
 		}
 	case 235:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1358
+		//line sql.y:1359
 		{
 			yyVAL.statement = &DDL{Action: TruncateStr, Table: yyDollar[2].tableName}
 		}
 	case 236:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1363
+		//line sql.y:1364
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[3].tableName, NewName: yyDollar[3].tableName}
 		}
 	case 237:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1369
+		//line sql.y:1370
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 238:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1373
+		//line sql.y:1374
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 239:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1377
+		//line sql.y:1378
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 240:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1382
+		//line sql.y:1383
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 241:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1386
+		//line sql.y:1387
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 242:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1390
+		//line sql.y:1391
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 243:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1394
+		//line sql.y:1395
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 244:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1398
+		//line sql.y:1399
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 245:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1402
+		//line sql.y:1403
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 246:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1406
+		//line sql.y:1407
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 247:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1410
+		//line sql.y:1411
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 248:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1414
+		//line sql.y:1415
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 249:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1418
+		//line sql.y:1419
 		{
 			yyVAL.statement = &Show{Scope: yyDollar[2].str, Type: string(yyDollar[3].bytes)}
 		}
 	case 250:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1422
+		//line sql.y:1423
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 251:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1426
+		//line sql.y:1427
 		{
 			showTablesOpt := &ShowTablesOpt{Full: yyDollar[2].str, DbName: yyDollar[6].str, Filter: yyDollar[7].showFilter}
 			yyVAL.statement = &Show{Type: string(yyDollar[3].bytes), ShowTablesOpt: showTablesOpt, OnTable: yyDollar[5].tableName}
 		}
 	case 252:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1431
+		//line sql.y:1432
 		{
 			// this is ugly, but I couldn't find a better way for now
 			if yyDollar[3].str == "processlist" {
@@ -4198,614 +4198,614 @@ yydefault:
 		}
 	case 253:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1441
+		//line sql.y:1442
 		{
 			yyVAL.statement = &Show{Scope: yyDollar[2].str, Type: string(yyDollar[3].bytes)}
 		}
 	case 254:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1445
+		//line sql.y:1446
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 255:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1449
+		//line sql.y:1450
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 256:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1453
+		//line sql.y:1454
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes), ShowCollationFilterOpt: &yyDollar[4].expr}
 		}
 	case 257:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1457
+		//line sql.y:1458
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes), OnTable: yyDollar[4].tableName}
 		}
 	case 258:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1461
+		//line sql.y:1462
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 259:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1465
+		//line sql.y:1466
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 260:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1469
+		//line sql.y:1470
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 261:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1473
+		//line sql.y:1474
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 262:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1477
+		//line sql.y:1478
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 263:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1487
+		//line sql.y:1488
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 264:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1493
+		//line sql.y:1494
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 265:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1497
+		//line sql.y:1498
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 266:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1503
+		//line sql.y:1504
 		{
 			yyVAL.str = ""
 		}
 	case 267:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1507
+		//line sql.y:1508
 		{
 			yyVAL.str = "full "
 		}
 	case 268:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1513
+		//line sql.y:1514
 		{
 			yyVAL.str = ""
 		}
 	case 269:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1517
+		//line sql.y:1518
 		{
 			yyVAL.str = yyDollar[2].tableIdent.v
 		}
 	case 270:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1521
+		//line sql.y:1522
 		{
 			yyVAL.str = yyDollar[2].tableIdent.v
 		}
 	case 271:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1527
+		//line sql.y:1528
 		{
 			yyVAL.showFilter = nil
 		}
 	case 272:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1531
+		//line sql.y:1532
 		{
 			yyVAL.showFilter = &ShowFilter{Like: string(yyDollar[2].bytes)}
 		}
 	case 273:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1535
+		//line sql.y:1536
 		{
 			yyVAL.showFilter = &ShowFilter{Filter: yyDollar[2].expr}
 		}
 	case 274:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1541
+		//line sql.y:1542
 		{
 			yyVAL.str = ""
 		}
 	case 275:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1545
+		//line sql.y:1546
 		{
 			yyVAL.str = SessionStr
 		}
 	case 276:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1549
+		//line sql.y:1550
 		{
 			yyVAL.str = GlobalStr
 		}
 	case 277:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1555
+		//line sql.y:1556
 		{
 			yyVAL.statement = &Use{DBName: yyDollar[2].tableIdent}
 		}
 	case 278:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1559
+		//line sql.y:1560
 		{
 			yyVAL.statement = &Use{DBName: TableIdent{v: ""}}
 		}
 	case 279:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1565
+		//line sql.y:1566
 		{
 			yyVAL.statement = &Begin{}
 		}
 	case 280:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1569
+		//line sql.y:1570
 		{
 			yyVAL.statement = &Begin{}
 		}
 	case 281:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1575
+		//line sql.y:1576
 		{
 			yyVAL.statement = &Commit{}
 		}
 	case 282:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1581
+		//line sql.y:1582
 		{
 			yyVAL.statement = &Rollback{}
 		}
 	case 283:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1587
+		//line sql.y:1588
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 284:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1591
+		//line sql.y:1592
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 285:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1595
+		//line sql.y:1596
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 286:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1599
+		//line sql.y:1600
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 287:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1603
+		//line sql.y:1604
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 288:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1607
+		//line sql.y:1608
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 289:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1611
+		//line sql.y:1612
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 290:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1616
+		//line sql.y:1617
 		{
 			setAllowComments(yylex, true)
 		}
 	case 291:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1620
+		//line sql.y:1621
 		{
 			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 292:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1626
+		//line sql.y:1627
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 293:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1630
+		//line sql.y:1631
 		{
 			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 294:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1636
+		//line sql.y:1637
 		{
 			yyVAL.str = UnionStr
 		}
 	case 295:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1640
+		//line sql.y:1641
 		{
 			yyVAL.str = UnionAllStr
 		}
 	case 296:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1644
+		//line sql.y:1645
 		{
 			yyVAL.str = UnionDistinctStr
 		}
 	case 297:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1649
+		//line sql.y:1650
 		{
 			yyVAL.str = ""
 		}
 	case 298:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1653
+		//line sql.y:1654
 		{
 			yyVAL.str = SQLNoCacheStr
 		}
 	case 299:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1657
+		//line sql.y:1658
 		{
 			yyVAL.str = SQLCacheStr
 		}
 	case 300:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1662
+		//line sql.y:1663
 		{
 			yyVAL.str = ""
 		}
 	case 301:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1666
+		//line sql.y:1667
 		{
 			yyVAL.str = DistinctStr
 		}
 	case 302:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1671
+		//line sql.y:1672
 		{
 			yyVAL.str = ""
 		}
 	case 303:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1675
+		//line sql.y:1676
 		{
 			yyVAL.str = StraightJoinHint
 		}
 	case 304:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1680
+		//line sql.y:1681
 		{
 			yyVAL.selectExprs = nil
 		}
 	case 305:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1684
+		//line sql.y:1685
 		{
 			yyVAL.selectExprs = yyDollar[1].selectExprs
 		}
 	case 306:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1690
+		//line sql.y:1691
 		{
 			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 307:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1694
+		//line sql.y:1695
 		{
 			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 308:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1700
+		//line sql.y:1701
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 309:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1704
+		//line sql.y:1705
 		{
 			yyVAL.selectExpr = &AliasedExpr{Expr: yyDollar[1].expr, As: yyDollar[2].colIdent}
 		}
 	case 310:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1708
+		//line sql.y:1709
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Name: yyDollar[1].tableIdent}}
 		}
 	case 311:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1712
+		//line sql.y:1713
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}}
 		}
 	case 312:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1717
+		//line sql.y:1718
 		{
 			yyVAL.colIdent = ColIdent{}
 		}
 	case 313:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1721
+		//line sql.y:1722
 		{
 			yyVAL.colIdent = yyDollar[1].colIdent
 		}
 	case 314:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1725
+		//line sql.y:1726
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 316:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1732
+		//line sql.y:1733
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 317:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1737
+		//line sql.y:1738
 		{
 			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
 		}
 	case 318:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1741
+		//line sql.y:1742
 		{
 			yyVAL.tableExprs = yyDollar[2].tableExprs
 		}
 	case 319:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1747
+		//line sql.y:1748
 		{
 			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 320:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1751
+		//line sql.y:1752
 		{
 			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 323:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1761
+		//line sql.y:1762
 		{
 			yyVAL.tableExpr = yyDollar[1].aliasedTableName
 		}
 	case 324:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1765
+		//line sql.y:1766
 		{
 			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].subquery, As: yyDollar[3].tableIdent}
 		}
 	case 325:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1769
+		//line sql.y:1770
 		{
 			yyVAL.tableExpr = &ParenTableExpr{Exprs: yyDollar[2].tableExprs}
 		}
 	case 326:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1775
+		//line sql.y:1776
 		{
 			yyVAL.aliasedTableName = &AliasedTableExpr{Expr: yyDollar[1].tableName, As: yyDollar[2].tableIdent, Hints: yyDollar[3].indexHints}
 		}
 	case 327:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:1779
+		//line sql.y:1780
 		{
 			yyVAL.aliasedTableName = &AliasedTableExpr{Expr: yyDollar[1].tableName, Partitions: yyDollar[4].partitions, As: yyDollar[6].tableIdent, Hints: yyDollar[7].indexHints}
 		}
 	case 328:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1785
+		//line sql.y:1786
 		{
 			yyVAL.columns = Columns{yyDollar[1].colIdent}
 		}
 	case 329:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1789
+		//line sql.y:1790
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[3].colIdent)
 		}
 	case 330:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1795
+		//line sql.y:1796
 		{
 			yyVAL.partitions = Partitions{yyDollar[1].colIdent}
 		}
 	case 331:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1799
+		//line sql.y:1800
 		{
 			yyVAL.partitions = append(yyVAL.partitions, yyDollar[3].colIdent)
 		}
 	case 332:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1812
+		//line sql.y:1813
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 333:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1816
+		//line sql.y:1817
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 334:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1820
+		//line sql.y:1821
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 335:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1824
+		//line sql.y:1825
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 336:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1830
+		//line sql.y:1831
 		{
 			yyVAL.joinCondition = JoinCondition{On: yyDollar[2].expr}
 		}
 	case 337:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:1832
+		//line sql.y:1833
 		{
 			yyVAL.joinCondition = JoinCondition{Using: yyDollar[3].columns}
 		}
 	case 338:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1836
+		//line sql.y:1837
 		{
 			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 339:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1838
+		//line sql.y:1839
 		{
 			yyVAL.joinCondition = yyDollar[1].joinCondition
 		}
 	case 340:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1842
+		//line sql.y:1843
 		{
 			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 341:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1844
+		//line sql.y:1845
 		{
 			yyVAL.joinCondition = JoinCondition{On: yyDollar[2].expr}
 		}
 	case 342:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1847
+		//line sql.y:1848
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 343:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1849
+		//line sql.y:1850
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 344:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1852
+		//line sql.y:1853
 		{
 			yyVAL.tableIdent = NewTableIdent("")
 		}
 	case 345:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1856
+		//line sql.y:1857
 		{
 			yyVAL.tableIdent = yyDollar[1].tableIdent
 		}
 	case 346:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1860
+		//line sql.y:1861
 		{
 			yyVAL.tableIdent = yyDollar[2].tableIdent
 		}
 	case 348:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1867
+		//line sql.y:1868
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 349:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1873
+		//line sql.y:1874
 		{
 			yyVAL.str = JoinStr
 		}
 	case 350:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1877
+		//line sql.y:1878
 		{
 			yyVAL.str = JoinStr
 		}
 	case 351:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1881
+		//line sql.y:1882
 		{
 			yyVAL.str = JoinStr
 		}
 	case 352:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1887
+		//line sql.y:1888
 		{
 			yyVAL.str = StraightJoinStr
 		}
 	case 353:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1893
+		//line sql.y:1894
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 354:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1897
+		//line sql.y:1898
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 355:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1901
+		//line sql.y:1902
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 356:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1905
+		//line sql.y:1906
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 357:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1911
+		//line sql.y:1912
 		{
 			yyVAL.str = NaturalJoinStr
 		}
 	case 358:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1915
+		//line sql.y:1916
 		{
 			if yyDollar[2].str == LeftJoinStr {
 				yyVAL.str = NaturalLeftJoinStr
@@ -4815,457 +4815,457 @@ yydefault:
 		}
 	case 359:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1925
+		//line sql.y:1926
 		{
 			yyVAL.tableName = yyDollar[2].tableName
 		}
 	case 360:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1929
+		//line sql.y:1930
 		{
 			yyVAL.tableName = yyDollar[1].tableName
 		}
 	case 361:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1935
+		//line sql.y:1936
 		{
 			yyVAL.tableName = TableName{Name: yyDollar[1].tableIdent}
 		}
 	case 362:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1939
+		//line sql.y:1940
 		{
 			yyVAL.tableName = TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}
 		}
 	case 363:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1944
+		//line sql.y:1945
 		{
 			yyVAL.indexHints = nil
 		}
 	case 364:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1948
+		//line sql.y:1949
 		{
 			yyVAL.indexHints = &IndexHints{Type: UseStr, Indexes: yyDollar[4].columns}
 		}
 	case 365:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1952
+		//line sql.y:1953
 		{
 			yyVAL.indexHints = &IndexHints{Type: IgnoreStr, Indexes: yyDollar[4].columns}
 		}
 	case 366:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:1956
+		//line sql.y:1957
 		{
 			yyVAL.indexHints = &IndexHints{Type: ForceStr, Indexes: yyDollar[4].columns}
 		}
 	case 367:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1961
+		//line sql.y:1962
 		{
 			yyVAL.expr = nil
 		}
 	case 368:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1965
+		//line sql.y:1966
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 369:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1971
+		//line sql.y:1972
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 370:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1975
+		//line sql.y:1976
 		{
 			yyVAL.expr = &AndExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 371:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1979
+		//line sql.y:1980
 		{
 			yyVAL.expr = &OrExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 372:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1983
+		//line sql.y:1984
 		{
 			yyVAL.expr = &NotExpr{Expr: yyDollar[2].expr}
 		}
 	case 373:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1987
+		//line sql.y:1988
 		{
 			yyVAL.expr = &IsExpr{Operator: yyDollar[3].str, Expr: yyDollar[1].expr}
 		}
 	case 374:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1991
+		//line sql.y:1992
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 375:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1995
+		//line sql.y:1996
 		{
 			yyVAL.expr = &Default{ColName: yyDollar[2].str}
 		}
 	case 376:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2001
+		//line sql.y:2002
 		{
 			yyVAL.str = ""
 		}
 	case 377:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2005
+		//line sql.y:2006
 		{
 			yyVAL.str = string(yyDollar[2].bytes)
 		}
 	case 378:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2011
+		//line sql.y:2012
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 379:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2015
+		//line sql.y:2016
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 380:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2021
+		//line sql.y:2022
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: yyDollar[2].str, Right: yyDollar[3].expr}
 		}
 	case 381:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2025
+		//line sql.y:2026
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: InStr, Right: yyDollar[3].colTuple}
 		}
 	case 382:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2029
+		//line sql.y:2030
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotInStr, Right: yyDollar[4].colTuple}
 		}
 	case 383:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2033
+		//line sql.y:2034
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: LikeStr, Right: yyDollar[3].expr, Escape: yyDollar[4].expr}
 		}
 	case 384:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2037
+		//line sql.y:2038
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotLikeStr, Right: yyDollar[4].expr, Escape: yyDollar[5].expr}
 		}
 	case 385:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2041
+		//line sql.y:2042
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: RegexpStr, Right: yyDollar[3].expr}
 		}
 	case 386:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2045
+		//line sql.y:2046
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotRegexpStr, Right: yyDollar[4].expr}
 		}
 	case 387:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2049
+		//line sql.y:2050
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
 		}
 	case 388:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2053
+		//line sql.y:2054
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
 		}
 	case 389:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2057
+		//line sql.y:2058
 		{
 			yyVAL.expr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 390:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2063
+		//line sql.y:2064
 		{
 			yyVAL.str = IsNullStr
 		}
 	case 391:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2067
+		//line sql.y:2068
 		{
 			yyVAL.str = IsNotNullStr
 		}
 	case 392:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2071
+		//line sql.y:2072
 		{
 			yyVAL.str = IsTrueStr
 		}
 	case 393:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2075
+		//line sql.y:2076
 		{
 			yyVAL.str = IsNotTrueStr
 		}
 	case 394:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2079
+		//line sql.y:2080
 		{
 			yyVAL.str = IsFalseStr
 		}
 	case 395:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2083
+		//line sql.y:2084
 		{
 			yyVAL.str = IsNotFalseStr
 		}
 	case 396:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2089
+		//line sql.y:2090
 		{
 			yyVAL.str = EqualStr
 		}
 	case 397:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2093
+		//line sql.y:2094
 		{
 			yyVAL.str = LessThanStr
 		}
 	case 398:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2097
+		//line sql.y:2098
 		{
 			yyVAL.str = GreaterThanStr
 		}
 	case 399:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2101
+		//line sql.y:2102
 		{
 			yyVAL.str = LessEqualStr
 		}
 	case 400:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2105
+		//line sql.y:2106
 		{
 			yyVAL.str = GreaterEqualStr
 		}
 	case 401:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2109
+		//line sql.y:2110
 		{
 			yyVAL.str = NotEqualStr
 		}
 	case 402:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2113
+		//line sql.y:2114
 		{
 			yyVAL.str = NullSafeEqualStr
 		}
 	case 403:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2118
+		//line sql.y:2119
 		{
 			yyVAL.expr = nil
 		}
 	case 404:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2122
+		//line sql.y:2123
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 405:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2128
+		//line sql.y:2129
 		{
 			yyVAL.colTuple = yyDollar[1].valTuple
 		}
 	case 406:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2132
+		//line sql.y:2133
 		{
 			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 407:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2136
+		//line sql.y:2137
 		{
 			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 408:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2142
+		//line sql.y:2143
 		{
 			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 409:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2148
+		//line sql.y:2149
 		{
 			yyVAL.exprs = Exprs{yyDollar[1].expr}
 		}
 	case 410:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2152
+		//line sql.y:2153
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 411:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2158
+		//line sql.y:2159
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 412:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2162
+		//line sql.y:2163
 		{
 			yyVAL.expr = yyDollar[1].boolVal
 		}
 	case 413:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2166
+		//line sql.y:2167
 		{
 			yyVAL.expr = yyDollar[1].colName
 		}
 	case 414:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2170
+		//line sql.y:2171
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 415:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2174
+		//line sql.y:2175
 		{
 			yyVAL.expr = yyDollar[1].subquery
 		}
 	case 416:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2178
+		//line sql.y:2179
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitAndStr, Right: yyDollar[3].expr}
 		}
 	case 417:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2182
+		//line sql.y:2183
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitOrStr, Right: yyDollar[3].expr}
 		}
 	case 418:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2186
+		//line sql.y:2187
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitXorStr, Right: yyDollar[3].expr}
 		}
 	case 419:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2190
+		//line sql.y:2191
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: PlusStr, Right: yyDollar[3].expr}
 		}
 	case 420:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2194
+		//line sql.y:2195
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MinusStr, Right: yyDollar[3].expr}
 		}
 	case 421:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2198
+		//line sql.y:2199
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MultStr, Right: yyDollar[3].expr}
 		}
 	case 422:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2202
+		//line sql.y:2203
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: DivStr, Right: yyDollar[3].expr}
 		}
 	case 423:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2206
+		//line sql.y:2207
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: IntDivStr, Right: yyDollar[3].expr}
 		}
 	case 424:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2210
+		//line sql.y:2211
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 425:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2214
+		//line sql.y:2215
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 426:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2218
+		//line sql.y:2219
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftLeftStr, Right: yyDollar[3].expr}
 		}
 	case 427:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2222
+		//line sql.y:2223
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftRightStr, Right: yyDollar[3].expr}
 		}
 	case 428:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2226
+		//line sql.y:2227
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONExtractOp, Right: yyDollar[3].expr}
 		}
 	case 429:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2230
+		//line sql.y:2231
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONUnquoteExtractOp, Right: yyDollar[3].expr}
 		}
 	case 430:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2234
+		//line sql.y:2235
 		{
 			yyVAL.expr = &CollateExpr{Expr: yyDollar[1].expr, Charset: yyDollar[3].str}
 		}
 	case 431:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2238
+		//line sql.y:2239
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BinaryStr, Expr: yyDollar[2].expr}
 		}
 	case 432:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2242
+		//line sql.y:2243
 		{
 			yyVAL.expr = &UnaryExpr{Operator: UBinaryStr, Expr: yyDollar[2].expr}
 		}
 	case 433:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2246
+		//line sql.y:2247
 		{
 			yyVAL.expr = &UnaryExpr{Operator: Utf8mb4Str, Expr: yyDollar[2].expr}
 		}
 	case 434:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2250
+		//line sql.y:2251
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				yyVAL.expr = num
@@ -5275,7 +5275,7 @@ yydefault:
 		}
 	case 435:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2258
+		//line sql.y:2259
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				// Handle double negative
@@ -5291,19 +5291,19 @@ yydefault:
 		}
 	case 436:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2272
+		//line sql.y:2273
 		{
 			yyVAL.expr = &UnaryExpr{Operator: TildaStr, Expr: yyDollar[2].expr}
 		}
 	case 437:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2276
+		//line sql.y:2277
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BangStr, Expr: yyDollar[2].expr}
 		}
 	case 438:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2280
+		//line sql.y:2281
 		{
 			// This rule prevents the usage of INTERVAL
 			// as a function. If support is needed for that,
@@ -5313,259 +5313,259 @@ yydefault:
 		}
 	case 443:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2298
+		//line sql.y:2299
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Exprs: yyDollar[3].selectExprs}
 		}
 	case 444:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2302
+		//line sql.y:2303
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 445:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2306
+		//line sql.y:2307
 		{
 			yyVAL.expr = &FuncExpr{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].colIdent, Exprs: yyDollar[5].selectExprs}
 		}
 	case 446:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2316
+		//line sql.y:2317
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("left"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 447:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2320
+		//line sql.y:2321
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("right"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 448:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2324
+		//line sql.y:2325
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 449:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2328
+		//line sql.y:2329
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 450:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2332
+		//line sql.y:2333
 		{
 			yyVAL.expr = &ConvertUsingExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].str}
 		}
 	case 451:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2336
+		//line sql.y:2337
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: nil}
 		}
 	case 452:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:2340
+		//line sql.y:2341
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 453:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:2344
+		//line sql.y:2345
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 454:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2348
+		//line sql.y:2349
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: nil}
 		}
 	case 455:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:2352
+		//line sql.y:2353
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 456:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:2356
+		//line sql.y:2357
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 457:
 		yyDollar = yyS[yypt-9 : yypt+1]
-		//line sql.y:2360
+		//line sql.y:2361
 		{
 			yyVAL.expr = &MatchExpr{Columns: yyDollar[3].selectExprs, Expr: yyDollar[7].expr, Option: yyDollar[8].str}
 		}
 	case 458:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:2364
+		//line sql.y:2365
 		{
 			yyVAL.expr = &GroupConcatExpr{Distinct: yyDollar[3].str, Exprs: yyDollar[4].selectExprs, OrderBy: yyDollar[5].orderBy, Separator: yyDollar[6].str}
 		}
 	case 459:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2368
+		//line sql.y:2369
 		{
 			yyVAL.expr = &CaseExpr{Expr: yyDollar[2].expr, Whens: yyDollar[3].whens, Else: yyDollar[4].expr}
 		}
 	case 460:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2372
+		//line sql.y:2373
 		{
 			yyVAL.expr = &ValuesFuncExpr{Name: yyDollar[3].colName}
 		}
 	case 461:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2382
+		//line sql.y:2383
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_timestamp")}
 		}
 	case 462:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2386
+		//line sql.y:2387
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_timestamp")}
 		}
 	case 463:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2390
+		//line sql.y:2391
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_time")}
 		}
 	case 464:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2394
+		//line sql.y:2395
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_date")}
 		}
 	case 465:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2399
+		//line sql.y:2400
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtime")}
 		}
 	case 466:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2404
+		//line sql.y:2405
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtimestamp")}
 		}
 	case 467:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2409
+		//line sql.y:2410
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_date")}
 		}
 	case 468:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2414
+		//line sql.y:2415
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_time")}
 		}
 	case 471:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2428
+		//line sql.y:2429
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("if"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 472:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2432
+		//line sql.y:2433
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("database"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 473:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2436
+		//line sql.y:2437
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("mod"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 474:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2440
+		//line sql.y:2441
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("replace"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 475:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2446
+		//line sql.y:2447
 		{
 			yyVAL.str = ""
 		}
 	case 476:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2450
+		//line sql.y:2451
 		{
 			yyVAL.str = BooleanModeStr
 		}
 	case 477:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2454
+		//line sql.y:2455
 		{
 			yyVAL.str = NaturalLanguageModeStr
 		}
 	case 478:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:2458
+		//line sql.y:2459
 		{
 			yyVAL.str = NaturalLanguageModeWithQueryExpansionStr
 		}
 	case 479:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2462
+		//line sql.y:2463
 		{
 			yyVAL.str = QueryExpansionStr
 		}
 	case 480:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2468
+		//line sql.y:2469
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 481:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2472
+		//line sql.y:2473
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 482:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2478
+		//line sql.y:2479
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 483:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2482
+		//line sql.y:2483
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal, Charset: yyDollar[3].str, Operator: CharacterSetStr}
 		}
 	case 484:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2486
+		//line sql.y:2487
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal, Charset: string(yyDollar[3].bytes)}
 		}
 	case 485:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2490
+		//line sql.y:2491
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 486:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2494
+		//line sql.y:2495
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 487:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2498
+		//line sql.y:2499
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 			yyVAL.convertType.Length = yyDollar[2].LengthScaleOption.Length
@@ -5573,169 +5573,169 @@ yydefault:
 		}
 	case 488:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2504
+		//line sql.y:2505
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 489:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2508
+		//line sql.y:2509
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 490:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2512
+		//line sql.y:2513
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 491:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2516
+		//line sql.y:2517
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 492:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2520
+		//line sql.y:2521
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].optVal}
 		}
 	case 493:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2524
+		//line sql.y:2525
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 494:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2528
+		//line sql.y:2529
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 495:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2533
+		//line sql.y:2534
 		{
 			yyVAL.expr = nil
 		}
 	case 496:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2537
+		//line sql.y:2538
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 497:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2542
+		//line sql.y:2543
 		{
 			yyVAL.str = string("")
 		}
 	case 498:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2546
+		//line sql.y:2547
 		{
 			yyVAL.str = " separator '" + string(yyDollar[2].bytes) + "'"
 		}
 	case 499:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2552
+		//line sql.y:2553
 		{
 			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 500:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2556
+		//line sql.y:2557
 		{
 			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 501:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2562
+		//line sql.y:2563
 		{
 			yyVAL.when = &When{Cond: yyDollar[2].expr, Val: yyDollar[4].expr}
 		}
 	case 502:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2567
+		//line sql.y:2568
 		{
 			yyVAL.expr = nil
 		}
 	case 503:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2571
+		//line sql.y:2572
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 504:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2577
+		//line sql.y:2578
 		{
 			yyVAL.colName = &ColName{Name: yyDollar[1].colIdent}
 		}
 	case 505:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2581
+		//line sql.y:2582
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Name: yyDollar[1].tableIdent}, Name: yyDollar[3].colIdent}
 		}
 	case 506:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2585
+		//line sql.y:2586
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}, Name: yyDollar[5].colIdent}
 		}
 	case 507:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2591
+		//line sql.y:2592
 		{
 			yyVAL.expr = NewStrVal(yyDollar[1].bytes)
 		}
 	case 508:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2595
+		//line sql.y:2596
 		{
 			yyVAL.expr = NewHexVal(yyDollar[1].bytes)
 		}
 	case 509:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2599
+		//line sql.y:2600
 		{
 			yyVAL.expr = NewBitVal(yyDollar[1].bytes)
 		}
 	case 510:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2603
+		//line sql.y:2604
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 511:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2607
+		//line sql.y:2608
 		{
 			yyVAL.expr = NewFloatVal(yyDollar[1].bytes)
 		}
 	case 512:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2611
+		//line sql.y:2612
 		{
 			yyVAL.expr = NewHexNum(yyDollar[1].bytes)
 		}
 	case 513:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2615
+		//line sql.y:2616
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 514:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2619
+		//line sql.y:2620
 		{
 			yyVAL.expr = &NullVal{}
 		}
 	case 515:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2625
+		//line sql.y:2626
 		{
 			// TODO(sougou): Deprecate this construct.
 			if yyDollar[1].colIdent.Lowered() != "value" {
@@ -5746,237 +5746,237 @@ yydefault:
 		}
 	case 516:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2634
+		//line sql.y:2635
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 517:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2638
+		//line sql.y:2639
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 518:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2643
+		//line sql.y:2644
 		{
 			yyVAL.exprs = nil
 		}
 	case 519:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2647
+		//line sql.y:2648
 		{
 			yyVAL.exprs = yyDollar[3].exprs
 		}
 	case 520:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2652
+		//line sql.y:2653
 		{
 			yyVAL.expr = nil
 		}
 	case 521:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2656
+		//line sql.y:2657
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 522:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2661
+		//line sql.y:2662
 		{
 			yyVAL.orderBy = nil
 		}
 	case 523:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2665
+		//line sql.y:2666
 		{
 			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 524:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2671
+		//line sql.y:2672
 		{
 			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 525:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2675
+		//line sql.y:2676
 		{
 			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 526:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2681
+		//line sql.y:2682
 		{
 			yyVAL.order = &Order{Expr: yyDollar[1].expr, Direction: yyDollar[2].str}
 		}
 	case 527:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2686
+		//line sql.y:2687
 		{
 			yyVAL.str = AscScr
 		}
 	case 528:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2690
+		//line sql.y:2691
 		{
 			yyVAL.str = AscScr
 		}
 	case 529:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2694
+		//line sql.y:2695
 		{
 			yyVAL.str = DescScr
 		}
 	case 530:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2699
+		//line sql.y:2700
 		{
 			yyVAL.limit = nil
 		}
 	case 531:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2703
+		//line sql.y:2704
 		{
 			yyVAL.limit = &Limit{Rowcount: yyDollar[2].expr}
 		}
 	case 532:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2707
+		//line sql.y:2708
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[2].expr, Rowcount: yyDollar[4].expr}
 		}
 	case 533:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2711
+		//line sql.y:2712
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[4].expr, Rowcount: yyDollar[2].expr}
 		}
 	case 534:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2716
+		//line sql.y:2717
 		{
 			yyVAL.str = ""
 		}
 	case 535:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2720
+		//line sql.y:2721
 		{
 			yyVAL.str = ForUpdateStr
 		}
 	case 536:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2724
+		//line sql.y:2725
 		{
 			yyVAL.str = ShareModeStr
 		}
 	case 537:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2737
+		//line sql.y:2738
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[2].values}
 		}
 	case 538:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2741
+		//line sql.y:2742
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[1].selStmt}
 		}
 	case 539:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2745
+		//line sql.y:2746
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Rows: yyDollar[2].selStmt}
 		}
 	case 540:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2750
+		//line sql.y:2751
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].values}
 		}
 	case 541:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:2754
+		//line sql.y:2755
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[4].selStmt}
 		}
 	case 542:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:2758
+		//line sql.y:2759
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].selStmt}
 		}
 	case 543:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2765
+		//line sql.y:2766
 		{
 			yyVAL.columns = Columns{yyDollar[1].colIdent}
 		}
 	case 544:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2769
+		//line sql.y:2770
 		{
 			yyVAL.columns = Columns{yyDollar[3].colIdent}
 		}
 	case 545:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2773
+		//line sql.y:2774
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[3].colIdent)
 		}
 	case 546:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2777
+		//line sql.y:2778
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[5].colIdent)
 		}
 	case 547:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2782
+		//line sql.y:2783
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 548:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:2786
+		//line sql.y:2787
 		{
 			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 549:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2792
+		//line sql.y:2793
 		{
 			yyVAL.values = Values{yyDollar[1].valTuple}
 		}
 	case 550:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2796
+		//line sql.y:2797
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].valTuple)
 		}
 	case 551:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2802
+		//line sql.y:2803
 		{
 			yyVAL.valTuple = yyDollar[1].valTuple
 		}
 	case 552:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2806
+		//line sql.y:2807
 		{
 			yyVAL.valTuple = ValTuple{}
 		}
 	case 553:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2812
+		//line sql.y:2813
 		{
 			yyVAL.valTuple = ValTuple(yyDollar[2].exprs)
 		}
 	case 554:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2818
+		//line sql.y:2819
 		{
 			if len(yyDollar[1].valTuple) == 1 {
 				yyVAL.expr = &ParenExpr{yyDollar[1].valTuple[0]}
@@ -5986,271 +5986,271 @@ yydefault:
 		}
 	case 555:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2828
+		//line sql.y:2829
 		{
 			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 556:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2832
+		//line sql.y:2833
 		{
 			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 557:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2838
+		//line sql.y:2839
 		{
 			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].expr}
 		}
 	case 558:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2844
+		//line sql.y:2845
 		{
 			yyVAL.setExprs = SetExprs{yyDollar[1].setExpr}
 		}
 	case 559:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2848
+		//line sql.y:2849
 		{
 			yyVAL.setExprs = append(yyDollar[1].setExprs, yyDollar[3].setExpr)
 		}
 	case 560:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2854
+		//line sql.y:2855
 		{
 			yyVAL.setExpr = &SetExpr{Name: yyDollar[1].colIdent, Expr: NewStrVal([]byte("on"))}
 		}
 	case 561:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2858
+		//line sql.y:2859
 		{
 			yyVAL.setExpr = &SetExpr{Name: yyDollar[1].colIdent, Expr: yyDollar[3].expr}
 		}
 	case 562:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2862
+		//line sql.y:2863
 		{
 			yyVAL.setExpr = &SetExpr{Name: NewColIdent(string(yyDollar[1].bytes)), Expr: yyDollar[2].expr}
 		}
 	case 564:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2869
+		//line sql.y:2870
 		{
 			yyVAL.bytes = []byte("charset")
 		}
 	case 566:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2876
+		//line sql.y:2877
 		{
 			yyVAL.expr = NewStrVal([]byte(yyDollar[1].colIdent.String()))
 		}
 	case 567:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2880
+		//line sql.y:2881
 		{
 			yyVAL.expr = NewStrVal(yyDollar[1].bytes)
 		}
 	case 568:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2884
+		//line sql.y:2885
 		{
 			yyVAL.expr = &Default{}
 		}
 	case 571:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2893
+		//line sql.y:2894
 		{
 			yyVAL.byt = 0
 		}
 	case 572:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2895
+		//line sql.y:2896
 		{
 			yyVAL.byt = 1
 		}
 	case 573:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2898
+		//line sql.y:2899
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 574:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:2900
+		//line sql.y:2901
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 575:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2903
+		//line sql.y:2904
 		{
 			yyVAL.str = ""
 		}
 	case 576:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2905
+		//line sql.y:2906
 		{
 			yyVAL.str = IgnoreStr
 		}
 	case 577:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2909
+		//line sql.y:2910
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 578:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2911
+		//line sql.y:2912
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 579:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2913
+		//line sql.y:2914
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 580:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2915
+		//line sql.y:2916
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 581:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2917
+		//line sql.y:2918
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 582:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2919
+		//line sql.y:2920
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 583:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2921
+		//line sql.y:2922
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 584:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2923
+		//line sql.y:2924
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 585:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2925
+		//line sql.y:2926
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 586:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2927
+		//line sql.y:2928
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 587:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2930
+		//line sql.y:2931
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 588:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2932
+		//line sql.y:2933
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 589:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2934
+		//line sql.y:2935
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 590:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2938
+		//line sql.y:2939
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 591:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2940
+		//line sql.y:2941
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 592:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2943
+		//line sql.y:2944
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 593:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2945
+		//line sql.y:2946
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 594:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2947
+		//line sql.y:2948
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 595:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:2950
+		//line sql.y:2951
 		{
 			yyVAL.colIdent = ColIdent{}
 		}
 	case 596:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:2952
+		//line sql.y:2953
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 597:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2956
+		//line sql.y:2957
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 598:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2960
+		//line sql.y:2961
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 600:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2967
+		//line sql.y:2968
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 601:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2973
+		//line sql.y:2974
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 602:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2977
+		//line sql.y:2978
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 604:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:2984
+		//line sql.y:2985
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 800:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:3205
+		//line sql.y:3206
 		{
 			if incNesting(yylex) {
 				yylex.Error("max nesting level reached")
@@ -6259,31 +6259,31 @@ yydefault:
 		}
 	case 801:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:3214
+		//line sql.y:3215
 		{
 			decNesting(yylex)
 		}
 	case 802:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:3219
+		//line sql.y:3220
 		{
 			forceEOF(yylex)
 		}
 	case 803:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:3224
+		//line sql.y:3225
 		{
 			forceEOF(yylex)
 		}
 	case 804:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:3228
+		//line sql.y:3229
 		{
 			forceEOF(yylex)
 		}
 	case 805:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:3232
+		//line sql.y:3233
 		{
 			forceEOF(yylex)
 		}

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -252,7 +252,8 @@ func forceEOF(yylex interface{}) {
 %type <setExprs> set_list transaction_chars
 %type <bytes> charset_or_character_set
 %type <updateExpr> update_expression
-%type <setExpr> set_expression transaction_char isolation_level
+%type <setExpr> set_expression transaction_char
+%type <str> isolation_level
 %type <bytes> for_from
 %type <str> ignore_opt default_opt
 %type <str> full_opt from_database_opt tables_or_processlist
@@ -500,33 +501,33 @@ transaction_chars:
 transaction_char:
   ISOLATION LEVEL isolation_level
   {
-    $$ = $3
+    $$ = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte($3))}
   }
 | READ WRITE
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_read_only"), Expr: NewIntVal([]byte("0"))}
+    $$ = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadWrite))}
   }
 | READ ONLY
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_read_only"), Expr: NewIntVal([]byte("1"))}
+    $$ = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadOnly))}
   }
 
 isolation_level:
   REPEATABLE READ
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("repeatable read"))}
+    $$ = IsolationLevelRepeatableRead
   }
 | READ COMMITTED
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("read committed"))}
+    $$ = IsolationLevelReadCommitted
   }
 | READ UNCOMMITTED
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("read uncommitted"))}
+    $$ = IsolationLevelReadUncommitted
   }
 | SERIALIZABLE
   {
-    $$ = &SetExpr{Name: NewColIdent("tx_isolation"), Expr: NewStrVal([]byte("serializable"))}
+    $$ = IsolationLevelSerializable
   }
 
 set_session_or_global:

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -608,6 +608,13 @@ func (e *Executor) handleSet(ctx context.Context, safeSession *SafeSession, sql 
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid transaction_mode: %s", val)
 			}
 			safeSession.TransactionMode = vtgatepb.TransactionMode(out)
+		case sqlparser.TransactionStr:
+			// Parser ensures it's well-formed.
+
+			// TODO: This is a NOP, modeled off of tx_isolation and tx_read_only.  It's incredibly
+			// dangerous that it's a NOP, but fixing that is left to. Note that vtqueryservice needs
+			// to be updated as well:
+			// https://github.com/vitessio/vitess/issues/4127
 		case "tx_isolation":
 			val, ok := v.(string)
 			if !ok {
@@ -615,7 +622,7 @@ func (e *Executor) handleSet(ctx context.Context, safeSession *SafeSession, sql 
 			}
 			switch val {
 			case "repeatable read", "read committed", "read uncommitted", "serializable":
-				// no op
+				// TODO (4127): This is a dangerous NOP.
 			default:
 				return nil, fmt.Errorf("unexpected value for tx_isolation: %v", val)
 			}
@@ -626,7 +633,7 @@ func (e *Executor) handleSet(ctx context.Context, safeSession *SafeSession, sql 
 			}
 			switch val {
 			case 0, 1:
-				// no op
+				// TODO (4127): This is a dangerous NOP.
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value for tx_read_only: %d", val)
 			}


### PR DESCRIPTION
Per https://github.com/vitessio/vitess/issues/4127, SET TRANSACTION ...
has different semantics in absence of {SESSION,GLOBAL} than does SET
tx_isolation or SET tx_readonly. Modify the data structures to reflect
that difference.

Signed-off-by: Daniel Tahara <tahara@dropbox.com>