### PR TITLE
servenv: add new keepalive flag to grpc server

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -87,6 +87,11 @@ var (
 	// This is the minimum amount of time a client should wait before sending a keepalive ping.
 	GRPCKeepAliveEnforcementPolicyMinTime = flag.Duration("grpc_server_keepalive_enforcement_policy_min_time", 5*time.Minute, "grpc server minimum keepalive time")
 
+	// EnforcementPolicy PermitWithoutStream - If true, server allows keepalive pings
+	// even when there are no active streams (RPCs). If false, and client sends ping when
+	// there are no active streams, server will send GOAWAY and close the connection.
+	GRPCKeepAliveEnforcementPolicyPermitWithoutStream = flag.Bool("grpc_server_keepalive_enforcement_policy_permit_without_stream", false, "grpc server permit client keepalive pings even when there are no active streams (RPCs)")
+
 	authPlugin Authenticator
 )
 
@@ -148,7 +153,8 @@ func createGRPCServer() {
 	}
 
 	ep := keepalive.EnforcementPolicy{
-		MinTime: *GRPCKeepAliveEnforcementPolicyMinTime,
+		MinTime:             *GRPCKeepAliveEnforcementPolicyMinTime,
+		PermitWithoutStream: *GRPCKeepAliveEnforcementPolicyPermitWithoutStream,
 	}
 	opts = append(opts, grpc.KeepaliveEnforcementPolicy(ep))
 


### PR DESCRIPTION
This PR adds a single grpc configuration flag for keepalive enforcement policy: PermitWithoutStream:. It defaults to false, the same as previous behavior. The purpose is to prevent potential zombie connections from vtgate to vttablet on intermittently active streams. We're already setting this to be true by default on the client side here: https://github.com/vitessio/vitess/blob/2af0d638939905afeeb495f6ff2a076740906e52/go/vt/grpcclient/client.go#L68-L75

That setting doesn't take effect if it isn't also enabled server side.

>  // If true, server allows keepalive pings even when there are no active
    // streams(RPCs). If false, and client sends ping when there are no active
    // streams, server will send GOAWAY and close the connection.
https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy