### PR TITLE
Scrub BindVar values from log statements to hide PII

### DIFF
--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -436,7 +436,7 @@ func TestQueryDeadline(t *testing.T) {
 	// First run a query that is killed by the slow query killer after 2s
 	_, err = conn.ExecuteFetch("select sleep(5) from dual", 1000, false)
 	wantErr := "EOF (errno 2013) (sqlstate HY000) (CallerID: userData1): Sql: \"select sleep(:vtp1) from dual\", " +
-		"BindVars: {#maxLimit: \"type:INT64 value:\\\"10001\\\" \"vtp1: \"type:INT64 value:\\\"5\\\" \"} " +
+		"BindVars: {#maxLimit: \"type:INT64\" vtp1: \"type:INT64\" } " +
 		"(errno 2013) (sqlstate HY000) during query: select sleep(5) from dual"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("error want '%v', got '%v'", wantErr, err)

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -616,7 +616,7 @@ func TestLogTruncation(t *testing.T) {
 		"insert into vitess_test values(123, null, :data, null)",
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},
 	)
-	wantLog := `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null)", BindVars: {#maxLimit: "type:INT64 value:\"10001\" "data: "type:VARCHAR value:\"THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED\" "}`
+	wantLog := `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null)", BindVars: {#maxLimit: "type:INT64" data: "type:VARCHAR" }`
 	wantErr := wantLog
 	if err == nil {
 		t.Errorf("query unexpectedly succeeded")
@@ -636,7 +636,7 @@ func TestLogTruncation(t *testing.T) {
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},
 	)
 	wantLog = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess [TRUNCATED]", BindVars: {#maxLim [TRUNCATED]`
-	wantErr = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null)", BindVars: {#maxLimit: "type:INT64 value:\"10001\" "data: "type:VARCHAR value:\"THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED\" "}`
+	wantErr = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null)", BindVars: {#maxLimit: "type:INT64" data: "type:VARCHAR" }`
 	if err == nil {
 		t.Errorf("query unexpectedly succeeded")
 	}
@@ -654,7 +654,7 @@ func TestLogTruncation(t *testing.T) {
 		map[string]*querypb.BindVariable{"data": sqltypes.StringBindVariable("THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED")},
 	)
 	wantLog = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess [TRUNCATED] /* KEEP ME */", BindVars: {#maxLim [TRUNCATED]`
-	wantErr = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null) /* KEEP ME */", BindVars: {#maxLimit: "type:INT64 value:\"10001\" "data: "type:VARCHAR value:\"THIS IS A LONG LONG LONG LONG QUERY STRING THAT SHOULD BE SHORTENED\" "}`
+	wantErr = `Data too long for column 'charval' at row 1 (errno 1406) (sqlstate 22001) (CallerID: dev): Sql: "insert into vitess_test values(123, null, :data, null) /* KEEP ME */", BindVars: {#maxLimit: "type:INT64" data: "type:VARCHAR" }`
 	if err == nil {
 		t.Errorf("query unexpectedly succeeded")
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -152,12 +152,12 @@ type TabletServer struct {
 	// for health checks. This does not affect how queries are served.
 	// target specifies the primary target type, and also allow specifies
 	// secondary types that should be additionally allowed.
-	mu            sync.Mutex
-	state         int64
-	lameduck      sync2.AtomicInt32
-	target        querypb.Target
-	alsoAllow     []topodatapb.TabletType
-	requests      sync.WaitGroup
+	mu        sync.Mutex
+	state     int64
+	lameduck  sync2.AtomicInt32
+	target    querypb.Target
+	alsoAllow []topodatapb.TabletType
+	requests  sync.WaitGroup
 
 	// The following variables should be initialized only once
 	// before starting the tabletserver.
@@ -229,7 +229,7 @@ type TxPoolController interface {
 	AcceptReadOnly() error
 
 	// InitDBConfig must be called before Init.
-  InitDBConfig(dbcfgs *dbconfigs.DBConfigs)
+	InitDBConfig(dbcfgs *dbconfigs.DBConfigs)
 
 	// Init must be called once when vttablet starts for setting
 	// up the metadata tables.
@@ -1554,8 +1554,8 @@ func truncateSQLAndBindVars(sql string, bindVariables map[string]*querypb.BindVa
 	sort.Strings(keys)
 	var valString string
 	for _, key := range keys {
-		valString = fmt.Sprintf("%v", bindVariables[key])
-		fmt.Fprintf(buf, "%s: %q", key, valString)
+		valString = fmt.Sprintf("type:%v", bindVariables[key].Type)
+		fmt.Fprintf(buf, "%s: %q ", key, valString)
 	}
 	fmt.Fprintf(buf, "}")
 	bv := string(buf.Bytes())
@@ -2188,8 +2188,8 @@ func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable) s
 	sort.Strings(keys)
 	var valString string
 	for _, key := range keys {
-		valString = fmt.Sprintf("%v", bindVariables[key])
-		fmt.Fprintf(buf, "%s: %q", key, valString)
+		valString = fmt.Sprintf("type:%v", bindVariables[key].Type)
+		fmt.Fprintf(buf, "%s: %q ", key, valString)
 	}
 	fmt.Fprintf(buf, "}")
 	return string(buf.Bytes())

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2604,7 +2604,7 @@ func TestTerseErrorsBindVars(t *testing.T) {
 		t.Errorf("error got '%v', want '%s'", err, want)
 	}
 
-	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where a = :a\", BindVars: {a: \"type:INT64 value:\\\"1\\\" \"}"
+	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where a = :a\", BindVars: {a: \"type:INT64\" }"
 	if wantLog != getTestLog(0) {
 		t.Errorf("log got '%s', want '%s'", getTestLog(0), wantLog)
 	}
@@ -2654,7 +2654,7 @@ func TestTruncateErrors(t *testing.T) {
 		t.Errorf("error got '%v', want '%s'", err, wantErr)
 	}
 
-	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vt [TRUNCATED]\", BindVars: {vtg1: \"type:VARCHAR value:\\\"t [TRUNCATED]"
+	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vt [TRUNCATED]\", BindVars: {vtg1: \"type:VARCHAR\" }"
 	if wantLog != getTestLog(0) {
 		t.Errorf("log got '%s', want '%s'", getTestLog(0), wantLog)
 	}
@@ -2673,7 +2673,7 @@ func TestTruncateErrors(t *testing.T) {
 		t.Errorf("error got '%v', want '%s'", err, wantErr)
 	}
 
-	wantLog = "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {vtg1: \"type:VARCHAR value:\\\"this is kinda long eh\\\" \"}"
+	wantLog = "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table where xyz = :vtg1 order by abc desc\", BindVars: {vtg1: \"type:VARCHAR\" }"
 	if wantLog != getTestLog(1) {
 		t.Errorf("log got '%s', want '%s'", getTestLog(1), wantLog)
 	}


### PR DESCRIPTION
There's probably an elegant way to do this in a targeted manner, but this needs to go ASAP.

Signed-off-by: Aaron Young <young@squareup.com>