### PR TITLE
change s3_backup_aws_region flag to `""`

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -51,7 +51,7 @@ var (
 	region = flag.String("s3_backup_aws_region", "us-east-1", "AWS region to use")
 
 	// AWS endpoint, defaults to amazonaws.com but appliances may use a different location
-	endpoint = flag.String("s3_backup_aws_endpoint", "amazonaws.com", "endpoint of the S3 backend (region must be provided)")
+	endpoint = flag.String("s3_backup_aws_endpoint", "", "endpoint of the S3 backend (region must be provided)")
 
 	// bucket is where the backups will go.
 	bucket = flag.String("s3_backup_storage_bucket", "", "S3 bucket to use for backups")


### PR DESCRIPTION
based on feedback by @demmer in PR 4200

For reference, the docs for Config.Endpoint:
https://github.com/aws/aws-sdk-go/blob/8d83316e1e48/aws/config.go#L44
say "Set this to `""` to use the default generated endpoint."

Signed-off-by: Scott Lanning <scott.lanning@booking.com>