### PR TITLE
vreplication: reference tables

### DIFF
--- a/go/vt/topotools/rebuild_vschema_test.go
+++ b/go/vt/topotools/rebuild_vschema_test.go
@@ -104,7 +104,6 @@ func TestRebuildVSchema(t *testing.T) {
 		},
 		Tables: map[string]*vschemapb.Table{
 			"table1": {
-				Type: "sequence",
 				ColumnVindexes: []*vschemapb.ColumnVindex{
 					{
 						Column: "column1",

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -54,7 +54,7 @@ func TestSelectUnsharded(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`ExecuteMultiShard ks.0: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
@@ -65,7 +65,7 @@ func TestSelectUnsharded(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`StreamExecuteMulti dummy_select ks.0: {} `,
 	})
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
@@ -446,13 +446,17 @@ func TestSelectNext(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteStandalone dummy_select  ks -20`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
 	vc.Rewind()
-	_, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
-	expectError(t, "sel.StreamExecute", err, `query "dummy_select" cannot be used for streaming`)
+	result, _ = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
+	})
+	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }
 
 func TestSelectDBA(t *testing.T) {
@@ -476,13 +480,17 @@ func TestSelectDBA(t *testing.T) {
 	}
 	vc.ExpectLog(t, []string{
 		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteStandalone dummy_select  ks -20`,
+		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
 	vc.Rewind()
-	_, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
-	expectError(t, "sel.StreamExecute", err, `query "dummy_select" cannot be used for streaming`)
+	result, _ = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
+		`StreamExecuteMulti dummy_select ks.-20: {} `,
+	})
+	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }
 
 func TestRouteGetFields(t *testing.T) {
@@ -564,7 +572,7 @@ func TestRouteSort(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`ExecuteMultiShard ks.0: dummy_select {} false false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
@@ -650,7 +658,7 @@ func TestRouteSortTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`ExecuteMultiShard ks.0: dummy_select {} false false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
@@ -696,7 +704,7 @@ func TestRouteStreamTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`ExecuteMultiShard ks.0: dummy_select {} false false`,
 	})
 	wantResult := sqltypes.MakeTestResult(
@@ -743,7 +751,7 @@ func TestRouteStreamSortTruncate(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
 		`StreamExecuteMulti dummy_select ks.0: {} `,
 	})
 
@@ -774,11 +782,11 @@ func TestParamsFail(t *testing.T) {
 
 	vc := &loggingVCursor{shardErr: errors.New("shard error")}
 	_, err := sel.Execute(vc, map[string]*querypb.BindVariable{}, false)
-	expectError(t, "sel.Execute err", err, "paramsAllShards: shard error")
+	expectError(t, "sel.Execute err", err, "paramsAnyShard: shard error")
 
 	vc.Rewind()
 	_, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
-	expectError(t, "sel.StreamExecute err", err, "paramsAllShards: shard error")
+	expectError(t, "sel.StreamExecute err", err, "paramsAnyShard: shard error")
 }
 
 func TestExecFail(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -225,10 +225,18 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 		}
 		var eroute *engine.Route
 		switch {
+		case vst.Type == vindexes.TypeSequence:
+			eroute = engine.NewSimpleRoute(engine.SelectNext, vst.Keyspace)
 		case !vst.Keyspace.Sharded:
 			eroute = engine.NewSimpleRoute(engine.SelectUnsharded, vst.Keyspace)
+		case vst.Type == vindexes.TypeSequence:
+			eroute = engine.NewSimpleRoute(engine.SelectNext, vst.Keyspace)
 		case vst.Pinned == nil:
-			eroute = engine.NewSimpleRoute(engine.SelectScatter, vst.Keyspace)
+			if vst.Type == vindexes.TypeReference {
+				eroute = engine.NewSimpleRoute(engine.SelectReference, vst.Keyspace)
+			} else {
+				eroute = engine.NewSimpleRoute(engine.SelectScatter, vst.Keyspace)
+			}
 			eroute.TargetDestination = destTarget
 			eroute.TargetTabletType = destTableType
 		default:

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -227,16 +227,12 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 		switch {
 		case vst.Type == vindexes.TypeSequence:
 			eroute = engine.NewSimpleRoute(engine.SelectNext, vst.Keyspace)
+		case vst.Type == vindexes.TypeReference:
+			eroute = engine.NewSimpleRoute(engine.SelectReference, vst.Keyspace)
 		case !vst.Keyspace.Sharded:
 			eroute = engine.NewSimpleRoute(engine.SelectUnsharded, vst.Keyspace)
-		case vst.Type == vindexes.TypeSequence:
-			eroute = engine.NewSimpleRoute(engine.SelectNext, vst.Keyspace)
 		case vst.Pinned == nil:
-			if vst.Type == vindexes.TypeReference {
-				eroute = engine.NewSimpleRoute(engine.SelectReference, vst.Keyspace)
-			} else {
-				eroute = engine.NewSimpleRoute(engine.SelectScatter, vst.Keyspace)
-			}
+			eroute = engine.NewSimpleRoute(engine.SelectScatter, vst.Keyspace)
 			eroute.TargetDestination = destTarget
 			eroute.TargetTabletType = destTableType
 		default:

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -173,6 +173,11 @@ func loadSchema(t *testing.T, filename string) *vindexes.VSchema {
 	if err != nil {
 		t.Fatal(err)
 	}
+	for _, ks := range vschema.Keyspaces {
+		if ks.Error != nil {
+			t.Fatal(ks.Error)
+		}
+	}
 	return vschema
 }
 

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -163,6 +163,9 @@ func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) error {
 
 // PushOrderBy sets the order by for the route.
 func (rb *route) PushOrderBy(order *sqlparser.Order) error {
+	// By this time, if any single shard options were already present,
+	// multi-sharded options would have already been removed. So, this
+	// call is only for checking if the route has single shard options.
 	if rb.removeMultishardOptions() {
 		rb.Select.AddOrder(order)
 		return nil
@@ -532,7 +535,7 @@ outer:
 func (rb *route) removeMultishardOptions() bool {
 	return rb.removeOptions(func(ro *routeOption) bool {
 		switch ro.eroute.Opcode {
-		case engine.SelectUnsharded, engine.SelectDBA, engine.SelectNext, engine.SelectEqualUnique:
+		case engine.SelectUnsharded, engine.SelectDBA, engine.SelectNext, engine.SelectEqualUnique, engine.SelectReference:
 			return true
 		}
 		return false

--- a/go/vt/vtgate/planbuilder/route_option_test.go
+++ b/go/vt/vtgate/planbuilder/route_option_test.go
@@ -43,6 +43,10 @@ func TestIsBetterThan(t *testing.T) {
 		out:   false,
 	}, {
 		left:  engine.SelectUnsharded,
+		right: engine.SelectReference,
+		out:   false,
+	}, {
+		left:  engine.SelectUnsharded,
 		right: engine.SelectEqualUnique,
 		out:   true,
 	}, {
@@ -63,6 +67,10 @@ func TestIsBetterThan(t *testing.T) {
 		out:   false,
 	}, {
 		left:  engine.SelectDBA,
+		right: engine.SelectUnsharded,
+		out:   false,
+	}, {
+		left:  engine.SelectReference,
 		right: engine.SelectUnsharded,
 		out:   false,
 	}, {

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -229,8 +229,8 @@ func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) 
 				return nil, errors.New("unsupported: SELECT NEXT query in cross-shard query")
 			}
 			for _, ro := range rb.routeOptions {
-				if ro.eroute.Opcode != engine.SelectUnsharded {
-					return nil, errors.New("NEXT used on a sharded table")
+				if ro.eroute.Opcode != engine.SelectNext {
+					return nil, errors.New("NEXT used on a non-sequence table")
 				}
 				ro.eroute.Opcode = engine.SelectNext
 			}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -1008,6 +1008,21 @@
   }
 }
 
+# oreder by on a reference table
+"select col from ref order by col"
+{
+  "Original": "select col from ref order by col",
+  "Instructions": {
+    "Opcode": "SelectReference",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select col from ref order by col asc",
+    "FieldQuery": "select col from ref where 1 != 1"
+  }
+}
+
 # Group by invalid column number (code is duplicated from symab).
 "select id from user group by 1.1"
 "column number is not an int"

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -28,6 +28,36 @@
   }
 }
 
+# Select from sequence
+"select next 2 values from seq"
+{
+  "Original": "select next 2 values from seq",
+  "Instructions": {
+    "Opcode": "SelectNext",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select next 2 values from seq",
+    "FieldQuery": "select next 2 values from seq where 1 != 1"
+  }
+}
+
+# Select from reference
+"select * from ref"
+{
+  "Original": "select * from ref",
+  "Instructions": {
+    "Opcode": "SelectReference",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select * from ref",
+    "FieldQuery": "select * from ref where 1 != 1"
+  }
+}
+
 # Single information_schema query
 "select col from information_schema.foo"
 {
@@ -787,6 +817,66 @@
     "Vars": {
       "user_extra_user_id": 0
     }
+  }
+}
+
+# join with reference table
+"select user.col from user join ref"
+{
+  "Original": "select user.col from user join ref",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select user.col from user join ref",
+    "FieldQuery": "select user.col from user join ref where 1 != 1"
+  }
+}
+
+# reference table self-join
+"select r1.col from ref r1 join ref"
+{
+  "Original": "select r1.col from ref r1 join ref",
+  "Instructions": {
+    "Opcode": "SelectReference",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select r1.col from ref as r1 join ref",
+    "FieldQuery": "select r1.col from ref as r1 join ref where 1 != 1"
+  }
+}
+
+# reference table doesn't merge with other opcodes yet.
+"select ref.col from ref join user"
+{
+  "Original": "select ref.col from ref join user",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectReference",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select ref.col from ref",
+      "FieldQuery": "select ref.col from ref where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select 1 from user",
+      "FieldQuery": "select 1 from user where 1 != 1"
+    },
+    "Cols": [
+      -1
+    ]
   }
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -959,6 +959,21 @@
   }
 }
 
+# limit on reference table
+"select col from ref limit 1"
+{
+  "Original": "select col from ref limit 1",
+  "Instructions": {
+    "Opcode": "SelectReference",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select col from ref limit 1",
+    "FieldQuery": "select col from ref where 1 != 1"
+  }
+}
+
 # invalid limit expression
 "select id from user limit 1+1"
 "unexpected expression in LIMIT:  limit 1 + 1"

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -189,6 +189,9 @@
             }
           ]
         },
+        "ref": {
+          "type": "reference"
+        },
         "pin_test": {
           "pinned": "80"
         },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -344,7 +344,7 @@
 
 # nextval for simple route
 "select next value from user"
-"NEXT used on a sharded table"
+"NEXT used on a non-sequence table"
 
 # next n values for simple route
 "select next 2 values from seq"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -346,21 +346,6 @@
 "select next value from user"
 "NEXT used on a non-sequence table"
 
-# next n values for simple route
-"select next 2 values from seq"
-{
-  "Original": "select next 2 values from seq",
-  "Instructions": {
-    "Opcode": "SelectNext",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "Query": "select next 2 values from seq",
-    "FieldQuery": "select next 2 values from seq where 1 != 1"
-  }
-}
-
 # last_insert_id for unsharded route
 "select last_insert_id() from main.dual"
 {

--- a/go/vt/vtgate/vindexes/unicodeloosemd5.go
+++ b/go/vt/vtgate/vindexes/unicodeloosemd5.go
@@ -94,7 +94,7 @@ func (vind *UnicodeLooseMD5) Map(cursor VCursor, ids []sqltypes.Value) ([]key.De
 }
 
 func unicodeHash(key sqltypes.Value) ([]byte, error) {
-	collator := collatorPool.Get().(pooledCollator)
+	collator := collatorPool.Get().(*pooledCollator)
 	defer collatorPool.Put(collator)
 
 	norm, err := normalize(collator.col, collator.buf, key.ToBytes())
@@ -144,7 +144,7 @@ func newPooledCollator() interface{} {
 	// way to verify this.
 	// Also, the locale differences are not an issue for level 1,
 	// because the conservative comparison makes them all equal.
-	return pooledCollator{
+	return &pooledCollator{
 		col: collate.New(language.English, collate.Loose),
 		buf: new(collate.Buffer),
 	}

--- a/go/vt/vtgate/vindexes/unicodeloosemd5_test.go
+++ b/go/vt/vtgate/vindexes/unicodeloosemd5_test.go
@@ -137,7 +137,7 @@ func TestNormalization(t *testing.T) {
 		in:  "T",
 		out: "\x18\x16",
 	}}
-	collator := newPooledCollator().(pooledCollator)
+	collator := newPooledCollator().(*pooledCollator)
 	for _, tcase := range tcases {
 		norm, err := normalize(collator.col, collator.buf, []byte(tcase.in))
 		if err != nil {
@@ -158,7 +158,7 @@ func TestInvalidUnicodeNormalization(t *testing.T) {
 		"\x8a[\xdf,\u007fĄE\x92\xd2W+\xcd\x06h\xd2",
 	}
 	wantErr := "invalid UTF-8"
-	collator := newPooledCollator().(pooledCollator)
+	collator := newPooledCollator().(*pooledCollator)
 
 	for _, in := range inputs {
 		// We've observed that infinite looping is a possible failure mode for the
@@ -190,7 +190,7 @@ func BenchmarkNormalizeSafe(b *testing.B) {
 	input := []byte("testing")
 
 	for i := 0; i < b.N; i++ {
-		collator := newPooledCollator().(pooledCollator)
+		collator := newPooledCollator().(*pooledCollator)
 		normalize(collator.col, collator.buf, input)
 	}
 }
@@ -199,7 +199,7 @@ func BenchmarkNormalizeSafe(b *testing.B) {
 // are shared between iterations, assuming no concurrency.
 func BenchmarkNormalizeShared(b *testing.B) {
 	input := []byte("testing")
-	collator := newPooledCollator().(pooledCollator)
+	collator := newPooledCollator().(*pooledCollator)
 
 	for i := 0; i < b.N; i++ {
 		normalize(collator.col, collator.buf, input)
@@ -212,7 +212,7 @@ func BenchmarkNormalizePooled(b *testing.B) {
 	input := []byte("testing")
 
 	for i := 0; i < b.N; i++ {
-		collator := collatorPool.Get().(pooledCollator)
+		collator := collatorPool.Get().(*pooledCollator)
 		normalize(collator.col, collator.buf, input)
 		collatorPool.Put(collator)
 	}

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -31,6 +31,12 @@ import (
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
+// The following constants represent table types.
+const (
+	TypeSequence  = "sequence"
+	TypeReference = "reference"
+)
+
 // VSchema represents the denormalized version of SrvVSchema,
 // used for building routing plans.
 type VSchema struct {
@@ -60,7 +66,7 @@ func (rr *RoutingRule) MarshalJSON() ([]byte, error) {
 
 // Table represents a table in VSchema.
 type Table struct {
-	IsSequence              bool                 `json:"is_sequence,omitempty"`
+	Type                    string               `json:"type,omitempty"`
 	Name                    sqlparser.TableIdent `json:"name"`
 	Keyspace                *Keyspace            `json:"-"`
 	ColumnVindexes          []*ColumnVindex      `json:"column_vindexes,omitempty"`
@@ -147,7 +153,6 @@ func BuildVSchema(source *vschemapb.SrvVSchema) (vschema *VSchema, err error) {
 		Keyspaces:      make(map[string]*KeyspaceSchema),
 	}
 	buildKeyspaces(source, vschema)
-	buildTables(source, vschema)
 	resolveAutoIncrement(source, vschema)
 	addDual(vschema)
 	buildRoutingRule(source, vschema)
@@ -172,7 +177,6 @@ func BuildKeyspaceSchema(input *vschemapb.Keyspace, keyspace string) (*KeyspaceS
 		Keyspaces:      make(map[string]*KeyspaceSchema),
 	}
 	buildKeyspaces(formal, vschema)
-	buildTables(formal, vschema)
 	err := vschema.Keyspaces[keyspace].Error
 	return vschema.Keyspaces[keyspace], err
 }
@@ -186,7 +190,7 @@ func ValidateKeyspace(input *vschemapb.Keyspace) error {
 
 func buildKeyspaces(source *vschemapb.SrvVSchema, vschema *VSchema) {
 	for ksname, ks := range source.Keyspaces {
-		vschema.Keyspaces[ksname] = &KeyspaceSchema{
+		ksvschema := &KeyspaceSchema{
 			Keyspace: &Keyspace{
 				Name:    ksname,
 				Sharded: ks.Sharded,
@@ -194,122 +198,115 @@ func buildKeyspaces(source *vschemapb.SrvVSchema, vschema *VSchema) {
 			Tables:   make(map[string]*Table),
 			Vindexes: make(map[string]Vindex),
 		}
+		vschema.Keyspaces[ksname] = ksvschema
+		ksvschema.Error = buildTables(ks, vschema, ksvschema)
 	}
 }
 
-func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) {
-outer:
-	for ksname, ks := range source.Keyspaces {
-		ksvschema := vschema.Keyspaces[ksname]
-		keyspace := ksvschema.Keyspace
-		for vname, vindexInfo := range ks.Vindexes {
-			vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params)
-			if err != nil {
-				ksvschema.Error = err
-				continue outer
-			}
-			if _, ok := vschema.uniqueVindexes[vname]; ok {
-				vschema.uniqueVindexes[vname] = nil
-			} else {
-				vschema.uniqueVindexes[vname] = vindex
-			}
-			vschema.Keyspaces[ksname].Vindexes[vname] = vindex
+func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSchema) error {
+	keyspace := ksvschema.Keyspace
+	for vname, vindexInfo := range ks.Vindexes {
+		vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params)
+		if err != nil {
+			return err
 		}
-		for tname, table := range ks.Tables {
-			t := &Table{
-				Name:                    sqlparser.NewTableIdent(tname),
-				Keyspace:                keyspace,
-				ColumnListAuthoritative: table.ColumnListAuthoritative,
-			}
-			if table.Type == "sequence" {
-				t.IsSequence = true
-			}
-			if table.Pinned != "" {
-				decoded, err := hex.DecodeString(table.Pinned)
-				if err != nil {
-					ksvschema.Error = fmt.Errorf("could not decode the keyspace id for pin: %v", err)
-					continue outer
-				}
-				t.Pinned = decoded
-			} else if keyspace.Sharded && len(table.ColumnVindexes) == 0 {
-				ksvschema.Error = fmt.Errorf("missing primary col vindex for table: %s", tname)
-				continue outer
-			}
-
-			// Initialize Columns.
-			colNames := make(map[string]bool)
-			for _, col := range table.Columns {
-				name := sqlparser.NewColIdent(col.Name)
-				if colNames[name.Lowered()] {
-					ksvschema.Error = fmt.Errorf("duplicate column name '%v' for table: %s", name, tname)
-					continue outer
-				}
-				colNames[name.Lowered()] = true
-				t.Columns = append(t.Columns, Column{Name: name, Type: col.Type})
-			}
-
-			// Initialize ColumnVindexes.
-			for i, ind := range table.ColumnVindexes {
-				vindexInfo, ok := ks.Vindexes[ind.Name]
-				if !ok {
-					ksvschema.Error = fmt.Errorf("vindex %s not found for table %s", ind.Name, tname)
-					continue outer
-				}
-				vindex := vschema.Keyspaces[ksname].Vindexes[ind.Name]
-				owned := false
-				if _, ok := vindex.(Lookup); ok && vindexInfo.Owner == tname {
-					owned = true
-				}
-				var columns []sqlparser.ColIdent
-				if ind.Column != "" {
-					if len(ind.Columns) > 0 {
-						ksvschema.Error = fmt.Errorf("can't use column and columns at the same time in vindex (%s) and table (%s)", ind.Name, tname)
-						continue outer
-					}
-					columns = []sqlparser.ColIdent{sqlparser.NewColIdent(ind.Column)}
-				} else {
-					if len(ind.Columns) == 0 {
-						ksvschema.Error = fmt.Errorf("must specify at least one column for vindex (%s) and table (%s)", ind.Name, tname)
-						continue outer
-					}
-					for _, indCol := range ind.Columns {
-						columns = append(columns, sqlparser.NewColIdent(indCol))
-					}
-				}
-				columnVindex := &ColumnVindex{
-					Columns: columns,
-					Type:    vindexInfo.Type,
-					Name:    ind.Name,
-					Owned:   owned,
-					Vindex:  vindex,
-				}
-				if i == 0 {
-					// Perform Primary vindex check.
-					if !columnVindex.Vindex.IsUnique() {
-						ksvschema.Error = fmt.Errorf("primary vindex %s is not Unique for table %s", ind.Name, tname)
-						continue outer
-					}
-					if owned {
-						ksvschema.Error = fmt.Errorf("primary vindex %s cannot be owned for table %s", ind.Name, tname)
-						continue outer
-					}
-				}
-				t.ColumnVindexes = append(t.ColumnVindexes, columnVindex)
-				if owned {
-					t.Owned = append(t.Owned, columnVindex)
-				}
-			}
-			t.Ordered = colVindexSorted(t.ColumnVindexes)
-
-			// Add the table to the map entries.
-			if _, ok := vschema.uniqueTables[tname]; ok {
-				vschema.uniqueTables[tname] = nil
-			} else {
-				vschema.uniqueTables[tname] = t
-			}
-			vschema.Keyspaces[ksname].Tables[tname] = t
+		if _, ok := vschema.uniqueVindexes[vname]; ok {
+			vschema.uniqueVindexes[vname] = nil
+		} else {
+			vschema.uniqueVindexes[vname] = vindex
 		}
+		ksvschema.Vindexes[vname] = vindex
 	}
+	for tname, table := range ks.Tables {
+		t := &Table{
+			Name:                    sqlparser.NewTableIdent(tname),
+			Keyspace:                keyspace,
+			ColumnListAuthoritative: table.ColumnListAuthoritative,
+		}
+		switch table.Type {
+		case "", TypeSequence, TypeReference:
+			t.Type = table.Type
+		default:
+			return fmt.Errorf("unidentified table type %s", table.Type)
+		}
+		if table.Pinned != "" {
+			decoded, err := hex.DecodeString(table.Pinned)
+			if err != nil {
+				return fmt.Errorf("could not decode the keyspace id for pin: %v", err)
+			}
+			t.Pinned = decoded
+		} else if keyspace.Sharded && len(table.ColumnVindexes) == 0 {
+			return fmt.Errorf("missing primary col vindex for table: %s", tname)
+		}
+
+		// Initialize Columns.
+		colNames := make(map[string]bool)
+		for _, col := range table.Columns {
+			name := sqlparser.NewColIdent(col.Name)
+			if colNames[name.Lowered()] {
+				return fmt.Errorf("duplicate column name '%v' for table: %s", name, tname)
+			}
+			colNames[name.Lowered()] = true
+			t.Columns = append(t.Columns, Column{Name: name, Type: col.Type})
+		}
+
+		// Initialize ColumnVindexes.
+		for i, ind := range table.ColumnVindexes {
+			vindexInfo, ok := ks.Vindexes[ind.Name]
+			if !ok {
+				return fmt.Errorf("vindex %s not found for table %s", ind.Name, tname)
+			}
+			vindex := ksvschema.Vindexes[ind.Name]
+			owned := false
+			if _, ok := vindex.(Lookup); ok && vindexInfo.Owner == tname {
+				owned = true
+			}
+			var columns []sqlparser.ColIdent
+			if ind.Column != "" {
+				if len(ind.Columns) > 0 {
+					return fmt.Errorf("can't use column and columns at the same time in vindex (%s) and table (%s)", ind.Name, tname)
+				}
+				columns = []sqlparser.ColIdent{sqlparser.NewColIdent(ind.Column)}
+			} else {
+				if len(ind.Columns) == 0 {
+					return fmt.Errorf("must specify at least one column for vindex (%s) and table (%s)", ind.Name, tname)
+				}
+				for _, indCol := range ind.Columns {
+					columns = append(columns, sqlparser.NewColIdent(indCol))
+				}
+			}
+			columnVindex := &ColumnVindex{
+				Columns: columns,
+				Type:    vindexInfo.Type,
+				Name:    ind.Name,
+				Owned:   owned,
+				Vindex:  vindex,
+			}
+			if i == 0 {
+				// Perform Primary vindex check.
+				if !columnVindex.Vindex.IsUnique() {
+					return fmt.Errorf("primary vindex %s is not Unique for table %s", ind.Name, tname)
+				}
+				if owned {
+					return fmt.Errorf("primary vindex %s cannot be owned for table %s", ind.Name, tname)
+				}
+			}
+			t.ColumnVindexes = append(t.ColumnVindexes, columnVindex)
+			if owned {
+				t.Owned = append(t.Owned, columnVindex)
+			}
+		}
+		t.Ordered = colVindexSorted(t.ColumnVindexes)
+
+		// Add the table to the map entries.
+		if _, ok := vschema.uniqueTables[tname]; ok {
+			vschema.uniqueTables[tname] = nil
+		} else {
+			vschema.uniqueTables[tname] = t
+		}
+		ksvschema.Tables[tname] = t
+	}
+	return nil
 }
 
 func resolveAutoIncrement(source *vschemapb.SrvVSchema, vschema *VSchema) {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -224,7 +224,12 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 			ColumnListAuthoritative: table.ColumnListAuthoritative,
 		}
 		switch table.Type {
-		case "", TypeSequence, TypeReference:
+		case "", TypeReference:
+			t.Type = table.Type
+		case TypeSequence:
+			if keyspace.Sharded && table.Pinned == "" {
+				return fmt.Errorf("sequence table has to be in an unsharded keyspace or must be pinned: %s", tname)
+			}
 			t.Type = table.Type
 		default:
 			return fmt.Errorf("unidentified table type %s", table.Type)

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -240,7 +240,10 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 				return fmt.Errorf("could not decode the keyspace id for pin: %v", err)
 			}
 			t.Pinned = decoded
-		} else if keyspace.Sharded && len(table.ColumnVindexes) == 0 {
+		}
+
+		// If keyspace is sharded, then any table that's not a reference or pinned must have vindexes.
+		if keyspace.Sharded && t.Type != TypeReference && table.Pinned == "" && len(table.ColumnVindexes) == 0 {
 			return fmt.Errorf("missing primary col vindex for table: %s", tname)
 		}
 

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -1705,6 +1705,27 @@ func TestBadSequenceName(t *testing.T) {
 	}
 }
 
+func TestBadShardedSequence(t *testing.T) {
+	bad := vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"sharded": {
+				Sharded: true,
+				Tables: map[string]*vschemapb.Table{
+					"t1": {
+						Type: "sequence",
+					},
+				},
+			},
+		},
+	}
+	got, _ := BuildVSchema(&bad)
+	err := got.Keyspaces["sharded"].Error
+	want := "sequence table has to be in an unsharded keyspace or must be pinned: t1"
+	if err == nil || err.Error() != want {
+		t.Errorf("BuildVSchema: %v, want %v", err, want)
+	}
+}
+
 func TestFindTable(t *testing.T) {
 	input := vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -1019,14 +1019,14 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	t1a := &Table{
-		Name:       sqlparser.NewTableIdent("t1"),
-		Keyspace:   ksa,
-		IsSequence: true,
+		Name:     sqlparser.NewTableIdent("t1"),
+		Keyspace: ksa,
+		Type:     "sequence",
 	}
 	t1b := &Table{
-		Name:       sqlparser.NewTableIdent("t1"),
-		Keyspace:   ksb,
-		IsSequence: true,
+		Name:     sqlparser.NewTableIdent("t1"),
+		Keyspace: ksb,
+		Type:     "sequence",
 	}
 	duala := &Table{
 		Name:     sqlparser.NewTableIdent("dual"),
@@ -1504,9 +1504,9 @@ func TestSequence(t *testing.T) {
 		Sharded: true,
 	}
 	seq := &Table{
-		Name:       sqlparser.NewTableIdent("seq"),
-		Keyspace:   ksu,
-		IsSequence: true,
+		Name:     sqlparser.NewTableIdent("seq"),
+		Keyspace: ksu,
+		Type:     "sequence",
 	}
 	vindex1 := &stFU{
 		name: "stfu1",
@@ -2090,8 +2090,8 @@ func TestVSchemaJSON(t *testing.T) {
 					}},
 				},
 				"t2": {
-					IsSequence: true,
-					Name:       sqlparser.NewTableIdent("n2"),
+					Type: "sequence",
+					Name: sqlparser.NewTableIdent("n2"),
 				},
 			},
 		},
@@ -2161,7 +2161,7 @@ func TestVSchemaJSON(t *testing.T) {
         ]
       },
       "t2": {
-        "is_sequence": true,
+        "type": "sequence",
         "name": "n2"
       }
     }


### PR DESCRIPTION
Reference tables are unsharded tables, but are present in a sharded keyspace. They are expected to be present in all shards of a keyspace, and have identical content. Consequently, they do not have vindexes.

You can designate such tables by setting the table type to be `reference` in the vschema.

Selecting from reference tables will create a new `SelectReference` plan. This plan will make vtgate pick a random shard to read from. More importantly, when a sharded table is joined with a reference table, it becomes a local join.

Typically, reference tables are materialized from an unsharded source through vreplication. You can also specify a routing rule that unifies the source and destination. VTGate will then pick the 'best plan' depending on the query that was issued.