### PR TITLE
During PlannedReparentShard, use timeouts specified by -wait_slave_timeout for PromoteSlaveWhenCaughtUp

### DIFF
--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"
 
@@ -100,7 +101,7 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
-	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for slaves to catch up in reparenting")
+	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", *topo.RemoteOperationTimeout, "time to wait for slaves to catch up in reparenting")
 	keyspaceShard := subFlags.String("keyspace_shard", "", "keyspace/shard of the shard that needs to be reparented")
 	newMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
 	avoidMaster := subFlags.String("avoid_master", "", "alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master")

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -425,7 +425,7 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 		return fmt.Errorf("old master tablet %v DemoteMaster failed: %v", topoproto.TabletAliasString(shardInfo.MasterAlias), err)
 	}
 
-	remoteCtx, remoteCancel = context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+	remoteCtx, remoteCancel = context.WithTimeout(ctx, waitSlaveTimeout)
 	defer remoteCancel()
 
 	// Wait on the master-elect tablet until it reaches that position,


### PR DESCRIPTION
Slack discussion: https://vitess.slack.com/archives/C0PQY0PTK/p1556652127032000

I see that during PlannedReparentShard, there is a `wait_slave_timeout` param:
>  -wait_slave_timeout duration
>        time to wait for slaves to catch up in reparenting (default 30s)

`waitSlaveTimeout` appears to be used for:
1. searching for best new master candidate (which has executed most transactions): https://github.com/vitessio/vitess/blob/4efa9c18357ed5e1c98d8bdcaa09717de9a804d9/go/vt/wrangler/reparent.go#L388
2. reparenting all replicas to the new master after the new master has been enabled: https://github.com/vitessio/vitess/blob/4efa9c18357ed5e1c98d8bdcaa09717de9a804d9/go/vt/wrangler/reparent.go#L454

It is not used for waiting for replication to catch up on the new master: https://github.com/vitessio/vitess/blob/4efa9c18357ed5e1c98d8bdcaa09717de9a804d9/go/vt/wrangler/reparent.go#L428-L435

That uses `RemoteOperationTimeout` which defaults to 30s: https://github.com/vitessio/vitess/blob/4efa9c18357ed5e1c98d8bdcaa09717de9a804d9/go/vt/topo/locks.go#L53

Based on the flag description of the `wait_slave_timeout` flag, I'd expect it to be used for waiting for replication to catch up.

Signed-off-by: dleibovic <dleibovic@etsy.com>