### PR TITLE
helm: add support for EXTRA_MY_CNF + fix ISM Job

### DIFF
--- a/helm/vitess/README.md
+++ b/helm/vitess/README.md
@@ -11,8 +11,7 @@ This chart creates a Vitess cluster on Kubernetes in a single
 It currently includes all dependencies (e.g. etcd) and Vitess components
 (vtctld, vtgate, vttablet) inline (in `templates/`) rather than as sub-charts.
 
-**WARNING: This chart should be considered Alpha.
-Upgrading a release of this chart may or may not delete all your data.**
+**WARNING: This chart should be considered Beta.**
 
 ## Prerequisites
 
@@ -117,6 +116,28 @@ topology:
                 - type: "rdonly"
                   vttablet:
                     replicas: 2
+```
+
+### Append custom my.cnf to default Vitess settings
+
+Create a config map with one or more standard `my.cnf` formatted files. Any settings
+provided here will overwrite any colliding values from Vitess defaults.
+
+`kubectl create configmap shared-my-cnf --from-file=shared.my.cnf`
+
+*NOTE:* if using MySQL 8.0.x, this file must contain
+`default_authentication_plugin = mysql_native_password`
+
+```
+topology:
+  cells:
+    ...
+
+vttablet:
+
+  # The name of a config map with N files inside of it. Each file will be added
+  # to $EXTRA_MY_CNF, overriding any default my.cnf settings
+  extraMyCnf: shared-my-cnf
 ```
 
 ### Use a custom database image and a specific Vitess release

--- a/helm/vitess/templates/_helpers.tpl
+++ b/helm/vitess/templates/_helpers.tpl
@@ -87,7 +87,7 @@ nodeAffinity:
 {{- end -}}
 
 #############################
-# mycnf exec
+# mycnf exec - expects extraMyCnf config map name
 #############################
 {{- define "mycnf-exec" -}}
 
@@ -112,6 +112,12 @@ elif [ "$VT_DB_FLAVOR" = "mariadb103" ]; then
 fi
 
 export EXTRA_MY_CNF="$FLAVOR_MYCNF:/vtdataroot/tabletdata/report-host.cnf:/vt/config/mycnf/rbr.cnf"
+
+{{ if . }}
+for filename in /vt/userconfig/*; do
+  export EXTRA_MY_CNF="$EXTRA_MY_CNF:$filename"
+done
+{{ end }}
 
 {{- end -}}
 
@@ -291,6 +297,35 @@ cat $AWS_SHARED_CREDENTIALS_FILE
     {{ end }}
 
   {{ end }}
+
+{{ end }}
+
+{{- end -}}
+
+#############################
+# user config volume - expects config map name
+#############################
+{{- define "user-config-volume" -}}
+
+{{ if . }}
+
+- name: user-config
+  configMap:
+    name: {{ . }}
+
+{{ end }}
+
+{{- end -}}
+
+#############################
+# user config volumeMount - expects config map name
+#############################
+{{- define "user-config-volumeMount" -}}
+
+{{ if . }}
+
+- name: user-config
+  mountPath: /vt/userconfig
 
 {{ end }}
 

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -153,7 +153,7 @@ kind: Job
 metadata:
   name: {{ $shardName }}-init-shard-master
 spec:
-  backoffLimit: 0
+  backoffLimit: 1
   template:
     spec:
       restartPolicy: OnFailure

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -114,6 +114,7 @@ spec:
         - name: vt
           emptyDir: {}
 {{ include "backup-volume" $config.backup | indent 8 }}
+{{ include "user-config-volume" $defaultVttablet.extraMyCnf | indent 8 }}
 
   volumeClaimTemplates:
     - metadata:
@@ -359,6 +360,7 @@ spec:
     - name: vtdataroot
       mountPath: "/vtdataroot"
 {{ include "backup-volumeMount" $config.backup | indent 4 }}
+{{ include "user-config-volumeMount" $defaultVttablet.extraMyCnf | indent 4 }}
 
   resources:
 {{ toYaml (.resources | default $defaultVttablet.resources) | indent 6 }}
@@ -383,7 +385,7 @@ spec:
     - |
       set -ex
 
-{{ include "mycnf-exec" . | indent 6 }}
+{{ include "mycnf-exec" $defaultVttablet.extraMyCnf | indent 6 }}
 {{ include "backup-exec" $config.backup | indent 6 }}
       
       eval exec /vt/bin/vttablet $(cat <<END_OF_COMMAND
@@ -448,6 +450,7 @@ spec:
       mountPath: /vtdataroot
     - name: vt
       mountPath: /vt
+{{ include "user-config-volumeMount" $defaultVttablet.extraMyCnf | indent 4 }}
   resources:
 {{ toYaml (.mysqlResources | default $defaultVttablet.mysqlResources) | indent 6 }}
   env:
@@ -465,7 +468,7 @@ spec:
     - |
       set -ex
 
-{{ include "mycnf-exec" . | indent 6 }}
+{{ include "mycnf-exec" $defaultVttablet.extraMyCnf | indent 6 }}
 
       eval exec /vt/bin/mysqlctld $(cat <<END_OF_COMMAND
         -logtostderr=true

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -140,6 +140,11 @@ vttablet:
   # will block forever. "rdonly" tablets do not ACK.
   enableSemisync: false
 
+  # The name of a config map with N files inside of it. Each file will be added
+  # to $EXTRA_MY_CNF, overriding any default my.cnf settings
+  extraMyCnf: ""
+  # extraMyCnf: extra-my-cnf
+
   resources:
     # common production values 2-4CPU/4-8Gi RAM
     limits:


### PR DESCRIPTION
I've tested this and it works great. Adding `default_authentication_plugin = mysql_native_password` is the only way to get MySQL 8.0.x to work with Vitess.

This also fixes a regression in k8s that caused it to quit running the InitShardMaster job.