### PR TITLE
vreplication: check error for FindTablesOrVindexes

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -193,6 +193,14 @@
   }
 }
 
+# routing rules bad table
+"select * from bad_table"
+"keyspace none not found in vschema"
+
+# routing rules disabled table
+"select * from disabled"
+"table disabled has been disabled"
+
 # ',' join
 "select music.col from user, music"
 {

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -12,6 +12,12 @@
     }, {
       "from_table": "master_redirect@master",
       "to_tables": ["user.user"]
+    }, {
+      "from_table": "bad_table",
+      "to_tables": ["none.none"]
+    }, {
+      "from_table": "disabled",
+      "to_tables": []
     }]
   },
   "keyspaces": {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -493,6 +493,9 @@ func (vschema *VSchema) findTables(keyspace, tablename string, tabletType topoda
 	for _, name := range []string{fqtn, qualified} {
 		rr, ok := vschema.RoutingRules[name]
 		if ok {
+			if rr.Error != nil {
+				return nil, rr.Error
+			}
 			if len(rr.Tables) == 0 {
 				return nil, fmt.Errorf("table %s has been disabled", tablename)
 			}


### PR DESCRIPTION
Something I missed in the original implementation. Without the check, all failed tables would shown up as `table has been disabled`.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>