### PR TITLE
Change common unhandled packet error message to clarify origin

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -780,7 +780,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 			case 1:
 				c.Capabilities &^= CapabilityClientMultiStatements
 			default:
-				log.Errorf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data)
+				log.Errorf("Got unhandled packet (ComSetOption default) from client %v, returning error: %v", c.ConnectionID, data)
 				if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "error handling packet: %v", data); err != nil {
 					log.Errorf("Error writing error packet to client: %v", err)
 					return err
@@ -791,14 +791,14 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 				return err
 			}
 		} else {
-			log.Errorf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data)
+			log.Errorf("Got unhandled packet (ComSetOption else) from client %v, returning error: %v", c.ConnectionID, data)
 			if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "error handling packet: %v", data); err != nil {
 				log.Errorf("Error writing error packet to client: %v", err)
 				return err
 			}
 		}
 	default:
-		log.Errorf("Got unhandled packet from %s, returning error: %v", c, data)
+		log.Errorf("Got unhandled packet (default) from %s, returning error: %v", c, data)
 		c.recycleReadPacket()
 		if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "command handling not implemented yet: %v", data[0]); err != nil {
 			log.Errorf("Error writing error packet to %s: %s", c, err)


### PR DESCRIPTION
`conn.go` has 3 identical error messages for different situations so it's harder to identify where an error has been triggered. This change simply identifies the part of the code affected for easier analysis.

I basically saw this and without protocol knowledge it's not clear which part of the code is triggering the error:
```
E0124 12:51:40.010442     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 68 ...]
E0124 12:51:40.012055     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 72 ...]
E0124 12:51:40.012139     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 72 ...]
E0124 12:51:40.012210     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 82 ...]
E0124 12:51:40.012270     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 82 ...]
E0124 12:51:40.012329     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 85 ...]
E0124 12:51:40.012386     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 85 ...]
E0124 12:51:40.012450     838 conn.go:801] Got unhandled packet from client 478 (a.b.c.d:58121), returning error: [4 100 ...]
```