### PR TITLE
Cleanup logs, comments and fix issue with rebuild keyspace in init_tablet

### DIFF
--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -71,8 +71,6 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 	}
 
 	// This is safe to rebuild as long there are not srvKeyspaces with tablet controls set.
-	// TODO: Add this validation.
-
 	// Build the list of cells to work on: we get the union
 	// of all the Cells of all the Shards, limited to the provided cells.
 	//

--- a/go/vt/vttablet/tabletmanager/init_tablet.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet.go
@@ -131,7 +131,7 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 	case err == nil:
 		// NOOP
 	case topo.IsErrType(err, topo.NoNode):
-		err = topotools.RebuildKeyspaceLocked(ctx, logutil.NewConsoleLogger(), agent.TopoServer, *initKeyspace, []string{agent.TabletAlias.Cell})
+		err = topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), agent.TopoServer, *initKeyspace, []string{agent.TabletAlias.Cell})
 	default:
 		return vterrors.Wrap(err, "InitTablet failed to read srvKeyspace")
 	}

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -146,7 +146,7 @@ func (wr *Wrangler) printShards(ctx context.Context, si []*topo.ShardInfo) error
 				wr.Logger().Printf("        %v\n", row)
 			}
 		}
-		wr.Logger().Printf("      Served Types: %v\n", si.IsMasterServing)
+		wr.Logger().Printf("      Is Master Serving: %v\n", si.IsMasterServing)
 		if len(si.TabletControls) != 0 {
 			wr.Logger().Printf("      Tablet Controls: %v\n", si.TabletControls)
 		}


### PR DESCRIPTION
### Description 

* Init tablet was using rebuild keyspace locked without holding a lock. This
  change makes sure it holds a lock before calling rebuild keyspace.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>