### PR TITLE
Add vttablet option to set super_read_only during planned reparent

### DIFF
--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -76,6 +76,9 @@ type FakeMysqlDaemon struct {
 	// ReadOnly is the current value of the flag
 	ReadOnly bool
 
+	// SuperReadOnly is the current value of the flag
+	SuperReadOnly bool
+
 	// SetSlavePositionPos is matched against the input of SetSlavePosition.
 	// If it doesn't match, SetSlavePosition will return an error.
 	SetSlavePositionPos mysql.Position
@@ -236,6 +239,13 @@ func (fmd *FakeMysqlDaemon) IsReadOnly() (bool, error) {
 
 // SetReadOnly is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) SetReadOnly(on bool) error {
+	fmd.ReadOnly = on
+	return nil
+}
+
+// SetSuperReadOnly is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) SetSuperReadOnly(on bool) error {
+	fmd.SuperReadOnly = on
 	fmd.ReadOnly = on
 	return nil
 }

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -53,6 +53,7 @@ type MysqlDaemon interface {
 	MasterPosition() (mysql.Position, error)
 	IsReadOnly() (bool, error)
 	SetReadOnly(on bool) error
+	SetSuperReadOnly(on bool) error
 	SetSlavePosition(ctx context.Context, pos mysql.Position) error
 	SetMaster(ctx context.Context, masterHost string, masterPort int, slaveStopBefore bool, slaveStartAfter bool) error
 	WaitForReparentJournal(ctx context.Context, timeCreatedNS int64) error

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -161,6 +161,17 @@ var (
 	ErrNotMaster = errors.New("no master status")
 )
 
+// SetSuperReadOnly set/unset the super_read_only flag
+func (mysqld *Mysqld) SetSuperReadOnly(on bool) error {
+	query := "SET GLOBAL super_read_only = "
+	if on {
+		query += "ON"
+	} else {
+		query += "OFF"
+	}
+	return mysqld.ExecuteSuperQuery(context.TODO(), query)
+}
+
 // WaitMasterPos lets slaves wait to given replication position
 func (mysqld *Mysqld) WaitMasterPos(ctx context.Context, targetPos mysql.Position) error {
 	// Get a connection.

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -37,7 +37,8 @@ import (
 )
 
 var (
-	enableSemiSync = flag.Bool("enable_semi_sync", false, "Enable semi-sync when configuring replication, on master and replica tablets only (rdonly tablets will not ack).")
+	enableSemiSync   = flag.Bool("enable_semi_sync", false, "Enable semi-sync when configuring replication, on master and replica tablets only (rdonly tablets will not ack).")
+	setSuperReadOnly = flag.Bool("use_super_read_only", false, "Set super_read_only flag when performing planned failover.")
 )
 
 // SlaveStatus returns the replication status
@@ -331,17 +332,29 @@ func (agent *ActionAgent) DemoteMaster(ctx context.Context) (string, error) {
 
 	// Now, set the server read-only. Note all active connections are not
 	// affected.
-	if err := agent.MysqlDaemon.SetReadOnly(true); err != nil {
-		// if this failed, revert the change to serving
-		if _ /* state changed */, err1 := agent.QueryServiceControl.SetServingType(tablet.Type, true, nil); err1 != nil {
-			log.Warningf("SetServingType(serving=true) failed after failed SetReadOnly %v", err1)
+	if *setSuperReadOnly {
+		// Setting super_read_only also sets read_only
+		if err := agent.MysqlDaemon.SetSuperReadOnly(true); err != nil {
+			// if this failed, revert the change to serving
+			if _ /* state changed */, err1 := agent.QueryServiceControl.SetServingType(tablet.Type, true, nil); err1 != nil {
+				log.Warningf("SetServingType(serving=true) failed after failed SetSuperReadOnly %v", err1)
+			}
+			return "", err
 		}
-		return "", err
+	} else {
+		if err := agent.MysqlDaemon.SetReadOnly(true); err != nil {
+			// if this failed, revert the change to serving
+			if _ /* state changed */, err1 := agent.QueryServiceControl.SetServingType(tablet.Type, true, nil); err1 != nil {
+				log.Warningf("SetServingType(serving=true) failed after failed SetReadOnly %v", err1)
+			}
+			return "", err
+		}
 	}
 
 	// If using semi-sync, we need to disable master-side.
 	if err := agent.fixSemiSync(topodatapb.TabletType_REPLICA); err != nil {
 		// if this failed, set server read-only back to false, set tablet back to serving
+		// setting read_only OFF will also set super_read_only OFF if it was set
 		if err1 := agent.MysqlDaemon.SetReadOnly(false); err1 != nil {
 			log.Warningf("SetReadOnly(false) failed after failed fixSemiSync %v", err1)
 		}
@@ -355,6 +368,7 @@ func (agent *ActionAgent) DemoteMaster(ctx context.Context) (string, error) {
 	if err != nil {
 		// if DemoteMaster failed, undo all the steps before
 		// 1. set server back to read-only false
+		// setting read_only OFF will also set super_read_only OFF if it was set
 		if err1 := agent.MysqlDaemon.SetReadOnly(false); err1 != nil {
 			log.Warningf("SetReadOnly(false) failed after failed DemoteMaster %v", err1)
 		}


### PR DESCRIPTION
Signed-off-by: Miriam Lauter <lauter.miriam@gmail.com>

If vttablet is started with `-use_super_read_only=true`

```
$ ./lvtctl.sh ListShardTablets shard_test/-80
test-0000000200 shard_test -80 master localhost:15200 localhost:17200 []
test-0000000201 shard_test -80 replica localhost:15201 localhost:17201 []

# Before
mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 0
      @@global.super_read_only: 0
      1 row in set (0.00 sec)

# Fail over
$ ./lvtctl.sh PlannedReparentShard -keyspace_shard=shard_test/-80

mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 1
      @@global.super_read_only: 1
      1 row in set (0.00 sec)

# Fail back
$ ./lvtctl.sh PlannedReparentShard -keyspace_shard=shard_test/-80

mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 0
      @@global.super_read_only: 0
      1 row in set (0.00 sec)
```

If `-use_super_read_only` is false or unset (same as current behavior):
```
$ ./lvtctl.sh ListShardTablets shard_test/-80
test-0000000200 shard_test -80 master localhost:15200 localhost:17200 []
test-0000000201 shard_test -80 replica localhost:15201 localhost:17201 []

# Before
mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 0
      @@global.super_read_only: 0
      1 row in set (0.00 sec)

# Fail over
$ ./lvtctl.sh PlannedReparentShard -keyspace_shard=shard_test/-80

mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 1
      @@global.super_read_only: 0
      1 row in set (0.00 sec)

# Fail back
$ ./lvtctl.sh PlannedReparentShard -keyspace_shard=shard_test/-80

mysql> select @@global.read_only, @@global.super_read_only\G;
*************************** 1. row ***************************
      @@global.read_only: 0
      @@global.super_read_only: 0
      1 row in set (0.00 sec)
```