### PR TITLE
Added: api/keyspace/tablets/[shard]

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -189,7 +189,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		}
 		var shardNames []string
 		if len(parts) > 2 && parts[2] != "" {
-			shardNames = []string{parts[1]}
+			shardNames = []string{parts[2]}
 		} else {
 			var err error
 			shardNames, err = ts.GetShardNames(ctx, keyspace)

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -169,6 +169,43 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		}
 	})
 
+	handleCollection("ks_tablets", func(r *http.Request) (interface{}, error) {
+		// Valid requests: api/ks_tables/my_ks (all shards)
+		// Valid requests: api/ks_tables/my_ks/-80 (specific shard)
+		itemPath := getItemPath(r.URL.Path)
+		parts := strings.SplitN(itemPath, "/", 2)
+		keyspace := parts[0]
+		if keyspace == "" {
+			return nil, errors.New("keyspace is required")
+		}
+		var shardNames []string
+		if len(parts) > 1 && parts[1] != "" {
+			shardNames = []string{parts[1]}
+		} else {
+			var err error
+			shardNames, err = ts.GetShardNames(ctx, keyspace)
+			if err != nil {
+				return nil, err
+			}
+		}
+		tablets := [](*topodatapb.Tablet){}
+		for _, shard := range shardNames {
+			// Get tablets for this shard.
+			tabletAliases, err := ts.FindAllTabletAliasesInShard(ctx, keyspace, shard)
+			if err != nil && !topo.IsErrType(err, topo.PartialResult) {
+				return nil, err
+			}
+			for _, tabletAlias := range tabletAliases {
+				t, err := ts.GetTablet(ctx, tabletAlias)
+				if err != nil {
+					return nil, err
+				}
+				tablets = append(tablets, t.Tablet)
+			}
+		}
+		return tablets, nil
+	})
+
 	// Shards
 	handleCollection("shards", func(r *http.Request) (interface{}, error) {
 		shardPath := getItemPath(r.URL.Path)


### PR DESCRIPTION
Resubmission of https://github.com/vitessio/vitess/pull/4207, having messed up commit signoff.

This PR adds an API endpoint to `vtctld`:	

- ~~/api/ks_tables/my_keyspace~~
- ~~/api/ks_tables/my_keyspace/-80~~

**EDIT**: endpoint path has changed as per request, see comments below.

The API returns a list of all tablets for a given `keyspace`, optionally further filtered by `shard`.

The context for this PR is https://github.com/github/freno, and in particular https://github.com/github/freno/pull/70: giving the `freno` throttling tool an easy way to determine the roster of MySQL servers (host & port) it needs to poll for replication lag.

cc @github/database-infrastructure