### PR TITLE
[go/mysql] Avoid static buffer and use tiered pool in 

### DIFF
--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -150,11 +150,14 @@ func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readEphemeralPacket)
 	sConn.recycleReadPacket()
 
-	// All three writes, with readPacketDirect, if size allows it.
+	// All three writes, with readEphemeralPacketDirect, if size allows it.
 	if len(data) < MaxPacketSize {
-		verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readPacketDirect)
-		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readPacketDirect)
-		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readPacketDirect)
+		verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readEphemeralPacketDirect)
+		sConn.recycleReadPacket()
+		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readEphemeralPacketDirect)
+		sConn.recycleReadPacket()
+		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readEphemeralPacketDirect)
+		sConn.recycleReadPacket()
 	}
 }
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -204,7 +204,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 
 	// Wait for the client response. This has to be a direct read,
 	// so we don't buffer the TLS negotiation packets.
-	response, err := c.readPacketDirect()
+	response, err := c.readEphemeralPacketDirect()
 	if err != nil {
 		// Don't log EOF errors. They cause too much spam, same as main read loop.
 		if err != io.EOF {
@@ -217,6 +217,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		log.Errorf("Cannot parse client handshake response from %s: %v", c, err)
 		return
 	}
+
+	c.recycleReadPacket()
 
 	if c.Capabilities&CapabilityClientSSL > 0 {
 		// SSL was enabled. We need to re-read the auth packet.


### PR DESCRIPTION
Benchmark results:
```
benchmark                            old ns/op     new ns/op     delta
BenchmarkParallelShortQueries-8      3259          3368          +3.34%
BenchmarkParallelMediumQueries-8     6444          6561          +1.82%
BenchmarkParallelRandomQueries-8     5963212       5441551       -8.75%

benchmark                            old MB/s     new MB/s     speedup
BenchmarkParallelShortQueries-8      3.37         3.27         0.97x
BenchmarkParallelMediumQueries-8     2543.26      2497.78      0.98x

benchmark                            old allocs     new allocs     delta
BenchmarkParallelShortQueries-8      23             23             +0.00%
BenchmarkParallelMediumQueries-8     9              8              -11.11%
BenchmarkParallelRandomQueries-8     14             14             +0.00%

benchmark                            old bytes     new bytes     delta
BenchmarkParallelShortQueries-8      720           812           +12.78%
BenchmarkParallelMediumQueries-8     27205         22720         -16.49%
BenchmarkParallelRandomQueries-8     35898388      29652823      -17.40%
```

I added tiered pool here because without it performance hit is too big (apparently because we use smaller buffer for readOnePacket or something and then when we read query with very high probability buffer from the pool is that smaller buffer).
cc @danieltahara 