### PR TITLE
Changing 'HTTP' to 'HTTPS' for securing vitess.io access

### DIFF
--- a/go/vt/vitessdriver/doc.go
+++ b/go/vt/vitessdriver/doc.go
@@ -41,7 +41,7 @@ Using this SQL driver is as simple as:
 
 For a full example, please see: https://github.com/vitessio/vitess/blob/master/examples/local/client.go
 
-The full example is based on our tutorial for running Vitess locally: http://vitess.io/getting-started/local-instance/
+The full example is based on our tutorial for running Vitess locally: https://vitess.io/getting-started/local-instance/
 
 
 Vtgate

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -11,10 +11,10 @@ keywords:
   - sql
   - database
   - shard
-home: http://vitess.io
+home: https://vitess.io
 sources:
   - https://github.com/vitessio/vitess
 maintainers:
   - name: Vitess Project
     email: vitess@googlegroups.com
-icon: http://vitess.io/images/vitess_logo_with_border.svg
+icon: https://vitess.io/images/vitess_logo_with_border.svg


### PR DESCRIPTION
Currently, when we access the ***vitess.io* with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://vitess.io** by **https://vitess.io** for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>