### PR TITLE
Adds batch time as parameter

### DIFF
--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -38,7 +38,7 @@ import (
 var (
 	// vtexplain uses a logical clock to show order of execution in queries.
 	// Some vtexplain runs can change order depending on the duration of the batch time
-	batchTimeWaitDuration = flag.Duration("batch-time-wait-duration", 10*time.Millisecond, "Duration of a batch time logical clock.")
+	batchIntervalDuration = flag.Duration("batch-interval-duration", 10*time.Millisecond, "Duration of a batch time logical clock.")
 )
 
 // ExecutorMode controls the mode of operation for the vtexplain simulator
@@ -245,7 +245,7 @@ func Run(sql string) ([]*Explain, error) {
 
 		if sql != "" {
 			// Reset the global time simulator for each query
-			batchTime = sync2.NewBatcher(*batchTimeWaitDuration)
+			batchTime = sync2.NewBatcher(*batchIntervalDuration)
 			log.V(100).Infof("explain %s", sql)
 			e, err := explain(sql)
 			if err != nil {

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -36,9 +36,7 @@ import (
 )
 
 var (
-	// vtexplain uses a logical clock to show order of execution in queries.
-	// Some vtexplain runs can change order depending on the duration of the batch time
-	batchIntervalDuration = flag.Duration("batch-interval-duration", 10*time.Millisecond, "Duration of a batch time logical clock.")
+	batchInterval = flag.Duration("batch-interval", 10*time.Millisecond, "Interval between logical time slots.")
 )
 
 // ExecutorMode controls the mode of operation for the vtexplain simulator
@@ -245,7 +243,7 @@ func Run(sql string) ([]*Explain, error) {
 
 		if sql != "" {
 			// Reset the global time simulator for each query
-			batchTime = sync2.NewBatcher(*batchIntervalDuration)
+			batchTime = sync2.NewBatcher(*batchInterval)
 			log.V(100).Infof("explain %s", sql)
 			e, err := explain(sql)
 			if err != nil {

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -21,6 +21,7 @@ package vtexplain
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"sort"
 	"time"
@@ -32,6 +33,12 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var (
+	// vtexplain uses a logical clock to show order of execution in queries.
+	// Some vtexplain runs can change order depending on the duration of the batch time
+	batchTimeWaitDuration = flag.Duration("batch-time-wait-duration", 10*time.Millisecond, "Duration of a batch time logical clock.")
 )
 
 // ExecutorMode controls the mode of operation for the vtexplain simulator
@@ -238,7 +245,7 @@ func Run(sql string) ([]*Explain, error) {
 
 		if sql != "" {
 			// Reset the global time simulator for each query
-			batchTime = sync2.NewBatcher(time.Duration(10 * time.Millisecond))
+			batchTime = sync2.NewBatcher(*batchTimeWaitDuration)
 			log.V(100).Infof("explain %s", sql)
 			e, err := explain(sql)
 			if err != nil {


### PR DESCRIPTION
### Description

We are starting to use vtexplain for some automated tests inside slack. We ran into some small issue with flaky tests due to `batch` time. This PR allows vtexplain users to set this value explicitly. 
