### PR TITLE
Bind Go's bool type to querypb.Type_INT8

### DIFF
--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -57,6 +57,11 @@ func BuildBindVariables(in map[string]interface{}) (map[string]*querypb.BindVari
 	return out, nil
 }
 
+// Int8BindVariable converts an int8 to a bind var.
+func Int8BindVariable(v int8) *querypb.BindVariable {
+	return ValueBindVariable(NewInt8(v))
+}
+
 // Int32BindVariable converts an int32 to a bind var.
 func Int32BindVariable(v int32) *querypb.BindVariable {
 	return ValueBindVariable(NewInt32(v))
@@ -99,6 +104,11 @@ func BuildBindVariable(v interface{}) (*querypb.BindVariable, error) {
 		return StringBindVariable(v), nil
 	case []byte:
 		return BytesBindVariable(v), nil
+	case bool:
+		if v {
+			return Int8BindVariable(1), nil
+		}
+		return Int8BindVariable(0), nil
 	case int:
 		return &querypb.BindVariable{
 			Type:  querypb.Type_INT64,

--- a/go/sqltypes/bind_variables_test.go
+++ b/go/sqltypes/bind_variables_test.go
@@ -96,6 +96,18 @@ func TestBuildBindVariable(t *testing.T) {
 			Value: []byte("aa"),
 		},
 	}, {
+		in: true,
+		out: &querypb.BindVariable{
+			Type:  querypb.Type_INT8,
+			Value: []byte("1"),
+		},
+	}, {
+		in: false,
+		out: &querypb.BindVariable{
+			Type:  querypb.Type_INT8,
+			Value: []byte("0"),
+		},
+	}, {
 		in: int(1),
 		out: &querypb.BindVariable{
 			Type:  querypb.Type_INT64,

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -100,6 +100,11 @@ func NewInt64(v int64) Value {
 	return MakeTrusted(Int64, strconv.AppendInt(nil, v, 10))
 }
 
+// NewInt8 builds an Int8 Value.
+func NewInt8(v int8) Value {
+	return MakeTrusted(Int8, strconv.AppendInt(nil, int64(v), 10))
+}
+
 // NewInt32 builds an Int64 Value.
 func NewInt32(v int32) Value {
 	return MakeTrusted(Int32, strconv.AppendInt(nil, int64(v), 10))


### PR DESCRIPTION
This will allow the Go's `bool` to be bound to the MySQL `BOOL` type.
