### PR TITLE
Upgrade Guava, Protobuf, gRPC, Netty, and others

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -60,8 +60,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
-    <grpc.version>1.11.0</grpc.version>
-    <protobuf.java.version>3.0.0</protobuf.java.version>
+    <grpc.version>1.15.0</grpc.version>
+    <protobuf.java.version>3.5.1</protobuf.java.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->
@@ -70,28 +70,28 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.5</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>20.0</version>
+        <version>26.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.0.0</version>
+        <version>${protobuf.java.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
       </dependency>
 
       <dependency>
@@ -122,14 +122,14 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.22.Final</version>
+        <version>4.1.27.Final</version>
       </dependency>
       <!-- TODO(mberlin): When we upgrade grpc, check if we can remove this. Without,
         grpc-client TLS tests fail with error "Jetty ALPN/NPN has not been properly configured.". -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.7.Final</version>
+        <version>2.0.17.Final</version>
       </dependency>
 
       <dependency>
@@ -157,7 +157,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.5</version>
+        <version>2.10</version>
       </dependency>
 
       <dependency>
@@ -175,7 +175,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.1</version>
+        <version>4.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
grpc from 1.11 to 1.15
protobuf from 3.0.0 to 3.5.1
jsr305 from 3.0.0 to 3.0.2
gson from 2.8.0 to 2.8.5
guava from 20.0 to 26.0-jre
commons-io from 2.5 to 2.6
netty from 4.1.22 to 4.1.27
joda-time from 2.5 to 2.10
commons-collections4 from 4.1 to 4.2