### PR TITLE
Option to require secure connections from clients when server is configured for SSL/TLS

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -149,6 +149,9 @@ type Listener struct {
 
 	// shutdown indicates that Shutdown method was called.
 	shutdown sync2.AtomicBool
+
+	// RequireSecureTransport configures the server to reject connections from insecure clients
+	RequireSecureTransport bool
 }
 
 // NewFromListener creares a new mysql listener from an existing net.Listener
@@ -317,6 +320,9 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 			}
 		}
 	} else {
+		if l.RequireSecureTransport {
+			c.writeErrorPacketFromError(fmt.Errorf("Server does not allow insecure connections, client must use SSL/TLS"))
+		}
 		connCountByTLSVer.Add(versionNoTLS, 1)
 		defer connCountByTLSVer.Add(versionNoTLS, -1)
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -48,6 +48,8 @@ var (
 	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
 	mysqlServerVersion            = flag.String("mysql_server_version", mysql.DefaultServerVersion, "MySQL server version to advertise.")
 
+	mysqlServerRequireSecureTransport = flag.Bool("mysql_server_require_secure_transport", false, "Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided")
+
 	mysqlSslCert = flag.String("mysql_server_ssl_cert", "", "Path to the ssl cert for mysql server plugin SSL")
 	mysqlSslKey  = flag.String("mysql_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
 	mysqlSslCa   = flag.String("mysql_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
@@ -212,9 +214,9 @@ func initMySQLProtocol() {
 				log.Exitf("grpcutils.TLSServerConfig failed: %v", err)
 				return
 			}
+			mysqlListener.RequireSecureTransport = *mysqlServerRequireSecureTransport
 		}
 		mysqlListener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
-
 		// Check for the connection threshold
 		if *mysqlSlowConnectWarnThreshold != 0 {
 			log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)


### PR DESCRIPTION
add a flag to require secure connection from clients. will only be enforced if server is configured with certificate and key

Signed-off-by: deepthi <deepthi@planetscale.com>