### PR TITLE
Delay VTGateConnection closure when rotating connections

### DIFF
--- a/java/client/src/main/java/io/vitess/client/VTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateConnection.java
@@ -252,4 +252,11 @@ public class VTGateConnection implements Closeable {
         client.close();
     }
 
+    @Override
+    public String toString() {
+        return String.format("[VTGateConnection-%s client=%s]",
+                Integer.toHexString(this.hashCode()),
+                client.toString()
+        );
+    }
 }

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -31,7 +31,6 @@ import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import io.vitess.util.Constants;
 import io.vitess.util.StringUtils;
-import java.util.function.Function;
 
 public class ConnectionProperties {
 
@@ -194,6 +193,14 @@ public class ConnectionProperties {
         "refreshSeconds",
         "How often in seconds the driver will monitor for changes to the keystore and truststore files, when refreshConnection is enabled.",
         60);
+    private BooleanConnectionProperty refreshClosureDelayed = new BooleanConnectionProperty(
+            "refreshClosureDelayed",
+            "When enabled, the closing of the old connections will be delayed instead of happening instantly.",
+            false);
+    private LongConnectionProperty refreshClosureDelaySeconds = new LongConnectionProperty(
+            "refreshClosureDelaySeconds",
+            "How often in seconds the grace period before closing the old connections that had been recreated.",
+            300);
     private StringConnectionProperty keyStore = new StringConnectionProperty(
         Constants.Property.KEYSTORE,
         "The Java .JKS keystore file to use when TLS is enabled",
@@ -515,6 +522,22 @@ public class ConnectionProperties {
 
     public void setRefreshSeconds(long refreshSeconds) {
         this.refreshSeconds.setValue(refreshSeconds);
+    }
+
+    public boolean getRefreshClosureDelayed() {
+        return refreshClosureDelayed.getValueAsBoolean();
+    }
+
+    public void setRefreshClosureDelayed(boolean refreshClosureDelayed) {
+        this.refreshClosureDelayed.setValue(refreshClosureDelayed);
+    }
+
+    public long getRefreshClosureDelaySeconds() {
+        return refreshClosureDelaySeconds.getValueAsLong();
+    }
+
+    public void setRefreshClosureDelaySeconds(long refreshClosureDelaySeconds) {
+        this.refreshClosureDelaySeconds.setValue(refreshClosureDelaySeconds);
     }
 
     public String getKeyStore() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -152,7 +152,7 @@ public class VitessVTGateManager {
 
     private static void closeRefreshedConnection(final VTGateConnection old) {
         if (vtgateClosureTimer != null) {
-            logger.info("Closing " + old + " with a delay of " + vtgateClosureDelaySeconds + " seconds");
+            logger.info(String.format("%s Closing connection with a %s second delay", old, vtgateClosureDelaySeconds));
             vtgateClosureTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
@@ -167,10 +167,10 @@ public class VitessVTGateManager {
 
     private static void actuallyCloseRefreshedConnection(final VTGateConnection old) {
         try {
-            logger.info("Closing old connection " + old);
+            logger.info(old + " Closing connection because it had been refreshed");
             old.close();
         } catch (IOException ioe) {
-            logger.log(Level.WARNING, "Error closing VTGateConnection", ioe);
+            logger.log(Level.WARNING, String.format("Error closing VTGateConnection %s", old), ioe);
         }
     }
 

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -16,7 +16,6 @@
 
 package io.vitess.jdbc;
 
-import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -30,10 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
-import com.google.common.io.Closeables;
-
 import io.vitess.client.Context;
-import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConnection;
 import io.vitess.client.RefreshableVTGateConnection;
 import io.vitess.client.grpc.GrpcClientFactory;
@@ -52,6 +48,8 @@ public class VitessVTGateManager {
     private static ConcurrentHashMap<String, VTGateConnection> vtGateConnHashMap =
         new ConcurrentHashMap<>();
     private static Timer vtgateConnRefreshTimer = null;
+    private static Timer vtgateClosureTimer = null;
+    private static long vtgateClosureDelaySeconds = 0L;
 
     /**
      * VTGateConnections object consist of vtGateIdentifire list and return vtGate object in round robin.
@@ -66,6 +64,7 @@ public class VitessVTGateManager {
          * @param connection
          */
         public VTGateConnections(final VitessConnection connection) {
+            maybeStartClosureTimer(connection);
             for (final VitessJDBCUrl.HostInfo hostInfo : connection.getUrl().getHostInfos()) {
                 String identifier = getIdentifer(hostInfo.getHostname(), hostInfo.getPort(), connection.getUsername(), connection.getTarget());
                 synchronized (VitessVTGateManager.class) {
@@ -105,6 +104,17 @@ public class VitessVTGateManager {
 
     }
 
+    private static void maybeStartClosureTimer(VitessConnection connection) {
+        if (connection.getRefreshClosureDelayed() && vtgateClosureTimer == null) {
+            synchronized (VitessVTGateManager.class) {
+                if (vtgateClosureTimer == null) {
+                    vtgateClosureTimer = new Timer("vtgate-conn-closure", true);
+                    vtgateClosureDelaySeconds = connection.getRefreshClosureDelaySeconds();
+                }
+            }
+        }
+    }
+
     private static String getIdentifer(String hostname, int port, String userIdentifer, String keyspace) {
         return (hostname + port + userIdentifer + keyspace);
     }
@@ -130,17 +140,37 @@ public class VitessVTGateManager {
                     if (existing.checkKeystoreUpdates()) {
                         updatedCount++;
                         VTGateConnection old = vtGateConnHashMap.replace(entry.getKey(), getVtGateConn(hostInfo, connection));
-                        try {
-                            old.close();
-                        } catch (IOException ioe) {
-                            logger.log(Level.WARNING, "Error closing VTGateConnection", ioe);
-                        }
+                        closeRefreshedConnection(old);
                     }
                 }
             }
             if (updatedCount > 0) {
                 logger.info("refreshed " + updatedCount + " vtgate connections due to keystore update");
             }
+        }
+    }
+
+    private static void closeRefreshedConnection(final VTGateConnection old) {
+        if (vtgateClosureTimer != null) {
+            logger.info("Closing " + old + " with a delay of " + vtgateClosureDelaySeconds + " seconds");
+            vtgateClosureTimer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    actuallyCloseRefreshedConnection(old);
+                }
+            },
+            TimeUnit.SECONDS.toMillis(vtgateClosureDelaySeconds));
+        } else {
+            actuallyCloseRefreshedConnection(old);
+        }
+    }
+
+    private static void actuallyCloseRefreshedConnection(final VTGateConnection old) {
+        try {
+            logger.info("Closing old connection " + old);
+            old.close();
+        } catch (IOException ioe) {
+            logger.log(Level.WARNING, "Error closing VTGateConnection", ioe);
         }
     }
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -31,7 +31,7 @@ import io.vitess.util.Constants;
 
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 37;
+    private static final int NUM_PROPS = 39;
 
     @Test
     public void testReflection() throws Exception {
@@ -154,8 +154,8 @@ public class ConnectionPropertiesTest {
         Assert.assertEquals("grpcRetriesInitialBackoffMillis", infos[7].name);
         Assert.assertEquals("grpcRetriesMaxBackoffMillis", infos[8].name);
         Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[9].name);
-        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[19].name);
-        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[27].name);
+        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[21].name);
+        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[29].name);
     }
 
     @Test


### PR DESCRIPTION
At HubSpot we see a lot high volume applications take a lot of impact during channel rotations due to a race condition that will provide a shutdown channel to the `VitessStatement` and `VitessPreparedStatement` when the certificate rotator thread closes the `VTGateConnection`

This PR adds a more graceful way to handle refresh channel closures by adding a strategy to delay closure of the connection to a later time.

This will reduce the pain on any currently running transactions as well as any stream calls that had not completed when the rotation happens.

@acharis @harshit-gangal 