### PR TITLE
Fix some typos in docs

### DIFF
--- a/doc/ReplicatoinLagBasedThrottlingOfTransactions.md
+++ b/doc/ReplicatoinLagBasedThrottlingOfTransactions.md
@@ -17,7 +17,7 @@ throttler:
 
 * *enable-tx-throttler*
 
-A boolean flag controling whether the replication-lag-based throttling is enabled.
+A boolean flag controlling whether the replication-lag-based throttling is enabled.
 
 * *tx-throttler-config*
 
@@ -37,6 +37,6 @@ the non-RDONLY replicas found in these cells for replication lag.
 the replication lag under the desired limit; as such the desired replication 
 lag limit may occasionally be slightly violated.
 
-* Transactions are considered homegenous. There is currently no support
+* Transactions are considered homogenous. There is currently no support
 for specifying how "expensive" a transaction is.
 

--- a/go/vt/workflow/parallel_runner.go
+++ b/go/vt/workflow/parallel_runner.go
@@ -112,7 +112,7 @@ func NewParallelRunner(ctx context.Context, rootUINode *Node, cp *CheckpointWrit
 	return p
 }
 
-// Run is the entry point for controling task executions.
+// Run is the entry point for controlling task executions.
 func (p *ParallelRunner) Run() error {
 	// default value is 0. The task will not run in this case.
 	var parallelNum int


### PR DESCRIPTION
"controling" to "controlling" in line 20 and 115.
"homegenous" to "homogenous" in line 40.