### PR TITLE
Add more timings binlog player

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -315,7 +315,6 @@ func (blp *BinlogPlayer) applyEvents(ctx context.Context) error {
 		// get the response
 		recvStartTime := time.Now()
 		response, err := stream.Recv()
-		// Records how long it took between stream messages
 		blp.blplStats.Timings.Record(BlplReceive, recvStartTime)
 		// Check context before checking error, because canceled
 		// contexts could be wrapped as regular errors.


### PR DESCRIPTION
### Desc

We are in the process of investigating some slowness with binlog player during shard splits. The following adds metric to help find where the bottleneck is. Specifically:

* Metric to track how long it takes to receive message from BinlogStreamer
* Add warning when binlog player is being throttled. 

Note: There are already timings for mysql time while processing transactions. 