### PR TITLE
Use a more specific "in use" message for the tx killer's rollback

### DIFF
--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -178,7 +178,7 @@ func (axp *TxPool) RollbackNonBusy(ctx context.Context) {
 
 func (axp *TxPool) transactionKiller() {
 	defer tabletenv.LogError()
-	for _, v := range axp.activePool.GetOutdated(time.Duration(axp.Timeout()), "for rollback") {
+	for _, v := range axp.activePool.GetOutdated(time.Duration(axp.Timeout()), "for tx killer rollback") {
 		conn := v.(*TxConnection)
 		log.Warningf("killing transaction (exceeded timeout: %v): %s", axp.Timeout(), conn.Format(nil))
 		tabletenv.KillStats.Add("Transactions", 1)


### PR DESCRIPTION
Someone who accidentally made a huge transaction asked what this error meant:
"vttablet: rpc error: code = Aborted desc = transaction 1548379105148705713: in use: for rollback"

It's less clear than the typical transaction killed error because the transaction was so large that
rolling it back probably took some time. This diff changes the in use reason to "for tx killer rollback"
which will hopefully be more clear.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>