### PR TITLE
correct the error parameter in the local example script

### DIFF
--- a/examples/local/203_vertical_split.sh
+++ b/examples/local/203_vertical_split.sh
@@ -33,6 +33,6 @@ source "$script_root/env.sh"
     -log_dir "$VTDATAROOT"/tmp \
     -alsologtostderr \
     -use_v3_resharding_mode \
-    VerticalSplitClone -min_healthy_rdonly_tablets=1 -tables=customer,corder customer/0
+    VerticalSplitClone -min_healthy_tablets=1 -tables=customer,corder customer/0
 
 disown -a


### PR DESCRIPTION
The parameter min_healthy_rdonly_tablets in the example script should be changed to min_healthy_tablets.

Signed-off-by: dcadevil <dcadevil@126.com>