### PR TITLE
Allow overriding of the default keepalive server-side enforcement policy min time

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -83,6 +83,10 @@ var (
 	// The lower bound for window size is 64K and any value smaller than that will be ignored.
 	GRPCInitialWindowSize = flag.Int("grpc_server_initial_window_size", 0, "grpc server initial window size")
 
+	// EnforcementPolicy MinTime that sets the keepalive enforcement policy on the server.
+	// This is the minimum amount of time a client should wait before sending a keepalive ping.
+	GRPCEnforcementPolicyMinTime = flag.Duration("grpc_enforcement_min_time", 5*time.Minute, "grpc server minimum keepalive time")
+
 	authPlugin Authenticator
 )
 
@@ -142,6 +146,11 @@ func createGRPCServer() {
 		log.Infof("Setting grpc server initial window size to %d", int32(*GRPCInitialWindowSize))
 		opts = append(opts, grpc.InitialWindowSize(int32(*GRPCInitialWindowSize)))
 	}
+
+	ep := keepalive.EnforcementPolicy{
+		MinTime: *GRPCEnforcementPolicyMinTime,
+	}
+	opts = append(opts, grpc.KeepaliveEnforcementPolicy(ep))
 
 	if GRPCMaxConnectionAge != nil {
 		ka := keepalive.ServerParameters{

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -148,7 +148,7 @@ func createGRPCServer() {
 	}
 
 	ep := keepalive.EnforcementPolicy{
-		MinTime: *GRPCEnforcementPolicyMinTime,
+		MinTime: *GRPCKeepAliveEnforcementPolicyMinTime,
 	}
 	opts = append(opts, grpc.KeepaliveEnforcementPolicy(ep))
 

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -85,7 +85,7 @@ var (
 
 	// EnforcementPolicy MinTime that sets the keepalive enforcement policy on the server.
 	// This is the minimum amount of time a client should wait before sending a keepalive ping.
-	GRPCEnforcementPolicyMinTime = flag.Duration("grpc_enforcement_min_time", 5*time.Minute, "grpc server minimum keepalive time")
+	GRPCKeepAliveEnforcementPolicyMinTime = flag.Duration("grpc_server_keepalive_enforcement_policy_min_time", 5*time.Minute, "grpc server minimum keepalive time")
 
 	authPlugin Authenticator
 )


### PR DESCRIPTION
Allow setting the keepalive server-side enforcement policy min time, so that the server doesn't preemptively close connections due to setting our client keepalive to a more aggressive value than the allowed server policy.

Signed-off-by: Maggie Zhou <mzhou@slack-corp.com>