### PR TITLE
No panic when could not find glog flag.

### DIFF
--- a/go/vt/logutil/level.go
+++ b/go/vt/logutil/level.go
@@ -23,11 +23,13 @@ import (
 func init() {
 	threshold := flag.Lookup("stderrthreshold")
 	if threshold == nil {
-		panic("the logging module doesn't specify a stderrthreshold flag")
+		// the logging module doesn't specify a stderrthreshold flag
+		return
 	}
+
 	const warningLevel = "1"
 	if err := threshold.Value.Set(warningLevel); err != nil {
-		panic(err)
+		return
 	}
 	threshold.DefValue = warningLevel
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

What we have in `go/vt/logutil/level.go` is _bad_. 
In file `go/vt/log/log.go` it says:
> You can modify this file to hook up a different logging library instead of glog.

But actually `level.go` is looking for `glog` flags (`stderrthreshold`) and panics (if not found)!

This PR (at least) removes `panic` from `init` function.
