### PR TITLE
scatter metrics for all route types

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -172,6 +172,11 @@ func (c *CountersWithSingleLabel) Add(name string, value int64) {
 	atomic.AddInt64(a, value)
 }
 
+// ResetAll clears the counters
+func (c *CountersWithSingleLabel) ResetAll() {
+	c.counters.ResetAll()
+}
+
 // CountersWithMultiLabels is a multidimensional counters implementation.
 // Internally, each tuple of dimensions ("labels") is stored as a single
 // label value where all label values are joined with ".".

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -134,6 +134,11 @@ func (code DeleteOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(delName[code])
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (del *Delete) RouteType() string {
+	return delName[del.Opcode]
+}
+
 // Execute performs a non-streaming exec.
 func (del *Delete) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch del.Opcode {

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -45,6 +45,10 @@ func (f *fakePrimitive) rewind() {
 	f.log = nil
 }
 
+func (f *fakePrimitive) RouteType() string {
+	return "Fake"
+}
+
 func (f *fakePrimitive) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	f.log = append(f.log, fmt.Sprintf("Execute %v %v", printBindVars(bindVars), wantfields))
 	if f.results == nil {

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -153,6 +153,11 @@ func (code InsertOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(insName[code])
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (ins *Insert) RouteType() string {
+	return insName[ins.Opcode]
+}
+
 // Execute performs a non-streaming exec.
 func (ins *Insert) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch ins.Opcode {

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -218,6 +218,11 @@ func (code JoinOpcode) MarshalJSON() ([]byte, error) {
 	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (jn *Join) RouteType() string {
+	return "Join"
+}
+
 func combineVars(bv1, bv2 map[string]*querypb.BindVariable) map[string]*querypb.BindVariable {
 	out := make(map[string]*querypb.BindVariable)
 	for k, v := range bv1 {

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -52,6 +52,11 @@ func (l *Limit) MarshalJSON() ([]byte, error) {
 	return json.Marshal(marshalLimit)
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (l *Limit) RouteType() string {
+	return l.Input.RouteType()
+}
+
 // Execute satisfies the Primtive interface.
 func (l *Limit) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	count, err := l.fetchCount(bindVars)

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -91,6 +91,11 @@ func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
 	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (oa *OrderedAggregate) RouteType() string {
+	return oa.Input.RouteType()
+}
+
 // Execute is a Primitive function.
 func (oa *OrderedAggregate) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	qr, err := oa.execute(vcursor, bindVars, wantfields)

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -119,6 +119,7 @@ func (p *Plan) Size() int {
 // Primitive is the interface that needs to be satisfied by
 // all primitives of a plan.
 type Primitive interface {
+	RouteType() string
 	Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error)
 	StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error
 	GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -173,6 +173,11 @@ func (code RouteOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(routeName[code])
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (route *Route) RouteType() string {
+	return routeName[route.Opcode]
+}
+
 // Execute performs a non-streaming exec.
 func (route *Route) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	if route.QueryTimeout != 0 {

--- a/go/vt/vtgate/engine/subquery.go
+++ b/go/vt/vtgate/engine/subquery.go
@@ -31,6 +31,11 @@ type Subquery struct {
 	Subquery Primitive
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (sq *Subquery) RouteType() string {
+	return sq.Subquery.RouteType()
+}
+
 // Execute performs a non-streaming exec.
 func (sq *Subquery) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	inner, err := sq.Subquery.Execute(vcursor, bindVars, wantfields)

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -129,6 +129,11 @@ func (code UpdateOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(updName[code])
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (upd *Update) RouteType() string {
+	return updName[upd.Opcode]
+}
+
 // Execute performs a non-streaming exec.
 func (upd *Update) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	switch upd.Opcode {

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -79,6 +79,11 @@ func (code VindexOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(vindexOpcodeName[code])
 }
 
+// RouteType returns a description of the query routing type used by the primitive
+func (vf *VindexFunc) RouteType() string {
+	return vindexOpcodeName[vf.Opcode]
+}
+
 // Execute performs a non-streaming exec.
 func (vf *VindexFunc) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	return vf.mapVindex(vcursor, bindVars)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1027,7 +1027,7 @@ func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sq
 	result, err := e.destinationExec(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
 
 	queriesProcessed.Add("Other", 1)
-	queriesRouted.Add("", int64(logStats.ShardQueries))
+	queriesRouted.Add("Other", int64(logStats.ShardQueries))
 
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -57,6 +57,9 @@ import (
 var (
 	errNoKeyspace     = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspace in database name specified. Supported database name format (items in <> are optional): keyspace<:shard><@type> or keyspace<[range]><@type>")
 	defaultTabletType topodatapb.TabletType
+
+	queriesProcessed = stats.NewCountersWithSingleLabel("QueriesProcessed", "Queries processed at vtgate by plan type", "Plan")
+	queriesRouted    = stats.NewCountersWithSingleLabel("QueriesRouted", "Queries routed from vtgate to vttablet by plan type", "Plan")
 )
 
 func init() {
@@ -229,6 +232,8 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 		// TODO(sougou): change this flow to go through V3 functions
 		// which will allow us to benefit from the autocommitable flag.
 
+		queriesProcessed.Add("ShardDirect", 1)
+
 		if destKeyspace == "" {
 			return nil, errNoKeyspace
 		}
@@ -259,6 +264,7 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 		logStats.BindVariables = bindVars
 		result, err := e.destinationExec(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
 		logStats.ExecuteTime = time.Now().Sub(execStart)
+		queriesRouted.Add("ShardDirect", int64(logStats.ShardQueries))
 		return result, err
 	}
 
@@ -282,7 +288,11 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 	}
 
 	qr, err := plan.Instructions.Execute(vcursor, bindVars, true)
+
 	logStats.ExecuteTime = time.Since(execStart)
+	queriesProcessed.Add(plan.Instructions.RouteType(), 1)
+	queriesRouted.Add(plan.Instructions.RouteType(), int64(logStats.ShardQueries))
+
 	var errCount uint64
 	if err != nil {
 		logStats.Error = err
@@ -337,6 +347,10 @@ func (e *Executor) handleDDL(ctx context.Context, safeSession *SafeSession, sql 
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	result, err := e.destinationExec(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
+
+	queriesProcessed.Add("DDL", 1)
+	queriesRouted.Add("DDL", int64(logStats.ShardQueries))
+
 	return result, err
 }
 
@@ -493,6 +507,9 @@ func (e *Executor) handleBegin(ctx context.Context, safeSession *SafeSession, sq
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	err := e.txConn.Begin(ctx, safeSession)
 	logStats.ExecuteTime = time.Since(execStart)
+
+	queriesProcessed.Add("Begin", 1)
+
 	return &sqltypes.Result{}, err
 }
 
@@ -500,6 +517,8 @@ func (e *Executor) handleCommit(ctx context.Context, safeSession *SafeSession, s
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	logStats.ShardQueries = uint32(len(safeSession.ShardSessions))
+	queriesProcessed.Add("Commit", 1)
+	queriesRouted.Add("Commit", int64(logStats.ShardQueries))
 	err := e.txConn.Commit(ctx, safeSession)
 	logStats.CommitTime = time.Since(execStart)
 	return &sqltypes.Result{}, err
@@ -509,6 +528,8 @@ func (e *Executor) handleRollback(ctx context.Context, safeSession *SafeSession,
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	logStats.ShardQueries = uint32(len(safeSession.ShardSessions))
+	queriesProcessed.Add("Rollback", 1)
+	queriesRouted.Add("Rollback", int64(logStats.ShardQueries))
 	err := e.txConn.Rollback(ctx, safeSession)
 	logStats.CommitTime = time.Since(execStart)
 	return &sqltypes.Result{}, err
@@ -1004,6 +1025,10 @@ func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sq
 	}
 	execStart := time.Now()
 	result, err := e.destinationExec(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
+
+	queriesProcessed.Add("Other", 1)
+	queriesRouted.Add("", int64(logStats.ShardQueries))
+
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
 }


### PR DESCRIPTION
## Description
Add scatter metrics for all vtgate route types

## Discussion
Building on the ideas implemented in #4235, I wanted to add a more holistic view of the number of queries of each type that were executed at vtgate, and then for each of those types, how many queries were routed to vttablet.

This PR adds a `RouteType()` accessor to all vtgate primitives. For the execution primitives (route, insert, delete, etc) it returns the opcode to distinguish things like SelectScatter from SelectIN. For the various aggregations and subqueries, it passes through to the Inner primitive to get the underlying route.

Then there are two new counters `QueriesProcessed` and `QueriesRouted` which track the corresponding metrics tagged by the plan routing type.

The previous work which added query logging to vtgate added a ShardQueries count in each of the logStats objects to measure fanout per-query. So this was readily available for counting in a metric without having to go deep into each of the routing primitives themselves.


## Testing
Note -- We haven't (yet) deployed this into any running systems.

But I ran the vtgate unit tests and printed out the route type used, and they all seemed like what I'd expect:

```
# go test -v |& grep queriesProcessed | sort | uniq
XXX queriesProcessed DeleteByDestination
XXX queriesProcessed DeleteEqual
XXX queriesProcessed DeleteScatter
XXX queriesProcessed DeleteUnsharded
XXX queriesProcessed InsertSharded
XXX queriesProcessed InsertShardedIgnore
XXX queriesProcessed InsertUnsharded
XXX queriesProcessed Join
XXX queriesProcessed SelectDBA
XXX queriesProcessed SelectEqual
XXX queriesProcessed SelectEqualUnique
XXX queriesProcessed SelectIN
XXX queriesProcessed SelectNext
XXX queriesProcessed SelectScatter
XXX queriesProcessed SelectUnsharded
XXX queriesProcessed UpdateEqual
XXX queriesProcessed UpdateScatter
XXX queriesProcessed UpdateUnsharded
```
