### PR TITLE
reload db-credentials-file upon SIGHUP

### DIFF
--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -148,8 +148,7 @@ func (a *AuthServerStatic) installSignalHandlers() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
-		for {
-			<-sigChan
+		for range sigChan {
 			a.loadConfigFromParams(*mysqlAuthServerStaticFile, "")
 		}
 	}()

--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -40,7 +40,7 @@ var (
 	dbCredentialsServer = flag.String("db-credentials-server", "file", "db credentials server type (use 'file' for the file implementation)")
 
 	// 'file' implementation flags
-	dbCredentialsFile = flag.String("db-credentials-file", "", "db credentials file")
+	dbCredentialsFile = flag.String("db-credentials-file", "", "db credentials file; send SIGHUP to reload this file")
 
 	// ErrUnknownUser is returned by credential server when the
 	// user doesn't exist
@@ -137,7 +137,9 @@ func init() {
 			<-sigChan
 			fcs, ok := AllCredentialsServers["file"].(*FileCredentialsServer)
 			if ok {
+				fcs.mu.Lock()
 				fcs.dbCredentials = nil
+				fcs.mu.Unlock()
 			}
 		}
 	}()

--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -133,10 +133,8 @@ func init() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
-		for {
-			<-sigChan
-			fcs, ok := AllCredentialsServers["file"].(*FileCredentialsServer)
-			if ok {
+		for range sigChan {
+			if fcs, ok := AllCredentialsServers["file"].(*FileCredentialsServer); ok {
 				fcs.mu.Lock()
 				fcs.dbCredentials = nil
 				fcs.mu.Unlock()

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -374,8 +374,7 @@ func (tsv *TabletServer) InitACL(tableACLConfigFile string, enforceTableACLConfi
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
-		for {
-			<-sigChan
+		for range sigChan {
 			tsv.initACL(tableACLConfigFile, enforceTableACLConfig)
 		}
 	}()


### PR DESCRIPTION
why we want this is a bit of a long story, but reloading creds on receipt of SIGHUP seems like a good idea.

Signed-off-by: Alex Charis <acharis@hubspot.com>