### PR TITLE
Adding a reset of the slave on blank restore

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -820,6 +820,12 @@ func Restore(
 	if len(bhs) == 0 {
 		// There are no backups (not even broken/incomplete ones).
 		logger.Errorf("No backup to restore on BackupStorage for directory %v. Starting up empty.", dir)
+		// Since this Was an empty database make sure we start replication at the beginning
+		if err = mysqld.ResetReplication(ctx); err == nil {
+			logger.Errorf("Error reseting slave replication: %v. Continuing", err)
+			err = ErrNoBackup
+		}
+
 		if err = PopulateMetadataTables(mysqld, localMetadata); err == nil {
 			err = ErrNoBackup
 		}


### PR DESCRIPTION
In the event we are restoring from a backup, but there is no backup we need to reset master to accomidate flavors that write to the binlog on startup ( I'm looking at you MariaDB )

Signed-off-by: Dan Kozlowski <koz@planetscale.com>