### PR TITLE
[go/mysql] implement Shutdown for mysql.lListener

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -440,6 +440,9 @@ const (
 	// SSHandshakeError is ER_HANDSHAKE_ERROR
 	SSHandshakeError = "08S01"
 
+	// SSServerShutdown is ER_SERVER_SHUTDOWN
+	SSServerShutdown = "08S01"
+
 	// SSDataTooLong is ER_DATA_TOO_LONG
 	SSDataTooLong = "22001"
 


### PR DESCRIPTION
This method closes listener and forces all Ping requests to fail with ERServerShutdown.
The idea is to use this mechanism for graceful stop, we shutdown listener and clients will know that they should finish their work on connection ASAP
I used
https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_server_shutdown
as a reference.
/cc @danieltahara 