### PR TITLE
Return TabletManager.GetPermissions results in a consistent order

### DIFF
--- a/go/vt/mysqlctl/permissions.go
+++ b/go/vt/mysqlctl/permissions.go
@@ -22,13 +22,15 @@ import (
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 )
 
-// GetPermissions lists the permissions on the mysqld
+// GetPermissions lists the permissions on the mysqld.
+// The rows are sorted in primary key order to help with comparing
+// permissions between tablets.
 func GetPermissions(mysqld MysqlDaemon) (*tabletmanagerdatapb.Permissions, error) {
 	ctx := context.TODO()
 	permissions := &tabletmanagerdatapb.Permissions{}
 
 	// get Users
-	qr, err := mysqld.FetchSuperQuery(ctx, "SELECT * FROM mysql.user")
+	qr, err := mysqld.FetchSuperQuery(ctx, "SELECT * FROM mysql.user ORDER BY host, user")
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +39,7 @@ func GetPermissions(mysqld MysqlDaemon) (*tabletmanagerdatapb.Permissions, error
 	}
 
 	// get Dbs
-	qr, err = mysqld.FetchSuperQuery(ctx, "SELECT * FROM mysql.db")
+	qr, err = mysqld.FetchSuperQuery(ctx, "SELECT * FROM mysql.db ORDER BY host, db, user")
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2064,7 +2064,7 @@ func commandGetPermissions(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 	}
 	p, err := wr.GetPermissions(ctx, tabletAlias)
 	if err == nil {
-		wr.Logger().Infof("%v", p.String()) // they can contain '%'
+		printJSON(wr.Logger(), p)
 	}
 	return err
 }


### PR DESCRIPTION
This avoids false alarms from vtctl ValidatePermissionsKeyspace which
seems to assume the results will be in a consistent order but doesn't
explicitly sort them. MyISAM does not seem to return results in a
consistent order from mysql.user or mysql.db without an explicit ORDER BY.

Another change: "vtctl GetPermissions" will now print a json result to stdout
instead of logging an asciiproto to stderr/INFO so it's easier to examine or
debug output.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>