### PR TITLE
Adding '#!/bin/bash' as a shebang line in env.sh

### DIFF
--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This commit aims to add shebang line that indicates scripts use
bash shell for interpreting.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>