### PR TITLE
Recommended fix for https://nvd.nist.gov/vuln/detail/CVE-2017-18342

### DIFF
--- a/test/cluster/keytar/requirements.txt
+++ b/test/cluster/keytar/requirements.txt
@@ -1,2 +1,2 @@
 Flask==0.12.3
-pyyaml==3.10
+pyyaml==4.2b1


### PR DESCRIPTION
We've recently turned on [Security Alerts](https://github.blog/2017-11-16-introducing-security-alerts-on-github/) and found this alert marked as high severity. This change takes the recommendation to update to this verision of pyyaml.