### PR TITLE
pass 5 specific env vars to make_mycnf hook

### DIFF
--- a/go/vt/hook/hook.go
+++ b/go/vt/hook/hook.go
@@ -85,6 +85,11 @@ func NewSimpleHook(name string) *Hook {
 	return &Hook{Name: name}
 }
 
+// NewHook returns a Hook object with the provided name and params.
+func NewHookWithEnv(name string, params []string, env map[string]string) *Hook {
+	return &Hook{Name: name, Parameters: params, ExtraEnv: env}
+}
+
 // findHook trie to locate the hook, and returns the exec.Cmd for it.
 func (hook *Hook) findHook() (*exec.Cmd, int, error) {
 	// Check the hook path.

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -23,7 +23,9 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/env"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var MycnfPath = "/tmp/my.cnf"
@@ -74,5 +76,79 @@ func TestMycnf(t *testing.T) {
 	// MySQL server-id should be 22222, different from Tablet UID.
 	if got, want := mycnf.ServerID, uint32(22222); got != want {
 		t.Errorf("mycnf.ServerID = %v, want %v", got, want)
+	}
+}
+
+// Use this test if any changes are made to hook handling / make_mycnf hook
+// other tests fail if we keep the hook around
+// 1. ln -snf $VTTOP/test/vthook-make_mycnf $VTROOT/vthook/make_mycnf
+// 2. Remove "No" prefix
+// 3. go test
+// 4. \rm $VTROOT/vthook/make_mycnf
+
+func NoTestMycnfHook(t *testing.T) {
+	os.Setenv("MYSQL_FLAVOR", "MariaDB")
+	uid := uint32(11111)
+	cnf := NewMycnf(uid, 6802)
+	// Assigning ServerID to be different from tablet UID to make sure that there are no
+	// assumptions in the code that those IDs are the same.
+	cnf.ServerID = 22222
+
+	// expect these in the output my.cnf
+	os.Setenv("KEYSPACE", "test-messagedb")
+	os.Setenv("SHARD", "0")
+	os.Setenv("TABLET_TYPE", "MASTER")
+	os.Setenv("TABLET_ID", "11111")
+	os.Setenv("TABLET_DIR", TabletDir(uid))
+	// this is not being passed, so it should be nil
+	os.Setenv("MY_VAR", "myvalue")
+
+	dbcfgs, err := dbconfigs.Init(cnf.SocketFile)
+	mysqld := NewMysqld(dbcfgs)
+	servenv.OnClose(mysqld.Close)
+
+	err = mysqld.InitConfig(cnf)
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+	_, err = ioutil.ReadFile(cnf.path)
+	if err != nil {
+		t.Errorf("failed reading, err %v", err)
+		return
+	}
+	mycnf := NewMycnf(uid, 0)
+	mycnf.path = cnf.path
+	mycnf, err = ReadMycnf(mycnf)
+	if err != nil {
+		t.Errorf("failed reading, err %v", err)
+	} else {
+		t.Logf("socket file %v", mycnf.SocketFile)
+	}
+	// Tablet UID should be 11111, which determines tablet/data dir.
+	if got, want := mycnf.DataDir, "/vt_0000011111/"; !strings.Contains(got, want) {
+		t.Errorf("mycnf.DataDir = %v, want *%v*", got, want)
+	}
+	// MySQL server-id should be 22222, different from Tablet UID.
+	if got, want := mycnf.ServerID, uint32(22222); got != want {
+		t.Errorf("mycnf.ServerID = %v, want %v", got, want)
+	}
+	// check that the env variables we set were passed correctly to the hook
+	if got, want := mycnf.lookup("KEYSPACE"), "test-messagedb"; got != want {
+		t.Errorf("Error passing env %v, got %v, want %v", "KEYSPACE", got, want)
+	}
+	if got, want := mycnf.lookup("SHARD"), "0"; got != want {
+		t.Errorf("Error passing env %v, got %v, want %v", "SHARD", got, want)
+	}
+	if got, want := mycnf.lookup("TABLET_TYPE"), "MASTER"; got != want {
+		t.Errorf("Error passing env %v, got %v, want %v", "TABLET_TYPE", got, want)
+	}
+	if got, want := mycnf.lookup("TABLET_ID"), "11111"; got != want {
+		t.Errorf("Error passing env %v, got %v, want %v", "TABLET_ID", got, want)
+	}
+	if got, want := mycnf.lookup("TABLET_DIR"), "/vt_0000011111"; !strings.Contains(got, want) {
+		t.Errorf("Error passing env %v, got %v, want %v", "TABLET_DIR", got, want)
+	}
+	if got := mycnf.lookup("MY_VAR"); got != "" {
+		t.Errorf("Unexpected env %v set to %v", "MY_VAR", got)
 	}
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -595,7 +595,13 @@ func (mysqld *Mysqld) initConfig(root string, cnf *Mycnf, outFile string) error 
 	var err error
 	var configData string
 
-	switch hr := hook.NewSimpleHook("make_mycnf").Execute(); hr.ExitStatus {
+	env := make(map[string]string)
+	envVars := []string{"KEYSPACE", "SHARD", "TABLET_TYPE", "TABLET_ID", "TABLET_DIR"}
+	for _, v := range envVars {
+		env[v] = os.Getenv(v)
+	}
+
+	switch hr := hook.NewHookWithEnv("make_mycnf", nil, env).Execute(); hr.ExitStatus {
 	case hook.HOOK_DOES_NOT_EXIST:
 		log.Infof("make_mycnf hook doesn't exist, reading template files")
 		configData, err = cnf.makeMycnf(getMycnfTemplates(root))

--- a/test/vthook-make_mycnf
+++ b/test/vthook-make_mycnf
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2018 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script creates a dummy my.cnf which won't actually work 
+echo "KEYSPACE="$KEYSPACE
+echo "SHARD="$SHARD
+echo "TABLET_TYPE="$TABLET_TYPE
+echo "TABLET_ID="$TABLET_ID
+echo "TABLET_DIR="$TABLET_DIR
+
+echo "server-id = 22222"
+echo "datadir = /vt/vtdataroot/vt_0000011111/data"
+echo "port = 6802"


### PR DESCRIPTION
The env variables that are being passed to make_mycnf are:
KEYSPACE
SHARD
TABLET_TYPE
TABLET_ID
TABLET_DIR

Signed-off-by: deepthi <deepthi@planetscale.com>