### PR TITLE
Populate metadata table when not restoring from backup

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -318,6 +318,13 @@ func NewActionAgent(
 		if err := agent.lock(batchCtx); err != nil {
 			return nil, err
 		}
+
+		// Populate metadata table
+		localMetadata := agent.getLocalMetadataValues(agent.Tablet().Type)
+		if err = mysqlctl.PopulateMetadataTables(mysqld, localMetadata); err == nil {
+			return nil, err
+		}
+
 		if err := agent.refreshTablet(batchCtx, "Start"); err != nil {
 			agent.unlock()
 			return nil, err


### PR DESCRIPTION
### Desc 

When starting a tablet without restoring from backup, metadata tables are not being created. This could create issues later on. For instance, orchestrator uses this table to get tablet alias info during a failover. 

The following, makes sure that metadata table gets created in this case as well. 

### Tests

* TODO: To verify that this works as expected in an integration environment. Opening the PR to get travis run agains it. 