### PR TITLE
Using bash shell to interpret the script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2164
 
 # Copyright 2017 Google Inc.


### PR DESCRIPTION
Adding `#!/usr/bin/env bash` in order to indicate that scripts use
bash shell for interpreting.

Signed-off-by: Nguyen Hai Truong <nguyenhaitruonghp@gmail.com>