### PR TITLE
Update go vet invocation in a go 1.12 compatible way

### DIFF
--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -24,25 +24,14 @@ if [ -z "$GOPATH" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+packages=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | sed 's|/[^/]*$|/...|' | uniq | sed 's|^|./|')
 
 # If any checks are found to be useless, they can be disabled here.
-# See the output of "go tool vet" for a list of flags.
-vetflags="-all=true"
+# See the output of "go tool vet help" for a list of flags.
+vetflags=""
 
-errors=
+if ! go vet $vetflags $packages 2>&1; then
+  echo "\nPlease fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
+  exit 1
+fi
 
-# Run on one file at a time because a single invocation of "go tool vet"
-# with multiple files requires the files to all be in one package.
-for gofile in $gofiles
-do
-    if ! go tool vet $vetflags $gofile 2>&1; then
-        errors=YES
-    fi
-done
-
-[ -z  "$errors" ] && exit 0
-
-echo
-echo "Please fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
-exit 1

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -24,13 +24,14 @@ if [ -z "$GOPATH" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-packages=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | sed 's|/[^/]*$|/...|' | uniq | sed 's|^|./|')
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
 
 # If any checks are found to be useless, they can be disabled here.
-# See the output of "go tool vet help" for a list of flags.
+# See the output of "go doc cmd/vet" for a list of flags.
 vetflags=""
 
-if ! go vet $vetflags $packages 2>&1; then
+if ! go vet $vetflags $gopackages 2>&1; then
   echo "\nPlease fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
   exit 1
 fi

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -32,65 +32,23 @@ fi
 # xargs -n1 because dirname on MacOS does not support multiple arguments.
 gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
 
-warnings=
+errors=
 
 # If any checks are found to be useless, they can be disabled here.
 # See the output of "go doc cmd/vet" for a list of flags.
 vetflags=""
 
 # Run on one package at a time
-gopackages_with_warnings=()
 for gopackage in $gopackages
 do
-  warningcount="$(go vet $vetflags "vitess.io/vitess/$gopackage" 2>&1 | grep -v ^# | wc -l)"
-  if [ "$warningcount" -gt "0" ]; then
-    warnings=YES
-    echo "$warningcount reports for:"
-    echo "go vet $vetflags vitess.io/vitess/$gopackage"
-    gopackages_with_warnings+=($gopackage)
-  fi
+    if ! go vet $vetflags "vitess.io/vitess/$gopackage" 2>&1; then
+        errors=YES
+    fi
 done
 
-[ -z "$warnings" ] && exit 0
+[ -z "$errors" ] && exit 0
 
-# git doesn't give us access to user input, so let's steal it.
-exec < /dev/tty
-if [[ $? -eq 0 ]]; then
-  # interactive shell. Prompt the user.
-  echo
-  echo "Suggestions from the go vet program were found."
-  echo "They're not enforced, but we're pausing to let you know"
-  echo "before they get clobbered in the scrollback buffer."
-  echo
-  read -r -p 'Press enter to cancel, "s" to step through the warnings or type "ack" to continue: '
-  if [ "$REPLY" = "ack" ]; then
-    exit 0
-  fi
-  if [ "$REPLY" = "s" ]; then
-    first_file="true"
-    for gopackage in "${gopackages_with_warnings[@]}"
-    do
-      echo
-      if [ "$first_file" != "true" ]; then
-        echo "Press enter to show the warnings for the next file."
-        read
-      fi
-      go vet $vetflags "vitess.io/vitess/$gopackage"
-      first_file="false"
-    done
-  fi
-else
-  # non-interactive shell (e.g. called from Eclipse). Just display the warnings.
-  for gopackage in "${gopackages_with_warnings[@]}"
-  do
-    go vet $vetflags "vitess.io/vitess/$gopackage"
-  done
-fi
+echo
+echo "Please fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
 exit 1
-
-if ! go vet $vetflags $(echo $gofiles) 2>&1; then
-  echo ""
-  echo "Please fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
-  exit 1
-fi
 

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -24,14 +24,69 @@ if [ -z "$GOPATH" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 if [ "$gofiles" = "" ]; then
   exit 0
 fi
 
+# xargs -n1 because dirname on MacOS does not support multiple arguments.
+gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
+
+warnings=
+
 # If any checks are found to be useless, they can be disabled here.
 # See the output of "go doc cmd/vet" for a list of flags.
 vetflags=""
+
+# Run on one package at a time
+gopackages_with_warnings=()
+for gopackage in $gopackages
+do
+  warningcount="$(go vet $vetflags "vitess.io/vitess/$gopackage" 2>&1 | grep -v ^# | wc -l)"
+  if [ "$warningcount" -gt "0" ]; then
+    warnings=YES
+    echo "$warningcount reports for:"
+    echo "go vet $vetflags vitess.io/vitess/$gopackage"
+    gopackages_with_warnings+=($gopackage)
+  fi
+done
+
+[ -z "$warnings" ] && exit 0
+
+# git doesn't give us access to user input, so let's steal it.
+exec < /dev/tty
+if [[ $? -eq 0 ]]; then
+  # interactive shell. Prompt the user.
+  echo
+  echo "Suggestions from the go vet program were found."
+  echo "They're not enforced, but we're pausing to let you know"
+  echo "before they get clobbered in the scrollback buffer."
+  echo
+  read -r -p 'Press enter to cancel, "s" to step through the warnings or type "ack" to continue: '
+  if [ "$REPLY" = "ack" ]; then
+    exit 0
+  fi
+  if [ "$REPLY" = "s" ]; then
+    first_file="true"
+    for gopackage in "${gopackages_with_warnings[@]}"
+    do
+      echo
+      if [ "$first_file" != "true" ]; then
+        echo "Press enter to show the warnings for the next file."
+        read
+      fi
+      go vet $vetflags "vitess.io/vitess/$gopackage"
+      first_file="false"
+    done
+  fi
+else
+  # non-interactive shell (e.g. called from Eclipse). Just display the warnings.
+  for gopackage in "${gopackages_with_warnings[@]}"
+  do
+    go vet $vetflags "vitess.io/vitess/$gopackage"
+  done
+fi
+exit 1
 
 if ! go vet $vetflags $(echo $gofiles) 2>&1; then
   echo ""

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,14 +25,17 @@ fi
 
 # This script does not handle file names that contain spaces.
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
-gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
+if [ "$gofiles" = "" ]; then
+  exit 0
+fi
 
 # If any checks are found to be useless, they can be disabled here.
 # See the output of "go doc cmd/vet" for a list of flags.
 vetflags=""
 
-if ! go vet $vetflags $gopackages 2>&1; then
-  echo "\nPlease fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
+if ! go vet $vetflags $(echo $gofiles) 2>&1; then
+  echo ""
+  echo "Please fix the go vet warnings above. To disable certain checks, change vetflags in misc/git/hooks/govet."
   exit 1
 fi
 

--- a/misc/git/hooks/staticcheck
+++ b/misc/git/hooks/staticcheck
@@ -18,6 +18,7 @@ gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' |
 if [ "$gofiles" = "" ]; then
   exit 0
 fi
+
 # xargs -n1 because dirname on MacOS does not support multiple arguments.
 gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
 


### PR DESCRIPTION
This is a reworking of what @acharis started in #4777.
I had to revert `xargs -I{} -n1 dirname {}` back to `xargs -n1 dirname` because that version doesn't work correctly if gofiles is an array with more than 1 element.

Tested with simulated vet errors in 2 packages (2 files).

~~Note: go vet errors were fatal earlier, and now they are warnings. It is easy enough to change that back if someone has an objection to that.~~

@acharis @systay can one of you pull this down and make sure it works for you?