### PR TITLE
Add scope to oauth token for gcs backup storage client

### DIFF
--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -230,7 +230,7 @@ func (bs *GCSBackupStorage) client(ctx context.Context) (*storage.Client, error)
 		// the creation context, so we create a new one, but
 		// keep the span information.
 		ctx = trace.CopySpan(context.Background(), ctx)
-		authClient, err := google.DefaultClient(ctx)
+		authClient, err := google.DefaultClient(ctx, storage.ScopeFullControl)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`storage.ScopeFullControl` is the default scope for `storage.NewClient`, but the `option.WithHTTPClient` option appears to get rid of that, as we experience an `"Empty or missing scope not allowed."` error when attempting to use service account credentials.

The error is reproducible thusly: https://gist.github.com/Santiclause/52029d7cbc9e8e0236fb023c3945ac40

Using `GOOGLE_APPLICATION_CREDENTIALS=creds.json ./bucket-test <bucket>` yields the same error, and this fix fixes it.

It's possible that just removing the `WithHTTPClient` option is preferable, but I don't know enough about the decision to include it to chime in one way or the other.

Other possibility that merits figuring out: whether this option would somehow break using an oauth token as `GOOGLE_APPLICATION_CREDENTIALS` instead of service account creds.