### PR TITLE
Recommended fix for https://nvd.nist.gov/vuln/detail/CVE-2018-14404

### DIFF
--- a/vitess.io/Gemfile.lock
+++ b/vitess.io/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     neat (2.1.0)
       sass (~> 3.4)
       thor (~> 0.19)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)


### PR DESCRIPTION
We've recently turned on [Security Alerts](https://github.blog/2017-11-16-introducing-security-alerts-on-github/) and found this alert marked as moderate severity. This change takes the recommendation to update to this version of nokogiri.

Signed-off-by: Tom Krouper <tomkrouper@github.com>