### PR TITLE
Fix for vtgate panic when mysql-workbench is trying to connect

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -279,13 +279,13 @@ func (c *Conn) readEphemeralPacket() ([]byte, error) {
 		return nil, err
 	}
 
+	c.currentEphemeralPolicy = ephemeralRead
 	if length == 0 {
 		// This can be caused by the packet after a packet of
 		// exactly size MaxPacketSize.
 		return nil, nil
 	}
 
-	c.currentEphemeralPolicy = ephemeralRead
 	// Use the bufPool.
 	if length < MaxPacketSize {
 		c.currentEphemeralBuffer = bufPool.Get(length)
@@ -339,13 +339,13 @@ func (c *Conn) readEphemeralPacketDirect() ([]byte, error) {
 		return nil, err
 	}
 
+	c.currentEphemeralPolicy = ephemeralRead
 	if length == 0 {
 		// This can be caused by the packet after a packet of
 		// exactly size MaxPacketSize.
 		return nil, nil
 	}
 
-	c.currentEphemeralPolicy = ephemeralRead
 	if length < MaxPacketSize {
 		c.currentEphemeralBuffer = bufPool.Get(length)
 		if _, err := io.ReadFull(r, *c.currentEphemeralBuffer); err != nil {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -170,6 +170,10 @@ func TestPackets(t *testing.T) {
 	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	verifyPacketComms(t, cConn, sConn, data)
 
+	// 0 length packet
+	data = []byte{}
+	verifyPacketComms(t, cConn, sConn, data)
+
 	// Under the limit, still one packet.
 	data = make([]byte, MaxPacketSize-1)
 	data[0] = 0xab


### PR DESCRIPTION
If vtgate's mysql server receives a 0 size packet from a mysql client, it panics. Fix by maintaining the state of currentEphemeralPolicy correctly.

Signed-off-by: deepthi <deepthi@planetscale.com>