### PR TITLE
Initial import of change to parallelize backup compression

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -106,13 +106,13 @@ func (bh *S3BackupHandle) AddFile(ctx context.Context, filename string, filesize
 	}
 
 	// Calculate s3 upload part size using the source filesize
-	partSizeMB := s3manager.DefaultUploadPartSize
+	partSizeBytes := s3manager.DefaultUploadPartSize
 	if filesize > 0 {
 		minimumPartSize := float64(filesize) / float64(s3manager.MaxUploadParts)
-		// Convert partsize to mb and round up to ensure large enough partsize
-		calculatedPartSizeMB := int64(math.Ceil(minimumPartSize / 1024 * 1024))
-		if calculatedPartSizeMB > partSizeMB {
-			partSizeMB = calculatedPartSizeMB
+		// Round up to ensure large enough partsize
+		calculatedPartSizeBytes := int64(math.Ceil(minimumPartSize))
+		if calculatedPartSizeBytes > partSizeBytes {
+			partSizeBytes = calculatedPartSizeBytes
 		}
 	}
 
@@ -122,7 +122,7 @@ func (bh *S3BackupHandle) AddFile(ctx context.Context, filename string, filesize
 	go func() {
 		defer bh.waitGroup.Done()
 		uploader := s3manager.NewUploaderWithClient(bh.client, func(u *s3manager.Uploader) {
-			u.PartSize = partSizeMB
+			u.PartSize = partSizeBytes
 		})
 		object := objName(bh.dir, bh.name, filename)
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -639,6 +639,30 @@
 			"revisionTime": "2016-01-05T22:08:40Z"
 		},
 		{
+			"checksumSHA1": "rmCbOBewXcbEdHRerzoanS+kI2U=",
+			"path": "github.com/klauspost/compress/flate",
+			"revision": "b50017755d442260d792c34c7c43216d9ba7ffc7",
+			"revisionTime": "2018-08-01T09:52:37Z"
+		},
+		{
+			"checksumSHA1": "vGHBCcWkLCbAc3PJcRs7vFbvaYM=",
+			"path": "github.com/klauspost/cpuid",
+			"revision": "e7e905edc00ea8827e58662220139109efea09db",
+			"revisionTime": "2018-04-05T13:32:22Z"
+		},
+		{
+			"checksumSHA1": "6/zXof97s7P9tlNp3mUioXgeEVI=",
+			"path": "github.com/klauspost/crc32",
+			"revision": "bab58d77464aa9cf4e84200c3276da0831fe0c03",
+			"revisionTime": "2017-06-28T07:24:49Z"
+		},
+		{
+			"checksumSHA1": "N4EMcnfxHl1f4TQsKQWX/yLF/BE=",
+			"path": "github.com/klauspost/pgzip",
+			"revision": "c4ad2ed77aece7b3270909769a30a3fcea262a66",
+			"revisionTime": "2018-07-17T08:42:24Z"
+		},
+		{
 			"checksumSHA1": "DdH3xAkzAWJ4B/LGYJyCeRsly2I=",
 			"path": "github.com/mattn/go-runewidth",
 			"revision": "d6bea18f789704b5f83375793155289da36a3c7f",


### PR DESCRIPTION
Signed-off-by: Ameet Kotian <akotian@slack-corp.com>

**Overview of the Issue**
Backup compression in vitess is not parallelized. This patch imports [pgzip](https://github.com/klauspost/pgzip) library to parallelize compression during backups only. Restores cannot be parallelized. 
It adds introduces two options to vttablet to configure the parallelism 
* `backup_storage_block_size`
* `backup_storage_number_blocks` 

Secondly, also removed a bug from `AddFile` where it wrongly converting `partsize` to mb. The code was effectively not doing anything.  

From the tests, for the same host with the same data,  it appears that backup speeds are 4X time faster

Without the patch:
Max upload speed for a large file capped at 240 Mbps
<img width="1413" alt="screen shot 2018-09-17 at 5 51 13 pm" src="https://user-images.githubusercontent.com/13060696/45658147-53e84780-baa2-11e8-959b-1fcdf3bbbb2c.png">


With the patch:
Max upload speed for a large file capped at 1 Gbps
<img width="1442" alt="screen shot 2018-09-17 at 5 50 52 pm" src="https://user-images.githubusercontent.com/13060696/45658220-afb2d080-baa2-11e8-8336-77a950f27099.png">

