### PR TITLE
helm: general cleanup

### DIFF
--- a/helm/vitess/templates/_etcd.tpl
+++ b/helm/vitess/templates/_etcd.tpl
@@ -1,12 +1,12 @@
 ###################################
 # etcd cluster managed by pre-installed etcd operator
 ###################################
-{{- define "etcd" -}}
+{{ define "etcd" -}}
 # set tuple values to more recognizable variables
 {{- $name := index . 0 -}}
 {{- $replicas := index . 1 -}}
 {{- $version := index . 2 -}}
-{{- $resources := index . 3 -}}
+{{- $resources := index . 3 }}
 
 ###################################
 # EtcdCluster

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -1,7 +1,7 @@
 ###################################
 # Orchestrator Config
 ###################################
-{{- define "orchestrator-config" -}}
+{{ define "orchestrator-config" -}}
 # set tuple values to more recognizable variables
 {{- $orc := index . 0 -}}
 {{- $namespace := index . 1 -}}

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -1,7 +1,7 @@
 ###################################
 # Master Orchestrator Service
 ###################################
-{{- define "orchestrator" -}}
+{{ define "orchestrator" -}}
 # set tuple values to more recognizable variables
 {{- $orc := index . 0 -}}
 {{- $defaultVtctlclient := index . 1 }}
@@ -157,7 +157,7 @@ spec:
 ###################################
 # Per StatefulSet Orchestrator Service
 ###################################
-{{- define "orchestrator-statefulset-service" -}}
+{{ define "orchestrator-statefulset-service" -}}
 # set tuple values to more recognizable variables
 {{- $orc := index . 0 -}}
 {{- $i := index . 1 }}
@@ -191,8 +191,8 @@ spec:
 # init-container to copy and sed
 # Orchestrator config from ConfigMap
 ###################################
-{{- define "init-orchestrator" -}}
-{{- $orc := . -}}
+{{ define "init-orchestrator" -}}
+{{- $orc := . }}
 
 - name: init-orchestrator
   image: {{ $orc.image | quote }}

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -123,17 +123,21 @@ spec:
               value: "15999"
 
         - name: recovery-log
-          image: busybox
-          command: ["/bin/sh"]
-          args: ["-c", "tail -n+1 -F /tmp/recovery.log"]
+          image: vitess/logtail:latest
+          imagePullPolicy: Always
+          env:
+          - name: TAIL_FILEPATH
+            value: /tmp/recovery.log
           volumeMounts:
             - name: tmplogs
               mountPath: /tmp
 
         - name: audit-log
-          image: busybox
-          command: ["/bin/sh"]
-          args: ["-c", "tail -n+1 -F /tmp/orchestrator-audit.log"]
+          image: vitess/logtail:latest
+          imagePullPolicy: Always
+          env:
+          - name: TAIL_FILEPATH
+            value: /tmp/orchestrator-audit.log
           volumeMounts:
             - name: tmplogs
               mountPath: /tmp

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -137,7 +137,7 @@ spec:
 
 - name: "pmm-client"
   image: "vitess/pmm-client:{{ $pmm.pmmTag }}"
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: Always
   volumeMounts:
     - name: vtdataroot
       mountPath: "/vtdataroot"

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -1,10 +1,10 @@
 ###################################
 # pmm Service + Deployment
 ###################################
-{{- define "pmm" -}}
+{{ define "pmm" -}}
 # set tuple values to more recognizable variables
 {{- $pmm := index . 0 -}}
-{{- $namespace := index . 1 -}}
+{{- $namespace := index . 1 }}
 
 ###################################
 # pmm Service
@@ -131,9 +131,9 @@ spec:
 ###################################
 # sidecar container running pmm-client
 ###################################
-{{- define "cont-pmm-client" -}}
+{{ define "cont-pmm-client" -}}
 {{- $pmm := index . 0 -}}
-{{- $namespace := index . 1 -}}
+{{- $namespace := index . 1 }}
 
 - name: "pmm-client"
   image: "vitess/pmm-client:{{ $pmm.pmmTag }}"

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -179,9 +179,11 @@ spec:
       trap : TERM INT; sleep infinity & wait
 
 - name: pmm-client-metrics-log
-  image: busybox
-  command: ["/bin/sh"]
-  args: ["-c", "tail -n+1 -F /vtdataroot/pmm/pmm-mysql-metrics-42002.log"]
+  image: vitess/logtail:latest
+  imagePullPolicy: Always
+  env:
+  - name: TAIL_FILEPATH
+    value: /vtdataroot/pmm/pmm-mysql-metrics-42002.log
   volumeMounts:
     - name: vtdataroot
       mountPath: /vtdataroot

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -1,7 +1,7 @@
 ###################################
 # vtctld Service + Deployment
 ###################################
-{{- define "vtctld" -}}
+{{ define "vtctld" -}}
 # set tuple values to more recognizable variables
 {{- $topology := index . 0 -}}
 {{- $cell := index . 1 -}}
@@ -13,7 +13,7 @@
 
 # define image to use
 {{- $vitessTag := .vitessTag | default $defaultVtctld.vitessTag -}}
-{{- $cellClean := include "clean-label" $cell.name -}}
+{{- $cellClean := include "clean-label" $cell.name }}
 
 ###################################
 # vtctld Service
@@ -117,7 +117,7 @@ spec:
 ###################################
 # vtctld-affinity sets node/pod affinities
 ###################################
-{{- define "vtctld-affinity" -}}
+{{ define "vtctld-affinity" -}}
 # set tuple values to more recognizable variables
 {{- $cellClean := index . 0 -}}
 {{- $region := index . 1 -}}

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -60,6 +60,7 @@ spec:
       containers:
         - name: vtctld
           image: vitess/vtctld:{{$vitessTag}}
+          imagePullPolicy: Always
           readinessProbe:
             httpGet:
               path: /debug/health

--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -1,7 +1,7 @@
 ###################################
 # vtgate Service + Deployment
 ###################################
-{{- define "vtgate" -}}
+{{ define "vtgate" -}}
 # set tuple values to more recognizable variables
 {{- $topology := index . 0 -}}
 {{- $cell := index . 1 -}}
@@ -12,7 +12,7 @@
 
 # define image to use
 {{- $vitessTag := .vitessTag | default $defaultVtgate.vitessTag -}}
-{{- $cellClean := include "clean-label" $cell.name -}}
+{{- $cellClean := include "clean-label" $cell.name }}
 
 ###################################
 # vtgate Service
@@ -169,10 +169,10 @@ spec:
 ###################################
 # vtgate-affinity sets node/pod affinities
 ###################################
-{{- define "vtgate-affinity" -}}
+{{ define "vtgate-affinity" -}}
 # set tuple values to more recognizable variables
 {{- $cellClean := index . 0 -}}
-{{- $region := index . 1 -}}
+{{- $region := index . 1 }}
 
 # affinity pod spec
 affinity:
@@ -209,11 +209,11 @@ affinity:
 # it loops through the users and pulls out their
 # respective passwords from mounted secrets
 ###################################
-{{- define "init-mysql-creds" -}}
+{{ define "init-mysql-creds" -}}
 {{- $vitessTag := index . 0 -}}
 {{- $cell := index . 1 -}}
 
-{{- with $cell.mysqlProtocol -}}
+{{- with $cell.mysqlProtocol }}
 
 - name: init-mysql-creds
   image: "vitess/vtgate:{{$vitessTag}}"

--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -73,6 +73,7 @@ spec:
       containers:
         - name: vtgate
           image: vitess/vtgate:{{$vitessTag}}
+          imagePullPolicy: Always
           readinessProbe:
             httpGet:
               path: /debug/health
@@ -216,6 +217,7 @@ affinity:
 
 - name: init-mysql-creds
   image: "vitess/vtgate:{{$vitessTag}}"
+  imagePullPolicy: Always
   volumeMounts:
     - name: creds
       mountPath: "/mysqlcreds"

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -164,6 +164,7 @@ spec:
       containers:
       - name: init-shard-master
         image: "vitess/vtctlclient:{{$vitessTag}}"
+        imagePullPolicy: Always
         volumeMounts:
 {{ include "user-secret-volumeMounts" $defaultVtctlclient.secrets | indent 10 }}
 
@@ -254,7 +255,7 @@ spec:
 
 - name: "init-mysql"
   image: "vitess/mysqlctld:{{$vitessTag}}"
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: Always
   volumeMounts:
     - name: vtdataroot
       mountPath: "/vtdataroot"
@@ -295,6 +296,7 @@ spec:
 
 - name: init-vttablet
   image: "vitess/vtctl:{{$vitessTag}}"
+  imagePullPolicy: Always
   volumeMounts:
     - name: vtdataroot
       mountPath: "/vtdataroot"
@@ -360,6 +362,7 @@ spec:
 
 - name: vttablet
   image: "vitess/vttablet:{{$vitessTag}}"
+  imagePullPolicy: Always
   readinessProbe:
     httpGet:
       path: /debug/health
@@ -590,6 +593,7 @@ spec:
 
 - name: logrotate
   image: vitess/logrotate:latest
+  imagePullPolicy: Always
   volumeMounts:
     - name: vtdataroot
       mountPath: /vtdataroot

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -1,7 +1,7 @@
 ###################################
 # vttablet Service
 ###################################
-{{- define "vttablet-service" -}}
+{{ define "vttablet-service" -}}
 # set tuple values to more recognizable variables
 {{- $pmm := index . 0 }}
 apiVersion: v1
@@ -35,7 +35,7 @@ spec:
 ###################################
 # vttablet
 ###################################
-{{- define "vttablet" -}}
+{{ define "vttablet" -}}
 # set tuple values to more recognizable variables
 {{- $topology := index . 0 -}}
 {{- $cell := index . 1 -}}
@@ -63,7 +63,7 @@ spec:
 # define images to use
 {{- $vitessTag := .vitessTag | default $defaultVttablet.vitessTag -}}
 {{- $image := .image | default $defaultVttablet.image -}}
-{{- $mysqlImage := .mysqlImage | default $defaultVttablet.mysqlImage -}}
+{{- $mysqlImage := .mysqlImage | default $defaultVttablet.mysqlImage }}
 
 ###################################
 # vttablet StatefulSet
@@ -255,9 +255,9 @@ spec:
 ###################################
 # init-container to copy binaries for mysql
 ###################################
-{{- define "init-mysql" -}}
+{{ define "init-mysql" -}}
 {{- $vitessTag := index . 0 -}}
-{{- $cellClean := index . 1 -}}
+{{- $cellClean := index . 1 }}
 
 - name: "init-mysql"
   image: "vitess/mysqlctld:{{$vitessTag}}"
@@ -294,11 +294,11 @@ spec:
 # This converts the unique identity assigned by StatefulSet (pod name)
 # into a 31-bit unsigned integer for use as a Vitess tablet UID.
 ###################################
-{{- define "init-vttablet" -}}
+{{ define "init-vttablet" -}}
 {{- $vitessTag := index . 0 -}}
 {{- $cell := index . 1 -}}
 {{- $cellClean := index . 2 -}}
-{{- $namespace := index . 3 -}}
+{{- $namespace := index . 3 }}
 
 - name: init-vttablet
   image: "vitess/vtctl:{{$vitessTag}}"
@@ -347,7 +347,7 @@ spec:
 ##########################
 # main vttablet container
 ##########################
-{{- define "cont-vttablet" -}}
+{{ define "cont-vttablet" -}}
 
 {{- $topology := index . 0 -}}
 {{- $cell := index . 1 -}}
@@ -364,7 +364,7 @@ spec:
 {{- $totalTabletCount := index . 12 -}}
 
 {{- $cellClean := include "clean-label" $cell.name -}}
-{{- with $tablet.vttablet -}}
+{{- with $tablet.vttablet }}
 
 - name: vttablet
   image: "vitess/vttablet:{{$vitessTag}}"
@@ -514,7 +514,7 @@ spec:
 ##########################
 # main mysql container
 ##########################
-{{- define "cont-mysql" -}}
+{{ define "cont-mysql" -}}
 
 {{- $topology := index . 0 -}}
 {{- $cell := index . 1 -}}
@@ -524,7 +524,7 @@ spec:
 {{- $defaultVttablet := index . 5 -}}
 {{- $uid := index . 6 -}}
 
-{{- with $tablet.vttablet -}}
+{{- with $tablet.vttablet }}
 
 - name: mysql
   image: {{.mysqlImage | default $defaultVttablet.mysqlImage | quote}}
@@ -599,7 +599,7 @@ spec:
 ##########################
 # run logrotate for all log files in /vtdataroot/tabletdata
 ##########################
-{{- define "cont-logrotate" -}}
+{{ define "cont-logrotate" }}
 
 - name: logrotate
   image: vitess/logrotate:latest
@@ -613,7 +613,7 @@ spec:
 ##########################
 # redirect the error log file to stdout
 ##########################
-{{- define "cont-mysql-errorlog" -}}
+{{ define "cont-mysql-errorlog" }}
 
 - name: error-log
   image: vitess/logtail:latest
@@ -631,7 +631,7 @@ spec:
 ##########################
 # redirect the slow log file to stdout
 ##########################
-{{- define "cont-mysql-slowlog" -}}
+{{ define "cont-mysql-slowlog" }}
 
 - name: slow-log
   image: vitess/logtail:latest
@@ -649,7 +649,7 @@ spec:
 ##########################
 # redirect the general log file to stdout
 ##########################
-{{- define "cont-mysql-generallog" -}}
+{{ define "cont-mysql-generallog" }}
 
 - name: general-log
   image: vitess/logtail:latest
@@ -667,12 +667,12 @@ spec:
 ###################################
 # vttablet-affinity sets node/pod affinities
 ###################################
-{{- define "vttablet-affinity" -}}
+{{ define "vttablet-affinity" -}}
 # set tuple values to more recognizable variables
 {{- $cellClean := index . 0 -}}
 {{- $keyspaceClean := index . 1 -}}
 {{- $shardClean := index . 2 -}}
-{{- $region := index . 3 -}}
+{{- $region := index . 3 }}
 
 # affinity pod spec
 affinity:

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -490,6 +490,10 @@ spec:
         -health_check_interval "5s"
         -mysqlctl_socket "/vtdataroot/mysqlctl.sock"
         -enable_replication_reporter
+
+{{ if $defaultVttablet.useKeyspaceNameAsDbName }}
+        -init_db_name_override {{ $keyspace.name | quote }}
+{{ end }}
 {{ if $defaultVttablet.enableSemisync }}
         -enable_semi_sync
 {{ end }}

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -156,8 +156,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $shardName }}-init-shard-master
+  labels:
+    app: vitess
+    component: vttablet
+    cell: {{ $cellClean | quote }}
+    keyspace: {{ $keyspaceClean | quote }}
+    shard: {{ $shardClean | quote }}
 spec:
-  backoffLimit: 1
+  backoffLimit: 10
   template:
     spec:
       restartPolicy: OnFailure

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -150,6 +150,10 @@ vttablet:
   # will block forever. "rdonly" tablets do not ACK.
   enableSemisync: false
 
+  # This sets the vttablet flag "-init_db_name_override" to be the keyspace name, rather
+  # than "vt_keyspace". This works better with many MySQL client applications
+  useKeyspaceNameAsDbName: true
+
   # The name of a config map with N files inside of it. Each file will be added
   # to $EXTRA_MY_CNF, overriding any default my.cnf settings
   extraMyCnf: ""


### PR DESCRIPTION
This is a lot of cleanup work that feels good to have done. TL;DR:

1. I changed all the `imagePullPolicy` references to be `Always`. This was set inconsistently and caused some issues with people trying it out. If this causes too many pulls in production, we can add a user flag for it later.
1. I switched out a few logging containers that I forgot to handle in #4343 
1. The InitShardMaster job wasn't getting the proper labels
1. Setting `init_db_name_override=keyspace.name` is the most impactful change since I am changing a default. I did this because many database clients want to prefix the database name on calls. By making keyspace name == schema name, this allows those to work properly. I did add a setting to `values.yaml` to turn it off for compatibility.
1. There have been formatting issues where too much whitespace was being removed, so I reduced the amount of whitespace reduction that go templates are handling.