### PR TITLE
java: allow user to provide custom channels.

### DIFF
--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -51,6 +51,14 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.vitess</groupId>

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -27,6 +27,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.RpcClientFactory;
+import io.vitess.client.grpc.netty.DefaultChannelBuilderProvider;
+import io.vitess.client.grpc.netty.NettyChannelBuilderProvider;
 import io.vitess.client.grpc.tls.TlsOptions;
 
 import java.io.File;
@@ -50,17 +52,21 @@ import javax.net.ssl.SSLException;
  */
 public class GrpcClientFactory implements RpcClientFactory {
 
-  private RetryingInterceptorConfig config;
+  private NettyChannelBuilderProvider nettyChannelBuilderProvider;
   private CallCredentials callCredentials;
   private LoadBalancer.Factory loadBalancerFactory;
   private NameResolver.Factory nameResolverFactory;
 
   public GrpcClientFactory() {
-    this(RetryingInterceptorConfig.noOpConfig());
+    this(new DefaultChannelBuilderProvider(RetryingInterceptorConfig.noOpConfig()));
   }
 
   public GrpcClientFactory(RetryingInterceptorConfig config) {
-    this.config = config;
+    this(new DefaultChannelBuilderProvider(config));
+  }
+
+  public GrpcClientFactory(NettyChannelBuilderProvider nettyChannelBuilderProvider) {
+    this.nettyChannelBuilderProvider = nettyChannelBuilderProvider;
   }
 
   public GrpcClientFactory setCallCredentials(CallCredentials value) {
@@ -88,17 +94,14 @@ public class GrpcClientFactory implements RpcClientFactory {
    */
   @Override
   public RpcClient create(Context ctx, String target) {
-    NettyChannelBuilder channel = channelBuilder(target)
-        .negotiationType(NegotiationType.PLAINTEXT)
-        .intercept(new RetryingInterceptor(config));
+    NettyChannelBuilder channel = channelBuilder(target).negotiationType(NegotiationType.PLAINTEXT);
     if (loadBalancerFactory != null) {
       channel.loadBalancerFactory(loadBalancerFactory);
     }
     if (nameResolverFactory != null) {
       channel.nameResolverFactory(nameResolverFactory);
     }
-    return callCredentials != null
-        ? new GrpcClient(channel.build(), callCredentials, ctx)
+    return callCredentials != null ? new GrpcClient(channel.build(), callCredentials, ctx)
         : new GrpcClient(channel.build(), ctx);
   }
 
@@ -109,27 +112,23 @@ public class GrpcClientFactory implements RpcClientFactory {
    * for example:</p>
    *
    * <code>
-   *     {@literal @}Override
-   *     protected NettyChannelBuilder channelBuilder(String target) {
-   *       return super.channelBuilder(target)
-   *               .eventLoopGroup(new EpollEventLoopGroup())
-   *               .withOption(EpollChannelOption.TCP_USER_TIMEOUT,30);
-   *     }
+   * {@literal @}Override protected NettyChannelBuilder channelBuilder(String target) { return
+   * super.channelBuilder(target) .eventLoopGroup(new EpollEventLoopGroup())
+   * .withOption(EpollChannelOption.TCP_USER_TIMEOUT,30); }
    * </code>
    *
    * @param target target is passed to NettyChannelBuilder which will resolve based on scheme,
    *     by default dns.
    */
   protected NettyChannelBuilder channelBuilder(String target) {
-    return NettyChannelBuilder.forTarget(target);
+    return nettyChannelBuilderProvider.getChannelBuilder(target);
   }
 
   /**
    * <p>Factory method to construct a gRPC client connection with transport-layer security.</p>
    *
    * <p>Within the <code>tlsOptions</code> parameter value, the <code>trustStore</code> field
-   * should
-   * always be populated.  All other fields are optional.</p>
+   * should always be populated.  All other fields are optional.</p>
    *
    * @param ctx TODO: This parameter is not actually used, but probably SHOULD be so that
    *     timeout duration and caller ID settings aren't discarded
@@ -146,9 +145,9 @@ public class GrpcClientFactory implements RpcClientFactory {
     if (trustStore == null) {
       throw new RuntimeException("Could not load trustStore");
     }
-    final X509Certificate[] trustCertCollection = tlsOptions.getTrustAlias() == null
-        ? loadCertCollection(trustStore)
-        : loadCertCollectionForAlias(trustStore, tlsOptions.getTrustAlias());
+    final X509Certificate[] trustCertCollection =
+        tlsOptions.getTrustAlias() == null ? loadCertCollection(trustStore)
+            : loadCertCollectionForAlias(trustStore, tlsOptions.getTrustAlias());
     sslContextBuilder.trustManager(trustCertCollection);
 
     // keyManager should only be set if a keyStore is specified (meaning that client authentication
@@ -156,21 +155,19 @@ public class GrpcClientFactory implements RpcClientFactory {
     final KeyStore keyStore = loadKeyStore(tlsOptions.getKeyStore(),
         tlsOptions.getKeyStorePassword());
     if (keyStore != null) {
-      final PrivateKeyWrapper privateKeyWrapper = tlsOptions.getKeyAlias() == null
-          ? loadPrivateKeyEntry(keyStore, tlsOptions.getKeyStorePassword(),
-          tlsOptions.getKeyPassword())
-          : loadPrivateKeyEntryForAlias(keyStore, tlsOptions.getKeyAlias(),
-              tlsOptions.getKeyStorePassword(), tlsOptions.getKeyPassword());
+      final PrivateKeyWrapper privateKeyWrapper =
+          tlsOptions.getKeyAlias() == null ? loadPrivateKeyEntry(keyStore,
+              tlsOptions.getKeyStorePassword(), tlsOptions.getKeyPassword())
+              : loadPrivateKeyEntryForAlias(keyStore, tlsOptions.getKeyAlias(),
+                  tlsOptions.getKeyStorePassword(), tlsOptions.getKeyPassword());
       if (privateKeyWrapper == null) {
         throw new RuntimeException(
             "Could not retrieve private key and certificate chain from keyStore");
       }
 
-      sslContextBuilder.keyManager(
-          privateKeyWrapper.getPrivateKey(),
-          privateKeyWrapper.getPassword(),
-          privateKeyWrapper.getCertificateChain()
-      );
+      sslContextBuilder
+          .keyManager(privateKeyWrapper.getPrivateKey(), privateKeyWrapper.getPassword(),
+              privateKeyWrapper.getCertificateChain());
     }
 
     final SslContext sslContext;
@@ -181,8 +178,9 @@ public class GrpcClientFactory implements RpcClientFactory {
     }
 
     return new GrpcClient(
-        channelBuilder(target).negotiationType(NegotiationType.TLS).sslContext(sslContext)
-            .intercept(new RetryingInterceptor(config)).build(), ctx);
+        channelBuilder(target).negotiationType(NegotiationType.TLS).sslContext(sslContext).build(),
+        ctx
+    );
   }
 
   /**
@@ -213,12 +211,10 @@ public class GrpcClientFactory implements RpcClientFactory {
 
   /**
    * <p>Loads an X509 certificate from a keystore using a given alias, and returns it as a
-   * one-element
-   * array so that it can be passed to {@link SslContextBuilder#trustManager(File)}.</p>
+   * one-element array so that it can be passed to {@link SslContextBuilder#trustManager(File)}.</p>
    *
    * <p>Returns <code>null</code> if there is any problem accessing the keystore, or if the alias
-   * does
-   * not match an X509 certificate.</p>
+   * does not match an X509 certificate.</p>
    */
   private X509Certificate[] loadCertCollectionForAlias(final KeyStore keyStore,
       final String alias) {
@@ -227,9 +223,7 @@ public class GrpcClientFactory implements RpcClientFactory {
     }
 
     try {
-      return new X509Certificate[]{
-          (X509Certificate) keyStore.getCertificate(alias)
-      };
+      return new X509Certificate[]{(X509Certificate) keyStore.getCertificate(alias)};
     } catch (KeyStoreException | ClassCastException exc) {
       return null;
     }
@@ -237,12 +231,10 @@ public class GrpcClientFactory implements RpcClientFactory {
 
   /**
    * <p>Loads the first valid X509 certificate found in the keystore, and returns it as a
-   * one-element
-   * array so that it can be passed to {@link SslContextBuilder#trustManager(File)}.</p>
+   * one-element array so that it can be passed to {@link SslContextBuilder#trustManager(File)}.</p>
    *
    * <p>Returns <code>null</code> if there is any problem accessing the keystore, or if no X509
-   * certificates
-   * are found at all.</p>
+   * certificates are found at all.</p>
    */
   private X509Certificate[] loadCertCollection(final KeyStore keyStore) {
     if (keyStore == null) {
@@ -269,14 +261,12 @@ public class GrpcClientFactory implements RpcClientFactory {
 
   /**
    * <p>Loads from a keystore the private key entry matching a given alias, and returns it parsed
-   * and
-   * ready to be passed to {@link SslContextBuilder#keyManager(PrivateKey, String,
+   * and ready to be passed to {@link SslContextBuilder#keyManager(PrivateKey, String,
    * X509Certificate...)}.</p>
    *
    * <p>To access the private key, this method will first try using the <code>keyPassword</code>
-   * parameter
-   * value (this parameter can be set to <code>null</code> to explicitly indicate that there is no
-   * password). If that fails, then this method will then try using the
+   * parameter value (this parameter can be set to <code>null</code> to explicitly indicate that
+   * there is no password). If that fails, then this method will then try using the
    * <code>keyStorePassword</code> parameter value as the key value too.</p>
    *
    * <p>Returns null if there is any problem accessing the keystore, if neither
@@ -325,13 +315,12 @@ public class GrpcClientFactory implements RpcClientFactory {
 
   /**
    * <p>Loads from a keystore the first valid private key entry found, and returns it parsed and
-   * ready to be
-   * passed to {@link SslContextBuilder#keyManager(PrivateKey, String, X509Certificate...)}.</p>
+   * ready to be passed to {@link SslContextBuilder#keyManager(PrivateKey, String,
+   * X509Certificate...)}.</p>
    *
    * <p>To access the private key, this method will first try using the <code>keyPassword</code>
-   * parameter
-   * value (this parameter can be set to <code>null</code> to explicitly indicate that there is no
-   * password). If that fails, then this method will then try using the
+   * parameter value (this parameter can be set to <code>null</code> to explicitly indicate that
+   * there is no password). If that fails, then this method will then try using the
    * <code>keyStorePassword</code> parameter value as the key value too.</p>
    *
    * <p>Returns null if there is any problem accessing the keystore, if neither
@@ -341,8 +330,7 @@ public class GrpcClientFactory implements RpcClientFactory {
    * <code>alias</code>.</p>
    */
   private PrivateKeyWrapper loadPrivateKeyEntry(final KeyStore keyStore,
-      final String keyStorePassword,
-      final String keyPassword) {
+      final String keyStorePassword, final String keyPassword) {
     if (keyStore == null) {
       return null;
     }

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
@@ -36,7 +36,7 @@ public class RetryingInterceptor implements ClientInterceptor {
 
   private final RetryingInterceptorConfig config;
 
-  RetryingInterceptor(RetryingInterceptorConfig config) {
+  public RetryingInterceptor(RetryingInterceptorConfig config) {
     this.config = config;
   }
 

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/DefaultChannelBuilderProvider.java
@@ -1,0 +1,19 @@
+package io.vitess.client.grpc.netty;
+
+import io.grpc.netty.NettyChannelBuilder;
+import io.vitess.client.grpc.RetryingInterceptor;
+import io.vitess.client.grpc.RetryingInterceptorConfig;
+
+public class DefaultChannelBuilderProvider implements NettyChannelBuilderProvider {
+  private final RetryingInterceptorConfig config;
+
+  public DefaultChannelBuilderProvider(RetryingInterceptorConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public NettyChannelBuilder getChannelBuilder(String target) {
+    return NettyChannelBuilder.forTarget(target)
+        .intercept(new RetryingInterceptor(config));
+  }
+}

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/NettyChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/NettyChannelBuilderProvider.java
@@ -1,0 +1,8 @@
+package io.vitess.client.grpc.netty;
+
+import io.grpc.netty.NettyChannelBuilder;
+
+public interface NettyChannelBuilderProvider {
+
+  NettyChannelBuilder getChannelBuilder(String target);
+}

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/SimpleChannelBuilderProvider.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/netty/SimpleChannelBuilderProvider.java
@@ -1,0 +1,11 @@
+package io.vitess.client.grpc.netty;
+
+import io.grpc.netty.NettyChannelBuilder;
+
+public class SimpleChannelBuilderProvider implements NettyChannelBuilderProvider {
+
+  @Override
+  public NettyChannelBuilder getChannelBuilder(String target) {
+    return NettyChannelBuilder.forTarget(target);
+  }
+}

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -61,20 +61,17 @@ public class ConnectionProperties {
   private BooleanConnectionProperty blobsAreStrings = new BooleanConnectionProperty(
       "blobsAreStrings",
       "Should the driver always treat BLOBs as Strings - specifically to work around dubious "
-          + "metadata returned by the server for GROUP BY clauses?",
-      false);
+          + "metadata returned by the server for GROUP BY clauses?", false);
   private BooleanConnectionProperty functionsNeverReturnBlobs = new BooleanConnectionProperty(
       "functionsNeverReturnBlobs",
       "Should the driver always treat data from functions returning BLOBs as Strings - "
           + "specifically to work around dubious metadata returned by the server for GROUP BY "
-          + "clauses?",
-      false);
+          + "clauses?", false);
 
   // Configs for handing tinyint(1)
   private BooleanConnectionProperty tinyInt1isBit = new BooleanConnectionProperty("tinyInt1isBit",
       "Should the driver treat the datatype TINYINT(1) as the BIT type (because the server "
-          + "silently converts BIT -> TINYINT(1) when creating tables)?",
-      true);
+          + "silently converts BIT -> TINYINT(1) when creating tables)?", true);
   private BooleanConnectionProperty yearIsDateType = new BooleanConnectionProperty("yearIsDateType",
       "Should the JDBC driver treat the MySQL type \"YEAR\" as a java.sql.Date, or as a SHORT?",
       true);
@@ -91,29 +88,25 @@ public class ConnectionProperties {
       "useBlobToStoreUTF8OutsideBMP",
       "Tells the driver to treat [MEDIUM/LONG]BLOB columns as [LONG]VARCHAR columns holding text "
           + "encoded in UTF-8 that has characters outside the BMP (4-byte encodings), which MySQL"
-          + " server can't handle natively.",
-      false);
+          + " server can't handle natively.", false);
   private StringConnectionProperty utf8OutsideBmpIncludedColumnNamePattern =
       new StringConnectionProperty(
       "utf8OutsideBmpIncludedColumnNamePattern",
       "Used to specify exclusion rules to \"utf8OutsideBmpExcludedColumnNamePattern\". The regex "
-          + "must follow the patterns used for the java.util.regex package.",
-      null, null);
+          + "must follow the patterns used for the java.util.regex package.", null, null);
   private StringConnectionProperty utf8OutsideBmpExcludedColumnNamePattern =
       new StringConnectionProperty(
       "utf8OutsideBmpExcludedColumnNamePattern",
       "When \"useBlobToStoreUTF8OutsideBMP\" is set to \"true\", column names matching the given "
           + "regex will still be treated as BLOBs unless they match the regex specified for "
           + "\"utf8OutsideBmpIncludedColumnNamePattern\". The regex must follow the patterns used"
-          + " for the java.util.regex package.",
-      null, null);
+          + " for the java.util.regex package.", null, null);
 
   // Default encodings, for when one cannot be determined from field metadata
   private StringConnectionProperty characterEncoding = new StringConnectionProperty(
       "characterEncoding",
       "If a character encoding cannot be detected, which fallback should be used when dealing "
-          + "with strings? (defaults is to 'autodetect')",
-      null, null);
+          + "with strings? (defaults is to 'autodetect')", null, null);
 
   // Vitess-specific configs
   private StringConnectionProperty userName = new StringConnectionProperty(
@@ -121,8 +114,7 @@ public class ConnectionProperties {
       Constants.DEFAULT_USERNAME, null);
   private StringConnectionProperty target = new StringConnectionProperty(Constants.Property.TARGET,
       "Represents keyspace:shard@tabletType to be used to VTGates. keyspace, keyspace:shard, "
-          + "@tabletType all are optional.",
-      Constants.DEFAULT_TARGET, null);
+          + "@tabletType all are optional.", Constants.DEFAULT_TARGET, null);
   private StringConnectionProperty keyspace = new StringConnectionProperty(
       Constants.Property.KEYSPACE, "Targeted keyspace to execute queries on",
       Constants.DEFAULT_KEYSPACE, null);
@@ -145,8 +137,7 @@ public class ConnectionProperties {
   private BooleanConnectionProperty twopcEnabled = new BooleanConnectionProperty(
       Constants.Property.TWOPC_ENABLED,
       "Whether to enable two-phased commit, for atomic distributed commits. See http://vitess"
-          + ".io/user-guide/twopc/",
-      false);
+          + ".io/user-guide/twopc/", false);
   private EnumConnectionProperty<Query.ExecuteOptions.IncludedFields> includedFields =
       new EnumConnectionProperty<>(
       Constants.Property.INCLUDED_FIELDS,
@@ -160,19 +151,16 @@ public class ConnectionProperties {
   private BooleanConnectionProperty useAffectedRows = new BooleanConnectionProperty(
       "useAffectedRows",
       "Don't set the CLIENT_FOUND_ROWS flag when connecting to the server. The vitess default "
-          + "(useAffectedRows=true) is the opposite of mysql-connector-j.",
-      true);
+          + "(useAffectedRows=true) is the opposite of mysql-connector-j.", true);
 
   private BooleanConnectionProperty grpcRetriesEnabled = new BooleanConnectionProperty(
       "grpcRetriesEnabled",
       "If enabled, a gRPC interceptor will ensure retries happen in the case of TRANSIENT gRPC "
-          + "errors.",
-      true);
+          + "errors.", true);
   private LongConnectionProperty grpcRetryInitialBackoffMillis = new LongConnectionProperty(
       "grpcRetriesInitialBackoffMillis",
       "If grpcRetriesEnabled is set, what is the initial backoff time in milliseconds for "
-          + "exponential retry backoff.",
-      10);
+          + "exponential retry backoff.", 10);
   private LongConnectionProperty grpcRetryMaxBackoffMillis = new LongConnectionProperty(
       "grpcRetriesMaxBackoffMillis",
       "If grpcRetriesEnabled is set, what is the maximum backoff time in milliseconds for "
@@ -181,8 +169,12 @@ public class ConnectionProperties {
   private DoubleConnectionProperty grpcRetryBackoffMultiplier = new DoubleConnectionProperty(
       "grpcRetriesBackoffMultiplier",
       "If grpcRetriesEnabled is set, what multiplier should be used to increase exponential "
-          + "backoff on each retry.",
-      1.6);
+          + "backoff on each retry.", 1.6);
+  private StringConnectionProperty grpcChannelProvider = new StringConnectionProperty(
+      "grpcChannelBuilderProvider",
+      "Classname of an implementation of NettyChannelBuilderProvider. If set this class will be "
+          + "used to create channels for the GRPC client.", "", null);
+
   // TLS-related configs
   private BooleanConnectionProperty useSSL = new BooleanConnectionProperty(
       Constants.Property.USE_SSL, "Whether this connection should use transport-layer security",
@@ -190,22 +182,18 @@ public class ConnectionProperties {
   private BooleanConnectionProperty refreshConnection = new BooleanConnectionProperty(
       "refreshConnection",
       "When enabled, the driver will monitor for changes to the keystore and truststore files. If"
-          + " any are detected, SSL-enabled connections will be recreated.",
-      false);
+          + " any are detected, SSL-enabled connections will be recreated.", false);
   private LongConnectionProperty refreshSeconds = new LongConnectionProperty("refreshSeconds",
       "How often in seconds the driver will monitor for changes to the keystore and truststore "
-          + "files, when refreshConnection is enabled.",
-      60);
+          + "files, when refreshConnection is enabled.", 60);
   private BooleanConnectionProperty refreshClosureDelayed = new BooleanConnectionProperty(
       "refreshClosureDelayed",
       "When enabled, the closing of the old connections will be delayed instead of happening "
-          + "instantly.",
-      false);
+          + "instantly.", false);
   private LongConnectionProperty refreshClosureDelaySeconds = new LongConnectionProperty(
       "refreshClosureDelaySeconds",
       "How often in seconds the grace period before closing the old connections that had been "
-          + "recreated.",
-      300);
+          + "recreated.", 300);
   private StringConnectionProperty keyStore = new StringConnectionProperty(
       Constants.Property.KEYSTORE, "The Java .JKS keystore file to use when TLS is enabled", null,
       null);
@@ -215,14 +203,12 @@ public class ConnectionProperties {
   private StringConnectionProperty keyAlias = new StringConnectionProperty(
       Constants.Property.KEY_ALIAS,
       "Alias under which the private key is stored in the keystore file (if not specified, then "
-          + "the "
-          + "first valid `PrivateKeyEntry` will be used)", null, null);
+          + "the " + "first valid `PrivateKeyEntry` will be used)", null, null);
   private StringConnectionProperty keyPassword = new StringConnectionProperty(
       Constants.Property.KEY_PASSWORD,
       "The additional password protecting the private key entry within the keystore file (if not "
           + "specified, then the logic will fallback to the keystore password and then to no "
-          + "password at all)",
-      null, null);
+          + "password at all)", null, null);
   private StringConnectionProperty trustStore = new StringConnectionProperty(
       Constants.Property.TRUSTSTORE, "The Java .JKS truststore file to use when TLS is enabled",
       null, null);
@@ -232,20 +218,17 @@ public class ConnectionProperties {
   private StringConnectionProperty trustAlias = new StringConnectionProperty(
       Constants.Property.TRUST_ALIAS,
       "Alias under which the certficate chain is stored in the truststore file (if not specified,"
-          + " then "
-          + "the first valid `X509Certificate` will be used)", null, null);
+          + " then " + "the first valid `X509Certificate` will be used)", null, null);
 
   private BooleanConnectionProperty treatUtilDateAsTimestamp = new BooleanConnectionProperty(
       "treatUtilDateAsTimestamp",
       "Should the driver treat java.util.Date as a TIMESTAMP for the purposes of "
-          + "PreparedStatement.setObject()",
-      true);
+          + "PreparedStatement.setObject()", true);
 
   private LongConnectionProperty timeout = new LongConnectionProperty("timeout",
       "The default timeout, in millis, to use for queries, connections, and transaction "
           + "commit/rollback. Query timeout can be overridden by explicitly calling "
-          + "setQueryTimeout",
-      Constants.DEFAULT_TIMEOUT);
+          + "setQueryTimeout", Constants.DEFAULT_TIMEOUT);
 
   // Caching of some hot properties to avoid casting over and over
   private Topodata.TabletType tabletTypeCache;
@@ -502,6 +485,14 @@ public class ConnectionProperties {
 
   public void setGrpcRetryBackoffMultiplier(DoubleConnectionProperty grpcRetryBackoffMultiplier) {
     this.grpcRetryBackoffMultiplier = grpcRetryBackoffMultiplier;
+  }
+
+  public String getGrpcChannelProvider() {
+    return grpcChannelProvider.getValueAsString();
+  }
+
+  public void setGrpcChannelProvider(String grpcChannelProviderClassName) {
+    this.grpcChannelProvider.setValue(grpcChannelProviderClassName);
   }
 
   public boolean getUseSSL() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -231,7 +231,7 @@ public class VitessVTGateManager {
         conn.getGrpcRetryMaxBackoffMillis(), conn.getGrpcRetryBackoffMultiplier());
   }
 
-  private static NettyChannelBuilderProvider getChannelProviderFromProperties(
+  static NettyChannelBuilderProvider getChannelProviderFromProperties(
       VitessConnection connection) {
     // Skip reflection in default case
     if (Strings.isNullOrEmpty(connection.getGrpcChannelProvider())) {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -43,7 +43,7 @@ import org.mockito.Mockito;
 
 public class ConnectionPropertiesTest {
 
-  private static final int NUM_PROPS = 39;
+  private static final int NUM_PROPS = 40;
 
   @Test
   public void testReflection() throws Exception {
@@ -166,13 +166,15 @@ public class ConnectionPropertiesTest {
     assertEquals("characterEncoding", infos[2].name);
     assertEquals("executeType", infos[3].name);
     assertEquals("functionsNeverReturnBlobs", infos[4].name);
-    assertEquals("grpcRetriesEnabled", infos[5].name);
-    assertEquals("grpcRetriesBackoffMultiplier", infos[6].name);
-    assertEquals("grpcRetriesInitialBackoffMillis", infos[7].name);
-    assertEquals("grpcRetriesMaxBackoffMillis", infos[8].name);
-    assertEquals(Constants.Property.INCLUDED_FIELDS, infos[9].name);
-    assertEquals(Constants.Property.TABLET_TYPE, infos[21].name);
-    assertEquals(Constants.Property.TWOPC_ENABLED, infos[29].name);
+
+    assertEquals("grpcChannelBuilderProvider", infos[5].name);
+    assertEquals("grpcRetriesEnabled", infos[6].name);
+    assertEquals("grpcRetriesBackoffMultiplier", infos[7].name);
+    assertEquals("grpcRetriesInitialBackoffMillis", infos[8].name);
+    assertEquals("grpcRetriesMaxBackoffMillis", infos[9].name);
+    assertEquals(Constants.Property.INCLUDED_FIELDS, infos[10].name);
+    assertEquals(Constants.Property.TABLET_TYPE, infos[22].name);
+    assertEquals(Constants.Property.TWOPC_ENABLED, infos[30].name);
   }
 
   @Test

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -20,6 +20,8 @@ import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConnection;
 import io.vitess.client.grpc.GrpcClientFactory;
+import io.vitess.client.grpc.netty.NettyChannelBuilderProvider;
+import io.vitess.client.grpc.netty.SimpleChannelBuilderProvider;
 import io.vitess.proto.Vtrpc;
 
 import org.joda.time.Duration;
@@ -100,6 +102,21 @@ public class VitessVTGateManagerTest {
         .get(VitessVTGateManager.class);
     Assert.assertEquals(3, map.size());
     VitessVTGateManager.close();
+  }
+
+  @Test
+  public void testGetChannelProviderFromProperties() throws SQLException {
+    VitessVTGateManager.close();
+
+    Properties info = new Properties();
+    info.setProperty("grpcChannelBuilderProvider", SimpleChannelBuilderProvider.class.getCanonicalName());
+
+    VitessConnection connection = new VitessConnection(
+        "jdbc:vitess://10.33.17.231:15991:xyz,10.33.17.232:15991:xyz,10.33.17"
+            + ".233:15991/shipment/shipment?tabletType=master", info);
+
+    NettyChannelBuilderProvider channelBuilderProvider = VitessVTGateManager.getChannelProviderFromProperties(connection);
+    Assert.assertTrue(SimpleChannelBuilderProvider.class.isAssignableFrom(channelBuilderProvider.getClass()));
   }
 
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -138,6 +138,16 @@
         <artifactId>netty-handler</artifactId>
         <version>${netty.handler.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.handler.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.handler.version}</version>
+      </dependency>
       <!-- TODO(mberlin): When we upgrade grpc, check if we can remove this. Without,
         grpc-client TLS tests fail with error "Jetty ALPN/NPN has not been properly configured.". -->
       <dependency>


### PR DESCRIPTION
At HubSpot we need to install a custom EventLoop for channels in vitess. In the past, we have done this simply by overriding the event loop for our internal build. This PR provides a more extensible way for the user to provide customized channels to the vitess client.

The existing `RetryingInterceptor` logic has been moved to the new `DefaultChannelBuilderProvider`

@leoxlin @acharis FYI