### PR TITLE
mysql: binlog_streamer unexpected panic

### DIFF
--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -51,6 +51,13 @@ const (
 // printJSONData parses the MySQL binary format for JSON data, and prints
 // the result as a string.
 func printJSONData(data []byte) ([]byte, error) {
+	// It's possible for data to be empty. If so, we have to
+	// treat it as 'null'.
+	// The mysql code also says why, but this wasn't reproduceable:
+	// https://github.com/mysql/mysql-server/blob/8.0/sql/json_binary.cc#L1070
+	if len(data) == 0 {
+		return []byte("'null'"), nil
+	}
 	result := &bytes.Buffer{}
 	typ := data[0]
 	if err := printJSONValue(typ, data[1:], true /* toplevel */, result); err != nil {

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -26,6 +26,9 @@ func TestJSON(t *testing.T) {
 		data     []byte
 		expected string
 	}{{
+		data:     []byte{},
+		expected: `'null'`,
+	}, {
 		data:     []byte{0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
 		expected: `JSON_OBJECT('a','b')`,
 	}, {


### PR DESCRIPTION
The binlog_streamer experienced a panic while processing
JSON data. It seems that there are situations where things
are empty. This is defensive code against such an occurence.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>