### PR TITLE
Disable uniqueness checks during split clone

### DIFF
--- a/go/vt/worker/defaults.go
+++ b/go/vt/worker/defaults.go
@@ -49,6 +49,7 @@ const (
 	defaultDestinationPackCount    = 10
 	defaultDestinationWriterCount  = 20
 	defaultMinHealthyRdonlyTablets = 2
+	defaultDisableUniquenessChecks = false
 	defaultDestTabletType          = "RDONLY"
 	defaultParallelDiffsCount      = 8
 	defaultMaxTPS                  = throttler.MaxRateModuleDisabled


### PR DESCRIPTION
This speeds up the clone and handles issues with inserts/deletes of rows that have the same secondary key if it is uniqueness constrained.

Signed-off-by: Jon Tirsen <jontirsen@squareup.com>