### PR TITLE
Add auth config consul

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -56,14 +56,13 @@ func (f Factory) Create(cell, serverAddr, root string) (topo.Conn, error) {
 
 func getClientConfig() (creds map[string]*AuthConsulClientCred, err error) {
 	creds = make(map[string]*AuthConsulClientCred)
-	// Check parameters.
+
 	if *consulAuthClientStaticFile == "" {
 		// Not configured, nothing to do.
-		log.Infof("Not configuring consul auth, as consul_auth_client_static_file was not provided")
+		log.Infof("Consul client auth is not set up. consul_auth_client_static_file was not provided")
 		return creds, nil
 	}
 
-	// Create and register auth server.
 	data, err := ioutil.ReadFile(*consulAuthClientStaticFile)
 	if err != nil {
 		err = fmt.Errorf("Failed to read consul_auth_client_static_file file: %v", err)

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -36,9 +36,10 @@ var (
 	consulAuthClientStaticFile = flag.String("consul_auth_client_static_file", "", "JSON File to read the topos/tokens from.")
 )
 
-// AuthConsulClientCred ...
-type AuthConsulClientCred struct {
-	Token string
+// AuthClientCred credential to use for consul clusters
+type AuthClientCred struct {
+	// AclToken when provided, the client will use this token when making requests to the Consul server.
+	AclToken string `json:"acl_token,omitempty"`
 }
 
 // Factory is the consul topo.Factory implementation.
@@ -54,8 +55,8 @@ func (f Factory) Create(cell, serverAddr, root string) (topo.Conn, error) {
 	return NewServer(cell, serverAddr, root)
 }
 
-func getClientConfig() (creds map[string]*AuthConsulClientCred, err error) {
-	creds = make(map[string]*AuthConsulClientCred)
+func getClientConfig() (creds map[string]*AuthClientCred, err error) {
+	creds = make(map[string]*AuthClientCred)
 
 	if *consulAuthClientStaticFile == "" {
 		// Not configured, nothing to do.
@@ -109,7 +110,7 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	cfg := api.DefaultConfig()
 	cfg.Address = serverAddr
 	if creds[cell] != nil {
-		cfg.Token = creds[cell].Token
+		cfg.Token = creds[cell].AclToken
 	}
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -38,8 +38,8 @@ var (
 
 // AuthClientCred credential to use for consul clusters
 type AuthClientCred struct {
-	// AclToken when provided, the client will use this token when making requests to the Consul server.
-	AclToken string `json:"acl_token,omitempty"`
+	// ACLToken when provided, the client will use this token when making requests to the Consul server.
+	ACLToken string `json:"acl_token,omitempty"`
 }
 
 // Factory is the consul topo.Factory implementation.
@@ -110,7 +110,7 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	cfg := api.DefaultConfig()
 	cfg.Address = serverAddr
 	if creds[cell] != nil {
-		cfg.Token = creds[cell].AclToken
+		cfg.Token = creds[cell].ACLToken
 	}
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/go/vt/topo/consultopo/server_test.go
+++ b/go/vt/topo/consultopo/server_test.go
@@ -182,7 +182,7 @@ func TestConsulTopoWithAuth(t *testing.T) {
 
 	*consulAuthClientStaticFile = tmpFile.Name()
 
-	jsonConfig := "{\"global\":{\"Token\":\"123456\"}, \"test\":{\"Token\":\"123456\"}}"
+	jsonConfig := "{\"global\":{\"acl_token\":\"123456\"}, \"test\":{\"acl_token\":\"123456\"}}"
 	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 
 	*consulAuthClientStaticFile = tmpFile.Name()
 
-	jsonConfig := "{\"global\":{\"Token\":\"badtoken\"}}"
+	jsonConfig := "{\"global\":{\"acl_token\":\"badtoken\"}}"
 	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}

--- a/go/vt/topo/consultopo/server_test.go
+++ b/go/vt/topo/consultopo/server_test.go
@@ -187,12 +187,6 @@ func TestConsulTopoWithAuth(t *testing.T) {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 
-	// Re-register consul factory but with client creds set
-	topo.DeregisterFactory("consul")
-	factory := Factory{}
-	factory.initClientConfig()
-	topo.RegisterFactory("consul", factory)
-
 	test.TopoServerTestSuite(t, func() *topo.Server {
 		// Each test will use its own sub-directories.
 		testRoot := fmt.Sprintf("test-%v", testIndex)
@@ -241,12 +235,6 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
-
-	// Re-register consul factory but with client creds set
-	topo.DeregisterFactory("consul")
-	factory := Factory{}
-	factory.initClientConfig()
-	topo.RegisterFactory("consul", factory)
 
 	// Create the server on the new root.
 	ts, err := topo.OpenServer("consul", serverAddr, path.Join("globalRoot", topo.GlobalCell))

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -168,6 +168,11 @@ func RegisterFactory(name string, factory Factory) {
 	factories[name] = factory
 }
 
+// DeregisterFactory deregisters a Factory for an implementation for a Server. Only to be used within the context of tests.
+func DeregisterFactory(name string) {
+	factories[name] = nil
+}
+
 // NewWithFactory creates a new Server based on the given Factory.
 // It also opens the global cell connection.
 func NewWithFactory(factory Factory, serverAddress, root string) (*Server, error) {

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -168,11 +168,6 @@ func RegisterFactory(name string, factory Factory) {
 	factories[name] = factory
 }
 
-// DeregisterFactory deregisters a Factory for an implementation for a Server. Only to be used within the context of tests.
-func DeregisterFactory(name string) {
-	factories[name] = nil
-}
-
 // NewWithFactory creates a new Server based on the given Factory.
 // It also opens the global cell connection.
 func NewWithFactory(factory Factory, serverAddress, root string) (*Server, error) {


### PR DESCRIPTION
### Description

* The following PR adds a way to connect to consul cluster using consul ACL tokens. This is a pre-requisite to talk to consul cluster directly and not use the agent. 
* One thing I was hesitant is that I'll be parsing the file every we call `factory.Create`. However it looks ok. FWIW, we do something similar for the zookeper factory. @sougou would love to get your thoughts on this. 

### Tests

* I haven't test this against a real cluster, only the unit tests so far. 