### PR TITLE
Correcting web file path in Docker file for alpine

### DIFF
--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -4,8 +4,8 @@ FROM alpine:3.8 AS staging
 
 RUN mkdir -p /vt/vtdataroot/ && mkdir -p /vt/bin && mkdir -p /vt/src/vitess.io/vitess/web/vtctld2
 
-COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld /vt/src/vitess.io/web/vtctld
-COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld2/app /vt/src/vitess.io/web/vtctld2/app
+COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld /vt/src/vitess.io/vitess/web/vtctld
+COPY --from=builder /vt/src/vitess.io/vitess/web/vtctld2/app /vt/src/vitess.io/vitess/web/vtctld2/app
 COPY --from=builder /vt/src/vitess.io/vitess/config /vt/config
 COPY --from=builder /vt/bin/mysqlctld /vt/bin/
 COPY --from=builder /vt/bin/vtctld /vt/bin/


### PR DESCRIPTION
The current path's in the Alpine Dockerfile for the Web files are incorrect. This prevents vtctld from rendering a web UI correctly. This change fixes the paths. 

Signed-off-by: DK <dk@planetscale.com>