### PR TITLE
Alphabetically sorted modules import

### DIFF
--- a/examples/kubernetes/guestbook/main.py
+++ b/examples/kubernetes/guestbook/main.py
@@ -15,9 +15,9 @@
 """Main python file."""
 
 import argparse
+import json
 import os
 import time
-import json
 
 from flask import Flask
 

--- a/test/base_sharding.py
+++ b/test/base_sharding.py
@@ -17,9 +17,9 @@
 """This module contains a base class and utility functions for sharding tests.
 """
 
-import struct
-
 import logging
+
+import struct
 
 from vtdb import keyrange_constants
 

--- a/test/cluster/k8s_environment.py
+++ b/test/cluster/k8s_environment.py
@@ -14,8 +14,8 @@
 
 """Kubernetes environment."""
 
-import json
 import getpass
+import json
 import logging
 import os
 import subprocess


### PR DESCRIPTION
Modules which are imported to python are sorted alphabetically are
quicker to read and searchable.

Co-Authored-By: Dao Cong Tien tiendc@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>