### PR TITLE
[MySQL] Make Connection Close threadsafe

### DIFF
--- a/go/sync2/atomic.go
+++ b/go/sync2/atomic.go
@@ -139,6 +139,18 @@ func (i *AtomicBool) Get() bool {
 	return atomic.LoadInt32(&i.int32) != 0
 }
 
+// CompareAndSwap atomatically swaps the old with the new value.
+func (i *AtomicBool) CompareAndSwap(o, n bool) bool {
+	var old, new int32
+	if o {
+		old = 1
+	}
+	if n {
+		new = 1
+	}
+	return atomic.CompareAndSwapInt32(&i.int32, old, new)
+}
+
 // AtomicString gives you atomic-style APIs for string, but
 // it's only a convenience wrapper that uses a mutex. So, it's
 // not as efficient as the rest of the atomic types.

--- a/go/sync2/atomic_test.go
+++ b/go/sync2/atomic_test.go
@@ -56,4 +56,20 @@ func TestAtomicBool(t *testing.T) {
 	if !b.Get() {
 		t.Error("b.Get: false, want true")
 	}
+
+	if b.CompareAndSwap(false, true) {
+		t.Error("b.CompareAndSwap false, true should fail")
+	}
+	if !b.CompareAndSwap(true, false) {
+		t.Error("b.CompareAndSwap true, false should succeed")
+	}
+	if !b.CompareAndSwap(false, false) {
+		t.Error("b.CompareAndSwap false, false should NOP")
+	}
+	if !b.CompareAndSwap(false, true) {
+		t.Error("b.CompareAndSwap false, true should succeed")
+	}
+	if !b.CompareAndSwap(true, true) {
+		t.Error("b.CompareAndSwap true, true should NOP")
+	}
 }


### PR DESCRIPTION
Close can be called from another goroutine, but it's safe to call from
two different goroutines (or even IsClosed() and Closed() from two
different places). Wrap in a mutex.

Signed-off-by: Daniel Tahara <tahara@dropbox.com>