### PR TITLE
java: Use compatible netty-handler and tcnative-boring-ssl versions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,7 +23,7 @@
   <modules>
     <module>client</module>
     <module>example</module>
-    <module>grpc-client</module> 
+    <module>grpc-client</module>
     <module>hadoop</module>
     <module>jdbc</module>
   </modules>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,6 +68,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
     <grpc.version>1.16.0</grpc.version>
+    <!-- NOTE Netty handler and boring SSL must be kept compatible with grpc
+      https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
+    <netty.handler.version>4.1.30.Final</netty.handler.version>
+    <tcnative.boring.ssl.version>2.0.17.Final</tcnative.boring.ssl.version>
+
     <protobuf.java.version>3.6.1</protobuf.java.version>
     <protobuf.protoc.version>3.6.1</protobuf.protoc.version>
   </properties>
@@ -130,14 +135,14 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.27.Final</version>
+        <version>${netty.handler.version}</version>
       </dependency>
       <!-- TODO(mberlin): When we upgrade grpc, check if we can remove this. Without,
         grpc-client TLS tests fail with error "Jetty ALPN/NPN has not been properly configured.". -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.17.Final</version>
+        <version>${tcnative.boring.ssl.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
We use the unshaded version of grpc-netty which requires the netty-handler and tcnative-boring-ssl versions to be kept in sync with gRPC.

The recommended version combination for gRPC 1.16.x is:
- netty-handler: 4.1.30.Final (upgraded in this PR from 4.1.27)
- tcnative-boring-ssl: 2.0.17.Final

We ran into some compatibility issues as we are attempting to upgrade our vitess jdbc version.
https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

A recommended alternative is to use the shaded version of grpc which will keep all these libraries in sync. Would love to hear the thoughts on that from other vitess java users.

cc @acharis 