### PR TITLE
Make kmysql.sh work on Vitess on a single K8s node setup by Kubeadm.(

### DIFF
--- a/examples/helm/kmysql.sh
+++ b/examples/helm/kmysql.sh
@@ -19,4 +19,18 @@
 host=$(minikube service vtgate-zone1 --format "{{.IP}}" | tail -n 1)
 port=$(minikube service vtgate-zone1 --format "{{.Port}}" | tail -n 1)
 
+if [ -z $port ]; then 
+	#This checks K8s runing on an single node by kubeadm
+	if [ $(kubectl get nodes | grep -v NAM | wc -l) -eq 1 -o $(kubectl get nodes | grep -v NAM | grep master | wc -l ) -eq 1 ]; then
+		host="127.0.0.1"
+		port=`kubectl describe service vtgate-zone1 | grep NodePort | grep mysql | awk '{print $3}' | awk -F'/' '{print $1}'`
+	fi
+fi
+
+if [ -z $port ]; then
+	echo "Error: failed to obtain [host:port] minikube or kubectl."
+	exit 1;
+
+fi
+
 mysql -h "$host" -P "$port" $*


### PR DESCRIPTION
I am installed vitess on a single [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/) cluster, partly following [Run Vitess on Kubernetes](https://vitess.io/docs/tutorials/kubernetes/). and it works. So I updated the script to support the kubeadm enviroment.