### PR TITLE
[vt/sqlparser] Use strings.Builder in compliantName

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -3691,7 +3691,7 @@ mustEscape:
 }
 
 func compliantName(in string) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for i, c := range in {
 		if !isLetter(uint16(c)) {
 			if i == 0 || !isDigit(uint16(c)) {


### PR DESCRIPTION
It halves allocations.
I would like to use it for Myprintf also very much, but I definitely need more research :)