### PR TITLE
[go/mysql] add Shutdown method for listener

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 )
@@ -316,7 +318,7 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 }
 
 // ComQuery is part of the mysql.Handler interface.
-func (db *DB) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
+func (db *DB) ComQuery(ctx context.Context, c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	return db.Handler.HandleQuery(c, query, callback)
 }
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -75,7 +75,7 @@ func (th *testHandler) NewConnection(c *Conn) {
 func (th *testHandler) ConnectionClosed(c *Conn) {
 }
 
-func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComQuery(ctx context.Context, c *Conn, query string, callback func(*sqltypes.Result) error) error {
 	switch query {
 	case "error":
 		return th.err

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -96,14 +96,11 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 	}
 }
 
-func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	var ctx context.Context
+func (vh *vtgateHandler) ComQuery(ctx context.Context, c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	var cancel context.CancelFunc
 	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		ctx, cancel = context.WithTimeout(ctx, *mysqlQueryTimeout)
 		defer cancel()
-	} else {
-		ctx = context.Background()
 	}
 
 	ctx = callinfo.MysqlCallInfo(ctx, c)

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -39,7 +39,7 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
-func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComQuery(ctx context.Context, c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -86,14 +86,11 @@ func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
 	}
 }
 
-func (mh *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
-	var ctx context.Context
+func (mh *proxyHandler) ComQuery(ctx context.Context, c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	var cancel context.CancelFunc
 	if *mysqlQueryTimeout != 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), *mysqlQueryTimeout)
+		ctx, cancel = context.WithTimeout(ctx, *mysqlQueryTimeout)
 		defer cancel()
-	} else {
-		ctx = context.Background()
 	}
 	// Fill in the ImmediateCallerID with the UserData returned by
 	// the AuthServer plugin for that user. If nothing was

--- a/go/vt/vtqueryserver/plugin_mysql_server_test.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server_test.go
@@ -39,7 +39,7 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
-func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComQuery(ctx context.Context, c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 


### PR DESCRIPTION
It's useful to have such method for initiating graceful shutdown - new
connections won't be accepted and old can decide to close after failed
ping.

Signed-off-by: Alexander Morozov <lk4d4math@gmail.com>