### PR TITLE
Route "show tables from <keyspace>" to the named keyspace

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -749,6 +749,10 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		}, nil
 	case sqlparser.KeywordString(sqlparser.TABLES):
 		if show.ShowTablesOpt != nil && show.ShowTablesOpt.DbName != "" {
+			if destKeyspace == "" {
+				// Change "show tables from <keyspace>" to "show tables" directed to that keyspace.
+				destKeyspace = show.ShowTablesOpt.DbName
+			}
 			show.ShowTablesOpt.DbName = ""
 		}
 		sql = sqlparser.String(show)


### PR DESCRIPTION
This only applies when the query has not already selected a target keyspace.
Some queries that previously error'd should succeed now, but queries that
previously succeeded should not be affected.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>