### PR TITLE
Replace 404 links in doc

### DIFF
--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -706,7 +706,7 @@ x509: failed to load system roots and no roots provided
 It usually means that your Kubernetes nodes are running a host OS
 that puts root certificates in a different place than our configuration
 expects by default (for example, Fedora). See the comments in the
-[etcd controller template](https://github.com/vitessio/vitess/blob/master/examples/kubernetes/etcd-controller-template.yaml)
+[etcd controller template](https://github.com/kubernetes/examples/blob/master/staging/storage/vitess/etcd-controller-template.yaml)
 for examples of how to set the right location for your host OS.
 You'll also need to adjust the same certificate path settings in the
 `vtctld` and `vttablet` templates.

--- a/doc/ReplicatoinLagBasedThrottlingOfTransactions.md
+++ b/doc/ReplicatoinLagBasedThrottlingOfTransactions.md
@@ -25,7 +25,7 @@ A text-format representation of the  [throttlerdata.Configuration](https://githu
 that contains configuration options for the throttler. 
 The most important fields in that message are *target_replication_lag_sec* and 
 *max_replication_lag_sec* that specify the desired limits on the replication lag. See the comments in the protocol definition file for more details.
-If this is not specified a [default](https://github.com/vitessio/vitess/blob/master/go/vt/tabletserver/tabletenv/config.go) configuration will be used.
+If this is not specified a [default](https://github.com/vitessio/vitess/tree/master/go/vt/vttablet/tabletserver/tabletenv/config.go) configuration will be used.
 
 * *tx-throttler-healthcheck-cells*
 

--- a/doc/ServerConfiguration.md
+++ b/doc/ServerConfiguration.md
@@ -504,7 +504,7 @@ This URL prints out a simple "ok" or “not ok” string that can be used to che
 
 #### /querylogz, /debug/querylog, /txlogz, /debug/txlog
 
-* /debug/querylog is a never-ending stream of currently executing queries with verbose information about each query. This URL can generate a lot of data because it streams every query processed by VTTablet. The details are as per this function: [https://github.com/vitessio/vitess/blob/master/go/vt/tabletserver/logstats.go#L202](https://github.com/vitessio/vitess/blob/master/go/vt/tabletserver/logstats.go#L202)
+* /debug/querylog is a never-ending stream of currently executing queries with verbose information about each query. This URL can generate a lot of data because it streams every query processed by VTTablet. The details are as per this function: [https://github.com/vitessio/vitess/tree/master/go/vt/vttablet/tabletserver/tabletenv/logstats.go#L202](https://github.com/vitessio/vitess/tree/master/go/vt/vttablet/tabletserver/tabletenv/logstats.go#L202)
 * /querylogz is a limited human readable version of /debug/querylog. It prints the next 300 queries by default. The limit can be specified with a limit=N parameter on the URL.
 * /txlogz is like /querylogz, but for transactions.
 * /debug/txlog is the JSON counterpart to /txlogz.

--- a/doc/V3HighLevelDesign.md
+++ b/doc/V3HighLevelDesign.md
@@ -1194,7 +1194,7 @@ The overall strategy is as follows:
 
 In order to align ourselves with our priorities, we’ll start off with a limited set of primitives, and then we can expand from there.
 
-VTGate already has `Route` and `RouteMerge` as primitives. To this list, let’s add `Join` and `LeftJoin`. Using these primitives, we should be able to cover priorities 1-3 (mentioned in the [Prioritization](https://github.com/vitessio/vitess/blob/sugudoc/doc/V3HighLevelDesign.md#prioritization) section). So, any constructs that will require VTGate to do additional work will not be supported. Here’s a recap of what each primitive must do:
+VTGate already has `Route` and `RouteMerge` as primitives. To this list, let’s add `Join` and `LeftJoin`. Using these primitives, we should be able to cover priorities 1-3 (mentioned in the [Prioritization](https://github.com/vitessio/vitess/blob/master/doc/V3HighLevelDesign.md#prioritization) section). So, any constructs that will require VTGate to do additional work will not be supported. Here’s a recap of what each primitive must do:
 
 * `Route`: Sends a query to a single shard or unsharded keyspace.
 * `RouteMerge`: Sends a (mostly) identical query to multiple shards and returns the combined results in no particular order.


### PR DESCRIPTION
The following links in doc return "404 page not found" error:
https://github.com/vitessio/vitess/blob/master/examples/kubernetes/etcd-controller-template.yaml
https://github.com/vitessio/vitess/blob/master/go/vt/tabletserver/tabletenv/config.go
https://github.com/vitessio/vitess/blob/master/go/vt/tabletserver/logstats.go#L202
https://github.com/vitessio/vitess/blob/sugudoc/doc/V3HighLevelDesign.md#prioritization

This PR replaces them with correct working links.