### PR TITLE
helm: add per shard backup cron jobs

### DIFF
--- a/helm/vitess/templates/_jobs.tpl
+++ b/helm/vitess/templates/_jobs.tpl
@@ -1,0 +1,77 @@
+###################################
+# backup cron
+###################################
+{{ define "vttablet-backup-cron" -}}
+# set tuple values to more recognizable variables
+{{- $cellClean := index . 0 -}}
+{{- $keyspaceClean := index . 1 -}}
+{{- $shardClean := index . 2 -}}
+{{- $shardName := index . 3 -}}
+{{- $keyspace := index . 4 -}}
+{{- $shard := index . 5 -}}
+{{- $vitessTag := index . 6 -}}
+{{- $backup := index . 7 -}}
+{{- $namespace := index . 8 -}}
+{{- $defaultVtctlclient := index . 9 }}
+
+{{ if $backup.enabled }}
+# create cron job for current shard
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ $shardName }}-backup
+  labels:
+    app: vitess
+    component: vttablet
+    cell: {{ $cellClean | quote }}
+    keyspace: {{ $keyspaceClean | quote }}
+    shard: {{ $shardClean | quote }}
+
+spec:
+  schedule: {{ $shard.backup.cron.schedule | default $backup.cron.schedule | quote }}
+  concurrencyPolicy: Forbid
+  suspend: {{ $shard.backup.cron.suspend | default $backup.cron.suspend }}
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 20
+
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: vitess
+            component: vttablet
+            cell: {{ $cellClean | quote }}
+            keyspace: {{ $keyspaceClean | quote }}
+            shard: {{ $shardClean | quote }}
+        # pod spec
+        spec:
+          restartPolicy: Never
+{{ include "pod-security" . | indent 10 }}
+
+          containers:
+          - name: backup
+            image: "vitess/vtctlclient:{{$vitessTag}}"
+            volumeMounts:
+{{ include "user-secret-volumeMounts" $defaultVtctlclient.secrets | indent 14 }}
+
+            command: ["bash"]
+            args:
+              - "-c"
+              - |
+                set -ex
+
+                VTCTLD_SVC=vtctld.{{ $namespace }}:15999
+                VTCTL_EXTRA_FLAGS=({{ include "format-flags-inline" $defaultVtctlclient.extraFlags }})
+
+                vtctlclient ${VTCTL_EXTRA_FLAGS[@]} -server $VTCTLD_SVC BackupShard {{ $keyspace.name }}/{{ $shard.name }}
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 20Mi
+
+{{ end }}
+
+{{- end -}}

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -147,6 +147,9 @@ spec:
       shard: {{ $shardClean | quote }}
       type: {{ $tablet.type | quote }}
 
+# conditionally add cron job
+{{ include "vttablet-backup-cron" (tuple $cellClean $keyspaceClean $shardClean $shardName $keyspace $shard $vitessTag $config.backup $namespace $defaultVtctlclient) }}
+
 {{ if eq $tablet.type "replica" }}
 ---
 ###################################

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -22,6 +22,15 @@ config:
 
     enabled: false
 
+    # this creates 1 cron job per shard that will execute a backup using vtctlclient
+    # on this schedule. The job itself uses almost no resources.
+    cron:
+      # the default schedule runs daily at midnight unless overridden by the individual shard
+      schedule: "0 0 * * *"
+
+      # if this is set to true, the cron jobs are created, but never execute
+      suspend: false
+
     # choose a backup service - valid values are gcs/s3
     # TODO: add file and ceph support
     # backup_storage_implementation: gcs


### PR DESCRIPTION
This creates a native kubernetes cron job that executes according to a customer provided schedule to run backups. The schedule can be defined globally or can be overridden on a per-shard basis.

~After #4333 is merged, we'll need to add the extra flags to this call as well to support encryption and any other user provided flags.~ Done