### PR TITLE
add support for vtexplain to override the dbname target

### DIFF
--- a/data/test/vtexplain/multi-output/options-output.txt
+++ b/data/test/vtexplain/multi-output/options-output.txt
@@ -14,7 +14,7 @@ select * from user where id in (1,2,3,4,5,6,7,8)
 1 ks_sharded/c0-: select * from user where id in (4, 6, 7, 8) limit 10001
 
 ----------------------------------------------------------------------
-insert into user (id, name) values(2, 'bob')
+insert into user (id, name) values (2, 'bob')
 
 1 ks_sharded/c0-: begin
 1 ks_sharded/c0-: insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */ /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */

--- a/data/test/vtexplain/multi-output/target-output.txt
+++ b/data/test/vtexplain/multi-output/target-output.txt
@@ -1,0 +1,18 @@
+----------------------------------------------------------------------
+select * from user where email='null@void.com'
+
+1 ks_sharded/40-80: select * from user where email = 'null@void.com' limit 10001
+
+----------------------------------------------------------------------
+select * from user where id in (1,2,3,4,5,6,7,8)
+
+1 ks_sharded/40-80: select * from user where id in (1, 2, 3, 4, 5, 6, 7, 8) limit 10001
+
+----------------------------------------------------------------------
+insert into user (id, name) values (2, 'bob')
+
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: insert into user(id, name) values (2, 'bob')/* vtgate:: filtered_replication_unfriendly */
+2 ks_sharded/40-80: commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/options-queries.sql
+++ b/data/test/vtexplain/options-queries.sql
@@ -1,3 +1,3 @@
 select * from user where email='null@void.com';
 select * from user where id in (1,2,3,4,5,6,7,8);
-insert into user (id, name) values(2, 'bob');
+insert into user (id, name) values (2, 'bob');

--- a/data/test/vtexplain/target-queries.sql
+++ b/data/test/vtexplain/target-queries.sql
@@ -1,0 +1,8 @@
+/*
+ * These are the same set of queries from "options-queries.sql" but
+ * are run with an explicit shard target of ks_sharded/40-80 which
+ * bypasses the normal v3 routing.
+ */
+select * from user where email='null@void.com';
+select * from user where id in (1,2,3,4,5,6,7,8);
+insert into user (id, name) values (2, 'bob');

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -40,6 +40,7 @@ var (
 	replicationMode = flag.String("replication-mode", "ROW", "The replication mode to simulate -- must be set to either ROW or STATEMENT")
 	normalize       = flag.Bool("normalize", false, "Whether to enable vtgate normalization")
 	outputMode      = flag.String("output-mode", "text", "Output in human-friendly text or json")
+	dbName          = flag.String("dbname", "", "Optional database target to override normal routing")
 
 	// vtexplainFlags lists all the flags that should show in usage
 	vtexplainFlags = []string{
@@ -53,6 +54,7 @@ var (
 		"sql-file",
 		"vschema",
 		"vschema-file",
+		"dbname",
 	}
 )
 
@@ -153,6 +155,7 @@ func parseAndRun() error {
 		ReplicationMode: *replicationMode,
 		NumShards:       *numShards,
 		Normalize:       *normalize,
+		Target:          *dbName,
 	}
 
 	log.V(100).Infof("sql %s\n", sql)

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -63,6 +63,10 @@ type Options struct {
 	// StrictDDL is used in unit tests only to verify that the schema
 	// is parsed properly.
 	StrictDDL bool
+
+	// Target is used to override the "database" target in the
+	// vtgate session to simulate `USE <target>`
+	Target string
 }
 
 // TabletQuery defines a query that was sent to a given tablet and how it was

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -144,6 +144,16 @@ func TestOptions(t *testing.T) {
 
 	testExplain("options", opts, t)
 }
+func TestTarget(t *testing.T) {
+	opts := &Options{
+		ReplicationMode: "ROW",
+		NumShards:       4,
+		Normalize:       false,
+		Target:          "ks_sharded/40-80",
+	}
+
+	testExplain("target", opts, t)
+}
 
 func TestComments(t *testing.T) {
 	testExplain("comments", defaultTestOpts(), t)

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -46,7 +46,7 @@ var (
 	healthCheck    *discovery.FakeHealthCheck
 
 	vtgateSession = &vtgatepb.Session{
-		TargetString: "@master",
+		TargetString: "",
 		Autocommit:   true,
 	}
 )
@@ -61,6 +61,8 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 	if err != nil {
 		return err
 	}
+
+	vtgateSession.TargetString = opts.Target
 
 	streamSize := 10
 	queryPlanCacheSize := int64(10)


### PR DESCRIPTION
This change adds a --dbname option to the vtexplain binary so that
callers can simulate what vtgate will do when the application connects
with a specific database name.

Add a test to show how this can be used to bypass the v3 routing and
send queries directly to a shard.

As an example, I used the same queries as the "options" test in a new "target" test where the shard is forced to `ks_sharded/-40`:

```
--- data/test/vtexplain/multi-output/options-output.txt	2018-08-16 06:57:55.000000000 -0700
+++ data/test/vtexplain/multi-output/target-output.txt	2018-08-23 06:14:05.000000000 -0700
@@ -1,26 +1,18 @@
 ----------------------------------------------------------------------
 select * from user where email='null@void.com'

-1 ks_sharded/-40: select * from user where email = 'null@void.com' limit 10001
 1 ks_sharded/40-80: select * from user where email = 'null@void.com' limit 10001
-1 ks_sharded/80-c0: select * from user where email = 'null@void.com' limit 10001
-1 ks_sharded/c0-: select * from user where email = 'null@void.com' limit 10001

 ----------------------------------------------------------------------
 select * from user where id in (1,2,3,4,5,6,7,8)

-1 ks_sharded/-40: select * from user where id in (1, 2) limit 10001
-1 ks_sharded/40-80: select * from user where id in (3, 5) limit 10001
-1 ks_sharded/c0-: select * from user where id in (4, 6, 7, 8) limit 10001
+1 ks_sharded/40-80: select * from user where id in (1, 2, 3, 4, 5, 6, 7, 8) limit 10001

 ----------------------------------------------------------------------
 insert into user (id, name) values (2, 'bob')

-1 ks_sharded/c0-: begin
-1 ks_sharded/c0-: insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */ /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
-2 ks_sharded/-40: begin
-2 ks_sharded/-40: insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */ /* vtgate:: keyspace_id:06e7ea22ce92708f */
-3 ks_sharded/c0-: commit
-4 ks_sharded/-40: commit
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: insert into user(id, name) values (2, 'bob')/* vtgate:: filtered_replication_unfriendly */
+2 ks_sharded/40-80: commit

 ----------------------------------------------------------------------
```