### PR TITLE
[go/mysql] use sync.Pool for reusing bufio readers and writers

### DIFF
--- a/go/mysql/bufio_pool.go
+++ b/go/mysql/bufio_pool.go
@@ -1,0 +1,117 @@
+package mysql
+
+import (
+	"bufio"
+	"io"
+	"sync"
+)
+
+// Reader implementation
+
+type bufioReader interface {
+	Read([]byte) (int, error)
+	Reset(io.Reader)
+}
+
+var readersPool = sync.Pool{New: func() interface{} { return bufio.NewReaderSize(nil, connBufferSize) }}
+
+func (pbr *poolBufioReader) getReader() {
+	if pbr.br != nil {
+		return
+	}
+	pbr.br = readersPool.Get().(*bufio.Reader)
+	pbr.br.Reset(pbr.r)
+}
+
+func (pbr *poolBufioReader) putReader() {
+	if pbr.br == nil {
+		return
+	}
+	// remove reference
+	pbr.br.Reset(nil)
+	readersPool.Put(pbr.br)
+	pbr.br = nil
+}
+
+type poolBufioReader struct {
+	r  io.Reader
+	br *bufio.Reader
+}
+
+func newReader(r io.Reader) bufioReader {
+	return &poolBufioReader{
+		r: r,
+	}
+}
+
+func (pbr *poolBufioReader) Read(b []byte) (int, error) {
+	pbr.getReader()
+	n, err := pbr.br.Read(b)
+	if pbr.br.Buffered() == 0 {
+		pbr.putReader()
+	}
+	return n, err
+}
+
+func (pbr *poolBufioReader) Reset(r io.Reader) {
+	pbr.putReader()
+	pbr.r = r
+}
+
+// Writer implementation
+
+var writersPool = sync.Pool{New: func() interface{} { return bufio.NewWriterSize(nil, connBufferSize) }}
+
+type bufioWriter interface {
+	Write([]byte) (int, error)
+	Reset(io.Writer)
+	Flush() error
+}
+
+func (pbw *poolBufioWriter) getWriter() {
+	if pbw.bw != nil {
+		return
+	}
+	pbw.bw = writersPool.Get().(*bufio.Writer)
+	pbw.bw.Reset(pbw.w)
+}
+
+func (pbw *poolBufioWriter) putWriter() {
+	if pbw.bw == nil {
+		return
+	}
+	// remove reference
+	pbw.bw.Reset(nil)
+	writersPool.Put(pbw.bw)
+	pbw.bw = nil
+}
+
+type poolBufioWriter struct {
+	w  io.Writer
+	bw *bufio.Writer
+}
+
+func newWriter(w io.Writer) bufioWriter {
+	return &poolBufioWriter{
+		w: w,
+	}
+}
+
+func (pbw *poolBufioWriter) Write(b []byte) (int, error) {
+	pbw.getWriter()
+	return pbw.bw.Write(b)
+}
+
+func (pbw *poolBufioWriter) Reset(w io.Writer) {
+	pbw.putWriter()
+	pbw.w = w
+}
+
+func (pbw *poolBufioWriter) Flush() error {
+	if pbw.bw == nil {
+		return nil
+	}
+	err := pbw.bw.Flush()
+	pbw.putWriter()
+	return err
+}

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"net"
@@ -136,8 +135,8 @@ type Conn struct {
 	ClientData interface{}
 
 	// Packet encoding variables.
-	reader   *bufio.Reader
-	writer   *bufio.Writer
+	reader   bufioReader
+	writer   bufioWriter
 	sequence uint8
 
 	// fields contains the fields definitions for an on-going
@@ -169,8 +168,8 @@ func newConn(conn net.Conn) *Conn {
 	return &Conn{
 		conn: conn,
 
-		reader:   bufio.NewReaderSize(conn, connBufferSize),
-		writer:   bufio.NewWriterSize(conn, connBufferSize),
+		reader:   newReader(conn),
+		writer:   newWriter(conn),
 		sequence: 0,
 	}
 }


### PR DESCRIPTION
Readers recycle objects on Read if there are no buffered bytes. Writers recycle objects on Flush. Both recycle on Reset.
Maybe we should also recycle writers on Write in similar to Read manner.
/cc @danieltahara @sougou 
benchmark results:
```
benchmark                            old ns/op      new ns/op      delta
BenchmarkParallelShortQueries-8      3443           3439           -0.12%
BenchmarkParallelMediumQueries-8     19907          23057          +15.82%
BenchmarkParallelRandomQueries-8     1098953101     1077136194     -1.99%

benchmark                            old MB/s     new MB/s     speedup
BenchmarkParallelShortQueries-8      6.10         6.10         1.00x
BenchmarkParallelMediumQueries-8     823.82       711.25       0.86x

benchmark                            old allocs     new allocs     delta
BenchmarkParallelShortQueries-8      24             24             +0.00%
BenchmarkParallelMediumQueries-8     24             25             +4.17%
BenchmarkParallelRandomQueries-8     32292          31851          -1.37%

benchmark                            old bytes     new bytes     delta
BenchmarkParallelShortQueries-8      867           873           +0.69%
BenchmarkParallelMediumQueries-8     63241         69361         +9.68%
BenchmarkParallelRandomQueries-8     147128744     142483592     -3.16%

```