### PR TITLE
Kill vtctld commands that outlive the http request context

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -454,8 +454,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		logstream := logutil.NewMemoryLogger()
 
 		wr := wrangler.New(logstream, ts, tmClient)
-		// TODO(enisoc): Context for run command should be request-scoped.
-		err := vtctl.RunCommand(ctx, wr, args)
+		err := vtctl.RunCommand(r.Context(), wr, args)
 		if err != nil {
 			resp.Error = err.Error()
 		}


### PR DESCRIPTION
Caution: I haven't tested this yet.

I've encountered situations where a vtctld command hangs and leaves a lock file sitting around in the topology.

The default timeout for vtctl is 24 hours, so in these situations you have to manually go into the topology and delete lock files.