### PR TITLE
We should always time out health connections to a vttablet.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -527,24 +527,17 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, name string) {
 		// between the goroutine that sets it and the check for its value
 		// later.
 		timedout := sync2.NewAtomicBool(false)
-		serving := hcc.tabletStats.Serving
 		go func() {
 			for {
 				select {
-				case serving = <-servingStatus:
+				case <-servingStatus:
 					continue
 				case <-time.After(hc.healthCheckTimeout):
-					// Ignore if not serving.
-					if !serving {
-						continue
-					}
 					timedout.Set(true)
 					streamCancel()
 					return
 				case <-streamCtx.Done():
-					// If stream returns while serving is false, the function
-					// will get stuck in an infinite loop. This code path
-					// breaks the loop.
+					// If the stream is done, stop watching.
 					return
 				}
 			}


### PR DESCRIPTION
Otherwise when a connection goes dead and the vttablet procees restarts
the vtgate will never try to reestablish the connection.

Signed-off-by: Michael Pawliszyn <mikepaw@squareup.com>