### PR TITLE
Embedder: embedding of multiple instances of a server object in a single process

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -38,8 +38,9 @@ CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
 
 # Admin user with all privileges.
 CREATE USER 'vt_dba'@'localhost';
-GRANT ALL ON *.* TO 'vt_dba'@'localhost';
-GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';
+# Including 127.0.0.1 allows local tcp connections.
+GRANT ALL ON *.* TO 'vt_dba'@'localhost', 'vt_dba'@'127.0.0.1';
+GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost', 'vt_dba'@'127.0.0.1';
 
 # User for app traffic, with global read-write access.
 CREATE USER 'vt_app'@'localhost';
@@ -47,11 +48,11 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
   LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
   SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
-  ON *.* TO 'vt_app'@'localhost';
+  ON *.* TO 'vt_app'@'localhost', 'vt_app'@'127.0.0.1';
 
 # User for app debug traffic, with global read access.
 CREATE USER 'vt_appdebug'@'localhost';
-GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';
+GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost', 'vt_appdebug'@'127.0.0.1';
 
 # User for administrative operations that need to be executed as non-SUPER.
 # Same permissions as vt_app here.

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	// vtgate configuration and init
-	resilientServer = srvtopo.NewResilientServer(ts, "ResilientSrvTopoServer")
+	resilientServer = srvtopo.NewResilientServer("ResilientSrvTopoServer", ts)
 	healthCheck = discovery.NewHealthCheck(1*time.Millisecond /*retryDelay*/, 1*time.Hour /*healthCheckTimeout*/)
 	tabletTypesToWait := []topodatapb.TabletType{
 		topodatapb.TabletType_MASTER,

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -57,6 +57,9 @@ var (
 	ts *topo.Server
 )
 
+var resilientServer *srvtopo.ResilientServer
+var healthCheck discovery.HealthCheck
+
 func init() {
 	servenv.RegisterDefaultFlags()
 }
@@ -119,8 +122,8 @@ func main() {
 	}
 
 	// vtgate configuration and init
-	resilientServer := srvtopo.NewResilientServer(ts, "ResilientSrvTopoServer")
-	healthCheck := discovery.NewHealthCheck(1*time.Millisecond /*retryDelay*/, 1*time.Hour /*healthCheckTimeout*/)
+	resilientServer = srvtopo.NewResilientServer(ts, "ResilientSrvTopoServer")
+	healthCheck = discovery.NewHealthCheck(1*time.Millisecond /*retryDelay*/, 1*time.Hour /*healthCheckTimeout*/)
 	tabletTypesToWait := []topodatapb.TabletType{
 		topodatapb.TabletType_MASTER,
 		topodatapb.TabletType_REPLICA,
@@ -130,10 +133,14 @@ func main() {
 	vtgate.QueryLogHandler = "/debug/vtgate/querylog"
 	vtgate.QueryLogzHandler = "/debug/vtgate/querylogz"
 	vtgate.QueryzHandler = "/debug/vtgate/queryz"
-	vtgate.Init(context.Background(), healthCheck, resilientServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
+	vtg := vtgate.Init(context.Background(), healthCheck, resilientServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
 
 	// vtctld configuration and init
 	vtctld.InitVtctld(ts)
+
+	servenv.OnRun(func() {
+		addStatusParts(vtg)
+	})
 
 	servenv.OnTerm(func() {
 		// FIXME(alainjobart): stop vtgate

--- a/go/cmd/vtcombo/status.go
+++ b/go/cmd/vtcombo/status.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/gateway"
+
+	_ "vitess.io/vitess/go/vt/status"
+)
+
+// For use by plugins which wish to avoid racing when registering status page parts.
+var onStatusRegistered func()
+
+func addStatusParts(vtg *vtgate.VTGate) {
+	// Override and reparse the template string so we can point tablet server urls to a local path.
+	*discovery.TabletURLTemplateString = "{{.EmbeddedStatusURL}}"
+	discovery.ParseTabletURLTemplateFromFlag()
+
+	servenv.AddStatusPart("Executor", vtgate.ExecutorTemplate, func() interface{} {
+		return nil
+	})
+	servenv.AddStatusPart("VSchema", vtgate.VSchemaTemplate, func() interface{} {
+		return vtg.VSchemaStats()
+	})
+	servenv.AddStatusFuncs(srvtopo.StatusFuncs)
+	servenv.AddStatusPart("Topology Cache", srvtopo.TopoTemplate, func() interface{} {
+		return resilientServer.CacheStatus()
+	})
+	servenv.AddStatusPart("Gateway Status", gateway.StatusTemplate, func() interface{} {
+		return vtg.GetGatewayCacheStatus()
+	})
+	servenv.AddStatusPart("Health Check Cache", discovery.HealthCheckTemplate, func() interface{} {
+		return healthCheck.CacheStatus()
+	})
+	if onStatusRegistered != nil {
+		onStatusRegistered()
+	}
+}

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -66,7 +66,7 @@ func main() {
 	ts := topo.Open()
 	defer ts.Close()
 
-	resilientServer = srvtopo.NewResilientServer(ts, "ResilientSrvTopoServer")
+	resilientServer = srvtopo.NewResilientServer("ResilientSrvTopoServer", ts)
 
 	healthCheck = discovery.NewHealthCheck(*healthCheckRetryDelay, *healthCheckTimeout)
 	healthCheck.RegisterStats()

--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -72,22 +72,25 @@ var (
     </td>
     <td width="25%" border="">
       <a href="/schemaz">Schema</a></br>
-      <a href="/debug/tablet_plans">Schema&nbsp;Query&nbsp;Plans</a></br>
-      <a href="/debug/query_stats">Schema&nbsp;Query&nbsp;Stats</a></br>
-      <a href="/debug/table_stats">Schema&nbsp;Table&nbsp;Stats</a></br>
-    </td>
-    <td width="25%" border="">
       <a href="/queryz">Query&nbsp;Stats</a></br>
+      <a href="/debug/query_stats">JSON&nbsp;Query&nbsp;Stats</a></br>
       <a href="/streamqueryz">Streaming&nbsp;Query&nbsp;Stats</a></br>
       <a href="/debug/consolidations">Consolidations</a></br>
-      <a href="/querylogz">Current&nbsp;Query&nbsp;Log</a></br>
-      <a href="/txlogz">Current&nbsp;Transaction&nbsp;Log</a></br>
-      <a href="/twopcz">In-flight&nbsp;2PC&nbsp;Transactions</a></br>
     </td>
     <td width="25%" border="">
-      <a href="/healthz">Health Check</a></br>
-      <a href="/debug/health">Query Service Health Check</a></br>
-      <a href="/streamqueryz">Current Stream Queries</a></br>
+      <a href="/debug/tablet_plans">Query&nbsp;Plans</a></br>
+      <a href="/querylogz">Current&nbsp;Query&nbsp;Log</a></br>
+      <a href="/debug/querylog">Query&nbsp;Log&nbsp;Stream</a></br>
+      <a href="/txlogz">Current&nbsp;Transaction&nbsp;Log</a></br>
+      <a href="/debug/txlog">Transaction&nbsp;Log&nbsp;Stream</a></br>
+    </td>
+    <td width="25%" border="">
+      <a href="/healthz">Health&nbsp;Check</a></br>
+      <a href="/debug/health">Query&nbsp;Service&nbsp;Health&nbsp;Check</a></br>
+      <a href="/streamqueryz">Current&nbsp;Stream&nbsp;Queries</a></br>
+      <a href="/debug/hotrows">Hot&nbsp;Rows</a></br>
+      <a href="/debug/query_rules">Blacklisted&nbsp;Queries</a></br>
+      <a href="/twopcz">In-flight&nbsp;2PC&nbsp;Transactions</a></br>
     </td>
   </tr>
 </table>

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -101,7 +101,7 @@ func main() {
 
 	// creates and registers the query service
 	ts := topo.Open()
-	qsc := tabletserver.NewServer(ts, *tabletAlias)
+	qsc := tabletserver.NewServer("", ts, *tabletAlias)
 	servenv.OnRun(func() {
 		qsc.Register()
 		addStatusParts(qsc)

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -55,6 +55,9 @@ func (result *Result) Repair(fields []*querypb.Field) {
 
 // Copy creates a deep copy of Result.
 func (result *Result) Copy() *Result {
+	if result == nil {
+		return nil
+	}
 	out := &Result{
 		InsertID:     result.InsertID,
 		RowsAffected: result.RowsAffected,

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -74,6 +74,11 @@ func TestCopy(t *testing.T) {
 	if !reflect.DeepEqual(out, in) {
 		t.Errorf("Copy:\n%v, want\n%v", out, in)
 	}
+
+	in = nil
+	if got := in.Copy(); got != nil {
+		t.Errorf("Copy(nil): %v, want nil", got)
+	}
 }
 
 func TestTruncate(t *testing.T) {

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -52,23 +52,23 @@ type ConnectionPool struct {
 	mysqlStats *stats.Timings
 }
 
-// NewConnectionPool creates a new ConnectionPool. The name is used
+// NewConnectionPool creates a new ConnectionPool. The instanceName is used
 // to publish stats only.
-func NewConnectionPool(name string, capacity int, idleTimeout time.Duration) *ConnectionPool {
+func NewConnectionPool(instanceName string, capacity int, idleTimeout time.Duration) *ConnectionPool {
 	cp := &ConnectionPool{capacity: capacity, idleTimeout: idleTimeout}
-	if name == "" {
+	if instanceName == "" {
 		return cp
 	}
-	env := servenv.NewEmbedder(name, name)
-	env.NewGaugeFunc("Capacity", "Connection pool capacity", cp.Capacity)
-	env.NewGaugeFunc("Available", "Connection pool available", cp.Available)
-	env.NewGaugeFunc("Active", "Connection pool active", cp.Active)
-	env.NewGaugeFunc("InUse", "Connection pool in-use", cp.InUse)
-	env.NewGaugeFunc("MaxCap", "Connection pool max cap", cp.MaxCap)
-	env.NewCounterFunc("WaitCount", "Connection pool wait count", cp.WaitCount)
-	env.NewCounterDurationFunc("WaitTime", "Connection pool wait time", cp.WaitTime)
-	env.NewGaugeDurationFunc("IdleTimeout", "Connection pool idle timeout", cp.IdleTimeout)
-	env.NewGaugeFunc("IdleClosed", "Connection pool idle closed", cp.IdleClosed)
+	servenv.AssignPrefix(instanceName, instanceName)
+	servenv.NewGaugeFunc(instanceName, "Capacity", "Connection pool capacity", cp.Capacity)
+	servenv.NewGaugeFunc(instanceName, "Available", "Connection pool available", cp.Available)
+	servenv.NewGaugeFunc(instanceName, "Active", "Connection pool active", cp.Active)
+	servenv.NewGaugeFunc(instanceName, "InUse", "Connection pool in-use", cp.InUse)
+	servenv.NewGaugeFunc(instanceName, "MaxCap", "Connection pool max cap", cp.MaxCap)
+	servenv.NewCounterFunc(instanceName, "WaitCount", "Connection pool wait count", cp.WaitCount)
+	servenv.NewCounterDurationFunc(instanceName, "WaitTime", "Connection pool wait time", cp.WaitTime)
+	servenv.NewGaugeDurationFunc(instanceName, "IdleTimeout", "Connection pool idle timeout", cp.IdleTimeout)
+	servenv.NewGaugeFunc(instanceName, "IdleClosed", "Connection pool idle closed", cp.IdleClosed)
 	return cp
 }
 
@@ -79,11 +79,11 @@ func (cp *ConnectionPool) pool() (p *pools.ResourcePool) {
 	return p
 }
 
-// Open must be call before starting to use the pool.
+// Open must be called before starting to use the pool.
 //
 // For instance:
 // mysqlStats := stats.NewTimings("Mysql")
-// pool := dbconnpool.NewConnectionPool("name", 10, 30*time.Second)
+// pool := dbconnpool.NewConnectionPool("instanceName", 10, 30*time.Second)
 // pool.Open(info, mysqlStats)
 // ...
 // conn, err := pool.Get()

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -56,6 +56,7 @@ import (
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
@@ -69,8 +70,10 @@ var (
 	hcErrorCounters          = stats.NewCountersWithMultiLabels("HealthcheckErrors", "Healthcheck Errors", []string{"Keyspace", "ShardName", "TabletType"})
 	hcMasterPromotedCounters = stats.NewCountersWithMultiLabels("HealthcheckMasterPromoted", "Master promoted in keyspace/shard name because of health check errors", []string{"Keyspace", "ShardName"})
 	healthcheckOnce          sync.Once
-	tabletURLTemplateString  = flag.String("tablet_url_template", "http://{{.GetTabletHostPort}}", "format string describing debug tablet url formatting. See the Go code for getTabletDebugURL() how to customize this.")
-	tabletURLTemplate        *template.Template
+
+	// TabletURLTemplateString is a flag to generate URLs for the tablets that vtgate discovers.
+	TabletURLTemplateString = flag.String("tablet_url_template", "http://{{.GetTabletHostPort}}", "format string describing debug tablet url formatting. See the Go code for getTabletDebugURL() how to customize this.")
+	tabletURLTemplate       *template.Template
 )
 
 // See the documentation for NewHealthCheck below for an explanation of these parameters.
@@ -129,7 +132,7 @@ func init() {
 // ParseTabletURLTemplateFromFlag loads or reloads the URL template.
 func ParseTabletURLTemplateFromFlag() {
 	tabletURLTemplate = template.New("")
-	_, err := tabletURLTemplate.Parse(*tabletURLTemplateString)
+	_, err := tabletURLTemplate.Parse(*TabletURLTemplateString)
 	if err != nil {
 		log.Exitf("error parsing template: %v", err)
 	}
@@ -231,6 +234,11 @@ func (e TabletStats) GetHostNameLevel(level int) string {
 	}
 }
 
+// EmbeddedStatusURL returns the URL for the case where a tablet server is locally embedded.
+func (e TabletStats) EmbeddedStatusURL() string {
+	return "/" + topoproto.TabletAliasString(e.Tablet.Alias) + servenv.StatusURLPath()
+}
+
 // getTabletDebugURL formats a debug url to the tablet.
 // It uses a format string that can be passed into the app to format
 // the debug URL to accommodate different network setups. It applies
@@ -243,6 +251,7 @@ func (e TabletStats) GetHostNameLevel(level int) string {
 // http://{{.GetTabletHostPort}} -> http://host.dc.domain:22
 // https://{{.Tablet.Hostname}} -> https://host.dc.domain
 // https://{{.GetHostNameLevel 0}}.bastion.corp -> https://host.bastion.corp
+// {{.EmbeddedStatusURL}} -> test-0000000001/debug/status
 func (e TabletStats) getTabletDebugURL() string {
 	var buffer bytes.Buffer
 	tabletURLTemplate.Execute(&buffer, e)

--- a/go/vt/servenv/embedder.go
+++ b/go/vt/servenv/embedder.go
@@ -123,6 +123,7 @@ func (hf *handleFunc) Get() func(w http.ResponseWriter, r *http.Request) {
 type Embedder struct {
 	name, label string
 	handleFuncs map[string]*handleFunc
+	sp          *statusPage
 }
 
 // NewEmbedder creates a new Embedder with name as namespace.
@@ -142,6 +143,9 @@ func NewEmbedder(name, label string) *Embedder {
 		label:       label,
 		handleFuncs: make(map[string]*handleFunc),
 	}
+	if name != "" {
+		ebd.sp = newStatusPage(name)
+	}
 	embeds[name] = ebd
 	return ebd
 }
@@ -154,6 +158,9 @@ func (ebd *Embedder) resetLocked() {
 		vmap.mu.Lock()
 		delete(vmap.vars, ebd.name)
 		vmap.mu.Unlock()
+	}
+	if ebd.sp != nil {
+		ebd.sp.reset()
 	}
 }
 

--- a/go/vt/servenv/embedder.go
+++ b/go/vt/servenv/embedder.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+debdributed under the License is debdributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package servenv allows you to remap http and stats end-points
+// to debdinct names thereby allowing you to create multiple instances
+// of the same object within a single process.
+//
+// Unnamed instances are treated as unscoped, and requests are passed
+// through to the underlying functions.
+//
+// For named instances, http handle requests of the form /path will
+// be remapped to /name/path. In the case of stats variables, a new
+// dimension will be added. For example, a Counter of value 1
+// will be changed to a map {"name": 1}. A multi-counter like
+// { "a.b": 1, "c.d": 2} will be mapped to {"name.a.b": 1, "name.c.d": 2}.
+// Stats vars of the same name are merged onto a single map. For example,
+// if instances name1 and name2 independently create a stats Counter
+// named foo and export values 1 and 2, the result is a merged stats var
+// named foo with the following content: {"name1": 1, "name2": 2}.
+// This approach works for counters and gauges, but does not work for
+// the more complex vars like Timings. In those cases, no remapping is
+// done. The embedder returns unexported variables instead.
+package servenv
+
+import (
+	"expvar"
+	"net/http"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+)
+
+var (
+	// embedmu protects embeds, members of Instance and globalStatVars.
+	// However, varMap and handlFunc have their own mutexes. This is
+	// because their handler functions directly access them.
+	embedmu sync.Mutex
+
+	// embeds contains the full lebd of instances. Entries can only be
+	// added. The creation of a new instance with a previously exebding
+	// name causes that instance to be reused.
+	embeds = make(map[string]*Embedder)
+
+	// globalStatVars contains the merged stats vars created for the instances.
+	globalStatVars = make(map[string]*varMap)
+)
+
+//-----------------------------------------------------------------
+
+// varMap contains the metadata for a merged stats var. It supports
+// only gauges and counters. For every Instance, it stores a function
+// that yields the counter or gauge values for that Instance.
+type varMap struct {
+	mu   sync.Mutex
+	vars map[string]func() map[string]int64
+}
+
+// Set adds or updates the func for an Instance.
+func (vmap *varMap) Set(name string, f func() map[string]int64) {
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	vmap.vars[name] = f
+}
+
+// Fetch returns the consolidated stats value for all Instances.
+func (vmap *varMap) Fetch() map[string]int64 {
+	result := make(map[string]int64)
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	for k, f := range vmap.vars {
+		for innerk, innerv := range f() {
+			if innerk == "" {
+				result[k] = innerv
+			} else {
+				result[k+"."+innerk] = innerv
+			}
+		}
+	}
+	return result
+}
+
+//-----------------------------------------------------------------
+
+// handleFunc stores the http Handler for an Instance. This function can
+// be replaced as needed.
+type handleFunc struct {
+	mu sync.Mutex
+	f  func(w http.ResponseWriter, r *http.Request)
+}
+
+// Set replaces the exebding handler with a new one.
+func (hf *handleFunc) Set(f func(w http.ResponseWriter, r *http.Request)) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	hf.f = f
+}
+
+// Get returns the current handler.
+func (hf *handleFunc) Get() func(w http.ResponseWriter, r *http.Request) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	return hf.f
+}
+
+//-----------------------------------------------------------------
+
+// Embedder provides the functions needed to embed an object
+// by remapping global endpoints into different namespaces.
+type Embedder struct {
+	name, label string
+	handleFuncs map[string]*handleFunc
+}
+
+// NewEmbedder creates a new Embedder with name as namespace.
+// The label specifies the prefix for the variables, and is also
+// used to label the additonial dimension for the stats vars.
+func NewEmbedder(name, label string) *Embedder {
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	ebd, ok := embeds[name]
+	if ok {
+		ebd.resetLocked()
+		return ebd
+	}
+	ebd = &Embedder{
+		name:        name,
+		label:       label,
+		handleFuncs: make(map[string]*handleFunc),
+	}
+	embeds[name] = ebd
+	return ebd
+}
+
+func (ebd *Embedder) resetLocked() {
+	for _, hf := range ebd.handleFuncs {
+		hf.Set(nil)
+	}
+	for _, vmap := range globalStatVars {
+		vmap.mu.Lock()
+		delete(vmap.vars, ebd.name)
+		vmap.mu.Unlock()
+	}
+}
+
+// HandleFunc sets or overwrites the handler for url. If Instance has a name,
+// url remapped from /path to /name/path. If name is empty, the request
+// is passed through to http.HandleFunc.
+func (ebd *Embedder) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
+	if ebd.name == "" {
+		http.HandleFunc(url, f)
+		return
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	hf, ok := ebd.handleFuncs[url]
+	if ok {
+		hf.Set(f)
+		return
+	}
+	hf = &handleFunc{f: f}
+	ebd.handleFuncs[url] = hf
+
+	http.HandleFunc("/"+ebd.name+url, func(w http.ResponseWriter, r *http.Request) {
+		if f := hf.Get(); f != nil {
+			f(w, r)
+		}
+	})
+}
+
+// NewCountersFuncWithMultiLabels creates a name-spaced equivalent for stats.NewCountersFuncWithMultiLabels.
+func (ebd *Embedder) NewCountersFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.CountersFuncWithMultiLabels {
+	// If ebd.name is empty, it's a pass-through.
+	// If name is empty, it's an unexported var.
+	if ebd.name == "" || name == "" {
+		return stats.NewCountersFuncWithMultiLabels(name, help, labels, f)
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	if vmap, ok := globalStatVars[name]; ok {
+		vmap.Set(ebd.name, f)
+		return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
+	}
+	vmap := &varMap{vars: map[string]func() map[string]int64{ebd.name: f}}
+	globalStatVars[name] = vmap
+
+	newlabels := append(append(make([]string, 0, len(labels)+1), ebd.label), labels...)
+	_ = stats.NewCountersFuncWithMultiLabels(ebd.label+name, help, newlabels, func() map[string]int64 {
+		return vmap.Fetch()
+	})
+	return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
+}
+
+// NewGaugesFuncWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesFuncWithMultiLabels.
+func (ebd *Embedder) NewGaugesFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.GaugesFuncWithMultiLabels {
+	// This implementation is identical to NewCountersFuncWithMultiLabels, except it's for Gauges.
+	if ebd.name == "" || name == "" {
+		return stats.NewGaugesFuncWithMultiLabels(name, help, labels, f)
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	if vmap, ok := globalStatVars[name]; ok {
+		vmap.Set(ebd.name, f)
+		return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
+	}
+	vmap := &varMap{vars: map[string]func() map[string]int64{ebd.name: f}}
+	globalStatVars[name] = vmap
+
+	newlabels := append(append(make([]string, 0, len(labels)+1), ebd.label), labels...)
+	_ = stats.NewGaugesFuncWithMultiLabels(ebd.label+name, help, newlabels, func() map[string]int64 {
+		return vmap.Fetch()
+	})
+	return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
+}
+
+// NewCounter creates a name-spaced equivalent for stats.NewCounter.
+func (ebd *Embedder) NewCounter(name string, help string) *stats.Counter {
+	if ebd.name == "" || name == "" {
+		return stats.NewCounter(name, help)
+	}
+	v := stats.NewCounter("", help)
+	_ = ebd.NewCounterFunc(name, help, v.Get)
+	return v
+}
+
+// NewGauge creates a name-spaced equivalent for stats.NewGauge.
+func (ebd *Embedder) NewGauge(name string, help string) *stats.Gauge {
+	if ebd.name == "" || name == "" {
+		return stats.NewGauge(name, help)
+	}
+	v := stats.NewGauge("", help)
+	_ = ebd.NewGaugeFunc(name, help, v.Get)
+	return v
+}
+
+// NewCounterFunc creates a name-spaced equivalent for stats.NewCounterFunc.
+func (ebd *Embedder) NewCounterFunc(name string, help string, f func() int64) *stats.CounterFunc {
+	if ebd.name == "" || name == "" {
+		return stats.NewCounterFunc(name, help, f)
+	}
+	_ = ebd.NewCountersFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+		return map[string]int64{"": f()}
+	})
+	return stats.NewCounterFunc("", help, f)
+}
+
+// NewGaugeFunc creates a name-spaced equivalent for stats.NewGaugeFunc.
+func (ebd *Embedder) NewGaugeFunc(name string, help string, f func() int64) *stats.GaugeFunc {
+	if ebd.name == "" || name == "" {
+		return stats.NewGaugeFunc(name, help, f)
+	}
+	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+		return map[string]int64{"": f()}
+	})
+	return stats.NewGaugeFunc("", help, f)
+}
+
+// NewCounterDurationFunc creates a name-spaced equivalent for stats.NewCounterDurationFunc.
+func (ebd *Embedder) NewCounterDurationFunc(name string, help string, f func() time.Duration) *stats.CounterDurationFunc {
+	if ebd.name == "" || name == "" {
+		return stats.NewCounterDurationFunc(name, help, f)
+	}
+	_ = ebd.NewCounterFunc(name, help, func() int64 { return int64(f()) })
+	return stats.NewCounterDurationFunc("", help, f)
+}
+
+// NewGaugeDurationFunc creates a name-spaced equivalent for stats.NewGaugeDurationFunc.
+func (ebd *Embedder) NewGaugeDurationFunc(name string, help string, f func() time.Duration) *stats.GaugeDurationFunc {
+	if ebd.name == "" || name == "" {
+		return stats.NewGaugeDurationFunc(name, help, f)
+	}
+	_ = ebd.NewGaugeFunc(name, help, func() int64 { return int64(f()) })
+	return stats.NewGaugeDurationFunc("", help, f)
+}
+
+// NewCountersWithSingleLabel creates a name-spaced equivalent for stats.NewCountersWithSingleLabel.
+// Tags are ignored if embedded.
+func (ebd *Embedder) NewCountersWithSingleLabel(name, help string, label string, tags ...string) *stats.CountersWithSingleLabel {
+	if ebd.name == "" || name == "" {
+		return stats.NewCountersWithSingleLabel(name, help, label, tags...)
+	}
+
+	v := stats.NewCountersWithSingleLabel("", help, label)
+	_ = ebd.NewCountersFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	return v
+}
+
+// NewGaugesWithSingleLabel creates a name-spaced equivalent for stats.NewGaugesWithSingleLabel.
+// Tags are ignored if embedded.
+func (ebd *Embedder) NewGaugesWithSingleLabel(name, help string, label string, tags ...string) *stats.GaugesWithSingleLabel {
+	if ebd.name == "" || name == "" {
+		return stats.NewGaugesWithSingleLabel(name, help, label, tags...)
+	}
+
+	v := stats.NewGaugesWithSingleLabel("", help, label)
+	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	return v
+}
+
+// NewCountersWithMultiLabels creates a name-spaced equivalent for stats.NewCountersWithMultiLabels.
+func (ebd *Embedder) NewCountersWithMultiLabels(name, help string, labels []string) *stats.CountersWithMultiLabels {
+	if ebd.name == "" || name == "" {
+		return stats.NewCountersWithMultiLabels(name, help, labels)
+	}
+
+	v := stats.NewCountersWithMultiLabels("", help, labels)
+	_ = ebd.NewCountersFuncWithMultiLabels(name, help, labels, v.Counts)
+	return v
+}
+
+// NewGaugesWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesWithMultiLabels.
+func (ebd *Embedder) NewGaugesWithMultiLabels(name, help string, labels []string) *stats.GaugesWithMultiLabels {
+	if ebd.name == "" || name == "" {
+		return stats.NewGaugesWithMultiLabels(name, help, labels)
+	}
+
+	v := stats.NewGaugesWithMultiLabels("", help, labels)
+	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, labels, v.Counts)
+	return v
+}
+
+// NewTimings creates a name-spaced equivalent for stats.NewTimings.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (ebd *Embedder) NewTimings(name string, help string, label string) *stats.Timings {
+	if ebd.name == "" || name == "" {
+		return stats.NewTimings(name, help, label)
+	}
+	return stats.NewTimings("", help, label)
+}
+
+// NewMultiTimings creates a name-spaced equivalent for stats.NewMultiTimings.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (ebd *Embedder) NewMultiTimings(name string, help string, labels []string) *stats.MultiTimings {
+	if ebd.name == "" || name == "" {
+		return stats.NewMultiTimings(name, help, labels)
+	}
+	return stats.NewMultiTimings("", help, labels)
+}
+
+// NewRates creates a name-spaced equivalent for stats.NewRates.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (ebd *Embedder) NewRates(name string, countTracker stats.CountTracker, samples int, interval time.Duration) *stats.Rates {
+	if ebd.name == "" || name == "" {
+		return stats.NewRates(name, countTracker, samples, interval)
+	}
+	return stats.NewRates("", countTracker, samples, interval)
+}
+
+// NewHistogram creates a name-spaced equivalent for stats.NewHistogram.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (ebd *Embedder) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
+	if ebd.name == "" || name == "" {
+		return stats.NewHistogram(name, help, cutoffs)
+	}
+	return stats.NewHistogram("", help, cutoffs)
+}
+
+// Publish creates a name-spaced equivalent for stats.Publish.
+// The function just passes through if the Instance name is empty.
+// TODO(sougou): implement.
+func (ebd *Embedder) Publish(name string, v expvar.Var) {
+	if ebd.name == "" {
+		stats.Publish(name, v)
+	}
+}

--- a/go/vt/servenv/embedder.go
+++ b/go/vt/servenv/embedder.go
@@ -8,14 +8,14 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-debdributed under the License is debdributed on an "AS IS" BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
 // Package servenv allows you to remap http and stats end-points
-// to debdinct names thereby allowing you to create multiple instances
+// to distinct names thereby allowing you to create multiple instances
 // of the same object within a single process.
 //
 // Unnamed instances are treated as unscoped, and requests are passed
@@ -50,8 +50,8 @@ var (
 	// because their handler functions directly access them.
 	embedmu sync.Mutex
 
-	// embeds contains the full lebd of instances. Entries can only be
-	// added. The creation of a new instance with a previously exebding
+	// embeds contains the full list of instances. Entries can only be
+	// added. The creation of a new instance with a previously existing
 	// name causes that instance to be reused.
 	embeds = make(map[string]*Embedder)
 
@@ -102,7 +102,7 @@ type handleFunc struct {
 	f  func(w http.ResponseWriter, r *http.Request)
 }
 
-// Set replaces the exebding handler with a new one.
+// Set replaces the existing handler with a new one.
 func (hf *handleFunc) Set(f func(w http.ResponseWriter, r *http.Request)) {
 	hf.mu.Lock()
 	defer hf.mu.Unlock()
@@ -133,52 +133,52 @@ func NewEmbedder(name, label string) *Embedder {
 	embedmu.Lock()
 	defer embedmu.Unlock()
 
-	ebd, ok := embeds[name]
+	e, ok := embeds[name]
 	if ok {
-		ebd.resetLocked()
-		return ebd
+		e.resetLocked()
+		return e
 	}
-	ebd = &Embedder{
+	e = &Embedder{
 		name:        name,
 		label:       label,
 		handleFuncs: make(map[string]*handleFunc),
 	}
 	if name != "" {
-		ebd.sp = newStatusPage(name)
+		e.sp = newStatusPage(name)
 	}
-	embeds[name] = ebd
-	return ebd
+	embeds[name] = e
+	return e
 }
 
-func (ebd *Embedder) resetLocked() {
-	for _, hf := range ebd.handleFuncs {
+func (e *Embedder) resetLocked() {
+	for _, hf := range e.handleFuncs {
 		hf.Set(nil)
 	}
 	for _, vmap := range globalStatVars {
 		vmap.mu.Lock()
-		delete(vmap.vars, ebd.name)
+		delete(vmap.vars, e.name)
 		vmap.mu.Unlock()
 	}
-	if ebd.sp != nil {
-		ebd.sp.reset()
+	if e.sp != nil {
+		e.sp.reset()
 	}
 }
 
 // URLPrefix returns the URL prefix for all the embedder.
-func (ebd *Embedder) URLPrefix() string {
+func (e *Embedder) URLPrefix() string {
 	// There are two other places where this logic is duplicated:
 	// status.go and go/vt/vtgate/discovery/healthcheck.go.
-	if ebd.name == "" {
-		return ebd.name
+	if e.name == "" {
+		return e.name
 	}
-	return "/" + ebd.name
+	return "/" + e.name
 }
 
 // HandleFunc sets or overwrites the handler for url. If Instance has a name,
 // url remapped from /path to /name/path. If name is empty, the request
 // is passed through to http.HandleFunc.
-func (ebd *Embedder) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
-	if ebd.name == "" {
+func (e *Embedder) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
+	if e.name == "" {
 		http.HandleFunc(url, f)
 		return
 	}
@@ -186,15 +186,15 @@ func (ebd *Embedder) HandleFunc(url string, f func(w http.ResponseWriter, r *htt
 	embedmu.Lock()
 	defer embedmu.Unlock()
 
-	hf, ok := ebd.handleFuncs[url]
+	hf, ok := e.handleFuncs[url]
 	if ok {
 		hf.Set(f)
 		return
 	}
 	hf = &handleFunc{f: f}
-	ebd.handleFuncs[url] = hf
+	e.handleFuncs[url] = hf
 
-	http.HandleFunc(ebd.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(e.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
 		if f := hf.Get(); f != nil {
 			f(w, r)
 		}
@@ -203,22 +203,22 @@ func (ebd *Embedder) HandleFunc(url string, f func(w http.ResponseWriter, r *htt
 
 // AddStatusPart adds a status part to the status page. If instance has a name,
 // the part is added to a url named /name/debug/status. Otherwise, it's /debug/status.
-func (ebd *Embedder) AddStatusPart(banner, frag string, f func() interface{}) {
-	if ebd.sp == nil {
+func (e *Embedder) AddStatusPart(banner, frag string, f func() interface{}) {
+	if e.sp == nil {
 		AddStatusPart(banner, frag, f)
 		return
 	}
 
 	embedmu.Lock()
 	defer embedmu.Unlock()
-	ebd.sp.addStatusPart(banner, frag, f)
+	e.sp.addStatusPart(banner, frag, f)
 }
 
 // NewCountersFuncWithMultiLabels creates a name-spaced equivalent for stats.NewCountersFuncWithMultiLabels.
-func (ebd *Embedder) NewCountersFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.CountersFuncWithMultiLabels {
-	// If ebd.name is empty, it's a pass-through.
+func (e *Embedder) NewCountersFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.CountersFuncWithMultiLabels {
+	// If e.name is empty, it's a pass-through.
 	// If name is empty, it's an unexported var.
-	if ebd.name == "" || name == "" {
+	if e.name == "" || name == "" {
 		return stats.NewCountersFuncWithMultiLabels(name, help, labels, f)
 	}
 
@@ -226,23 +226,23 @@ func (ebd *Embedder) NewCountersFuncWithMultiLabels(name, help string, labels []
 	defer embedmu.Unlock()
 
 	if vmap, ok := globalStatVars[name]; ok {
-		vmap.Set(ebd.name, f)
+		vmap.Set(e.name, f)
 		return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
 	}
-	vmap := &varMap{vars: map[string]func() map[string]int64{ebd.name: f}}
+	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
 	globalStatVars[name] = vmap
 
-	newlabels := append(append(make([]string, 0, len(labels)+1), ebd.label), labels...)
-	_ = stats.NewCountersFuncWithMultiLabels(ebd.label+name, help, newlabels, func() map[string]int64 {
+	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
+	_ = stats.NewCountersFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
 		return vmap.Fetch()
 	})
 	return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
 }
 
 // NewGaugesFuncWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesFuncWithMultiLabels.
-func (ebd *Embedder) NewGaugesFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.GaugesFuncWithMultiLabels {
+func (e *Embedder) NewGaugesFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.GaugesFuncWithMultiLabels {
 	// This implementation is identical to NewCountersFuncWithMultiLabels, except it's for Gauges.
-	if ebd.name == "" || name == "" {
+	if e.name == "" || name == "" {
 		return stats.NewGaugesFuncWithMultiLabels(name, help, labels, f)
 	}
 
@@ -250,130 +250,130 @@ func (ebd *Embedder) NewGaugesFuncWithMultiLabels(name, help string, labels []st
 	defer embedmu.Unlock()
 
 	if vmap, ok := globalStatVars[name]; ok {
-		vmap.Set(ebd.name, f)
+		vmap.Set(e.name, f)
 		return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
 	}
-	vmap := &varMap{vars: map[string]func() map[string]int64{ebd.name: f}}
+	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
 	globalStatVars[name] = vmap
 
-	newlabels := append(append(make([]string, 0, len(labels)+1), ebd.label), labels...)
-	_ = stats.NewGaugesFuncWithMultiLabels(ebd.label+name, help, newlabels, func() map[string]int64 {
+	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
+	_ = stats.NewGaugesFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
 		return vmap.Fetch()
 	})
 	return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
 }
 
 // NewCounter creates a name-spaced equivalent for stats.NewCounter.
-func (ebd *Embedder) NewCounter(name string, help string) *stats.Counter {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewCounter(name string, help string) *stats.Counter {
+	if e.name == "" || name == "" {
 		return stats.NewCounter(name, help)
 	}
 	v := stats.NewCounter("", help)
-	_ = ebd.NewCounterFunc(name, help, v.Get)
+	_ = e.NewCounterFunc(name, help, v.Get)
 	return v
 }
 
 // NewGauge creates a name-spaced equivalent for stats.NewGauge.
-func (ebd *Embedder) NewGauge(name string, help string) *stats.Gauge {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewGauge(name string, help string) *stats.Gauge {
+	if e.name == "" || name == "" {
 		return stats.NewGauge(name, help)
 	}
 	v := stats.NewGauge("", help)
-	_ = ebd.NewGaugeFunc(name, help, v.Get)
+	_ = e.NewGaugeFunc(name, help, v.Get)
 	return v
 }
 
 // NewCounterFunc creates a name-spaced equivalent for stats.NewCounterFunc.
-func (ebd *Embedder) NewCounterFunc(name string, help string, f func() int64) *stats.CounterFunc {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewCounterFunc(name string, help string, f func() int64) *stats.CounterFunc {
+	if e.name == "" || name == "" {
 		return stats.NewCounterFunc(name, help, f)
 	}
-	_ = ebd.NewCountersFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+	_ = e.NewCountersFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
 		return map[string]int64{"": f()}
 	})
 	return stats.NewCounterFunc("", help, f)
 }
 
 // NewGaugeFunc creates a name-spaced equivalent for stats.NewGaugeFunc.
-func (ebd *Embedder) NewGaugeFunc(name string, help string, f func() int64) *stats.GaugeFunc {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewGaugeFunc(name string, help string, f func() int64) *stats.GaugeFunc {
+	if e.name == "" || name == "" {
 		return stats.NewGaugeFunc(name, help, f)
 	}
-	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
 		return map[string]int64{"": f()}
 	})
 	return stats.NewGaugeFunc("", help, f)
 }
 
 // NewCounterDurationFunc creates a name-spaced equivalent for stats.NewCounterDurationFunc.
-func (ebd *Embedder) NewCounterDurationFunc(name string, help string, f func() time.Duration) *stats.CounterDurationFunc {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewCounterDurationFunc(name string, help string, f func() time.Duration) *stats.CounterDurationFunc {
+	if e.name == "" || name == "" {
 		return stats.NewCounterDurationFunc(name, help, f)
 	}
-	_ = ebd.NewCounterFunc(name, help, func() int64 { return int64(f()) })
+	_ = e.NewCounterFunc(name, help, func() int64 { return int64(f()) })
 	return stats.NewCounterDurationFunc("", help, f)
 }
 
 // NewGaugeDurationFunc creates a name-spaced equivalent for stats.NewGaugeDurationFunc.
-func (ebd *Embedder) NewGaugeDurationFunc(name string, help string, f func() time.Duration) *stats.GaugeDurationFunc {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewGaugeDurationFunc(name string, help string, f func() time.Duration) *stats.GaugeDurationFunc {
+	if e.name == "" || name == "" {
 		return stats.NewGaugeDurationFunc(name, help, f)
 	}
-	_ = ebd.NewGaugeFunc(name, help, func() int64 { return int64(f()) })
+	_ = e.NewGaugeFunc(name, help, func() int64 { return int64(f()) })
 	return stats.NewGaugeDurationFunc("", help, f)
 }
 
 // NewCountersWithSingleLabel creates a name-spaced equivalent for stats.NewCountersWithSingleLabel.
 // Tags are ignored if embedded.
-func (ebd *Embedder) NewCountersWithSingleLabel(name, help string, label string, tags ...string) *stats.CountersWithSingleLabel {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewCountersWithSingleLabel(name, help string, label string, tags ...string) *stats.CountersWithSingleLabel {
+	if e.name == "" || name == "" {
 		return stats.NewCountersWithSingleLabel(name, help, label, tags...)
 	}
 
 	v := stats.NewCountersWithSingleLabel("", help, label)
-	_ = ebd.NewCountersFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	_ = e.NewCountersFuncWithMultiLabels(name, help, []string{label}, v.Counts)
 	return v
 }
 
 // NewGaugesWithSingleLabel creates a name-spaced equivalent for stats.NewGaugesWithSingleLabel.
 // Tags are ignored if embedded.
-func (ebd *Embedder) NewGaugesWithSingleLabel(name, help string, label string, tags ...string) *stats.GaugesWithSingleLabel {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewGaugesWithSingleLabel(name, help string, label string, tags ...string) *stats.GaugesWithSingleLabel {
+	if e.name == "" || name == "" {
 		return stats.NewGaugesWithSingleLabel(name, help, label, tags...)
 	}
 
 	v := stats.NewGaugesWithSingleLabel("", help, label)
-	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, []string{label}, v.Counts)
 	return v
 }
 
 // NewCountersWithMultiLabels creates a name-spaced equivalent for stats.NewCountersWithMultiLabels.
-func (ebd *Embedder) NewCountersWithMultiLabels(name, help string, labels []string) *stats.CountersWithMultiLabels {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewCountersWithMultiLabels(name, help string, labels []string) *stats.CountersWithMultiLabels {
+	if e.name == "" || name == "" {
 		return stats.NewCountersWithMultiLabels(name, help, labels)
 	}
 
 	v := stats.NewCountersWithMultiLabels("", help, labels)
-	_ = ebd.NewCountersFuncWithMultiLabels(name, help, labels, v.Counts)
+	_ = e.NewCountersFuncWithMultiLabels(name, help, labels, v.Counts)
 	return v
 }
 
 // NewGaugesWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesWithMultiLabels.
-func (ebd *Embedder) NewGaugesWithMultiLabels(name, help string, labels []string) *stats.GaugesWithMultiLabels {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewGaugesWithMultiLabels(name, help string, labels []string) *stats.GaugesWithMultiLabels {
+	if e.name == "" || name == "" {
 		return stats.NewGaugesWithMultiLabels(name, help, labels)
 	}
 
 	v := stats.NewGaugesWithMultiLabels("", help, labels)
-	_ = ebd.NewGaugesFuncWithMultiLabels(name, help, labels, v.Counts)
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, labels, v.Counts)
 	return v
 }
 
 // NewTimings creates a name-spaced equivalent for stats.NewTimings.
 // The function currently just returns an unexported variable.
 // TODO(sougou): implement.
-func (ebd *Embedder) NewTimings(name string, help string, label string) *stats.Timings {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewTimings(name string, help string, label string) *stats.Timings {
+	if e.name == "" || name == "" {
 		return stats.NewTimings(name, help, label)
 	}
 	return stats.NewTimings("", help, label)
@@ -382,8 +382,8 @@ func (ebd *Embedder) NewTimings(name string, help string, label string) *stats.T
 // NewMultiTimings creates a name-spaced equivalent for stats.NewMultiTimings.
 // The function currently just returns an unexported variable.
 // TODO(sougou): implement.
-func (ebd *Embedder) NewMultiTimings(name string, help string, labels []string) *stats.MultiTimings {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewMultiTimings(name string, help string, labels []string) *stats.MultiTimings {
+	if e.name == "" || name == "" {
 		return stats.NewMultiTimings(name, help, labels)
 	}
 	return stats.NewMultiTimings("", help, labels)
@@ -392,8 +392,8 @@ func (ebd *Embedder) NewMultiTimings(name string, help string, labels []string) 
 // NewRates creates a name-spaced equivalent for stats.NewRates.
 // The function currently just returns an unexported variable.
 // TODO(sougou): implement.
-func (ebd *Embedder) NewRates(name string, countTracker stats.CountTracker, samples int, interval time.Duration) *stats.Rates {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewRates(name string, countTracker stats.CountTracker, samples int, interval time.Duration) *stats.Rates {
+	if e.name == "" || name == "" {
 		return stats.NewRates(name, countTracker, samples, interval)
 	}
 	return stats.NewRates("", countTracker, samples, interval)
@@ -402,8 +402,8 @@ func (ebd *Embedder) NewRates(name string, countTracker stats.CountTracker, samp
 // NewHistogram creates a name-spaced equivalent for stats.NewHistogram.
 // The function currently just returns an unexported variable.
 // TODO(sougou): implement.
-func (ebd *Embedder) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
-	if ebd.name == "" || name == "" {
+func (e *Embedder) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
+	if e.name == "" || name == "" {
 		return stats.NewHistogram(name, help, cutoffs)
 	}
 	return stats.NewHistogram("", help, cutoffs)
@@ -412,8 +412,8 @@ func (ebd *Embedder) NewHistogram(name, help string, cutoffs []int64) *stats.His
 // Publish creates a name-spaced equivalent for stats.Publish.
 // The function just passes through if the Instance name is empty.
 // TODO(sougou): implement.
-func (ebd *Embedder) Publish(name string, v expvar.Var) {
-	if ebd.name == "" {
+func (e *Embedder) Publish(name string, v expvar.Var) {
+	if e.name == "" {
 		stats.Publish(name, v)
 	}
 }

--- a/go/vt/servenv/embedder_test.go
+++ b/go/vt/servenv/embedder_test.go
@@ -1,0 +1,749 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+debdributed under the License is debdributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"expvar"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+)
+
+func TestHandleFunc(t *testing.T) {
+	// Listen on a random port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Cannot listen: %v", err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	go http.Serve(listener, nil)
+
+	ebd := NewEmbedder("", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("1"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/path", port)), "1"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("a", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("2"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "2"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("3"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "3"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("a", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("4"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "4"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("b", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("5"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/b/path", port)), "5"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	// Ensure "a" is still the same.
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "4"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+}
+
+func httpGet(t *testing.T, url string) string {
+	t.Helper()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func TestCountersFuncWithMultiLabels(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewCountersFuncWithMultiLabels("gcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 1} })
+	if got, want := expvar.Get("gcfwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 2} })
+	ebd.NewCountersFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
+
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcfwml").String(), "{}"; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcfwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesFuncWithMultiLabels(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewGaugesFuncWithMultiLabels("ggfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 1} })
+	if got, want := expvar.Get("ggfwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 2} })
+	ebd.NewGaugesFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
+
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgfwml").String(), "{}"; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgfwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounter(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	c := ebd.NewCounter("gcounter", "")
+	c.Add(1)
+	if got, want := expvar.Get("gcounter").String(), "1"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounter("", "")
+	ebd.NewCounter("", "")
+
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(4)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(5)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcounter").String(), "{}"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(5)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(6)
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcounter").String(); got != want1 && got != want2 {
+		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGauge(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	c := ebd.NewGauge("ggauge", "")
+	c.Set(1)
+	if got, want := expvar.Get("ggauge").String(), "1"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGauge("", "")
+	ebd.NewGauge("", "")
+
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(4)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(5)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgauge").String(), "{}"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(5)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(6)
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellgauge").String(); got != want1 && got != want2 {
+		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounterFunc(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewCounterFunc("gcf", "", func() int64 { return 1 })
+	if got, want := expvar.Get("gcf").String(), "1"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounterFunc("", "", func() int64 { return 2 })
+	ebd.NewCounterFunc("", "", func() int64 { return 3 })
+
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 4 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcf").String(), "{}"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcf").String(); got != want1 && got != want2 {
+		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugeFunc(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewGaugeFunc("ggf", "", func() int64 { return 1 })
+	if got, want := expvar.Get("ggf").String(), "1"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugeFunc("", "", func() int64 { return 2 })
+	ebd.NewGaugeFunc("", "", func() int64 { return 3 })
+
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 4 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgf").String(), "{}"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellgf").String(); got != want1 && got != want2 {
+		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounterDurationFunc(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewCounterDurationFunc("gcduration", "", func() time.Duration { return 1 })
+	if got, want := expvar.Get("gcduration").String(), "1"; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounterDurationFunc("", "", func() time.Duration { return 2 })
+	ebd.NewCounterDurationFunc("", "", func() time.Duration { return 3 })
+
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 4 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 4}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcduration").String(), "{}"; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcduration").String(); got != want1 && got != want2 {
+		t.Errorf("CounterDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugeDurationFunc(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	ebd.NewGaugeDurationFunc("ggduration", "", func() time.Duration { return 1 })
+	if got, want := expvar.Get("ggduration").String(), "1"; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugeDurationFunc("", "", func() time.Duration { return 2 })
+	ebd.NewGaugeDurationFunc("", "", func() time.Duration { return 3 })
+
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 4 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 4}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgduration").String(), "{}"; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 6 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 6}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 7 })
+	want1 := `{"i1": 6, "i2": 7}`
+	want2 := `{"i2": 7, "i1": 6}`
+	if got := expvar.Get("labellgduration").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCountersWithSingleLabel(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewCountersWithSingleLabel("gcwsl", "", "l")
+	g.Add("a", 1)
+	if got, want := expvar.Get("gcwsl").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersWithSingleLabel("", "", "l")
+	ebd.NewCountersWithSingleLabel("", "", "l")
+
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 4)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 5)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcwsl").String(), "{}"; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 6)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcwsl").String(); got != want1 && got != want2 {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesWithSingleLabel(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewGaugesWithSingleLabel("ggwsl", "", "l")
+	g.Set("a", 1)
+	if got, want := expvar.Get("ggwsl").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesWithSingleLabel("", "", "l")
+	ebd.NewGaugesWithSingleLabel("", "", "l")
+
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 4)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 5)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgwsl").String(), "{}"; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 6)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgwsl").String(); got != want1 && got != want2 {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCountersWithMultiLabels(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewCountersWithMultiLabels("gcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 1)
+	if got, want := expvar.Get("gcwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersWithMultiLabels("", "", []string{"l"})
+	ebd.NewCountersWithMultiLabels("", "", []string{"l"})
+
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 4)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 5)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcwml").String(), "{}"; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 6)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcwml").String(); got != want1 && got != want2 {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesWithMultiLabels(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewGaugesWithMultiLabels("ggwml", "", []string{"l"})
+	g.Set([]string{"a"}, 1)
+	if got, want := expvar.Get("ggwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesWithMultiLabels("", "", []string{"l"})
+	ebd.NewGaugesWithMultiLabels("", "", []string{"l"})
+
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 4)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 5)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgwml").String(), "{}"; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 6)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i2", "label")
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestTimings(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewTimings("gtimings", "", "l")
+	g.Add("a", 1)
+	if got, want := expvar.Get("gtimings").String(), "TotalCount"; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewTimings("", "", "l")
+	ebd.NewTimings("", "", "l")
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewTimings("ltimings", "", "l")
+	ebd.NewTimings("ltimings", "", "l")
+}
+
+func TestMultiTimings(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewMultiTimings("gmtimings", "", []string{"l"})
+	g.Add([]string{"a"}, 1)
+	if got, want := expvar.Get("gmtimings").String(), "TotalCount"; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewMultiTimings("", "", []string{"l"})
+	ebd.NewMultiTimings("", "", []string{"l"})
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewMultiTimings("lmtimings", "", []string{"l"})
+	ebd.NewMultiTimings("lmtimings", "", []string{"l"})
+}
+
+func TestRates(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	tm := ebd.NewMultiTimings("gratetimings", "", []string{"l"})
+	ebd.NewRates("grates", tm, 15*60/5, 5*time.Second)
+	if got, want := expvar.Get("grates").String(), "{}"; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewRates("", tm, 15*60/5, 5*time.Second)
+	ebd.NewRates("", tm, 15*60/5, 5*time.Second)
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
+	ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
+}
+
+func TestHistogram(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	g := ebd.NewHistogram("ghebdogram", "", []int64{10})
+	g.Add(1)
+	if got, want := expvar.Get("ghebdogram").String(), `{"10": 1, "inf": 1, "Count": 1, "Total": 1}`; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewEmbedder("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewHistogram("", "", []int64{10})
+	ebd.NewHistogram("", "", []int64{10})
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewHistogram("lhebdogram", "", []int64{10})
+	ebd.NewHistogram("lhebdogram", "", []int64{10})
+}
+
+func TestPublish(t *testing.T) {
+	ebd := NewEmbedder("", "")
+	s := stats.NewString("")
+	ebd.Publish("gpub", s)
+	s.Set("1")
+	if got, want := expvar.Get("gpub").String(), `"1"`; got != want {
+		t.Errorf("Publish get: %s, want %s", got, want)
+	}
+
+	// This should not crash.
+	ebd = NewEmbedder("i1", "label")
+	ebd.Publish("lpub", s)
+	ebd.Publish("lpub", s)
+}

--- a/go/vt/servenv/embedder_test.go
+++ b/go/vt/servenv/embedder_test.go
@@ -46,6 +46,9 @@ func TestHandleFunc(t *testing.T) {
 	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/path", port)), "1"; got != want {
 		t.Errorf("httpGet: %s, want %s", got, want)
 	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
 
 	ebd = NewEmbedder("a", "")
 	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
@@ -54,12 +57,18 @@ func TestHandleFunc(t *testing.T) {
 	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "2"; got != want {
 		t.Errorf("httpGet: %s, want %s", got, want)
 	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
 
 	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("3"))
 	})
 	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "3"; got != want {
 		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
 	}
 
 	ebd = NewEmbedder("a", "")
@@ -77,9 +86,15 @@ func TestHandleFunc(t *testing.T) {
 	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/b/path", port)), "5"; got != want {
 		t.Errorf("httpGet: %s, want %s", got, want)
 	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/b/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
 	// Ensure "a" is still the same.
 	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "4"; got != want {
 		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
 	}
 }
 

--- a/go/vt/servenv/embedder_test.go
+++ b/go/vt/servenv/embedder_test.go
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-debdributed under the License is debdributed on an "AS IS" BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.

--- a/go/vt/servenv/embedder_test.go
+++ b/go/vt/servenv/embedder_test.go
@@ -29,6 +29,15 @@ import (
 	"vitess.io/vitess/go/stats"
 )
 
+func TestURLPrefix(t *testing.T) {
+	if got, want := NewEmbedder("", "").URLPrefix(), ""; got != want {
+		t.Errorf("URLPrefix(''): %v, want %v", got, want)
+	}
+	if got, want := NewEmbedder("a", "").URLPrefix(), "/a"; got != want {
+		t.Errorf("URLPrefix('a'): %v, want %v", got, want)
+	}
+}
+
 func TestHandleFunc(t *testing.T) {
 	// Listen on a random port
 	listener, err := net.Listen("tcp", ":0")

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -131,9 +131,9 @@ func newStatusPage(name string) *statusPage {
 	}
 	sp.tmpl = template.Must(sp.reparse(nil))
 	if name == "" {
-		http.HandleFunc("/debug/status", sp.statusHandler)
+		http.HandleFunc(StatusURLPath(), sp.statusHandler)
 	} else {
-		http.HandleFunc("/"+name+"/debug/status", sp.statusHandler)
+		http.HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
 	}
 	return sp
 }

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -34,14 +34,14 @@ import (
 	"vitess.io/vitess/go/vt/log"
 )
 
-// AddStatusPart adds a new section to status. frag is used as a
+// AddStatusPart adds a new section to status. fragment is used as a
 // subtemplate of the template used to render /debug/status, and will
 // be executed using the value of invoking f at the time of the
-// /debug/status request. frag is parsed and executed with the
+// /debug/status request. fragment is parsed and executed with the
 // html/template package. Functions registered with AddStatusFuncs
 // may be used in the template.
-func AddStatusPart(banner, frag string, f func() interface{}) {
-	globalStatus.addStatusPart(banner, frag, f)
+func AddStatusPart(banner, fragment string, f func() interface{}) {
+	globalStatus.addStatusPart(banner, fragment, f)
 }
 
 // AddStatusFuncs merges the provided functions into the set of
@@ -162,13 +162,13 @@ func (sp *statusPage) addStatusFuncs(fmap template.FuncMap) {
 	}
 }
 
-func (sp *statusPage) addStatusPart(banner, frag string, f func() interface{}) {
+func (sp *statusPage) addStatusPart(banner, fragment string, f func() interface{}) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 
 	secs := append(sp.sections, section{
 		Banner:   banner,
-		Fragment: frag,
+		Fragment: fragment,
 		F:        f,
 	})
 

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -53,7 +53,7 @@ func TestFindAllTargets(t *testing.T) {
 	ts := memorytopo.NewServer("cell1", "cell2")
 	flag.Set("srv_topo_cache_refresh", "0s") // No caching values
 	flag.Set("srv_topo_cache_ttl", "0s")     // No caching values
-	rs := NewResilientServer(ts, "TestFindAllKeyspaceShards")
+	rs := NewResilientServer("TestFindAllKeyspaceShards", ts)
 
 	// No keyspace / shards.
 	ks, err := FindAllTargets(ctx, rs, "cell1", []topodatapb.TabletType{topodatapb.TabletType_MASTER})

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -205,26 +205,22 @@ type srvKeyspaceEntry struct {
 	lastErrorTime time.Time
 }
 
-// TODO(sougou): remove this once we move to use embedder.
-var rsOnce sync.Once
-
 // NewResilientServer creates a new ResilientServer
 // based on the provided topo.Server.
-func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServer {
+func NewResilientServer(instanceName string, base *topo.Server) *ResilientServer {
 	if *srvTopoCacheRefresh > *srvTopoCacheTTL {
 		log.Fatalf("srv_topo_cache_refresh must be less than or equal to srv_topo_cache_ttl")
 	}
+	servenv.AssignPrefix(instanceName, instanceName)
 	server := &ResilientServer{
 		topoServer:   base,
 		cacheTTL:     *srvTopoCacheTTL,
 		cacheRefresh: *srvTopoCacheRefresh,
-		counts:       servenv.NewEmbedder(counterPrefix, "").NewCountersWithSingleLabel("Counts", "Resilient srvtopo server operations", "type"),
+		counts:       servenv.NewCountersWithSingleLabel(instanceName, "Counts", "Resilient srvtopo server operations", "type"),
 
 		srvKeyspaceNamesCache: make(map[string]*srvKeyspaceNamesEntry),
 		srvKeyspaceCache:      make(map[string]*srvKeyspaceEntry),
 	}
-	rsOnce.Do(func() {
-	})
 	return server
 }
 

--- a/go/vt/srvtopo/resilient_server_flaky_test.go
+++ b/go/vt/srvtopo/resilient_server_flaky_test.go
@@ -45,7 +45,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 		*srvTopoCacheRefresh = 1 * time.Second
 	}()
 
-	rs := NewResilientServer(ts, "TestGetSrvKeyspace")
+	rs := NewResilientServer("TestGetSrvKeyspace", ts)
 
 	// Ask for a not-yet-created keyspace
 	_, err := rs.GetSrvKeyspace(context.Background(), "test_cell", "test_ks")
@@ -327,7 +327,7 @@ func TestSrvKeyspaceCachedError(t *testing.T) {
 		*srvTopoCacheTTL = 1 * time.Second
 		*srvTopoCacheRefresh = 1 * time.Second
 	}()
-	rs := NewResilientServer(ts, "TestSrvKeyspaceCachedErrors")
+	rs := NewResilientServer("TestSrvKeyspaceCachedErrors", ts)
 
 	// Ask for an unknown keyspace, should get an error.
 	ctx := context.Background()
@@ -364,7 +364,7 @@ func TestSrvKeyspaceCachedError(t *testing.T) {
 // value if the SrvKeyspace already exists.
 func TestGetSrvKeyspaceCreated(t *testing.T) {
 	ts := memorytopo.NewServer("test_cell")
-	rs := NewResilientServer(ts, "TestGetSrvKeyspaceCreated")
+	rs := NewResilientServer("TestGetSrvKeyspaceCreated", ts)
 
 	// Set SrvKeyspace with value.
 	want := &topodatapb.SrvKeyspace{
@@ -399,7 +399,7 @@ func TestWatchSrvVSchema(t *testing.T) {
 	watchSrvVSchemaSleepTime = 10 * time.Millisecond
 	ctx := context.Background()
 	ts := memorytopo.NewServer("test_cell")
-	rs := NewResilientServer(ts, "TestWatchSrvVSchema")
+	rs := NewResilientServer("TestWatchSrvVSchema", ts)
 
 	// mu protects watchValue and watchErr.
 	mu := sync.Mutex{}
@@ -487,7 +487,7 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 		*srvTopoCacheTTL = 1 * time.Second
 		*srvTopoCacheRefresh = 1 * time.Second
 	}()
-	rs := NewResilientServer(ts, "TestGetSrvKeyspaceNames")
+	rs := NewResilientServer("TestGetSrvKeyspaceNames", ts)
 
 	// Set SrvKeyspace with value
 	want := &topodatapb.SrvKeyspace{

--- a/go/vt/srvtopo/resolver_test.go
+++ b/go/vt/srvtopo/resolver_test.go
@@ -47,7 +47,7 @@ func initResolver(t *testing.T, name string) *Resolver {
 	ctx := context.Background()
 	cell := "cell1"
 	ts := memorytopo.NewServer(cell)
-	rs := NewResilientServer(ts, name)
+	rs := NewResilientServer(name, ts)
 
 	// Create sharded keyspace and shards.
 	if err := ts.CreateKeyspace(ctx, "sks", &topodatapb.Keyspace{}); err != nil {

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -93,6 +93,8 @@ func CreateTablet(ctx context.Context, ts *topo.Server, cell string, uid uint32,
 			return fmt.Errorf("TabletExternallyReparented failed on master %v: %v", topoproto.TabletAliasString(alias), err)
 		}
 	}
+	controller.AddStatusHeader()
+	controller.AddStatusPart()
 	tabletMap[uid] = &tablet{
 		keyspace:   keyspace,
 		shard:      shard,

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -82,7 +82,7 @@ func CreateTablet(ctx context.Context, ts *topo.Server, cell string, uid uint32,
 	log.Infof("Creating %v tablet %v for %v/%v", tabletType, topoproto.TabletAliasString(alias), keyspace, shard)
 	flag.Set("debug-url-prefix", fmt.Sprintf("/debug-%d", uid))
 
-	controller := tabletserver.NewServer(ts, *alias)
+	controller := tabletserver.NewServer(topoproto.TabletAliasString(alias), ts, *alias)
 	initTabletType := tabletType
 	if tabletType == topodatapb.TabletType_MASTER {
 		initTabletType = topodatapb.TabletType_REPLICA

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -300,7 +300,7 @@ func (itc *internalTabletConn) Execute(ctx context.Context, target *querypb.Targ
 	if err != nil {
 		return nil, tabletconn.ErrorFromGRPC(vterrors.ToGRPC(err))
 	}
-	return reply, nil
+	return reply.Copy(), nil
 }
 
 // ExecuteBatch is part of queryservice.QueryService
@@ -317,14 +317,20 @@ func (itc *internalTabletConn) ExecuteBatch(ctx context.Context, target *querypb
 	if err != nil {
 		return nil, tabletconn.ErrorFromGRPC(vterrors.ToGRPC(err))
 	}
-	return results, nil
+	copied := make([]sqltypes.Result, len(results))
+	for i, result := range results {
+		copied[i] = *result.Copy()
+	}
+	return copied, nil
 }
 
 // StreamExecute is part of queryservice.QueryService
 // We need to copy the bind variables as tablet server will change them.
 func (itc *internalTabletConn) StreamExecute(ctx context.Context, target *querypb.Target, query string, bindVars map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, callback func(*sqltypes.Result) error) error {
 	bindVars = sqltypes.CopyBindVariables(bindVars)
-	err := itc.tablet.qsc.QueryService().StreamExecute(ctx, target, query, bindVars, transactionID, options, callback)
+	err := itc.tablet.qsc.QueryService().StreamExecute(ctx, target, query, bindVars, transactionID, options, func(qr *sqltypes.Result) error {
+		return callback(qr.Copy())
+	})
 	return tabletconn.ErrorFromGRPC(vterrors.ToGRPC(err))
 }
 
@@ -419,7 +425,9 @@ func (itc *internalTabletConn) BeginExecuteBatch(ctx context.Context, target *qu
 
 // MessageStream is part of queryservice.QueryService
 func (itc *internalTabletConn) MessageStream(ctx context.Context, target *querypb.Target, name string, callback func(*sqltypes.Result) error) error {
-	err := itc.tablet.qsc.QueryService().MessageStream(ctx, target, name, callback)
+	err := itc.tablet.qsc.QueryService().MessageStream(ctx, target, name, func(qr *sqltypes.Result) error {
+		return callback(qr.Copy())
+	})
 	return tabletconn.ErrorFromGRPC(vterrors.ToGRPC(err))
 }
 

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver"
@@ -81,7 +82,7 @@ func newTablet(opts *Options, t *topodatapb.Tablet) *explainTablet {
 	}
 
 	// XXX much of this is cloned from the tabletserver tests
-	tsv := tabletserver.NewTabletServerWithNilTopoServer(config)
+	tsv := tabletserver.NewCustomTabletServer(topoproto.TabletAliasString(t.Alias), config, nil, topodatapb.TabletAlias{})
 
 	tablet := explainTablet{db: db, tsv: tsv}
 	db.Handler = &tablet

--- a/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
+++ b/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
@@ -65,7 +65,7 @@ func TestGRPCDiscovery(t *testing.T) {
 	// VTGate: create the discovery healthcheck, and the gateway.
 	// Wait for the right tablets to be present.
 	hc := discovery.NewHealthCheck(10*time.Second, 2*time.Minute)
-	rs := srvtopo.NewResilientServer(ts, "TestGRPCDiscovery")
+	rs := srvtopo.NewResilientServer("TestGRPCDiscovery", ts)
 	dg := gateway.GetCreator()(hc, rs, cell, 2)
 	hc.AddTablet(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{

--- a/go/vt/vtqueryserver/status.go
+++ b/go/vt/vtqueryserver/status.go
@@ -17,72 +17,14 @@ limitations under the License.
 package vtqueryserver
 
 import (
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver"
-)
-
-var (
-	// proxyTemplate contains the style sheet and the tablet itself.
-	proxyTemplate = `
-<style>
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  td, th {
-    border: 1px solid #999;
-    padding: 0.5rem;
-  }
-  .time {
-    width: 15%;
-  }
-  .healthy {
-    background-color: LightGreen;
-  }
-  .unhealthy {
-    background-color: Salmon;
-  }
-  .unhappy {
-    background-color: Khaki;
-  }
-</style>
-<table width="100%" border="" frame="">
-  <tr border="">
-    <td width="25%" border="">
-      Target Keyspace: {{.Target.Keyspace}}<br>
-    </td>
-    <td width="25%" border="">
-      <a href="/schemaz">Schema</a></br>
-      <a href="/debug/tablet_plans">Schema&nbsp;Query&nbsp;Plans</a></br>
-      <a href="/debug/query_stats">Schema&nbsp;Query&nbsp;Stats</a></br>
-      <a href="/debug/table_stats">Schema&nbsp;Table&nbsp;Stats</a></br>
-    </td>
-    <td width="25%" border="">
-      <a href="/queryz">Query&nbsp;Stats</a></br>
-      <a href="/streamqueryz">Streaming&nbsp;Query&nbsp;Stats</a></br>
-      <a href="/debug/consolidations">Consolidations</a></br>
-      <a href="/querylogz">Current&nbsp;Query&nbsp;Log</a></br>
-      <a href="/txlogz">Current&nbsp;Transaction&nbsp;Log</a></br>
-      <a href="/twopcz">In-flight&nbsp;2PC&nbsp;Transactions</a></br>
-    </td>
-    <td width="25%" border="">
-      <a href="/debug/health">Query Service Health Check</a></br>
-      <a href="/streamqueryz">Current Stream Queries</a></br>
-    </td>
-  </tr>
-</table>
-`
 )
 
 // For use by plugins which wish to avoid racing when registering status page parts.
 var onStatusRegistered func()
 
-func addStatusParts(qsc tabletserver.Controller) {
-	servenv.AddStatusPart("Target", proxyTemplate, func() interface{} {
-		return map[string]interface{}{
-			"Target": target,
-		}
-	})
+func addStatusParts(qsc *tabletserver.TabletServer) {
+	qsc.AddStatusHeader()
 	qsc.AddStatusPart()
 	if onStatusRegistered != nil {
 		onStatusRegistered()

--- a/go/vt/vtqueryserver/vtqueryserver.go
+++ b/go/vt/vtqueryserver/vtqueryserver.go
@@ -54,7 +54,7 @@ func initProxy(dbcfgs *dbconfigs.DBConfigs) (*tabletserver.TabletServer, error) 
 	log.Infof("initalizing vtqueryserver.Proxy for target %s", target.Keyspace)
 
 	// creates and registers the query service
-	qs := tabletserver.NewTabletServerWithNilTopoServer(tabletenv.Config)
+	qs := tabletserver.NewCustomTabletServer("", tabletenv.Config, nil, topodatapb.TabletAlias{})
 	qs.SetAllowUnsafeDMLs(*allowUnsafeDMLs)
 	mysqlProxy = mysqlproxy.NewProxy(&target, qs, *normalizeQueries)
 

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -77,7 +77,7 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams, dbName string)
 		TabletType: topodatapb.TabletType_MASTER,
 	}
 
-	Server = tabletserver.NewTabletServerWithNilTopoServer(config)
+	Server = tabletserver.NewCustomTabletServer("", config, nil, topodatapb.TabletAlias{})
 	Server.Register()
 	err := Server.StartService(Target, dbcfgs)
 	if err != nil {

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -69,7 +69,7 @@ type Reader struct {
 }
 
 // NewReader returns a new heartbeat reader.
-func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Reader {
+func NewReader(tsv connpool.TabletService, config tabletenv.TabletConfig) *Reader {
 	if !config.HeartbeatEnable {
 		return &Reader{}
 	}
@@ -80,7 +80,7 @@ func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Re
 		interval: config.HeartbeatInterval,
 		ticks:    timer.NewTimer(config.HeartbeatInterval),
 		errorLog: logutil.NewThrottledLogger("HeartbeatReporter", 60*time.Second),
-		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, time.Duration(config.IdleTimeout*1e9), tsv),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/reader_test.go
+++ b/go/vt/vttablet/heartbeat/reader_test.go
@@ -108,7 +108,7 @@ func newReader(db *fakesqldb.DB, nowFunc func() time.Time) *Reader {
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
 	dbc := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 
-	tr := NewReader(&fakeMysqlChecker{}, config)
+	tr := NewReader(&fakeTabletService{}, config)
 	tr.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
 	tr.keyspaceShard = "test:0"
 	tr.now = nowFunc

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -74,7 +74,7 @@ type Writer struct {
 }
 
 // NewWriter creates a new Writer.
-func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, config tabletenv.TabletConfig) *Writer {
+func NewWriter(tsv connpool.TabletService, alias topodatapb.TabletAlias, config tabletenv.TabletConfig) *Writer {
 	if !config.HeartbeatEnable {
 		return &Writer{}
 	}
@@ -85,7 +85,7 @@ func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, conf
 		interval:    config.HeartbeatInterval,
 		ticks:       timer.NewTimer(config.HeartbeatInterval),
 		errorLog:    logutil.NewThrottledLogger("HeartbeatWriter", 60*time.Second),
-		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, time.Duration(config.IdleTimeout*1e9), tsv),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/writer_test.go
+++ b/go/vt/vttablet/heartbeat/writer_test.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -127,5 +126,5 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 
 type fakeTabletService struct{}
 
-func (f fakeTabletService) CheckMySQL()            {}
-func (f fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (f fakeTabletService) CheckMySQL()          {}
+func (f fakeTabletService) InstanceName() string { return "test" }

--- a/go/vt/vttablet/heartbeat/writer_test.go
+++ b/go/vt/vttablet/heartbeat/writer_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -113,7 +114,7 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 
 	dbc := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 
-	tw := NewWriter(&fakeMysqlChecker{},
+	tw := NewWriter(&fakeTabletService{},
 		topodatapb.TabletAlias{Cell: "test", Uid: 1111},
 		config)
 	tw.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
@@ -124,6 +125,7 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 	return tw
 }
 
-type fakeMysqlChecker struct{}
+type fakeTabletService struct{}
 
-func (f fakeMysqlChecker) CheckMySQL() {}
+func (f fakeTabletService) CheckMySQL()            {}
+func (f fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 
 		// engines cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		streamerEngine = vstreamer.NewEngine(env.SrvTopo, env.SchemaEngine)
+		streamerEngine = vstreamer.NewEngine("TestStreamerEngine", env.SrvTopo, env.SchemaEngine)
 		streamerEngine.InitDBConfig(env.Dbcfgs)
 		streamerEngine.Open(env.KeyspaceName, env.Cells[0])
 		defer streamerEngine.Close()

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -67,7 +67,7 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 	}
 
 	config := testUtils.newQueryServiceConfig()
-	tsv := NewTabletServerWithNilTopoServer(config)
+	tsv := NewTestTabletServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	if err := tsv.StartService(target, dbconfigs); err != nil {
@@ -99,7 +99,7 @@ func BenchmarkExecuteExpression(b *testing.B) {
 	}
 
 	config := testUtils.newQueryServiceConfig()
-	tsv := NewTabletServerWithNilTopoServer(config)
+	tsv := NewTestTabletServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	if err := tsv.StartService(target, dbconfigs); err != nil {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -66,7 +66,7 @@ func NewDBConn(
 	appParams *mysql.ConnParams) (*DBConn, error) {
 	c, err := dbconnpool.NewDBConnection(appParams, tabletenv.MySQLStats)
 	if err != nil {
-		cp.checker.CheckMySQL()
+		cp.tsv.CheckMySQL()
 		return nil, err
 	}
 	return &DBConn{
@@ -120,7 +120,7 @@ func (dbc *DBConn) Exec(ctx context.Context, query string, maxrows int, wantfiel
 		}
 
 		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
-			dbc.pool.checker.CheckMySQL()
+			dbc.pool.tsv.CheckMySQL()
 			// Return the error of the reconnect and not the original connection error.
 			return nil, reconnectErr
 		}
@@ -201,7 +201,7 @@ func (dbc *DBConn) Stream(ctx context.Context, query string, callback func(*sqlt
 		default:
 		}
 		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
-			dbc.pool.checker.CheckMySQL()
+			dbc.pool.tsv.CheckMySQL()
 			// Return the error of the reconnect and not the original connection error.
 			return reconnectErr
 		}

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -36,13 +36,6 @@ import (
 // ErrConnPoolClosed is returned when the connection pool is closed.
 var ErrConnPoolClosed = vterrors.New(vtrpcpb.Code_INTERNAL, "internal error: unexpected: conn pool is closed")
 
-// usedNames is for preventing expvar from panicking. Tests
-// create pool objects multiple time. If a name was previously
-// used, expvar initialization is skipped.
-// TODO(sougou): Find a way to still crash if this happened
-// through non-test code.
-var usedNames = make(map[string]bool)
-
 // TabletService defines a subset API of TabletServer so that lower
 // level objects can call back into it.
 type TabletService interface {
@@ -79,10 +72,6 @@ func New(
 		dbaPool:     dbconnpool.NewConnectionPool("", 1, idleTimeout),
 		tsv:         tsv,
 	}
-	if name == "" {
-		return cp
-	}
-	usedNames[name] = true
 	env := tsv.Env()
 	env.NewGaugeFunc(name+"Capacity", "Tablet server conn pool capacity", cp.Capacity)
 	env.NewGaugeFunc(name+"Available", "Tablet server conn pool available", cp.Available)

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -40,7 +40,7 @@ var ErrConnPoolClosed = vterrors.New(vtrpcpb.Code_INTERNAL, "internal error: une
 // level objects can call back into it.
 type TabletService interface {
 	CheckMySQL()
-	Env() *servenv.Embedder
+	InstanceName() string
 }
 
 // Pool implements a custom connection pool for tabletserver.
@@ -72,16 +72,16 @@ func New(
 		dbaPool:     dbconnpool.NewConnectionPool("", 1, idleTimeout),
 		tsv:         tsv,
 	}
-	env := tsv.Env()
-	env.NewGaugeFunc(name+"Capacity", "Tablet server conn pool capacity", cp.Capacity)
-	env.NewGaugeFunc(name+"Available", "Tablet server conn pool available", cp.Available)
-	env.NewGaugeFunc(name+"Active", "Tablet server conn pool active", cp.Active)
-	env.NewGaugeFunc(name+"InUse", "Tablet server conn pool in use", cp.InUse)
-	env.NewGaugeFunc(name+"MaxCap", "Tablet server conn pool max cap", cp.MaxCap)
-	env.NewCounterFunc(name+"WaitCount", "Tablet server conn pool wait count", cp.WaitCount)
-	env.NewCounterDurationFunc(name+"WaitTime", "Tablet server wait time", cp.WaitTime)
-	env.NewGaugeDurationFunc(name+"IdleTimeout", "Tablet server idle timeout", cp.IdleTimeout)
-	env.NewCounterFunc(name+"IdleClosed", "Tablet server conn pool idle closed", cp.IdleClosed)
+	instanceName := tsv.InstanceName()
+	servenv.NewGaugeFunc(instanceName, name+"Capacity", "Tablet server conn pool capacity", cp.Capacity)
+	servenv.NewGaugeFunc(instanceName, name+"Available", "Tablet server conn pool available", cp.Available)
+	servenv.NewGaugeFunc(instanceName, name+"Active", "Tablet server conn pool active", cp.Active)
+	servenv.NewGaugeFunc(instanceName, name+"InUse", "Tablet server conn pool in use", cp.InUse)
+	servenv.NewGaugeFunc(instanceName, name+"MaxCap", "Tablet server conn pool max cap", cp.MaxCap)
+	servenv.NewCounterFunc(instanceName, name+"WaitCount", "Tablet server conn pool wait count", cp.WaitCount)
+	servenv.NewCounterDurationFunc(instanceName, name+"WaitTime", "Tablet server wait time", cp.WaitTime)
+	servenv.NewGaugeDurationFunc(instanceName, name+"IdleTimeout", "Tablet server idle timeout", cp.IdleTimeout)
+	servenv.NewCounterFunc(instanceName, name+"IdleClosed", "Tablet server conn pool idle closed", cp.IdleClosed)
 	return cp
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/servenv"
 
 	"golang.org/x/net/context"
 )
@@ -220,18 +221,17 @@ func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 	}
 }
 
-type dummyChecker struct {
+type fakeTabletService struct {
 }
 
-func (dummyChecker) CheckMySQL() {}
-
-var checker = dummyChecker{}
+func (fakeTabletService) CheckMySQL()            {}
+func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
 
 func newPool() *Pool {
 	return New(
 		fmt.Sprintf("TestPool%d", rand.Int63()),
 		100,
 		10*time.Second,
-		checker,
+		fakeTabletService{},
 	)
 }

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -24,7 +24,6 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/callerid"
-	"vitess.io/vitess/go/vt/servenv"
 
 	"golang.org/x/net/context"
 )
@@ -224,8 +223,8 @@ func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 type fakeTabletService struct {
 }
 
-func (fakeTabletService) CheckMySQL()            {}
-func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (fakeTabletService) CheckMySQL()          {}
+func (fakeTabletService) InstanceName() string { return "test" }
 
 func newPool() *Pool {
 	return New(

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -42,7 +41,7 @@ import (
 // that the messager needs for callback.
 type TabletService interface {
 	CheckMySQL()
-	Env() *servenv.Embedder
+	InstanceName() string
 	PostponeMessages(ctx context.Context, target *querypb.Target, name string, ids []string) (count int64, err error)
 	PurgeMessages(ctx context.Context, target *querypb.Target, name string, timeCutoff int64) (count int64, err error)
 }

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -41,6 +42,7 @@ import (
 // that the messager needs for callback.
 type TabletService interface {
 	CheckMySQL()
+	Env() *servenv.Embedder
 	PostponeMessages(ctx context.Context, target *querypb.Target, name string, ids []string) (count int64, err error)
 	PurgeMessages(ctx context.Context, target *querypb.Target, name string, timeCutoff int64) (count int64, err error)
 }

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -30,7 +30,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -754,8 +753,8 @@ type fakeTabletServer struct {
 
 func newFakeTabletServer() *fakeTabletServer { return &fakeTabletServer{} }
 
-func (fts *fakeTabletServer) CheckMySQL()            {}
-func (fts *fakeTabletServer) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (fts *fakeTabletServer) CheckMySQL()          {}
+func (fts *fakeTabletServer) InstanceName() string { return "test" }
 
 func (fts *fakeTabletServer) SetChannel(ch chan string) {
 	fts.mu.Lock()

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -753,7 +754,8 @@ type fakeTabletServer struct {
 
 func newFakeTabletServer() *fakeTabletServer { return &fakeTabletServer{} }
 
-func (fts *fakeTabletServer) CheckMySQL() {}
+func (fts *fakeTabletServer) CheckMySQL()            {}
+func (fts *fakeTabletServer) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
 
 func (fts *fakeTabletServer) SetChannel(ch chan string) {
 	fts.mu.Lock()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -937,7 +937,7 @@ func (qre *QueryExecutor) execSQL(conn poolConn, sql string, wantfields bool) (*
 	warnThreshold := qre.tsv.qe.warnResultSize.Get()
 	if res != nil && warnThreshold > 0 && int64(len(res.Rows)) > warnThreshold {
 		callerID := callerid.ImmediateCallerIDFromContext(qre.ctx)
-		tabletenv.Warnings.Add("ResultsExceeded", 1)
+		qre.tsv.warnings.Add("ResultsExceeded", 1)
 		log.Warningf("CallerID: %s Results returned (%v) exceeds warning threshold (%v): %q", callerID.Username, len(res.Rows), warnThreshold, sql)
 	}
 	return res, err

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -2053,7 +2053,7 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	} else {
 		config.TwoPCAbandonAge = 10
 	}
-	tsv := NewTabletServerWithNilTopoServer(config)
+	tsv := NewTestTabletServer(config)
 	testUtils := newTestUtils()
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}

--- a/go/vt/vttablet/tabletserver/replication_watcher.go
+++ b/go/vt/vttablet/tabletserver/replication_watcher.go
@@ -55,18 +55,19 @@ type ReplicationWatcher struct {
 }
 
 // NewReplicationWatcher creates a new ReplicationWatcher.
-func NewReplicationWatcher(env *servenv.Embedder, se *schema.Engine, config tabletenv.TabletConfig) *ReplicationWatcher {
+func NewReplicationWatcher(instanceName string, se *schema.Engine, config tabletenv.TabletConfig) *ReplicationWatcher {
 	rpw := &ReplicationWatcher{
 		watchReplication: config.WatchReplication,
 		se:               se,
 	}
-	env.Publish("EventTokenPosition", stats.StringFunc(func() string {
+	servenv.Publish(instanceName, "EventTokenPosition", stats.StringFunc(func() string {
 		if e := rpw.EventToken(); e != nil {
 			return e.Position
 		}
 		return ""
 	}))
-	env.NewGaugeFunc(
+	servenv.NewGaugeFunc(
+		instanceName,
 		"EventTokenTimestamp",
 		"Replication watcher event token timestamp",
 		func() int64 {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema/schematest"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -416,19 +417,20 @@ func TestStatsURL(t *testing.T) {
 	se.ServeHTTP(response, request)
 }
 
-type dummyChecker struct {
+type fakeTabletService struct {
 }
 
-func (dummyChecker) CheckMySQL() {}
+func (fakeTabletService) CheckMySQL()            {}
+func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
 
-var DummyChecker = dummyChecker{}
+var FakeTabletService = fakeTabletService{}
 
 func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout time.Duration, strict bool, db *fakesqldb.DB) *Engine {
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.SchemaReloadTime = float64(reloadTime) / 1e9
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	se := NewEngine(DummyChecker, config)
+	se := NewEngine(FakeTabletService, config)
 	se.InitDBConfig(newDBConfigs(db))
 	return se
 }

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -32,7 +32,6 @@ import (
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema/schematest"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -420,8 +419,8 @@ func TestStatsURL(t *testing.T) {
 type fakeTabletService struct {
 }
 
-func (fakeTabletService) CheckMySQL()            {}
-func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (fakeTabletService) CheckMySQL()          {}
+func (fakeTabletService) InstanceName() string { return "test" }
 
 var FakeTabletService = fakeTabletService{}
 

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -221,7 +221,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	appParams := db.ConnParams()
 	dbaParams := db.ConnParams()
 	connPoolIdleTimeout := 10 * time.Second
-	connPool := connpool.New("", 2, connPoolIdleTimeout, DummyChecker)
+	connPool := connpool.New("", 2, connPoolIdleTimeout, FakeTabletService)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -19,6 +19,7 @@ package tabletserver
 import (
 	"time"
 
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -182,11 +183,11 @@ type queryserviceStatus struct {
 
 // AddStatusHeader registers a standlone header for the status page.
 func (tsv *TabletServer) AddStatusHeader() {
-	tsv.env.AddStatusPart("Tablet Server", headerTemplate, func() interface{} {
+	servenv.AddInstanceStatusPart(tsv.instanceName, "Tablet Server", headerTemplate, func() interface{} {
 		tsv.mu.Lock()
 		defer tsv.mu.Unlock()
 		return map[string]interface{}{
-			"Prefix": tsv.env.URLPrefix(),
+			"Prefix": servenv.URLPrefix(tsv.instanceName),
 			"Target": tsv.target,
 		}
 	})
@@ -194,7 +195,7 @@ func (tsv *TabletServer) AddStatusHeader() {
 
 // AddStatusPart registers the status part for the status page.
 func (tsv *TabletServer) AddStatusPart() {
-	tsv.env.AddStatusPart("Queryservice", queryserviceStatusTemplate, func() interface{} {
+	servenv.AddInstanceStatusPart(tsv.instanceName, "Queryservice", queryserviceStatusTemplate, func() interface{} {
 		status := queryserviceStatus{
 			State:   tsv.GetState(),
 			History: tsv.history.Records(),

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -68,8 +68,6 @@ var (
 	)
 	// InternalErrors shows number of errors from internal components.
 	InternalErrors = stats.NewCountersWithSingleLabel("InternalErrors", "Internal component errors", "type", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages")
-	// Warnings shows number of warnings
-	Warnings = stats.NewCountersWithSingleLabel("Warnings", "Warnings", "type", "ResultsExceeded")
 	// Unresolved tracks unresolved items. For now it's just Prepares.
 	Unresolved = stats.NewGaugesWithSingleLabel("Unresolved", "Unresolved items", "item_type", "Prepares")
 	// UserTableQueryCount shows number of queries received for each CallerID/table combination.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -254,9 +254,6 @@ type TxPoolController interface {
 	Rollback(ctx context.Context, transactionID int64) error
 }
 
-var tsOnce sync.Once
-var srvTopoServer srvtopo.Server
-
 // NewCustomTabletServer creates a tablet server based on the input config.
 func NewCustomTabletServer(name string, config tabletenv.TabletConfig, topoServer *topo.Server, alias topodatapb.TabletAlias) *TabletServer {
 	return NewTabletServer(name, config, topoServer, alias)
@@ -287,8 +284,8 @@ func NewTabletServer(name string, config tabletenv.TabletConfig, topoServer *top
 	tsv.messager = messager.NewEngine(tsv, tsv.se, config)
 	tsv.watcher = NewReplicationWatcher(tsv.env, tsv.se, config)
 	tsv.updateStreamList = &binlog.StreamList{}
-	srvTopoServer = srvtopo.NewResilientServer(topoServer, "TabletSrvTopo")
-	tsv.vstreamer = vstreamer.NewEngine(srvTopoServer, tsv.se)
+	srvTopoServer := srvtopo.NewResilientServer(topoServer, "TabletSrvTopo")
+	tsv.vstreamer = vstreamer.NewEngine(tsv.env, srvTopoServer, tsv.se)
 	tsv.env.NewGaugeFunc("TabletState", "Tablet server state", func() int64 {
 		tsv.mu.Lock()
 		state := tsv.state

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -515,6 +515,8 @@ func (tsv *TabletServer) decideAction(tabletType topodatapb.TabletType, serving 
 			// We're already in the desired state.
 			return actionNone, nil
 		}
+	} else {
+		log.Infof("TabletServer tablet type: %v -> %v", tsv.target.TabletType, tabletType)
 	}
 	tsv.target.TabletType = tabletType
 	switch tsv.state {

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -25,7 +25,6 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -34,8 +33,8 @@ var errRejected = errors.New("rejected")
 type fakeTabletService struct {
 }
 
-func (fakeTabletService) CheckMySQL()            {}
-func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (fakeTabletService) CheckMySQL()          {}
+func (fakeTabletService) InstanceName() string { return "test" }
 
 var FakeTabletService = fakeTabletService{}
 

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -25,17 +25,19 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 var errRejected = errors.New("rejected")
 
-type dummyChecker struct {
+type fakeTabletService struct {
 }
 
-func (dummyChecker) CheckMySQL() {}
+func (fakeTabletService) CheckMySQL()            {}
+func (fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
 
-var DummyChecker = dummyChecker{}
+var FakeTabletService = fakeTabletService{}
 
 type testUtils struct{}
 

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -98,7 +98,7 @@ type TxEngine struct {
 }
 
 // NewTxEngine creates a new TxEngine.
-func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *TxEngine {
+func NewTxEngine(tsv connpool.TabletService, config tabletenv.TabletConfig) *TxEngine {
 	te := &TxEngine{
 		shutdownGracePeriod: time.Duration(config.TxShutDownGracePeriod * 1e9),
 	}
@@ -119,7 +119,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 		time.Duration(config.TransactionTimeout*1e9),
 		time.Duration(config.IdleTimeout*1e9),
 		config.TxPoolWaiterCap,
-		checker,
+		tsv,
 		limiter,
 	)
 	te.twopcEnabled = config.TwoPCEnable
@@ -147,7 +147,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 		config.PoolNamePrefix+"TxReadPool",
 		3,
 		time.Duration(config.IdleTimeout*1e9),
-		checker,
+		tsv,
 	)
 	te.twoPC = NewTwoPC(readPool)
 	te.transitionSignal = make(chan struct{})

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -42,7 +42,7 @@ func TestTxEngineClose(t *testing.T) {
 	config.TransactionCap = 10
 	config.TransactionTimeout = 0.5
 	config.TxShutDownGracePeriod = 0
-	te := NewTxEngine(nil, config)
+	te := NewTxEngine(FakeTabletService, config)
 	te.InitDBConfig(dbcfgs)
 
 	// Normal close.
@@ -464,7 +464,7 @@ func setupTxEngine(db *fakesqldb.DB) *TxEngine {
 	config.TransactionCap = 10
 	config.TransactionTimeout = 0.5
 	config.TxShutDownGracePeriod = 0
-	te := NewTxEngine(nil, config)
+	te := NewTxEngine(FakeTabletService, config)
 	te.InitDBConfig(dbcfgs)
 	return te
 }

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -33,6 +33,7 @@ import (
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/messager"
@@ -124,8 +125,8 @@ func NewTxPool(
 	}
 	// Careful: conns also exports name+"xxx" vars,
 	// but we know it doesn't export Timeout.
-	tsv.Env().NewGaugeDurationFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
-	tsv.Env().NewGaugeFunc(prefix+"TransactionPoolWaiters", "Transaction pool waiters", axp.waiters.Get)
+	servenv.NewGaugeDurationFunc(tsv.InstanceName(), prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
+	servenv.NewGaugeFunc(tsv.InstanceName(), prefix+"TransactionPoolWaiters", "Transaction pool waiters", axp.waiters.Get)
 	return axp
 }
 

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -645,7 +645,7 @@ func newTxPool() *TxPool {
 		transactionTimeout,
 		idleTimeout,
 		waiterCap,
-		DummyChecker,
+		FakeTabletService,
 		limiter,
 	)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -83,6 +83,7 @@ func NewEngine(ts srvtopo.Server, se *schema.Engine) *Engine {
 		ts:        ts,
 		se:        se,
 	}
+	// TODO(sougou): migrate this to use embedder.
 	once.Do(func() {
 		vschemaErrors = stats.NewCounter("VSchemaErrors", "Count of VSchema errors")
 		vschemaUpdates = stats.NewCounter("VSchemaUpdates", "Count of VSchema updates. Does not include errors")

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -77,17 +77,14 @@ type Engine struct {
 // NewEngine creates a new Engine.
 // Initialization sequence is: NewEngine->InitDBConfig->Open.
 // Open and Close can be called multiple times and are idempotent.
-func NewEngine(env *servenv.Embedder, ts srvtopo.Server, se *schema.Engine) *Engine {
+func NewEngine(instanceName string, ts srvtopo.Server, se *schema.Engine) *Engine {
 	vse := &Engine{
 		streamers: make(map[int]*vstreamer),
 		kschema:   &vindexes.KeyspaceSchema{},
 		ts:        ts,
 		se:        se,
 	}
-	// TODO(sougou): migrate this to use embedder.
-	once.Do(func() {
-		env.HandleFunc("/debug/tablet_vschema", vse.ServeHTTP)
-	})
+	servenv.HandleFunc(instanceName, "/debug/tablet_vschema", vse.ServeHTTP)
 	return vse
 }
 

--- a/go/vt/vttablet/tabletserver/vstreamer/main_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"testing"
 
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 )
 
@@ -49,7 +48,7 @@ func TestMain(m *testing.M) {
 
 		// engine cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		engine = NewEngine(servenv.NewEmbedder("test", ""), env.SrvTopo, env.SchemaEngine)
+		engine = NewEngine("TestStreamerEngine", env.SrvTopo, env.SchemaEngine)
 		engine.InitDBConfig(env.Dbcfgs)
 		engine.Open(env.KeyspaceName, env.Cells[0])
 		defer engine.Close()

--- a/go/vt/vttablet/tabletserver/vstreamer/main_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 )
 
@@ -48,7 +49,7 @@ func TestMain(m *testing.M) {
 
 		// engine cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		engine = NewEngine(env.SrvTopo, env.SchemaEngine)
+		engine = NewEngine(servenv.NewEmbedder("test", ""), env.SrvTopo, env.SchemaEngine)
 		engine.InitDBConfig(env.Dbcfgs)
 		engine.Open(env.KeyspaceName, env.Cells[0])
 		defer engine.Close()

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -27,11 +27,11 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topotools"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttest"
@@ -56,11 +56,10 @@ type Env struct {
 	SchemaEngine *schema.Engine
 }
 
-type checker struct{}
+type fakeTabletService struct{}
 
-var _ = connpool.MySQLChecker(checker{})
-
-func (checker) CheckMySQL() {}
+func (f fakeTabletService) CheckMySQL()            {}
+func (f fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
 
 // Init initializes an Env.
 func Init() (*Env, error) {
@@ -107,7 +106,7 @@ func Init() (*Env, error) {
 
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
-	te.SchemaEngine = schema.NewEngine(checker{}, tabletenv.DefaultQsConfig)
+	te.SchemaEngine = schema.NewEngine(fakeTabletService{}, tabletenv.DefaultQsConfig)
 	te.SchemaEngine.InitDBConfig(te.Dbcfgs)
 
 	// The first vschema should not be empty. Leads to Node not found error.

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -58,8 +57,8 @@ type Env struct {
 
 type fakeTabletService struct{}
 
-func (f fakeTabletService) CheckMySQL()            {}
-func (f fakeTabletService) Env() *servenv.Embedder { return servenv.NewEmbedder("test", "") }
+func (f fakeTabletService) CheckMySQL()        {}
+func (fakeTabletService) InstanceName() string { return "test" }
 
 // Init initializes an Env.
 func Init() (*Env, error) {
@@ -77,7 +76,7 @@ func Init() (*Env, error) {
 	if err := te.TopoServ.CreateShard(ctx, te.KeyspaceName, te.ShardName); err != nil {
 		panic(err)
 	}
-	te.SrvTopo = srvtopo.NewResilientServer(te.TopoServ, "TestTopo")
+	te.SrvTopo = srvtopo.NewResilientServer("TestTopo", te.TopoServ)
 
 	cfg := vttest.Config{
 		Topology: &vttestpb.VTTestTopology{


### PR DESCRIPTION
The Embedder is a new feature in servenv that supports instantiation of multiple instances of a server object within the same process.

A server object typically registers http URL handlers, status parts and stats variables. Such objects will generate panics if instantiated multiple times within the same process. The Embedder provides equivalent APIs. If used, it remaps the endpoints into different name-spaces.

In the case of URLs, and additional prefix is added: `/url` -> `/name/url`.
In the case of stats vars, an additional dimension gets added: `{"a": 1}` -> `{"name.a": 1}`

The TabletServer, which is multiply instantiated in vtcombo, has been changed to use the Embedder, and the related hacks have cleaned up. There is no additional overhead if a TabletServer is instantiated anonymously, like in the case of vttablet. In the embedded case, there is a negligible overhead in some stats cases because some variable access has to be wrapped with accessor functions.

With this change, vtcombo has a functional status page that points to individual status sub-urls for each tablet server it instantiates.