### PR TITLE
vtctl: run BackupShard on replica, rdonly or spare

### DIFF
--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -103,8 +103,10 @@ func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	var secondsBehind uint32
 
 	for i := range tablets {
-		// don't run a backup on a non-slave type
-		if !tablets[i].IsSlaveType() {
+		// only run a backup on a replica, rdonly or spare tablet type
+		switch tablets[i].Type {
+		case topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY, topodatapb.TabletType_SPARE:
+		default:
 			continue
 		}
 


### PR DESCRIPTION
The current implementation of BackupShard is too permissive on what types it will run a backup on. I want to use the experimental type to test out `MyRocks`, but I need to make sure that it isn't used for backups.