### PR TITLE
store 3 error messages from filtered replication instead of just last message

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
+	"vitess.io/vitess/go/history"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
@@ -72,7 +73,7 @@ type Stats struct {
 	lastPosition      mysql.Position
 
 	SecondsBehindMaster sync2.AtomicInt64
-	LastMessage         sync2.AtomicString
+	History             *history.History
 }
 
 // SetLastPosition sets the last replication position.
@@ -89,11 +90,24 @@ func (bps *Stats) LastPosition() mysql.Position {
 	return bps.lastPosition
 }
 
+// MessageHistory gets all the messages, we store 3 at a time
+func (bps *Stats) MessageHistory() []string {
+	strs := make([]string, 0, 3)
+	for _, h := range bps.History.Records() {
+		h1, _ := h.(*StatsHistoryRecord)
+		if h1 != nil {
+			strs = append(strs, h1.Message)
+		}
+	}
+	return strs
+}
+
 // NewStats creates a new Stats structure.
 func NewStats() *Stats {
 	bps := &Stats{}
 	bps.Timings = stats.NewTimings("", "", "")
 	bps.Rates = stats.NewRates("", bps.Timings, 15, 60e9)
+	bps.History = history.New(3)
 	return bps
 }
 
@@ -156,15 +170,16 @@ func NewBinlogPlayerTables(dbClient DBClient, tablet *topodatapb.Tablet, tables 
 // If an error is encountered, it updates the vreplication state to "Error".
 // If a stop position was specifed, and reached, the state is updated to "Stopped".
 func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
-	// Clear previous error, if any.
 	if err := setVReplicationState(blp.dbClient, blp.uid, BlpRunning, ""); err != nil {
 		log.Errorf("Error writing Running state: %v", err)
 	}
-	blp.blplStats.LastMessage.Set("")
 
 	if err := blp.applyEvents(ctx); err != nil {
 		msg := err.Error()
-		blp.blplStats.LastMessage.Set(msg)
+		blp.blplStats.History.Add(&StatsHistoryRecord{
+			Time:    time.Now(),
+			Message: msg,
+		})
 		if err := setVReplicationState(blp.dbClient, blp.uid, BlpError, msg); err != nil {
 			log.Errorf("Error writing stop state: %v", err)
 		}
@@ -581,4 +596,19 @@ func encodeString(in string) string {
 // given shard from the _vt.vreplication table.
 func ReadVReplicationPos(index uint32) string {
 	return fmt.Sprintf("select pos from _vt.vreplication where id=%v", index)
+}
+
+// StatsHistoryRecord is used to store a Message with timestamp
+type StatsHistoryRecord struct {
+	Time    time.Time
+	Message string
+}
+
+// IsDuplicate implements history.Deduplicable
+func (r *StatsHistoryRecord) IsDuplicate(other interface{}) bool {
+	rother, ok := other.(*StatsHistoryRecord)
+	if !ok {
+		return false
+	}
+	return r.Message == rother.Message
 }

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -606,9 +606,5 @@ type StatsHistoryRecord struct {
 
 // IsDuplicate implements history.Deduplicable
 func (r *StatsHistoryRecord) IsDuplicate(other interface{}) bool {
-	rother, ok := other.(*StatsHistoryRecord)
-	if !ok {
-		return false
-	}
-	return r.Message == rother.Message
+	return false
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -137,7 +137,7 @@ func (st *vrStats) status() *EngineStatus {
 			Rates:               ct.blpStats.Rates.Get(),
 			State:               state,
 			SourceTablet:        ct.sourceTablet.Get(),
-			LastMessage:         ct.blpStats.LastMessage.Get(),
+			Messages:            ct.blpStats.MessageHistory(),
 		}
 		i++
 	}
@@ -163,7 +163,7 @@ type ControllerStatus struct {
 	Rates               map[string][]float64
 	State               string
 	SourceTablet        string
-	LastMessage         string
+	Messages            []string
 }
 
 var vreplicationTemplate = `
@@ -191,7 +191,7 @@ var vreplicationTemplate = `
       <td>{{.SecondsBehindMaster}}</td>
       <td>{{range $key, $value := .Counts}}<b>{{$key}}</b>: {{$value}}<br>{{end}}</td>
       <td>{{range $key, $values := .Rates}}<b>{{$key}}</b>: {{range $values}}{{.}} {{end}}<br>{{end}}</td>
-      <td>{{.LastMessage}}</td>
+      <td>{{range $index, $value := .Messages}}{{$value}}<br>{{end}}</td>
     </tr>{{end}}
 </table>{{else}}VReplication is closed.{{end}}
 `

--- a/go/vt/vttablet/tabletmanager/vreplication/stats_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"html/template"
 	"testing"
+	"time"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -51,7 +52,7 @@ VReplication state: Open</br>
       <td>2</td>
       <td><b>All</b>: 0<br></td>
       <td></td>
-      <td>Test Message</td>
+      <td>Test Message2<br>Test Message1<br></td>
     </tr><tr>
       <td>2</td>
       <td>keyspace:&#34;ks&#34; shard:&#34;1&#34; </td>
@@ -62,7 +63,7 @@ VReplication state: Open</br>
       <td>2</td>
       <td><b>All</b>: 0<br></td>
       <td></td>
-      <td>Test Message</td>
+      <td>Test Message2<br>Test Message1<br></td>
     </tr>
 </table>
 `
@@ -76,7 +77,8 @@ func TestStatusHtml(t *testing.T) {
 	blpStats := binlogplayer.NewStats()
 	blpStats.SetLastPosition(pos)
 	blpStats.SecondsBehindMaster.Set(2)
-	blpStats.LastMessage.Set("Test Message")
+	blpStats.History.Add(&binlogplayer.StatsHistoryRecord{Time: time.Now(), Message: "Test Message1"})
+	blpStats.History.Add(&binlogplayer.StatsHistoryRecord{Time: time.Now(), Message: "Test Message2"})
 
 	testStats := &vrStats{}
 	testStats.isOpen = true


### PR DESCRIPTION
Currently, vreplication stores only the last message. Everytime we call applyEvents on the binlog_player, the last message is cleared. This PR changes that to (a) store up to 3 messages and (b) not clear the message history each time applyEvents is called.
#4147 

Signed-off-by: deepthi <deepthi@planetscale.com>