### PR TITLE
Add in stats counters for ExecuteOptions_DBA inuse and total transactions.

### DIFF
--- a/go/pools/numbered.go
+++ b/go/pools/numbered.go
@@ -190,6 +190,33 @@ func (nu *Numbered) GetIdle(timeout time.Duration, purpose string) (vals []inter
 	return vals
 }
 
+// GetPersistent returns a list of resources that have been executed with
+// ExecuteOptions_DBA (and thus don't have an enforced timeout).
+func (nu *Numbered) GetPersistent() (vals []interface{}) {
+	nu.mu.Lock()
+	defer nu.mu.Unlock()
+	for _, nw := range nu.resources {
+		if !nw.enforceTimeout {
+			vals = append(vals, nw.val)
+		}
+	}
+	return vals
+}
+
+// GetPersistentInUse returns a list of resources that have been executed with
+// ExecuteOptions_DBA (and thus don't have an enforced timeout) and also are
+// currently in use.
+func (nu *Numbered) GetPersistentInUse() (vals []interface{}) {
+	nu.mu.Lock()
+	defer nu.mu.Unlock()
+	for _, nw := range nu.resources {
+		if !nw.enforceTimeout && nw.inUse {
+			vals = append(vals, nw.val)
+		}
+	}
+	return vals
+}
+
 // WaitForEmpty returns as soon as the pool becomes empty
 func (nu *Numbered) WaitForEmpty() {
 	nu.mu.Lock()

--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -78,6 +78,19 @@ func (client *QueryClient) Begin(clientFoundRows bool) error {
 	return nil
 }
 
+// BeginWithOptions is like Begin, but you can pass in your custom ExecuteOptions.
+func (client *QueryClient) BeginWithOptions(options *querypb.ExecuteOptions) error {
+	if client.transactionID != 0 {
+		return errors.New("already in transaction")
+	}
+	transactionID, err := client.server.Begin(client.ctx, &client.target, options)
+	if err != nil {
+		return err
+	}
+	client.transactionID = transactionID
+	return nil
+}
+
 // Commit commits the current transaction.
 func (client *QueryClient) Commit() error {
 	defer func() { client.transactionID = 0 }()

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -128,8 +128,21 @@ func NewTxPool(
 		// but we know it doesn't export Timeout.
 		stats.NewGaugeDurationFunc(prefix+"TransactionPoolTimeout", "Transaction pool timeout", axp.timeout.Get)
 		stats.NewGaugeFunc(prefix+"TransactionPoolWaiters", "Transaction pool waiters", axp.waiters.Get)
+		stats.NewGaugeFunc(prefix+"TransactionPoolDbaInUse", "Transaction pool ExecuteOptions_DBA transactions currently in use", axp.GetDBAInUseCount)
+		stats.NewGaugeFunc(prefix+"TransactionPoolDbaTotal", "Transaction pool ExecuteOptions_DBA transactions", axp.GetDBACount)
 	})
 	return axp
+}
+
+// GetDBACount returns the number of ExecuteOptions_DBA transactions
+func (axp *TxPool) GetDBACount() int64 {
+	return int64(len(axp.activePool.GetPersistent()))
+}
+
+// GetDBAInUseCount returns the number of ExecuteOptions_DBA transactions that
+// are currently in use
+func (axp *TxPool) GetDBAInUseCount() int64 {
+	return int64(len(axp.activePool.GetPersistentInUse()))
 }
 
 // Open makes the TxPool operational. This also starts the transaction killer


### PR DESCRIPTION
A step towards tackling #4197 - tracking DBA transactions that are running but have been idle. The idea is that as long as we have external visibility over this number, we can alert and handle the scenario where leaky transactions are growing for some reason.

Apologies, it's my first time contributing and:

1) I'm not sure I've gotten the terminology correct re: Active / Idle / Persistent, etc.
2) I'm not sure what should go into `numbered.go` vs `tx_pool.go` - I could have e.g. had `GetPersistent` return just a number, but I tried to not put highly tx_pool specific stuff into the more generic Numbered struct.
3) I'm not sure of the approach of using a Gauge function and counting the thing on-demand instead of having an `sync2.AtomicInt64` (like `tx_pool.go:waiters`) and incrementing / decrementing it manually in each appropriate spot - seemed like that approach had many more edge cases and this was simpler.
4) I'm not sure if there are any gaps - any other numbers we'd like to add in while we're at it.

Happy to make any changes.
