### PR TITLE
Upgrade grpc-go to 1.15

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -959,6 +959,12 @@
 			"revisionTime": "2016-07-30T22:43:56Z"
 		},
 		{
+			"checksumSHA1": "Tr5yx/ucT6KllmNwUIRQUweZhWI=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "ec83556a53fe16b65c452a104ea9d1e86a671852",
+			"revisionTime": "2018-11-19T19:44:06Z"
+		},
+		{
 			"checksumSHA1": "Gwx30TD3lMSgskBCmXTDXbICPRQ=",
 			"path": "golang.org/x/text/collate",
 			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
@@ -1115,100 +1121,100 @@
 			"revisionTime": "2017-05-31T20:35:52Z"
 		},
 		{
-			"checksumSHA1": "Ts0J7j6y5Js06AhCzZj9XNJoB+g=",
+			"checksumSHA1": "qniZg+TMtxqdBOxLukGnd5fBsmc=",
 			"path": "google.golang.org/grpc",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "xBhmO0Vn4kzbmySioX+2gBImrkk=",
+			"checksumSHA1": "B+kZFVP8zRiQMpoEb39Mp2oSmqg=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "CPWX/IgaQSR3+78j4sPrvHNkW+U=",
+			"checksumSHA1": "lw+L836hLeH8+//le+C+ycddCCU=",
 			"path": "google.golang.org/grpc/balancer/base",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "DJ1AtOk4Pu7bqtUMob95Hw8HPNw=",
 			"path": "google.golang.org/grpc/balancer/roundrobin",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "j8Qs+yfgwYYOtodB/1bSlbzV5rs=",
+			"checksumSHA1": "R3tuACGAPyK4lr+oSNt1saUzC0M=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "KthiDKNPHMeIu967enqtE4NaZzI=",
+			"checksumSHA1": "wA6y5rkH1v4bWBe5M1r/Hdtgma4=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "QbufP1o0bXrtd5XecqdRCK/Vl0M=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "mJTBJC0n9J2CV+tHX+dJosYOZmg=",
+			"checksumSHA1": "cfLb+pzWB+Glwp82rgfcEST1mv8=",
 			"path": "google.golang.org/grpc/encoding",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
 			"path": "google.golang.org/grpc/encoding/proto",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
 			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
 			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
+			"checksumSHA1": "ZPPSFisPDz2ANO4FBZIft+fRxyk=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "QyasSHZlgle+PHSIQ2/p+fr+ihY=",
@@ -1219,100 +1225,140 @@
 			"versionExact": "v1.11.2"
 		},
 		{
-			"checksumSHA1": "Qvf3zdmRCSsiM/VoBv0qB/naHtU=",
+			"checksumSHA1": "8uLpHZuwD6Ug/QlvN94QyHaOack=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
+		},
+		{
+			"checksumSHA1": "uDJA7QK2iGnEwbd9TPqkLaM+xuU=",
+			"path": "google.golang.org/grpc/internal/backoff",
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
+		},
+		{
+			"checksumSHA1": "8dcRbrJWAcFQIXVuchR6z4ItIzg=",
+			"path": "google.golang.org/grpc/internal/channelz",
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
+		},
+		{
+			"checksumSHA1": "5dFUCEaPjKwza9kwKqgljp8ckU4=",
+			"path": "google.golang.org/grpc/internal/envconfig",
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
+		},
+		{
+			"checksumSHA1": "70gndc/uHwyAl3D45zqp7vyHWlo=",
+			"path": "google.golang.org/grpc/internal/grpcrand",
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
+		},
+		{
+			"checksumSHA1": "3/+ZIaJhkKSSqt6Z3VDS0Q8zMXA=",
+			"path": "google.golang.org/grpc/internal/transport",
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "RUgjR0iUFLCgdLAnNqiH+8jTzuk=",
+			"checksumSHA1": "OjIAi5AzqlQ7kLtdAyjvdgMf6hc=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "5dwF592DPvhF2Wcex3m7iV6aGRQ=",
+			"checksumSHA1": "VvGBoawND0urmYDy11FT+U1IHtU=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "qbA3XLvX0RTvaqQefvFDtE9GaJs=",
+			"checksumSHA1": "GEq6wwE1qWLmkaM02SjxBmmnHDo=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "WpWF+bDzObsHf+bjoGpb/abeFxo=",
+			"checksumSHA1": "90rwIeFK1zLW8M57MfzmejpCwP4=",
 			"path": "google.golang.org/grpc/resolver/dns",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
 			"path": "google.golang.org/grpc/resolver/passthrough",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
-			"checksumSHA1": "FXiovlBmrYdS4QT0Z4nV+x+v5HI=",
+			"checksumSHA1": "t/NhHuykWsxY0gEBd2WIv5RVBK8=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
+			"revisionTime": "2018-09-11T17:48:51Z",
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "sg7RY87LaWXaZMj0cuLQQaJJQYo=",
 			"path": "google.golang.org/grpc/transport",
 			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
 			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"version": "v1.15.0",
+			"versionExact": "v1.15.0"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
The grpc-java we use in the client is upgraded to 1.15.0 in https://github.com/vitessio/vitess/pull/4218

This upgrades the grpc-go server version to match the client version.

We've seen improvements to graceful closures on the upgrade as there had been numerous transport level bug fixes since 1.11.

cc @acharis 

Signed-off-by: Leo Xuzhang Lin <llin@hubspot.com>