### PR TITLE
Bump default Zookeper version to 3.4.14

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -177,7 +177,7 @@ function install_zookeeper() {
   local dist="$2"
 
   zk="zookeeper-$version"
-  wget "http://apache.org/dist/zookeeper/$zk/$zk.tar.gz"
+  wget "https://apache.org/dist/zookeeper/$zk/$zk.tar.gz"
   tar -xzf "$zk.tar.gz"
   ant -f "$zk/build.xml" package
   ant -f "$zk/src/contrib/fatjar/build.xml" jar
@@ -186,7 +186,7 @@ function install_zookeeper() {
   zip -d "lib/$zk-fatjar.jar" 'META-INF/*.SF' 'META-INF/*.RSA' 'META-INF/*SF' || true # needed for >=3.4.10 <3.5
   rm -rf "$zk" "$zk.tar.gz"
 }
-zk_ver=${ZK_VERSION:-3.4.13}
+zk_ver=${ZK_VERSION:-3.4.14}
 install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist/vt-zookeeper-$zk_ver" install_zookeeper
 
 
@@ -363,7 +363,7 @@ if [ "$BUILD_TESTS" == 1 ] ; then
  echo "bootstrap finished - run 'source dev.env' in your shell before building."
 else
  echo
- echo "bootstrap finished - run 'source build.env' in your shell before building."    
+ echo "bootstrap finished - run 'source build.env' in your shell before building."
 fi
 
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -78,7 +78,7 @@ In addition, Vitess requires the software and libraries listed below.
     [MySQL 5.6](https://dev.mysql.com/downloads/mysql). You can use any
     installation method (src/bin/rpm/deb), but be sure to include the client
     development headers (`libmariadbclient-dev` or `libmysqlclient-dev`).
- 
+
     The Vitess development team currently tests against MariaDB 10.0.21
     and MySQL 5.6.27.
 
@@ -116,7 +116,7 @@ In addition, Vitess requires the software and libraries listed below.
 4.  Select a lock service from the options listed below. It is technically
     possible to use another lock server, but plugins currently exist only
     for ZooKeeper, etcd and consul.
-    - ZooKeeper 3.4.13 is included by default. 
+    - ZooKeeper 3.4.14 is included by default.
     - [Install etcd v3.0+](https://github.com/coreos/etcd/releases).
       If you use etcd, remember to include the `etcd` command
       on your path.
@@ -151,28 +151,28 @@ In addition, Vitess requires the software and libraries listed below.
     ``` sh
     $ sudo apt-get install openjdk-7-jre
     ```
-    
+
 #### OS X
 
 1.  [Install Homebrew](https://brew.sh/). If your /usr/local directory is not empty and you never used Homebrew before,
-    it will be 
-    [mandatory](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/El_Capitan_and_Homebrew.md) 
+    it will be
+    [mandatory](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/El_Capitan_and_Homebrew.md)
     to run the following command:
-    
+
     ``` sh
     sudo chown -R $(whoami):admin /usr/local
     ```
 
 2.  On OS X, MySQL 5.6 has to be used, MariaDB doesn't work for some reason yet. It should be installed from Homebrew
     (`install steps are below`).
-    
-3.  If Xcode is installed (with Console tools, which should be bundled automatically since the 7.1 version), all 
+
+3.  If Xcode is installed (with Console tools, which should be bundled automatically since the 7.1 version), all
     the dev dependencies should be satisfied in this step. If no Xcode is present, it is necessary to install pkg-config.
-     
+
     ``` sh
     brew install pkg-config
     ```
-   
+
 4.  ZooKeeper is used as lock service.
 
 5.  Run the following commands:
@@ -185,23 +185,23 @@ In addition, Vitess requires the software and libraries listed below.
     pip install tox
 
     ```
-    
+
 6.  The Vitess bootstrap script makes some checks for the go runtime, so it is recommended to have the following
     commands in your ~/.profile or ~/.bashrc or ~/.zshrc or ~/.bash_profile:
-    
+
     ``` sh
     export PATH="/usr/local/opt/mysql@5.6/bin:$PATH"
     export PATH=/usr/local/go/bin:$PATH
     export GOROOT=/usr/local/go
     ```
-    
+
 7.  For the Vitess hostname resolving functions to work correctly, a new entry has to be added into the /etc/hosts file
     with the current LAN IP address of the computer (preferably IPv4) and the current hostname, which you get by
     typing the 'hostname' command in the terminal.
-    
-    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) 
+
+    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net)
     in your ~/.profile or ~/.bashrc or ~/.zshrc:
-    
+
     ```
     export GODEBUG=netdns=go
     ```
@@ -210,7 +210,7 @@ In addition, Vitess requires the software and libraries listed below.
 
 1.  Navigate to the directory where you want to download the Vitess
     source code and clone the Vitess Github repo. After doing so,
-    navigate to the `src/vitess.io/vitess` directory. For go to work 
+    navigate to the `src/vitess.io/vitess` directory. For go to work
     correctly, you should create a symbolic link to this inide your ${HOME}/go/src
 
     ``` sh
@@ -237,7 +237,7 @@ In addition, Vitess requires the software and libraries listed below.
 
     ``` sh
     # export VT_MYSQL_ROOT=/usr/local/mysql
-    
+
     # on OS X, this is the correct value:
     export VT_MYSQL_ROOT=/usr/local/opt/mysql@5.6
     ```
@@ -254,7 +254,7 @@ In addition, Vitess requires the software and libraries listed below.
     If your machine requires a proxy to access the Internet, you will need
     to set the usual environment variables (e.g. `http_proxy`,
     `https_proxy`, `no_proxy`).
-    
+
     Run the boostrap.sh script:
 
     ``` sh
@@ -414,7 +414,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     turn is configured to point to the local instance. In our sample scripts,
     they are both hosted in the same ZooKeeper service.
 
-    If you want to use Etcd as a distributed lock service, The following script 
+    If you want to use Etcd as a distributed lock service, The following script
     creates a Etcd instance:
 
     ``` sh
@@ -424,7 +424,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     ### example output:
     # enter etcd2 env
     # etcdmain: etcd Version: 3.X.X
-    # ... 
+    # ...
     # etcd start done...
     ```
 
@@ -462,7 +462,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
 1.  **Start vttablets**
 
     The `vttablet-up.sh` script brings up three vttablets, and assigns them to
-    a [keyspace]({% link overview/concepts.md %}#keyspace) and [shard]({% link overview/concepts.md %}#shard) 
+    a [keyspace]({% link overview/concepts.md %}#keyspace) and [shard]({% link overview/concepts.md %}#shard)
     according to the variables set at the top of the script file.
 
     ``` sh
@@ -483,7 +483,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     see a keyspace named `test_keyspace` with a single shard named `0`.
     This is what an unsharded keyspace looks like.
 
-    If you click on the shard box, you'll see a list of [tablets]({% link overview/concepts.md %}#tablet) 
+    If you click on the shard box, you'll see a list of [tablets]({% link overview/concepts.md %}#tablet)
     in that shard. Note that it's normal for the tablets to be unhealthy at this point, since
     you haven't initialized them yet.
 
@@ -583,11 +583,11 @@ lock service. ZooKeeper is included in the Vitess distribution.
     In the examples, we are just using a single database with no specific
     configuration. So we just need to make that (empty) configuration visible
     for serving. This is done by running the following command:
-    
+
     ``` sh
     vitess/examples/local$ ./lvtctl.sh RebuildVSchemaGraph
     ```
-    
+
     (As it works, this command will not display any output.)
 
 1.  **Start vtgate**

--- a/go/vt/zkctl/zksrv.sh
+++ b/go/vt/zkctl/zksrv.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ logdir="$1"
 config="$2"
 pidfile="$3"
 
-zk_ver=${ZK_VERSION:-3.4.13}
+zk_ver=${ZK_VERSION:-3.4.14}
 classpath="$VTROOT/dist/vt-zookeeper-$zk_ver/lib/zookeeper-$zk_ver-fatjar.jar:/usr/local/lib/zookeeper-$zk_ver-fatjar.jar:/usr/share/java/zookeeper-$zk_ver.jar"
 
 mkdir -p "$logdir"
@@ -60,7 +60,7 @@ $cmd < /dev/null &> /dev/null &
 pid=$!
 
 log "INFO pid: $pid pidfile: $pidfile"
-if [ "$pidfile" ]; then 
+if [ "$pidfile" ]; then
   if [ -f "$pidfile" ]; then
     rm "$pidfile"
   fi


### PR DESCRIPTION
### Description
- upgrade Zookeper to version 3.4.14
- use HTTPS

### Why
Today the Zookeper team [released](https://zookeeper.apache.org/releases.html) version 3.4.14. The previous version is not present anymore on http://apache.org/dist/zookeeper/. 

Due to that, without a custom `ZK_VERSION ` set, the Vitess build will fail with an HTTP 404