### PR TITLE
Fix go panic caused by unaligned atomic fields on certain architectures.

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -48,19 +48,20 @@ type Resource interface {
 
 // ResourcePool allows you to use a pool of resources.
 type ResourcePool struct {
-	resources   chan resourceWrapper
-	factory     Factory
-	capacity    sync2.AtomicInt64
-	idleTimeout sync2.AtomicDuration
-	idleTimer   *timer.Timer
-
-	// stats
+	// stats. Atomic fields must remain at the top in order to prevent panics on certain architectures.
 	available  sync2.AtomicInt64
 	active     sync2.AtomicInt64
 	inUse      sync2.AtomicInt64
 	waitCount  sync2.AtomicInt64
 	waitTime   sync2.AtomicDuration
 	idleClosed sync2.AtomicInt64
+
+	capacity    sync2.AtomicInt64
+	idleTimeout sync2.AtomicDuration
+
+	resources chan resourceWrapper
+	factory   Factory
+	idleTimer *timer.Timer
 }
 
 type resourceWrapper struct {


### PR DESCRIPTION
On certain architectures (such as ARM and x86_32) the misalignment of these fields will cause a panic when an update is attempted.

On a side note, I've only checked this part of the repo - I came across this as it is depended on by ThalesIgnite/crypto11 - More checking might be required to fix this if it occurs in other places.

Relates to golang/go#599 and golang/go#23345