### PR TITLE
Support ExecuteFetchAsApp in vtctld

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -208,6 +208,9 @@ var commands = []commandGroup{
 				"<tablet alias> <hook name> [<param1=value1> <param2=value2> ...]",
 				"Runs the specified hook on the given tablet. A hook is a script that resides in the $VTROOT/vthook directory. You can put any script into that directory and use this command to run that script.\n" +
 					"For this command, the param=value arguments are parameters that the command passes to the specified hook."},
+			{"ExecuteFetchAsApp", commandExecuteFetchAsApp,
+				"[-max_rows=10000] [-json] <tablet alias> <sql command>",
+				"Runs the given SQL command as a App on the remote tablet."},
 			{"ExecuteFetchAsDba", commandExecuteFetchAsDba,
 				"[-max_rows=10000] [-disable_binlogs] [-json] <tablet alias> <sql command>",
 				"Runs the given SQL command as a DBA on the remote tablet."},
@@ -1026,8 +1029,36 @@ func commandSleep(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fla
 	return wr.TabletManagerClient().Sleep(ctx, ti.Tablet, duration)
 }
 
+func commandExecuteFetchAsApp(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	maxRows := subFlags.Int("max_rows", 10000, "Specifies the maximum number of rows to allow in fetch")
+	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
+
+	if err := subFlags.Parse(args); err != nil {
+		return err
+	}
+	if subFlags.NArg() != 2 {
+		return fmt.Errorf("the <tablet alias> and <sql command> arguments are required for the ExecuteFetchAsApp command")
+	}
+
+	alias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
+	if err != nil {
+		return err
+	}
+	query := subFlags.Arg(1)
+	qrproto, err := wr.ExecuteFetchAsApp(ctx, alias, query, *maxRows)
+	if err != nil {
+		return err
+	}
+	qr := sqltypes.Proto3ToResult(qrproto)
+	if *json {
+		return printJSON(wr.Logger(), qr)
+	}
+	printQueryResult(loggerWriter{wr.Logger()}, qr)
+	return nil
+}
+
 func commandExecuteFetchAsDba(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	maxRows := subFlags.Int("max_rows", 10000, "Specifies the maximum number of rows to allow in reset")
+	maxRows := subFlags.Int("max_rows", 10000, "Specifies the maximum number of rows to allow in fetch")
 	disableBinlogs := subFlags.Bool("disable_binlogs", false, "Disables writing to binlogs during the query")
 	reloadSchema := subFlags.Bool("reload_schema", false, "Indicates whether the tablet schema will be reloaded after executing the SQL command. The default value is <code>false</code>, which indicates that the tablet schema will not be reloaded.")
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -209,7 +209,7 @@ var commands = []commandGroup{
 				"Runs the specified hook on the given tablet. A hook is a script that resides in the $VTROOT/vthook directory. You can put any script into that directory and use this command to run that script.\n" +
 					"For this command, the param=value arguments are parameters that the command passes to the specified hook."},
 			{"ExecuteFetchAsApp", commandExecuteFetchAsApp,
-				"[-max_rows=10000] [-json] <tablet alias> <sql command>",
+				"[-max_rows=10000] [-json] [-use_pool] <tablet alias> <sql command>",
 				"Runs the given SQL command as a App on the remote tablet."},
 			{"ExecuteFetchAsDba", commandExecuteFetchAsDba,
 				"[-max_rows=10000] [-disable_binlogs] [-json] <tablet alias> <sql command>",
@@ -1031,6 +1031,7 @@ func commandSleep(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fla
 
 func commandExecuteFetchAsApp(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	maxRows := subFlags.Int("max_rows", 10000, "Specifies the maximum number of rows to allow in fetch")
+	usePool := subFlags.Bool("use_pool", false, "Use connection from pool")
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
 
 	if err := subFlags.Parse(args); err != nil {
@@ -1045,7 +1046,7 @@ func commandExecuteFetchAsApp(ctx context.Context, wr *wrangler.Wrangler, subFla
 		return err
 	}
 	query := subFlags.Arg(1)
-	qrproto, err := wr.ExecuteFetchAsApp(ctx, alias, query, *maxRows)
+	qrproto, err := wr.ExecuteFetchAsApp(ctx, alias, *usePool, query, *maxRows)
 	if err != nil {
 		return err
 	}

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -174,12 +174,12 @@ func (wr *Wrangler) RefreshTabletState(ctx context.Context, tabletAlias *topodat
 }
 
 // ExecuteFetchAsApp executes a query remotely using the App pool
-func (wr *Wrangler) ExecuteFetchAsApp(ctx context.Context, tabletAlias *topodatapb.TabletAlias, query string, maxRows int) (*querypb.QueryResult, error) {
+func (wr *Wrangler) ExecuteFetchAsApp(ctx context.Context, tabletAlias *topodatapb.TabletAlias, usePool bool, query string, maxRows int) (*querypb.QueryResult, error) {
 	ti, err := wr.ts.GetTablet(ctx, tabletAlias)
 	if err != nil {
 		return nil, err
 	}
-	return wr.tmc.ExecuteFetchAsApp(ctx, ti.Tablet, false, []byte(query), maxRows)
+	return wr.tmc.ExecuteFetchAsApp(ctx, ti.Tablet, usePool, []byte(query), maxRows)
 }
 
 // ExecuteFetchAsDba executes a query remotely using the DBA pool

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -173,6 +173,15 @@ func (wr *Wrangler) RefreshTabletState(ctx context.Context, tabletAlias *topodat
 	return wr.tmc.RefreshState(ctx, ti.Tablet)
 }
 
+// ExecuteFetchAsApp executes a query remotely using the App pool
+func (wr *Wrangler) ExecuteFetchAsApp(ctx context.Context, tabletAlias *topodatapb.TabletAlias, query string, maxRows int) (*querypb.QueryResult, error) {
+	ti, err := wr.ts.GetTablet(ctx, tabletAlias)
+	if err != nil {
+		return nil, err
+	}
+	return wr.tmc.ExecuteFetchAsApp(ctx, ti.Tablet, false, []byte(query), maxRows)
+}
+
 // ExecuteFetchAsDba executes a query remotely using the DBA pool
 func (wr *Wrangler) ExecuteFetchAsDba(ctx context.Context, tabletAlias *topodatapb.TabletAlias, query string, maxRows int, disableBinlogs bool, reloadSchema bool) (*querypb.QueryResult, error) {
 	ti, err := wr.ts.GetTablet(ctx, tabletAlias)

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -42,7 +42,7 @@ select_one_table_output = """
 +---+
 | 1 |
 +---+
-""".strip()
+""".lstrip()
 
 
 def setUpModule():

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -36,6 +36,14 @@ shard_1_replica = tablet.Tablet()
 # all tablets
 tablets = [shard_0_master, shard_0_replica, shard_1_master, shard_1_replica]
 
+select_one_table_output = """
++---+
+| a |
++---+
+| 1 |
++---+
+""".strip()
+
 
 def setUpModule():
   try:
@@ -191,13 +199,15 @@ class TestVtctld(unittest.TestCase):
     # All we care is that it's the human-readable table, not JSON or protobuf.
     out, _ = utils.run_vtctl(['ExecuteFetchAsDba', shard_0_replica.tablet_alias,
                               'SELECT 1 AS a'], trap_output=True)
-    want = """+---+
-| a |
-+---+
-| 1 |
-+---+
-"""
-    self.assertEqual(want, out)
+    self.assertEqual(select_one_table_output, out)
+
+  def test_execute_fetch_as_dba(self):
+    """Make sure ExecuteFetchAsApp prints a human-readable table by default."""
+    # Use a simple example so we're not sensitive to alignment settings, etc.
+    # All we care is that it's the human-readable table, not JSON or protobuf.
+    out, _ = utils.run_vtctl(['ExecuteFetchAsApp', shard_0_replica.tablet_alias,
+                              'SELECT 1 AS a'], trap_output=True)
+    self.assertEqual(select_one_table_output, out)
 
 if __name__ == '__main__':
   utils.main()


### PR DESCRIPTION
Currently, vtctld support the tabletmanager rpc call `ExecuteFetchAsDba` but not `ExecuteFetchAsApp`. 

We use the vtctld via vtctlclient for some internal tooling but run into occasional dba closure problems: https://github.com/vitessio/vitess/issues/4334

This provides an alternative for us and make vtctld's api closer to tabletmanager 