### PR TITLE
Trivial fix: Remove the redundant words

### DIFF
--- a/doc/VitessApi.md
+++ b/doc/VitessApi.md
@@ -666,7 +666,7 @@ StreamExecute executes a streaming query based on shards. It depends on the quer
 | <code>BIT</code> | <code>2073</code> | BIT specifies a BIT type. Properties: 25, IsQuoted.  |
 | <code>ENUM</code> | <code>2074</code> | ENUM specifies an ENUM type. Properties: 26, IsQuoted.  |
 | <code>SET</code> | <code>2075</code> | SET specifies a SET type. Properties: 27, IsQuoted.  |
-| <code>TUPLE</code> | <code>28</code> | TUPLE specifies a a tuple. This cannot be returned in a QueryResult, but it can be sent as a bind var. Properties: 28, None.  |
+| <code>TUPLE</code> | <code>28</code> | TUPLE specifies a tuple. This cannot be returned in a QueryResult, but it can be sent as a bind var. Properties: 28, None.  |
 | <code>GEOMETRY</code> | <code>2077</code> | GEOMETRY specifies a GEOMETRY type. Properties: 29, IsQuoted.  |
 | <code>JSON</code> | <code>2078</code> | JSON specified a JSON type. Properties: 30, IsQuoted.  |
 

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -225,7 +225,7 @@ const (
 	// SET specifies a SET type.
 	// Properties: 27, IsQuoted.
 	Type_SET Type = 2075
-	// TUPLE specifies a a tuple. This cannot
+	// TUPLE specifies a tuple. This cannot
 	// be returned in a QueryResult, but it can
 	// be sent as a bind var.
 	// Properties: 28, None.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -191,7 +191,7 @@ enum Type {
   // SET specifies a SET type.
   // Properties: 27, IsQuoted.
   SET = 2075;
-  // TUPLE specifies a a tuple. This cannot
+  // TUPLE specifies a tuple. This cannot
   // be returned in a QueryResult, but it can
   // be sent as a bind var.
   // Properties: 28, None.


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>