### PR TITLE
helm: Use MYSQL_FLAVOR to set flavor instead of EXTRA_MY_CNF

### DIFF
--- a/helm/vitess/templates/_helpers.tpl
+++ b/helm/vitess/templates/_helpers.tpl
@@ -103,26 +103,27 @@ nodeAffinity:
 {{- define "mycnf-exec" -}}
 
 if [ "$VT_DB_FLAVOR" = "percona" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mysql56.cnf
+  MYSQL_FLAVOR=Percona
 
 elif [ "$VT_DB_FLAVOR" = "mysql" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mysql56.cnf
+  MYSQL_FLAVOR=MySQL56
 
 elif [ "$VT_DB_FLAVOR" = "mysql56" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mysql56.cnf
+  MYSQL_FLAVOR=MySQL56
 
 elif [ "$VT_DB_FLAVOR" = "maria" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mariadb.cnf
+  MYSQL_FLAVOR=MariaDB
 
 elif [ "$VT_DB_FLAVOR" = "mariadb" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mariadb.cnf
+  MYSQL_FLAVOR=MariaDB
 
 elif [ "$VT_DB_FLAVOR" = "mariadb103" ]; then
-  FLAVOR_MYCNF=/vt/config/mycnf/master_mariadb103.cnf
+  MYSQL_FLAVOR=MariaDB103
 
 fi
 
-export EXTRA_MY_CNF="$FLAVOR_MYCNF:/vtdataroot/tabletdata/report-host.cnf:/vt/config/mycnf/rbr.cnf"
+export MYSQL_FLAVOR
+export EXTRA_MY_CNF="/vtdataroot/tabletdata/report-host.cnf:/vt/config/mycnf/rbr.cnf"
 
 {{ if . }}
 for filename in /vt/userconfig/*.cnf; do


### PR DESCRIPTION
mysqlctl uses env MYSQL_FLAVOR to set MySQL Flavor.
But helper template use EXTRA_MY_CNF to set MySQL Flavor.

This cause a bug when use mariadb or mariadb103.
mysqlctl set mariadb.conf or mariadb103.conf and 'mysql56.conf' in my.cnf.
And this wrong config cause failure to run mariadb or mariadb103.

Signed-off-by: Jungsub Shin <supsup5642@gmail.com>