### PR TITLE
orchestrator: Add more detail to error messages.

### DIFF
--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -139,13 +139,13 @@ func (orc *orcClient) InActiveShardRecovery(tablet *topodatapb.Tablet) (bool, er
 	resp, err := orc.apiGet("audit-recovery", "alias", alias)
 
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("error calling Orchestrator API: %v", err)
 	}
 
 	var r []map[string]interface{}
 
 	if err := json.Unmarshal(resp, &r); err != nil {
-		return false, err
+		return false, fmt.Errorf("error parsing JSON response from Orchestrator: %v; response: %q", err, string(resp))
 	}
 
 	// Orchestrator returns a 0-length response when it has no history of recovery on this cluster.


### PR DESCRIPTION
While trying to debug something here, it would have been helpful to log the content of the response that couldn't be parsed. For example, it might contain an Orchestrator error message.