### PR TITLE
Tweaks to vagrant setup

### DIFF
--- a/vagrant-scripts/bootstrap_vm.sh
+++ b/vagrant-scripts/bootstrap_vm.sh
@@ -69,6 +69,9 @@ printf "\nSetting higher limit for max number of open files\n"
 echo "fs.file-max = 10000" >> /etc/sysctl.conf
 sysctl -p
 
+# Set vitess env in .bashrc
+cat /vagrant/src/vitess.io/vitess/vagrant-scripts/vagrant-bashrc  >> /home/vagrant/.bashrc
+
 # Provisioning completed
 touch $SEED_FILE
 printf "\nProvisioning completed!\n\n"

--- a/vagrant-scripts/vagrant-bashrc
+++ b/vagrant-scripts/vagrant-bashrc
@@ -1,0 +1,18 @@
+cd $VITESS_WORKSPACE
+seed_file=$HOME/.vitess_bootstrap_done
+
+if [ ! -f $seed_file ];
+then
+    printf "\nVM Vitess hasn't been build in this VM. Downloading and setting up vitess deps. \n"
+    ./vagrant-scripts/vitess/build.sh
+    touch $seed_file
+fi
+
+ulimit -n 10000
+export MYSQL_FLAVOR=MySQL56
+export VT_MYSQL_ROOT=/usr
+# This is just to make sure the vm can write into these directories
+sudo chown "$(whoami)":"$(whoami)" /vagrant
+sudo chown "$(whoami)":"$(whoami)" /vagrant/src
+source dev.env
+source /vagrant/dist/grpc/usr/local/bin/activate

--- a/vagrant-scripts/vagrant-bashrc
+++ b/vagrant-scripts/vagrant-bashrc
@@ -1,4 +1,4 @@
-cd $VITESS_WORKSPACE
+cd $VITESS_WORKSPACE || exit
 seed_file=$HOME/.vitess_bootstrap_done
 
 if [ ! -f $seed_file ];

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -3,7 +3,6 @@
 # See http://vitess.io/getting-started/local-instance.html#manual-build
 # for more info
 #
-set -ex
 
 ulimit -n 10000
 export MYSQL_FLAVOR=MySQL56
@@ -23,4 +22,4 @@ source /vagrant/dist/grpc/usr/local/bin/activate
 pip install mysqlclient
 make build
 
-printf "\Build completed\n\n."
+printf "\Build completed\n\n"


### PR DESCRIPTION
## Description

* Improve vagrant setup so from the moment you ssh to the VM , all the environment is ready to build vitess. If you are using the VM as your base dev environment, this becomes very handy. I found myself  many times doing something like this:
  ```
  vagrant ssh
  cd $VITESS_WORKSPACE
  ulimit -n 10000
  export MYSQL_FLAVOR=MySQL56
  export VT_MYSQL_ROOT=/usr
  source dev.env
  source /vagrant/dist/grpc/usr/local/bin/activate
  ```
