### PR TITLE
build: fix broken build for other flavors

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -52,7 +52,7 @@ ENV PKG_CONFIG_PATH $VTROOT/lib
 ENV USER vitess
 
 # Copy files needed for bootstrap
-COPY bootstrap.sh dev.env /vt/src/vitess.io/vitess/
+COPY bootstrap.sh dev.env build.env /vt/src/vitess.io/vitess/
 COPY config /vt/src/vitess.io/vitess/config
 COPY third_party /vt/src/vitess.io/vitess/third_party
 COPY tools /vt/src/vitess.io/vitess/tools

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -9,5 +9,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
 
+ENV MYSQL_FLAVOR MariaDB
 USER vitess
 RUN ./bootstrap.sh

--- a/go/mysql/endtoend/client_test.go
+++ b/go/mysql/endtoend/client_test.go
@@ -150,11 +150,6 @@ func doTestMultiResult(t *testing.T, disableClientDeprecateEOF bool) {
 	expectNoError(t, err)
 	defer conn.Close()
 
-	connParams.DisableClientDeprecateEOF = false
-
-	expectFlag(t, "Negotiated ClientDeprecateEOF flag", (conn.Capabilities&mysql.CapabilityClientDeprecateEOF) != 0, !disableClientDeprecateEOF)
-	defer conn.Close()
-
 	qr, more, err := conn.ExecuteFetchMulti("select 1 from dual; set autocommit=1; select 1 from dual", 10, true)
 	expectNoError(t, err)
 	expectFlag(t, "ExecuteMultiFetch(multi result)", more, true)

--- a/go/mysql/endtoend/query_test.go
+++ b/go/mysql/endtoend/query_test.go
@@ -247,11 +247,6 @@ func doTestWarnings(t *testing.T, disableClientDeprecateEOF bool) {
 	expectNoError(t, err)
 	defer conn.Close()
 
-	connParams.DisableClientDeprecateEOF = false
-
-	expectFlag(t, "Negotiated ClientDeprecateEOF flag", (conn.Capabilities&mysql.CapabilityClientDeprecateEOF) != 0, !disableClientDeprecateEOF)
-	defer conn.Close()
-
 	result, err := conn.ExecuteFetch("create table a(id int, val int not null, primary key(id))", 0, false)
 	if err != nil {
 		t.Fatalf("create table failed: %v", err)

--- a/go/mysql/endtoend/schema_test.go
+++ b/go/mysql/endtoend/schema_test.go
@@ -52,10 +52,9 @@ func testDescribeTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// MariaDB has '81' instead of '90' of Extra ColumnLength.
-	// Just try it and see if it's the only difference.
-	if conn.IsMariaDB() && result.Fields[5].ColumnLength == 81 {
-		result.Fields[5].ColumnLength = 90
+	// Zero-out the column lengths, because they can't be compared.
+	for i := range result.Fields {
+		result.Fields[i].ColumnLength = 0
 	}
 
 	if !sqltypes.FieldsEqual(result.Fields, mysql.DescribeTableFields) {

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -34,6 +34,8 @@ import (
 // DescribeTableFields contains the fields returned by a
 // 'describe <table>' command. They are validated by the testDescribeTable
 // test.
+// Column lengths returned seem to differ between versions. So, we
+// don't compare them.
 var DescribeTableFields = []*querypb.Field{
 	{
 		Name:         "Field",
@@ -42,7 +44,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "COLUMN_NAME",
-		ColumnLength: 192,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
@@ -53,7 +55,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "COLUMN_TYPE",
-		ColumnLength: 589815,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG | querypb.MySqlFlag_BLOB_FLAG),
 	},
@@ -64,7 +66,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "IS_NULLABLE",
-		ColumnLength: 9,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
@@ -75,7 +77,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "COLUMN_KEY",
-		ColumnLength: 9,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
@@ -86,7 +88,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "COLUMN_DEFAULT",
-		ColumnLength: 589815,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_BLOB_FLAG),
 	},
@@ -97,7 +99,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgTable:     "COLUMNS",
 		Database:     "information_schema",
 		OrgName:      "EXTRA",
-		ColumnLength: 90,
+		ColumnLength: 0,
 		Charset:      33,
 		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},


### PR DESCRIPTION
There were a few regressions that got introduced due to
recent changes:
* MYSQL_FLAVOR got dropped from Dockerfile.mariadb.
* New build.env did not get included in the docker builds.
* CapabilityClientDeprecateEOF behaves differently for MySQL 5.7
  vs older versions: MySQL 5.6 and MariaDB. For 5.7, the capability
  always comes back true, but it comes back as true or false
  for other versions. So, I just removed the check.

Also removed column length check in one of the tests because
they are not consistent across flavors.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>