### PR TITLE
tableacls: remove deprecated -legacy-table-acl option from vttablet

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -137,31 +137,6 @@ func (pt PlanType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(pt.String())
 }
 
-// MinRole is the minimum Role required to execute this PlanType.
-func (pt PlanType) MinRole() tableacl.Role {
-	return tableACLRoles[pt]
-}
-
-var tableACLRoles = map[PlanType]tableacl.Role{
-	PlanPassSelect:       tableacl.READER,
-	PlanSelectLock:       tableacl.READER,
-	PlanSet:              tableacl.READER,
-	PlanPassDML:          tableacl.WRITER,
-	PlanDMLPK:            tableacl.WRITER,
-	PlanDMLSubquery:      tableacl.WRITER,
-	PlanInsertPK:         tableacl.WRITER,
-	PlanInsertSubquery:   tableacl.WRITER,
-	PlanInsertMessage:    tableacl.WRITER,
-	PlanDDL:              tableacl.ADMIN,
-	PlanSelectStream:     tableacl.READER,
-	PlanOtherRead:        tableacl.READER,
-	PlanOtherAdmin:       tableacl.ADMIN,
-	PlanUpsertPK:         tableacl.WRITER,
-	PlanNextval:          tableacl.WRITER,
-	PlanMessageStream:    tableacl.WRITER,
-	PlanSelectImpossible: tableacl.READER,
-}
-
 //_______________________________________________
 
 // ReasonType indicates why a query plan fails to build

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -58,10 +58,9 @@ import (
 // and track stats.
 type TabletPlan struct {
 	*planbuilder.Plan
-	Fields           []*querypb.Field
-	Rules            *rules.Rules
-	LegacyAuthorized *tableacl.ACLResult
-	Authorized       []*tableacl.ACLResult
+	Fields     []*querypb.Field
+	Rules      *rules.Rules
+	Authorized []*tableacl.ACLResult
 
 	mu         sync.Mutex
 	QueryCount int64
@@ -344,7 +343,6 @@ func (qe *QueryEngine) GetPlan(ctx context.Context, logStats *tabletenv.LogStats
 	}
 	plan := &TabletPlan{Plan: splan}
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
-	plan.LegacyAuthorized = tableacl.Authorized(plan.TableName().String(), plan.PlanID.MinRole())
 	plan.buildAuthorized()
 	if plan.PlanID.IsSelect() {
 		if plan.FieldQuery != nil {
@@ -406,7 +404,6 @@ func (qe *QueryEngine) GetStreamPlan(sql string) (*TabletPlan, error) {
 	}
 	plan := &TabletPlan{Plan: splan}
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
-	plan.LegacyAuthorized = tableacl.Authorized(plan.TableName().String(), plan.PlanID.MinRole())
 	plan.buildAuthorized()
 	return plan, nil
 }
@@ -421,7 +418,6 @@ func (qe *QueryEngine) GetMessageStreamPlan(name string) (*TabletPlan, error) {
 	}
 	plan := &TabletPlan{Plan: splan}
 	plan.Rules = qe.queryRuleSources.FilterByPlan("stream from "+name, plan.PlanID, plan.TableName().String())
-	plan.LegacyAuthorized = tableacl.Authorized(plan.TableName().String(), plan.PlanID.MinRole())
 	plan.buildAuthorized()
 	return plan, nil
 }


### PR DESCRIPTION
If anyone out there is using legacy behavior, seems like it should
be possible to switch to the newer behavior.

The legacy behavior has a weaker understanding of what queries do
and seems like if anything would be stricter than the newer behavior.