### PR TITLE
vtgate: health-check api

### DIFF
--- a/go/vt/vtgate/api.go
+++ b/go/vt/vtgate/api.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2018 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/log"
+)
+
+// This file implements a REST-style API for the vtgate web interface.
+
+const (
+	apiPrefix = "/api/"
+
+	jsonContentType = "application/json; charset=utf-8"
+)
+
+func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...interface{}) {
+	errMsg := fmt.Sprintf(format, args...)
+	log.Errorf("HTTP error on %v: %v, request: %#v", r.URL.Path, errMsg, r)
+	http.Error(w, errMsg, http.StatusInternalServerError)
+}
+
+func handleAPI(apiPath string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
+	http.HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if x := recover(); x != nil {
+				httpErrorf(w, r, "uncaught panic: %v", x)
+			}
+		}()
+		if err := handlerFunc(w, r); err != nil {
+			httpErrorf(w, r, "%v", err)
+		}
+	})
+}
+
+func handleCollection(collection string, getFunc func(*http.Request) (interface{}, error)) {
+	handleAPI(collection+"/", func(w http.ResponseWriter, r *http.Request) error {
+		// Get the requested object.
+		obj, err := getFunc(r)
+		if err != nil {
+			return fmt.Errorf("can't get %v: %v", collection, err)
+		}
+
+		// JSON encode response.
+		data, err := json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			return fmt.Errorf("cannot marshal data: %v", err)
+		}
+		w.Header().Set("Content-Type", jsonContentType)
+		w.Write(data)
+		return nil
+	})
+}
+
+func getItemPath(url string) string {
+	// Strip API prefix.
+	if !strings.HasPrefix(url, apiPrefix) {
+		return ""
+	}
+	url = url[len(apiPrefix):]
+
+	// Strip collection name.
+	parts := strings.SplitN(url, "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func unmarshalRequest(r *http.Request, v interface{}) error {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func initAPI(ctx context.Context, hc discovery.HealthCheck) {
+	// Healthcheck real time status per (cell, keyspace, tablet type, metric).
+	handleCollection("health-check", func(r *http.Request) (interface{}, error) {
+		cacheStatus := hc.CacheStatus()
+
+		itemPath := getItemPath(r.URL.Path)
+		if itemPath == "" {
+			return cacheStatus, nil
+		}
+		parts := strings.SplitN(itemPath, "/", 2)
+		collectionFilter := parts[0]
+		if collectionFilter == "" {
+			return cacheStatus, nil
+		}
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid health-check path: %q  expected path: / or /cell/<cell> or /keyspace/<keyspace> or /tablet/<tablet|mysql_hostname>", itemPath)
+		}
+		value := parts[1]
+
+		switch collectionFilter {
+		case "cell":
+			{
+				filteredStatus := make(discovery.TabletsCacheStatusList, 0)
+				for _, tabletCacheStatus := range cacheStatus {
+					if tabletCacheStatus.Cell == value {
+						filteredStatus = append(filteredStatus, tabletCacheStatus)
+					}
+				}
+				return filteredStatus, nil
+			}
+		case "keyspace":
+			{
+				filteredStatus := make(discovery.TabletsCacheStatusList, 0)
+				for _, tabletCacheStatus := range cacheStatus {
+					if tabletCacheStatus.Target.Keyspace == value {
+						filteredStatus = append(filteredStatus, tabletCacheStatus)
+					}
+				}
+				return filteredStatus, nil
+			}
+		case "tablet":
+			{
+				// Return a _specific tablet_
+				for _, tabletCacheStatus := range cacheStatus {
+					for _, tabletStats := range tabletCacheStatus.TabletsStats {
+						if tabletStats.Name == value || tabletStats.Tablet.MysqlHostname == value {
+							return tabletStats, nil
+						}
+					}
+				}
+			}
+		}
+		return nil, fmt.Errorf("cannot find health for: %s", itemPath)
+	})
+}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -253,6 +253,8 @@ func Init(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, ce
 		log.Fatalf("error initializing query logger: %v", err)
 	}
 
+	initAPI(ctx, hc)
+
 	return rpcVTGate
 }
 


### PR DESCRIPTION
This PR adds a `api/health-check` endpoint to `vtgate`. Previously, `vtgate` never served API, just HTML.

This PR provides the "HealthCheck Tablet Cache" section from `vtgate`'s HTML status page, as `JSON`.

The endpoint is flexible and can be any one of:

- `api/health-check`: return all tablets from all cells
- `api/health-check/cell/<cellname>`: return only tablets of a specific cell
- `api/health-check/keyspace/<keyspace>`: return only tablets of a specific keyspace
- `api/health-check/tablet/<tablet-alias|mysql-hostname>`: return a single tablet whose alias or mysql-hostname exactly matches path parameter.

We have this running in production and use this to get de-facto information on which tablets are actually serving traffic. It's one thing that a tablet says "I'm healthy and serving", and another when `vtgate` confirms it's happy to send traffic to the tablet.

Our use case is a work-in-progress in running always-on, rotating deployments of `vttablet`. The `vtgate` API let's us know when a 2nd tablet process is getting traffic, at which time we can take down the 1st. This WIP is described in chat https://vitess.slack.com/archives/C0PQY0PTK/p1539413751000100

Last, I believe `vtagte` should have an API, same as all other services.

cc @github/datababase-infrastructure
