### PR TITLE
Fix getGeneratedKeys when no insert during batch upsert

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -619,7 +619,7 @@ public class VitessStatement implements Statement {
                     updateCounts[i] = truncatedUpdateCount;
                     long insertId = cursorWithError.getCursor().getInsertId();
                     if (this.retrieveGeneratedKeys && !queryBatchUpsert || insertId > 0) {
-                        generatedKeys.add(new long[]{cursorWithError.getCursor().getInsertId(), truncatedUpdateCount});
+                        generatedKeys.add(new long[]{insertId, truncatedUpdateCount});
                     }
                 } catch (SQLException ex) {
                         /* This case should not happen as API has returned cursor and not error.

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -618,7 +618,7 @@ public class VitessStatement implements Statement {
                     }
                     updateCounts[i] = truncatedUpdateCount;
                     long insertId = cursorWithError.getCursor().getInsertId();
-                    if (this.retrieveGeneratedKeys && !queryBatchUpsert || insertId > 0) {
+                    if (this.retrieveGeneratedKeys && (!queryBatchUpsert || insertId > 0)) {
                         generatedKeys.add(new long[]{insertId, truncatedUpdateCount});
                     }
                 } catch (SQLException ex) {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -591,7 +591,7 @@ public class VitessStatement implements Statement {
     protected int[] generateBatchUpdateResult(List<CursorWithError> cursorWithErrorList, List<String> batchedArgs)
         throws BatchUpdateException {
         int[] updateCounts = new int[cursorWithErrorList.size()];
-        long[][] generatedKeys = new long[cursorWithErrorList.size()][2];
+        ArrayList<long[]> generatedKeys = new ArrayList<long[]>();
 
         Vtrpc.RPCError rpcError = null;
         String batchCommand = null;
@@ -603,6 +603,7 @@ public class VitessStatement implements Statement {
                 try {
                     long rowsAffected = cursorWithError.getCursor().getRowsAffected();
                     int truncatedUpdateCount;
+                    boolean queryBatchUpsert = false;
                     if (rowsAffected > Integer.MAX_VALUE) {
                         truncatedUpdateCount = Integer.MAX_VALUE;
                     } else {
@@ -610,13 +611,15 @@ public class VitessStatement implements Statement {
                             // mimicking mysql-connector-j here.
                             // but it would fail for: insert into t1 values ('a'), ('b') on duplicate key update ts = now();
                             truncatedUpdateCount = 1;
+                            queryBatchUpsert = true;
                         } else {
                             truncatedUpdateCount = (int) rowsAffected;
                         }
                     }
                     updateCounts[i] = truncatedUpdateCount;
-                    if (this.retrieveGeneratedKeys) {
-                        generatedKeys[i] = new long[]{cursorWithError.getCursor().getInsertId(), truncatedUpdateCount};
+                    long insertId = cursorWithError.getCursor().getInsertId();
+                    if (this.retrieveGeneratedKeys && !queryBatchUpsert || insertId > 0) {
+                        generatedKeys.add(new long[]{cursorWithError.getCursor().getInsertId(), truncatedUpdateCount});
                     }
                 } catch (SQLException ex) {
                         /* This case should not happen as API has returned cursor and not error.
@@ -624,14 +627,14 @@ public class VitessStatement implements Statement {
                          */
                     updateCounts[i] = Statement.SUCCESS_NO_INFO;
                     if (this.retrieveGeneratedKeys) {
-                        generatedKeys[i] = new long[]{Statement.SUCCESS_NO_INFO, Statement.SUCCESS_NO_INFO};
+                        generatedKeys.add(new long[]{Statement.SUCCESS_NO_INFO, Statement.SUCCESS_NO_INFO});
                     }
                 }
             } else {
                 rpcError = cursorWithError.getError();
                 updateCounts[i] = Statement.EXECUTE_FAILED;
                 if (this.retrieveGeneratedKeys) {
-                    generatedKeys[i] = new long[]{Statement.EXECUTE_FAILED, Statement.EXECUTE_FAILED};
+                    generatedKeys.add(new long[]{Statement.EXECUTE_FAILED, Statement.EXECUTE_FAILED});
                 }
             }
         }
@@ -642,7 +645,7 @@ public class VitessStatement implements Statement {
             throw new BatchUpdateException(rpcError.toString(), sqlState, errno, updateCounts);
         }
         if (this.retrieveGeneratedKeys) {
-            this.batchGeneratedKeys = generatedKeys;
+            this.batchGeneratedKeys = generatedKeys.toArray(new long[generatedKeys.size()][2]);
         }
         return updateCounts;
     }

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
@@ -742,5 +742,15 @@ import io.vitess.util.Constants;
             Assert.assertEquals(i, 0); // we should only have one
             i++;
         }
+
+        VitessStatement noUpdate = new VitessStatement(mockConn);
+        PowerMockito.when(mockCursor.getInsertId()).thenReturn(0L);
+        PowerMockito.when(mockCursor.getRowsAffected()).thenReturn(1L);
+
+        noUpdate.addBatch(sqlUpsert);
+        noUpdate.executeBatch();
+
+        ResultSet empty = noUpdate.getGeneratedKeys();
+        Assert.assertFalse(empty.next());
     }
 }


### PR DESCRIPTION
- We uses batched upsert statements at HubSpot and have seen inconsistent behaviors between MySQL vs Vitess. We saw that a statement doing `ON DUPLICATE KEY UPDATE` will return `[0]` even when no new rows was inserted.

- `java.sql.Statement` expects `getGeneratedKeys` to return an empty ResultSet when there are no keys generated by the statement.
https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#getGeneratedKeys--

- MySQLConnect4j checks for the `beginAt` (insertId) before including an id into the generatedKeys set.
https://github.com/mysql/mysql-connector-j/blob/9cc87a48e75c2d2e87c1a293b2862ce651cb256e/src/com/mysql/jdbc/StatementImpl.java#L1750

@acharis @harshit-gangal 
