### PR TITLE
helm: safer shutdown + flag defaults

### DIFF
--- a/helm/release.sh
+++ b/helm/release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+version_tag=1.0.3
+
+docker pull vitess/k8s:latest
+docker tag vitess/k8s:latest vitess/k8s:helm-$version_tag
+docker push vitess/k8s:helm-$version_tag
+
+docker pull vitess/vtgate:latest
+docker tag vitess/vtgate:latest vitess/vtgate:helm-$version_tag
+docker push vitess/vtgate:helm-$version_tag
+
+docker pull vitess/vttablet:latest
+docker tag vitess/vttablet:latest vitess/vttablet:helm-$version_tag
+docker push vitess/vttablet:helm-$version_tag
+
+docker pull vitess/mysqlctld:latest
+docker tag vitess/mysqlctld:latest vitess/mysqlctld:helm-$version_tag
+docker push vitess/mysqlctld:helm-$version_tag
+
+docker pull vitess/vtctl:latest
+docker tag vitess/vtctl:latest vitess/vtctl:helm-$version_tag
+docker push vitess/vtctl:helm-$version_tag
+
+docker pull vitess/vtctlclient:latest
+docker tag vitess/vtctlclient:latest vitess/vtctlclient:helm-$version_tag
+docker push vitess/vtctlclient:helm-$version_tag
+
+docker pull vitess/vtctld:latest
+docker tag vitess/vtctld:latest vitess/vtctld:helm-$version_tag
+docker push vitess/vtctld:helm-$version_tag
+
+docker pull vitess/vtworker:latest
+docker tag vitess/vtworker:latest vitess/vtworker:helm-$version_tag
+docker push vitess/vtworker:helm-$version_tag
+
+docker pull vitess/logrotate:latest
+docker tag vitess/logrotate:latest vitess/logrotate:helm-$version_tag
+docker push vitess/logrotate:helm-$version_tag
+
+docker pull vitess/logtail:latest
+docker tag vitess/logtail:latest vitess/logtail:helm-$version_tag
+docker push vitess/logtail:helm-$version_tag
+
+docker pull vitess/pmm-client:latest
+docker tag vitess/pmm-client:latest vitess/pmm-client:helm-$version_tag
+docker push vitess/pmm-client:helm-$version_tag
+
+docker pull vitess/orchestrator:latest
+docker tag vitess/orchestrator:latest vitess/orchestrator:helm-$version_tag
+docker push vitess/orchestrator:helm-$version_tag

--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.0.3 - 2018-12-20
+
+### Changes
+* Start tagging helm images and use them as default
+* Added commonly used flags to values.yaml for vtgate & vttablet for discoverability.
+Some match the binary flag defaults, and some have been set to more production ready values.
+* Extended vttablet terminationGracePeriodSeconds from 600 to 60000000.
+This will block on `PlannedReparent` in the `preStopHook` forever to prevent
+unsafe `EmergencyReparent` operations when the pod is killed.
+
+### Bug fixes
+* Use `$MYSQL_FLAVOR` to set flavor instead of `$EXTRA_MY_CNF`
+
 ## 1.0.2 - 2018-12-11
 
 ### Bug fixes
@@ -15,4 +28,4 @@
 ### Bug fixes
 * PMM wouldn't bootstrap correctly on a new cluster
 
-## 1.0.0, 2018-12-03 Vitess Helm Chart goes GA!
+## 1.0.0 - 2018-12-03 Vitess Helm Chart goes GA!

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 1.0.2
+version: 1.0.3
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -123,7 +123,7 @@ spec:
               value: "15999"
 
         - name: recovery-log
-          image: vitess/logtail:latest
+          image: vitess/logtail:helm-1.0.3
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH
@@ -133,7 +133,7 @@ spec:
               mountPath: /tmp
 
         - name: audit-log
-          image: vitess/logtail:latest
+          image: vitess/logtail:helm-1.0.3
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -218,7 +218,7 @@ spec:
       trap : TERM INT; sleep infinity & wait
 
 - name: pmm-client-metrics-log
-  image: vitess/logtail:latest
+  image: vitess/logtail:helm-1.0.3
   imagePullPolicy: IfNotPresent
   env:
   - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -96,7 +96,7 @@ spec:
         shard: {{ $shardClean | quote }}
         type: {{ $tablet.type | quote }}
     spec:
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: 60000000
 {{ include "pod-security" . | indent 6 }}
 {{ include "vttablet-affinity" (tuple $cellClean $keyspaceClean $shardClean $cell.region) | indent 6 }}
 
@@ -344,7 +344,7 @@ spec:
             # - use GTID_SUBTRACT
 
             RETRY_COUNT=0
-            MAX_RETRY_COUNT=5
+            MAX_RETRY_COUNT=100000
 
             # retry reparenting
             until [ $DONE_REPARENTING ]; do

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -513,7 +513,7 @@ spec:
 {{ define "cont-logrotate" }}
 
 - name: logrotate
-  image: vitess/logrotate:latest
+  image: vitess/logrotate:helm-1.0.3
   imagePullPolicy: IfNotPresent
   volumeMounts:
     - name: vtdataroot
@@ -527,7 +527,7 @@ spec:
 {{ define "cont-mysql-errorlog" }}
 
 - name: error-log
-  image: vitess/logtail:latest
+  image: vitess/logtail:helm-1.0.3
   imagePullPolicy: IfNotPresent
 
   env:
@@ -545,7 +545,7 @@ spec:
 {{ define "cont-mysql-slowlog" }}
 
 - name: slow-log
-  image: vitess/logtail:latest
+  image: vitess/logtail:helm-1.0.3
   imagePullPolicy: IfNotPresent
 
   env:
@@ -563,7 +563,7 @@ spec:
 {{ define "cont-mysql-generallog" }}
 
 - name: general-log
-  image: vitess/logtail:latest
+  image: vitess/logtail:helm-1.0.3
   imagePullPolicy: IfNotPresent
 
   env:

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -177,7 +177,7 @@ etcd:
 # Default values for vtctld resources defined in 'topology'
 vtctld:
   serviceType: ClusterIP
-  vitessTag: latest
+  vitessTag: helm-1.0.3
   resources:
     # requests:
     #   cpu: 100m
@@ -188,7 +188,7 @@ vtctld:
 # Default values for vtgate resources defined in 'topology'
 vtgate:
   serviceType: ClusterIP
-  vitessTag: latest
+  vitessTag: helm-1.0.3
   resources:
     # requests:
     #   cpu: 500m
@@ -207,13 +207,13 @@ vtgate:
 
 # Default values for vtctlclient resources defined in 'topology'
 vtctlclient:
-  vitessTag: latest
+  vitessTag: helm-1.0.3
   extraFlags: {}
   secrets: [] # secrets are mounted under /vt/usersecrets/{secretname}
 
 # Default values for vtworker resources defined in 'jobs'
 vtworker:
-  vitessTag: latest
+  vitessTag: helm-1.0.3
   extraFlags: {}
   resources:
     # requests:
@@ -224,7 +224,7 @@ vtworker:
 
 # Default values for vttablet resources defined in 'topology'
 vttablet:
-  vitessTag: latest
+  vitessTag: helm-1.0.3
 
   # valid values are
   # - mysql56 (for MySQL 8.0)

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -290,10 +290,6 @@ vttablet:
     # Size of the connection pool for dba connections
     dba_pool_size: 20
 
-    # size of a special pool that will be used if the client requests
-    # that statements be executed with the CLIENT_FOUND_ROWS option of MySQL.
-    client-found-rows-pool-size: 0
-
   # User secrets that will be mounted under /vt/usersecrets/{secretname}/
   secrets: []
 

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -193,7 +193,16 @@ vtgate:
     # requests:
     #   cpu: 500m
     #   memory: 512Mi
-  extraFlags: {}
+
+  # Additional flags that will be appended to the vtgate command.
+  # The options below are the most commonly adjusted, but any flag can be put here.
+  # run vtgate --help to see all available flags
+  extraFlags:
+    # MySQL server version to advertise. (default "5.5.10-Vitess")
+    # If running 8.0, you may need to use something like "8.0.13-Vitess"
+    # to prevent db clients from running deprecated queries on startup
+    mysql_server_version: "5.5.10-Vitess"
+
   secrets: [] # secrets are mounted under /vt/usersecrets/{secretname}
 
 # Default values for vtctlclient resources defined in 'topology'
@@ -248,8 +257,42 @@ vttablet:
   # If the value is "test", then mysql is instanitated with a smaller footprint.
   mysqlSize: prod
 
-  # Additional flags that will be appended to the vttablet command
-  extraFlags: {}
+  # Additional flags that will be appended to the vttablet command.
+  # The options below are the most commonly adjusted, but any flag can be put here.
+  # run vttablet --help to see all available flags
+  extraFlags:
+    # query server max result size, maximum number of rows allowed to return
+    # from vttablet for non-streaming queries.
+    queryserver-config-max-result-size: 10000
+
+    # query server query timeout (in seconds), this is the query timeout in vttablet side.
+    # If a query takes more than this timeout, it will be killed.
+    queryserver-config-query-timeout: 30
+
+    # query server connection pool size, connection pool is used by
+    # regular queries (non streaming, not in a transaction)
+    queryserver-config-pool-size: 24
+
+    # query server stream connection pool size, stream pool is used by stream queries:
+    # queries that return results to client in a streaming fashion
+    queryserver-config-stream-pool-size: 100
+
+    # query server transaction cap is the maximum number of transactions allowed to
+    # happen at any given point of a time for a single vttablet.
+    # e.g. by setting transaction cap to 100, there are at most 100 transactions
+    # will be processed by a vttablet and the 101th transaction will be blocked
+    # (and fail if it cannot get connection within specified timeout)
+    queryserver-config-transaction-cap: 300
+
+    # Size of the connection pool for app connections
+    app_pool_size: 40
+
+    # Size of the connection pool for dba connections
+    dba_pool_size: 20
+
+    # size of a special pool that will be used if the client requests
+    # that statements be executed with the CLIENT_FOUND_ROWS option of MySQL.
+    client-found-rows-pool-size: 0
 
   # User secrets that will be mounted under /vt/usersecrets/{secretname}/
   secrets: []


### PR DESCRIPTION
I've been bitten by the `preStopHook` not successfully executing a `PlannedReparent`, leading to bad GTIDs, botched Orchestrator failovers and split brain. This sets `terminationGracePeriodSeconds` out to a few years, so it doesn't complete until the reparent is successful.

I also surfaced some commonly adjusted flags in the values.yaml file. I think it is a good way to show usage, plus I pulled some recommendations to @hmcgonig from @sougou on Slack.
https://vitess.slack.com/archives/C0PQY0PTK/p1525981802000569

Any other flag recommendations are more than welcome.