### PR TITLE
fix a bootstrap.sh error

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -20,7 +20,7 @@
 #   to build a package to be run under a POSIX shell so non-POSIX
 #   syntax will break that as dev.env will not be sourced by bash..
 
-source build.env
+source ./build.env
 
 export GOTOP=$VTTOP/go
 export PYTOP=$VTTOP/py


### PR DESCRIPTION
The error from bootstrap.sh was:
"./dev.env: line 23: source: build.env: file not found".

I think it broke in commit 157ebf5830e6c .
Not sure if this is the right fix, but it worked for me
(bootstrap.sh does `source ./build.env`, so it's probably ok).

Signed-off-by: Scott Lanning <scott.lanning@booking.com>