### PR TITLE
Don't return cached heartbeat read when query service is down to avoi…

### DIFF
--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -227,3 +227,7 @@ func (r *Reader) recordError(err error) {
 	r.errorLog.Errorf("%v", err)
 	readErrors.Add(1)
 }
+
+func (r *Reader) IsOpen() bool {
+	return r.isOpen
+}


### PR DESCRIPTION
…d situation where replica tablet never recovers.

Closes https://github.com/vitessio/vitess/issues/4673

The core of the problem in 4673, is that the HeartbeatReporter does not obey the contract expected by the healthcheck - that it reports a current reading of the health. I don't see a straightforward way to fix this without rewriting the reader entirely. The next best thing I could see to do was to return healthy when we knew the reader was closed and the query service was shutdown. This will force the healthcheck to attempt to restart the query service and if that fails, then it will report that error and remain unhealthy. I considered putting this logic in the reader, but if we only know the reader is closed then there's the possibility of a pathological situation where the query service is running and the reader is closed and then we would have no visibility into this.

cc @leoxlin 