### PR TITLE
vindexes.BuildVSchema: prevent one bad sequence from breaking all oth…

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -301,7 +301,7 @@ func resolveAutoIncrement(source *vschemapb.SrvVSchema, vschema *VSchema) {
 			seq, err := vschema.findQualified(table.AutoIncrement.Sequence)
 			if err != nil {
 				ksvschema.Error = fmt.Errorf("cannot resolve sequence %s: %v", table.AutoIncrement.Sequence, err)
-				break
+				continue
 			}
 			t.AutoIncrement.Sequence = seq
 		}


### PR DESCRIPTION
…er sequences

PR #4371 made vtgate more permissive about allowing bad data in a vschema
without failing requests that only involve properly-defined tables.

This PR extends that so a single table entry in the vschema that references a bad
sequence won't disable the sequences for all the other tables with valid sequence
configs.