### PR TITLE
improve error if topo server is not specified

### DIFF
--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -207,6 +207,9 @@ func OpenServer(implementation, serverAddress, root string) (*Server, error) {
 // Open returns a Server using the command line parameter flags
 // for implementation, address and root. It log.Exits out if an error occurs.
 func Open() *Server {
+	if *topoGlobalServerAddress == "" {
+		log.Exitf("topo_global_server_address must be configured")
+	}
 	ts, err := OpenServer(*topoImplementation, *topoGlobalServerAddress, *topoGlobalRoot)
 	if err != nil {
 		log.Exitf("Failed to open topo server (%v,%v,%v): %v", *topoImplementation, *topoGlobalServerAddress, *topoGlobalRoot, err)


### PR DESCRIPTION
Tiny change to improve the error message if someone runs a vitess binary that depends on the topo server, but the address isn't specified on the command line.

Prior to this change:
```
# vtgate
F0830 06:39:34.011174   63539 server.go:215] Failed to open topo server (zookeeper,,): node doesn't exist: zookeeper
```

New behavior:
```
# vtgate
F0830 06:41:50.283712   63998 server.go:211] topo_global_server_address must be configured
```

We could also consider printing `flag.Usage()` here... I went back and forth on that.