### PR TITLE
Improve warning so it's not that verbose.

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -110,11 +110,14 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 	}
 	cfg := api.DefaultConfig()
 	cfg.Address = serverAddr
-	if creds != nil && creds[cell] != nil {
-		cfg.Token = creds[cell].ACLToken
-	} else {
-		log.Warningf("Client auth not configured for cell: %v", cell)
+	if creds != nil {
+		if creds[cell] != nil {
+			cfg.Token = creds[cell].ACLToken
+		} else {
+			log.Warningf("Client auth not configured for cell: %v", cell)
+		}
 	}
+
 	client, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description. 

We should only warn when the creds file is provided and a cred is not found.
Before this change it was going to warn even when the file was not provided.