### PR TITLE
Adds removed vschema

### DIFF
--- a/examples/local/vschema.json
+++ b/examples/local/vschema.json
@@ -1,0 +1,18 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+    "messages": {
+      "column_vindexes": [
+        {
+          "column": "page",
+          "name": "hash"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Description 

* This vschema is still used by Vagrant setup. It was removed in a previous refactor. We can fully deprecate later by refactoring Vagrant start script to not use it. 