### PR TITLE
WIP: do not merge. test for order by which is incorrectly planned cross-shard

### DIFF
--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -398,6 +398,123 @@
   }
 }
 
+# ORDER BY non-key column for join
+"select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by a"
+{
+  "Original": "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by a",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by a asc",
+      "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [1]
+    },
+    "Right": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select music.col3 from music where music.id = :user_id",
+      "FieldQuery": "select music.col3 from music where 1 != 1",
+      "Vindex": "music_user_map",
+      "Values": [":user_id"]
+    },
+    "Cols": [
+      -1,
+      -2,
+      1
+    ],
+    "Vars": {
+      "user_id": 2
+    }
+  }
+}
+
+# ORDER BY non-key column for implicit join
+"select user.col1 as a, user.col2, music.col3 from user, music where user.id = music.id and user.id = 1 order by a"
+{
+  "Original": "select user.col1 as a, user.col2, music.col3 from user, music where user.id = music.id and user.id = 1 order by a",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by a asc",
+      "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [1]
+    },
+    "Right": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select music.col3 from music where music.id = :user_id",
+      "FieldQuery": "select music.col3 from music where 1 != 1",
+      "Vindex": "music_user_map",
+      "Values": [":user_id"]
+    },
+    "Cols": [
+      -1,
+      -2,
+      1
+    ],
+    "Vars": {
+      "user_id": 2
+    }
+  }
+}
+
+# ORDER BY non-key column from second table for implicit join FAILS!!
+"select user.col1 a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
+{
+  "Original": "select user.col1 a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user.col1 a, user.col2 b, user.id from user where user.id = 1",
+      "FieldQuery": "select user.col1 a, user.col2 b, user.id from user where 1 != 1",
+      "Vindex": "user_index",
+      "Values": [1]
+    },
+    "Right": {
+      "Opcode": "SelectEqualUnique",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select music.col3 c from music where music.id = :user_id order by c",
+      "FieldQuery": "select music.col3 c from music where 1 != 1",
+      "Vindex": "music_user_map",
+      "Values": [":user_id"]
+    },
+    "Cols": [
+      -1,
+      -2,
+      1
+    ],
+    "Vars": {
+      "user_id": 2
+    }
+  }
+}
+
 # ORDER BY NULL after pull-out subquery
 "select col from user where col in (select col2 from user) order by null"
 {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -476,45 +476,6 @@
   }
 }
 
-# ORDER BY non-key column from second table for implicit join FAILS!!
-"select user.col1 a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
-{
-  "Original": "select user.col1 a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c",
-  "Instructions": {
-    "Opcode": "Join",
-    "Left": {
-      "Opcode": "SelectEqualUnique",
-      "Keyspace": {
-        "Name": "user",
-        "Sharded": true
-      },
-      "Query": "select user.col1 a, user.col2 b, user.id from user where user.id = 1",
-      "FieldQuery": "select user.col1 a, user.col2 b, user.id from user where 1 != 1",
-      "Vindex": "user_index",
-      "Values": [1]
-    },
-    "Right": {
-      "Opcode": "SelectEqualUnique",
-      "Keyspace": {
-        "Name": "user",
-        "Sharded": true
-      },
-      "Query": "select music.col3 c from music where music.id = :user_id order by c",
-      "FieldQuery": "select music.col3 c from music where 1 != 1",
-      "Vindex": "music_user_map",
-      "Values": [":user_id"]
-    },
-    "Cols": [
-      -1,
-      -2,
-      1
-    ],
-    "Vars": {
-      "user_id": 2
-    }
-  }
-}
-
 # ORDER BY NULL after pull-out subquery
 "select col from user where col in (select col2 from user) order by null"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -55,6 +55,10 @@
 "select id from (select user.id, user.col from user join user_extra) as t order by id"
 "unsupported: cannot order by on a cross-shard subquery"
 
+# order by on a cross-shard query. Note: this is only a problem when an order by column is from the second table
+"select user.col1 as a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
+"unsupported: order by spans across shards"
+
 # scatter order by with * expression
 "select * from user order by id"
 "unsupported: in scatter query: order by must reference a column in the select list: id asc"

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -237,7 +237,7 @@ func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {
 			out = string(bout)
 		}
 		if out != tcase.output {
-			t.Errorf("File: %s, Line:%v\n%s, want\n%s", filename, tcase.lineno, out, tcase.output)
+			t.Errorf("File: %s, Line:%v\n got:\n%s, \nwant:\n%s", filename, tcase.lineno, out, tcase.output)
 			// Uncomment these lines to re-generate input files
 			if err != nil {
 				out = fmt.Sprintf("\"%s\"", out)


### PR DESCRIPTION
add tests to show that implicit joins with `order by` work fine if ordering by columns of first table, but not if ordering by columns of second table

Signed-off-by: deepthi <deepthi@planetscale.com>