### PR TITLE
helm: logging improvements

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -56,5 +56,5 @@ COPY --from=base $VTTOP/config/mycnf/backup.cnf /vt/config/mycnf/
 COPY --from=base $VTTOP/config/mycnf/rbr.cnf /vt/config/mycnf/
 
 # add vitess user and add permissions
-RUN groupadd -r --gid 999 vitess && useradd -r -g vitess --uid 999 vitess && \
+RUN groupadd -r --gid 2000 vitess && useradd -r -g vitess --uid 1000 vitess && \
    chown -R vitess:vitess /vt;

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -2,16 +2,18 @@ FROM debian:stretch-slim
 
 ADD logrotate.conf /vt/logrotate.conf
 
+ADD rotate.sh /vt/rotate.sh
+
 RUN mkdir -p /vt && \
    apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install mysql-client logrotate -qq --no-install-recommends && \
+   apt-get install logrotate -qq --no-install-recommends && \
    apt-get autoremove -qq && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/* && \
    groupadd -r --gid 2000 vitess && \
    useradd -r -g vitess --uid 1000 vitess && \
    chown -R vitess:vitess /vt && \
-   echo "0 * * * *	vitess	/usr/sbin/logrotate -s /vt/logrotate.status /vt/logrotate.conf" >> /etc/crontab
+   chmod +x /vt/rotate.sh
 
-CMD ["cron", "-f"]
+ENTRYPOINT [ "/vt/rotate.sh" ]

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stretch-slim
+
+ADD logrotate.conf /vt/logrotate.conf
+
+RUN mkdir -p /vt && \
+   apt-get update && \
+   apt-get upgrade -qq && \
+   apt-get install mysql-client logrotate -qq --no-install-recommends && \
+   apt-get autoremove -qq && \
+   apt-get clean && \
+   rm -rf /var/lib/apt/lists/* && \
+   groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   echo "0 * * * *	vitess	/usr/sbin/logrotate -s /vt/logrotate.status /vt/logrotate.conf" >> /etc/crontab
+
+CMD ["cron", "-f"]

--- a/docker/k8s/logrotate/logrotate.conf
+++ b/docker/k8s/logrotate/logrotate.conf
@@ -1,0 +1,13 @@
+/vtdataroot/tabletdata/*.log {
+   create 660 vitess vitess
+   daily
+   size 100M
+   rotate 1
+   missingok
+   nocompress
+   notifempty
+   sharedscripts
+   postrotate
+      /usr/bin/mysql --socket=/vtdataroot/tabletdata/mysql.sock -uroot -e 'select @@global.long_query_time into @lqt_save; set global long_query_time=2000; select sleep(2); FLUSH LOGS; select sleep(2); set global long_query_time=@lqt_save;'
+   endscript
+}

--- a/docker/k8s/logrotate/rotate.sh
+++ b/docker/k8s/logrotate/rotate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+# SIGTERM-handler
+term_handler() {
+  exit;
+}
+
+# setup handlers
+# on callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
+trap 'kill ${!}; term_handler' SIGINT SIGTERM SIGHUP
+
+# wait forever
+while true
+do
+  /usr/sbin/logrotate -s /vt/logrotate.status /vt/logrotate.conf
+  # run once an hour
+  sleep 3600 & wait ${!}
+done

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch-slim
+
+ENV TAIL_FILEPATH /dev/null
+
+ADD tail.sh /vt/tail.sh
+
+RUN mkdir -p /vt && \
+   apt-get update && \
+   apt-get upgrade -qq && \
+   apt-get install mysql-client -qq --no-install-recommends && \
+   apt-get autoremove -qq && \
+   apt-get clean && \
+   rm -rf /var/lib/apt/lists/* && \
+   groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chmod +x /vt/tail.sh
+
+ENTRYPOINT [ "/vt/tail.sh" ]

--- a/docker/k8s/logtail/tail.sh
+++ b/docker/k8s/logtail/tail.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# SIGTERM-handler
+term_handler() {
+  # block shutting down mysqlctld until vttablet shuts down first
+  until [ $MYSQL_GONE ]; do
+
+    # poll every 5 seconds to see if vttablet is still running
+    mysqladmin ping -uroot --socket=/vtdataroot/tabletdata/mysql.sock
+
+    if [ $? -ne 0 ]; then
+      MYSQL_GONE=true
+    fi
+
+    sleep 5
+  done
+  
+  exit;
+}
+
+# setup handlers
+# on callback, kill the last background process, which is `tail -f /dev/null` and execute the specified handler
+trap 'kill ${!}; term_handler' SIGINT SIGTERM SIGHUP
+
+# wait forever
+while true
+do
+  tail -n+1 -F "$TAIL_FILEPATH" & wait ${!}
+done

--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -15,7 +15,7 @@ ENV VTDATAROOT /vtdataroot
 
 # Prepare directory structure.
 RUN mkdir -p /vt/bin && \
-   mkdir -p /vt/config
+   mkdir -p /vt/config && mkdir -p /vtdataroot
 
 # Copy binaries
 COPY --from=k8s /vt/bin/mysqlctld /vt/bin/
@@ -25,3 +25,9 @@ COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificate
 
 # copy vitess config
 COPY --from=k8s /vt/config /vt/config
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -6,10 +6,16 @@ FROM debian:stretch-slim
 ENV VTROOT /vt
 
 # Prepare directory structure.
-RUN mkdir -p /vt/bin
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
 
 # Copy certs to allow https calls
 COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binaries
 COPY --from=k8s /vt/bin/vtctl /vt/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -10,5 +10,11 @@ RUN apt-get update && \
    rm -rf /var/lib/apt/lists/*
 
 COPY --from=k8s /vt/bin/vtctlclient /usr/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot
     
 CMD ["/usr/bin/vtctlclient"]

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -7,7 +7,7 @@ ENV VTROOT /vt
 
 # Prepare directory structure.
 RUN mkdir -p /vt/bin && \
-   mkdir -p /vt/web
+   mkdir -p /vt/web && mkdir -p /vtdataroot
 
 # Copy binaries
 COPY --from=k8s /vt/bin/vtctld /vt/bin/
@@ -17,3 +17,9 @@ COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificate
 
 # copy web admin files
 COPY --from=k8s /vt/web /vt/web
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -6,10 +6,16 @@ FROM debian:stretch-slim
 ENV VTROOT /vt
 
 # Prepare directory structure.
-RUN mkdir -p /vt/bin
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
 
 # Copy certs to allow https calls
 COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binaries
 COPY --from=k8s /vt/bin/vtgate /vt/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -15,7 +15,7 @@ ENV VTROOT /vt
 ENV VTDATAROOT /vtdataroot
 
 # Prepare directory structure.
-RUN mkdir -p /vt/bin
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
 
 # Copy binaries
 COPY --from=k8s /vt/bin/vttablet /vt/bin/
@@ -23,3 +23,9 @@ COPY --from=k8s /vt/bin/vtctlclient /vt/bin/
 
 # Copy certs to allow https calls
 COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/k8s/vtworker/Dockerfile
+++ b/docker/k8s/vtworker/Dockerfile
@@ -6,10 +6,16 @@ FROM debian:stretch-slim
 ENV VTROOT /vt
 
 # Prepare directory structure.
-RUN mkdir -p /vt/bin
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
 
 # Copy certs to allow https calls
 COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binaries
 COPY --from=k8s /vt/bin/vtworker /vt/bin/
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -591,9 +591,13 @@ spec:
 {{- define "cont-mysql-errorlog" -}}
 
 - name: error-log
-  image: debian:stretch-slim
-  command: ["/bin/sh"]
-  args: ["-c", "tail -n+1 -F /vtdataroot/tabletdata/error.log"]
+  image: vitess/logtail:latest
+  imagePullPolicy: Always
+
+  env:
+  - name: TAIL_FILEPATH
+    value: /vtdataroot/tabletdata/error.log
+
   volumeMounts:
     - name: vtdataroot
       mountPath: /vtdataroot
@@ -605,9 +609,13 @@ spec:
 {{- define "cont-mysql-slowlog" -}}
 
 - name: slow-log
-  image: debian:stretch-slim
-  command: ["/bin/sh"]
-  args: ["-c", "tail -n+1 -F /vtdataroot/tabletdata/slow.log"]
+  image: vitess/logtail:latest
+  imagePullPolicy: Always
+
+  env:
+  - name: TAIL_FILEPATH
+    value: /vtdataroot/tabletdata/slow.log
+
   volumeMounts:
     - name: vtdataroot
       mountPath: /vtdataroot

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -266,6 +266,10 @@ spec:
       cp /bin/busybox /vttmp/bin/
       cp -R /vt/config /vttmp/
 
+      # make sure the log files exist
+      touch /vtdataroot/tabletdata/error.log
+      touch /vtdataroot/tabletdata/slow.log
+
 {{- end -}}
 
 ###################################
@@ -571,7 +575,7 @@ spec:
 {{- define "cont-mysql-errorlog" -}}
 
 - name: error-log
-  image: busybox
+  image: debian:stretch-slim
   command: ["/bin/sh"]
   args: ["-c", "tail -n+1 -F /vtdataroot/tabletdata/error.log"]
   volumeMounts:
@@ -585,7 +589,7 @@ spec:
 {{- define "cont-mysql-slowlog" -}}
 
 - name: slow-log
-  image: busybox
+  image: debian:stretch-slim
   command: ["/bin/sh"]
   args: ["-c", "tail -n+1 -F /vtdataroot/tabletdata/slow.log"]
   volumeMounts:

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -106,6 +106,7 @@ spec:
       containers:
 {{ include "cont-mysql" (tuple $topology $cell $keyspace $shard $tablet $defaultVttablet $uid) | indent 8 }}
 {{ include "cont-vttablet" (tuple $topology $cell $keyspace $shard $tablet $defaultVttablet $vitessTag $uid $namespace $config $orc $totalTabletCount) | indent 8 }}
+{{ include "cont-logrotate" . | indent 8 }}
 {{ include "cont-mysql-errorlog" . | indent 8 }}
 {{ include "cont-mysql-slowlog" . | indent 8 }}
 {{ if $pmm.enabled }}{{ include "cont-pmm-client" (tuple $pmm $namespace) | indent 8 }}{{ end }}
@@ -567,6 +568,21 @@ spec:
       )
 
 {{- end -}}
+{{- end -}}
+
+##########################
+# run logrotate for all log files in /vtdataroot/tabletdata
+##########################
+{{- define "cont-logrotate" -}}
+
+- name: logrotate
+  image: vitess/logrotate:latest
+  volumeMounts:
+    - name: vtdataroot
+      mountPath: /vtdataroot
+  securityContext:
+    # logrotate requires root privileges
+    runAsUser: 0
 {{- end -}}
 
 ##########################

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -580,9 +580,7 @@ spec:
   volumeMounts:
     - name: vtdataroot
       mountPath: /vtdataroot
-  securityContext:
-    # logrotate requires root privileges
-    runAsUser: 0
+
 {{- end -}}
 
 ##########################


### PR DESCRIPTION
This PR adds log rotation via logrotate to the helm chart. By default, it rotates logs at 100M, running on an hourly cron.

This also uses the same `debian:stretch-slim` to tail the error and slow logs, and adds a vitess user/group.

@sougou - Can you create a new Docker repo for `logrotate` and `logtail` and have them auto-build like the others?