### PR TITLE
Replaced ". ./dev.env" with "source ./dev.env" in GettingStarted.md

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -271,7 +271,7 @@ In addition, Vitess requires the software and libraries listed below.
 
     ``` sh
     # Remaining commands to build Vitess
-    . ./dev.env
+    source ./dev.env
     make build
     ```
 


### PR DESCRIPTION
The GettingStarted.md file had a wrong command. Instead of using "source ./dev.env", there was ". ./dev.env". I fixed the command there.