### PR TITLE
Deprecate use shard cells when rebuilding keyspace graph in a cell. 

### DIFF
--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -141,12 +141,10 @@ func (ki *KeyspaceInfo) UpdateServedFromMap(tabletType topodatapb.TabletType, ce
 func (ki *KeyspaceInfo) ComputeCellServedFrom(cell string) []*topodatapb.SrvKeyspace_ServedFrom {
 	var result []*topodatapb.SrvKeyspace_ServedFrom
 	for _, ksf := range ki.ServedFroms {
-		if InCellList(cell, ksf.Cells) {
-			result = append(result, &topodatapb.SrvKeyspace_ServedFrom{
-				TabletType: ksf.TabletType,
-				Keyspace:   ksf.Keyspace,
-			})
-		}
+		result = append(result, &topodatapb.SrvKeyspace_ServedFrom{
+			TabletType: ksf.TabletType,
+			Keyspace:   ksf.Keyspace,
+		})
 	}
 	return result
 }

--- a/go/vt/topo/keyspace_test.go
+++ b/go/vt/topo/keyspace_test.go
@@ -138,22 +138,25 @@ func TestComputeCellServedFrom(t *testing.T) {
 			ServedFroms: []*topodatapb.Keyspace_ServedFrom{
 				{
 					TabletType: topodatapb.TabletType_MASTER,
-					Cells:      nil,
 					Keyspace:   "source",
 				},
 				{
 					TabletType: topodatapb.TabletType_REPLICA,
-					Cells:      []string{"c1", "c2"},
 					Keyspace:   "source",
 				},
 			},
 		},
 	}
 
+	// Tablets are served from any cell
 	m := ki.ComputeCellServedFrom("c3")
 	if !reflect.DeepEqual(m, []*topodatapb.SrvKeyspace_ServedFrom{
 		{
 			TabletType: topodatapb.TabletType_MASTER,
+			Keyspace:   "source",
+		},
+		{
+			TabletType: topodatapb.TabletType_REPLICA,
 			Keyspace:   "source",
 		},
 	}) {

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -496,9 +496,7 @@ func (si *ShardInfo) GetServedType(tabletType topodatapb.TabletType) *topodatapb
 func (si *ShardInfo) GetServedTypesPerCell(cell string) []topodatapb.TabletType {
 	result := make([]topodatapb.TabletType, 0, len(si.ServedTypes))
 	for _, st := range si.ServedTypes {
-		if InCellList(cell, st.Cells) {
-			result = append(result, st.TabletType)
-		}
+		result = append(result, st.TabletType)
 	}
 	return result
 }

--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -353,7 +353,7 @@ func TestGetServedType(t *testing.T) {
 		&topodatapb.Shard{
 			ServedTypes: []*topodatapb.Shard_ServedType{
 				&topodatapb.Shard_ServedType{
-					TabletType: topodatapb.TabletType_RDONLY,
+					TabletType: topodatapb.TabletType_REPLICA,
 				},
 			},
 		},

--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -345,3 +345,27 @@ func TestUpdateServedTypesMap(t *testing.T) {
 		t.Fatalf("expected empty map after removing all")
 	}
 }
+
+func TestGetServedType(t *testing.T) {
+	si := NewShardInfo(
+		"ks",
+		"sh",
+		&topodatapb.Shard{
+			ServedTypes: []*topodatapb.Shard_ServedType{
+				&topodatapb.Shard_ServedType{
+					TabletType: topodatapb.TabletType_RDONLY,
+				},
+			},
+		},
+		nil)
+
+	servedType := si.GetServedType(topodatapb.TabletType_BACKUP)
+	if servedType != nil {
+		t.Fatalf("expected servedType to be nil, got: %v", servedType)
+	}
+
+	servedType = si.GetServedType(topodatapb.TabletType_REPLICA)
+	if servedType == nil {
+		t.Fatalf("expected servedType to be TabletType_REPLICA, got: nil")
+	}
+}

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -80,7 +80,7 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 
 	// Rebuild keyspace graph in all known cells if empty cells are provided
 	if len(cells) == 0 {
-		cells, err = ts.GetKnownCells(ctx)
+		cells, err = ts.GetCellInfoNames(ctx)
 		if err != nil {
 			return err
 		}

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -78,6 +78,14 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 		return err
 	}
 
+	// Rebuild keyspace graph in all known cells if empty cells are provided
+	if len(cells) == 0 {
+		cells, err = ts.GetKnownCells(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Build the list of cells to work on: we get the union
 	// of all the Cells of all the Shards, limited to the provided cells.
 	//

--- a/go/vt/topotools/rebuild_keyspace_test.go
+++ b/go/vt/topotools/rebuild_keyspace_test.go
@@ -1,0 +1,169 @@
+/*
+ Copyright 2018 The Vitess Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package topotools
+
+import (
+	"golang.org/x/net/context"
+	"reflect"
+	"testing"
+
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestRebuildKeyspace(t *testing.T) {
+	ts := createSetup(context.Background(), t)
+	err := RebuildKeyspace(
+		context.Background(),
+		logutil.NewConsoleLogger(),
+		ts,
+		"test_keyspace",
+		[]string{"test_cell"},
+	)
+
+	if err != nil {
+		t.Fatalf("Expected error to be nil got: %v", err)
+	}
+
+	expectedSrvKeyspace := &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			&topodatapb.SrvKeyspace_KeyspacePartition{
+				ServedType: topodatapb.TabletType_MASTER,
+				ShardReferences: []*topodatapb.ShardReference{
+					&topodatapb.ShardReference{Name: "0"},
+				},
+			},
+			&topodatapb.SrvKeyspace_KeyspacePartition{
+				ServedType: topodatapb.TabletType_REPLICA,
+				ShardReferences: []*topodatapb.ShardReference{
+					&topodatapb.ShardReference{Name: "0"},
+				},
+			},
+			// Note: even though there are no rdonly tablets, this is
+			// a served type in the shard, so it should show up in the
+			// srvkeyspace
+			&topodatapb.SrvKeyspace_KeyspacePartition{
+				ServedType: topodatapb.TabletType_RDONLY,
+				ShardReferences: []*topodatapb.ShardReference{
+					&topodatapb.ShardReference{Name: "0"},
+				},
+			},
+		},
+	}
+
+	srvKeyspace, err := ts.GetSrvKeyspace(context.Background(), "test_cell", "test_keyspace")
+	if err != nil {
+		t.Fatalf("Expected error to be nil got: %v", err)
+	}
+	if !reflect.DeepEqual(srvKeyspace, expectedSrvKeyspace) {
+		t.Errorf("SrvKeyspace: invalid output expected %v, got :%v", srvKeyspace, expectedSrvKeyspace)
+	}
+
+	// It should fail to get a srvkeyspace that hasn't been generated
+	srvKeyspace, err = ts.GetSrvKeyspace(context.Background(), "test_cell_2", "test_keyspace")
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+
+	err = RebuildKeyspace(
+		context.Background(),
+		logutil.NewConsoleLogger(),
+		ts,
+		"test_keyspace",
+		[]string{"test_cell_2"},
+	)
+	if err != nil {
+		t.Fatalf("Expected error to be nil got: %v", err)
+	}
+
+	// It should generate srvkeyspace for cells that have no tablets
+	srvKeyspace, err = ts.GetSrvKeyspace(context.Background(), "test_cell_2", "test_keyspace")
+	if err != nil {
+		t.Fatalf("Expected error to be nil got: %v", err)
+	}
+	if !reflect.DeepEqual(srvKeyspace, expectedSrvKeyspace) {
+		t.Errorf("SrvKeyspace: invalid output expected %v, got :%v", srvKeyspace, expectedSrvKeyspace)
+	}
+
+}
+
+func createSetup(ctx context.Context, t *testing.T) *topo.Server {
+	// Create an in memory toposerver
+	ts := memorytopo.NewServer("test_cell", "test_cell_2")
+
+	// create a keyspace and a couple tablets
+	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); err != nil {
+		t.Fatalf("cannot create keyspace: %v", err)
+	}
+	if err := ts.CreateShard(ctx, "test_keyspace", "0"); err != nil {
+		t.Fatalf("cannot create shard: %v", err)
+	}
+	if _, err := ts.UpdateShardFields(ctx, "test_keyspace", "0", func(si *topo.ShardInfo) error {
+		si.Cells = []string{}
+		return nil
+	}); err != nil {
+		t.Fatalf("cannot update shard: %v", err)
+	}
+	tablet1 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: "test_cell",
+			Uid:  123,
+		},
+		Hostname:      "masterhost",
+		MysqlHostname: "masterhost",
+		PortMap: map[string]int32{
+			"vt":   8101,
+			"gprc": 8102,
+		},
+		Keyspace:       "test_keyspace",
+		Shard:          "0",
+		Type:           topodatapb.TabletType_MASTER,
+		DbNameOverride: "",
+		KeyRange:       nil,
+	}
+	topoproto.SetMysqlPort(tablet1, 3306)
+	if err := ts.CreateTablet(ctx, tablet1); err != nil {
+		t.Fatalf("cannot create master tablet: %v", err)
+	}
+	tablet2 := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: "test_cell",
+			Uid:  234,
+		},
+		PortMap: map[string]int32{
+			"vt":   8101,
+			"grpc": 8102,
+		},
+		Hostname:      "slavehost",
+		MysqlHostname: "slavehost",
+
+		Keyspace:       "test_keyspace",
+		Shard:          "0",
+		Type:           topodatapb.TabletType_REPLICA,
+		DbNameOverride: "",
+		KeyRange:       nil,
+	}
+	topoproto.SetMysqlPort(tablet2, 3306)
+	if err := ts.CreateTablet(ctx, tablet2); err != nil {
+		t.Fatalf("cannot create slave tablet: %v", err)
+	}
+	return ts
+}

--- a/go/vt/topotools/rebuild_keyspace_test.go
+++ b/go/vt/topotools/rebuild_keyspace_test.go
@@ -19,6 +19,7 @@ package topotools
 import (
 	"golang.org/x/net/context"
 	"reflect"
+	"sort"
 	"testing"
 
 	"vitess.io/vitess/go/vt/logutil"
@@ -73,6 +74,9 @@ func TestRebuildKeyspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected error to be nil got: %v", err)
 	}
+	sort.Slice(srvKeyspace.Partitions, func(i, j int) bool {
+		return srvKeyspace.Partitions[i].ServedType > srvKeyspace.Partitions[i].ServedType
+	})
 	if !reflect.DeepEqual(srvKeyspace, expectedSrvKeyspace) {
 		t.Errorf("SrvKeyspace: invalid output expected %v, got :%v", srvKeyspace, expectedSrvKeyspace)
 	}
@@ -96,6 +100,9 @@ func TestRebuildKeyspace(t *testing.T) {
 
 	// It should generate srvkeyspace for cells that have no tablets
 	srvKeyspace, err = ts.GetSrvKeyspace(context.Background(), "test_cell_2", "test_keyspace")
+	sort.Slice(srvKeyspace.Partitions, func(i, j int) bool {
+		return srvKeyspace.Partitions[i].ServedType > srvKeyspace.Partitions[i].ServedType
+	})
 	if err != nil {
 		t.Fatalf("Expected error to be nil got: %v", err)
 	}
@@ -147,6 +154,9 @@ func TestRebuildKeyspaceAllCells(t *testing.T) {
 	}
 
 	srvKeyspace, err := ts.GetSrvKeyspace(context.Background(), "test_cell", "test_keyspace")
+	sort.Slice(srvKeyspace.Partitions, func(i, j int) bool {
+		return srvKeyspace.Partitions[i].ServedType > srvKeyspace.Partitions[i].ServedType
+	})
 	if err != nil {
 		t.Fatalf("Expected error to be nil got: %v", err)
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -915,7 +915,6 @@ func commandRefreshState(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 }
 
 func commandRefreshStateByShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells whose tablets are included. If empty, all cells are considered.")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -932,11 +931,7 @@ func commandRefreshStateByShard(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 
-	var cells []string
-	if *cellsStr != "" {
-		cells = strings.Split(*cellsStr, ",")
-	}
-	return wr.RefreshTabletsByShard(ctx, si, nil /* tabletTypes */, cells)
+	return wr.RefreshTabletsByShard(ctx, si, nil /* tabletTypes */)
 }
 
 func commandRunHealthCheck(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -1621,7 +1616,6 @@ func commandSetKeyspaceShardingInfo(ctx context.Context, wr *wrangler.Wrangler, 
 func commandSetKeyspaceServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	source := subFlags.String("source", "", "Specifies the source keyspace name")
 	remove := subFlags.Bool("remove", false, "Indicates whether to add (default) or remove the served from record")
-	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to affect")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -1633,12 +1627,7 @@ func commandSetKeyspaceServedFrom(ctx context.Context, wr *wrangler.Wrangler, su
 	if err != nil {
 		return err
 	}
-	var cells []string
-	if *cellsStr != "" {
-		cells = strings.Split(*cellsStr, ",")
-	}
-
-	return wr.SetKeyspaceServedFrom(ctx, keyspace, servedType, cells, *source, *remove)
+	return wr.SetKeyspaceServedFrom(ctx, keyspace, servedType, *source, *remove)
 }
 
 func commandRebuildKeyspaceGraph(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -1681,7 +1670,6 @@ func commandValidateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlag
 }
 
 func commandMigrateServedTypes(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
 	reverse := subFlags.Bool("reverse", false, "Moves the served tablet type backward instead of forward. Use in case of trouble")
 	skipReFreshState := subFlags.Bool("skip-refresh-state", false, "Skips refreshing the state of the source tablets after the migration, meaning that the refresh will need to be done manually, replica and rdonly only)")
 	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "Specifies the maximum time to wait, in seconds, for filtered replication to catch up on master migrations")
@@ -1704,16 +1692,11 @@ func commandMigrateServedTypes(ctx context.Context, wr *wrangler.Wrangler, subFl
 	if servedType == topodatapb.TabletType_MASTER && *skipReFreshState {
 		return fmt.Errorf("the skip-refresh-state flag can only be specified for non-master migrations")
 	}
-	var cells []string
-	if *cellsStr != "" {
-		cells = strings.Split(*cellsStr, ",")
-	}
-	return wr.MigrateServedTypes(ctx, keyspace, shard, cells, servedType, *reverse, *skipReFreshState, *filteredReplicationWaitTime, *reverseReplication)
+	return wr.MigrateServedTypes(ctx, keyspace, shard, servedType, *reverse, *skipReFreshState, *filteredReplicationWaitTime, *reverseReplication)
 }
 
 func commandMigrateServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	reverse := subFlags.Bool("reverse", false, "Moves the served tablet type backward instead of forward. Use in case of trouble")
-	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
 	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "Specifies the maximum time to wait, in seconds, for filtered replication to catch up on master migrations")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -1730,11 +1713,7 @@ func commandMigrateServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFla
 	if err != nil {
 		return err
 	}
-	var cells []string
-	if *cellsStr != "" {
-		cells = strings.Split(*cellsStr, ",")
-	}
-	return wr.MigrateServedFrom(ctx, keyspace, shard, servedType, cells, *reverse, *filteredReplicationWaitTime)
+	return wr.MigrateServedFrom(ctx, keyspace, shard, servedType, *reverse, *filteredReplicationWaitTime)
 }
 
 func commandCancelResharding(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
+++ b/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
@@ -61,13 +61,13 @@ func (mr *MockReshardingWranglerMockRecorder) WaitForFilteredReplication(ctx, ke
 }
 
 // MigrateServedTypes mocks base method
-func (m *MockReshardingWrangler) MigrateServedTypes(ctx context.Context, keyspace, shard string, cells []string, servedType topodata.TabletType, reverse, skipReFreshState bool, filteredReplicationWaitTime time.Duration, reverseReplication bool) error {
-	ret := m.ctrl.Call(m, "MigrateServedTypes", ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
+func (m *MockReshardingWrangler) MigrateServedTypes(ctx context.Context, keyspace, shard string, servedType topodata.TabletType, reverse, skipReFreshState bool, filteredReplicationWaitTime time.Duration, reverseReplication bool) error {
+	ret := m.ctrl.Call(m, "MigrateServedTypes", ctx, keyspace, shard, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MigrateServedTypes indicates an expected call of MigrateServedTypes
-func (mr *MockReshardingWranglerMockRecorder) MigrateServedTypes(ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateServedTypes", reflect.TypeOf((*MockReshardingWrangler)(nil).MigrateServedTypes), ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
+func (mr *MockReshardingWranglerMockRecorder) MigrateServedTypes(ctx, keyspace, shard, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateServedTypes", reflect.TypeOf((*MockReshardingWrangler)(nil).MigrateServedTypes), ctx, keyspace, shard, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
 }

--- a/go/vt/workflow/resharding/resharding_wrangler.go
+++ b/go/vt/workflow/resharding/resharding_wrangler.go
@@ -33,5 +33,5 @@ type ReshardingWrangler interface {
 
 	WaitForFilteredReplication(ctx context.Context, keyspace, shard string, maxDelay time.Duration) error
 
-	MigrateServedTypes(ctx context.Context, keyspace, shard string, cells []string, servedType topodatapb.TabletType, reverse, skipReFreshState bool, filteredReplicationWaitTime time.Duration, reverseReplication bool) error
+	MigrateServedTypes(ctx context.Context, keyspace, shard string, servedType topodatapb.TabletType, reverse, skipReFreshState bool, filteredReplicationWaitTime time.Duration, reverseReplication bool) error
 }

--- a/go/vt/workflow/resharding/tasks.go
+++ b/go/vt/workflow/resharding/tasks.go
@@ -120,5 +120,5 @@ func (hw *horizontalReshardingWorkflow) runMigrate(ctx context.Context, t *workf
 		return fmt.Errorf("wrong served type to be migrated: %v", servedTypeStr)
 	}
 
-	return hw.wr.MigrateServedTypes(ctx, keyspace, sourceShard, nil /* cells */, servedType, false /* reverse */, false /* skipReFreshState */, wrangler.DefaultFilteredReplicationWaitTime, false /* reverseReplication */)
+	return hw.wr.MigrateServedTypes(ctx, keyspace, sourceShard, servedType, false /* reverse */, false /* skipReFreshState */, wrangler.DefaultFilteredReplicationWaitTime, false /* reverseReplication */)
 }

--- a/go/vt/workflow/resharding/workflow_test.go
+++ b/go/vt/workflow/resharding/workflow_test.go
@@ -166,7 +166,7 @@ func setupMockWrangler(ctrl *gomock.Controller, keyspace string) *MockResharding
 		topodatapb.TabletType_REPLICA,
 		topodatapb.TabletType_MASTER}
 	for _, servedType := range servedTypeParams {
-		mockWranglerInterface.EXPECT().MigrateServedTypes(gomock.Any(), keyspace, "0", nil /* cells */, servedType, false /* reverse */, false /* skipReFreshState */, wrangler.DefaultFilteredReplicationWaitTime, false /* reverseReplication */).Return(nil)
+		mockWranglerInterface.EXPECT().MigrateServedTypes(gomock.Any(), keyspace, "0", servedType, false /* reverse */, false /* skipReFreshState */, wrangler.DefaultFilteredReplicationWaitTime, false /* reverseReplication */).Return(nil)
 	}
 	return mockWranglerInterface
 }

--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -112,11 +112,11 @@ func (wr *Wrangler) SetShardTabletControl(ctx context.Context, keyspace, shard s
 	_, err = wr.ts.UpdateShardFields(ctx, keyspace, shard, func(si *topo.ShardInfo) error {
 		if len(blacklistedTables) == 0 && !remove {
 			// we are setting the DisableQueryService flag only
-			return si.UpdateDisableQueryService(ctx, tabletType, cells, disableQueryService)
+			return si.UpdateDisableQueryService(ctx, tabletType, disableQueryService)
 		}
 
 		// we are setting / removing the blacklisted tables only
-		return si.UpdateSourceBlacklistedTables(ctx, tabletType, cells, remove, blacklistedTables)
+		return si.UpdateSourceBlacklistedTables(ctx, tabletType, remove, blacklistedTables)
 	})
 	return err
 }

--- a/test/legacy_resharding.py
+++ b/test/legacy_resharding.py
@@ -40,7 +40,6 @@ We start with shards -80 and 80-. We then split 80- into 80-c0 and c0-.
 This test is the main resharding test. It not only tests the regular resharding
 workflow for an horizontal split, but also a lot of error cases and side
 effects, like:
-- migrating the traffic one cell at a time.
 - migrating rdonly traffic back and forth.
 - making sure we can't migrate the master until replica and rdonly are migrated.
 - has a background thread to insert data during migration.
@@ -488,26 +487,7 @@ primary key (name)
     # service is not running (if not healthy this would exception out)
     shard_3_master.get_healthz()
 
-    # now serve rdonly from the split shards, in test_nj only
-    utils.run_vtctl(['MigrateServedTypes', '--cells=test_nj',
-                     'test_keyspace/80-', 'rdonly'], auto_log=True)
-    utils.check_srv_keyspace('test_nj', 'test_keyspace',
-                             'Partitions(master): -80 80-\n'
-                             'Partitions(rdonly): -80 80-c0 c0-\n'
-                             'Partitions(replica): -80 80-\n',
-                             keyspace_id_type=keyspace_id_type,
-                             sharding_column_name='custom_ksid_col')
-    utils.check_srv_keyspace('test_ny', 'test_keyspace',
-                             'Partitions(master): -80 80-\n'
-                             'Partitions(rdonly): -80 80-\n'
-                             'Partitions(replica): -80 80-\n',
-                             keyspace_id_type=keyspace_id_type,
-                             sharding_column_name='custom_ksid_col')
-    utils.check_tablet_query_service(self, shard_0_ny_rdonly, True, False)
-    utils.check_tablet_query_service(self, shard_1_ny_rdonly, True, False)
-    utils.check_tablet_query_service(self, shard_1_rdonly1, False, True)
-
-    # now serve rdonly from the split shards, everywhere
+    # now serve rdonly from the split shards
     utils.run_vtctl(['MigrateServedTypes', 'test_keyspace/80-', 'rdonly'],
                     auto_log=True)
     utils.check_srv_keyspace('test_nj', 'test_keyspace',

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -140,8 +140,7 @@ class TestTabletManager(unittest.TestCase):
     utils.run_vtctl(['Ping', tablet_62344.tablet_alias])
     utils.run_vtctl(['RefreshState', tablet_62344.tablet_alias])
     utils.run_vtctl(['RefreshStateByShard', 'test_keyspace/0'])
-    utils.run_vtctl(['RefreshStateByShard', '--cells=test_nj',
-                     'test_keyspace/0'])
+    utils.run_vtctl(['RefreshStateByShard', 'test_keyspace/0'])
 
     # Quickly check basic actions.
     utils.run_vtctl(['SetReadOnly', tablet_62344.tablet_alias])

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -46,12 +46,7 @@ healthy_expr = re.compile(r'Current status: <span.+?>healthy')
 def setUpModule():
   try:
     topo_flavor = environment.topo_server().flavor()
-    if topo_flavor == 'zk2':
-      # This is a one-off test to make sure our 'zk2' implementation
-      # behave with a server that is not DNS-resolveable.
-      environment.topo_server().setup(add_bad_host=True)
-    else:
-      environment.topo_server().setup()
+    environment.topo_server().setup()
 
     # start mysql instance external to the test
     setup_procs = [


### PR DESCRIPTION
### Description

* Part of #4482.  Deprecates cells use in `RebuildKeyspaceGraph`.
* Adds some missing tests. 
* This can't be merged yet. Exploratory work. 