### PR TITLE
Fix PMM

### DIFF
--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -7,6 +7,7 @@ COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificate
 
 RUN apt-get update && \
     apt-get upgrade -qq && \
+    apt-get install -y procps && \
     apt-get install wget -qq --no-install-recommends && \
     wget https://www.percona.com/redir/downloads/pmm-client/1.15.0/binary/debian/stretch/x86_64/pmm-client_1.15.0-1.stretch_amd64.deb && \
     dpkg -i pmm-client_1.15.0-1.stretch_amd64.deb && \

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -169,8 +169,11 @@ spec:
       pmm-admin config --server pmm.{{ $namespace }} --force
 
       # creates a systemd service
-      # TODO: remove "|| true" after https://jira.percona.com/projects/PMM/issues/PMM-1985 is resolved
-      pmm-admin add mysql:metrics --user root --socket /vtdataroot/tabletdata/mysql.sock --force || true
+      until [ -e /vtdataroot/tabletdata/mysql.sock ]; do
+        echo "Waiting for mysql.sock"
+        sleep 1
+      done
+      pmm-admin add mysql:metrics --user root --socket /vtdataroot/tabletdata/mysql.sock --force
 
       # keep the container alive but still responsive to stop requests
       trap : TERM INT; sleep infinity & wait


### PR DESCRIPTION
There is a race condition where PMM can come up before the `mysql.sock` file is ready.  PMM will fail to start and then permanently crash.  Instead, wait for the sock file to be available and then proceed with PMM initialization.

Also, latest fix to the `vitess/pmm-client` image means we no longer need the `|| true` fix for `pmm-admin add`.