### PR TITLE
Support MySQL 8.0 with config files

### DIFF
--- a/config/mycnf/default-fast.cnf
+++ b/config/mycnf/default-fast.cnf
@@ -32,8 +32,6 @@ max_connections = 100
 net_write_timeout = 60
 pid-file = {{.PidFile}}
 port = {{.MysqlPort}}
-query_cache_size = 0
-query_cache_type = 0
 # all db instances should start in read-only mode - once the db is started and
 # fully functional, we'll push it into read-write mode
 read-only

--- a/config/mycnf/default-fast.cnf
+++ b/config/mycnf/default-fast.cnf
@@ -37,6 +37,7 @@ port = {{.MysqlPort}}
 read-only
 read_buffer_size = 1M
 read_rnd_buffer_size = 1M
+secure_file_priv = NULL
 server-id = {{.ServerID}}
 skip-name-resolve
 # we now need networking for replication. this is a tombstone to simpler times.

--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -36,6 +36,7 @@ port = {{.MysqlPort}}
 read-only
 read_buffer_size = 1M
 read_rnd_buffer_size = 1M
+secure_file_priv = NULL
 server-id = {{.ServerID}}
 skip-name-resolve
 # all db instances should skip the slave startup - that way we can do any

--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -31,8 +31,6 @@ max_connections = 100
 net_write_timeout = 60
 pid-file = {{.PidFile}}
 port = {{.MysqlPort}}
-query_cache_size = 0
-query_cache_type = 0
 # all db instances should start in read-only mode - once the db is started and
 # fully functional, we'll push it into read-write mode
 read-only


### PR DESCRIPTION
This PR removes the `query_cache_size` option from the cnf files and adds `secure_file_priv = NULL`. Since Vitess doesn't support `INFILE` or `OUTFILE` to my knowledge, this should be a no-op.

Fixes #4238 