### PR TITLE
[local/examples] Fixes grpc auth options 

### DIFF
--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -55,10 +55,11 @@ then
 fi
 
 optional_auth_args='-mysql_auth_server_impl none'
+optional_grpc_auth_args=''
 if [ "$1" = "--enable-grpc-static-auth" ];
 then
 	  echo "Enabling Auth with static authentication in grpc"
-    optional_auth_args='-grpc_auth_static_client_creds ./grpc_static_client_auth.json'
+    optional_grpc_auth_args='-grpc_auth_static_client_creds ./grpc_static_client_auth.json'
 fi
 
 if [ "$1" = "--enable-mysql-static-auth" ];
@@ -84,6 +85,7 @@ $VTROOT/bin/vtgate \
   -service_map 'grpc-vtgateservice' \
   -pid_file $VTDATAROOT/tmp/vtgate.pid \
   $optional_auth_args \
+  $optional_grpc_auth_args \
   $optional_tls_args \
   > $VTDATAROOT/tmp/vtgate.out 2>&1 &
 


### PR DESCRIPTION
### Description

* There is a small regression introduced in: https://github.com/vitessio/vitess/commit/06cb4f4ab7ed284873ec3db5af0ec9f20f96958d#diff-c9cc9e15a55d3ec55e871a18bd5255b7L57. Now mysql auth overwrites grpc auth, so you can't use them in conjunction. This PR adds this functionality back. 