### PR TITLE
messager: avoid taking locks if there's no work to do

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -130,6 +130,11 @@ func (me *Engine) Subscribe(ctx context.Context, name string, send func(*sqltype
 // LockDB obtains db locks for all messages that need to
 // be updated and returns the counterpart unlock function.
 func (me *Engine) LockDB(newMessages map[string][]*MessageRow, changedMessages map[string][]string) func() {
+	// Short-circuit to avoid taking any locks if there's nothing to do.
+	if len(newMessages) == 0 && len(changedMessages) == 0 {
+		return func() {}
+	}
+
 	// Build the set of affected messages tables.
 	combined := make(map[string]struct{})
 	for name := range newMessages {
@@ -174,6 +179,11 @@ func (me *Engine) LockDB(newMessages map[string][]*MessageRow, changedMessages m
 
 // UpdateCaches updates the caches for the committed changes.
 func (me *Engine) UpdateCaches(newMessages map[string][]*MessageRow, changedMessages map[string][]string) {
+	// Short-circuit to avoid taking any locks if there's nothing to do.
+	if len(newMessages) == 0 && len(changedMessages) == 0 {
+		return
+	}
+
 	me.mu.Lock()
 	defer me.mu.Unlock()
 	now := time.Now().UnixNano()


### PR DESCRIPTION
In reviewing #4739 I noticed that the txpool calls into the messager engine on every committed transaction with the list of new messages / changed messages.

For all cases in which the transaction did not actually change a messages table, the two lists are empty, but the messager engine still takes internal locks to process these empty lists.

It seems like this could cause unnecessary lock contention, so add an initial short-circuit check in case both lists are empty.