### PR TITLE
[Sqlparser] Normalizer should skip TableName and ColName

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -69,6 +69,10 @@ func (nz *normalizer) WalkStatement(node SQLNode) (bool, error) {
 		nz.convertSQLVal(node)
 	case *ComparisonExpr:
 		nz.convertComparison(node)
+	case *ColName, TableName:
+		// Common node types that never contain SQLVals or ListArgs but create a lot of object
+		// allocations.
+		return false, nil
 	}
 	return true, nil
 }
@@ -80,6 +84,10 @@ func (nz *normalizer) WalkSelect(node SQLNode) (bool, error) {
 		nz.convertSQLValDedup(node)
 	case *ComparisonExpr:
 		nz.convertComparison(node)
+	case *ColName, TableName:
+		// Common node types that never contain SQLVals or ListArgs but create a lot of object
+		// allocations.
+		return false, nil
 	}
 	return true, nil
 }
@@ -211,6 +219,10 @@ func GetBindvars(stmt Statement) map[string]struct{} {
 	bindvars := make(map[string]struct{})
 	_ = Walk(func(node SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
+		case *ColName, TableName:
+			// Common node types that never contain SQLVals or ListArgs but create a lot of object
+			// allocations.
+			return false, nil
 		case *SQLVal:
 			if node.Type == ValArg {
 				bindvars[string(node.Val[1:])] = struct{}{}

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -204,3 +204,20 @@ func TestGetBindVars(t *testing.T) {
 		t.Errorf("GetBindVars: %v, want: %v", got, want)
 	}
 }
+
+/*
+Skipping ColName, TableName:
+BenchmarkNormalize-8     1000000              2205 ns/op             821 B/op         27 allocs/op
+Prior to skip:
+BenchmarkNormalize-8      500000              3620 ns/op            1461 B/op         55 allocs/op
+*/
+func BenchmarkNormalize(b *testing.B) {
+	sql := "select 'abcd', 20, 30.0, eid from a where 1=eid and name='3'"
+	ast, err := Parse(sql)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		Normalize(ast, map[string]*querypb.BindVariable{}, "")
+	}
+}


### PR DESCRIPTION
TableName and ColName are the most frequent node types but are
effectively terminal -- they won't contain the nodes types that the
normalizer targets. Therefore, skip walking their children.

Signed-off-by: Daniel Tahara <tahara@dropbox.com>