### PR TITLE
Fix panic in vtgate when MakeRowTrusted gets bad result

### DIFF
--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -185,9 +185,12 @@ func ResultsEqual(r1, r2 []Result) bool {
 // Every place this function is called, a comment is needed that explains
 // why it's justified.
 func MakeRowTrusted(fields []*querypb.Field, row *querypb.Row) []Value {
+	fieldCount := len(fields)
+
 	sqlRow := make([]Value, len(row.Lengths))
 	var offset int64
-	for i, length := range row.Lengths {
+	for i := 0; i < fieldCount; i++ {
+		length := row.Lengths[i]
 		if length < 0 {
 			continue
 		}

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -185,16 +185,14 @@ func ResultsEqual(r1, r2 []Result) bool {
 // Every place this function is called, a comment is needed that explains
 // why it's justified.
 func MakeRowTrusted(fields []*querypb.Field, row *querypb.Row) []Value {
-	fieldCount := len(fields)
-
-	sqlRow := make([]Value, len(row.Lengths))
+	sqlRow := make([]Value, len(fields))
 	var offset int64
-	for i := 0; i < fieldCount; i++ {
+	for i, fld := range fields {
 		length := row.Lengths[i]
 		if length < 0 {
 			continue
 		}
-		sqlRow[i] = MakeTrusted(fields[i].Type, row.Values[offset:offset+length])
+		sqlRow[i] = MakeTrusted(fld.Type, row.Values[offset:offset+length])
 		offset += length
 	}
 	return sqlRow


### PR DESCRIPTION
## Context

When a schema change is made to a tablet to add a new field VTTablet executions of `select *` may return `querypb.QueryResult` objects that have an outdated `Fields` attribute. This contradicts the docs which promise `...As returned by Execute, len(fields) is always equal to len(row) (for each row in rows).`

The `MakeRowTrusted` implementation relies on that promise that len(fields) === len(row.Lengths) so when we hit the case described above the vtgate panics trying to construct a query result.

The stack trace that led us to this conclusion (I'd love alternate readings) follows:

<details>

```
go/src/runtime/panic.go:505
go/src/runtime/panic.go:28
src/vitess.io/vitess/go/sqltypes/result.go:194
src/vitess.io/vitess/go/sqltypes/proto3.go:79
src/vitess.io/vitess/go/sqltypes/proto3.go:108
src/vitess.io/vitess/go/vt/vttablet/grpctabletconn/conn.go:113
src/vitess.io/vitess/go/vt/vttablet/queryservice/wrapped.go:170
src/vitess.io/vitess/go/vt/vtgate/gateway/discoverygateway.go:322
src/vitess.io/vitess/go/vt/vtgate/gateway/discoverygateway.go:133
src/vitess.io/vitess/go/vt/vttablet/queryservice/wrapped.go:168
src/vitess.io/vitess/go/vt/vtgate/scatter_conn.go:210
src/vitess.io/vitess/go/vt/vtgate/scatter_conn.go:796
src/vitess.io/vitess/go/vt/vtgate/scatter_conn.go:796
src/vitess.io/vitess/go/vt/vtgate/scatter_conn.go:811
src/vitess.io/vitess/go/vt/vtgate/scatter_conn.go:187
src/vitess.io/vitess/go/vt/vtgate/vcursor_impl.go:162
src/vitess.io/vitess/go/vt/vtgate/engine/route.go:228
src/vitess.io/vitess/go/vt/vtgate/engine/route.go:188
src/vitess.io/vitess/go/vt/vtgate/executor.go:301
src/vitess.io/vitess/go/vt/vtgate/executor.go:175
src/vitess.io/vitess/go/vt/vtgate/executor.go:126
src/vitess.io/vitess/go/vt/vtgate/vtgate.go:288
src/vitess.io/vitess/go/vt/vtgate/plugin_mysql_server.go:154
src/vitess.io/vitess/go/mysql/conn.go:730
src/vitess.io/vitess/go/mysql/server.go:439
go/src/runtime/asm_amd64.s:2361
```

</details>

## Change

This PR doesn't impact the root cause (tracked as https://github.com/vitessio/vitess/issues/4661) but it does protect the vtgate from panicking while handling this case. This is beneficial for several reasons:

1. Until such a time as the VTTablet is using an updated schema we'll continue to successfully serve requests using the "old" (pre-column-add) schema. This is essential for applications anyway because schema changes aren't atomically applied so they already already support this behavior;
2. I believe that adding columns to a table is a more frequent change than removing columns and this means that the common-case is better supported without introducing any new failure modes;
3. If a similar bug is exposed during column removal we'll hit the same panic; that's not ideal but it seems more safe than silently ignoring that (likely) we're encoding a value into an incorrectly typed column;
4. In the case that columns are added and removed such that the net number of fields does not change this behaves the same as the previous case.

**A Caveat**: That said, a new failure mode _is_ introduced if a column is added in the middle of a table: it will now be returned instead of having the vtgate panic and shares the same issues as item 4 above.

## Testing
Unit+integration tests pass (per `test.sh` driver in vagrant setup), added unit tests to cover the case that was previously panicking.