### PR TITLE
Updating list of acceptable TLS Ciphers

### DIFF
--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -28,7 +28,11 @@ import (
 // This removed CBC mode ciphers that are suseptiable to Lucky13 style attacks
 func newTLSConfig() *tls.Config {
 	return &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		// the MySQL client on the CI server does not work with tls1.2
+		// Newer versions of the client do work
+		// TODO: Update the CI server to use a newer version of the mysql client
+		//MinVersion: tls.VersionTLS12,
+
 		// Default ordering taken from
 		// go 1.11 crypto/tls/cipher_suites.go
 		CipherSuites: []uint16{

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -23,10 +23,33 @@ import (
 	"io/ioutil"
 )
 
+// Updated list of acceptable cipher suits to address
+// Fixed upstream in https://github.com/golang/go/issues/13385
+// This removed CBC mode ciphers that are suseptiable to Lucky13 style attacks
+func newTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// Default ordering taken from
+		// go 1.11 crypto/tls/cipher_suites.go
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		},
+	}
+}
+
 // ClientConfig returns the TLS config to use for a client to
 // connect to a server with the provided parameters.
 func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := newTLSConfig()
 
 	// Load the client-side cert & key if any.
 	if cert != "" && key != "" {
@@ -61,7 +84,7 @@ func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
 // ServerConfig returns the TLS config to use for a server to
 // accept client connections.
 func ServerConfig(cert, key, ca string) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := newTLSConfig()
 
 	// Load the server cert and key.
 	crt, err := tls.LoadX509KeyPair(cert, key)

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -28,10 +28,9 @@ import (
 // This removed CBC mode ciphers that are suseptiable to Lucky13 style attacks
 func newTLSConfig() *tls.Config {
 	return &tls.Config{
-		// the MySQL client on the CI server does not work with tls1.2
-		// Newer versions of the client do work
-		// TODO: Update the CI server to use a newer version of the mysql client
-		//MinVersion: tls.VersionTLS12,
+		// MySQL Community edition has some problems with TLS1.2
+		// TODO: Validate this will not break servers using mysql community edition < 5.7.10
+		// MinVersion: tls.VersionTLS12,
 
 		// Default ordering taken from
 		// go 1.11 crypto/tls/cipher_suites.go
@@ -46,6 +45,8 @@ func newTLSConfig() *tls.Config {
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 		},
 	}
 }


### PR DESCRIPTION
Updating list of acceptable TLS Ciphers to remove those with known
susceptibility to CBC Padding oracles and the SWEET32 attack