### PR TITLE
enable query logging to file in the local examples

### DIFF
--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -66,6 +66,7 @@ fi
 $VTROOT/bin/vtgate \
   $TOPOLOGY_FLAGS \
   -log_dir $VTDATAROOT/tmp \
+  -log_queries_to_file $VTDATAROOT/tmp/vtgate_querylog.txt \
   -port $web_port \
   -grpc_port $grpc_port \
   -mysql_server_port $mysql_server_port \

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -95,6 +95,7 @@ for uid_index in $uids; do
   grpc_port=$[$grpc_port_base + $uid_index]
   printf -v alias '%s-%010d' $cell $uid
   printf -v tablet_dir 'vt_%010d' $uid
+  printf -v tablet_logfile 'vttablet_%010d_querylog.txt' $uid
   tablet_type=replica
   if [[ $uid_index -gt 2 ]]; then
     tablet_type=rdonly
@@ -105,6 +106,7 @@ for uid_index in $uids; do
   $VTROOT/bin/vttablet \
     $TOPOLOGY_FLAGS \
     -log_dir $VTDATAROOT/tmp \
+    -log_queries_to_file $VTDATAROOT/tmp/$tablet_logfile \
     -tablet-path $alias \
     -tablet_hostname "$tablet_hostname" \
     -init_keyspace $keyspace \


### PR DESCRIPTION
I found this useful when testing #4151 and figured for the local example we might as well include the query logging to show off how it all works.
