### PR TITLE
InitShardMaster: make it more idempotent

### DIFF
--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -87,6 +87,7 @@ func (mariadbFlavor) resetReplicationCommands() []string {
 		"RESET SLAVE ALL", // "ALL" makes it forget master host:port.
 		"RESET MASTER",
 		"SET GLOBAL gtid_slave_pos = ''",
+		"SET GLOBAL rpl_semi_sync_master_enabled = false, GLOBAL rpl_semi_sync_slave_enabled = false", // semi-sync will be enabled if needed when slave is started.
 	}
 }
 

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -69,6 +69,7 @@ func (mysqlFlavor) resetReplicationCommands() []string {
 		"STOP SLAVE",
 		"RESET SLAVE ALL", // "ALL" makes it forget master host:port.
 		"RESET MASTER",    // This will also clear gtid_executed and gtid_purged.
+		"SET GLOBAL rpl_semi_sync_master_enabled = false, GLOBAL rpl_semi_sync_slave_enabled = false", // semi-sync will be enabled if needed when slave is started.
 	}
 }
 


### PR DESCRIPTION
If ISM is retried, it's possible it gets stuck. The specific use
case where this happens is when the first attempt went past the
point where semi-sync gets enabled. If we retry ISM after that,
the part where we create the reparent journal table will hang
because the master will have semi-sync enabled, but no replica
will be pointing to it.

To overcome this, we always disable semi-sync when resetting
replication. All the code that enables replication turns semi
sync on as needed already.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>