### PR TITLE
Use jsonpb marshaling for vtctl's GetVSchema

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2108,7 +2108,7 @@ func commandGetVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	if err != nil {
 		return err
 	}
-	b, err := json.MarshalIndent(schema, "", "  ")
+	b, err := json2.MarshalIndentPB(schema, "  ")
 	if err != nil {
 		wr.Logger().Printf("%v\n", err)
 		return err


### PR DESCRIPTION
Protobufs should generally go through jsonpb to convert to and from json.
One specific thing that's different with jsonpb's encoding is that
"columnListAuthoritative" is camelCase vs json's encoding using snake_case.

jsonpb is lenient about parsing json, accepting either snake or camel case.

There's a risk that custom scripts based on the old behavior of GetVSchema might break if they only support snake case and parse the output. jsonpb's `Unmarshal()` should accept either snake or camel case.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>