### PR TITLE
Support multiple GTIDs in MariaDB GTIDSets

### DIFF
--- a/go/mysql/replication_position_test.go
+++ b/go/mysql/replication_position_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestPositionEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.Equal(input2); got != want {
@@ -33,8 +33,8 @@ func TestPositionEqual(t *testing.T) {
 }
 
 func TestPositionNotEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 12345}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 12345}}}
 	want := false
 
 	if got := input1.Equal(input2); got != want {
@@ -43,7 +43,7 @@ func TestPositionNotEqual(t *testing.T) {
 }
 
 func TestPositionEqualZero(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := Position{}
 	want := false
 
@@ -63,8 +63,8 @@ func TestPositionZeroEqualZero(t *testing.T) {
 }
 
 func TestPositionAtLeastLess(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1233}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1233}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -73,8 +73,8 @@ func TestPositionAtLeastLess(t *testing.T) {
 }
 
 func TestPositionAtLeastEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -83,8 +83,8 @@ func TestPositionAtLeastEqual(t *testing.T) {
 }
 
 func TestPositionAtLeastGreater(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -93,8 +93,8 @@ func TestPositionAtLeastGreater(t *testing.T) {
 }
 
 func TestPositionAtLeastDifferentServer(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 4444, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4444, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -103,8 +103,8 @@ func TestPositionAtLeastDifferentServer(t *testing.T) {
 }
 
 func TestPositionAtLeastDifferentDomain(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 4, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -114,7 +114,7 @@ func TestPositionAtLeastDifferentDomain(t *testing.T) {
 
 func TestPositionZeroAtLeast(t *testing.T) {
 	input1 := Position{}
-	input2 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -123,7 +123,7 @@ func TestPositionZeroAtLeast(t *testing.T) {
 }
 
 func TestPositionAtLeastZero(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := Position{}
 	want := true
 
@@ -143,7 +143,7 @@ func TestPositionZeroAtLeastZero(t *testing.T) {
 }
 
 func TestPositionString(t *testing.T) {
-	input := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := "3-5555-1234"
 
 	if got := input.String(); got != want {
@@ -170,7 +170,7 @@ func TestPositionIsZero(t *testing.T) {
 }
 
 func TestPositionIsNotZero(t *testing.T) {
-	input := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input.IsZero(); got != want {
@@ -179,9 +179,9 @@ func TestPositionIsNotZero(t *testing.T) {
 }
 
 func TestPositionAppend(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}
-	want := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}
+	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)
@@ -189,9 +189,9 @@ func TestPositionAppend(t *testing.T) {
 }
 
 func TestPositionAppendNil(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := GTID(nil)
-	want := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)
@@ -201,7 +201,7 @@ func TestPositionAppendNil(t *testing.T) {
 func TestPositionAppendToZero(t *testing.T) {
 	input1 := Position{}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}
-	want := Position{GTIDSet: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)

--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -237,10 +237,12 @@ func TestStreamerParseRBREvents(t *testing.T) {
 			eventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -477,10 +479,12 @@ func TestStreamerParseRBRNameEscapes(t *testing.T) {
 			eventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -103,10 +103,12 @@ func TestStreamerParseEventsXID(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -157,10 +159,12 @@ func TestStreamerParseEventsCommit(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -504,10 +508,12 @@ func TestStreamerParseEventsRollback(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -520,10 +526,12 @@ func TestStreamerParseEventsRollback(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -568,10 +576,12 @@ func TestStreamerParseEventsDMLWithoutBegin(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -581,10 +591,12 @@ func TestStreamerParseEventsDMLWithoutBegin(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -632,10 +644,12 @@ func TestStreamerParseEventsBeginWithoutCommit(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -645,10 +659,12 @@ func TestStreamerParseEventsBeginWithoutCommit(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -698,10 +714,12 @@ func TestStreamerParseEventsSetInsertID(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -788,10 +806,12 @@ func TestStreamerParseEventsOtherDB(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -842,10 +862,12 @@ func TestStreamerParseEventsOtherDBBegin(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 0x0d,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 0x0d,
+						},
 					},
 				}),
 			},
@@ -938,10 +960,12 @@ func TestStreamerParseEventsMariadbBeginGTID(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1409892744,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 10,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 10,
+						},
 					},
 				}),
 			},
@@ -989,10 +1013,12 @@ func TestStreamerParseEventsMariadbStandaloneGTID(t *testing.T) {
 			EventToken: &querypb.EventToken{
 				Timestamp: 1409892744,
 				Position: mysql.EncodePosition(mysql.Position{
-					GTIDSet: mysql.MariadbGTID{
-						Domain:   0,
-						Server:   62344,
-						Sequence: 9,
+					GTIDSet: mysql.MariadbGTIDSet{
+						mysql.MariadbGTID{
+							Domain:   0,
+							Server:   62344,
+							Sequence: 9,
+						},
 					},
 				}),
 			},

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -171,7 +171,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 			},
 		}
 		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-			GTIDSet: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
+			GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 			"STOP SLAVE",

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -213,7 +213,7 @@ func (tc *splitCloneTestCase) setUpWithConcurrency(v3 bool, concurrency, writeQu
 			},
 		}
 		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-			GTIDSet: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
+			GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 			"STOP SLAVE",

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -132,7 +132,7 @@ func TestVerticalSplitClone(t *testing.T) {
 		},
 	}
 	sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
+		GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 	}
 	sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -98,10 +98,12 @@ func TestBackupRestore(t *testing.T) {
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
 	sourceTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 457,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 457,
+			},
 		},
 	}
 	sourceTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -138,10 +140,12 @@ func TestBackupRestore(t *testing.T) {
 	destTablet.FakeMysqlDaemon.ReadOnly = true
 	destTablet.FakeMysqlDaemon.Replicating = true
 	destTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 457,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 457,
+			},
 		},
 	}
 	destTablet.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -49,10 +49,12 @@ func TestEmergencyReparentShard(t *testing.T) {
 	newMaster.FakeMysqlDaemon.ReadOnly = true
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 456,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 456,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -62,10 +64,12 @@ func TestEmergencyReparentShard(t *testing.T) {
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
 	newMaster.FakeMysqlDaemon.PromoteSlaveResult = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 456,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 456,
+			},
 		},
 	}
 	newMaster.StartActionLoop(t, wr)
@@ -80,10 +84,12 @@ func TestEmergencyReparentShard(t *testing.T) {
 	goodSlave1.FakeMysqlDaemon.ReadOnly = true
 	goodSlave1.FakeMysqlDaemon.Replicating = true
 	goodSlave1.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 455,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 455,
+			},
 		},
 	}
 	goodSlave1.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
@@ -99,10 +105,12 @@ func TestEmergencyReparentShard(t *testing.T) {
 	goodSlave2.FakeMysqlDaemon.ReadOnly = true
 	goodSlave2.FakeMysqlDaemon.Replicating = false
 	goodSlave2.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 454,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 454,
+			},
 		},
 	}
 	goodSlave2.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
@@ -165,10 +173,12 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// new master
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 456,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 456,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -184,10 +194,12 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// more advanced slave
 	moreAdvancedSlave.FakeMysqlDaemon.Replicating = true
 	moreAdvancedSlave.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   2,
-			Server:   123,
-			Sequence: 457,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   2,
+				Server:   123,
+				Sequence: 457,
+			},
 		},
 	}
 	moreAdvancedSlave.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/wrangler/testlib/init_shard_master_test.go
+++ b/go/vt/wrangler/testlib/init_shard_master_test.go
@@ -58,10 +58,12 @@ func TestInitMasterShard(t *testing.T) {
 	// Master: set a plausible ReplicationPosition to return,
 	// and expect to add entry in _vt.reparent_journal
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 890,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 890,
+			},
 		},
 	}
 	master.FakeMysqlDaemon.ReadOnly = true
@@ -186,10 +188,12 @@ func TestInitMasterShardOneSlaveFails(t *testing.T) {
 	// Master: set a plausible ReplicationPosition to return,
 	// and expect to add entry in _vt.reparent_journal
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 890,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 890,
+			},
 		},
 	}
 	master.FakeMysqlDaemon.ReadOnly = true

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -81,10 +81,12 @@ func TestMigrateServedFrom(t *testing.T) {
 	// sourceMaster will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
 	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 892,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 892,
+			},
 		},
 	}
 	sourceMaster.StartActionLoop(t, wr)

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -116,10 +116,12 @@ func TestMigrateServedTypes(t *testing.T) {
 	// sourceMaster will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
 	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 892,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 892,
+			},
 		},
 	}
 	sourceMaster.StartActionLoop(t, wr)

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -46,17 +46,21 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 	newMaster.FakeMysqlDaemon.ReadOnly = true
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   7,
-			Server:   123,
-			Sequence: 990,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   7,
+				Server:   123,
+				Sequence: 990,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.PromoteSlaveResult = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   7,
-			Server:   456,
-			Sequence: 991,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   7,
+				Server:   456,
+				Sequence: 991,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -148,17 +152,21 @@ func TestPlannedReparentShard(t *testing.T) {
 	newMaster.FakeMysqlDaemon.ReadOnly = true
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   7,
-			Server:   123,
-			Sequence: 990,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   7,
+				Server:   123,
+				Sequence: 990,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.PromoteSlaveResult = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   7,
-			Server:   456,
-			Sequence: 991,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   7,
+				Server:   456,
+				Sequence: 991,
+			},
 		},
 	}
 	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -54,10 +54,12 @@ func TestShardReplicationStatuses(t *testing.T) {
 
 	// master action loop (to initialize host and port)
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 892,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 892,
+			},
 		},
 	}
 	master.StartActionLoop(t, wr)
@@ -65,10 +67,12 @@ func TestShardReplicationStatuses(t *testing.T) {
 
 	// slave loop
 	slave.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTID{
-			Domain:   5,
-			Server:   456,
-			Sequence: 890,
+		GTIDSet: mysql.MariadbGTIDSet{
+			mysql.MariadbGTID{
+				Domain:   5,
+				Server:   456,
+				Sequence: 890,
+			},
 		},
 	}
 	slave.FakeMysqlDaemon.CurrentMasterHost = topoproto.MysqlHostname(master.Tablet)


### PR DESCRIPTION
The current GTIDSet implementation for MariaDB doesn't properly support MariaDB GTIDs - a `gtid_slave_pos` of, for example, `1-1-141129273,2-2-3551534,3-3-805048` is not supported. This consequently breaks (at the very least) the replication reporter.