### PR TITLE
Fix some misspells in comment

### DIFF
--- a/doc/ReferenceTables.md
+++ b/doc/ReferenceTables.md
@@ -26,7 +26,7 @@ just a corner case of the vertical splits Vitess already supports.
 
 Action items:
 
-* First, this setup probably needs to be explicitely mentioned somewhere in the
+* First, this setup probably needs to be explicitly mentioned somewhere in the
   topology, not just as SourceShard objects in the destination keyspace, so
   Vitess can know about this setup at a higher level. Let's add a `repeated
   ReferenceKeyspace` field to the Keyspace object. Each `ReferenceKeyspace`
@@ -59,7 +59,7 @@ the Reference Tables feature is enabled.
 Action items:
 
 * Each step of the process would know what to do because of the
-  `ReferenceKeyspace` entries in the destinatin keyspace.
+  `ReferenceKeyspace` entries in the destination keyspace.
 
 * `vtctl CopySchemaShard` needs to also copy the schema of the reference tables.
 
@@ -82,7 +82,7 @@ Action items:
 
 ## Other Use Cases
 
-Other scenarios might also need to be supported, or explicitely disabled:
+Other scenarios might also need to be supported, or explicitly disabled:
 
 * Simple schema changes, or complicated Schema Swap in the reference keyspace:
   They would also need to be applied to the destination keyspace, the same way.

--- a/go/mysql/endtoend/schema_test.go
+++ b/go/mysql/endtoend/schema_test.go
@@ -42,7 +42,7 @@ func testDescribeTable(t *testing.T) {
 	// This is because without this, we have exceptions:
 	// - MariaDB and MySQL 5.6 return '0' as default.
 	// - MySQL 5.7 returns NULL as default.
-	// So we explicitely set it, to avoid having to check both cases below.
+	// So we explicitly set it, to avoid having to check both cases below.
 	if _, err := conn.ExecuteFetch("create table for_describe(id int default 0, name varchar(128), primary key(id))", 0, false); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
1. "explicitely" to "explicitly".
2. "destinatin" to "destination".