### PR TITLE
healthcheck: Cache regions in tablet_stats_cache

### DIFF
--- a/go/vt/discovery/tablet_stats_cache_test.go
+++ b/go/vt/discovery/tablet_stats_cache_test.go
@@ -38,8 +38,9 @@ func TestTabletStatsCache(t *testing.T) {
 	// HealthCheck object, so we can't call NewTabletStatsCache.
 	// So we just construct this object here.
 	tsc := &TabletStatsCache{
-		cell:    "cell",
-		entries: make(map[string]map[string]map[topodatapb.TabletType]*tabletStatsCacheEntry),
+		cell:        "cell",
+		entries:     make(map[string]map[string]map[topodatapb.TabletType]*tabletStatsCacheEntry),
+		cellRegions: make(map[string]string),
 	}
 
 	// empty


### PR DESCRIPTION
This adds caches getRegionByCell call to improve initial vtgate healthcheck performance.

We've seen some significant initial healthcheck slow down in our recent vitess upgrade that resulted in the gateway timing out before finishing waiting for the `-tablet_types_to_wait`

We were able to diagnose this via a lock contention profile that showed `StatsUpdate` to be the pain point. From there @sougou was able to identify the uncached cell region call.

Signed-off-by: Leo Xuzhang Lin <llin@hubspot.com>