### PR TITLE
helm: fixes for PMM and minor tweaks

### DIFF
--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.0.1, 2018-12-07
+## 1.0.2 - 2018-12-11
+
+### Bug fixes
+* Renamed ImagePullPolicy to imagePullPolicy
+* Added user-secret-volumes to backup CronJob
+
+## 1.0.1 - 2018-12-07
 
 ### Changes
 * Added support for [MySQL Custom Queries](https://www.percona.com/blog/2018/10/10/percona-monitoring-and-management-pmm-1-15-0-is-now-available/) in PMM
@@ -6,7 +12,7 @@
 * Added keyspace and shard labels to jobs
 * Remove old mysql.sock file in vttablet InitContainer
 
-### Bug fixes:
+### Bug fixes
 * PMM wouldn't bootstrap correctly on a new cluster
 
 ## 1.0.0, 2018-12-03 Vitess Helm Chart goes GA!

--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,0 +1,12 @@
+## 1.0.1, 2018-12-07
+
+### Changes
+* Added support for [MySQL Custom Queries](https://www.percona.com/blog/2018/10/10/percona-monitoring-and-management-pmm-1-15-0-is-now-available/) in PMM
+* Added Linux host monitoring for PMM
+* Added keyspace and shard labels to jobs
+* Remove old mysql.sock file in vttablet InitContainer
+
+### Bug fixes:
+* PMM wouldn't bootstrap correctly on a new cluster
+
+## 1.0.0, 2018-12-03 Vitess Helm Chart goes GA!

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 1.0.1
+version: 1.0.2
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 1.0.0
+version: 1.0.1
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/templates/_cron-jobs.tpl
+++ b/helm/vitess/templates/_cron-jobs.tpl
@@ -27,6 +27,7 @@ metadata:
     cell: {{ $cellClean | quote }}
     keyspace: {{ $keyspaceClean | quote }}
     shard: {{ $shardClean | quote }}
+    backupJob: "true"
 
 spec:
   schedule: {{ $shard.backup.cron.schedule | default $backup.cron.schedule | quote }}
@@ -45,6 +46,8 @@ spec:
             cell: {{ $cellClean | quote }}
             keyspace: {{ $keyspaceClean | quote }}
             shard: {{ $shardClean | quote }}
+            backupJob: "true"
+
         # pod spec
         spec:
           restartPolicy: Never

--- a/helm/vitess/templates/_jobs.tpl
+++ b/helm/vitess/templates/_jobs.tpl
@@ -20,6 +20,12 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app: vitess
+        component: vtctlclient
+        vtctlclientJob: "true"
+
     spec:
       restartPolicy: OnFailure
       containers:
@@ -62,6 +68,12 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app: vitess
+        component: vtworker
+        vtworkerJob: "true"
+
     spec:
 {{ include "pod-security" . | indent 6 }}
       restartPolicy: OnFailure

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -177,6 +177,11 @@ spec:
       if [ ! -z "$FIRST_RUN" ]; then
         cp -r /usr/local/percona_tmp/* /vtdataroot/pmm/percona || :
         cp -r /etc/init.d_tmp/* /vtdataroot/pmm/init.d || :
+      fi
+
+      # if this doesn't return an error, pmm-admin has already been configured
+      # and we want to stop/remove running services, in case pod ips have changed
+      if pmm-admin info; then
         pmm-admin stop --all
         pmm-admin rm --all
       fi

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -133,7 +133,8 @@ spec:
 ###################################
 {{ define "cont-pmm-client" -}}
 {{- $pmm := index . 0 -}}
-{{- $namespace := index . 1 }}
+{{- $namespace := index . 1 -}}
+{{- $keyspace := index . 2 }}
 
 - name: "pmm-client"
   image: "vitess/pmm-client:{{ $pmm.pmmTag }}"
@@ -141,6 +142,11 @@ spec:
   volumeMounts:
     - name: vtdataroot
       mountPath: "/vtdataroot"
+{{ if $keyspace.pmm }}{{if $keyspace.pmm.config }}
+    - name: config
+      mountPath: "/vt-pmm-config"
+{{ end }}{{ end }}
+
   ports:
     - containerPort: 42001
       name: query-data
@@ -173,11 +179,19 @@ spec:
       ln -s /vtdataroot/pmm/init.d /etc/init.d
       ln -s /vtdataroot/pmm/pmm-mysql-metrics-42002.log /var/log/pmm-mysql-metrics-42002.log
 
-      # workaround for when pod ips change
       if [ ! -z "$FIRST_RUN" ]; then
         cp -r /usr/local/percona_tmp/* /vtdataroot/pmm/percona || :
         cp -r /etc/init.d_tmp/* /vtdataroot/pmm/init.d || :
       fi
+
+{{ if $keyspace.pmm }}{{if $keyspace.pmm.config }}
+      # link all the configmap files into their expected file locations
+      for filename in /vt-pmm-config/*; do
+        DEST_FILE=/vtdataroot/pmm/percona/pmm-client/$(basename "$filename")
+        rm -f $DEST_FILE
+        ln -s "$filename" $DEST_FILE
+      done
+{{ end }}{{ end }}
 
       # if this doesn't return an error, pmm-admin has already been configured
       # and we want to stop/remove running services, in case pod ips have changed

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -210,6 +210,7 @@ spec:
       done
 
       # creates systemd services
+      pmm-admin add linux:metrics
       pmm-admin add mysql:metrics --user root --socket /vtdataroot/tabletdata/mysql.sock --force
       pmm-admin add mysql:queries --user root --socket /vtdataroot/tabletdata/mysql.sock --force --query-source=perfschema
 

--- a/helm/vitess/templates/_shard.tpl
+++ b/helm/vitess/templates/_shard.tpl
@@ -29,6 +29,15 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app: vitess
+        component: vttablet
+        cell: {{ $cellClean | quote }}
+        keyspace: {{ $keyspaceClean | quote }}
+        shard: {{ $shardClean | quote }}
+        initShardMasterJob: "true"
+
     spec:
       restartPolicy: OnFailure
       containers:
@@ -123,6 +132,15 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app: vitess
+        component: vttablet
+        cell: {{ $cellClean | quote }}
+        keyspace: {{ $keyspaceClean | quote }}
+        shard: {{ $shardClean | quote }}
+        copySchemaShardJob: "true"
+
     spec:
       restartPolicy: OnFailure
       containers:

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -111,7 +111,7 @@ spec:
 {{ include "cont-mysql-generallog" . | indent 8 }}
 {{ include "cont-mysql-errorlog" . | indent 8 }}
 {{ include "cont-mysql-slowlog" . | indent 8 }}
-{{ if $pmm.enabled }}{{ include "cont-pmm-client" (tuple $pmm $namespace) | indent 8 }}{{ end }}
+{{ if $pmm.enabled }}{{ include "cont-pmm-client" (tuple $pmm $namespace $keyspace) | indent 8 }}{{ end }}
 
       volumes:
         - name: vt
@@ -119,6 +119,11 @@ spec:
 {{ include "backup-volume" $config.backup | indent 8 }}
 {{ include "user-config-volume" (.extraMyCnf | default $defaultVttablet.extraMyCnf) | indent 8 }}
 {{ include "user-secret-volumes" (.secrets | default $defaultVttablet.secrets) | indent 8 }}
+{{ if $keyspace.pmm }}{{if $keyspace.pmm.config }}
+        - name: config
+          configMap:
+            name: {{ $keyspace.pmm.config }}
+{{ end }}{{ end }}
 
   volumeClaimTemplates:
     - metadata:

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -193,6 +193,9 @@ spec:
       touch /vtdataroot/tabletdata/slow-query.log
       touch /vtdataroot/tabletdata/general.log
 
+      # remove the old socket file if it is still around
+      rm -f /vtdataroot/tabletdata/mysql.sock
+
 {{- end -}}
 
 ###################################

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -129,6 +129,13 @@ topology:
       #           }
       #         }
 
+          ## this defines keyspace specific information for PMM
+          # pmm:
+            ## PMM supports collecting metrics from custom SQL queries in a file named queries-mysqld.yml
+            #  The specified ConfigMap will be mounted in a directory, so the file name is important.
+            #  https://www.percona.com/blog/2018/10/10/percona-monitoring-and-management-pmm-1-15-0-is-now-available/
+            # config: pmm-commerce-config
+
       # enable or disable mysql protocol support, with accompanying auth details
       mysqlProtocol:
         enabled: false


### PR DESCRIPTION
Here are some helm usability changes. The major new feature here is supporting PMM custom queries and other metrics collection. I'm using it now to run queries to get message metrics into prometheus, and it lays the groundwork for auto-importing Vitess metrics in a future release.

I'd like to start tagging all the docker images with helm release tags. It'd be relatively simple at first, just tag the latest image of each with `helm-1.0.1` or something like that. Since we rarely tag Vitess releases, this provides some kind of confidence that those helm tags will work with the corresponding helm version. Can I get access to tagging privileges?