### PR TITLE
add support for client cert auth for mysql protocol vtgate connections

### DIFF
--- a/go/cmd/vtgate/plugin_auth_clientcert.go
+++ b/go/cmd/vtgate/plugin_auth_clientcert.go
@@ -1,0 +1,12 @@
+package main
+
+// This plugin imports clientcert to register the client certificate implementation of AuthServer.
+
+import (
+	"vitess.io/vitess/go/mysql/clientcert"
+	"vitess.io/vitess/go/vt/vtgate"
+)
+
+func init() {
+	vtgate.RegisterPluginInitializer(func() { clientcert.Init() })
+}

--- a/go/cmd/vtgate/plugin_auth_clientcert.go
+++ b/go/cmd/vtgate/plugin_auth_clientcert.go
@@ -3,10 +3,10 @@ package main
 // This plugin imports clientcert to register the client certificate implementation of AuthServer.
 
 import (
-	"vitess.io/vitess/go/mysql/clientcert"
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/vtgate"
 )
 
 func init() {
-	vtgate.RegisterPluginInitializer(func() { clientcert.Init() })
+	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerClientCert() })
 }

--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -14,12 +14,13 @@ type AuthServerClientCert struct {
 }
 
 // Init is public so it can be called from plugin_auth_clientcert.go (go/cmd/vtgate)
-func Init() {
+func InitAuthServerClientCert() {
+	if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
+		log.Info("Not configuring AuthServerClientCert because mysql_server_ssl_ca is empty")
+		return
+	}
 	if *clientcertAuthMethod != MysqlClearPassword && *clientcertAuthMethod != MysqlDialog {
 		log.Exitf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
-	}
-	if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
-		log.Exitf("clientcert auth plugin requires the -mysql_server_ssl_ca flag to be set")
 	}
 	ascc := &AuthServerClientCert{
 		Method: *clientcertAuthMethod,

--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -1,27 +1,21 @@
-package clientcert
+package mysql
 
 import (
 	"flag"
 	"fmt"
 	"net"
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
-	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-var clientcertAuthMethod = flag.String("mysql_clientcert_auth_method", mysql.MysqlClearPassword, "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
+var clientcertAuthMethod = flag.String("mysql_clientcert_auth_method", MysqlClearPassword, "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
 
 type AuthServerClientCert struct {
 	Method string
 }
 
-type UserData struct {
-	querypb.VTGateCallerID
-}
-
-// Init is public so it can be called from plugin_auth_ldap.go (go/cmd/vtgate)
+// Init is public so it can be called from plugin_auth_clientcert.go (go/cmd/vtgate)
 func Init() {
-	if *clientcertAuthMethod != mysql.MysqlClearPassword && *clientcertAuthMethod != mysql.MysqlDialog {
+	if *clientcertAuthMethod != MysqlClearPassword && *clientcertAuthMethod != MysqlDialog {
 		log.Exitf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
 	}
 	if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
@@ -30,7 +24,7 @@ func Init() {
 	ascc := &AuthServerClientCert{
 		Method: *clientcertAuthMethod,
 	}
-	mysql.RegisterAuthServerImpl("clientcert", ascc)
+	RegisterAuthServerImpl("clientcert", ascc)
 }
 
 // AuthMethod is part of the AuthServer interface.
@@ -40,37 +34,37 @@ func (ascc *AuthServerClientCert) AuthMethod(user string) (string, error) {
 
 // Salt is not used for this plugin.
 func (ascc *AuthServerClientCert) Salt() ([]byte, error) {
-	return mysql.NewSalt()
+	return NewSalt()
 }
 
 // ValidateHash is unimplemented.
-func (ascc *AuthServerClientCert) ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (mysql.Getter, error) {
+func (ascc *AuthServerClientCert) ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
 	panic("unimplemented")
 }
 
 // Negotiate is part of the AuthServer interface.
-func (ascc *AuthServerClientCert) Negotiate(c *mysql.Conn, user string, remoteAddr net.Addr) (mysql.Getter, error) {
+func (ascc *AuthServerClientCert) Negotiate(c *Conn, user string, remoteAddr net.Addr) (Getter, error) {
 	// This code depends on the fact that golang's tls server enforces client cert verification.
 	// Note that the -mysql_server_ssl_ca flag must be set in order for the vtgate to accept client certs.
 	// If not set, the vtgate will effectively deny all incoming mysql connections, since they will all lack certificates.
 	// For more info, check out go/vt/vtttls/vttls.go
 	certs := c.GetTLSClientCerts()
-	if certs == nil || len(certs) == 0 {
+	if len(certs) == 0 {
 		return nil, fmt.Errorf("no client certs for connection ID %v", c.ConnectionID)
 	}
 
-	if _, err := mysql.AuthServerReadPacketString(c); err != nil {
+	if _, err := AuthServerReadPacketString(c); err != nil {
 		return nil, err
 	}
 
-	return &UserData{
-		VTGateCallerID: querypb.VTGateCallerID{
-			Username: certs[0].Subject.CommonName,
-			Groups:   certs[0].DNSNames,
-		},
-	}, nil
-}
+	commonName := certs[0].Subject.CommonName
 
-func (ud *UserData) Get() *querypb.VTGateCallerID {
-	return &ud.VTGateCallerID
+	if user != commonName {
+		return nil, fmt.Errorf("MySQL connection username '%v' does not match client cert common name '%v'", user, commonName)
+	}
+
+	return &StaticUserData{
+		username: commonName,
+		groups:   certs[0].DNSNames,
+	}, nil
 }

--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -1,0 +1,157 @@
+package mysql
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+	"vitess.io/vitess/go/vt/tlstest"
+	"vitess.io/vitess/go/vt/vttls"
+)
+
+const clientCertUsername = "Client Cert"
+
+func TestValidCert(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := &AuthServerClientCert{
+		Method: MysqlClearPassword,
+	}
+
+	// Create the listener, so we can get its host.
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root, err := ioutil.TempDir("", "TestSSLConnection")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", clientCertUsername)
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		path.Join(root, "ca-cert.pem"))
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	l.TLSConfig = serverConfig
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: clientCertUsername,
+		Pass:  "",
+		// SSL flags.
+		Flags:      CapabilityClientSSL,
+		SslCa:      path.Join(root, "ca-cert.pem"),
+		SslCert:    path.Join(root, "client-cert.pem"),
+		SslKey:     path.Join(root, "client-key.pem"),
+		ServerName: "server.example.com",
+	}
+
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Make sure this went through SSL.
+	result, err := conn.ExecuteFetch("ssl echo", 10000, true)
+	if err != nil {
+		t.Fatalf("ExecuteFetch failed: %v", err)
+	}
+	if result.Rows[0][0].ToString() != "ON" {
+		t.Errorf("Got wrong result from ExecuteFetch(ssl echo): %v", result)
+	}
+
+	userData := th.lastConn.UserData.Get()
+	if userData.Username != clientCertUsername {
+		t.Errorf("userdata username is %v, expected %v", userData.Username, clientCertUsername)
+	}
+
+	expectedGroups := []string{"localhost", "127.0.0.1", clientCertUsername}
+	if !reflect.DeepEqual(userData.Groups, expectedGroups) {
+		t.Errorf("userdata groups is %v, expected %v", userData.Groups, expectedGroups)
+	}
+
+	// Send a ComQuit to avoid the error message on the server side.
+	conn.writeComQuit()
+}
+
+func TestNoCert(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := &AuthServerClientCert{
+		Method: MysqlClearPassword,
+	}
+
+	// Create the listener, so we can get its host.
+	l, err := NewListener("tcp", ":0", authServer, th, 0, 0)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root, err := ioutil.TempDir("", "TestSSLConnection")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		path.Join(root, "ca-cert.pem"))
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	l.TLSConfig = serverConfig
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:       host,
+		Port:       port,
+		Uname:      "user1",
+		Pass:       "",
+		Flags:      CapabilityClientSSL,
+		SslCa:      path.Join(root, "ca-cert.pem"),
+		ServerName: "server.example.com",
+	}
+
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err == nil {
+		t.Errorf("Connect() should have errored due to no client cert")
+	}
+	if conn != nil {
+		conn.Close()
+	}
+}

--- a/go/mysql/clientcert/auth_server_clientcert.go
+++ b/go/mysql/clientcert/auth_server_clientcert.go
@@ -24,6 +24,9 @@ func Init() {
 	if *clientcertAuthMethod != mysql.MysqlClearPassword && *clientcertAuthMethod != mysql.MysqlDialog {
 		log.Exitf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
 	}
+	if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
+		log.Exitf("clientcert auth plugin requires the -mysql_server_ssl_ca flag to be set")
+	}
 	ascc := &AuthServerClientCert{
 		Method: *clientcertAuthMethod,
 	}

--- a/go/mysql/clientcert/auth_server_clientcert.go
+++ b/go/mysql/clientcert/auth_server_clientcert.go
@@ -1,0 +1,73 @@
+package clientcert
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/log"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var clientcertAuthMethod = flag.String("mysql_clientcert_auth_method", mysql.MysqlClearPassword, "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
+
+type AuthServerClientCert struct {
+	Method string
+}
+
+type UserData struct {
+	querypb.VTGateCallerID
+}
+
+// Init is public so it can be called from plugin_auth_ldap.go (go/cmd/vtgate)
+func Init() {
+	if *clientcertAuthMethod != mysql.MysqlClearPassword && *clientcertAuthMethod != mysql.MysqlDialog {
+		log.Exitf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
+	}
+	ascc := &AuthServerClientCert{
+		Method: *clientcertAuthMethod,
+	}
+	mysql.RegisterAuthServerImpl("clientcert", ascc)
+}
+
+// AuthMethod is part of the AuthServer interface.
+func (ascc *AuthServerClientCert) AuthMethod(user string) (string, error) {
+	return ascc.Method, nil
+}
+
+// Salt is not used for this plugin.
+func (ascc *AuthServerClientCert) Salt() ([]byte, error) {
+	return mysql.NewSalt()
+}
+
+// ValidateHash is unimplemented.
+func (ascc *AuthServerClientCert) ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (mysql.Getter, error) {
+	panic("unimplemented")
+}
+
+// Negotiate is part of the AuthServer interface.
+func (ascc *AuthServerClientCert) Negotiate(c *mysql.Conn, user string, remoteAddr net.Addr) (mysql.Getter, error) {
+	// This code depends on the fact that golang's tls server enforces client cert verification.
+	// Note that the -mysql_server_ssl_ca flag must be set in order for the vtgate to accept client certs.
+	// If not set, the vtgate will effectively deny all incoming mysql connections, since they will all lack certificates.
+	// For more info, check out go/vt/vtttls/vttls.go
+	certs := c.GetTLSClientCerts()
+	if certs == nil || len(certs) == 0 {
+		return nil, fmt.Errorf("no client certs for connection ID %v", c.ConnectionID)
+	}
+
+	if _, err := mysql.AuthServerReadPacketString(c); err != nil {
+		return nil, err
+	}
+
+	return &UserData{
+		VTGateCallerID: querypb.VTGateCallerID{
+			Username: certs[0].Subject.CommonName,
+			Groups:   certs[0].DNSNames,
+		},
+	}, nil
+}
+
+func (ud *UserData) Get() *querypb.VTGateCallerID {
+	return &ud.VTGateCallerID
+}

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -18,6 +18,8 @@ package mysql
 
 import (
 	"bufio"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -981,4 +983,11 @@ func ParseErrorPacket(data []byte) error {
 	msg := string(data[pos:])
 
 	return NewSQLError(int(code), string(sqlState), "%v", msg)
+}
+
+func (conn *Conn) GetTLSClientCerts() []*x509.Certificate {
+	if tlsConn, ok := conn.conn.(*tls.Conn); ok {
+		return tlsConn.ConnectionState().PeerCertificates
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds a new vtgate auth plugin (`clientcert`) which populates the `VTGateCallerID` from the CommonName and DNSNames values in the connection's client certificate (similar to gRPC).