### PR TITLE
Fixing the bug of resharding workflow can't completely disable the all approvals

### DIFF
--- a/go/vt/workflow/resharding/workflow.go
+++ b/go/vt/workflow/resharding/workflow.go
@@ -77,8 +77,8 @@ func (*Factory) Init(m *workflow.Manager, w *workflowpb.Workflow, args []string)
 	minHealthyRdonlyTablets := subFlags.String("min_healthy_rdonly_tablets", "1", "Minimum number of healthy RDONLY tablets required in source shards")
 	splitCmd := subFlags.String("split_cmd", "SplitClone", "Split command to use to perform horizontal resharding (either SplitClone or LegacySplitClone)")
 	splitDiffDestTabletType := subFlags.String("split_diff_dest_tablet_type", "RDONLY", "Specifies tablet type to use in destination shards while performing SplitDiff operation")
-	phaseEnaableApprovalsDesc := fmt.Sprintf("Comma separated phases that require explicit approval in the UI to execute. Phase names are: %v", strings.Join(WorkflowPhases(), ","))
-	phaseEnableApprovalsStr := subFlags.String("phase_enable_approvals", strings.Join(WorkflowPhases(), ","), phaseEnaableApprovalsDesc)
+	phaseEnableApprovalsDesc := fmt.Sprintf("Comma separated phases that require explicit approval in the UI to execute. Phase names are: %v", strings.Join(WorkflowPhases(), ","))
+	phaseEnableApprovalsStr := subFlags.String("phase_enable_approvals", "", phaseEnableApprovalsDesc)
 
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/workflow/reshardingworkflowgen/workflow.go
+++ b/go/vt/workflow/reshardingworkflowgen/workflow.go
@@ -63,7 +63,7 @@ func (*Factory) Init(m *workflow.Manager, w *workflowpb.Workflow, args []string)
 	splitDiffDestTabletType := subFlags.String("split_diff_dest_tablet_type", "RDONLY", "Specifies tablet type to use in destination shards while performing SplitDiff operation")
 	skipStartWorkflows := subFlags.Bool("skip_start_workflows", true, "If true, newly created workflows will have skip_start set")
 	phaseEnableApprovalsDesc := fmt.Sprintf("Comma separated phases that require explicit approval in the UI to execute. Phase names are: %v", strings.Join(resharding.WorkflowPhases(), ","))
-	phaseEnableApprovalsStr := subFlags.String("phase_enable_approvals", strings.Join(resharding.WorkflowPhases(), ","), phaseEnableApprovalsDesc)
+	phaseEnableApprovalsStr := subFlags.String("phase_enable_approvals", "", phaseEnableApprovalsDesc)
 
 	if err := subFlags.Parse(args); err != nil {
 		return err


### PR DESCRIPTION
I start a resharding workflow by the web UI, and disable all approvals. 
But all the approvals 'll be enabled, and I have to click the button at each phases of resharding. 

Signed-off-by: dcadevil <dcadevil@126.com>