### PR TITLE
vtgate: improve region support

### DIFF
--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -42,6 +42,7 @@ func addStatusParts(vtg *vtgate.VTGate) {
 	servenv.AddStatusPart("Gateway Status", gateway.StatusTemplate, func() interface{} {
 		return vtg.GetGatewayCacheStatus()
 	})
+	servenv.AddStatusFuncs(discovery.StatusFuncs)
 	servenv.AddStatusPart("Health Check Cache", discovery.HealthCheckTemplate, func() interface{} {
 		return healthCheck.CacheStatus()
 	})

--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -29,8 +29,9 @@ import (
 var onStatusRegistered func()
 
 func addStatusParts(vtg *vtgate.VTGate) {
+	servenv.AddStatusFuncs(discovery.StatusFuncs)
 	servenv.AddStatusPart("Executor", vtgate.ExecutorTemplate, func() interface{} {
-		return nil
+		return vtg.Executor()
 	})
 	servenv.AddStatusPart("VSchema", vtgate.VSchemaTemplate, func() interface{} {
 		return vtg.VSchemaStats()
@@ -42,7 +43,6 @@ func addStatusParts(vtg *vtgate.VTGate) {
 	servenv.AddStatusPart("Gateway Status", gateway.StatusTemplate, func() interface{} {
 		return vtg.GetGatewayCacheStatus()
 	})
-	servenv.AddStatusFuncs(discovery.StatusFuncs)
 	servenv.AddStatusPart("Health Check Cache", discovery.HealthCheckTemplate, func() interface{} {
 		return healthCheck.CacheStatus()
 	})

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -122,6 +122,7 @@ const (
 `
 )
 
+// StatusFuncs are used to render the debug UI
 var StatusFuncs = template.FuncMap{
 	"github_com_vitessio_vitess_discovery_region_for_cell": statusGetRegion,
 }

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -594,7 +594,7 @@ func TestTemplate(t *testing.T) {
 		Target:       &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
 		TabletsStats: ts,
 	}
-	templ := template.New("").Funcs(status.StatusFuncs)
+	templ := template.New("").Funcs(status.StatusFuncs).Funcs(StatusFuncs)
 	templ, err := templ.Parse(HealthCheckTemplate)
 	if err != nil {
 		t.Fatalf("error parsing template: %v", err)
@@ -626,7 +626,7 @@ func TestDebugURLFormatting(t *testing.T) {
 		Target:       &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
 		TabletsStats: ts,
 	}
-	templ := template.New("").Funcs(status.StatusFuncs)
+	templ := template.New("").Funcs(status.StatusFuncs).Funcs(StatusFuncs)
 	templ, err := templ.Parse(HealthCheckTemplate)
 	if err != nil {
 		t.Fatalf("error parsing template: %v", err)

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -653,6 +653,10 @@ func (l *listener) StatsUpdate(ts *TabletStats) {
 	l.output <- ts
 }
 
+func (l *listener) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}
+
 func createFakeConn(tablet *topodatapb.Tablet, c chan *querypb.StreamHealthResponse) *fakeConn {
 	key := TabletToMapKey(tablet)
 	conn := &fakeConn{

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -266,7 +266,7 @@ func (tc *TabletStatsCache) StatsUpdate(ts *TabletStats) {
 func (tc *TabletStatsCache) makeAggregateMap(stats []*TabletStats) map[string]*querypb.AggregateStats {
 	result := make(map[string]*querypb.AggregateStats)
 	for _, ts := range stats {
-		region := tc.getRegionByCell(ts.Tablet.Alias.Cell)
+		region := topo.GetRegion(ts.Tablet.Alias.Cell)
 		agg, ok := result[region]
 		if !ok {
 			agg = &querypb.AggregateStats{
@@ -376,7 +376,7 @@ func (tc *TabletStatsCache) GetAggregateStats(target *querypb.Target) (*querypb.
 			return agg, nil
 		}
 	}
-	targetRegion := tc.getRegionByCell(target.Cell)
+	targetRegion := topo.GetRegion(target.Cell)
 	agg, ok := e.aggregates[targetRegion]
 	if !ok {
 		return nil, topo.NewError(topo.NoNode, topotools.TargetIdent(target))

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"sync"
 
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -193,13 +192,10 @@ func (tc *TabletStatsCache) getOrCreateEntry(target *querypb.Target) *tabletStat
 	return e
 }
 
-func (tc *TabletStatsCache) getRegionByCell(cell string) string {
-	return topo.GetRegionByCell(context.Background(), tc.ts, cell)
-}
-
 // StatsUpdate is part of the HealthCheckStatsListener interface.
 func (tc *TabletStatsCache) StatsUpdate(ts *TabletStats) {
-	if ts.Target.TabletType != topodatapb.TabletType_MASTER && ts.Tablet.Alias.Cell != tc.cell && tc.getRegionByCell(ts.Tablet.Alias.Cell) != tc.getRegionByCell(tc.cell) {
+	if ts.Target.TabletType != topodatapb.TabletType_MASTER &&
+		topo.GetRegion(ts.Tablet.Alias.Cell) != topo.GetRegion(tc.cell) {
 		// this is for a non-master tablet in a different cell and a different region, drop it
 		return
 	}

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -338,6 +338,23 @@ func (tc *TabletStatsCache) GetHealthyTabletStats(keyspace, shard string, tablet
 	return result
 }
 
+// InStatsCache returns true if the tablet with the given key is in the cache
+func (tc *TabletStatsCache) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	e := tc.getEntry(keyspace, shard, tabletType)
+	if e == nil {
+		return false
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for _, ts := range e.healthy {
+		if ts.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 // ResetForTesting is for use in tests only.
 func (tc *TabletStatsCache) ResetForTesting() {
 	tc.mu.Lock()

--- a/go/vt/discovery/tablet_stats_cache_test.go
+++ b/go/vt/discovery/tablet_stats_cache_test.go
@@ -27,8 +27,8 @@ import (
 
 // TestTabletStatsCache tests the functionality of the TabletStatsCache class.
 func TestTabletStatsCache(t *testing.T) {
-	defer topo.UpdateCellsToRegionsForTests(map[string]string{})
-	topo.UpdateCellsToRegionsForTests(map[string]string{
+	defer topo.SetRegionMap(map[string]string{})
+	topo.SetRegionMap(map[string]string{
 		"cell":  "region1",
 		"cell1": "region1",
 		"cell2": "region2",

--- a/go/vt/discovery/tablet_stats_cache_test.go
+++ b/go/vt/discovery/tablet_stats_cache_test.go
@@ -47,6 +47,9 @@ func TestTabletStatsCache(t *testing.T) {
 	if len(a) != 0 {
 		t.Errorf("wrong result, expected empty list: %v", a)
 	}
+	if tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t1") {
+		t.Errorf("didn't expect ts1 to be in cache")
+	}
 
 	// add a tablet
 	tablet1 := topo.NewTablet(10, "cell", "host1")
@@ -69,6 +72,9 @@ func TestTabletStatsCache(t *testing.T) {
 	if len(a) != 1 || !ts1.DeepEqual(&a[0]) {
 		t.Errorf("unexpected result: %v", a)
 	}
+	if !tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t1") {
+		t.Errorf("expected ts1 to be in cache")
+	}
 
 	// update stats with a change that won't change health array
 	stillHealthyTs1 := &TabletStats{
@@ -90,6 +96,9 @@ func TestTabletStatsCache(t *testing.T) {
 	if len(a) != 1 || !ts1.DeepEqual(&a[0]) {
 		t.Errorf("unexpected result: %v", a)
 	}
+	if !tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t1") {
+		t.Errorf("expected ts1 to be in cache")
+	}
 
 	// update stats with a change that will change arrays
 	notHealthyTs1 := &TabletStats{
@@ -110,6 +119,9 @@ func TestTabletStatsCache(t *testing.T) {
 	a = tsc.GetHealthyTabletStats("k", "s", topodatapb.TabletType_REPLICA)
 	if len(a) != 1 || !notHealthyTs1.DeepEqual(&a[0]) {
 		t.Errorf("unexpected result: %v", a)
+	}
+	if !tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t1") {
+		t.Errorf("expected ts1 to be in cache")
 	}
 
 	// add a second tablet
@@ -146,6 +158,9 @@ func TestTabletStatsCache(t *testing.T) {
 		if !ts1.DeepEqual(&a[0]) || !ts2.DeepEqual(&a[1]) {
 			t.Errorf("unexpected result: %v", a)
 		}
+	}
+	if !tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t2") {
+		t.Errorf("expected ts2 to be in cache")
 	}
 
 	// one tablet goes unhealthy
@@ -235,6 +250,9 @@ func TestTabletStatsCache(t *testing.T) {
 	if len(a) != 1 {
 		t.Errorf("unexpected result: %v", a)
 	}
+	if !tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t3") {
+		t.Errorf("expected ts3 to be in cache")
+	}
 
 	// add a 4th slave tablet in a diff cell, diff region
 	tablet4 := topo.NewTablet(13, "cell2", "host4")
@@ -255,5 +273,8 @@ func TestTabletStatsCache(t *testing.T) {
 	a = tsc.GetHealthyTabletStats("k", "s", topodatapb.TabletType_REPLICA)
 	if len(a) != 1 {
 		t.Errorf("unexpected result: %v", a)
+	}
+	if tsc.InStatsCache("k", "s", topodatapb.TabletType_REPLICA, "t4") {
+		t.Errorf("expected ts4 to not be in cache")
 	}
 }

--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -805,6 +805,11 @@ func (shardSwap *shardSchemaSwap) StatsUpdate(newTabletStats *discovery.TabletSt
 	}
 }
 
+// InStatsCache is part of the discovery.HealthCheckStatsListener interface
+func (shardSwap *shardSchemaSwap) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}
+
 // getTabletList returns the list of all known tablets in the shard so that the caller
 // could operate with it without holding the allTabletsLock.
 func (shardSwap *shardSchemaSwap) getTabletList() []discovery.TabletStats {

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -285,6 +285,11 @@ func (c *client) StatsUpdate(ts *discovery.TabletStats) {
 	c.throttler.RecordReplicationLag(time.Now(), ts)
 }
 
+// InStatsCache is part of the discovery.HealthCheckStatsListener interface
+func (c *client) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}
+
 func main() {
 	flag.Parse()
 

--- a/go/vt/topo/region.go
+++ b/go/vt/topo/region.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Google Inc.
+Copyright 2018 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/topo/region.go
+++ b/go/vt/topo/region.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topo
+
+import (
+	"golang.org/x/net/context"
+)
+
+type regionMap struct {
+	cellsToRegions map[string]string
+}
+
+var regions = regionMap{
+	cellsToRegions: make(map[string]string),
+}
+
+// InitRegions resolves the region name for the given set of
+// cells. It must be called during initialization time before
+// GetRegion is ever used.
+//
+// By convention, if there is no region specified in the cell info,
+// we use the cell name itself as the region.
+func InitRegions(ctx context.Context, ts *Server, cells []string) error {
+	for _, cell := range cells {
+		info, err := ts.GetCellInfo(ctx, cell, false)
+		switch {
+		case err == nil:
+			if info.Region != "" {
+				regions.cellsToRegions[cell] = info.Region
+			} else {
+				regions.cellsToRegions[cell] = cell
+			}
+		case IsErrType(err, NoNode):
+			regions.cellsToRegions[cell] = cell
+		default:
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetRegionMap is used only for tests.
+func SetRegionMap(cellsToRegions map[string]string) {
+	regions.cellsToRegions = cellsToRegions
+}
+
+// GetRegion returns the region for the given `cell`.
+//
+// By convention, if there is no region specified in the cell info,
+// we use the cell name itself as the region.
+//
+// Note that the access to regions is *NOT* protected by a
+// mutex. All region mappings must be defined statically at
+// initialization time so this mapping is safe to access
+// concurrently.
+func GetRegion(cell string) string {
+	if region, ok := regions.cellsToRegions[cell]; ok {
+		return region
+	}
+	return cell
+}

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -245,7 +245,7 @@ func TestAPI(t *testing.T) {
 		// Tablet Health
 		{"GET", "tablet_health/cell1/100", "", `{ "Key": "", "Tablet": { "alias": { "cell": "cell1", "uid": 100 },"port_map": { "vt": 100 }, "keyspace": "ks1", "shard": "-80", "type": 2},
 		  "Name": "", "Target": { "keyspace": "ks1", "shard": "-80", "tablet_type": 2 }, "Up": true, "Serving": true, "TabletExternallyReparentedTimestamp": 0,
-		  "Stats": { "seconds_behind_master": 100 }, "LastError": null }`},
+		  "Stats": { "seconds_behind_master": 100 }, "LastError": null, "InStatsCache": false }`},
 		{"GET", "tablet_health/cell1", "", "can't get tablet_health: invalid tablet_health path: \"cell1\"  expected path: /tablet_health/<cell>/<uid>"},
 		{"GET", "tablet_health/cell1/gh", "", "can't get tablet_health: incorrect uid: bad tablet uid strconv.ParseUint: parsing \"gh\": invalid syntax"},
 

--- a/go/vt/vtctld/tablet_stats_cache.go
+++ b/go/vt/vtctld/tablet_stats_cache.go
@@ -165,6 +165,11 @@ func (c *tabletStatsCache) StatsUpdate(stats *discovery.TabletStats) {
 	*ts = *stats
 }
 
+// InStatsCache is part of the HealthCheckStatsListener interface
+func (c *tabletStatsCache) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}
+
 func tabletToMapKey(stats *discovery.TabletStats) string {
 	return stats.Tablet.Alias.String()
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1225,6 +1225,11 @@ func (e *Executor) VSchema() *vindexes.VSchema {
 	return e.vschema
 }
 
+// Cell returns the current Cell.
+func (e *Executor) Cell() string {
+	return e.cell
+}
+
 // SaveVSchema updates the vschema and stats
 func (e *Executor) SaveVSchema(vschema *vindexes.VSchema, stats *VSchemaStats) {
 	e.mu.Lock()

--- a/go/vt/vtgate/executor_stats.go
+++ b/go/vt/vtgate/executor_stats.go
@@ -29,6 +29,8 @@ const (
 </td>
 
 <td width="50%" style="padding: 20px;">
+  <b>Cell:</b> {{github_com_vitessio_vitess_discovery_region_for_cell .Cell}}{{.Cell}}<br>
+  <br>
   <a href="/debug/health">Health</a><br>
   <a href="/debug/querylogz">Current Query Log</a><br>
   <a href="/debug/queryz">Query Plan Stats</a><br>

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -109,6 +109,16 @@ func createDiscoveryGateway(hc discovery.HealthCheck, serv srvtopo.Server, cell 
 	// We set sendDownEvents=true because it's required by TabletStatsCache.
 	hc.SetListener(dg, true /* sendDownEvents */)
 
+	// Resolve the cell to region mapping at initialization time before
+	// loading any of the tablets.
+	if topoServer != nil {
+		log.Infof("loading region information for cells: %v", *cellsToWatch)
+		err := topo.InitRegions(context.Background(), topoServer, strings.Split(*cellsToWatch, ","))
+		if err != nil {
+			log.Exitf("cannot load regions for cells: %v", err)
+		}
+	}
+
 	log.Infof("loading tablets for cells: %v", *cellsToWatch)
 	for _, c := range strings.Split(*cellsToWatch, ",") {
 		if c == "" {

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -182,6 +182,12 @@ func (dg *discoveryGateway) StatsUpdate(ts *discovery.TabletStats) {
 	}
 }
 
+// InStatsCache is called by HealthCheck to determine if the given tablet is
+// in the cache
+func (dg *discoveryGateway) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return dg.tsc.InStatsCache(keyspace, shard, tabletType, key)
+}
+
 // WaitForTablets is part of the gateway.Gateway interface.
 func (dg *discoveryGateway) WaitForTablets(ctx context.Context, tabletTypesToWait []topodatapb.TabletType) error {
 	// Skip waiting for tablets if we are not told to do so.

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -128,8 +128,8 @@ func TestDiscoveryGatewayGetTablets(t *testing.T) {
 }
 
 func TestShuffleTablets(t *testing.T) {
-	defer topo.UpdateCellsToRegionsForTests(map[string]string{})
-	topo.UpdateCellsToRegionsForTests(map[string]string{
+	defer topo.SetRegionMap(map[string]string{})
+	topo.SetRegionMap(map[string]string{
 		"cell1": "region1",
 		"cell2": "region1",
 	})
@@ -312,7 +312,7 @@ func TestDiscoveryGatewayGetTabletsWithRegion(t *testing.T) {
 	shard := "0"
 	hc := discovery.NewFakeHealthCheck()
 	dg := createDiscoveryGateway(hc, nil, "local", 2).(*discoveryGateway)
-	topo.UpdateCellsToRegionsForTests(map[string]string{
+	topo.SetRegionMap(map[string]string{
 		"local-west": "local",
 		"local-east": "local",
 		"local":      "local",

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -238,7 +238,7 @@ func TestDiscoveryGatewayGetAggregateStatsRegion(t *testing.T) {
 	hc := discovery.NewFakeHealthCheck()
 	dg := createDiscoveryGateway(hc, nil, "local-east", 2).(*discoveryGateway)
 
-	topo.UpdateCellsToRegionsForTests(map[string]string{
+	topo.SetRegionMap(map[string]string{
 		"local-west": "local",
 		"local-east": "local",
 		"remote":     "remote",
@@ -350,7 +350,7 @@ func benchmarkCellsGetAggregateStats(i int, b *testing.B) {
 		cellsToregions[cell] = "local"
 	}
 
-	topo.UpdateCellsToRegionsForTests(cellsToregions)
+	topo.SetRegionMap(cellsToregions)
 	hc.Reset()
 	dg.tsc.ResetForTesting()
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -273,6 +273,11 @@ func (vtg *VTGate) Gateway() gateway.Gateway {
 	return vtg.gw
 }
 
+// Executor returns the executor. Used for the debug status UI
+func (vtg *VTGate) Executor() *Executor {
+	return vtg.executor
+}
+
 // Execute executes a non-streaming query. This is a V3 function.
 func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable) (newSession *vtgatepb.Session, qr *sqltypes.Result, err error) {
 	// In this context, we don't care if we can't fully parse destination

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -329,3 +329,8 @@ func (ts *txThrottlerState) StatsUpdate(tabletStats *discovery.TabletStats) {
 	}
 	ts.throttler.RecordReplicationLag(time.Now(), tabletStats)
 }
+
+// InStatsCache is part of the discovery.HealthCheckStatsListener interface
+func (ts *txThrottlerState) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -1165,6 +1165,11 @@ func (scw *SplitCloneWorker) StatsUpdate(ts *discovery.TabletStats) {
 	}
 }
 
+// InStatsCache is part of the discovery.HealthCheckStatsListener interface
+func (scw *SplitCloneWorker) InStatsCache(keyspace, shard string, tabletType topodatapb.TabletType, key string) bool {
+	return false
+}
+
 func (scw *SplitCloneWorker) createThrottlers() error {
 	scw.throttlersMu.Lock()
 	defer scw.throttlersMu.Unlock()


### PR DESCRIPTION
## Description
Refactor the region mapping support and improve the vtgate debug status page to show regions.

## Details
There are three sets of changes in the PR:

1. Rework the topo implementation to resolve a region for a given cell.

The previous implementation of the cell to region mapping relied on lazily populating the mapping of cells to regions as part of the ~query routing tier~ healthcheck update path, using a local in memory cache backed by potentially fetching from the topo on demand.

Rework the API so that the region mapping is initialized proactively as part of the gateway initialization path, which allows the map to be used *without a wrapping mutex* by the query serving tier and better reflects the intended design.

This is safe because the cells to watch are known at initialization time and it never needs to resolve a region for some cell that we're not watching.

2.  Expose a HealthCheckStatsListener hook to query the stats cache

As part of debugging problems in the cross-cell region support, it was important to know whether or not a tablet was being populated in the TabletStatsCache, but the existing debug status UI didn't expose this information.

To make this work, add a new method to the HealthCheckStatsListener interface to query whether or not a given tablet is being tracked in the downstream cache, and call this from the debug UI when populating the healthcheck data.

3. Add region information to the debug status page

Expose the cell through the Executor to be able to show which cell the vtgate is configured into, prefixed with the region if the name of the region doesn't match the name of the cell.

Using the new topo.GetRegion API, do the same for all the tablets being monitored by healthcheck.
 

## Screenshots
Vtgate running in cell "us_east_1" which also happens to be region "us_east_1" in our setup:
![image](https://user-images.githubusercontent.com/3308504/50167680-8f133600-029e-11e9-80ed-76e806df0c99.png)

Same vtgate but restarted to be in cell "us_east_1a" in region "us_east_1":
![image](https://user-images.githubusercontent.com/3308504/50167819-da2d4900-029e-11e9-8175-2540a33fb3e2.png)

Also same vtgate showing a number of tablets in us_east_1 (same cell and region) and one tablet in cell us_east_1a (region us_east_1). Note that all are "In Cache" even though they are different cells:
![image](https://user-images.githubusercontent.com/3308504/50167729-ace09b00-029e-11e9-8383-8007d1c12ee1.png)

