### PR TITLE
reformat using go 1.11 formatter

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -308,8 +308,8 @@ func ShowIndexFromTableRow(table string, unique bool, keyName string, seqInIndex
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(columnName)),
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte("A")), // Collation
 		sqltypes.MakeTrusted(sqltypes.Int64, []byte("0")),   // Cardinality
-		sqltypes.NULL,                                       // Sub_part
-		sqltypes.NULL,                                       // Packed
+		sqltypes.NULL, // Sub_part
+		sqltypes.NULL, // Packed
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(nullableStr)),
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte("BTREE")), // Index_type
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte("")),      // Comment

--- a/go/vt/automation/scheduler.go
+++ b/go/vt/automation/scheduler.go
@@ -82,11 +82,11 @@ func NewScheduler() (*Scheduler, error) {
 		registeredClusterOperations:    defaultClusterOperations,
 		idGenerator:                    IDGenerator{},
 		toBeScheduledClusterOperations: make(chan ClusterOperationInstance, 10),
-		state:                     stateNotRunning,
-		taskCreator:               defaultTaskCreator,
-		pendingOpsWg:              &sync.WaitGroup{},
-		activeClusterOperations:   make(map[string]ClusterOperationInstance),
-		finishedClusterOperations: make(map[string]ClusterOperationInstance),
+		state:                          stateNotRunning,
+		taskCreator:                    defaultTaskCreator,
+		pendingOpsWg:                   &sync.WaitGroup{},
+		activeClusterOperations:        make(map[string]ClusterOperationInstance),
+		finishedClusterOperations:      make(map[string]ClusterOperationInstance),
 	}
 
 	return s, nil

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -37,8 +37,8 @@ var (
 		InsertID:     0,
 		Rows: [][]sqltypes.Value{
 			{
-				sqltypes.NewVarBinary("MariaDB/0-1-1083"),    // pos
-				sqltypes.NULL,                                // stop_pos
+				sqltypes.NewVarBinary("MariaDB/0-1-1083"), // pos
+				sqltypes.NULL, // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
 			},

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -85,18 +85,18 @@ func TestHealthCheck(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Up:      true,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Up:                                  true,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 10,
 	}
 	input <- shr
@@ -116,12 +116,12 @@ func TestHealthCheck(t *testing.T) {
 		Cell:   "cell",
 		Target: &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
 		TabletsStats: TabletStatsList{{
-			Key:     "a,vt:1",
-			Tablet:  tablet,
-			Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-			Up:      true,
-			Serving: true,
-			Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+			Key:                                 "a,vt:1",
+			Tablet:                              tablet,
+			Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+			Up:                                  true,
+			Serving:                             true,
+			Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 			TabletExternallyReparentedTimestamp: 10,
 		}},
 	}}
@@ -132,20 +132,20 @@ func TestHealthCheck(t *testing.T) {
 
 	// TabletType changed, should get both old and new event
 	shr = &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.5},
 	}
 	input <- shr
 	t.Logf(`input <- {{Keyspace: "k", Shard: "s", TabletType: REPLICA}, Serving: true, TabletExternallyReparentedTimestamp: 0, {SecondsBehindMaster: 1, CpuUsage: 0.5}}`)
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Up:      false,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Up:                                  false,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 10,
 	}
 	res = <-l.output
@@ -153,12 +153,12 @@ func TestHealthCheck(t *testing.T) {
 		t.Errorf(`<-l.output: %+v; want %+v`, res, want)
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      true,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.5},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  true,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.5},
 		TabletExternallyReparentedTimestamp: 0,
 	}
 	res = <-l.output
@@ -173,18 +173,18 @@ func TestHealthCheck(t *testing.T) {
 
 	// Serving & RealtimeStats changed
 	shr = &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving: false,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             false,
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      true,
-		Serving: false,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  true,
+		Serving:                             false,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 		TabletExternallyReparentedTimestamp: 0,
 	}
 	input <- shr
@@ -197,18 +197,18 @@ func TestHealthCheck(t *testing.T) {
 
 	// HealthError
 	shr = &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      true,
-		Serving: false,
-		Stats:   &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  true,
+		Serving:                             false,
+		Stats:                               &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
 		TabletExternallyReparentedTimestamp: 0,
 		LastError:                           fmt.Errorf("vttablet error: some error"),
 	}
@@ -224,12 +224,12 @@ func TestHealthCheck(t *testing.T) {
 	hc.deleteConn(tablet)
 	t.Logf(`hc.RemoveTablet({Host: "a", PortMap: {"vt": 1}})`)
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      false,
-		Serving: false,
-		Stats:   &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  false,
+		Serving:                             false,
+		Stats:                               &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
 		TabletExternallyReparentedTimestamp: 0,
 		LastError:                           context.Canceled,
 	}
@@ -271,18 +271,18 @@ func TestHealthCheckStreamError(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      true,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  true,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 0,
 	}
 	input <- shr
@@ -295,12 +295,12 @@ func TestHealthCheckStreamError(t *testing.T) {
 	// Stream error
 	fc.errCh <- fmt.Errorf("some stream error")
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Up:      true,
-		Serving: false,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Up:                                  true,
+		Serving:                             false,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 0,
 		LastError:                           fmt.Errorf("some stream error"),
 	}
@@ -342,9 +342,9 @@ func TestHealthCheckVerifiesTabletAlias(t *testing.T) {
 	}
 
 	input <- &querypb.StreamHealthResponse{
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		TabletAlias: &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
-		Serving:     true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		TabletAlias:                         &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
@@ -360,9 +360,9 @@ func TestHealthCheckVerifiesTabletAlias(t *testing.T) {
 	}
 
 	input <- &querypb.StreamHealthResponse{
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		TabletAlias: &topodatapb.TabletAlias{Uid: 1, Cell: "cell"},
-		Serving:     true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		TabletAlias:                         &topodatapb.TabletAlias{Uid: 1, Cell: "cell"},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
@@ -409,18 +409,18 @@ func TestHealthCheckCloseWaitsForGoRoutines(t *testing.T) {
 
 	// Verify that the listener works in general.
 	shr := &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Up:      true,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Up:                                  true,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 10,
 	}
 	input <- shr
@@ -504,18 +504,18 @@ func TestHealthCheckTimeout(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving: true,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletStats{
-		Key:     "a,vt:1",
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Up:      true,
-		Serving: true,
-		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Key:                                 "a,vt:1",
+		Tablet:                              tablet,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Up:                                  true,
+		Serving:                             true,
+		Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 		TabletExternallyReparentedTimestamp: 10,
 	}
 	input <- shr
@@ -580,12 +580,12 @@ func TestTemplate(t *testing.T) {
 	tablet := topo.NewTablet(0, "cell", "a")
 	ts := []*TabletStats{
 		{
-			Key:     "a",
-			Tablet:  tablet,
-			Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-			Up:      true,
-			Serving: false,
-			Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
+			Key:                                 "a",
+			Tablet:                              tablet,
+			Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+			Up:                                  true,
+			Serving:                             false,
+			Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 			TabletExternallyReparentedTimestamp: 0,
 		},
 	}
@@ -612,12 +612,12 @@ func TestDebugURLFormatting(t *testing.T) {
 	tablet := topo.NewTablet(0, "cell", "host.dc.domain")
 	ts := []*TabletStats{
 		{
-			Key:     "a",
-			Tablet:  tablet,
-			Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-			Up:      true,
-			Serving: false,
-			Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
+			Key:                                 "a",
+			Tablet:                              tablet,
+			Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+			Up:                                  true,
+			Serving:                             false,
+			Stats:                               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 			TabletExternallyReparentedTimestamp: 0,
 		},
 	}

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -318,7 +318,7 @@ func MakeAggregateMapDiff(keyspace, shard string, tabletType topodatapb.TabletTy
 					TabletType: tabletType,
 					Cell:       cell,
 				},
-				Stats: newValue,
+				Stats:                               newValue,
 				TabletExternallyReparentedTimestamp: ter,
 			})
 		} else {
@@ -347,7 +347,7 @@ func MakeAggregateMapDiff(keyspace, shard string, tabletType topodatapb.TabletTy
 				TabletType: tabletType,
 				Cell:       cell,
 			},
-			Stats: newValue,
+			Stats:                               newValue,
 			TabletExternallyReparentedTimestamp: ter,
 		})
 	}
@@ -460,7 +460,7 @@ func (tc *TabletStatsCache) Subscribe() (int, []srvtopo.TargetStatsEntry, <-chan
 							TabletType: tabletType,
 							Cell:       cell,
 						},
-						Stats: agg,
+						Stats:                               agg,
 						TabletExternallyReparentedTimestamp: ter,
 					})
 				}

--- a/go/vt/srvtopo/keyspace_filtering_server_test.go
+++ b/go/vt/srvtopo/keyspace_filtering_server_test.go
@@ -36,15 +36,15 @@ var (
 	stockCtx       = context.Background()
 	stockFilters   = []string{"bar", "baz"}
 	stockKeyspaces = map[string]*topodatapb.SrvKeyspace{
-		"foo": &topodatapb.SrvKeyspace{ShardingColumnName: "foo"},
-		"bar": &topodatapb.SrvKeyspace{ShardingColumnName: "bar"},
-		"baz": &topodatapb.SrvKeyspace{ShardingColumnName: "baz"},
+		"foo": {ShardingColumnName: "foo"},
+		"bar": {ShardingColumnName: "bar"},
+		"baz": {ShardingColumnName: "baz"},
 	}
 	stockVSchema = &vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
-			"foo": &vschemapb.Keyspace{Sharded: true},
-			"bar": &vschemapb.Keyspace{Sharded: true},
-			"baz": &vschemapb.Keyspace{Sharded: false},
+			"foo": {Sharded: true},
+			"bar": {Sharded: true},
+			"baz": {Sharded: false},
 		},
 	}
 )

--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -94,8 +94,8 @@ func TestBuffer(t *testing.T) {
 	// an external failover tool, the timestamp will be increased (even though
 	// the master did not change.)
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: oldMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              oldMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -124,8 +124,8 @@ func TestBuffer(t *testing.T) {
 	// Mimic the failover end.
 	now = now.Add(1 * time.Second)
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -185,8 +185,8 @@ func TestBuffer(t *testing.T) {
 	}
 	// Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: oldMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              oldMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 	if err := <-stopped4; err != nil {
@@ -322,8 +322,8 @@ func TestDryRun(t *testing.T) {
 
 	// End of failover is tracked as well.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
 	if err := waitForState(b, stateIdle); err != nil {
@@ -374,8 +374,8 @@ func TestLastReparentTooRecent_BufferingSkipped(t *testing.T) {
 	// very recently (time.Now()).
 	// vtgate should see this immediately after the start.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: oldMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              oldMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -383,8 +383,8 @@ func TestLastReparentTooRecent_BufferingSkipped(t *testing.T) {
 	// Do not start buffering.
 	now = now.Add(1 * time.Second)
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -418,8 +418,8 @@ func TestLastReparentTooRecent_Buffering(t *testing.T) {
 	// very recently (time.Now()).
 	// vtgate should see this immediately after the start.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: oldMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              oldMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -427,8 +427,8 @@ func TestLastReparentTooRecent_Buffering(t *testing.T) {
 	// there was 0 QPS traffic and no buffering was started.
 	now = now.Add(1 * time.Second)
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -442,8 +442,8 @@ func TestLastReparentTooRecent_Buffering(t *testing.T) {
 	}
 	// And then the failover end.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
@@ -481,8 +481,8 @@ func TestPassthroughDuringDrain(t *testing.T) {
 
 	// Stop buffering and trigger drain.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
 	if got, want := b.getOrCreateBuffer(keyspace, shard).state, stateDraining; got != want {
@@ -596,8 +596,8 @@ func testRequestCanceled(t *testing.T, explicitEnd bool) {
 
 	if explicitEnd {
 		b.StatsUpdate(&discovery.TabletStats{
-			Tablet: newMaster,
-			Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+			Tablet:                              newMaster,
+			Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 			TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 		})
 	}
@@ -615,8 +615,8 @@ func testRequestCanceled(t *testing.T, explicitEnd bool) {
 	// shortly after. In that case, the buffer should ignore it.
 	if !explicitEnd {
 		b.StatsUpdate(&discovery.TabletStats{
-			Tablet: newMaster,
-			Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+			Tablet:                              newMaster,
+			Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 			TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 		})
 	}
@@ -661,8 +661,8 @@ func TestEviction(t *testing.T) {
 
 	// End of failover. Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
 
@@ -744,8 +744,8 @@ func TestEvictionNotPossible(t *testing.T) {
 
 	// End of failover. Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
-		Tablet: newMaster,
-		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		Tablet:                              newMaster,
+		Target:                              &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
 	if err := <-stoppedFirstFailover; err != nil {

--- a/go/vt/vtgate/gateway/gateway.go
+++ b/go/vt/vtgate/gateway/gateway.go
@@ -148,7 +148,7 @@ func StreamHealthFromTargetStatsListener(ctx context.Context, l srvtopo.TargetSt
 	// Send all current entries.
 	for _, e := range entries {
 		shr := &querypb.StreamHealthResponse{
-			Target: e.Target,
+			Target:                              e.Target,
 			TabletExternallyReparentedTimestamp: e.TabletExternallyReparentedTimestamp,
 			AggregateStats:                      e.Stats,
 		}
@@ -168,7 +168,7 @@ func StreamHealthFromTargetStatsListener(ctx context.Context, l srvtopo.TargetSt
 				return fmt.Errorf("channel closed")
 			}
 			shr := &querypb.StreamHealthResponse{
-				Target: e.Target,
+				Target:                              e.Target,
 				TabletExternallyReparentedTimestamp: e.TabletExternallyReparentedTimestamp,
 				AggregateStats:                      e.Stats,
 			}

--- a/go/vt/vtgate/gatewaytest/suite.go
+++ b/go/vt/vtgate/gatewaytest/suite.go
@@ -49,8 +49,8 @@ func CreateFakeServers(t *testing.T) (*tabletconntest.FakeQueryService, *topo.Se
 	f := tabletconntest.CreateFakeServer(t)
 	f.TestingGateway = true
 	f.StreamHealthResponse = &querypb.StreamHealthResponse{
-		Target:  tabletconntest.TestTarget,
-		Serving: true,
+		Target:                              tabletconntest.TestTarget,
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 1234589,
 		RealtimeStats: &querypb.RealtimeStats{
 			SecondsBehindMaster: 1,

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -751,14 +751,14 @@ var TestStreamHealthStreamHealthResponse = &querypb.StreamHealthResponse{
 		Shard:      "test_shard",
 		TabletType: topodatapb.TabletType_RDONLY,
 	},
-	Serving: true,
+	Serving:                             true,
 	TabletExternallyReparentedTimestamp: 1234589,
 	RealtimeStats: &querypb.RealtimeStats{
 		HealthError:                            "random error",
 		SecondsBehindMaster:                    234,
 		BinlogPlayersCount:                     1,
 		SecondsBehindMasterFilteredReplication: 2,
-		CpuUsage: 1.0,
+		CpuUsage:                               1.0,
 	},
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -39,8 +39,8 @@ var (
 		InsertID:     0,
 		Rows: [][]sqltypes.Value{
 			{
-				sqltypes.NewVarBinary("MariaDB/0-1-1083"),    // pos
-				sqltypes.NULL,                                // stop_pos
+				sqltypes.NewVarBinary("MariaDB/0-1-1083"), // pos
+				sqltypes.NULL, // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
 			},

--- a/go/vt/vttablet/tabletserver/splitquery/splitter_test.go
+++ b/go/vt/vttablet/tabletserver/splitquery/splitter_test.go
@@ -459,7 +459,7 @@ func TestSplitWithExistingBindVariables(t *testing.T) {
 					" (id < :_splitquery_end_id or" +
 					" (id = :_splitquery_end_id and user_id < :_splitquery_end_user_id))",
 				BindVariables: map[string]*querypb.BindVariable{
-					"foo": sqltypes.Int64BindVariable(100),
+					"foo":                       sqltypes.Int64BindVariable(100),
 					"_splitquery_start_id":      sqltypes.Int64BindVariable(1),
 					"_splitquery_start_user_id": sqltypes.Int64BindVariable(2),
 					"_splitquery_end_id":        sqltypes.Int64BindVariable(1),
@@ -476,7 +476,7 @@ func TestSplitWithExistingBindVariables(t *testing.T) {
 					" (id < :_splitquery_end_id or" +
 					" (id = :_splitquery_end_id and user_id < :_splitquery_end_user_id))",
 				BindVariables: map[string]*querypb.BindVariable{
-					"foo": sqltypes.Int64BindVariable(100),
+					"foo":                       sqltypes.Int64BindVariable(100),
 					"_splitquery_start_id":      sqltypes.Int64BindVariable(1),
 					"_splitquery_start_user_id": sqltypes.Int64BindVariable(3),
 					"_splitquery_end_id":        sqltypes.Int64BindVariable(5),
@@ -490,7 +490,7 @@ func TestSplitWithExistingBindVariables(t *testing.T) {
 					" :_splitquery_start_id < id or" +
 					" (:_splitquery_start_id = id and :_splitquery_start_user_id <= user_id)",
 				BindVariables: map[string]*querypb.BindVariable{
-					"foo": sqltypes.Int64BindVariable(100),
+					"foo":                       sqltypes.Int64BindVariable(100),
 					"_splitquery_start_user_id": sqltypes.Int64BindVariable(1),
 					"_splitquery_start_id":      sqltypes.Int64BindVariable(5),
 				},

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1770,9 +1770,9 @@ func (tsv *TabletServer) BroadcastHealth(terTimestamp int64, stats *querypb.Real
 	target := tsv.target
 	tsv.mu.Unlock()
 	shr := &querypb.StreamHealthResponse{
-		Target:      &target,
-		TabletAlias: &tsv.alias,
-		Serving:     tsv.IsServing(),
+		Target:                              &target,
+		TabletAlias:                         &tsv.alias,
+		Serving:                             tsv.IsServing(),
 		TabletExternallyReparentedTimestamp: terTimestamp,
 		RealtimeStats:                       stats,
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2497,8 +2497,8 @@ func TestTabletServerSplitQueryEqualSplitsOnStringColumn(t *testing.T) {
 		&querypb.BoundQuery{Sql: sql},
 		// EQUAL_SPLITS should not work on a string column.
 		[]string{"name_string"}, /* splitColumns */
-		10, /* splitCount */
-		0,  /* numRowsPerQueryPart */
+		10,                      /* splitCount */
+		0,                       /* numRowsPerQueryPart */
 		querypb.SplitQueryRequest_EQUAL_SPLITS)
 	want :=
 		"using the EQUAL_SPLITS algorithm in SplitQuery" +

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -112,17 +112,17 @@ type TxSerializer struct {
 // New returns a TxSerializer object.
 func New(dryRun bool, maxQueueSize, maxGlobalQueueSize, concurrentTransactions int) *TxSerializer {
 	return &TxSerializer{
-		ConsolidatorCache:      sync2.NewConsolidatorCache(1000),
-		dryRun:                 dryRun,
-		maxQueueSize:           maxQueueSize,
-		maxGlobalQueueSize:     maxGlobalQueueSize,
-		concurrentTransactions: concurrentTransactions,
+		ConsolidatorCache:            sync2.NewConsolidatorCache(1000),
+		dryRun:                       dryRun,
+		maxQueueSize:                 maxQueueSize,
+		maxGlobalQueueSize:           maxGlobalQueueSize,
+		concurrentTransactions:       concurrentTransactions,
 		log:                          logutil.NewThrottledLogger("HotRowProtection", 5*time.Second),
 		logDryRun:                    logutil.NewThrottledLogger("HotRowProtection DryRun", 5*time.Second),
 		logWaitsDryRun:               logutil.NewThrottledLogger("HotRowProtection Waits DryRun", 5*time.Second),
 		logQueueExceededDryRun:       logutil.NewThrottledLogger("HotRowProtection QueueExceeded DryRun", 5*time.Second),
 		logGlobalQueueExceededDryRun: logutil.NewThrottledLogger("HotRowProtection GlobalQueueExceeded DryRun", 5*time.Second),
-		queues: make(map[string]*queue),
+		queues:                       make(map[string]*queue),
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -255,8 +255,8 @@ func newTxThrottlerState(config *txThrottlerConfig, keyspace, shard string,
 ) (*txThrottlerState, error) {
 	t, err := throttlerFactory(
 		TxThrottlerName,
-		"TPS", /* unit */
-		1,     /* threadCount */
+		"TPS",                           /* unit */
+		1,                               /* threadCount */
 		throttler.MaxRateModuleDisabled, /* maxRate */
 		config.throttlerConfig.MaxReplicationLagSec /* maxReplicationLag */)
 	if err != nil {

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -180,7 +180,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &legacyTestQueryService{
-			t: tc.t,
+			t:                        tc.t,
 			StreamHealthQueryService: qs,
 		})
 	}

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -330,8 +330,8 @@ func newTestQueryService(t *testing.T, target querypb.Target, shqs *fakes.Stream
 		fields = v3Fields
 	}
 	return &testQueryService{
-		t:      t,
-		target: target,
+		t:                        t,
+		target:                   target,
 		StreamHealthQueryService: shqs,
 		shardIndex:               shardIndex,
 		shardCount:               shardCount,

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -265,7 +265,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &sourceTabletServer{
-			t: t,
+			t:                        t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			v3:                       v3,
@@ -276,7 +276,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs := fakes.NewStreamHealthQueryService(destRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &destinationTabletServer{
-			t: t,
+			t:                        t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 		})

--- a/go/vt/worker/vertical_split_diff.go
+++ b/go/vt/worker/vertical_split_diff.go
@@ -68,11 +68,11 @@ type VerticalSplitDiffWorker struct {
 // NewVerticalSplitDiffWorker returns a new VerticalSplitDiffWorker object.
 func NewVerticalSplitDiffWorker(wr *wrangler.Wrangler, cell, keyspace, shard string, minHealthyRdonlyTablets, parallelDiffsCount int, destintationTabletType topodatapb.TabletType) Worker {
 	return &VerticalSplitDiffWorker{
-		StatusWorker: NewStatusWorker(),
-		wr:           wr,
-		cell:         cell,
-		keyspace:     keyspace,
-		shard:        shard,
+		StatusWorker:            NewStatusWorker(),
+		wr:                      wr,
+		cell:                    cell,
+		keyspace:                keyspace,
+		shard:                   shard,
 		minHealthyRdonlyTablets: minHealthyRdonlyTablets,
 		destinationTabletType:   destintationTabletType,
 		parallelDiffsCount:      parallelDiffsCount,

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -171,7 +171,7 @@ func TestVerticalSplitDiff(t *testing.T) {
 		qs := fakes.NewStreamHealthQueryService(rdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(rdonly.RPCServer, &verticalDiffTabletServer{
-			t: t,
+			t:                        t,
 			StreamHealthQueryService: qs,
 		})
 	}


### PR DESCRIPTION
WIP since I noticed go 1.11 seems to format differently.
