### PR TITLE
Add annotations value to EtcdCluster in helm chart

### DIFF
--- a/helm/vitess/templates/_etcd.tpl
+++ b/helm/vitess/templates/_etcd.tpl
@@ -16,6 +16,8 @@ apiVersion: "etcd.database.coreos.com/v1beta2"
 kind: "EtcdCluster"
 metadata:
   name: "etcd-{{ $name }}"
+  ## Adding this annotation make this cluster managed by clusterwide operators
+  ## namespaced operators ignore it
   annotations:
   {{ if $clusterWide }}
     etcd.database.coreos.com/scope: clusterwide

--- a/helm/vitess/templates/_etcd.tpl
+++ b/helm/vitess/templates/_etcd.tpl
@@ -7,6 +7,7 @@
 {{- $replicas := index . 1 -}}
 {{- $version := index . 2 -}}
 {{- $resources := index . 3 }}
+{{- $clusterWide := index . 4 }}
 
 ###################################
 # EtcdCluster
@@ -15,6 +16,10 @@ apiVersion: "etcd.database.coreos.com/v1beta2"
 kind: "EtcdCluster"
 metadata:
   name: "etcd-{{ $name }}"
+  annotations:
+  {{ if $clusterWide }}
+    etcd.database.coreos.com/scope: clusterwide
+  {{ end }}
 spec:
   size: {{ $replicas }}
   version: {{ $version | quote }}

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -29,8 +29,9 @@
 {{- $replicas := $.Values.topology.globalCell.replicas | default $.Values.etcd.replicas -}}
 {{- $version := $.Values.topology.globalCell.version | default $.Values.etcd.version -}}
 {{- $resources := $.Values.topology.globalCell.resources | default $.Values.etcd.resources -}}
+{{- $clusterWide := $.Values.topology.globalCell.resources | default $.Values.etcd.clusterWide -}}
 
-{{ include "etcd" (tuple "global" $replicas $version $resources) }}
+{{ include "etcd" (tuple "global" $replicas $version $resources $clusterWide) }}
 
 # Create requested resources in each cell.
 {{ range $cell := $.Values.topology.cells }}
@@ -41,8 +42,9 @@
 {{- $replicas := $cell.etcd.replicas | default $.Values.etcd.replicas -}}
 {{- $version := $cell.etcd.version | default $.Values.etcd.version -}}
 {{- $resources := $cell.etcd.resources | default $.Values.etcd.resources -}}
+{{- $clusterWide := $cell.etcd.clusterWide | default $.Values.etcd.clusterWide -}}
 
-{{ include "etcd" (tuple $cellClean $replicas $version $resources) }}
+{{ include "etcd" (tuple $cellClean $replicas $version $resources $clusterWide) }}
 ---
 # create one controller per cell
 {{ include "vtctld" (tuple $.Values.topology $cell $.Values.vtctld $.Release.Namespace $.Values.config) }}

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -173,6 +173,7 @@ etcd:
     requests:
       cpu: 200m
       memory: 100Mi
+  # clusterWide: true
 
 # Default values for vtctld resources defined in 'topology'
 vtctld:

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -173,6 +173,8 @@ etcd:
     requests:
       cpu: 200m
       memory: 100Mi
+  # If clusterWide is set to true, will add an annotation to EtcdCluster
+  # to make this cluster managed by clusterwide operators
   # clusterWide: true
 
 # Default values for vtctld resources defined in 'topology'


### PR DESCRIPTION
Add annotations value to EtcdCluster in helm chart to make etcd cluster could be managed by clusterwide etcd-operator.

Implements #4758 .