### PR TITLE
Allow planned reparenting to work without master/avoid master flags

### DIFF
--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -360,11 +360,11 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 	}
 
 	// Check corner cases we're going to depend on
-	if topoproto.TabletAliasEqual(masterElectTabletAlias, avoidMasterTabletAlias) {
+	if masterElectTabletAlias != nil && avoidMasterTabletAlias != nil && topoproto.TabletAliasEqual(masterElectTabletAlias, avoidMasterTabletAlias) {
 		return fmt.Errorf("master-elect tablet %v is the same as the tablet to avoid", topoproto.TabletAliasString(masterElectTabletAlias))
 	}
 	if masterElectTabletAlias == nil {
-		if !topoproto.TabletAliasEqual(avoidMasterTabletAlias, shardInfo.MasterAlias) {
+		if masterElectTabletAlias != nil && avoidMasterTabletAlias != nil && topoproto.TabletAliasEqual(masterElectTabletAlias, avoidMasterTabletAlias) {
 			event.DispatchUpdate(ev, "current master is different than -avoid_master, nothing to do")
 			return nil
 		}
@@ -539,9 +539,9 @@ func (wr *Wrangler) chooseNewMaster(
 	avoidMasterTabletAlias *topodatapb.TabletAlias,
 	waitSlaveTimeout time.Duration) (*topodatapb.TabletAlias, error) {
 
-	if avoidMasterTabletAlias == nil {
-		return nil, fmt.Errorf("tablet to avoid for reparent is not provided, cannot choose new master")
-	}
+	// if avoidMasterTabletAlias == nil {
+	// 	return nil, fmt.Errorf("tablet to avoid for reparent is not provided, cannot choose new master")
+	// }
 	var masterCell string
 	if shardInfo.MasterAlias != nil {
 		masterCell = shardInfo.MasterAlias.Cell

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -364,7 +364,7 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 		return fmt.Errorf("master-elect tablet %v is the same as the tablet to avoid", topoproto.TabletAliasString(masterElectTabletAlias))
 	}
 	if masterElectTabletAlias == nil {
-		if masterElectTabletAlias != nil && avoidMasterTabletAlias != nil && topoproto.TabletAliasEqual(masterElectTabletAlias, avoidMasterTabletAlias) {
+		if avoidMasterTabletAlias != nil && topoproto.TabletAliasEqual(masterElectTabletAlias, avoidMasterTabletAlias) {
 			event.DispatchUpdate(ev, "current master is different than -avoid_master, nothing to do")
 			return nil
 		}


### PR DESCRIPTION
### Description.

It came to our attention that planned reparenting requires **avoid_master** flag in order to work. There are several checks along the stack that validate this, so I'm assuming there is a reason behind this. Could we relax this requirement? I think as long as chooseMaster ignores current master, there shouldn't be any need in enforcing this requirement. 

Opening this PR to start discussion around this. The following has POC of this change. If we think this is something we should do, I can polish it and add more tests.

cc: @demmer, @sougou, @zmagg  
