### PR TITLE
[vt/discovery] Add region context in `GetAggregateStats`

### DIFF
--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -70,7 +70,6 @@ type tabletStatsCacheEntry struct {
 	healthy []*TabletStats
 	// aggregates has the per-cell aggregates.
 	aggregates map[string]*querypb.AggregateStats
-
 	// aggregatesPerRegion has the per-region aggregates.
 	aggregatesPerRegion map[string]*querypb.AggregateStats
 }

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -498,6 +498,7 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 			return agg, nil
 		}
 	}
+
 	targetRegion := tc.getRegionByCell(target.Cell)
 	regionAggregateStats := &querypb.AggregateStats{SecondsBehindMasterMin: math.MaxUint32}
 	regionAggrFound := false

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -70,6 +70,9 @@ type tabletStatsCacheEntry struct {
 	healthy []*TabletStats
 	// aggregates has the per-cell aggregates.
 	aggregates map[string]*querypb.AggregateStats
+
+	// aggregatesPerRegion has the per-region aggregates.
+	aggregatesPerRegion map[string]*querypb.AggregateStats
 }
 
 func (e *tabletStatsCacheEntry) updateHealthyMapForMaster(ts *TabletStats) {
@@ -266,18 +269,21 @@ func (tc *TabletStatsCache) StatsUpdate(ts *TabletStats) {
 	tc.updateAggregateMap(ts.Target.Keyspace, ts.Target.Shard, ts.Target.TabletType, e, allArray)
 }
 
-// MakeAggregateMap takes a list of TabletStats and builds a per-cell
+// makeAggregateMap takes a list of TabletStats and builds a per-cell
 // AggregateStats map.
-func MakeAggregateMap(stats []*TabletStats) map[string]*querypb.AggregateStats {
+func (tc *TabletStatsCache) makeAggregateMap(stats []*TabletStats, buildForRegion bool) map[string]*querypb.AggregateStats {
 	result := make(map[string]*querypb.AggregateStats)
 	for _, ts := range stats {
-		cell := ts.Tablet.Alias.Cell
-		agg, ok := result[cell]
+		cellOrRegion := ts.Tablet.Alias.Cell
+		if buildForRegion {
+			cellOrRegion = tc.getRegionByCell(cellOrRegion)
+		}
+		agg, ok := result[cellOrRegion]
 		if !ok {
 			agg = &querypb.AggregateStats{
 				SecondsBehindMasterMin: math.MaxUint32,
 			}
-			result[cell] = agg
+			result[cellOrRegion] = agg
 		}
 
 		if ts.Serving && ts.LastError == nil {
@@ -295,9 +301,9 @@ func MakeAggregateMap(stats []*TabletStats) map[string]*querypb.AggregateStats {
 	return result
 }
 
-// MakeAggregateMapDiff computes the entries that need to be broadcast
+// makeAggregateMapDiff computes the entries that need to be broadcast
 // when the map goes from oldMap to newMap.
-func MakeAggregateMapDiff(keyspace, shard string, tabletType topodatapb.TabletType, ter int64, oldMap map[string]*querypb.AggregateStats, newMap map[string]*querypb.AggregateStats) []*srvtopo.TargetStatsEntry {
+func makeAggregateMapDiff(keyspace, shard string, tabletType topodatapb.TabletType, ter int64, oldMap map[string]*querypb.AggregateStats, newMap map[string]*querypb.AggregateStats) []*srvtopo.TargetStatsEntry {
 	var result []*srvtopo.TargetStatsEntry
 	for cell, oldValue := range oldMap {
 		newValue, ok := newMap[cell]
@@ -360,8 +366,9 @@ func MakeAggregateMapDiff(keyspace, shard string, tabletType topodatapb.TabletTy
 func (tc *TabletStatsCache) updateAggregateMap(keyspace, shard string, tabletType topodatapb.TabletType, e *tabletStatsCacheEntry, stats []*TabletStats) {
 	// Save the new value
 	oldAgg := e.aggregates
-	newAgg := MakeAggregateMap(stats)
+	newAgg := tc.makeAggregateMap(stats /* buildForRegion */, false)
 	e.aggregates = newAgg
+	e.aggregatesPerRegion = tc.makeAggregateMap(stats /* buildForRegion */, true)
 
 	// And broadcast the change in the background, if we need to.
 	tc.mu.RLock()
@@ -376,7 +383,7 @@ func (tc *TabletStatsCache) updateAggregateMap(keyspace, shard string, tabletTyp
 	if len(stats) > 0 {
 		ter = stats[0].TabletExternallyReparentedTimestamp
 	}
-	diffs := MakeAggregateMapDiff(keyspace, shard, tabletType, ter, oldAgg, newAgg)
+	diffs := makeAggregateMapDiff(keyspace, shard, tabletType, ter, oldAgg, newAgg)
 	tc.aggregatesChan <- diffs
 }
 
@@ -498,29 +505,12 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 			return agg, nil
 		}
 	}
-
 	targetRegion := tc.getRegionByCell(target.Cell)
-	regionAggregateStats := &querypb.AggregateStats{SecondsBehindMasterMin: math.MaxUint32}
-	regionAggrFound := false
-	for cell, agg := range e.aggregates {
-		cellRegion := tc.getRegionByCell(cell)
-		if cellRegion == targetRegion {
-			regionAggrFound = true
-			regionAggregateStats.HealthyTabletCount += agg.HealthyTabletCount
-			regionAggregateStats.UnhealthyTabletCount += agg.UnhealthyTabletCount
-			if agg.SecondsBehindMasterMin < regionAggregateStats.SecondsBehindMasterMin {
-				regionAggregateStats.SecondsBehindMasterMin = agg.SecondsBehindMasterMin
-			}
-			if regionAggregateStats.SecondsBehindMasterMax > agg.SecondsBehindMasterMax {
-				regionAggregateStats.SecondsBehindMasterMax = agg.SecondsBehindMasterMax
-			}
-		}
-	}
-	if !regionAggrFound {
+	agg, ok := e.aggregatesPerRegion[targetRegion]
+	if !ok {
 		return nil, topo.NewError(topo.NoNode, topotools.TargetIdent(target))
 	}
-	return regionAggregateStats, nil
-
+	return agg, nil
 }
 
 // GetMasterCell is part of the TargetStatsListener interface.

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -347,7 +347,12 @@ func benchmarkCellsGetAggregateStats(i int, b *testing.B) {
 	cellsToregions := make(map[string]string)
 	for j := 0; j < i; j++ {
 		cell := fmt.Sprintf("cell%v", j)
-		cellsToregions[cell] = "local"
+		// let's assume that there are few local cells
+		if j <= 4 {
+			cellsToregions[cell] = "local"
+		} else {
+			cellsToregions[cell] = "remote"
+		}
 	}
 
 	topo.UpdateCellsToRegionsForTests(cellsToregions)

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -206,6 +206,107 @@ func TestShuffleTablets(t *testing.T) {
 	}
 }
 
+func TestDiscoveryGatewayGetAggregateStats(t *testing.T) {
+	keyspace := "ks"
+	shard := "0"
+	hc := discovery.NewFakeHealthCheck()
+	dg := createDiscoveryGateway(hc, nil, "cell1", 2).(*discoveryGateway)
+
+	// replica should only use local ones
+	hc.Reset()
+	dg.tsc.ResetForTesting()
+	hc.AddTestTablet("cell1", "1.1.1.1", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+	hc.AddTestTablet("cell1", "2.2.2.2", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+	target := &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_REPLICA,
+		Cell:       "cell1",
+	}
+	tsl, err := dg.tsc.GetAggregateStats(target)
+	if err != nil {
+		t.Error(err)
+	}
+	if tsl.HealthyTabletCount != 2 {
+		t.Errorf("Expected 2 healthy replica tablets, got: %v", tsl.HealthyTabletCount)
+	}
+}
+
+func TestDiscoveryGatewayGetAggregateStatsRegion(t *testing.T) {
+	keyspace := "ks"
+	shard := "0"
+	hc := discovery.NewFakeHealthCheck()
+	dg := createDiscoveryGateway(hc, nil, "local-east", 2).(*discoveryGateway)
+
+	topo.UpdateCellsToRegionsForTests(map[string]string{
+		"local-west": "local",
+		"local-east": "local",
+		"remote":     "remote",
+	})
+
+	hc.Reset()
+	dg.tsc.ResetForTesting()
+	hc.AddTestTablet("remote", "1.1.1.1", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+	hc.AddTestTablet("local-west", "2.2.2.2", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+	hc.AddTestTablet("local-east", "3.3.3.3", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+
+	// Non master targets in the same region as the gateway should be discoverable
+	target := &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_REPLICA,
+		Cell:       "local-west",
+	}
+	tsl, err := dg.tsc.GetAggregateStats(target)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if tsl.HealthyTabletCount != 2 {
+		t.Errorf("Expected 2 healthy replica tablets, got: %v", tsl.HealthyTabletCount)
+	}
+}
+
+func TestDiscoveryGatewayGetAggregateStatsMaster(t *testing.T) {
+	keyspace := "ks"
+	shard := "0"
+	hc := discovery.NewFakeHealthCheck()
+	dg := createDiscoveryGateway(hc, nil, "cell1", 2).(*discoveryGateway)
+
+	// replica should only use local ones
+	hc.Reset()
+	dg.tsc.ResetForTesting()
+	hc.AddTestTablet("cell1", "1.1.1.1", 1001, keyspace, shard, topodatapb.TabletType_MASTER, true, 10, nil)
+	target := &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_MASTER,
+		Cell:       "cell1",
+	}
+	tsl, err := dg.tsc.GetAggregateStats(target)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if tsl.HealthyTabletCount != 1 {
+		t.Errorf("Expected one healthy master, got: %v", tsl.HealthyTabletCount)
+	}
+
+	// You can get aggregate regardless of the cell when requesting a master
+	target = &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_MASTER,
+		Cell:       "cell2",
+	}
+
+	tsl, err = dg.tsc.GetAggregateStats(target)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if tsl.HealthyTabletCount != 1 {
+		t.Errorf("Expected one healthy master, got: %v", tsl.HealthyTabletCount)
+	}
+}
+
 func TestDiscoveryGatewayGetTabletsWithRegion(t *testing.T) {
 	keyspace := "ks"
 	shard := "0"
@@ -227,6 +328,50 @@ func TestDiscoveryGatewayGetTabletsWithRegion(t *testing.T) {
 	tsl := dg.tsc.GetHealthyTabletStats(keyspace, shard, topodatapb.TabletType_REPLICA)
 	if len(tsl) != 2 || (!topo.TabletEquality(tsl[0].Tablet, ep1) && !topo.TabletEquality(tsl[0].Tablet, ep2)) {
 		t.Errorf("want %+v or %+v, got %+v", ep1, ep2, tsl)
+	}
+}
+
+func BenchmarkOneCellGetAggregateStats(b *testing.B) { benchmarkCellsGetAggregateStats(1, b) }
+
+func BenchmarkTenCellGetAggregateStats(b *testing.B) { benchmarkCellsGetAggregateStats(10, b) }
+
+func Benchmark100CellGetAggregateStats(b *testing.B) { benchmarkCellsGetAggregateStats(100, b) }
+
+func Benchmark1000CellGetAggregateStats(b *testing.B) { benchmarkCellsGetAggregateStats(1000, b) }
+
+func benchmarkCellsGetAggregateStats(i int, b *testing.B) {
+	keyspace := "ks"
+	shard := "0"
+	hc := discovery.NewFakeHealthCheck()
+	dg := createDiscoveryGateway(hc, nil, "cell0", 2).(*discoveryGateway)
+	cellsToregions := make(map[string]string)
+	for j := 0; j < i; j++ {
+		cell := fmt.Sprintf("cell%v", j)
+		cellsToregions[cell] = "local"
+	}
+
+	topo.UpdateCellsToRegionsForTests(cellsToregions)
+	hc.Reset()
+	dg.tsc.ResetForTesting()
+
+	for j := 0; j < i; j++ {
+		cell := fmt.Sprintf("cell%v", j)
+		ip := fmt.Sprintf("%v.%v.%v,%v", j, j, j, j)
+		hc.AddTestTablet(cell, ip, 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
+	}
+
+	target := &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      shard,
+		TabletType: topodatapb.TabletType_REPLICA,
+		Cell:       "cell0",
+	}
+
+	for n := 0; n < b.N; n++ {
+		_, err := dg.tsc.GetAggregateStats(target)
+		if err != nil {
+			b.Fatalf("Expected no error, got %v", err)
+		}
 	}
 }
 

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -347,12 +347,7 @@ func benchmarkCellsGetAggregateStats(i int, b *testing.B) {
 	cellsToregions := make(map[string]string)
 	for j := 0; j < i; j++ {
 		cell := fmt.Sprintf("cell%v", j)
-		// let's assume that there are few local cells
-		if j <= 4 {
-			cellsToregions[cell] = "local"
-		} else {
-			cellsToregions[cell] = "remote"
-		}
+		cellsToregions[cell] = "local"
 	}
 
 	topo.UpdateCellsToRegionsForTests(cellsToregions)


### PR DESCRIPTION
### Description

While testing a multi-cell setup using the regions feature, I discovered that there was a bug in the [original implementation](https://github.com/vitessio/vitess/pull/3460). 

As part of that PR [healthy](https://github.com/tinyspeck/vitess/blob/master/go/vt/discovery/tablet_stats_cache.go#L70) `tablet_stats` was modified to take the region into consideration. However, this was not the case for the [aggregates](https://github.com/tinyspeck/vitess/blob/master/go/vt/discovery/tablet_stats_cache.go#L72). This has the side effect that the [resolver](https://github.com/tinyspeck/vitess/blob/master/go/vt/srvtopo/resolver.go#L194) was not being able to find tablets that are in a different cell, but same region. 

My first idea was to change the aggregates to not be by cell but by region, but that creates some complications as these aggregates are used as part of `TargetStatsListener` interface which broadcast changes of targets. At the moment,`l2vtgates` rely on this interface.

I tried different approaches and right now I'm leaning towards adding `aggregatesPerRegion` to `tablet_stats_cache` and change the implementation of `GetAggregateStats` so it takes region into consideration when looking for aggregates stats.

I was pondering if it would make sense to make the Target aware of the region, but that seems like a very invasive change. 

### Tests

* I added some unit tests that were missing.
* My initial approach was to build **aggregates per region** on the fly, but that introduced a performance regression in `GetAggregateStats`... I added some benchmarks to make sure these changes do not introduce a regression in the resolver. 
* Tested these changes in our dev cluster.

### TODO

* **This implementation fixes this problem for vtgates. l2vtgates would need to be updated to have a similar fix. If we decide that the current approach is viable, I think we can do that as part of a different PR**
* Add an end-to-end test for multi-cell region functionality. Also, would like to add that once we decide on the approach here. 