### PR TITLE
Cleans up vtexplain environment

### DIFF
--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -178,5 +178,7 @@ func parseAndRun() error {
 		fmt.Print(vtexplain.ExplainsAsJSON(plans))
 	}
 
+	vtexplain.Stop()
+
 	return nil
 }

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -169,6 +169,16 @@ func Init(vSchemaStr, sqlSchema string, opts *Options) error {
 	return nil
 }
 
+// Stop and cleans up fake execution environment
+func Stop() {
+	// Cleanup all created fake dbs.
+	if explainTopo != nil {
+		for _, conn := range explainTopo.TabletConns {
+			conn.db.Close()
+		}
+	}
+}
+
 func parseSchema(sqlSchema string, opts *Options) ([]*sqlparser.DDL, error) {
 	parsedDDLs := make([]*sqlparser.DDL, 0, 16)
 	for {


### PR DESCRIPTION
###  Desc

* Vtexplain was not cleaning up sockets created by fakedb. This PR adds a method to "Stop" vtexplain environment and cleans fakes db's that were created by vtexplain. 

###  Tests

* Tested this locally. 

