### PR TITLE
Use protobuf 3.5.1-1 for protoc version

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -84,7 +84,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.0</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.java.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <protoSourceRoot>../../proto</protoSourceRoot>
           <includes>
             <include>query.proto</include>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -100,7 +100,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.0</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.java.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <protoSourceRoot>../../proto</protoSourceRoot>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,7 +16,7 @@
   <modules>
     <module>client</module>
     <module>example</module>
-    <module>grpc-client</module> 
+    <module>grpc-client</module>
     <!-- <module>hadoop</module> -->
     <module>jdbc</module>
   </modules>
@@ -62,6 +62,7 @@
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
     <grpc.version>1.15.0</grpc.version>
     <protobuf.java.version>3.5.1</protobuf.java.version>
+    <protobuf.protoc.version>3.5.1-1</protobuf.protoc.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->


### PR DESCRIPTION
Protobuf introduced a GLIBC 2.14 dependency in 3.5.1 which is fixed in 3.5.1-1.

This causes build issues on machines without GLIBC 2.14 (i.e. Centos 6)

https://github.com/protocolbuffers/protobuf/issues/4138

Signed-off-by: Leo Xuzhang Lin <llin@hubspot.com>