### PR TITLE
mysqlctl: add MyRocks dir/files to backups

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -164,13 +164,19 @@ func isDbDir(p string) bool {
 		return true
 	}
 
-	// Look for at least one .frm file
+	// Look for at least one database file
 	fis, err := ioutil.ReadDir(p)
 	if err != nil {
 		return false
 	}
 	for _, fi := range fis {
 		if strings.HasSuffix(fi.Name(), ".frm") {
+			return true
+		}
+
+		// the MyRocks engine stores data in RocksDB .sst files
+		// https://github.com/facebook/rocksdb/wiki/Rocksdb-BlockBasedTable-Format
+		if strings.HasSuffix(fi.Name(), ".sst") {
 			return true
 		}
 


### PR DESCRIPTION
Using MyRocks changes the data location from a normal MySQL installation. It leaves an `.sdi` file in the schema directory, where InnoDB would have an `.ibd` file. All the actual data however for all schemas is stored in a single `.rocksdb` directory at the data root, with no table specific files. This PR just adds a new file extension check for `.sst` to confirm a data directory to backup.

```
ls $DATADIR/schemaname/
-rw-r----- 1 vitess vitess 7.3K Jan 24 02:18 urls_519.sdi

ls $DATADIR/.rocksdb/
-rw-r----- 1 vitess vitess 8.5K Jan 24 02:18 000003.log
-rw-r----- 1 vitess vitess  18M Jan 24 01:44 000011.sst
-rw-r----- 1 vitess vitess  19M Jan 24 01:44 000012.sst
...
-rw-r----- 1 vitess vitess   16 Jan 23 17:51 CURRENT
-rw-r----- 1 vitess vitess   37 Jan 23 17:51 IDENTITY
-rw-r----- 1 vitess vitess    0 Jan 23 17:51 LOCK
-rw-r----- 1 vitess vitess  42K Jan 24 02:18 LOG
-rw-r----- 1 vitess vitess   13 Jan 23 17:51 MANIFEST-000001
-rw-r----- 1 vitess vitess 3.7K Jan 24 02:18 MANIFEST-000006
-rw-r----- 1 vitess vitess 7.1K Jan 23 17:51 OPTIONS-000008
-rw-r----- 1 vitess vitess 7.1K Jan 23 17:51 OPTIONS-000010
```