### PR TITLE
helm: release 1.0.5

### DIFF
--- a/helm/release.sh
+++ b/helm/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version_tag=1.0.4
+version_tag=1.0.5
 
 docker pull vitess/k8s:latest
 docker tag vitess/k8s:latest vitess/k8s:helm-$version_tag

--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.5 - 2019-01-12
+
+### Changes
+* Set FailMasterPromotionIfSQLThreadNotUpToDate = true in Orchestrator config, to prevent
+lagging replicas from being promoted to master and causing errant GTID problems.
+
+**NOTE:** You need to manually restart your Orchestrator pods for this change to take effect
+
 ## 1.0.4 - 2019-01-01
 
 ### Changes

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 1.0.4
+version: 1.0.5
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -123,7 +123,7 @@ spec:
               value: "15999"
 
         - name: recovery-log
-          image: vitess/logtail:helm-1.0.4
+          image: vitess/logtail:helm-1.0.5
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH
@@ -133,7 +133,7 @@ spec:
               mountPath: /tmp
 
         - name: audit-log
-          image: vitess/logtail:helm-1.0.4
+          image: vitess/logtail:helm-1.0.5
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -218,7 +218,7 @@ spec:
       trap : TERM INT; sleep infinity & wait
 
 - name: pmm-client-metrics-log
-  image: vitess/logtail:helm-1.0.4
+  image: vitess/logtail:helm-1.0.5
   imagePullPolicy: IfNotPresent
   env:
   - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -533,7 +533,7 @@ spec:
 {{ define "cont-logrotate" }}
 
 - name: logrotate
-  image: vitess/logrotate:helm-1.0.4
+  image: vitess/logrotate:helm-1.0.5
   imagePullPolicy: IfNotPresent
   volumeMounts:
     - name: vtdataroot
@@ -547,7 +547,7 @@ spec:
 {{ define "cont-mysql-errorlog" }}
 
 - name: error-log
-  image: vitess/logtail:helm-1.0.4
+  image: vitess/logtail:helm-1.0.5
   imagePullPolicy: IfNotPresent
 
   env:
@@ -565,7 +565,7 @@ spec:
 {{ define "cont-mysql-slowlog" }}
 
 - name: slow-log
-  image: vitess/logtail:helm-1.0.4
+  image: vitess/logtail:helm-1.0.5
   imagePullPolicy: IfNotPresent
 
   env:
@@ -583,7 +583,7 @@ spec:
 {{ define "cont-mysql-generallog" }}
 
 - name: general-log
-  image: vitess/logtail:helm-1.0.4
+  image: vitess/logtail:helm-1.0.5
   imagePullPolicy: IfNotPresent
 
   env:

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -177,7 +177,7 @@ etcd:
 # Default values for vtctld resources defined in 'topology'
 vtctld:
   serviceType: ClusterIP
-  vitessTag: helm-1.0.4
+  vitessTag: helm-1.0.5
   resources:
     # requests:
     #   cpu: 100m
@@ -188,7 +188,7 @@ vtctld:
 # Default values for vtgate resources defined in 'topology'
 vtgate:
   serviceType: ClusterIP
-  vitessTag: helm-1.0.4
+  vitessTag: helm-1.0.5
   resources:
     # requests:
     #   cpu: 500m
@@ -207,13 +207,13 @@ vtgate:
 
 # Default values for vtctlclient resources defined in 'topology'
 vtctlclient:
-  vitessTag: helm-1.0.4
+  vitessTag: helm-1.0.5
   extraFlags: {}
   secrets: [] # secrets are mounted under /vt/usersecrets/{secretname}
 
 # Default values for vtworker resources defined in 'jobs'
 vtworker:
-  vitessTag: helm-1.0.4
+  vitessTag: helm-1.0.5
   extraFlags: {}
   resources:
     # requests:
@@ -224,7 +224,7 @@ vtworker:
 
 # Default values for vttablet resources defined in 'topology'
 vttablet:
-  vitessTag: helm-1.0.4
+  vitessTag: helm-1.0.5
 
   # valid values are
   # - mysql56 (for MySQL 8.0)


### PR DESCRIPTION
This is an important release to prevent Orchestrator from promoting lagging replicas to master.