### PR TITLE
Fix docker build issues for MySQL 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ docker_base_percona57:
 
 docker_base_percona80:
 	chmod -R o=g *
-	docker build -f docker/base/Dockerfile.percona57 -t vitess/base:percona80 .
+	docker build -f docker/base/Dockerfile.percona80 -t vitess/base:percona80 .
 
 # Run "make docker_lite PROMPT_NOTICE=false" to avoid that the script
 # prompts you to press ENTER and confirm that the vitess/base image is not

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -186,7 +186,7 @@ docker_base_mysql56:
 
 docker_base_mysql80:
 	chmod -R o=g *
-	docker build -f docker/base/Dockerfile.mysql56 -t vitess/base:mysql80 .
+	docker build -f docker/base/Dockerfile.mysql80 -t vitess/base:mysql80 .
 
 docker_base_mariadb:
 	chmod -R o=g *

--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -42,6 +42,7 @@ COPY --from=base $VTTOP/config/init_db.sql /vt/config/
 
 # mysql flavor files for db specific .cnf settings
 COPY --from=base $VTTOP/config/mycnf/master_mysql56.cnf /vt/config/mycnf/
+COPY --from=base $VTTOP/config/mycnf/master_mysql80.cnf /vt/config/mycnf/
 COPY --from=base $VTTOP/config/mycnf/master_mariadb.cnf /vt/config/mycnf/
 COPY --from=base $VTTOP/config/mycnf/master_mariadb103.cnf /vt/config/mycnf/
 


### PR DESCRIPTION
MySQL/Percona 8 containers were being built with the incorrect Dockerfiles and were not receiving the v8.0 my.cnf files they were expecting.

I also deleted some very important-looking whitespace, so let me know if I need to put that back.