### PR TITLE
Adds stats to topo

### DIFF
--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -30,8 +30,8 @@ var (
 		[]string{"Operation", "Cell"})
 
 	topoStatsConnErrors = stats.NewCountersWithMultiLabels(
-		"TopologyErrors",
-		"Operation errors to topology cells",
+		"TopologyConnErrors",
+		"TopologyConnErrors errors per operation",
 		[]string{"Operation", "Cell"})
 )
 

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -1,13 +1,10 @@
 /*
-Copyright 2017 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
+Copyright 2018 The Vitess Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreedto in writing, software
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -25,16 +25,12 @@ var _ Conn = (*StatsConn)(nil)
 
 var (
 	topoStatsConnTimings = stats.NewMultiTimings(
-		"TopologyConn",
-		"TopologyConn timings",
-		[]string{"Operation", "Cell"})
-	topoStatsConnCounts = stats.NewCountersWithMultiLabels(
-		"TopologyConnCounts",
-		"Operation counts to topology cells",
+		"TopologyConnOperations",
+		"TopologyConnOperations timings",
 		[]string{"Operation", "Cell"})
 
 	topoStatsConnErrors = stats.NewCountersWithMultiLabels(
-		"TopologyConnErrors",
+		"TopologyErrors",
 		"Operation errors to topology cells",
 		[]string{"Operation", "Cell"})
 )
@@ -63,7 +59,6 @@ func (st *StatsConn) ListDir(ctx context.Context, dirPath string, full bool) ([]
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -77,7 +72,6 @@ func (st *StatsConn) Create(ctx context.Context, filePath string, contents []byt
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -91,7 +85,6 @@ func (st *StatsConn) Update(ctx context.Context, filePath string, contents []byt
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -105,7 +98,6 @@ func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version,
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return bytes, version, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return bytes, version, err
 }
 
@@ -119,7 +111,6 @@ func (st *StatsConn) Delete(ctx context.Context, filePath string, version Versio
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return err
 }
 
@@ -133,7 +124,6 @@ func (st *StatsConn) Lock(ctx context.Context, dirPath, contents string) (LockDe
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -142,7 +132,6 @@ func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *Watch
 	startTime := time.Now()
 	statsKey := []string{"Watch", st.cell}
 	defer topoStatsConnTimings.Record(statsKey, startTime)
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return st.conn.Watch(ctx, filePath)
 }
 
@@ -156,7 +145,6 @@ func (st *StatsConn) NewMasterParticipation(name, id string) (MasterParticipatio
 		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -165,6 +153,5 @@ func (st *StatsConn) Close() {
 	startTime := time.Now()
 	statsKey := []string{"Close", st.cell}
 	defer topoStatsConnTimings.Record(statsKey, startTime)
-	topoStatsConnCounts.Add(statsKey, int64(1))
 	st.conn.Close()
 }

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -27,16 +27,16 @@ import (
 var _ Conn = (*StatsConn)(nil)
 
 var (
-	timings = stats.NewMultiTimings(
+	topoStatsConnTimings = stats.NewMultiTimings(
 		"TopologyConn",
 		"TopologyConn timings",
 		[]string{"Operation", "Cell"})
-	counts = stats.NewCountersWithMultiLabels(
+	topoStatsConnCounts = stats.NewCountersWithMultiLabels(
 		"TopologyConnCounts",
 		"Operation counts to topology cells",
 		[]string{"Operation", "Cell"})
 
-	errors = stats.NewCountersWithMultiLabels(
+	topoStatsConnErrors = stats.NewCountersWithMultiLabels(
 		"TopologyConnErrors",
 		"Operation errors to topology cells",
 		[]string{"Operation", "Cell"})
@@ -60,13 +60,13 @@ func NewStatsConn(cell string, conn Conn) *StatsConn {
 func (st *StatsConn) ListDir(ctx context.Context, dirPath string, full bool) ([]DirEntry, error) {
 	startTime := time.Now()
 	statsKey := []string{"ListDir", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.ListDir(ctx, dirPath, full)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -74,13 +74,13 @@ func (st *StatsConn) ListDir(ctx context.Context, dirPath string, full bool) ([]
 func (st *StatsConn) Create(ctx context.Context, filePath string, contents []byte) (Version, error) {
 	startTime := time.Now()
 	statsKey := []string{"Create", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.Create(ctx, filePath, contents)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -88,13 +88,13 @@ func (st *StatsConn) Create(ctx context.Context, filePath string, contents []byt
 func (st *StatsConn) Update(ctx context.Context, filePath string, contents []byte, version Version) (Version, error) {
 	startTime := time.Now()
 	statsKey := []string{"Update", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.Update(ctx, filePath, contents, version)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -102,13 +102,13 @@ func (st *StatsConn) Update(ctx context.Context, filePath string, contents []byt
 func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version, error) {
 	startTime := time.Now()
 	statsKey := []string{"Get", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	bytes, version, err := st.conn.Get(ctx, filePath)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return bytes, version, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return bytes, version, err
 }
 
@@ -116,13 +116,13 @@ func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version,
 func (st *StatsConn) Delete(ctx context.Context, filePath string, version Version) error {
 	startTime := time.Now()
 	statsKey := []string{"Delete", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	err := st.conn.Delete(ctx, filePath, version)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return err
 }
 
@@ -130,13 +130,13 @@ func (st *StatsConn) Delete(ctx context.Context, filePath string, version Versio
 func (st *StatsConn) Lock(ctx context.Context, dirPath, contents string) (LockDescriptor, error) {
 	startTime := time.Now()
 	statsKey := []string{"Lock", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.Lock(ctx, dirPath, contents)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -144,8 +144,8 @@ func (st *StatsConn) Lock(ctx context.Context, dirPath, contents string) (LockDe
 func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc) {
 	startTime := time.Now()
 	statsKey := []string{"Watch", st.cell}
-	defer timings.Record(statsKey, startTime)
-	counts.Add(statsKey, int64(1))
+	defer topoStatsConnTimings.Record(statsKey, startTime)
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return st.conn.Watch(ctx, filePath)
 }
 
@@ -153,13 +153,13 @@ func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *Watch
 func (st *StatsConn) NewMasterParticipation(name, id string) (MasterParticipation, error) {
 	startTime := time.Now()
 	statsKey := []string{"NewMasterParticipation", st.cell}
-	defer timings.Record(statsKey, startTime)
+	defer topoStatsConnTimings.Record(statsKey, startTime)
 	res, err := st.conn.NewMasterParticipation(name, id)
 	if err != nil {
-		errors.Add(statsKey, int64(1))
+		topoStatsConnErrors.Add(statsKey, int64(1))
 		return res, err
 	}
-	counts.Add(statsKey, int64(1))
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	return res, err
 }
 
@@ -167,7 +167,7 @@ func (st *StatsConn) NewMasterParticipation(name, id string) (MasterParticipatio
 func (st *StatsConn) Close() {
 	startTime := time.Now()
 	statsKey := []string{"Close", st.cell}
-	defer timings.Record(statsKey, startTime)
-	counts.Add(statsKey, int64(1))
+	defer topoStatsConnTimings.Record(statsKey, startTime)
+	topoStatsConnCounts.Add(statsKey, int64(1))
 	st.conn.Close()
 }

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+	"vitess.io/vitess/go/stats"
+)
+
+var _ Conn = (*StatsConn)(nil)
+
+// The StatsConn is a wrapper for a Conn that emits stats for every operation
+type StatsConn struct {
+	cell string
+	conn Conn
+
+	timings *stats.MultiTimings
+	counts  *stats.CountersWithMultiLabels
+	errors  *stats.CountersWithMultiLabels
+}
+
+// NewStatsConn returns a StatsConn
+func NewStatsConn(cell string, conn Conn) *StatsConn {
+	return &StatsConn{
+		cell: cell,
+		conn: conn,
+		timings: stats.NewMultiTimings(
+			"TopologyConn",
+			"TopologyConn timings",
+			[]string{"Operation", "Cell"}),
+		counts: stats.NewCountersWithMultiLabels(
+			"TopologyConnCounts",
+			"Operation counts to topology cells",
+			[]string{"Operation", "Cell"}),
+		errors: stats.NewCountersWithMultiLabels(
+			"TopologyConnErrors",
+			"Operation errors to topology cells",
+			[]string{"Operation", "Cell"}),
+	}
+}
+
+// ListDir is part of the Conn interface
+func (st *StatsConn) ListDir(ctx context.Context, dirPath string, full bool) ([]DirEntry, error) {
+	startTime := time.Now()
+	statsKey := []string{"ListDir", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	res, err := st.ListDir(ctx, dirPath, full)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return res, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return res, err
+}
+
+// Create is part of the Conn interface
+func (st *StatsConn) Create(ctx context.Context, filePath string, contents []byte) (Version, error) {
+	startTime := time.Now()
+	statsKey := []string{"Create", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	res, err := st.Create(ctx, filePath, contents)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return res, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return res, err
+}
+
+// Update is part of the Conn interface
+func (st *StatsConn) Update(ctx context.Context, filePath string, contents []byte, version Version) (Version, error) {
+	startTime := time.Now()
+	statsKey := []string{"Update", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	res, err := st.Update(ctx, filePath, contents, version)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return res, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return res, err
+}
+
+// Get is part of the Conn interface
+func (st *StatsConn) Get(ctx context.Context, filePath string) ([]byte, Version, error) {
+	startTime := time.Now()
+	statsKey := []string{"Get", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	bytes, version, err := st.Get(ctx, filePath)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return bytes, version, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return bytes, version, err
+}
+
+// Delete is part of the Conn interface
+func (st *StatsConn) Delete(ctx context.Context, filePath string, version Version) error {
+	startTime := time.Now()
+	statsKey := []string{"Delete", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	err := st.Delete(ctx, filePath, version)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return err
+}
+
+// Lock is part of the Conn interface
+func (st *StatsConn) Lock(ctx context.Context, dirPath, contents string) (LockDescriptor, error) {
+	startTime := time.Now()
+	statsKey := []string{"Lock", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	res, err := st.Lock(ctx, dirPath, contents)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return res, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return res, err
+}
+
+// Watch is part of the Conn interface
+func (st *StatsConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc) {
+	startTime := time.Now()
+	statsKey := []string{"Watch", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	st.counts.Add(statsKey, int64(1))
+	return st.Watch(ctx, filePath)
+}
+
+// NewMasterParticipation is part of the Conn interface
+func (st *StatsConn) NewMasterParticipation(name, id string) (MasterParticipation, error) {
+	startTime := time.Now()
+	statsKey := []string{"NewMasterParticipation", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	res, err := st.NewMasterParticipation(name, id)
+	if err != nil {
+		st.errors.Add(statsKey, int64(1))
+		return res, err
+	}
+	st.counts.Add(statsKey, int64(1))
+	return res, err
+}
+
+// Close is part of the Conn interface
+func (st *StatsConn) Close() {
+	startTime := time.Now()
+	statsKey := []string{"Close", st.cell}
+	defer st.timings.Record(statsKey, startTime)
+	st.counts.Add(statsKey, int64(1))
+	st.Close()
+}

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+// The fakeConn is a wrapper for a Conn that emits stats for every operation
+type fakeConn struct {
+	v Version
+}
+
+// ListDir is part of the Conn interface
+func (st *fakeConn) ListDir(ctx context.Context, dirPath string, full bool) (res []DirEntry, err error) {
+	if dirPath == "error" {
+		return res, fmt.Errorf("Dummy error")
+
+	}
+	return res, err
+}
+
+// Create is part of the Conn interface
+func (st *fakeConn) Create(ctx context.Context, filePath string, contents []byte) (ver Version, err error) {
+	if filePath == "error" {
+		return ver, fmt.Errorf("Dummy error")
+
+	}
+	return ver, err
+}
+
+// Update is part of the Conn interface
+func (st *fakeConn) Update(ctx context.Context, filePath string, contents []byte, version Version) (ver Version, err error) {
+	if filePath == "error" {
+		return ver, fmt.Errorf("Dummy error")
+
+	}
+	return ver, err
+}
+
+// Get is part of the Conn interface
+func (st *fakeConn) Get(ctx context.Context, filePath string) (bytes []byte, ver Version, err error) {
+	if filePath == "error" {
+		return bytes, ver, fmt.Errorf("Dummy error")
+
+	}
+	return bytes, ver, err
+}
+
+// Delete is part of the Conn interface
+func (st *fakeConn) Delete(ctx context.Context, filePath string, version Version) (err error) {
+	if filePath == "error" {
+		return fmt.Errorf("Dummy error")
+	}
+	return err
+}
+
+// Lock is part of the Conn interface
+func (st *fakeConn) Lock(ctx context.Context, dirPath, contents string) (lock LockDescriptor, err error) {
+	if dirPath == "error" {
+		return lock, fmt.Errorf("Dummy error")
+
+	}
+	return lock, err
+}
+
+// Watch is part of the Conn interface
+func (st *fakeConn) Watch(ctx context.Context, filePath string) (current *WatchData, changes <-chan *WatchData, cancel CancelFunc) {
+	return current, changes, cancel
+}
+
+// NewMasterParticipation is part of the Conn interface
+func (st *fakeConn) NewMasterParticipation(name, id string) (mp MasterParticipation, err error) {
+	if name == "error" {
+		return mp, fmt.Errorf("Dummy error")
+
+	}
+	return mp, err
+}
+
+// Close is part of the Conn interface
+func (st *fakeConn) Close() {
+}
+
+//TestStatsConnTopoListDir emits stats on ListDir
+func TestStatsConnTopoListDir(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.ListDir(ctx, "", true)
+	timningCounts := timings.Counts()["ListDir.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["ListDir.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["ListDir.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.ListDir(ctx, "error", true)
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["ListDir.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoCreate emits stats on Create
+func TestStatsConnTopoCreate(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Create(ctx, "", []byte{})
+	timningCounts := timings.Counts()["Create.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Create.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["Create.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.Create(ctx, "error", []byte{})
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["Create.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoUpdate emits stats on Update
+func TestStatsConnTopoUpdate(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Update(ctx, "", []byte{}, conn.v)
+	timningCounts := timings.Counts()["Update.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Update.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["Update.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.Update(ctx, "error", []byte{}, conn.v)
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["Update.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoGet emits stats on Get
+func TestStatsConnTopoGet(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Get(ctx, "")
+	timningCounts := timings.Counts()["Get.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Get.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["Get.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.Get(ctx, "error")
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["Get.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoDelete emits stats on Delete
+func TestStatsConnTopoDelete(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Delete(ctx, "", conn.v)
+	timningCounts := timings.Counts()["Delete.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Delete.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["Delete.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.Delete(ctx, "error", conn.v)
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["Delete.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoLock emits stats on Lock
+func TestStatsConnTopoLock(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Lock(ctx, "", "")
+	timningCounts := timings.Counts()["Lock.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Lock.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["Lock.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.Lock(ctx, "error", "")
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["Lock.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoWatch emits stats on Watch
+func TestStatsConnTopoWatch(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+	ctx := context.Background()
+
+	statsConn.Watch(ctx, "")
+	timningCounts := timings.Counts()["Watch.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Watch.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoNewMasterParticipation emits stats on NewMasterParticipation
+func TestStatsConnTopoNewMasterParticipation(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+
+	statsConn.NewMasterParticipation("", "")
+	timningCounts := timings.Counts()["NewMasterParticipation.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["NewMasterParticipation.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	// error if zero before getting an error
+	errorCount := errors.Counts()["NewMasterParticipation.global"]
+	if got, want := errorCount, int64(0); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	statsConn.NewMasterParticipation("error", "")
+
+	// error stats gets emitted
+	errorCount = errors.Counts()["NewMasterParticipation.global"]
+	if got, want := errorCount, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}
+
+//TestStatsConnTopoClose emits stats on Close
+func TestStatsConnTopoClose(t *testing.T) {
+	conn := &fakeConn{}
+	statsConn := NewStatsConn("global", conn)
+
+	statsConn.Close()
+	timningCounts := timings.Counts()["Close.global"]
+	if got, want := timningCounts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+
+	counts := counts.Counts()["Close.global"]
+	if got, want := counts, int64(1); got != want {
+		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
+	}
+}

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -106,18 +106,18 @@ func TestStatsConnTopoListDir(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.ListDir(ctx, "", true)
-	timningCounts := timings.Counts()["ListDir.global"]
+	timningCounts := topoStatsConnTimings.Counts()["ListDir.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["ListDir.global"]
+	counts := topoStatsConnCounts.Counts()["ListDir.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["ListDir.global"]
+	errorCount := topoStatsConnErrors.Counts()["ListDir.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -125,7 +125,7 @@ func TestStatsConnTopoListDir(t *testing.T) {
 	statsConn.ListDir(ctx, "error", true)
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["ListDir.global"]
+	errorCount = topoStatsConnErrors.Counts()["ListDir.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -138,18 +138,18 @@ func TestStatsConnTopoCreate(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Create(ctx, "", []byte{})
-	timningCounts := timings.Counts()["Create.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Create.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Create.global"]
+	counts := topoStatsConnCounts.Counts()["Create.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["Create.global"]
+	errorCount := topoStatsConnErrors.Counts()["Create.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -157,7 +157,7 @@ func TestStatsConnTopoCreate(t *testing.T) {
 	statsConn.Create(ctx, "error", []byte{})
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["Create.global"]
+	errorCount = topoStatsConnErrors.Counts()["Create.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -170,18 +170,18 @@ func TestStatsConnTopoUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Update(ctx, "", []byte{}, conn.v)
-	timningCounts := timings.Counts()["Update.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Update.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Update.global"]
+	counts := topoStatsConnCounts.Counts()["Update.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["Update.global"]
+	errorCount := topoStatsConnErrors.Counts()["Update.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -189,7 +189,7 @@ func TestStatsConnTopoUpdate(t *testing.T) {
 	statsConn.Update(ctx, "error", []byte{}, conn.v)
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["Update.global"]
+	errorCount = topoStatsConnErrors.Counts()["Update.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -202,18 +202,18 @@ func TestStatsConnTopoGet(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Get(ctx, "")
-	timningCounts := timings.Counts()["Get.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Get.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Get.global"]
+	counts := topoStatsConnCounts.Counts()["Get.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["Get.global"]
+	errorCount := topoStatsConnErrors.Counts()["Get.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -221,7 +221,7 @@ func TestStatsConnTopoGet(t *testing.T) {
 	statsConn.Get(ctx, "error")
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["Get.global"]
+	errorCount = topoStatsConnErrors.Counts()["Get.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -234,18 +234,18 @@ func TestStatsConnTopoDelete(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Delete(ctx, "", conn.v)
-	timningCounts := timings.Counts()["Delete.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Delete.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Delete.global"]
+	counts := topoStatsConnCounts.Counts()["Delete.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["Delete.global"]
+	errorCount := topoStatsConnErrors.Counts()["Delete.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -253,7 +253,7 @@ func TestStatsConnTopoDelete(t *testing.T) {
 	statsConn.Delete(ctx, "error", conn.v)
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["Delete.global"]
+	errorCount = topoStatsConnErrors.Counts()["Delete.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -266,18 +266,18 @@ func TestStatsConnTopoLock(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Lock(ctx, "", "")
-	timningCounts := timings.Counts()["Lock.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Lock.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Lock.global"]
+	counts := topoStatsConnCounts.Counts()["Lock.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["Lock.global"]
+	errorCount := topoStatsConnErrors.Counts()["Lock.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -285,7 +285,7 @@ func TestStatsConnTopoLock(t *testing.T) {
 	statsConn.Lock(ctx, "error", "")
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["Lock.global"]
+	errorCount = topoStatsConnErrors.Counts()["Lock.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -298,12 +298,12 @@ func TestStatsConnTopoWatch(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Watch(ctx, "")
-	timningCounts := timings.Counts()["Watch.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Watch.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Watch.global"]
+	counts := topoStatsConnCounts.Counts()["Watch.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -315,18 +315,18 @@ func TestStatsConnTopoNewMasterParticipation(t *testing.T) {
 	statsConn := NewStatsConn("global", conn)
 
 	statsConn.NewMasterParticipation("", "")
-	timningCounts := timings.Counts()["NewMasterParticipation.global"]
+	timningCounts := topoStatsConnTimings.Counts()["NewMasterParticipation.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["NewMasterParticipation.global"]
+	counts := topoStatsConnCounts.Counts()["NewMasterParticipation.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
 	// error if zero before getting an error
-	errorCount := errors.Counts()["NewMasterParticipation.global"]
+	errorCount := topoStatsConnErrors.Counts()["NewMasterParticipation.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -334,7 +334,7 @@ func TestStatsConnTopoNewMasterParticipation(t *testing.T) {
 	statsConn.NewMasterParticipation("error", "")
 
 	// error stats gets emitted
-	errorCount = errors.Counts()["NewMasterParticipation.global"]
+	errorCount = topoStatsConnErrors.Counts()["NewMasterParticipation.global"]
 	if got, want := errorCount, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
@@ -346,12 +346,12 @@ func TestStatsConnTopoClose(t *testing.T) {
 	statsConn := NewStatsConn("global", conn)
 
 	statsConn.Close()
-	timningCounts := timings.Counts()["Close.global"]
+	timningCounts := topoStatsConnTimings.Counts()["Close.global"]
 	if got, want := timningCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := counts.Counts()["Close.global"]
+	counts := topoStatsConnCounts.Counts()["Close.global"]
 	if got, want := counts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -103,17 +103,12 @@ func TestStatsConnTopoListDir(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.ListDir(ctx, "", true)
-	timningCounts := topoStatsConnTimings.Counts()["ListDir.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["ListDir.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["ListDir.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["ListDir.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -135,17 +130,12 @@ func TestStatsConnTopoCreate(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Create(ctx, "", []byte{})
-	timningCounts := topoStatsConnTimings.Counts()["Create.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Create.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Create.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["Create.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -167,17 +157,12 @@ func TestStatsConnTopoUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Update(ctx, "", []byte{}, conn.v)
-	timningCounts := topoStatsConnTimings.Counts()["Update.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Update.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Update.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["Update.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -199,17 +184,12 @@ func TestStatsConnTopoGet(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Get(ctx, "")
-	timningCounts := topoStatsConnTimings.Counts()["Get.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Get.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Get.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["Get.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -231,17 +211,12 @@ func TestStatsConnTopoDelete(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Delete(ctx, "", conn.v)
-	timningCounts := topoStatsConnTimings.Counts()["Delete.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Delete.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Delete.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["Delete.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -263,17 +238,12 @@ func TestStatsConnTopoLock(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Lock(ctx, "", "")
-	timningCounts := topoStatsConnTimings.Counts()["Lock.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Lock.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Lock.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["Lock.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -295,15 +265,11 @@ func TestStatsConnTopoWatch(t *testing.T) {
 	ctx := context.Background()
 
 	statsConn.Watch(ctx, "")
-	timningCounts := topoStatsConnTimings.Counts()["Watch.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Watch.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["Watch.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
 }
 
 //TestStatsConnTopoNewMasterParticipation emits stats on NewMasterParticipation
@@ -312,17 +278,12 @@ func TestStatsConnTopoNewMasterParticipation(t *testing.T) {
 	statsConn := NewStatsConn("global", conn)
 
 	statsConn.NewMasterParticipation("", "")
-	timningCounts := topoStatsConnTimings.Counts()["NewMasterParticipation.global"]
-	if got, want := timningCounts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["NewMasterParticipation.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 
-	counts := topoStatsConnCounts.Counts()["NewMasterParticipation.global"]
-	if got, want := counts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	// error if zero before getting an error
+	// error is zero before getting an error
 	errorCount := topoStatsConnErrors.Counts()["NewMasterParticipation.global"]
 	if got, want := errorCount, int64(0); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
@@ -343,13 +304,8 @@ func TestStatsConnTopoClose(t *testing.T) {
 	statsConn := NewStatsConn("global", conn)
 
 	statsConn.Close()
-	timningCounts := topoStatsConnTimings.Counts()["Close.global"]
-	if got, want := timningCounts, int64(1); got != want {
-		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
-	}
-
-	counts := topoStatsConnCounts.Counts()["Close.global"]
-	if got, want := counts, int64(1); got != want {
+	timingCounts := topoStatsConnTimings.Counts()["Close.global"]
+	if got, want := timingCounts, int64(1); got != want {
 		t.Errorf("stats were not properly recorded: got = %d, want = %d", got, want)
 	}
 }

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -1,13 +1,10 @@
 /*
-Copyright 2017 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
+Copyright 2018 The Vitess Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreedto in writing, software
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and


### PR DESCRIPTION
### Description

We are in the process of doing a topology migration. While we are doing this, it will be helpful to have more telemetry into the operations that Vitess is doing to the underlying lock service. 

The following PR adds `stats_conn`. This is a decorator for the topology connection that emits stats when any operation is performed. It maintains stats per operation and cell. 

### Tests

I added relevant unit tests and tested in our dev environment. 