### PR TITLE
[go/mysql] use tiered pool for buffers to avoid false hits

### DIFF
--- a/go/bucketpool/bucketpool.go
+++ b/go/bucketpool/bucketpool.go
@@ -1,0 +1,91 @@
+package bucketpool
+
+import (
+	"math"
+	"sync"
+)
+
+type sizedPool struct {
+	size int
+	pool sync.Pool
+}
+
+func newSizedPool(size int) *sizedPool {
+	return &sizedPool{
+		size: size,
+		pool: sync.Pool{
+			New: func() interface{} { return makeSlicePointer(size) },
+		},
+	}
+}
+
+// Pool is actually multiple pools which store buffers of specific size.
+// i.e. it can be three pools which return buffers 32K, 64K and 128K.
+type Pool struct {
+	minSize int
+	maxSize int
+	pools   []*sizedPool
+}
+
+// New returns Pool which has buckets from minSize to maxSize.
+// Buckets increase with the power of two, i.e with multiplier 2: [2b, 4b, 16b, ... , 1024b]
+// Last pool will always be capped to maxSize.
+func New(minSize, maxSize int) *Pool {
+	if maxSize < minSize {
+		panic("maxSize can't be less than minSize")
+	}
+	const multiplier = 2
+	var pools []*sizedPool
+	curSize := minSize
+	for curSize < maxSize {
+		pools = append(pools, newSizedPool(curSize))
+		curSize *= multiplier
+	}
+	pools = append(pools, newSizedPool(maxSize))
+	return &Pool{
+		minSize: minSize,
+		maxSize: maxSize,
+		pools:   pools,
+	}
+}
+
+func (p *Pool) findPool(size int) *sizedPool {
+	if size > p.maxSize {
+		return nil
+	}
+	idx := int(math.Ceil(math.Log2(float64(size) / float64(p.minSize))))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(p.pools)-1 {
+		return nil
+	}
+	return p.pools[idx]
+}
+
+// Get returns pointer to []byte which has len size.
+// If there is no bucket with buffers >= size, slice will be allocated.
+func (p *Pool) Get(size int) *[]byte {
+	sp := p.findPool(size)
+	if sp == nil {
+		return makeSlicePointer(size)
+	}
+	buf := sp.pool.Get().(*[]byte)
+	*buf = (*buf)[:size]
+	return buf
+}
+
+// Put returns pointer to slice to some bucket. Discards slice for which there is no bucket
+func (p *Pool) Put(b *[]byte) {
+	sp := p.findPool(cap(*b))
+	if sp == nil {
+		return
+	}
+	*b = (*b)[:cap(*b)]
+	sp.pool.Put(b)
+}
+
+func makeSlicePointer(size int) *[]byte {
+	data := make([]byte, size)
+	return &data
+}

--- a/go/bucketpool/bucketpool_test.go
+++ b/go/bucketpool/bucketpool_test.go
@@ -1,0 +1,202 @@
+package bucketpool
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestPool(t *testing.T) {
+	maxSize := 16384
+	pool := New(1024, maxSize)
+	if pool.maxSize != maxSize {
+		t.Fatalf("Invalid max pool size: %d, expected %d", pool.maxSize, maxSize)
+	}
+	if len(pool.pools) != 5 {
+		t.Fatalf("Invalid number of pools: %d, expected %d", len(pool.pools), 5)
+	}
+
+	buf := pool.Get(64)
+	if len(*buf) != 64 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1024 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+
+	// get from same pool, check that length is right
+	buf = pool.Get(128)
+	if len(*buf) != 128 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1024 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	// get boundary size
+	buf = pool.Get(1024)
+	if len(*buf) != 1024 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1024 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	// get from the middle
+	buf = pool.Get(5000)
+	if len(*buf) != 5000 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 8192 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	// check last pool
+	buf = pool.Get(16383)
+	if len(*buf) != 16383 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 16384 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	// get big buffer
+	buf = pool.Get(16385)
+	if len(*buf) != 16385 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 16385 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+}
+
+func TestPoolOneSize(t *testing.T) {
+	maxSize := 1024
+	pool := New(1024, maxSize)
+	if pool.maxSize != maxSize {
+		t.Fatalf("Invalid max pool size: %d, expected %d", pool.maxSize, maxSize)
+	}
+	buf := pool.Get(64)
+	if len(*buf) != 64 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1024 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	buf = pool.Get(1025)
+	if len(*buf) != 1025 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1025 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+}
+
+func TestPoolTwoSizeNotMultiplier(t *testing.T) {
+	maxSize := 2000
+	pool := New(1024, maxSize)
+	if pool.maxSize != maxSize {
+		t.Fatalf("Invalid max pool size: %d, expected %d", pool.maxSize, maxSize)
+	}
+	buf := pool.Get(64)
+	if len(*buf) != 64 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 1024 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	buf = pool.Get(2001)
+	if len(*buf) != 2001 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 2001 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+}
+
+func TestPoolWeirdMaxSize(t *testing.T) {
+	maxSize := 15000
+	pool := New(1024, maxSize)
+	if pool.maxSize != maxSize {
+		t.Fatalf("Invalid max pool size: %d, expected %d", pool.maxSize, maxSize)
+	}
+
+	buf := pool.Get(14000)
+	if len(*buf) != 14000 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 15000 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+
+	buf = pool.Get(16383)
+	if len(*buf) != 16383 {
+		t.Fatalf("unexpected buf length: %d", len(*buf))
+	}
+	if cap(*buf) != 16383 {
+		t.Fatalf("unexepected buf cap: %d", cap(*buf))
+	}
+	pool.Put(buf)
+}
+
+func TestFuzz(t *testing.T) {
+	maxTestSize := 16384
+	for i := 0; i < 20000; i++ {
+		minSize := rand.Intn(maxTestSize)
+		maxSize := rand.Intn(maxTestSize-minSize) + minSize
+		p := New(minSize, maxSize)
+		bufSize := rand.Intn(maxTestSize)
+		buf := p.Get(bufSize)
+		if len(*buf) != bufSize {
+			t.Fatalf("Invalid length %d, expected %d", len(*buf), bufSize)
+		}
+		sPool := p.findPool(bufSize)
+		if sPool == nil {
+			if cap(*buf) != len(*buf) {
+				t.Fatalf("Invalid cap %d, expected %d", cap(*buf), len(*buf))
+			}
+		} else {
+			if cap(*buf) != sPool.size {
+				t.Fatalf("Invalid cap %d, expected %d", cap(*buf), sPool.size)
+			}
+		}
+		p.Put(buf)
+	}
+}
+
+func BenchmarkPool(b *testing.B) {
+	pool := New(2, 16384)
+	b.SetParallelism(16)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			randomSize := rand.Intn(pool.maxSize)
+			data := pool.Get(randomSize)
+			pool.Put(data)
+		}
+	})
+}
+
+func BenchmarkPoolGet(b *testing.B) {
+	pool := New(2, 16384)
+	b.SetParallelism(16)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			randomSize := rand.Intn(pool.maxSize)
+			data := pool.Get(randomSize)
+			_ = data
+		}
+	})
+}


### PR DESCRIPTION
Now when we get smaller than we want buffer from pool, we just put it
back and allocate a new one. This might be quite inefficient.
So, instead use multiple pools which always return buffers >= request
size.
Benchmark results:
```
benchmark                            old ns/op     new ns/op     delta
BenchmarkParallelShortQueries-8      3347          3327          -0.60%
BenchmarkParallelMediumQueries-8     6535          5789          -11.42%
BenchmarkParallelRandomQueries-8     6001539       5453566       -9.13%

benchmark                            old MB/s     new MB/s     speedup
BenchmarkParallelShortQueries-8      3.29         3.31         1.01x
BenchmarkParallelMediumQueries-8     2507.72      2830.78      1.13x

benchmark                            old allocs     new allocs     delta
BenchmarkParallelShortQueries-8      23             23             +0.00%
BenchmarkParallelMediumQueries-8     9              8              -11.11%
BenchmarkParallelRandomQueries-8     15             14             -6.67%

benchmark                            old bytes     new bytes     delta
BenchmarkParallelShortQueries-8      720           720           +0.00%
BenchmarkParallelMediumQueries-8     27243         20865         -23.41%
BenchmarkParallelRandomQueries-8     36496086      29452887      -19.30%
```
This is new package and internal to vitess. So, we can make interface less flexible maybe. Like allow only powers of two and say that multiplier is always 2.