### PR TITLE
mysql: support warning counts

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -232,7 +232,10 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 
 	// Remember a subset of the capabilities, so we can use them
 	// later in the protocol.
-	c.Capabilities = capabilities & (CapabilityClientDeprecateEOF)
+	c.Capabilities = 0
+	if !params.DisableClientDeprecateEOF {
+		c.Capabilities = capabilities & (CapabilityClientDeprecateEOF)
+	}
 
 	// Handle switch to SSL if necessary.
 	if params.Flags&CapabilityClientSSL > 0 {

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -38,6 +38,10 @@ type ConnParams struct {
 	// The following is only set when the deprecated "dbname" flags are
 	// supplied and will be removed.
 	DeprecatedDBName string
+
+	// The following is only set to force the client to connect without
+	// using CapabilityClientDeprecateEOF
+	DisableClientDeprecateEOF bool
 }
 
 // EnableSSL will set the right flag on the parameters.

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -320,6 +320,11 @@ func (db *DB) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Resu
 	return db.Handler.HandleQuery(c, query, callback)
 }
 
+// WarningCount is part of the mysql.Handler interface.
+func (db *DB) WarningCount(c *mysql.Conn) uint16 {
+	return 0
+}
+
 // HandleQuery is the default implementation of the QueryHandler interface
 func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	if db.AllowAll {

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -311,22 +311,45 @@ func (c *Conn) ExecuteFetchMulti(query string, maxrows int, wantfields bool) (re
 		return nil, false, err
 	}
 
-	return c.ReadQueryResult(maxrows, wantfields)
+	res, more, _, err := c.ReadQueryResult(maxrows, wantfields)
+	return res, more, err
+}
+
+// ExecuteFetchWithWarningCount is for fetching results and a warning count
+// Note: In a future iteration this should be abolished and merged into the
+// ExecuteFetch API.
+func (c *Conn) ExecuteFetchWithWarningCount(query string, maxrows int, wantfields bool) (result *sqltypes.Result, warnings uint16, err error) {
+	defer func() {
+		if err != nil {
+			if sqlerr, ok := err.(*SQLError); ok {
+				sqlerr.Query = query
+			}
+		}
+	}()
+
+	// Send the query as a COM_QUERY packet.
+	if err = c.WriteComQuery(query); err != nil {
+		return nil, 0, err
+	}
+
+	res, _, warnings, err := c.ReadQueryResult(maxrows, wantfields)
+	return res, warnings, err
 }
 
 // ReadQueryResult gets the result from the last written query.
-func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.Result, more bool, err error) {
+func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.Result, more bool, warnings uint16, err error) {
 	// Get the result.
-	affectedRows, lastInsertID, colNumber, more, err := c.readComQueryResponse()
+	affectedRows, lastInsertID, colNumber, more, warnings, err := c.readComQueryResponse()
 	if err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
+
 	if colNumber == 0 {
 		// OK packet, means no results. Just use the numbers.
 		return &sqltypes.Result{
 			RowsAffected: affectedRows,
 			InsertID:     lastInsertID,
-		}, more, nil
+		}, more, warnings, nil
 	}
 
 	fields := make([]querypb.Field, colNumber)
@@ -341,11 +364,11 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.R
 
 		if wantfields {
 			if err := c.readColumnDefinition(result.Fields[i], i); err != nil {
-				return nil, false, err
+				return nil, false, 0, err
 			}
 		} else {
 			if err := c.readColumnDefinitionType(result.Fields[i], i); err != nil {
-				return nil, false, err
+				return nil, false, 0, err
 			}
 		}
 	}
@@ -354,19 +377,21 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.R
 		// EOF is only present here if it's not deprecated.
 		data, err := c.readEphemeralPacket()
 		if err != nil {
-			return nil, false, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
+			return nil, false, 0, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
 		if isEOFPacket(data) {
+
 			// This is what we expect.
 			// Warnings and status flags are ignored.
 			c.recycleReadPacket()
 			// goto: read row loop
+
 		} else if isErrorPacket(data) {
 			defer c.recycleReadPacket()
-			return nil, false, ParseErrorPacket(data)
+			return nil, false, 0, ParseErrorPacket(data)
 		} else {
 			defer c.recycleReadPacket()
-			return nil, false, fmt.Errorf("unexpected packet after fields: %v", data)
+			return nil, false, 0, fmt.Errorf("unexpected packet after fields: %v", data)
 		}
 	}
 
@@ -374,7 +399,7 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.R
 	for {
 		data, err := c.ReadPacket()
 		if err != nil {
-			return nil, false, err
+			return nil, false, 0, err
 		}
 
 		if isEOFPacket(data) {
@@ -383,28 +408,41 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (result *sqltypes.R
 				result.Fields = nil
 			}
 			result.RowsAffected = uint64(len(result.Rows))
-			more, err := parseEOFPacket(data)
-			if err != nil {
-				return nil, false, err
+
+			// The deprecated EOF packets change means that this is either an
+			// EOF packet or an OK packet with the EOF type code.
+			if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+				warnings, more, err = parseEOFPacket(data)
+				if err != nil {
+					return nil, false, 0, err
+				}
+			} else {
+				var statusFlags uint16
+				_, _, statusFlags, warnings, err = parseOKPacket(data)
+				if err != nil {
+					return nil, false, 0, err
+				}
+				more = (statusFlags & ServerMoreResultsExists) != 0
 			}
-			return result, more, nil
+			return result, more, warnings, nil
+
 		} else if isErrorPacket(data) {
 			// Error packet.
-			return nil, false, ParseErrorPacket(data)
+			return nil, false, 0, ParseErrorPacket(data)
 		}
 
 		// Check we're not over the limit before we add more.
 		if len(result.Rows) == maxrows {
 			if err := c.drainResults(); err != nil {
-				return nil, false, err
+				return nil, false, 0, err
 			}
-			return nil, false, NewSQLError(ERVitessMaxRowsExceeded, SSUnknownSQLState, "Row count exceeded %d", maxrows)
+			return nil, false, 0, NewSQLError(ERVitessMaxRowsExceeded, SSUnknownSQLState, "Row count exceeded %d", maxrows)
 		}
 
 		// Regular row.
 		row, err := c.parseRow(data, result.Fields)
 		if err != nil {
-			return nil, false, err
+			return nil, false, 0, err
 		}
 		result.Rows = append(result.Rows, row)
 	}
@@ -428,36 +466,35 @@ func (c *Conn) drainResults() error {
 	}
 }
 
-func (c *Conn) readComQueryResponse() (uint64, uint64, int, bool, error) {
+func (c *Conn) readComQueryResponse() (affectedRows uint64, lastInsertID uint64, status int, more bool, warnings uint16, err error) {
 	data, err := c.readEphemeralPacket()
 	if err != nil {
-		return 0, 0, 0, false, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
+		return 0, 0, 0, false, 0, NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 	}
 	defer c.recycleReadPacket()
 	if len(data) == 0 {
-		return 0, 0, 0, false, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "invalid empty COM_QUERY response packet")
+		return 0, 0, 0, false, 0, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "invalid empty COM_QUERY response packet")
 	}
 
 	switch data[0] {
 	case OKPacket:
-		affectedRows, lastInsertID, status, _, err := parseOKPacket(data)
-		return affectedRows, lastInsertID, 0, (status & ServerMoreResultsExists) != 0, err
+		affectedRows, lastInsertID, status, warnings, err := parseOKPacket(data)
+		return affectedRows, lastInsertID, 0, (status & ServerMoreResultsExists) != 0, warnings, err
 	case ErrPacket:
 		// Error
-		return 0, 0, 0, false, ParseErrorPacket(data)
+		return 0, 0, 0, false, 0, ParseErrorPacket(data)
 	case 0xfb:
 		// Local infile
-		return 0, 0, 0, false, fmt.Errorf("not implemented")
+		return 0, 0, 0, false, 0, fmt.Errorf("not implemented")
 	}
-
 	n, pos, ok := readLenEncInt(data, 0)
 	if !ok {
-		return 0, 0, 0, false, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "cannot get column number")
+		return 0, 0, 0, false, 0, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "cannot get column number")
 	}
 	if pos != len(data) {
-		return 0, 0, 0, false, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "extra data in COM_QUERY response")
+		return 0, 0, 0, false, 0, NewSQLError(CRMalformedPacket, SSUnknownSQLState, "extra data in COM_QUERY response")
 	}
-	return 0, 0, int(n), false, nil
+	return 0, 0, int(n), false, 0, nil
 }
 
 //
@@ -598,20 +635,20 @@ func (c *Conn) writeRows(result *sqltypes.Result) error {
 
 // writeEndResult concludes the sending of a Result.
 // if more is set to true, then it means there are more results afterwords
-func (c *Conn) writeEndResult(more bool) error {
+func (c *Conn) writeEndResult(more bool, affectedRows, lastInsertID uint64, warnings uint16) error {
 	// Send either an EOF, or an OK packet.
 	// See doc.go.
-	flag := c.StatusFlags
+	flags := c.StatusFlags
 	if more {
-		flag |= ServerMoreResultsExists
+		flags |= ServerMoreResultsExists
 	}
 	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
-		if err := c.writeEOFPacket(flag, 0); err != nil {
+		if err := c.writeEOFPacket(flags, warnings); err != nil {
 			return err
 		}
 	} else {
 		// This will flush too.
-		if err := c.writeOKPacketWithEOFHeader(0, 0, flag, 0); err != nil {
+		if err := c.writeOKPacketWithEOFHeader(affectedRows, lastInsertID, flags, warnings); err != nil {
 			return err
 		}
 	}

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -300,20 +300,24 @@ func checkQuery(t *testing.T, query string, sConn, cConn *Conn, result *sqltypes
 
 	sConn.Capabilities = 0
 	cConn.Capabilities = 0
-	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, true /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, false /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, false /* allRows */)
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, true /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, false /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, false /* allRows */, false /* warnings */)
+
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */, true /* warnings */)
 
 	sConn.Capabilities = CapabilityClientDeprecateEOF
 	cConn.Capabilities = CapabilityClientDeprecateEOF
-	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, true /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, false /* allRows */)
-	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, false /* allRows */)
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, true /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, false /* allRows */, false /* warnings */)
+	checkQueryInternal(t, query, sConn, cConn, result, false /* wantfields */, false /* allRows */, false /* warnings */)
+
+	checkQueryInternal(t, query, sConn, cConn, result, true /* wantfields */, true /* allRows */, true /* warnings */)
 }
 
-func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *sqltypes.Result, wantfields, allRows bool) {
+func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *sqltypes.Result, wantfields, allRows, warnings bool) {
 
 	if sConn.Capabilities&CapabilityClientDeprecateEOF > 0 {
 		query += " NOEOF"
@@ -331,6 +335,14 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		query += " PARTIAL"
 	}
 
+	var warningCount uint16
+	if warnings {
+		query += " WARNINGS"
+		warningCount = 99
+	} else {
+		query += " NOWARNINGS"
+	}
+
 	// Use a go routine to run ExecuteFetch.
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -343,7 +355,7 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 			// Asking for just one row max. The results that have more will fail.
 			maxrows = 1
 		}
-		got, err := cConn.ExecuteFetch(query, maxrows, wantfields)
+		got, gotWarnings, err := cConn.ExecuteFetchWithWarningCount(query, maxrows, wantfields)
 		if !allRows && len(result.Rows) > 1 {
 			if err == nil {
 				t.Errorf("ExecuteFetch should have failed but got: %v", got)
@@ -369,6 +381,10 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 				}
 			}
 			t.Fatalf("ExecuteFetch(wantfields=%v) returned:\n%v\nBut was expecting:\n%v", wantfields, got, expected)
+		}
+
+		if gotWarnings != warningCount {
+			t.Errorf("ExecuteFetch(%v) expected %v warnings got %v", query, warningCount, gotWarnings)
 		}
 
 		// Test ExecuteStreamFetch, build a Result.
@@ -426,7 +442,8 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 	}
 
 	handler := testHandler{
-		result: result,
+		result:   result,
+		warnings: warningCount,
 	}
 
 	for i := 0; i < count; i++ {
@@ -449,7 +466,7 @@ func writeResult(conn *Conn, result *sqltypes.Result) error {
 	if err := conn.writeRows(result); err != nil {
 		return err
 	}
-	return conn.writeEndResult(false)
+	return conn.writeEndResult(false, 0, 0, 0)
 }
 
 func RowString(row []sqltypes.Value) string {

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -425,22 +425,15 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		count--
 	}
 
+	handler := testHandler{
+		result: result,
+	}
+
 	for i := 0; i < count; i++ {
-		comQuery, err := sConn.ReadPacket()
+		err := sConn.handleNextCommand(&handler)
 		if err != nil {
-			t.Fatalf("server cannot read query: %v", err)
+			t.Fatalf("error handling command: %v", err)
 		}
-		if comQuery[0] != ComQuery {
-			t.Fatalf("server got bad packet: %v", comQuery)
-		}
-		got := sConn.parseComQuery(comQuery)
-		if got != query {
-			t.Errorf("server got query '%v' but expected '%v'", got, query)
-		}
-		if err := writeResult(sConn, result); err != nil {
-			t.Errorf("Error writing result to client: %v", err)
-		}
-		sConn.sequence = 0
 	}
 
 	wg.Wait()

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -84,6 +84,13 @@ type Handler interface {
 	// the first call to callback. So the Handler should not
 	// hang on to the byte slice.
 	ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error
+
+	// WarningCount is called at the end of each query to obtain
+	// the value to be returned to the client in the EOF packet.
+	// Note that this will be called either in the context of the
+	// ComQuery callback if the result does not contain any fields,
+	// or after the last ComQuery call completes.
+	WarningCount(c *Conn) uint16
 }
 
 // Listener is the MySQL server protocol listener.

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -18,7 +18,6 @@ package mysql
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -232,7 +231,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	if l.connReadTimeout != 0 || l.connWriteTimeout != 0 {
 		conn = netutil.NewConnWithTimeouts(conn, l.connReadTimeout, l.connWriteTimeout)
 	}
-	c := newServerConn(conn, l.connReadBufferSize)
+	c := newServerConn(conn, l)
 	c.ConnectionID = connectionID
 
 	// Catch panics, and close the connection in any case.
@@ -378,149 +377,9 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	}
 
 	for {
-		c.sequence = 0
-		data, err := c.readEphemeralPacket()
+		err := c.handleNextCommand(l.handler)
 		if err != nil {
-			// Don't log EOF errors. They cause too much spam.
-			// Note the EOF detection is not 100%
-			// guaranteed, in the case where the client
-			// connection is already closed before we call
-			// 'readEphemeralPacket'.  This is a corner
-			// case though, and very unlikely to happen,
-			// and the only downside is we log a bit more then.
-			if err != io.EOF {
-				log.Errorf("Error reading packet from %s: %v", c, err)
-			}
 			return
-		}
-
-		switch data[0] {
-		case ComQuit:
-			c.recycleReadPacket()
-			return
-		case ComInitDB:
-			db := c.parseComInitDB(data)
-			c.recycleReadPacket()
-			c.SchemaName = db
-			if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
-				log.Errorf("Error writing ComInitDB result to %s: %v", c, err)
-				return
-			}
-		case ComQuery:
-			// flush is called at the end of this block.
-			// We cannot encapsulate it with a defer inside a func because
-			// we have to return from this func if it fails.
-			c.startWriterBuffering()
-
-			queryStart := time.Now()
-			query := c.parseComQuery(data)
-			c.recycleReadPacket()
-			fieldSent := false
-			// sendFinished is set if the response should just be an OK packet.
-			sendFinished := false
-			err := l.handler.ComQuery(c, query, func(qr *sqltypes.Result) error {
-				if sendFinished {
-					// Failsafe: Unreachable if server is well-behaved.
-					return io.EOF
-				}
-
-				if !fieldSent {
-					fieldSent = true
-
-					if len(qr.Fields) == 0 {
-						sendFinished = true
-						// We should not send any more packets after this.
-						return c.writeOKPacket(qr.RowsAffected, qr.InsertID, c.StatusFlags, 0)
-					}
-					if err := c.writeFields(qr); err != nil {
-						return err
-					}
-				}
-
-				return c.writeRows(qr)
-			})
-
-			// If no field was sent, we expect an error.
-			if !fieldSent {
-				// This is just a failsafe. Should never happen.
-				if err == nil || err == io.EOF {
-					err = NewSQLErrorFromError(errors.New("unexpected: query ended without no results and no error"))
-				}
-				if werr := c.writeErrorPacketFromError(err); werr != nil {
-					// If we can't even write the error, we're done.
-					log.Errorf("Error writing query error to %s: %v", c, werr)
-					return
-				}
-			} else {
-				if err != nil {
-					// We can't send an error in the middle of a stream.
-					// All we can do is abort the send, which will cause a 2013.
-					log.Errorf("Error in the middle of a stream to %s: %v", c, err)
-					return
-				}
-
-				// Send the end packet only sendFinished is false (results were streamed).
-				if !sendFinished {
-					if err := c.writeEndResult(false); err != nil {
-						log.Errorf("Error writing result to %s: %v", c, err)
-						return
-					}
-				}
-			}
-
-			timings.Record(queryTimingKey, queryStart)
-
-			if err := c.flush(); err != nil {
-				log.Errorf("Conn %v: Flush() failed: %v", c.ID(), err)
-				return
-			}
-
-		case ComPing:
-			c.recycleReadPacket()
-			// Return error if listener was shut down and OK otherwise
-			if l.isShutdown() {
-				if err := c.writeErrorPacket(ERServerShutdown, SSServerShutdown, "Server shutdown in progress"); err != nil {
-					log.Errorf("Error writing ComPing error to %s: %v", c, err)
-					return
-				}
-			} else {
-				if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
-					log.Errorf("Error writing ComPing result to %s: %v", c, err)
-					return
-				}
-			}
-		case ComSetOption:
-			if operation, ok := c.parseComSetOption(data); ok {
-				switch operation {
-				case 0:
-					c.Capabilities |= CapabilityClientMultiStatements
-				case 1:
-					c.Capabilities &^= CapabilityClientMultiStatements
-				default:
-					log.Errorf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data)
-					if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "error handling packet: %v", data); err != nil {
-						log.Errorf("Error writing error packet to client: %v", err)
-						return
-					}
-				}
-				if err := c.writeEndResult(false); err != nil {
-					log.Errorf("Error writeEndResult error %v ", err)
-					return
-				}
-			} else {
-				log.Errorf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data)
-				if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "error handling packet: %v", data); err != nil {
-					log.Errorf("Error writing error packet to client: %v", err)
-					return
-				}
-			}
-		default:
-			log.Errorf("Got unhandled packet from %s, returning error: %v", c, data)
-			c.recycleReadPacket()
-			if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "command handling not implemented yet: %v", data[0]); err != nil {
-				log.Errorf("Error writing error packet to %s: %s", c, err)
-				return
-			}
 		}
 	}
 }

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -67,6 +67,7 @@ type testHandler struct {
 	lastConn *Conn
 	result   *sqltypes.Result
 	err      error
+	warnings uint16
 }
 
 func (th *testHandler) NewConnection(c *Conn) {
@@ -168,6 +169,10 @@ func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.R
 		callback(&sqltypes.Result{})
 	}
 	return nil
+}
+
+func (th *testHandler) WarningCount(c *Conn) uint16 {
+	return th.warnings
 }
 
 func getHostPort(t *testing.T, a net.Addr) (string, int) {

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -65,6 +65,7 @@ var selectRowsResult = &sqltypes.Result{
 
 type testHandler struct {
 	lastConn *Conn
+	result   *sqltypes.Result
 	err      error
 }
 
@@ -76,6 +77,11 @@ func (th *testHandler) ConnectionClosed(c *Conn) {
 }
 
 func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+	if th.result != nil {
+		callback(th.result)
+		return nil
+	}
+
 	switch query {
 	case "error":
 		return th.err

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -600,6 +600,23 @@ func TestServer(t *testing.T) {
 		!strings.Contains(output, "2 rows in set") {
 		t.Errorf("Unexpected output for 'select rows'")
 	}
+	if strings.Contains(output, "warnings") {
+		t.Errorf("Unexpected warnings in 'select rows'")
+	}
+
+	// Run a 'select rows' command with warnings
+	th.warnings = 13
+	output, ok = runMysql(t, params, "select rows")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	if !strings.Contains(output, "nice name") ||
+		!strings.Contains(output, "nicer name") ||
+		!strings.Contains(output, "2 rows in set") ||
+		!strings.Contains(output, "13 warnings") {
+		t.Errorf("Unexpected output for 'select rows': %v", output)
+	}
+	th.warnings = 0
 
 	// If there's an error after streaming has started,
 	// we should get a 2013

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -47,7 +47,7 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 	}
 
 	// Get the result.
-	_, _, colNumber, _, err := c.readComQueryResponse()
+	_, _, colNumber, _, _, err := c.readComQueryResponse()
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -158,6 +158,10 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 	return callback(result)
 }
 
+func (vh *vtgateHandler) WarningCount(c *mysql.Conn) uint16 {
+	return 0
+}
+
 var mysqlListener *mysql.Listener
 var mysqlUnixListener *mysql.Listener
 

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -43,6 +43,10 @@ func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes
 	return nil
 }
 
+func (th *testHandler) WarningCount(c *mysql.Conn) uint16 {
+	return 0
+}
+
 func TestConnectionUnixSocket(t *testing.T) {
 	th := &testHandler{}
 

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -481,7 +481,7 @@ func TestQueryDeadline(t *testing.T) {
 		t.Errorf("Unexpected error code: %d, want %d", got, want)
 	}
 
-	_, _, err = conn.ReadQueryResult(1000, false)
+	_, _, _, err = conn.ReadQueryResult(1000, false)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -132,6 +132,10 @@ func (mh *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sql
 	return callback(result)
 }
 
+func (mh *proxyHandler) WarningCount(c *mysql.Conn) uint16 {
+	return 0
+}
+
 var mysqlListener *mysql.Listener
 var mysqlUnixListener *mysql.Listener
 

--- a/go/vt/vtqueryserver/plugin_mysql_server_test.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server_test.go
@@ -43,6 +43,10 @@ func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes
 	return nil
 }
 
+func (th *testHandler) WarningCount(c *mysql.Conn) uint16 {
+	return 0
+}
+
 func TestConnectionUnixSocket(t *testing.T) {
 	th := &testHandler{}
 


### PR DESCRIPTION
## Description
Add support for warning counts to the mysql protocol implementation. (Part 2 of #4279)

## Details
This includes both client and server protocol changes to propagate the warning counts into the EOF or OK packets, based on the `CapabilityClientDeprecateEOF` flag.

This also changes the mysql server handler interface to include a `WarningCount()` API which is intended to get the warning counts from the previously executed query.

As part of this change I refactored the server implementation slightly to move the command handling into the `Conn` class instead of the `Listenener`, which enables it to be used more easily in the unit tests.

## Bug
Along the way I discovered a subtle bug in the client protocol handling which turns out to have no actual ramifications. But for completeness, when the `CapabilityClientDeprecateEOF` flag is set, then the last packet at the end of a query is actually an `OK` packet with the `EOF` type, and not an `EOF` packet.

It turns out though that our client was parsing the packet as an EOF regardless of the mode:
https://github.com/vitessio/vitess/blob/58ea83c54bf02ec694dc15a7d2a8732ff563f297/go/mysql/query.go#L380-L390

The only reason this works is that it turns out that the status flags happen to be in the same position in either an EOF or an OK packet IF affected_rows and last_insert_id are both 0:
https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html

As such, the code didn't need to distinguish between the two cases since DMLs go through a different code path, so this turned out to be a theoretical problem that couldn't actually affect anything.

Of course now that we want the warning counts, the distinction does matter so I've fixed the handling accordingly.

