### PR TITLE
WIP: Add median and 99th aggregate query timings to vtgate and vttablet.

### DIFF
--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -66,7 +66,7 @@ func (be PromBackend) publishPrometheusMetric(name string, v expvar.Var) {
 		newMultiTimingsCollector(st, be.buildPromName(name))
 	case *stats.Histogram:
 		newHistogramCollector(st, be.buildPromName(name))
-	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates:
+	case *stats.String, stats.StringFunc, stats.StringMapFunc, *stats.Rates, stats.JSONFunc:
 		// Silently ignore these types since they don't make sense to
 		// export to Prometheus' data model.
 	default:

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -67,6 +67,7 @@ func NewLogStats(ctx context.Context, methodName, sql string, bindVars map[strin
 func (stats *LogStats) Send() {
 	stats.EndTime = time.Now()
 	QueryLogger.Send(stats)
+	TimingStatistics.recordStats(stats)
 }
 
 // Context returns the context used by LogStats.

--- a/go/vt/vtgate/timingstats.go
+++ b/go/vt/vtgate/timingstats.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"encoding/json"
+	"flag"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"vitess.io/vitess/go/stats"
+)
+
+type TimingStats struct {
+	totalQueryTime prometheus.Summary
+}
+
+type TimingMeasurement struct {
+	Median      float64
+	NinetyNinth float64
+}
+
+type TimingMeasurements struct {
+	TotalQueryTime TimingMeasurement
+}
+
+var (
+	TimingStatistics = &TimingStats{totalQueryTime: prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name:       "total_query_time",
+			Help:       "Distributions of total time for vttablet queries.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+			MaxAge:     time.Minute})}
+	timingStatsEnabled = flag.Bool("enable-aggregate-vttablet-timings", false, "This enables median and 99th timings for all queries.")
+
+	publishOnce sync.Once
+)
+
+func (timingStats *TimingStats) recordStats(logStats *LogStats) {
+	if *timingStatsEnabled {
+		timingStats.registerIfNeeded()
+		timingStats.totalQueryTime.Observe(float64(logStats.TotalTime().Nanoseconds()))
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurementsJson() string {
+	b, err := json.MarshalIndent(TimingStatistics.GetMeasurements(), "", " ")
+	if err != nil {
+		return "{}"
+	} else {
+		return string(b)
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurements() TimingMeasurements {
+	return TimingMeasurements{TotalQueryTime: getMeasurement(timingStats.totalQueryTime)}
+}
+
+func (timingStats *TimingStats) registerIfNeeded() {
+	publishOnce.Do(func() {
+		stats.PublishJSONFunc("AggregateQueryTimings", func() string {
+			return TimingStatistics.GetMeasurementsJson()
+		})
+	})
+}
+
+func getMeasurement(summary prometheus.Summary) TimingMeasurement {
+	dtoMetric := &dto.Metric{}
+	summary.Write(dtoMetric)
+	return TimingMeasurement{Median: dtoMetric.Summary.GetQuantile()[0].GetValue(),
+		NinetyNinth: dtoMetric.Summary.GetQuantile()[1].GetValue()}
+}

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -101,6 +101,7 @@ func init() {
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flag.BoolVar(&Config.EnableConsolidator, "enable-consolidator", DefaultQsConfig.EnableConsolidator, "This option enables the query consolidator.")
+	flag.BoolVar(&Config.EnableAggregateQueryTimings, "enable-aggregate-query-timings", DefaultQsConfig.EnableAggregateQueryTimings, "This enables median and 99th timings for all queries.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -171,8 +172,9 @@ type TabletConfig struct {
 	HeartbeatEnable   bool
 	HeartbeatInterval time.Duration
 
-	EnforceStrictTransTables bool
-	EnableConsolidator       bool
+	EnforceStrictTransTables    bool
+	EnableConsolidator          bool
+	EnableAggregateQueryTimings bool
 }
 
 // TransactionLimitConfig captures configuration of transaction pool slots
@@ -246,8 +248,9 @@ var DefaultQsConfig = TabletConfig{
 	HeartbeatEnable:   false,
 	HeartbeatInterval: 1 * time.Second,
 
-	EnforceStrictTransTables: true,
-	EnableConsolidator:       true,
+	EnforceStrictTransTables:    true,
+	EnableConsolidator:          true,
+	EnableAggregateQueryTimings: false,
 }
 
 // defaultTxThrottlerConfig formats the default throttlerdata.Configuration

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -76,6 +76,9 @@ func NewLogStats(ctx context.Context, methodName string) *LogStats {
 func (stats *LogStats) Send() {
 	stats.EndTime = time.Now()
 	StatsLogger.Send(stats)
+	if Config.EnableAggregateQueryTimings {
+		TimingStatistics.recordStats(stats)
+	}
 }
 
 // Context returns the context used by LogStats.

--- a/go/vt/vttablet/tabletserver/tabletenv/timingstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/timingstats.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletenv
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"vitess.io/vitess/go/stats"
+)
+
+type TimingStats struct {
+	totalQueryTime            prometheus.Summary
+	mysqlQueryTime            prometheus.Summary
+	connectionAcquisitionTime prometheus.Summary
+}
+
+type TimingMeasurement struct {
+	Median      float64
+	NinetyNinth float64
+}
+
+type TimingMeasurements struct {
+	TotalQueryTime            TimingMeasurement
+	MysqlQueryTime            TimingMeasurement
+	ConnectionAcquisitionTime TimingMeasurement
+}
+
+var (
+	TimingStatistics = &TimingStats{totalQueryTime: prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name:       "total_query_time",
+			Help:       "Distributions of total time for vttablet queries.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+			MaxAge:     time.Minute}),
+		mysqlQueryTime: prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Name:       "mysql_query_time",
+				Help:       "Distributions of time querying msyql for vttablet queries.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+				MaxAge:     time.Minute}),
+		connectionAcquisitionTime: prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Name:       "connection_acquisition_time",
+				Help:       "Distributions of time spent acquiring msyql connections for vttablet queries.",
+				Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+				MaxAge:     time.Minute})}
+	publishOnce sync.Once
+)
+
+func (timingStats *TimingStats) recordStats(logStats *LogStats) {
+	timingStats.registerIfNeeded()
+	timingStats.totalQueryTime.Observe(float64(logStats.TotalTime().Nanoseconds()))
+	timingStats.mysqlQueryTime.Observe(float64(logStats.MysqlResponseTime.Nanoseconds()))
+	timingStats.connectionAcquisitionTime.Observe(float64(logStats.WaitingForConnection.Nanoseconds()))
+}
+
+func (timingStats *TimingStats) GetMeasurementsJson() string {
+	b, err := json.MarshalIndent(TimingStatistics.GetMeasurements(), "", " ")
+	if err != nil {
+		return "{}"
+	} else {
+		return string(b)
+	}
+}
+
+func (timingStats *TimingStats) GetMeasurements() TimingMeasurements {
+	return TimingMeasurements{TotalQueryTime: getMeasurement(timingStats.totalQueryTime),
+		MysqlQueryTime:            getMeasurement(timingStats.mysqlQueryTime),
+		ConnectionAcquisitionTime: getMeasurement(timingStats.connectionAcquisitionTime)}
+}
+
+func (timingStats *TimingStats) registerIfNeeded() {
+	publishOnce.Do(func() {
+		stats.PublishJSONFunc("AggregateQueryTimings", func() string {
+			return TimingStatistics.GetMeasurementsJson()
+		})
+	})
+}
+
+func getMeasurement(summary prometheus.Summary) TimingMeasurement {
+	dtoMetric := &dto.Metric{}
+	summary.Write(dtoMetric)
+	return TimingMeasurement{Median: dtoMetric.Summary.GetQuantile()[0].GetValue(),
+		NinetyNinth: dtoMetric.Summary.GetQuantile()[1].GetValue()}
+}


### PR DESCRIPTION
Signed-off-by:  <jschlather@hubspot.com>

Still working on this, but we wanted to get visibility into median and 99th query/request times. In particular we wanted to understand the latency of the app -> vtgate -> vttablet -> mysql call chain. 