### PR TITLE
docker: don't chown nonexistent /vt dir

### DIFF
--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -13,8 +13,6 @@ COPY --from=k8s /vt/bin/vtctlclient /usr/bin/
 
 # add vitess user/group and add permissions
 RUN groupadd -r --gid 2000 vitess && \
-   useradd -r -g vitess --uid 1000 vitess && \
-   chown -R vitess:vitess /vt && \
-   chown -R vitess:vitess /vtdataroot
+   useradd -r -g vitess --uid 1000 vitess
     
 CMD ["/usr/bin/vtctlclient"]


### PR DESCRIPTION
I think that `vtctlclient` hasn't been building for 3 months because it was trying to `chown /vt` without ensuring that the directory exists.