### PR TITLE
Add in option to re-resolve DNS names

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -187,7 +187,7 @@ func (c *Conn) Ping() error {
 	case ErrPacket:
 		return ParseErrorPacket(data)
 	}
-	return vterrors.Errorf(vtrpc.Code_INTERNAL,"unexpected packet type: %d", data[0])
+	return vterrors.Errorf(vtrpc.Code_INTERNAL, "unexpected packet type: %d", data[0])
 }
 
 // parseCharacterSet parses the provided character set.

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -150,7 +150,7 @@ func NewFakeMysqlDaemon(db *fakesqldb.DB) *FakeMysqlDaemon {
 		Running: true,
 	}
 	if db != nil {
-		result.appPool = dbconnpool.NewConnectionPool("AppConnPool", 5, time.Minute)
+		result.appPool = dbconnpool.NewConnectionPool("AppConnPool", 5, time.Minute, 0)
 		result.appPool.Open(db.ConnParams(), stats.NewTimings("", "", ""))
 	}
 	return result

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -67,6 +67,8 @@ var (
 	appPoolSize    = flag.Int("app_pool_size", 40, "Size of the connection pool for app connections")
 	appIdleTimeout = flag.Duration("app_idle_timeout", time.Minute, "Idle timeout for app connections")
 
+	poolDynamicHostnameResolution = flag.Duration("pool_hostname_update_rate", 0, "if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)")
+
 	socketFile        = flag.String("mysqlctl_socket", "", "socket file to use for remote mysqlctl actions (empty for local actions)")
 	mycnfTemplateFile = flag.String("mysqlctl_mycnf_template", "", "template file to use for generating the my.cnf file during server init")
 
@@ -98,11 +100,11 @@ func NewMysqld(dbcfgs *dbconfigs.DBConfigs) *Mysqld {
 	}
 
 	// Create and open the connection pool for dba access.
-	result.dbaPool = dbconnpool.NewConnectionPool("DbaConnPool", *dbaPoolSize, *dbaIdleTimeout)
+	result.dbaPool = dbconnpool.NewConnectionPool("DbaConnPool", *dbaPoolSize, *dbaIdleTimeout, *poolDynamicHostnameResolution)
 	result.dbaPool.Open(dbcfgs.Dba(), dbaMysqlStats)
 
 	// Create and open the connection pool for app access.
-	result.appPool = dbconnpool.NewConnectionPool("AppConnPool", *appPoolSize, *appIdleTimeout)
+	result.appPool = dbconnpool.NewConnectionPool("AppConnPool", *appPoolSize, *appIdleTimeout, *poolDynamicHostnameResolution)
 	result.appPool.Open(dbcfgs.AppWithDB(), appMysqlStats)
 
 	return result

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -67,7 +67,7 @@ var (
 	appPoolSize    = flag.Int("app_pool_size", 40, "Size of the connection pool for app connections")
 	appIdleTimeout = flag.Duration("app_idle_timeout", time.Minute, "Idle timeout for app connections")
 
-	poolDynamicHostnameResolution = flag.Duration("pool_hostname_update_rate", 0, "if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)")
+	poolDynamicHostnameResolution = flag.Duration("pool_hostname_resolve_interval", 0, "if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)")
 
 	socketFile        = flag.String("mysqlctl_socket", "", "socket file to use for remote mysqlctl actions (empty for local actions)")
 	mycnfTemplateFile = flag.String("mysqlctl_mycnf_template", "", "template file to use for generating the my.cnf file during server init")

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -75,7 +75,7 @@ func New(
 	cp := &Pool{
 		capacity:    capacity,
 		idleTimeout: idleTimeout,
-		dbaPool:     dbconnpool.NewConnectionPool("", 1, idleTimeout),
+		dbaPool:     dbconnpool.NewConnectionPool("", 1, idleTimeout, 0),
 		checker:     checker,
 	}
 	if name == "" || usedNames[name] {


### PR DESCRIPTION
This adds in the ability to re-resolve DNS names used in a connection
of an external database. The default is to do nothing new. A new
command line options `pool_hostname_update_rate` has been added that
will resolve the hostnames used in each pool at the given rate and
will force a reconnect if they have changed

Signed-off-by: Dan Kozlowski <koz@planetscale.com>