### PR TITLE
add a raw ParseTokenizer interface to call yyParse under the hood

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -114,6 +114,12 @@ func ParseStrictDDL(sql string) (Statement, error) {
 	return tokenizer.ParseTree, nil
 }
 
+// ParseTokenizer is a raw interface to parse from the given tokenizer.
+// This does not used pooled parsers, and should not be used in general.
+func ParseTokenizer(tokenizer *Tokenizer) int {
+	return yyParse(tokenizer)
+}
+
 // ParseNext parses a single SQL statement from the tokenizer
 // returning a Statement which is the AST representation of the query.
 // The tokenizer will always read up to the end of the statement, allowing for


### PR DESCRIPTION
The prior change to use pooled parsers meant that the generated
yyParse function was unused, triggering warnings from the `unused`
vet tool.

Add a public interface `ParseTokenizer` so that these unused warnings
no longer show up. Plus this _could_ be useful for some third-party
that wants to have raw access to the underlying tokenizer / parser.

