### PR TITLE
helm: handle Orchestrator during preStop shutdown hook

### DIFF
--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 # TODO: remove when https://github.com/vitessio/vitess/issues/3553 is fixed
 RUN apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install mysql-client jq -qq --no-install-recommends && \
+   apt-get install wget mysql-client jq -qq --no-install-recommends && \
    apt-get autoremove && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Per my conversation with @acharis on Slack, https://vitess.slack.com/archives/C0PQY0PTK/p1545344028308100, I've added some api calls to the k8s preStop shutdown hook.

The ordering that we discussed was:
1. vitess: PlannedReparentShard
1. orc: refresh/:host/:port
1. vitess: DeleteTablet
1. orc: forget/:host/:port

In addition to adding those calls, I also manually downtimed Orchestrator for ~30~ 10 seconds, though I'm curious to hear feedback on that. The final setup looks like:
1. orc: begin-downtime/$hostname.vttablet/3306/preStopHook/VitessPlannedReparent/10s
1. vitess: PlannedReparentShard
1. orc: end-downtime/$hostname.vttablet/3306
1. orc: refresh/$hostname.vttablet/3306
1. vitess: DeleteTablet
1. orc: forget/$hostname.vttablet/3306

_edit: changed Orchestrator downtime from 30 seconds to 10 seconds after discussing with @acharis on Slack_

cc @hmcgonig @shlomi-noach 