### PR TITLE
require golang version 1.11+

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,6 +45,7 @@ function fail() {
 [[ "$(dirname "$0")" = "." ]] || fail "bootstrap.sh must be run from its current directory"
 
 go version &>/dev/null  || fail "Go is not installed or is not on \$PATH"
+[[ "$(go version 2>&1)" =~ go1\.[1-9][1-9] ]] || fail "Go is not version 1.11+"
 
 # Set up the proper GOPATH for go get below.
 source ./dev.env


### PR DESCRIPTION
See also https://github.com/vitessio/vitess/pull/4470 and commit dba155b8f5e5
which introduced a dependency on golang 1.10+.
Some docs refer to 1.11+ so I made bootstrap.sh require that.

Signed-off-by: Scott Lanning <scott.lanning@booking.com>