### PR TITLE
vtexplain: properly use sqlparser.String to quote reserved table names

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -388,7 +388,7 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 	}
 
 	for i, ddl := range ddls {
-		table := ddl.Table.Name.String()
+		table := sqlparser.String(ddl.Table.Name)
 		schemaQueries[mysql.BaseShowTablesForTable(table)] = &sqltypes.Result{
 			Fields:       mysql.BaseShowTablesFields,
 			RowsAffected: 1,
@@ -511,9 +511,10 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 			return callback(&sqltypes.Result{})
 		}
 
-		colTypeMap := tableColumns[table.String()]
-		if colTypeMap == nil && table.String() != "dual" {
-			return fmt.Errorf("unable to resolve table name %s", table.String())
+		tableName := sqlparser.String(table)
+		colTypeMap := tableColumns[tableName]
+		if colTypeMap == nil && tableName != "dual" {
+			return fmt.Errorf("unable to resolve table name %s", tableName)
 		}
 
 		colNames := make([]string, 0, 4)


### PR DESCRIPTION
## Description
Fix for vtexplain not working with keyword names for tables such as `action`.

## Details
Previously, vtexplain would return an error such as:
```E0226 21:19:04.420743   30715 engine.go:157] Engine.Open: failed to load table action: Row count exceeded 0 (errno 10001) (sqlstate HY000) during query: select * from `action` where 1 != 1```

The problem was that the schema engine escaped tables when looking up the field signature, but vtexplain didn't do the same.

The fix is simply to consistently use `sqlparser.String` when getting the name of a table.
