### PR TITLE
java: shutdown GRPC channel cleanly

### DIFF
--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
@@ -20,10 +20,11 @@ import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+
 import io.grpc.CallCredentials;
+import io.grpc.InternalWithLogId;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-import io.grpc.InternalWithLogId;
 import io.vitess.client.Context;
 import io.vitess.client.Proto;
 import io.vitess.client.RpcClient;
@@ -65,6 +66,9 @@ import io.vitess.proto.Vtgate.StreamExecuteShardsResponse;
 import io.vitess.proto.grpc.VitessGrpc;
 import io.vitess.proto.grpc.VitessGrpc.VitessFutureStub;
 import io.vitess.proto.grpc.VitessGrpc.VitessStub;
+
+import org.joda.time.Duration;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -75,7 +79,6 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientException;
 import java.util.concurrent.TimeUnit;
-import org.joda.time.Duration;
 
 /**
  * GrpcClient is a gRPC-based implementation of Vitess RpcClient.
@@ -102,7 +105,7 @@ public class GrpcClient implements RpcClient {
     channelId = toChannelId(channel);
     asyncStub = VitessGrpc.newStub(channel);
     futureStub = VitessGrpc.newFutureStub(channel);
-    timeout = context.getTimeout() != null ? context.getTimeout() : DEFAULT_TIMEOUT;
+    timeout = getContextTimeoutOrDefault(context);
   }
 
   public GrpcClient(ManagedChannel channel, CallCredentials credentials, Context context) {
@@ -110,7 +113,7 @@ public class GrpcClient implements RpcClient {
     channelId = toChannelId(channel);
     asyncStub = VitessGrpc.newStub(channel).withCallCredentials(credentials);
     futureStub = VitessGrpc.newFutureStub(channel).withCallCredentials(credentials);
-    timeout = context.getTimeout() != null ? context.getTimeout() : DEFAULT_TIMEOUT;
+    timeout = getContextTimeoutOrDefault(context);
   }
 
   private String toChannelId(ManagedChannel channel) {
@@ -344,5 +347,13 @@ public class GrpcClient implements RpcClient {
               Integer.toHexString(this.hashCode()),
               channelId
       );
+  }
+
+  private static Duration getContextTimeoutOrDefault(Context context) {
+    if (context.getTimeout() == null || context.getTimeout().getStandardSeconds() < 0) {
+      return DEFAULT_TIMEOUT;
+    }
+
+    return context.getTimeout();
   }
 }

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -98,7 +98,7 @@ public class GrpcClientFactory implements RpcClientFactory {
       channel.nameResolverFactory(nameResolverFactory);
     }
     return callCredentials != null ?
-            new GrpcClient(channel.build(), callCredentials) : new GrpcClient(channel.build());
+            new GrpcClient(channel.build(), callCredentials, ctx) : new GrpcClient(channel.build(), ctx);
   }
 
   /**
@@ -174,7 +174,7 @@ public class GrpcClientFactory implements RpcClientFactory {
     }
 
     return new GrpcClient(
-            channelBuilder(target).negotiationType(NegotiationType.TLS).sslContext(sslContext).intercept(new RetryingInterceptor(config)).build());
+            channelBuilder(target).negotiationType(NegotiationType.TLS).sslContext(sslContext).intercept(new RetryingInterceptor(config)).build(), ctx);
   }
 
   /**


### PR DESCRIPTION
The existing `close` was causing GRPC to complain about orphaned channels because we were closing without waiting for operations to terminate. This improves the `close` implementation to correctly wait for shutdown and call `shutdownNow` if the channel does not terminate within the expected window.

