### PR TITLE
properly suppress begin...commit in autocommit logs

### DIFF
--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -264,22 +264,24 @@ func (te *TxEngine) AcceptReadOnly() error {
 	}
 }
 
-// Begin begins a transaction, and returns the associated transaction id.
+// Begin begins a transaction, and returns the associated transaction id and the
+// statement(s) used to execute the begin (if any).
+//
 // Subsequent statements can access the connection through the transaction id.
-func (te *TxEngine) Begin(ctx context.Context, options *querypb.ExecuteOptions) (int64, error) {
+func (te *TxEngine) Begin(ctx context.Context, options *querypb.ExecuteOptions) (int64, string, error) {
 	te.stateLock.Lock()
 
 	canOpenTransactions := te.state == AcceptingReadOnly || te.state == AcceptingReadAndWrite
 	if !canOpenTransactions {
 		// We are not in a state where we can start new transactions. Abort.
 		te.stateLock.Unlock()
-		return 0, vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "tx engine can't accept new transactions in state %v", te.state)
+		return 0, "", vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "tx engine can't accept new transactions in state %v", te.state)
 	}
 
 	isWriteTransaction := options == nil || options.TransactionIsolation != querypb.ExecuteOptions_CONSISTENT_SNAPSHOT_READ_ONLY
 	if te.state == AcceptingReadOnly && isWriteTransaction {
 		te.stateLock.Unlock()
-		return 0, vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "tx engine can only accept read-only transactions in current state")
+		return 0, "", vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "tx engine can only accept read-only transactions in current state")
 	}
 
 	// By Add() to beginRequests, we block others from initiating state
@@ -292,7 +294,7 @@ func (te *TxEngine) Begin(ctx context.Context, options *querypb.ExecuteOptions) 
 }
 
 // Commit commits the specified transaction.
-func (te *TxEngine) Commit(ctx context.Context, transactionID int64, mc messageCommitter) error {
+func (te *TxEngine) Commit(ctx context.Context, transactionID int64, mc messageCommitter) (string, error) {
 	return te.txPool.Commit(ctx, transactionID, mc)
 }
 
@@ -466,7 +468,7 @@ outer:
 		if txid > maxid {
 			maxid = txid
 		}
-		conn, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+		conn, _, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 		if err != nil {
 			allErr.RecordError(err)
 			continue

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -55,9 +55,12 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Normal close with timeout wait.
 	te.open()
-	c, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, beginSQL, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if beginSQL != "begin" {
+		t.Errorf("beginSQL: %q, want 'begin'", beginSQL)
 	}
 	c.Recycle()
 	start = time.Now()
@@ -68,7 +71,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close.
 	te.open()
-	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +85,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.open()
-	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +102,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period, but pool gets empty early.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.open()
-	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +126,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close, but connection is in use.
 	te.open()
-	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
+	c, beginSQL, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,6 +495,6 @@ func startTransaction(te *TxEngine, writeTransaction bool) error {
 	} else {
 		options.TransactionIsolation = querypb.ExecuteOptions_CONSISTENT_SNAPSHOT_READ_ONLY
 	}
-	_, err := te.Begin(context.Background(), options)
+	_, _, err := te.Begin(context.Background(), options)
 	return err
 }

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -192,23 +192,26 @@ func (axp *TxPool) WaitForEmpty() {
 	axp.activePool.WaitForEmpty()
 }
 
-// Begin begins a transaction, and returns the associated transaction id.
+// Begin begins a transaction, and returns the associated transaction id and
+// the statements (if any) executed to initiate the transaction. In autocommit
+// mode the statement will be "".
+//
 // Subsequent statements can access the connection through the transaction id.
-func (axp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions) (int64, error) {
+func (axp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions) (int64, string, error) {
 	var conn *connpool.DBConn
 	var err error
 	immediateCaller := callerid.ImmediateCallerIDFromContext(ctx)
 	effectiveCaller := callerid.EffectiveCallerIDFromContext(ctx)
 
 	if !axp.limiter.Get(immediateCaller, effectiveCaller) {
-		return 0, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "per-user transaction pool connection limit exceeded")
+		return 0, "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "per-user transaction pool connection limit exceeded")
 	}
 
 	waiterCount := axp.waiters.Add(1)
 	defer axp.waiters.Add(-1)
 
 	if waiterCount > axp.waiterCap.Get() {
-		return 0, vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool waiter count exceeded")
+		return 0, "", vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool waiter count exceeded")
 	}
 
 	var beginSucceeded bool
@@ -231,30 +234,33 @@ func (axp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions) (
 	if err != nil {
 		switch err {
 		case connpool.ErrConnPoolClosed:
-			return 0, err
+			return 0, "", err
 		case pools.ErrTimeout:
 			axp.LogActive()
-			return 0, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool connection limit exceeded")
+			return 0, "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool connection limit exceeded")
 		}
-		return 0, err
+		return 0, "", err
 	}
 
 	autocommitTransaction := false
-
+	beginQueries := ""
 	if queries, ok := txIsolations[options.GetTransactionIsolation()]; ok {
 		if queries.setIsolationLevel != "" {
 			if _, err := conn.Exec(ctx, "set transaction isolation level "+queries.setIsolationLevel, 1, false); err != nil {
-				return 0, err
+				return 0, "", err
 			}
+
+			beginQueries = queries.setIsolationLevel + "; "
 		}
 
 		if _, err := conn.Exec(ctx, queries.openTransaction, 1, false); err != nil {
-			return 0, err
+			return 0, "", err
 		}
+		beginQueries = beginQueries + queries.openTransaction
 	} else if options.GetTransactionIsolation() == querypb.ExecuteOptions_AUTOCOMMIT {
 		autocommitTransaction = true
 	} else {
-		return 0, fmt.Errorf("don't know how to open a transaction of this type: %v", options.GetTransactionIsolation())
+		return 0, "", fmt.Errorf("don't know how to open a transaction of this type: %v", options.GetTransactionIsolation())
 	}
 
 	beginSucceeded = true
@@ -271,14 +277,14 @@ func (axp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions) (
 		),
 		options.GetWorkload() != querypb.ExecuteOptions_DBA,
 	)
-	return transactionID, nil
+	return transactionID, beginQueries, nil
 }
 
 // Commit commits the specified transaction.
-func (axp *TxPool) Commit(ctx context.Context, transactionID int64, mc messageCommitter) error {
+func (axp *TxPool) Commit(ctx context.Context, transactionID int64, mc messageCommitter) (string, error) {
 	conn, err := axp.Get(transactionID, "for commit")
 	if err != nil {
-		return err
+		return "", err
 	}
 	return axp.LocalCommit(ctx, conn, mc)
 }
@@ -305,30 +311,31 @@ func (axp *TxPool) Get(transactionID int64, reason string) (*TxConnection, error
 // LocalBegin is equivalent to Begin->Get.
 // It's used for executing transactions within a request. It's safe
 // to always call LocalConclude at the end.
-func (axp *TxPool) LocalBegin(ctx context.Context, options *querypb.ExecuteOptions) (*TxConnection, error) {
-	transactionID, err := axp.Begin(ctx, options)
+func (axp *TxPool) LocalBegin(ctx context.Context, options *querypb.ExecuteOptions) (*TxConnection, string, error) {
+	transactionID, beginSQL, err := axp.Begin(ctx, options)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return axp.Get(transactionID, "for local query")
+	conn, err := axp.Get(transactionID, "for local query")
+	return conn, beginSQL, err
 }
 
 // LocalCommit is the commit function for LocalBegin.
-func (axp *TxPool) LocalCommit(ctx context.Context, conn *TxConnection, mc messageCommitter) error {
+func (axp *TxPool) LocalCommit(ctx context.Context, conn *TxConnection, mc messageCommitter) (string, error) {
 	defer conn.conclude(TxCommit, "transaction committed")
 	defer mc.LockDB(conn.NewMessages, conn.ChangedMessages)()
 
 	if conn.Autocommit {
 		mc.UpdateCaches(conn.NewMessages, conn.ChangedMessages)
-		return nil
+		return "", nil
 	}
 
 	if _, err := conn.Exec(ctx, "commit", 1, false); err != nil {
 		conn.Close()
-		return err
+		return "", err
 	}
 	mc.UpdateCaches(conn.NewMessages, conn.ChangedMessages)
-	return nil
+	return "commit", nil
 }
 
 // LocalConclude concludes a transaction started by LocalBegin.


### PR DESCRIPTION
## Description
Actually implement the proper logging of which statements are executed by Begin... Commit.

## Details
The previous (untested) implementation in #4819 turned out to be in the wrong place in the TabletServer execution tier and did not properly suppress the logs in ExecuteBatch autocommit.

Implement this the right way by returning the statements that were really executed out from the TxPool, then using those to determine whether or not to log the statement.

This has the nice side-benefit of including in the transaction logging the statements executed to create a transaction with a given isolation level.

## Testing
Verified (this time) that when using autocommit transactions with passthrough DML, the query logger just logs the DML statements and not misleading Begin/Commit.
