### PR TITLE
Ignore temporary files `*~` in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ releases
 
 # Vagrant
 .vagrant
+
+# emacs
+*~


### PR DESCRIPTION
Ignore temporary files *~ when editting source codes with
emacs.

Co-Authored-By: Dao Cong Tien tiendc@vn.fujitsu.com
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>