### PR TITLE
pools: option to prefill

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -78,15 +78,12 @@ type resourceWrapper struct {
 // maxCap specifies the extent to which the pool can be resized
 // in the future through the SetCapacity function.
 // You cannot resize the pool beyond maxCap.
-// If a resource is unused beyond idleTimeout, it's discarded.
+// If a resource is unused beyond idleTimeout, it's replaced
+// with a new one.
 // An idleTimeout of 0 means that there is no timeout.
-func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Duration) *ResourcePool {
-	return NewPrefilledResourcePool(factory, capacity, maxCap, idleTimeout, 0)
-}
-
-// NewPrefilledResourcePool creates a pre-filled resource pool.
-// prefillParallelism specifies how many resources can be opened in parallel.
-func NewPrefilledResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Duration, prefillParallelism int) *ResourcePool {
+// A non-zero value of prefillParallism causes the pool to be pre-filled.
+// The value specifies how many resources can be opened in parallel.
+func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Duration, prefillParallelism int) *ResourcePool {
 	if capacity <= 0 || maxCap <= 0 || capacity > maxCap {
 		panic(errors.New("invalid/out of range capacity"))
 	}
@@ -229,7 +226,7 @@ func (rp *ResourcePool) get(ctx context.Context) (resource Resource, err error) 
 // Put will return a resource to the pool. For every successful Get,
 // a corresponding Put is required. If you no longer need a resource,
 // you will need to call Put(nil) instead of returning the closed resource.
-// The will cause a new resource to be created in its place.
+// This will cause a new resource to be created in its place.
 func (rp *ResourcePool) Put(resource Resource) {
 	var wrapper resourceWrapper
 	if resource != nil {

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -210,6 +210,24 @@ func TestPrefill(t *testing.T) {
 	}
 }
 
+func TestPrefillTimeout(t *testing.T) {
+	lastID.Set(0)
+	count.Set(0)
+	saveTimeout := prefillTimeout
+	prefillTimeout = 1 * time.Millisecond
+	defer func() { prefillTimeout = saveTimeout }()
+
+	start := time.Now()
+	p := NewResourcePool(SlowFailFactory, 5, 5, time.Second, 1)
+	defer p.Close()
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Errorf("elapsed: %v, should be around 10ms", elapsed)
+	}
+	if p.Active() != 0 {
+		t.Errorf("p.Active(): %d, want 0", p.Active())
+	}
+}
+
 func TestShrinking(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -57,7 +57,7 @@ func TestOpen(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 6, 6, time.Second)
+	p := NewResourcePool(PoolFactory, 6, 6, time.Second, 0)
 	p.SetCapacity(5)
 	var resources [10]Resource
 
@@ -197,12 +197,12 @@ func TestOpen(t *testing.T) {
 func TestPrefill(t *testing.T) {
 	lastID.Set(0)
 	count.Set(0)
-	p := NewPrefilledResourcePool(PoolFactory, 5, 5, time.Second, 1)
+	p := NewResourcePool(PoolFactory, 5, 5, time.Second, 1)
 	defer p.Close()
 	if p.Active() != 5 {
 		t.Errorf("p.Active(): %d, want 5", p.Active())
 	}
-	p = NewPrefilledResourcePool(FailFactory, 5, 5, time.Second, 1)
+	p = NewResourcePool(FailFactory, 5, 5, time.Second, 1)
 	defer p.Close()
 	if p.Active() != 0 {
 		t.Errorf("p.Active(): %d, want 0", p.Active())
@@ -213,7 +213,7 @@ func TestShrinking(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 5, 5, time.Second)
+	p := NewResourcePool(PoolFactory, 5, 5, time.Second, 0)
 	var resources [10]Resource
 	// Leave one empty slot in the pool
 	for i := 0; i < 4; i++ {
@@ -352,7 +352,7 @@ func TestClosing(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 5, 5, time.Second)
+	p := NewResourcePool(PoolFactory, 5, 5, time.Second, 0)
 	var resources [10]Resource
 	for i := 0; i < 5; i++ {
 		r, err := p.Get(ctx)
@@ -406,7 +406,7 @@ func TestIdleTimeout(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 1, 1, 10*time.Millisecond)
+	p := NewResourcePool(PoolFactory, 1, 1, 10*time.Millisecond, 0)
 	defer p.Close()
 
 	r, err := p.Get(ctx)
@@ -517,7 +517,7 @@ func TestIdleTimeoutCreateFail(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 1, 1, 10*time.Millisecond)
+	p := NewResourcePool(PoolFactory, 1, 1, 10*time.Millisecond, 0)
 	defer p.Close()
 	r, err := p.Get(ctx)
 	if err != nil {
@@ -538,7 +538,7 @@ func TestCreateFail(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(FailFactory, 5, 5, time.Second)
+	p := NewResourcePool(FailFactory, 5, 5, time.Second, 0)
 	defer p.Close()
 	if _, err := p.Get(ctx); err.Error() != "Failed" {
 		t.Errorf("Expecting Failed, received %v", err)
@@ -554,7 +554,7 @@ func TestCreateFailOnPut(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 5, 5, time.Second)
+	p := NewResourcePool(PoolFactory, 5, 5, time.Second, 0)
 	defer p.Close()
 	_, err := p.Get(ctx)
 	if err != nil {
@@ -571,7 +571,7 @@ func TestSlowCreateFail(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(SlowFailFactory, 2, 2, time.Second)
+	p := NewResourcePool(SlowFailFactory, 2, 2, time.Second, 0)
 	defer p.Close()
 	ch := make(chan bool)
 	// The third Get should not wait indefinitely
@@ -593,7 +593,7 @@ func TestTimeout(t *testing.T) {
 	ctx := context.Background()
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 1, 1, time.Second)
+	p := NewResourcePool(PoolFactory, 1, 1, time.Second, 0)
 	defer p.Close()
 	r, err := p.Get(ctx)
 	if err != nil {
@@ -612,7 +612,7 @@ func TestTimeout(t *testing.T) {
 func TestExpired(t *testing.T) {
 	lastID.Set(0)
 	count.Set(0)
-	p := NewResourcePool(PoolFactory, 1, 1, time.Second)
+	p := NewResourcePool(PoolFactory, 1, 1, time.Second, 0)
 	defer p.Close()
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	r, err := p.Get(ctx)

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -122,9 +122,10 @@ func TestOpen(t *testing.T) {
 		t.Errorf("Unexpected error %v", err)
 	}
 	r.Close()
+	// A nil Put should cause the resource to be reopened.
 	p.Put(nil)
 	if count.Get() != 5 {
-		t.Errorf("Expecting 4, received %d", count.Get())
+		t.Errorf("Expecting 5, received %d", count.Get())
 	}
 	for i := 0; i < 5; i++ {
 		r, err := p.Get(ctx)

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -145,7 +145,7 @@ func (cp *ConnectionPool) Open(info *mysql.ConnParams, mysqlStats *stats.Timings
 	defer cp.mu.Unlock()
 	cp.info = info
 	cp.mysqlStats = mysqlStats
-	cp.connections = pools.NewResourcePool(cp.connect, cp.capacity, cp.capacity, cp.idleTimeout)
+	cp.connections = pools.NewResourcePool(cp.connect, cp.capacity, cp.capacity, cp.idleTimeout, 0)
 	// Check if we need to resolve a hostname (The Host is not just an IP  address).
 	if cp.resolutionFrequency > 0 && net.ParseIP(info.Host) == nil {
 		cp.hostIsNotIP = true
@@ -156,7 +156,7 @@ func (cp *ConnectionPool) Open(info *mysql.ConnParams, mysqlStats *stats.Timings
 			defer cp.wg.Done()
 			for {
 				select {
-				case _ = <-cp.ticker.C:
+				case <-cp.ticker.C:
 					cp.refreshdns()
 				case <-cp.stop:
 					return

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -80,7 +80,7 @@ func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Re
 		interval: config.HeartbeatInterval,
 		ticks:    timer.NewTimer(config.HeartbeatInterval),
 		errorLog: logutil.NewThrottledLogger("HeartbeatReporter", 60*time.Second),
-		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9), checker),
 	}
 }
 
@@ -227,6 +227,7 @@ func (r *Reader) recordError(err error) {
 	readErrors.Add(1)
 }
 
+// IsOpen returns true if Reader is open.
 func (r *Reader) IsOpen() bool {
 	return r.isOpen
 }

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -85,7 +85,7 @@ func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, conf
 		interval:    config.HeartbeatInterval,
 		ticks:       timer.NewTimer(config.HeartbeatInterval),
 		errorLog:    logutil.NewThrottledLogger("HeartbeatWriter", 60*time.Second),
-		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9), checker),
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -113,7 +113,7 @@ func (cp *Pool) Open(appParams, dbaParams, appDebugParams *mysql.ConnParams) {
 	f := func() (pools.Resource, error) {
 		return NewDBConn(cp, appParams)
 	}
-	cp.connections = pools.NewPrefilledResourcePool(f, cp.capacity, cp.capacity, cp.idleTimeout, cp.prefillParallelism)
+	cp.connections = pools.NewResourcePool(f, cp.capacity, cp.capacity, cp.idleTimeout, cp.prefillParallelism)
 	cp.appDebugParams = appDebugParams
 
 	cp.dbaPool.Open(dbaParams, tabletenv.MySQLStats)

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -231,6 +231,7 @@ func newPool() *Pool {
 	return New(
 		fmt.Sprintf("TestPool%d", rand.Int63()),
 		100,
+		0,
 		10*time.Second,
 		checker,
 	)

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -67,6 +67,7 @@ func NewEngine(tsv TabletService, se *schema.Engine, config tabletenv.TabletConf
 		conns: connpool.New(
 			config.PoolNamePrefix+"MessagerPool",
 			config.MessagePoolSize,
+			config.MessagePoolPrefillParallelism,
 			time.Duration(config.IdleTimeout*1e9),
 			tsv,
 		),

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -784,7 +784,7 @@ func (fts *fakeTabletServer) PurgeMessages(ctx context.Context, target *querypb.
 }
 
 func newMMConnPool(db *fakesqldb.DB) *connpool.Pool {
-	pool := connpool.New("", 20, time.Duration(10*time.Minute), newFakeTabletServer())
+	pool := connpool.New("", 20, 0, time.Duration(10*time.Minute), newFakeTabletServer())
 	dbconfigs := dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "")
 	pool.Open(dbconfigs.AppWithDB(), dbconfigs.DbaWithDB(), dbconfigs.AppDebugWithDB())
 	return pool

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -190,6 +190,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	qe.conns = connpool.New(
 		config.PoolNamePrefix+"ConnPool",
 		config.PoolSize,
+		config.PoolPrefillParallelism,
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)
@@ -198,6 +199,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	qe.streamConns = connpool.New(
 		config.PoolNamePrefix+"StreamConnPool",
 		config.StreamPoolSize,
+		config.StreamPoolPrefillParallelism,
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -71,7 +71,7 @@ func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *En
 	reloadTime := time.Duration(config.SchemaReloadTime * 1e9)
 	idleTimeout := time.Duration(config.IdleTimeout * 1e9)
 	se := &Engine{
-		conns:      connpool.New("", 3, idleTimeout, checker),
+		conns:      connpool.New("", 3, 0, idleTimeout, checker),
 		ticks:      timer.NewTimer(reloadTime),
 		reloadTime: reloadTime,
 	}

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -221,7 +221,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	appParams := db.ConnParams()
 	dbaParams := db.ConnParams()
 	connPoolIdleTimeout := 10 * time.Second
-	connPool := connpool.New("", 2, connPoolIdleTimeout, DummyChecker)
+	connPool := connpool.New("", 2, 0, connPoolIdleTimeout, DummyChecker)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -116,6 +116,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 		config.PoolNamePrefix,
 		config.TransactionCap,
 		config.FoundRowsPoolSize,
+		config.TxPoolPrefillParallelism,
 		time.Duration(config.TransactionTimeout*1e9),
 		time.Duration(config.IdleTimeout*1e9),
 		config.TxPoolWaiterCap,
@@ -146,6 +147,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 	readPool := connpool.New(
 		config.PoolNamePrefix+"TxReadPool",
 		3,
+		0,
 		time.Duration(config.IdleTimeout*1e9),
 		checker,
 	)

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -71,7 +71,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close.
 	te.open()
-	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, _, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.open()
-	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, _, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period, but pool gets empty early.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.open()
-	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, _, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close, but connection is in use.
 	te.open()
-	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, _, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -107,14 +107,15 @@ func NewTxPool(
 	prefix string,
 	capacity int,
 	foundRowsCapacity int,
+	prefillParallelism int,
 	timeout time.Duration,
 	idleTimeout time.Duration,
 	waiterCap int,
 	checker connpool.MySQLChecker,
 	limiter txlimiter.TxLimiter) *TxPool {
 	axp := &TxPool{
-		conns:         connpool.New(prefix+"TransactionPool", capacity, idleTimeout, checker),
-		foundRowsPool: connpool.New(prefix+"FoundRowsPool", foundRowsCapacity, idleTimeout, checker),
+		conns:         connpool.New(prefix+"TransactionPool", capacity, prefillParallelism, idleTimeout, checker),
+		foundRowsPool: connpool.New(prefix+"FoundRowsPool", foundRowsCapacity, prefillParallelism, idleTimeout, checker),
 		activePool:    pools.NewNumbered(),
 		lastID:        sync2.NewAtomicInt64(time.Now().UnixNano()),
 		timeout:       sync2.NewAtomicDuration(timeout),

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -64,7 +64,7 @@ func TestTxPoolExecuteCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	txConn.RecordQuery(sql)
-	_, err = txConn.Exec(ctx, sql, 1, true)
+	_, _ = txConn.Exec(ctx, sql, 1, true)
 	txConn.Recycle()
 
 	commitSQL, err := txPool.Commit(ctx, transactionID, &fakeMessageCommitter{})
@@ -700,6 +700,7 @@ func newTxPool() *TxPool {
 		poolName,
 		transactionCap,
 		transactionCap,
+		0,
 		transactionTimeout,
 		idleTimeout,
 		waiterCap,


### PR DESCRIPTION
Background: this change allows one to create prefilled resource
pools. This is useful when traffics suddenly shift while the
pool is still empty. This causes a thundering herd of Open requests
that can cause outage.

There is a proposal to rewrite this pool to natively accommodate
this feature. This change is a stand-in until that effort is
completed.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>