### PR TITLE
fall back to environment variables when building without git

### DIFF
--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -17,6 +17,10 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $DIR/shell_functions.inc
 
+# Normal builds run directly against the git repo, but when packaging (for example with rpms)
+# a tar ball might be used, which will prevent the git metadata from being available.
+# Should this be the case then allow environment variables to be used to source
+# this information instead.
 _build_git_rev=$(git rev-parse --short HEAD)
 if [ -z "$_build_git_rev" ]; then
     _build_git_rev="$BUILD_GIT_REV"

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -17,11 +17,20 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $DIR/shell_functions.inc
 
+_build_git_rev=$(git rev-parse --short HEAD)
+if [ -z "$_build_git_rev" ]; then
+    _build_git_rev="$BUILD_GIT_REV"
+fi
+_build_git_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ -z "$_build_git_branch" ]; then
+    _build_git_branch="$BUILD_GIT_BRANCH"
+fi
+
 echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)' \
+  -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${_build_git_rev}' \
+  -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${_build_git_branch}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
   -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
 "


### PR DESCRIPTION
In our RPM build process, for whatever reason
it builds packages from a .git-less source.
This leads to the buildGit* variables not being set
and the corresponding BuildGit* in /debug/vars being empty.
We can export BUILD_GIT_* environment variables
during the build, though; this would fall back to those
in case the git commands come up empty.

Signed-off-by: Scott Lanning <scott.lanning@booking.com>