### PR TITLE
Make zookeeper version adjustable (ZK_VERSION env)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -179,15 +179,14 @@ function install_zookeeper() {
   zk="zookeeper-$version"
   wget "http://apache.org/dist/zookeeper/$zk/$zk.tar.gz"
   tar -xzf "$zk.tar.gz"
+  ant -f "$zk/build.xml" package
+  ant -f "$zk/src/contrib/fatjar/build.xml" jar
   mkdir -p lib
-  cp "$zk/contrib/fatjar/$zk-fatjar.jar" lib
-  # TODO(sougou): when version changes, see if we can drop the 'zip -d' hack to get the fatjars working.
-  #               If yes, also delete "zip" from the Dockerfile files and the manual build instructions again.
-  # 3.4.13 workaround: Delete META-INF files which should not be in there.
-  zip -d "lib/$zk-fatjar.jar" 'META-INF/*.SF' 'META-INF/*.RSA' 'META-INF/*SF'
+  cp "$zk/build/contrib/fatjar/zookeeper-dev-fatjar.jar" "lib/$zk-fatjar.jar"
+  zip -d "lib/$zk-fatjar.jar" 'META-INF/*.SF' 'META-INF/*.RSA' 'META-INF/*SF' || true # needed for >=3.4.10 <3.5
   rm -rf "$zk" "$zk.tar.gz"
 }
-zk_ver=3.4.13
+zk_ver=${ZK_VERSION:-3.4.13}
 install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist/vt-zookeeper-$zk_ver" install_zookeeper
 
 

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -27,6 +27,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     xvfb \
     zip \
     libz-dev \
+    ant \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Maven 3.1+

--- a/go/vt/zkctl/zksrv.sh
+++ b/go/vt/zkctl/zksrv.sh
@@ -21,7 +21,7 @@ logdir="$1"
 config="$2"
 pidfile="$3"
 
-zk_ver=3.4.13
+zk_ver=${ZK_VERSION:-3.4.13}
 classpath="$VTROOT/dist/vt-zookeeper-$zk_ver/lib/zookeeper-$zk_ver-fatjar.jar:/usr/local/lib/zookeeper-$zk_ver-fatjar.jar:/usr/share/java/zookeeper-$zk_ver.jar"
 
 mkdir -p "$logdir"


### PR DESCRIPTION
This patch parameterizes the ZooKeeper version. Confirmed working with `ZK_VERSION=3.5.4-beta`. There is a comment about updating the `Dockerfile` but I'm not so familiar with that.

Not included in this patch but related:

```diff
diff --git a/config/zkcfg/zoo.cfg b/config/zkcfg/zoo.cfg
index 8b1b00994..b8f811706 100644
--- a/config/zkcfg/zoo.cfg
+++ b/config/zkcfg/zoo.cfg
@@ -1,9 +1,10 @@
 tickTime=2000
 dataDir={{.DataDir}}
 clientPort={{.ClientPort}}
 initLimit=5
 syncLimit=2
 maxClientCnxns=0
 {{range .Servers}}
 server.{{.ServerId}}={{.Hostname}}:{{.LeaderPort}}:{{.ElectionPort}}
 {{end}}
+4lw.commands.whitelist=conf,cons,crst,dump,envi,ruok,srst,srvr,stat,wchs,mntr
```

The default config for `4lw.commands.whitelist` is different in 3.5+. The above diff explicitly sets it to the default of 3.4. Without this, the `ruok` healthcheck fails. Alternatives: (a) parameterize (e.g., `{{.FourLetterWords}}`), (b) ability to add arbitrary config, (c) something else?
