### PR TITLE
Add `-topo_zk_auth_file` flag

### DIFF
--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -51,6 +51,8 @@ there are some slight differences in flag handling.
 
 zk -h - provide help on overriding cell selection
 
+zk addAuth digest user:pass
+
 zk cat /zk/path
 zk cat -l /zk/path1 /zk/path2 (list filename before file data)
 
@@ -111,18 +113,19 @@ var zconn *zk2topo.ZkConn
 
 func init() {
 	cmdMap = map[string]cmdFunc{
-		"cat":   cmdCat,
-		"chmod": cmdChmod,
-		"cp":    cmdCp,
-		"edit":  cmdEdit,
-		"ls":    cmdLs,
-		"rm":    cmdRm,
-		"stat":  cmdStat,
-		"touch": cmdTouch,
-		"unzip": cmdUnzip,
-		"wait":  cmdWait,
-		"watch": cmdWatch,
-		"zip":   cmdZip,
+		"addAuth": cmdAddAuth,
+		"cat":     cmdCat,
+		"chmod":   cmdChmod,
+		"cp":      cmdCp,
+		"edit":    cmdEdit,
+		"ls":      cmdLs,
+		"rm":      cmdRm,
+		"stat":    cmdStat,
+		"touch":   cmdTouch,
+		"unzip":   cmdUnzip,
+		"wait":    cmdWait,
+		"watch":   cmdWatch,
+		"zip":     cmdZip,
 	}
 }
 
@@ -498,6 +501,15 @@ func cmdRm(ctx context.Context, subFlags *flag.FlagSet, args []string) error {
 		return fmt.Errorf("rm: some paths had errors")
 	}
 	return nil
+}
+
+func cmdAddAuth(ctx context.Context, subFlags *flag.FlagSet, args []string) error {
+	subFlags.Parse(args)
+	if subFlags.NArg() < 2 {
+		return fmt.Errorf("addAuth: expected args <scheme> <auth>")
+	}
+	scheme, auth := subFlags.Arg(0), subFlags.Arg(1)
+	return zconn.AddAuth(ctx, scheme, []byte(auth))
 }
 
 func cmdCat(ctx context.Context, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -109,6 +109,7 @@ func (c *ZkConn) Get(ctx context.Context, path string) (data []byte, stat *zk.St
 	return
 }
 
+// GetW is part of the Conn interface.
 func (c *ZkConn) GetW(ctx context.Context, path string) (data []byte, stat *zk.Stat, watch <-chan zk.Event, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		data, stat, watch, err = conn.GetW(path)
@@ -117,6 +118,7 @@ func (c *ZkConn) GetW(ctx context.Context, path string) (data []byte, stat *zk.S
 	return
 }
 
+// Children is part of the Conn interface.
 func (c *ZkConn) Children(ctx context.Context, path string) (children []string, stat *zk.Stat, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		children, stat, err = conn.Children(path)
@@ -125,6 +127,7 @@ func (c *ZkConn) Children(ctx context.Context, path string) (children []string, 
 	return
 }
 
+// ChildrenW is part of the Conn interface.
 func (c *ZkConn) ChildrenW(ctx context.Context, path string) (children []string, stat *zk.Stat, watch <-chan zk.Event, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		children, stat, watch, err = conn.ChildrenW(path)
@@ -133,6 +136,7 @@ func (c *ZkConn) ChildrenW(ctx context.Context, path string) (children []string,
 	return
 }
 
+// Exists is part of the Conn interface.
 func (c *ZkConn) Exists(ctx context.Context, path string) (exists bool, stat *zk.Stat, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		exists, stat, err = conn.Exists(path)
@@ -141,6 +145,7 @@ func (c *ZkConn) Exists(ctx context.Context, path string) (exists bool, stat *zk
 	return
 }
 
+// ExistsW is part of the Conn interface.
 func (c *ZkConn) ExistsW(ctx context.Context, path string) (exists bool, stat *zk.Stat, watch <-chan zk.Event, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		exists, stat, watch, err = conn.ExistsW(path)
@@ -174,6 +179,7 @@ func (c *ZkConn) Delete(ctx context.Context, path string, version int32) error {
 	})
 }
 
+// GetACL is part of the Conn interface.
 func (c *ZkConn) GetACL(ctx context.Context, path string) (aclv []zk.ACL, stat *zk.Stat, err error) {
 	err = c.withRetry(ctx, func(conn *zk.Conn) error {
 		aclv, stat, err = conn.GetACL(path)
@@ -182,6 +188,7 @@ func (c *ZkConn) GetACL(ctx context.Context, path string) (aclv []zk.ACL, stat *
 	return
 }
 
+// SetACL is part of the Conn interface.
 func (c *ZkConn) SetACL(ctx context.Context, path string, aclv []zk.ACL, version int32) error {
 	return c.withRetry(ctx, func(conn *zk.Conn) error {
 		_, err := conn.SetACL(path, aclv, version)
@@ -189,6 +196,7 @@ func (c *ZkConn) SetACL(ctx context.Context, path string, aclv []zk.ACL, version
 	})
 }
 
+// AddAuth is part of the Conn interface.
 func (c *ZkConn) AddAuth(ctx context.Context, scheme string, auth []byte) error {
 	return c.withRetry(ctx, func(conn *zk.Conn) error {
 		err := conn.AddAuth(scheme, auth)


### PR DESCRIPTION
If the flag is specified, Vitess clients will send an auth packet at connect time. This allows for the use of ACLs on the ZooKeeper side. We are using this for basic `digest:user:pass` authentication. Relevant ZooKeeper docs:

https://zookeeper.apache.org/doc/r3.4.13/zookeeperProgrammers.html#sc_BuiltinACLSchemes