### PR TITLE
mysql: improve code structure for buffered vs unbuffered writes

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -508,7 +508,7 @@ func (c *Conn) writeSSLRequest(capabilities uint32, characterSet uint8, params *
 	pos = writeByte(data, pos, characterSet)
 
 	// And send it as is.
-	if err := c.writeEphemeralPacket(true /* direct */); err != nil {
+	if err := c.writeEphemeralPacket(); err != nil {
 		return NewSQLError(CRServerLost, SSUnknownSQLState, "cannot send SSLRequest: %v", err)
 	}
 	return nil
@@ -600,7 +600,7 @@ func (c *Conn) writeHandshakeResponse41(capabilities uint32, scrambledPassword [
 		return NewSQLError(CRMalformedPacket, SSUnknownSQLState, "writeHandshakeResponse41: only packed %v bytes, out of %v allocated", pos, len(data))
 	}
 
-	if err := c.writeEphemeralPacket(true /* direct */); err != nil {
+	if err := c.writeEphemeralPacket(); err != nil {
 		return NewSQLError(CRServerLost, SSUnknownSQLState, "cannot send HandshakeResponse41: %v", err)
 	}
 	return nil
@@ -627,5 +627,5 @@ func (c *Conn) writeClearTextPassword(params *ConnParams) error {
 	if pos != len(data) {
 		return fmt.Errorf("error building ClearTextPassword packet: got %v bytes expected %v", pos, len(data))
 	}
-	return c.writeEphemeralPacket(true)
+	return c.writeEphemeralPacket()
 }

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -250,8 +250,7 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 		// Switch to SSL.
 		conn := tls.Client(c.conn, clientConfig)
 		c.conn = conn
-		c.reader.Reset(conn)
-		c.writer.Reset(conn)
+		c.bufferedReader.Reset(conn)
 		c.Capabilities |= CapabilityClientSSL
 	}
 

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -77,25 +77,21 @@ func useWritePacket(t *testing.T, cConn *Conn, data []byte) {
 	if err := cConn.writePacket(data); err != nil {
 		t.Fatalf("writePacket failed: %v", err)
 	}
-	if err := cConn.flush(); err != nil {
-		t.Fatalf("flush failed: %v", err)
-	}
 }
 
-func useWriteEphemeralPacket(t *testing.T, cConn *Conn, data []byte) {
+func useWriteEphemeralPacketBuffered(t *testing.T, cConn *Conn, data []byte) {
 	defer func() {
 		if x := recover(); x != nil {
 			t.Fatalf("%v", x)
 		}
 	}()
+	cConn.startBuffering()
+	defer cConn.flush()
 
 	buf := cConn.startEphemeralPacket(len(data))
 	copy(buf, data)
-	if err := cConn.writeEphemeralPacket(false); err != nil {
+	if err := cConn.writeEphemeralPacket(); err != nil {
 		t.Fatalf("writeEphemeralPacket(false) failed: %v", err)
-	}
-	if err := cConn.flush(); err != nil {
-		t.Fatalf("flush failed: %v", err)
 	}
 }
 
@@ -108,7 +104,7 @@ func useWriteEphemeralPacketDirect(t *testing.T, cConn *Conn, data []byte) {
 
 	buf := cConn.startEphemeralPacket(len(data))
 	copy(buf, data)
-	if err := cConn.writeEphemeralPacket(true); err != nil {
+	if err := cConn.writeEphemeralPacket(); err != nil {
 		t.Fatalf("writeEphemeralPacket(true) failed: %v", err)
 	}
 }
@@ -139,13 +135,13 @@ func verifyPacketCommsSpecific(t *testing.T, cConn *Conn, data []byte,
 func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
 	// All three writes, with ReadPacket.
 	verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.ReadPacket)
-	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.ReadPacket)
+	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketBuffered, sConn.ReadPacket)
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.ReadPacket)
 
 	// All three writes, with readEphemeralPacket.
 	verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readEphemeralPacket)
 	sConn.recycleReadPacket()
-	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readEphemeralPacket)
+	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketBuffered, sConn.readEphemeralPacket)
 	sConn.recycleReadPacket()
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readEphemeralPacket)
 	sConn.recycleReadPacket()
@@ -154,7 +150,7 @@ func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
 	if len(data) < MaxPacketSize {
 		verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readEphemeralPacketDirect)
 		sConn.recycleReadPacket()
-		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readEphemeralPacketDirect)
+		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketBuffered, sConn.readEphemeralPacketDirect)
 		sConn.recycleReadPacket()
 		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readEphemeralPacketDirect)
 		sConn.recycleReadPacket()
@@ -256,9 +252,6 @@ func TestBasicPackets(t *testing.T) {
 	// Write EOF packet, read it, compare first byte. Payload is always ignored.
 	if err := sConn.writeEOFPacket(0x8912, 0xabba); err != nil {
 		t.Fatalf("writeEOFPacket failed: %v", err)
-	}
-	if err := sConn.flush(); err != nil {
-		t.Fatalf("flush failed: %v", err)
 	}
 	data, err = cConn.ReadPacket()
 	if err != nil || len(data) == 0 || !isEOFPacket(data) {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -85,7 +85,7 @@ func useWriteEphemeralPacketBuffered(t *testing.T, cConn *Conn, data []byte) {
 			t.Fatalf("%v", x)
 		}
 	}()
-	cConn.startBuffering()
+	cConn.startWriterBuffering()
 	defer cConn.flush()
 
 	buf := cConn.startEphemeralPacket(len(data))

--- a/go/mysql/replication.go
+++ b/go/mysql/replication.go
@@ -34,7 +34,7 @@ func (c *Conn) WriteComBinlogDump(serverID uint32, binlogFilename string, binlog
 	pos = writeUint16(data, pos, flags)
 	pos = writeUint32(data, pos, serverID)
 	pos = writeEOFString(data, pos, binlogFilename)
-	if err := c.writeEphemeralPacket(true); err != nil {
+	if err := c.writeEphemeralPacket(); err != nil {
 		return NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	return nil
@@ -62,7 +62,7 @@ func (c *Conn) WriteComBinlogDumpGTID(serverID uint32, binlogFilename string, bi
 	pos = writeUint64(data, pos, binlogPos)
 	pos = writeUint32(data, pos, uint32(len(gtidSet)))
 	pos += copy(data[pos:], gtidSet)
-	if err := c.writeEphemeralPacket(true); err != nil {
+	if err := c.writeEphemeralPacket(); err != nil {
 		return NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	return nil

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -185,6 +185,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		if x := recover(); x != nil {
 			log.Errorf("mysql_server caught panic:\n%v\n%s", x, tb.Stack(4))
 		}
+		// We call flush here in case there's a premature return after
+		// startWriterBuffering is called
+		c.flush()
+
 		conn.Close()
 	}()
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -603,8 +603,7 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []by
 		// Need to switch to TLS, and then re-read the packet.
 		conn := tls.Server(c.conn, l.TLSConfig)
 		c.conn = conn
-		c.reader.Reset(conn)
-		c.writer.Reset(conn)
+		c.bufferedReader.Reset(conn)
 		c.Capabilities |= CapabilityClientSSL
 		return "", "", nil, nil
 	}


### PR DESCRIPTION
@danieltahara @LK4D4: can you take a look at this approach?

The previous code had context sensitive functions that could not be freely reused because some assumed that they were using bufio and some didn't. This is now changed in such a way that the
buffering decision is made at a high level (only for ComQuery results).

This also changes how we would pool bufio.Writer compared to #4188.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>