### PR TITLE
vreplication: fix row move bug

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -446,7 +446,7 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 		return fmt.Errorf("unexpected event on table %s", rowEvent.TableName)
 	}
 	for _, change := range rowEvent.RowChanges {
-		if query := tplan.GenerateStatement(change); query != "" {
+		for _, query := range tplan.GenerateStatements(change) {
 			if err := vp.exec(ctx, query); err != nil {
 				return err
 			}


### PR DESCRIPTION
If the target pk for a row changes (row move), then a simple update
may not do the right thing, especially for aggregates. In such cases,
we should delete and insert.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>