### PR TITLE
Reorder USER commands in Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
-	go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+    go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 
 parser:
 	make -C go/vt/sqlparser
@@ -213,6 +213,9 @@ docker_lite_percona:
 
 docker_lite_percona57:
 	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) percona57
+
+docker_lite_alpine:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) alpine
 
 docker_guestbook:
 	cd examples/kubernetes/guestbook && ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
-    go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 
 parser:
 	make -C go/vt/sqlparser

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -12,9 +12,10 @@ FROM vitess/bootstrap:mysql57
 USER root
 COPY . /vt/src/vitess.io/vitess
 
+# Build Vitess
+RUN make build
+
 # Fix permissions
 RUN chown -R vitess:vitess /vt
 USER vitess
 
-# Build Vitess
-RUN make build

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -4,9 +4,10 @@ FROM vitess/bootstrap:mariadb
 USER root
 COPY . /vt/src/vitess.io/vitess
 
+# Build Vitess
+RUN make build
+
 # Fix permissions
 RUN chown -R vitess:vitess /vt
 USER vitess
 
-# Build Vitess
-RUN make build

--- a/docker/base/Dockerfile.mysql56
+++ b/docker/base/Dockerfile.mysql56
@@ -4,9 +4,10 @@ FROM vitess/bootstrap:mysql56
 USER root
 COPY . /vt/src/vitess.io/vitess
 
+# Build Vitess
+RUN make build
+
 # Fix permissions
 RUN chown -R vitess:vitess /vt
 USER vitess
 
-# Build Vitess
-RUN make build

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -4,9 +4,10 @@ FROM vitess/bootstrap:percona57
 USER root
 COPY . /vt/src/vitess.io/vitess
 
+# Build Vitess
+RUN make build
+
 # Fix permissions
 RUN chown -R vitess:vitess /vt
 USER vitess
 
-# Build Vitess
-RUN make build

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -8,8 +8,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-USER vitess
-# Required by e2e test dependencies e.g. test/environment.py.
-ENV USER vitess
-ENV MYSQL_FLAVOR MariaDB
+
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -9,8 +9,6 @@ RUN for i in $(seq 1 10); do apt-key adv --recv-keys --keyserver ha.pool.sks-key
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-USER vitess
-# Required by e2e test dependencies e.g. test/environment.py.
-ENV USER vitess
+
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -9,8 +9,6 @@ RUN for i in $(seq 1 10); do apt-key adv --recv-keys --keyserver ha.pool.sks-key
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-USER vitess
-# Required by e2e test dependencies e.g. test/environment.py.
-ENV USER vitess
+
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -15,8 +15,6 @@ RUN for i in $(seq 1 10); do apt-key adv --keyserver keys.gnupg.net --recv-keys 
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-USER vitess
-# Required by e2e test dependencies e.g. test/environment.py.
-ENV USER vitess
+
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -15,8 +15,6 @@ RUN for i in $(seq 1 10); do apt-key adv --keyserver keys.gnupg.net --recv-keys 
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-USER vitess
-# Required by e2e test dependencies e.g. test/environment.py.
-ENV USER vitess
+
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh

--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -1,0 +1,38 @@
+# This image is only meant to be built from within the build.sh script.
+FROM vitess/base AS builder
+FROM alpine:3.8 AS staging
+
+RUN mkdir -p /vt/vtdataroot/ && mkdir -p /vt/bin && mkdir -p /vt/src/vitess.io/vitess/web/vtctld2
+
+COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld /vt/src/vitess.io/web/
+COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld2/app /vt/src/vitess.io/web/vtctld2/
+COPY --from=builder /vt/src/vitess.io/vitess/config /vt/config
+COPY --from=builder /vt/bin/mysqlctld /vt/bin/
+COPY --from=builder /vt/bin/vtctld /vt/bin/
+COPY --from=builder /vt/bin/vtctlclient /vt/bin/
+COPY --from=builder /vt/bin/vtgate /vt/bin/
+COPY --from=builder /vt/bin/vttablet /vt/bin/
+COPY --from=builder /vt/bin/vtworker /vt/bin/
+
+FROM alpine:3.8 
+
+# Install dependencies
+RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
+    apk add --no-cache mariadb@edge mariadb-client@edge bzip2 bash
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTTOP /vt/src/vitess.io/vitess
+ENV VTROOT /vt
+ENV GOTOP $VTTOP/go
+ENV VTDATAROOT $VTROOT/vtdataroot
+ENV GOBIN $VTROOT/bin
+ENV GOPATH $VTROOT
+ENV PATH $VTROOT/bin:$PATH
+ENV VT_MYSQL_ROOT /usr
+ENV PKG_CONFIG_PATH $VTROOT/lib
+ENV MYSQL_FLAVOR MariaDB103
+
+# Create vitess user
+RUN addgroup -S vitess && adduser -S -G vitess vitess && mkdir -p /vt
+COPY --from=staging /vt/ /vt/
+USER vitess

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -30,3 +30,4 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot
+USER vitess

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -33,3 +33,4 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot
+USER vitess

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -35,3 +35,4 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot
+USER vitess

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -35,3 +35,4 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot
+USER vitess


### PR DESCRIPTION
This should be a no-op PR that moves the setting of the USER directive from the bootstrap containers to the base and lite containers. This allows the containers to build with `CGO_ENABLED=0`