### PR TITLE
Fix golint install in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -266,9 +266,9 @@ install_dep "chromedriver" "2.40" "$VTROOT/dist/chromedriver" install_chromedriv
 # Note: We explicitly do not vendor the tools below because a) we want to stay
 # on their latest version and b) it's easier to "go install" them this way.
 gotools=" \
-       github.com/golang/lint/golint \
        github.com/golang/mock/mockgen \
        github.com/kardianos/govendor \
+       golang.org/x/lint/golint \
        golang.org/x/tools/cmd/cover \
        golang.org/x/tools/cmd/goimports \
        golang.org/x/tools/cmd/goyacc \


### PR DESCRIPTION
We started noticing build failures in our vitess build due to the golint installation.

The official install doc recommends `go get -u golang.org/x/lint/golint` 
https://github.com/golang/lint#installation

A new import comment now enforces that 
https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58
This causes golint installed with `go get -u github.com/golang/lint/golint` to fail.

Signed-off-by: Leo Xuzhang Lin <llin@hubspot.com>

@sougou 