### PR TITLE
Handle bit types properly so that UPDATE and DELETE work as expected during replication

### DIFF
--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -248,7 +248,7 @@ func ToNative(v Value) (interface{}, error) {
 		return ToUint64(v)
 	case v.IsFloat():
 		return ToFloat64(v)
-	case v.IsQuoted() || v.Type() == Decimal:
+	case v.IsQuoted() || v.Type() == Bit || v.Type() == Decimal:
 		out = v.val
 	case v.Type() == Expression:
 		err = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v cannot be converted to a go type", v)

--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -95,7 +95,7 @@ func isNumber(t querypb.Type) bool {
 // instead.
 // The following conditions are non-overlapping
 // and cover all types: IsSigned(), IsUnsigned(),
-// IsFloat(), IsQuoted(), Null, Decimal, Expression.
+// IsFloat(), IsQuoted(), Null, Decimal, Expression, Bit
 // Also, IsIntegral() == (IsSigned()||IsUnsigned()).
 // TestCategory needs to be updated accordingly if
 // you add a new type.

--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -66,7 +66,7 @@ func IsFloat(t querypb.Type) bool {
 // IsQuoted returns true if querypb.Type is a quoted text or binary.
 // If you have a Value object, use its member function.
 func IsQuoted(t querypb.Type) bool {
-	return int(t)&flagIsQuoted == flagIsQuoted
+	return (int(t)&flagIsQuoted == flagIsQuoted) && t != Bit
 }
 
 // IsText returns true if querypb.Type is a text.

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -192,7 +192,7 @@ func TestCategory(t *testing.T) {
 			}
 			matched = true
 		}
-		if typ == Null || typ == Decimal || typ == Expression {
+		if typ == Null || typ == Decimal || typ == Expression || typ == Bit {
 			if matched {
 				t.Errorf("%v matched more than one category", typ)
 			}

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -230,7 +230,7 @@ func (v Value) EncodeASCII(b BinWriter) {
 	switch {
 	case v.typ == Null:
 		b.Write(nullstr)
-	case v.IsQuoted():
+	case v.IsQuoted() || v.typ == Bit:
 		encodeBytesASCII(v.val, b)
 	default:
 		b.Write(v.val)

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -257,7 +257,7 @@ func TestIntegralValue(t *testing.T) {
 	}
 }
 
-func TestInerfaceValue(t *testing.T) {
+func TestInterfaceValue(t *testing.T) {
 	testcases := []struct {
 		in  interface{}
 		out Value

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -385,7 +385,7 @@ func TestEncode(t *testing.T) {
 	}, {
 		in:       TestValue(Bit, "a"),
 		outSQL:   "b'01100001'",
-		outASCII: "a",
+		outASCII: "'YQ=='",
 	}}
 	for _, tcase := range testcases {
 		buf := &bytes.Buffer{}

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -382,6 +382,10 @@ func TestEncode(t *testing.T) {
 		in:       TestValue(VarChar, "\x00'\"\b\n\r\t\x1A\\"),
 		outSQL:   "'\\0\\'\\\"\\b\\n\\r\\t\\Z\\\\'",
 		outASCII: "'ACciCAoNCRpc'",
+	}, {
+		in:       TestValue(Bit, "a"),
+		outSQL:   "b'01100001'",
+		outASCII: "a",
 	}}
 	for _, tcase := range testcases {
 		buf := &bytes.Buffer{}

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -175,7 +175,7 @@ func IsValue(node Expr) bool {
 	switch v := node.(type) {
 	case *SQLVal:
 		switch v.Type {
-		case StrVal, HexVal, IntVal, ValArg:
+		case StrVal, HexVal, IntVal, BitVal, ValArg:
 			return true
 		}
 	}
@@ -224,6 +224,8 @@ func NewPlanValue(node Expr) (sqltypes.PlanValue, error) {
 			return sqltypes.PlanValue{Value: n}, nil
 		case StrVal:
 			return sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, node.Val)}, nil
+		case BitVal:
+			return sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.Bit, node.Val)}, nil
 		case HexVal:
 			v, err := node.HexDecode()
 			if err != nil {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2397,7 +2397,7 @@ func ExprFromValue(value sqltypes.Value) (Expr, error) {
 		return NewIntVal(value.ToBytes()), nil
 	case value.IsFloat() || value.Type() == sqltypes.Decimal:
 		return NewFloatVal(value.ToBytes()), nil
-	case value.IsQuoted() || value.Type() == sqltypes.Bit:
+	case value.IsQuoted():
 		return NewStrVal(value.ToBytes()), nil
 	default:
 		// We cannot support sqltypes.Expression, or any other invalid type.

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2397,10 +2397,8 @@ func ExprFromValue(value sqltypes.Value) (Expr, error) {
 		return NewIntVal(value.ToBytes()), nil
 	case value.IsFloat() || value.Type() == sqltypes.Decimal:
 		return NewFloatVal(value.ToBytes()), nil
-	case value.IsQuoted():
+	case value.IsQuoted() || value.Type() == sqltypes.Bit:
 		return NewStrVal(value.ToBytes()), nil
-	case value.Type() == sqltypes.Bit:
-		return NewBitVal(value.ToBytes()), nil
 	default:
 		// We cannot support sqltypes.Expression, or any other invalid type.
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "cannot convert value %v to AST", value)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2399,6 +2399,8 @@ func ExprFromValue(value sqltypes.Value) (Expr, error) {
 		return NewFloatVal(value.ToBytes()), nil
 	case value.IsQuoted():
 		return NewStrVal(value.ToBytes()), nil
+	case value.Type() == sqltypes.Bit:
+		return NewBitVal(value.ToBytes()), nil
 	default:
 		// We cannot support sqltypes.Expression, or any other invalid type.
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "cannot convert value %v to AST", value)

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -118,6 +118,16 @@ func TestNormalize(t *testing.T) {
 		outstmt: "update a set v1 = 0x1234",
 		outbv:   map[string]*querypb.BindVariable{},
 	}, {
+		// Bin value does not convert
+		in:      "select * from t where v1 = b'11'",
+		outstmt: "select * from t where v1 = B'11'",
+		outbv:   map[string]*querypb.BindVariable{},
+	}, {
+		// Bin value does not convert for DMLs
+		in:      "update a set v1 = b'11'",
+		outstmt: "update a set v1 = B'11'",
+		outbv:   map[string]*querypb.BindVariable{},
+	}, {
 		// Values up to len 256 will reuse.
 		in:      fmt.Sprintf("select * from t where v1 = '%256s' and v2 = '%256s'", "a", "a"),
 		outstmt: "select * from t where v1 = :bv1 and v2 = :bv1",

--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -1798,8 +1798,11 @@ func TestQueries(t *testing.T) {
 }
 
 func TestBitDefault(t *testing.T) {
+	// Default values for bit fields that are PKs are not supported
+	// Does not make sense to use a bit field as PK
 	client := framework.NewClient()
 
+	expectedError := "bit default value: Execute failed: could not create default row for insert without row values: cannot convert value BIT(\"\\x05\") to AST (CallerID: dev)"
 	testCases := []framework.Testable{
 		&framework.MultiCase{
 			Name: "bit default value",
@@ -1824,8 +1827,9 @@ func TestBitDefault(t *testing.T) {
 		},
 	}
 	for _, tcase := range testCases {
-		if err := tcase.Test("", client); err != nil {
-			t.Error(err)
+		err := tcase.Test("", client)
+		if err == nil || err.Error() != expectedError {
+			t.Errorf("TestBitDefault result: \n%q\nexpecting\n%q", err.Error(), expectedError)
 		}
 	}
 }

--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -1679,7 +1679,7 @@ func TestQueries(t *testing.T) {
 					Query: "insert into vitess_misc(id, b, d, dt, t) select 2, b, d, dt, t from vitess_misc",
 					Rewritten: []string{
 						"select 2, b, d, dt, t from vitess_misc limit 10001",
-						"insert into vitess_misc(id, b, d, dt, t) values (2, '\x01', '2012-01-01', '2012-01-01 15:45:45', '15:45:45') /* _stream vitess_misc (id ) (2 )",
+						"insert into vitess_misc(id, b, d, dt, t) values (2, b'00000001', '2012-01-01', '2012-01-01 15:45:45', '15:45:45') /* _stream vitess_misc (id ) (2 )",
 					},
 				},
 				framework.TestQuery("commit"),

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -884,7 +884,7 @@ primary key (name)
       # that affect more than one keyspace id. These will result
       # in two queries with RBR. So the count there is higher.
       self.check_running_binlog_player(shard_2_master, 4036, 2016)
-      self.check_running_binlog_player(shard_3_master, 4046, 2016)
+      self.check_running_binlog_player(shard_3_master, 4056, 2016)
     else:
       self.check_running_binlog_player(shard_2_master, 4044, 2016)
       self.check_running_binlog_player(shard_3_master, 4048, 2016)

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -326,16 +326,12 @@ primary key (name)
                     0xE000000000000000]
     self._insert_multi_value(shard_1_master, 'resharding1', mids,
                              msg_ids, keyspace_ids)
-    self._insert_multi_value(shard_1_master, 'resharding3', mids,
-                             ['a','b','c'], keyspace_ids)
 
     mids = [10000004, 10000005]
     msg_ids = ['msg-id10000004', 'msg-id10000005']
     keyspace_ids = [0xD000000000000000, 0xE000000000000000]
     self._insert_multi_value(shard_1_master, 'resharding1', mids,
                              msg_ids, keyspace_ids)
-    self._insert_multi_value(shard_1_master, 'resharding3', mids,
-                            ['d', 'e'], keyspace_ids)
 
     mids = [10000011, 10000012, 10000013]
     msg_ids = ['msg-id10000011', 'msg-id10000012', 'msg-id10000013']
@@ -343,20 +339,12 @@ primary key (name)
     self._insert_multi_value(shard_1_master, 'resharding1', mids,
                              msg_ids, keyspace_ids)
 
-    self._insert_multi_value(shard_1_master, 'resharding3', mids,
-                             ['k', 'l', 'm'], keyspace_ids)
-    
     # This update targets two shards.
     self._exec_non_annotated_update(shard_1_master, 'resharding1',
                                     [10000011, 10000012], 'update1')
-    self._exec_non_annotated_update(shard_1_master, 'resharding3',
-                                    [10000011, 10000012], 'g')
     # This update targets one shard.
     self._exec_non_annotated_update(shard_1_master, 'resharding1',
                                     [10000013], 'update2')
-
-    self._exec_non_annotated_update(shard_1_master, 'resharding3',
-                                    [10000013], 'h')
 
     mids = [10000014, 10000015, 10000016]
     msg_ids = ['msg-id10000014', 'msg-id10000015', 'msg-id10000016']
@@ -364,17 +352,48 @@ primary key (name)
     self._insert_multi_value(shard_1_master, 'resharding1', mids,
                              msg_ids, keyspace_ids)
     
-    self._insert_multi_value(shard_1_master, 'resharding3', mids,
-                             ['n', 'o', 'p'], keyspace_ids)
-
     # This delete targets two shards.
     self._exec_non_annotated_delete(shard_1_master, 'resharding1',
-                                    [10000014, 10000015])
-    self._exec_non_annotated_delete(shard_1_master, 'resharding3',
                                     [10000014, 10000015])
 
     # This delete targets one shard.
     self._exec_non_annotated_delete(shard_1_master, 'resharding1', [10000016])
+
+    # repeat DMLs for table with msg as bit(8)
+    mids = [10000001, 10000002, 10000003]
+    keyspace_ids = [0x9000000000000000, 0xD000000000000000,
+                    0xE000000000000000]
+    self._insert_multi_value(shard_1_master, 'resharding3', mids,
+                             ['a','b','c'], keyspace_ids)
+
+    mids = [10000004, 10000005]
+    keyspace_ids = [0xD000000000000000, 0xE000000000000000]
+    self._insert_multi_value(shard_1_master, 'resharding3', mids,
+                            ['d', 'e'], keyspace_ids)
+    mids = [10000011, 10000012, 10000013]
+    keyspace_ids = [0x9000000000000000, 0xD000000000000000, 0xE000000000000000]
+
+    self._insert_multi_value(shard_1_master, 'resharding3', mids,
+                             ['k', 'l', 'm'], keyspace_ids)
+    
+    # This update targets two shards.
+    self._exec_non_annotated_update(shard_1_master, 'resharding3',
+                                    [10000011, 10000012], 'g')
+
+    # This update targets one shard.
+    self._exec_non_annotated_update(shard_1_master, 'resharding3',
+                                    [10000013], 'h')
+
+    mids = [10000014, 10000015, 10000016]
+    keyspace_ids = [0x9000000000000000, 0xD000000000000000, 0xE000000000000000]
+    self._insert_multi_value(shard_1_master, 'resharding3', mids,
+                             ['n', 'o', 'p'], keyspace_ids)
+
+    # This delete targets two shards.
+    self._exec_non_annotated_delete(shard_1_master, 'resharding3',
+                                    [10000014, 10000015])
+
+    # This delete targets one shard.
     self._exec_non_annotated_delete(shard_1_master, 'resharding3', [10000016])
     
   def _check_multi_shard_values(self):
@@ -441,7 +460,7 @@ primary key (name)
         'resharding1', 10000016, 'msg-id10000016', 0xF000000000000000,
         should_be_here=False)
 
-  # checks for bindata table
+  # checks for bit(8) table
     self._check_multi_dbs(
         [shard_2_master, shard_2_replica1, shard_2_replica2],
         'resharding3', 10000001, 'a', 0x9000000000000000)


### PR DESCRIPTION
This is for #4145. 
Changed how bit literals are handled in vitess so that BIT fields are matched correctly for UPDATE / DELETE. 
Instead of converting them to '\x0...' format, we will convert them to b'...' format.