### PR TITLE
Build Vitess in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ _test/
 
 # Go vendored libs
 /vendor/*/
+vendor/cloud.google.com
+vendor/github.com
+vendor/golang.org
+vendor/google.golang.org
+vendor/gopkg.in
 
 # release folder
 releases

--- a/Makefile
+++ b/Makefile
@@ -249,3 +249,17 @@ release: docker_base
 	echo "A git tag was created, you can push it with:"
 	echo "git push origin v$(VERSION)"
 	echo "Also, don't forget the upload releases/v$(VERSION).tar.gz file to GitHub releases"
+
+prep_for_docker:
+	ln -s /opt/vendor_internal/cloud.google.com  vendor/cloud.google.com
+	ln -s /opt/vendor_internal/github.com        vendor/github.com
+	ln -s /opt/vendor_internal/golang.org        vendor/golang.org
+	ln -s /opt/vendor_internal/google.golang.org vendor/google.golang.org
+	ln -s /opt/vendor_internal/gopkg.in          vendor/gopkg.in
+
+enter_docker:
+	set -x ; docker run --rm -it \
+		-v `pwd`:/tmp/src/vitess.io/vitess \
+		-w /tmp/src/vitess.io/vitess \
+		accupara/vitess \
+		bash


### PR DESCRIPTION
Two targets added:
1. One to prepare the symbolic links that point to the vendor directories frozen inside the docker container
2. The docker command that enters the container and gets ready to build code.