### PR TITLE
travis: Disable remote-stats reporting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
     #       See: https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts
     # To diagnose stuck tests, add "-follow" to TEST_FLAGS below. Then test.go
     # will print the test's output.
-    - TEST_FLAGS="-docker -use_docker_cache -timeout=8m -print-log -remote-stats=http://enisoc.com:15123/travis/stats"
+    - TEST_FLAGS="-docker -use_docker_cache -timeout=8m -print-log"
   matrix:
     # NOTE: Travis CI schedules up to 5 tests simultaneously.
     #       All our tests should be spread out as evenly as possible across these 5 slots.

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ docker_unit_test:
 # tests in Travis. The results are saved in test/config.json, which you can
 # then commit and push.
 rebalance_tests:
-	go run test.go -rebalance 5 -remote-stats http://enisoc.com:15123/travis/stats
+	go run test.go -rebalance 5
 
 # Release a version.
 # This will generate a tar.gz file into the releases folder with the current source


### PR DESCRIPTION
I recently turned down the personal server that was hosting an endpoint to record test stats from travis, for use with the `-rebalance` feature of `test.go`.

This PR disables remote-stats reporting in our travis config, so it stops trying to connect to the non-existent endpoint.