### PR TITLE
vtexplain improvements

### DIFF
--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -55,6 +55,7 @@ var (
 		"vschema",
 		"vschema-file",
 		"dbname",
+		"queryserver-config-passthrough-dmls",
 	}
 )
 

--- a/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
@@ -56,3 +56,76 @@ update user set name='alicia' where name='alice'
 9 ks_sharded/c0-: commit
 
 ----------------------------------------------------------------------
+update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname=1 where nickname != ''
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: select name from name_info where nickname != '' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname = 1 where name in ('name_val_1')/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/-40: commit
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: select name from name_info where nickname != '' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname = 1 where name in ('name_val_1')/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/40-80: commit
+1 ks_sharded/80-c0: begin
+1 ks_sharded/80-c0: select name from name_info where nickname != '' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname = 1 where name in ('name_val_1')/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/80-c0: commit
+1 ks_sharded/c0-: begin
+1 ks_sharded/c0-: select name from name_info where nickname != '' limit 10001 for update/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname = 1 where name in ('name_val_1')/* vtgate:: filtered_replication_unfriendly */
+1 ks_sharded/c0-: commit
+
+----------------------------------------------------------------------
+update user set pet='rover' where name='alice'
+
+1 ks_sharded/40-80: begin
+1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001
+2 ks_sharded/-40: begin
+2 ks_sharded/-40: select id from user where name = 'alice' limit 10001 for update /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+2 ks_sharded/-40: update user set pet = 'rover' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+3 ks_sharded/40-80: commit
+4 ks_sharded/-40: commit
+
+----------------------------------------------------------------------
+begin
+
+
+----------------------------------------------------------------------
+update user set nickname='alice' where id=1
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+
+----------------------------------------------------------------------
+update user set nickname='bob' where id=1
+
+2 ks_sharded/-40: update user set nickname = 'bob' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+
+----------------------------------------------------------------------
+commit
+
+3 ks_sharded/-40: commit
+
+----------------------------------------------------------------------
+begin
+
+
+----------------------------------------------------------------------
+update user set nickname='alice' where id=1
+
+1 ks_sharded/-40: begin
+1 ks_sharded/-40: update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+
+----------------------------------------------------------------------
+update user set nickname='bob' where id=3
+
+2 ks_sharded/40-80: begin
+2 ks_sharded/40-80: update user set nickname = 'bob' where id in (3) /* vtgate:: keyspace_id:4eb190c9a2fa169c */
+
+----------------------------------------------------------------------
+commit
+
+3 ks_sharded/-40: commit
+4 ks_sharded/40-80: commit
+
+----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/updatesharded-queries.sql
+++ b/go/vt/vtexplain/testdata/updatesharded-queries.sql
@@ -6,5 +6,23 @@ update user set pet='fido' where id=1;
 update user set name='alicia' where id=1;
 update user set name='alicia' where name='alice';
 
-/* not supported - multi-shard update */
--- update user set pet='rover' where name='alice';
+/* scatter update -- supported but with nondeterministic output */
+/* update name_info set has_nickname=1 where nickname != ''; */
+
+/* scatter update autocommit */
+update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname=1 where nickname != '';
+
+/* multi-shard update by secondary vindex */
+update user set pet='rover' where name='alice';
+
+/* update in a transaction on one shard */
+begin;
+update user set nickname='alice' where id=1;
+update user set nickname='bob' where id=1;
+commit;
+
+/* update in a transaction on multiple shards */
+begin;
+update user set nickname='alice' where id=1;
+update user set nickname='bob' where id=3;
+commit;

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -256,8 +256,11 @@ func Run(sql string) ([]*Explain, error) {
 		}
 
 		if sql != "" {
-			// Reset the global time simulator for each query
-			batchTime = sync2.NewBatcher(*batchInterval)
+			// Reset the global time simulator unless there's an open transaction
+			// in the session from the previous staement.
+			if vtgateSession == nil || vtgateSession.GetInTransaction() == false {
+				batchTime = sync2.NewBatcher(*batchInterval)
+			}
 			log.V(100).Infof("explain %s", sql)
 			e, err := explain(sql)
 			if err != nil {

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -117,6 +117,11 @@ var _ queryservice.QueryService = (*explainTablet)(nil) // compile-time interfac
 func (t *explainTablet) Begin(ctx context.Context, target *querypb.Target, options *querypb.ExecuteOptions) (int64, error) {
 	t.mu.Lock()
 	t.currentTime = batchTime.Wait()
+	t.tabletQueries = append(t.tabletQueries, &TabletQuery{
+		Time: t.currentTime,
+		SQL:  "begin",
+	})
+
 	t.mu.Unlock()
 
 	return t.tsv.Begin(ctx, target, options)
@@ -126,7 +131,12 @@ func (t *explainTablet) Begin(ctx context.Context, target *querypb.Target, optio
 func (t *explainTablet) Commit(ctx context.Context, target *querypb.Target, transactionID int64) error {
 	t.mu.Lock()
 	t.currentTime = batchTime.Wait()
+	t.tabletQueries = append(t.tabletQueries, &TabletQuery{
+		Time: t.currentTime,
+		SQL:  "commit",
+	})
 	t.mu.Unlock()
+
 	return t.tsv.Commit(ctx, target, transactionID)
 }
 

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -73,7 +73,7 @@ type explainTablet struct {
 func newTablet(opts *Options, t *topodatapb.Tablet) *explainTablet {
 	db := fakesqldb.New(nil)
 
-	config := tabletenv.DefaultQsConfig
+	config := tabletenv.Config
 	if opts.ExecutionMode == ModeTwoPC {
 		config.TwoPCCoordinatorAddress = "XXX"
 		config.TwoPCAbandonAge = 1.0


### PR DESCRIPTION
## Description
Two small improvements to vtexplain to support `-queryserver-passthrough-dmls` and to properly model explicit `begin ... dml ... dml ... commit` transactions.

## Details
When initializing the vtexplain table, use `tabletenv.Config` instead of `tabletenv.DefaultQsConfig` so that the command line flags actually take effect, and include the `-queryserver-passthrough-dmls` in the help string.

To properly model explicit transactions, don't reset the batch clock if there are any open txns in the session, and add vtexplain logging for begin / commit statements.
