### PR TITLE
add a callinfo implementation for the mysql server protocol

### DIFF
--- a/go/vt/callinfo/plugin_mysql.go
+++ b/go/vt/callinfo/plugin_mysql.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Vitess Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package callinfo
+
+// This file implements the CallInfo interface for Mysql contexts.
+
+import (
+	"fmt"
+	"html/template"
+
+	"golang.org/x/net/context"
+	"vitess.io/vitess/go/mysql"
+)
+
+// MysqlCallInfo returns an augmented context with a CallInfo structure,
+// only for Mysql contexts.
+func MysqlCallInfo(ctx context.Context, c *mysql.Conn) context.Context {
+	return NewContext(ctx, &mysqlCallInfoImpl{
+		remoteAddr: c.RemoteAddr().String(),
+		user:       c.User,
+	})
+}
+
+type mysqlCallInfoImpl struct {
+	remoteAddr string
+	user       string
+}
+
+func (mci *mysqlCallInfoImpl) RemoteAddr() string {
+	return mci.remoteAddr
+}
+
+func (mci *mysqlCallInfoImpl) Username() string {
+	return mci.user
+}
+
+func (mci *mysqlCallInfoImpl) Text() string {
+	return fmt.Sprintf("%s@%s(Mysql)", mci.user, mci.remoteAddr)
+}
+
+func (mci *mysqlCallInfoImpl) HTML() template.HTML {
+	return template.HTML("<b>MySQL User:</b> " + mci.user + " <b>Remote Addr:<b> " + mci.remoteAddr)
+}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/callinfo"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttls"
@@ -104,6 +105,8 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 	} else {
 		ctx = context.Background()
 	}
+
+	ctx = callinfo.MysqlCallInfo(ctx, c)
 
 	// Fill in the ImmediateCallerID with the UserData returned by
 	// the AuthServer plugin for that user. If nothing was


### PR DESCRIPTION
Building off the analogous structure for GRPC, include a callinfo
implementation so that query logs and debug output in vtgate includes
context about the caller.

