### PR TITLE
helm/orchestrator: set FailMasterPromotionIfSQLThreadNotUpToDate = true

### DIFF
--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -40,6 +40,7 @@ data:
     "DiscoverByShowSlaveHosts": true,
     "EnableSyslog": false,
     "ExpiryHostnameResolvesMinutes": 60,
+    "FailMasterPromotionIfSQLThreadNotUpToDate": true,
     "FailureDetectionPeriodBlockMinutes": 60,
     "GraphiteAddr": "",
     "GraphiteConvertHostnameDotsToUnderscores": true,


### PR DESCRIPTION
implementing recommendation from @shlomi-noach 
> use `FailMasterPromotionIfSQLThreadNotUpToDate: true` to avoid promoting a replica which is not up-to-date. Work in progress to actually force `orchestrator` to wait for it to become up-to-date.

https://vitess.slack.com/archives/CB1H5S0JZ/p1546976863004700