### PR TITLE
Follow the MySQL handshake protocol and send 10 NULL bytes

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -591,8 +591,8 @@ func (c *Conn) writeHandshakeV10(serverVersion string, authServer AuthServer, en
 	// Always 21 (8 + 13).
 	pos = writeByte(data, pos, 21)
 
-	// Reserved
-	pos += 10
+	// Reserved 10 bytes: all 0
+	pos = writeZeroes(data, pos, 10)
 
 	// Second part of auth plugin data.
 	pos += copy(data[pos:], salt[8:])


### PR DESCRIPTION
See the docs:
https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake

MySQL server will send a 10 bytes (0 value) in the handshake.
Before this change, Vitess was sending same random value, that is
because the buffer we use here comes from the buffer pool, so that
could be same random memory values.

We caught this because our mysql client validates those 10 bytes being
value 0.

---

To simulate this, you can run this ruby script, which will get the 10 bytes from the handshake, and those could be any previous query that was used in the buffer previously:
```
require 'socket'
s = TCPSocket.new 'localhost', 15306
data = s.recv(85).unpack('c*')
pos = 4 # skip header
p data[pos + 1...pos + 14].pack('c*')
p data[pos + 36...pos + 36 + 10].pack('c*')
s.close
```

If I just had done a query like `mysql> select * from search_index_template_configurations;`

Running the script would return me: 
```
[arthurnn@snowball Desktop]$ ruby vt_handshake_t.rb
"5.5.10-Vitess"
"_index_tem"
```

You can see it got 10 bytes of the query. 

---

After this is merged, to avoid things like this in the future, we could zero byte the entire buffer before returning it to the pool. Or once we get it from the pool.

cc @demmer @sougou @brianmario @charliesome
