### PR TITLE
Strictly check the structure of mysql static auth json config

### DIFF
--- a/go/cmd/vtaclcheck/vtaclcheck.go
+++ b/go/cmd/vtaclcheck/vtaclcheck.go
@@ -28,11 +28,13 @@ import (
 )
 
 var (
-	aclFileFlag = flag.String("acl_file", "", "Identifies the JSON ACL file to check")
+	aclFileFlag        = flag.String("acl_file", "", "The path of the JSON ACL file to check")
+	staticAuthFileFlag = flag.String("static_auth_file", "", "The path of the auth_server_static JSON file to check")
 
 	// vtaclcheckFlags lists all the flags that should show in usage
 	vtaclcheckFlags = []string{
 		"acl_file",
+		"static_auth_file",
 	}
 )
 
@@ -41,7 +43,7 @@ func usage() {
 	for _, name := range vtaclcheckFlags {
 		f := flag.Lookup(name)
 		if f == nil {
-			panic("unkown flag " + name)
+			panic("unknown flag " + name)
 		}
 		flagUsage(f)
 	}
@@ -93,15 +95,12 @@ func main() {
 }
 
 func parseAndRun() error {
-	if aclFileFlag == nil {
-		return fmt.Errorf("-acl_file <filename> option not provided")
-	}
-
 	opts := &vtaclcheck.Options{
-		ACLFile: *aclFileFlag,
+		ACLFile:        *aclFileFlag,
+		StaticAuthFile: *staticAuthFileFlag,
 	}
 
-	log.V(100).Infof("acl_file %s\n", *aclFileFlag)
+	log.V(100).Infof("acl_file %s\nstatic_auth_file %s\n", *aclFileFlag, *staticAuthFileFlag)
 
 	if err := vtaclcheck.Init(opts); err != nil {
 		return err

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -62,6 +62,14 @@ func TestJsonConfigParser(t *testing.T) {
 	if len(config["mysql_user"][2].Groups) != 1 || config["mysql_user"][2].Groups[0] != "user_group" {
 		t.Fatalf("Groups should be equal to [\"user_group\"]")
 	}
+
+	jsonConfig = `{
+		"mysql_user": [{"Password": "123", "UserData": "mysql_user_all", "InvalidKey": "oops"}]
+	}`
+	err = parseConfig([]byte(jsonConfig), &config)
+	if err == nil {
+		t.Fatalf("Invalid config should have errored, but didn't")
+	}
 }
 
 func TestValidateHashGetter(t *testing.T) {


### PR DESCRIPTION
This updates the vtaclcheck command line utility to also be able to check mysql static auth file for validity.

Additionally, it enforces the structure of the mysql static auth config - currently, if you pass in entries with unrecognized keys, you might end up with a useless-but-valid auth config file: the current check just checks to make sure that there _are_ entries, not that they are non-empty.