### PR TITLE
vreplication: table copying phase 1: create list of tables to copy

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -52,6 +52,10 @@ var (
 	// BlplTransaction is the key for the stats map.
 	BlplTransaction = "Transaction"
 
+	// VReplicationInit is for the Init state.
+	VReplicationInit = "Init"
+	// VReplicationCopying is for the Copying state.
+	VReplicationCopying = "Copying"
 	// BlpRunning is for the Running state.
 	BlpRunning = "Running"
 	// BlpStopped is for the Stopped state.

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -195,18 +195,18 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 // applyEvents returns a recordable status message on termination or an error otherwise.
 func (blp *BinlogPlayer) applyEvents(ctx context.Context) error {
 	// Read starting values for vreplication.
-	pos, stopPos, maxTPS, maxReplicationLag, err := ReadVRSettings(blp.dbClient, blp.uid)
+	settings, err := ReadVRSettings(blp.dbClient, blp.uid)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
-	blp.position, err = mysql.DecodePosition(pos)
+	blp.position, err = mysql.DecodePosition(settings.StartPos)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
-	if stopPos != "" {
-		blp.stopPosition, err = mysql.DecodePosition(stopPos)
+	if settings.StopPos != "" {
+		blp.stopPosition, err = mysql.DecodePosition(settings.StopPos)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -216,8 +216,8 @@ func (blp *BinlogPlayer) applyEvents(ctx context.Context) error {
 		fmt.Sprintf("BinlogPlayer/%d", blp.uid),
 		"transactions",
 		1, /* threadCount */
-		maxTPS,
-		maxReplicationLag,
+		settings.MaxTPS,
+		settings.MaxReplicationLag,
 	)
 	if err != nil {
 		err := fmt.Errorf("failed to instantiate throttler: %v", err)
@@ -516,29 +516,44 @@ func SetVReplicationState(dbClient DBClient, uid uint32, state, message string) 
 	return nil
 }
 
+// VRSettings contains the settings of a vreplication table.
+type VRSettings struct {
+	StartPos          string
+	StopPos           string
+	MaxTPS            int64
+	MaxReplicationLag int64
+	State             string
+}
+
 // ReadVRSettings retrieves the throttler settings for
 // vreplication from the checkpoint table.
-func ReadVRSettings(dbClient DBClient, uid uint32) (pos, stopPos string, maxTPS, maxReplicationLag int64, err error) {
-	query := fmt.Sprintf("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=%v", uid)
+func ReadVRSettings(dbClient DBClient, uid uint32) (VRSettings, error) {
+	query := fmt.Sprintf("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=%v", uid)
 	qr, err := dbClient.ExecuteFetch(query, 1)
 	if err != nil {
-		return "", "", throttler.InvalidMaxRate, throttler.InvalidMaxReplicationLag, fmt.Errorf("error %v in selecting vreplication settings %v", err, query)
+		return VRSettings{}, fmt.Errorf("error %v in selecting vreplication settings %v", err, query)
 	}
 
 	if qr.RowsAffected != 1 {
-		return "", "", throttler.InvalidMaxRate, throttler.InvalidMaxReplicationLag, fmt.Errorf("checkpoint information not available in db for %v", uid)
+		return VRSettings{}, fmt.Errorf("checkpoint information not available in db for %v", uid)
 	}
 
-	maxTPS, err = sqltypes.ToInt64(qr.Rows[0][2])
+	maxTPS, err := sqltypes.ToInt64(qr.Rows[0][2])
 	if err != nil {
-		return "", "", throttler.InvalidMaxRate, throttler.InvalidMaxReplicationLag, fmt.Errorf("failed to parse max_tps column: %v", err)
+		return VRSettings{}, fmt.Errorf("failed to parse max_tps column: %v", err)
 	}
-	maxReplicationLag, err = sqltypes.ToInt64(qr.Rows[0][3])
+	maxReplicationLag, err := sqltypes.ToInt64(qr.Rows[0][3])
 	if err != nil {
-		return "", "", throttler.InvalidMaxRate, throttler.InvalidMaxReplicationLag, fmt.Errorf("failed to parse max_replication_lag column: %v", err)
+		return VRSettings{}, fmt.Errorf("failed to parse max_replication_lag column: %v", err)
 	}
 
-	return qr.Rows[0][0].ToString(), qr.Rows[0][1].ToString(), maxTPS, maxReplicationLag, nil
+	return VRSettings{
+		StartPos:          qr.Rows[0][0].ToString(),
+		StopPos:           qr.Rows[0][1].ToString(),
+		MaxTPS:            maxTPS,
+		MaxReplicationLag: maxReplicationLag,
+		State:             qr.Rows[0][4].ToString(),
+	}, nil
 }
 
 // CreateVReplication returns a statement to populate the first value into
@@ -550,12 +565,12 @@ func CreateVReplication(workflow string, source *binlogdatapb.BinlogSource, posi
 		encodeString(workflow), encodeString(source.String()), encodeString(position), maxTPS, maxReplicationLag, timeUpdated, BlpRunning)
 }
 
-// CreateVReplicationStopped returns a statement to create a stopped vreplication.
-func CreateVReplicationStopped(workflow string, source *binlogdatapb.BinlogSource, position string) string {
+// CreateVReplicationState returns a statement to create a stopped vreplication.
+func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource, position, state string) string {
 	return fmt.Sprintf("insert into _vt.vreplication "+
 		"(workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state) "+
 		"values (%v, %v, %v, %v, %v, %v, 0, '%v')",
-		encodeString(workflow), encodeString(source.String()), encodeString(position), throttler.MaxRateModuleDisabled, throttler.ReplicationLagModuleDisabled, time.Now().Unix(), BlpStopped)
+		encodeString(workflow), encodeString(source.String()), encodeString(position), throttler.MaxRateModuleDisabled, throttler.ReplicationLagModuleDisabled, time.Now().Unix(), state)
 }
 
 // GenerateUpdatePos returns a statement to update a value in the

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -41,6 +41,7 @@ var (
 				sqltypes.NULL, // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
@@ -51,7 +52,7 @@ var (
 func TestNewBinlogPlayerKeyRange(t *testing.T) {
 	dbClient := NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -82,7 +83,7 @@ func TestNewBinlogPlayerKeyRange(t *testing.T) {
 func TestNewBinlogPlayerTables(t *testing.T) {
 	dbClient := NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -114,7 +115,7 @@ func TestNewBinlogPlayerTables(t *testing.T) {
 func TestApplyEventsFail(t *testing.T) {
 	dbClient := NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, errors.New("err"))
 	dbClient.ExpectRequest("update _vt.vreplication set state='Error', message='error in processing binlog event failed query BEGIN, err: err' where id=1", testDMLResponse, nil)
 
@@ -145,10 +146,11 @@ func TestStopPosEqual(t *testing.T) {
 				sqltypes.NewVarBinary("MariaDB/0-1-1083"),    // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", posEqual, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", posEqual, nil)
 	dbClient.ExpectRequest(`update _vt.vreplication set state='Stopped', message='not starting BinlogPlayer, we\'re already at the desired position 0-1-1083' where id=1`, testDMLResponse, nil)
 
 	_ = newFakeBinlogClient()
@@ -177,10 +179,11 @@ func TestStopPosLess(t *testing.T) {
 				sqltypes.NewVarBinary("MariaDB/0-1-1082"),    // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", posEqual, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", posEqual, nil)
 	dbClient.ExpectRequest(`update _vt.vreplication set state='Stopped', message='starting point 0-1-1083 greater than stopping point 0-1-1082' where id=1`, testDMLResponse, nil)
 
 	_ = newFakeBinlogClient()
@@ -209,10 +212,11 @@ func TestStopPosGreater(t *testing.T) {
 				sqltypes.NewVarBinary("MariaDB/0-1-1085"),    // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", posEqual, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", posEqual, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -245,10 +249,11 @@ func TestContextCancel(t *testing.T) {
 				sqltypes.NewVarBinary("MariaDB/0-1-1085"),    // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", posEqual, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", posEqual, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -275,7 +280,7 @@ func TestContextCancel(t *testing.T) {
 func TestRetryOnDeadlock(t *testing.T) {
 	dbClient := NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	deadlocked := &mysql.SQLError{Num: 1213, Message: "deadlocked"}
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", nil, deadlocked)

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -44,6 +44,7 @@ var (
 				sqltypes.NULL, // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
@@ -64,7 +65,7 @@ func TestControllerKeyRange(t *testing.T) {
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -99,7 +100,7 @@ func TestControllerTables(t *testing.T) {
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -191,7 +192,7 @@ func TestControllerOverrides(t *testing.T) {
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -255,10 +256,10 @@ func TestControllerRetry(t *testing.T) {
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", nil, errors.New("(expected error)"))
-	dbClient.ExpectRequest("update _vt.vreplication set state='Error', message='error (expected error) in selecting vreplication settings select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1' where id=1", testDMLResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", nil, errors.New("(expected error)"))
+	dbClient.ExpectRequest("update _vt.vreplication set state='Error', message='error (expected error) in selecting vreplication settings select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -298,10 +299,11 @@ func TestControllerStopPosition(t *testing.T) {
 				sqltypes.NewVarBinary("MariaDB/0-1-1235"),    // stop_pos
 				sqltypes.NewVarBinary("9223372036854775807"), // max_tps
 				sqltypes.NewVarBinary("9223372036854775807"), // max_replication_lag
+				sqltypes.NewVarBinary("Running"),             // state
 			},
 		},
 	}
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", withStop, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", withStop, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -54,7 +54,7 @@ func TestEngineOpen(t *testing.T) {
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -107,7 +107,7 @@ func TestEngineExec(t *testing.T) {
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -147,7 +147,7 @@ func TestEngineExec(t *testing.T) {
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)
@@ -439,7 +439,7 @@ func TestCreateDBAndTable(t *testing.T) {
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag from _vt.vreplication where id=1", testSettingsResponse, nil)
+	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("insert into t values(1)", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set pos='MariaDB/0-1-1235', time_updated=.*", testDMLResponse, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -70,10 +70,6 @@ func init() {
 func TestMain(m *testing.M) {
 	flag.Parse() // Do not remove this comment, import into google3 depends on it
 
-	if testing.Short() {
-		os.Exit(m.Run())
-	}
-
 	exitCode := func() int {
 		var err error
 		env, err = testenv.Init()

--- a/go/vt/vttablet/tabletmanager/vreplication/player_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/player_plan.go
@@ -27,12 +27,14 @@ import (
 // PlayerPlan is the execution plan for a player stream.
 type PlayerPlan struct {
 	VStreamFilter *binlogdatapb.Filter
+	TargetTables  map[string]*TablePlan
 	TablePlans    map[string]*TablePlan
 }
 
 // TablePlan is the execution plan for a table within a player stream.
 type TablePlan struct {
 	Name         string
+	SendRule     *binlogdatapb.Rule
 	PKReferences []string               `json:",omitempty"`
 	Insert       *sqlparser.ParsedQuery `json:",omitempty"`
 	Update       *sqlparser.ParsedQuery `json:",omitempty"`

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -73,6 +73,11 @@ const (
 	insertIgnore
 )
 
+// buildPlayerPlan builds a PlayerPlan from the input filter.
+// The filter is matched against the target schema. For every table matched,
+// a table-specific rule is built to be sent to the source. We don't send the
+// original rule to the source because it may not match the same tables as the
+// target.
 func buildPlayerPlan(filter *binlogdatapb.Filter, tableKeys map[string][]string) (*PlayerPlan, error) {
 	plan := &PlayerPlan{
 		VStreamFilter: &binlogdatapb.Filter{},

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -136,7 +136,6 @@ func (vp *vplayer) initTablesForCopy(ctx context.Context) error {
 		if !isSQLErr || !(merr.Num == mysql.ERNoSuchTable || merr.Num == mysql.ERBadDb) {
 			return err
 		}
-		log.Info("Looks like _vt.copy_state table may not exist. Trying to create... ")
 		for _, query := range CreateCopyState {
 			if _, merr := vp.dbClient.ExecuteFetch(query, 0); merr != nil {
 				log.Errorf("Failed to ensure _vt.copy_state table exists: %v", merr)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_copy_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_copy_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestPlayerInitTables(t *testing.T) {
+	defer deleteTablet(addTablet(100, "0", topodatapb.TabletType_REPLICA, true, true))
+
+	execStatements(t, []string{
+		"create table src1(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.dst1(id int, val varbinary(128), primary key(id))", vrepldb),
+		"create table yes(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.yes(id int, val varbinary(128), primary key(id))", vrepldb),
+		"create table no(id int, val varbinary(128), primary key(id))",
+	})
+	defer execStatements(t, []string{
+		"drop table src1",
+		fmt.Sprintf("drop table %s.dst1", vrepldb),
+		"drop table yes",
+		fmt.Sprintf("drop table %s.yes", vrepldb),
+		"drop table no",
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst1",
+			Filter: "select * from src1",
+		}, {
+			Match:  "dst2",
+			Filter: "select id, val1, sum(val2) as sval2, count(*) as rcount from src2 group by id",
+		}, {
+			Match: "/yes",
+		}},
+	}
+
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.VReplicationInit)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDBClientQueries(t, []string{
+			"/delete",
+		})
+	}()
+
+	for q := range globalDBQueries {
+		if strings.HasPrefix(q, "create table if not exists _vt.copy_state") {
+			break
+		}
+	}
+
+	expectDBClientQueries(t, []string{
+		"begin",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		"commit",
+		"rollback",
+	})
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -560,12 +560,12 @@ func TestPlayerTypes(t *testing.T) {
 func TestPlayerDDL(t *testing.T) {
 	defer deleteTablet(addTablet(100, "0", topodatapb.TabletType_REPLICA, true, true))
 	execStatements(t, []string{
-		"create table dummy(id int, primary key(id))",
-		fmt.Sprintf("create table %s.dummy(id int, primary key(id))", vrepldb),
+		"create table t1(id int, primary key(id))",
+		fmt.Sprintf("create table %s.t1(id int, primary key(id))", vrepldb),
 	})
 	defer execStatements(t, []string{
-		"drop table dummy",
-		fmt.Sprintf("drop table %s.dummy", vrepldb),
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
 	})
 	env.SchemaEngine.Reload(context.Background())
 
@@ -580,23 +580,23 @@ func TestPlayerDDL(t *testing.T) {
 	// is a race between the DDLs and the schema loader of vstreamer.
 	// Root cause seems to be with MySQL where t1 shows up in information_schema before
 	// the actual table is created.
-	execStatements(t, []string{"insert into dummy values(1)"})
+	execStatements(t, []string{"insert into t1 values(1)"})
 	expectDBClientQueries(t, []string{
 		"begin",
-		"insert into dummy set id=1",
+		"insert into t1 set id=1",
 		"/update _vt.vreplication set pos=",
 		"commit",
 	})
 
-	execStatements(t, []string{"create table t1(id int, primary key(id))"})
-	execStatements(t, []string{"drop table t1"})
+	execStatements(t, []string{"alter table t1 add column val varchar(128)"})
+	execStatements(t, []string{"alter table t1 drop column val"})
 	expectDBClientQueries(t, []string{})
 	cancel()
 
 	cancel, id := startVReplication(t, filter, binlogdatapb.OnDDLAction_STOP, "")
-	execStatements(t, []string{"create table t1(id int, primary key(id))"})
+	execStatements(t, []string{"alter table t1 add column val varchar(128)"})
 	pos1 := masterPosition(t)
-	execStatements(t, []string{"drop table t1"})
+	execStatements(t, []string{"alter table t1 drop column val"})
 	pos2 := masterPosition(t)
 	// The stop position must be the GTID of the first DDL
 	expectDBClientQueries(t, []string{
@@ -620,49 +620,39 @@ func TestPlayerDDL(t *testing.T) {
 	})
 	cancel()
 
-	execStatements(t, []string{fmt.Sprintf("create table %s.t2(id int, primary key(id))", vrepldb)})
+	execStatements(t, []string{fmt.Sprintf("alter table %s.t1 add column val2 varchar(128)", vrepldb)})
 	cancel, _ = startVReplication(t, filter, binlogdatapb.OnDDLAction_EXEC, "")
-	execStatements(t, []string{"create table t1(id int, primary key(id))"})
+	execStatements(t, []string{"alter table t1 add column val1 varchar(128)"})
 	expectDBClientQueries(t, []string{
-		"create table t1(id int, primary key(id))",
+		"alter table t1 add column val1 varchar(128)",
 		"/update _vt.vreplication set pos=",
 	})
-	execStatements(t, []string{"create table t2(id int, primary key(id))"})
+	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
-		"create table t2(id int, primary key(id))",
+		"alter table t1 add column val2 varchar(128)",
 		"/update _vt.vreplication set state='Error'",
 	})
 	cancel()
 
-	// Don't test drop.
-	// MySQL rewrites them by uppercasing, which may be version specific.
 	execStatements(t, []string{
-		"drop table t1",
-		fmt.Sprintf("drop table %s.t1", vrepldb),
-		"drop table t2",
-		fmt.Sprintf("drop table %s.t2", vrepldb),
+		"alter table t1 drop column val1",
+		"alter table t1 drop column val2",
+		fmt.Sprintf("alter table %s.t1 drop column val1", vrepldb),
 	})
 
 	execStatements(t, []string{fmt.Sprintf("create table %s.t2(id int, primary key(id))", vrepldb)})
 	cancel, _ = startVReplication(t, filter, binlogdatapb.OnDDLAction_EXEC_IGNORE, "")
-	execStatements(t, []string{"create table t1(id int, primary key(id))"})
+	execStatements(t, []string{"alter table t1 add column val1 varchar(128)"})
 	expectDBClientQueries(t, []string{
-		"create table t1(id int, primary key(id))",
+		"alter table t1 add column val1 varchar(128)",
 		"/update _vt.vreplication set pos=",
 	})
-	execStatements(t, []string{"create table t2(id int, primary key(id))"})
+	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
-		"create table t2(id int, primary key(id))",
+		"alter table t1 add column val2 varchar(128)",
 		"/update _vt.vreplication set pos=",
 	})
 	cancel()
-
-	execStatements(t, []string{
-		"drop table t1",
-		fmt.Sprintf("drop table %s.t1", vrepldb),
-		"drop table t2",
-		fmt.Sprintf("drop table %s.t2", vrepldb),
-	})
 }
 
 func TestPlayerStopPos(t *testing.T) {
@@ -1051,8 +1041,8 @@ func TestPlayerBatching(t *testing.T) {
 	execStatements(t, []string{
 		"insert into t1 values(2, 'aaa')",
 		"insert into t1 values(3, 'aaa')",
-		"create table t2(id int, val varbinary(128), primary key(id))",
-		"drop table t2",
+		"alter table t1 add column val2 varbinary(128)",
+		"alter table t1 drop column val2",
 	})
 
 	// Release the lock.
@@ -1069,9 +1059,9 @@ func TestPlayerBatching(t *testing.T) {
 		"insert into t1 set id=3, val='aaa'",
 		"/update _vt.vreplication set pos=",
 		"commit",
-		"create table t2(id int, val varbinary(128), primary key(id))",
+		"alter table t1 add column val2 varbinary(128)",
 		"/update _vt.vreplication set pos=",
-		"/", // drop table is rewritten by mysql. Don't check.
+		"alter table t1 drop column val2",
 		"/update _vt.vreplication set pos=",
 	})
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -682,7 +682,7 @@ func TestPlayerStopPos(t *testing.T) {
 		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
 	}
 	startPos := masterPosition(t)
-	query := binlogplayer.CreateVReplicationStopped("test", bls, startPos)
+	query := binlogplayer.CreateVReplicationState("test", bls, startPos, binlogplayer.BlpStopped)
 	qr, err := playerEngine.Exec(query)
 	if err != nil {
 		t.Fatal(err)

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -697,7 +697,7 @@ func (wr *Wrangler) setupReverseReplication(ctx context.Context, sourceShards, d
 				Shard:    dest.ShardName(),
 				KeyRange: kr,
 			}
-			qr, err := wr.VReplicationExec(ctx, sourceShard.MasterAlias, binlogplayer.CreateVReplicationStopped("ReversedResharding", bls, masterPositions[j]))
+			qr, err := wr.VReplicationExec(ctx, sourceShard.MasterAlias, binlogplayer.CreateVReplicationState("ReversedResharding", bls, masterPositions[j], binlogplayer.BlpStopped))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We introduce two new states in vreplication: Init and Copying.
In the Init phase, one creates the vreplication row without a starting position. The VReplication will then copy tables from the source and keep them synced through vreplication. To achieve this, we have to identify the list of tables to copy. This PR is for this phase.

To find the list of tables to copy, we match the rules against the target (local) vttablet. Therefore, in order to be consistent, we don't send the same rules blindly to the source any more instead. Doing so may cause it to match a different set of tables than the target. Instead, we build an equivalent rule for each table that matched the source, and we send that to the source instead. This keeps the target and source consistent.