### PR TITLE
local example: fix typos

### DIFF
--- a/examples/local/306_down_shard_0.sh
+++ b/examples/local/306_down_shard_0.sh
@@ -21,6 +21,6 @@ set -e
 # shellcheck disable=SC2128
 script_root=$(dirname "${BASH_SOURCE}")
 
-CELL=zone1 UID_BASE=100 "$script_root/vttablet-down.sh"
+CELL=zone1 UID_BASE=200 "$script_root/vttablet-down.sh"
 
 disown -a

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -25,7 +25,7 @@ set -e
 script_root=$(dirname "${BASH_SOURCE}")
 
 ./vtgate-down.sh
-CELL=zone1 UID_BASE=200 "$script_root/vttablet-down.sh"
+CELL=zone1 UID_BASE=100 "$script_root/vttablet-down.sh"
 CELL=zone1 UID_BASE=300 "$script_root/vttablet-down.sh"
 CELL=zone1 UID_BASE=400 "$script_root/vttablet-down.sh"
 ./vtctld-down.sh
@@ -35,5 +35,7 @@ if [ "${TOPO}" = "etcd2" ]; then
 else
     CELL=zone1 "$script_root/zk-down.sh"
 fi
+
+rm -r $VTDATAROOT/*
 
 disown -a


### PR DESCRIPTION
The tablet kills were inverted between 100 vs 200
Also added a delete of all data on teardown

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>