### PR TITLE
vreplication: tablet type support for routing

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1996,7 +1996,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 		t.Errorf("getPlan(query1): plans must be equal: %p %p", plan1, plan2)
 	}
 	want := []string{
-		query1,
+		"@unknown:" + query1,
 	}
 	if keys := r.plans.Keys(); !reflect.DeepEqual(keys, want) {
 		t.Errorf("Plan keys: %s, want %s", keys, want)
@@ -2024,8 +2024,8 @@ func TestGetPlanUnnormalized(t *testing.T) {
 		t.Errorf("getPlan(query1, ks): plans must be equal: %p %p", plan3, plan4)
 	}
 	want = []string{
-		KsTestUnsharded + ":" + query1,
-		query1,
+		KsTestUnsharded + "@unknown:" + query1,
+		"@unknown:" + query1,
 	}
 	if keys := r.plans.Keys(); !reflect.DeepEqual(keys, want) {
 		t.Errorf("Plan keys: %s, want %s", keys, want)
@@ -2165,7 +2165,7 @@ func TestGetPlanNormalized(t *testing.T) {
 		t.Errorf("getPlan(query1): plans must be equal: %p %p", plan1, plan2)
 	}
 	want := []string{
-		normalized,
+		"@unknown:" + normalized,
 	}
 	if keys := r.plans.Keys(); !reflect.DeepEqual(keys, want) {
 		t.Errorf("Plan keys: %s, want %s", keys, want)
@@ -2228,8 +2228,8 @@ func TestGetPlanNormalized(t *testing.T) {
 		t.Errorf("getPlan(query1, ks): plans must be equal: %p %p", plan3, plan4)
 	}
 	want = []string{
-		KsTestUnsharded + ":" + normalized,
-		normalized,
+		KsTestUnsharded + "@unknown:" + normalized,
+		"@unknown:" + normalized,
 	}
 	if keys := r.plans.Keys(); !reflect.DeepEqual(keys, want) {
 		t.Errorf("Plan keys: %s, want %s", keys, want)

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -202,7 +202,7 @@ func (vw *vschemaWrapper) FindTablesOrVindex(tab sqlparser.TableName) ([]*vindex
 	if err != nil {
 		return nil, nil, destKeyspace, destTabletType, destTarget, err
 	}
-	tables, vindex, err := vw.v.FindTablesOrVindex(destKeyspace, tab.Name.String())
+	tables, vindex, err := vw.v.FindTablesOrVindex(destKeyspace, tab.Name.String(), topodatapb.TabletType_MASTER)
 	if err != nil {
 		return nil, nil, destKeyspace, destTabletType, destTarget, err
 	}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -178,6 +178,21 @@
   }
 }
 
+# routing rules with master targeting
+"select * from master_redirect"
+{
+  "Original": "select * from master_redirect",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select * from user as master_redirect",
+    "FieldQuery": "select * from user as master_redirect where 1 != 1"
+  }
+}
+
 # ',' join
 "select music.col from user, music"
 {

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -9,6 +9,9 @@
     }, {
       "from_table": "second_user.user",
       "to_tables": ["user.user"]
+    }, {
+      "from_table": "master_redirect@master",
+      "to_tables": ["user.user"]
     }]
   },
   "keyspaces": {

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -43,7 +43,7 @@ func TestQueryzHandler(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result, ok := executor.plans.Get(sql)
+	result, ok := executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
 	}
@@ -56,7 +56,7 @@ func TestQueryzHandler(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result, ok = executor.plans.Get(sql)
+	result, ok = executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
 	}
@@ -71,14 +71,14 @@ func TestQueryzHandler(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result, ok = executor.plans.Get(sql)
+	result, ok = executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
 	}
 	plan3 := result.(*engine.Plan)
 
 	// vindex insert from above execution
-	result, ok = executor.plans.Get("insert into name_user_map(name, user_id) values(:name0, :user_id0)")
+	result, ok = executor.plans.Get("@master:" + "insert into name_user_map(name, user_id) values(:name0, :user_id0)")
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -112,7 +112,7 @@ func (vc *vcursorImpl) FindTablesOrVindex(name sqlparser.TableName) ([]*vindexes
 	if destKeyspace == "" {
 		destKeyspace = vc.keyspace
 	}
-	tables, vindex, err := vc.executor.VSchema().FindTablesOrVindex(destKeyspace, name.Name.String())
+	tables, vindex, err := vc.executor.VSchema().FindTablesOrVindex(destKeyspace, name.Name.String(), vc.tabletType)
 	if err != nil {
 		return nil, nil, "", destTabletType, nil, err
 	}


### PR DESCRIPTION
This change will allow us to control routing of traffic based on tablet type. This will be used to deprecate the 'served from' keyspace type and allow us to use build more versatile resharding worklfows.

The routing rules allow any table name to be suffixed
with tablet type, like 'ks.t@master'. If so, ks.t will
match the rule only if the tablet type is the master.

The tablet more general rule is matched only if the
tablet type specific rule does not match.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>