### PR TITLE
v3: fix a panic and refactor for future primitives

### DIFF
--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -63,6 +63,11 @@ type builder interface {
 	// after analysis.
 	PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error)
 
+	// MakeDistinct makes the primitive handle the distinct clause.
+	MakeDistinct() error
+	// PushGroupBy makes the primitive handle the group by clause.
+	PushGroupBy(sqlparser.GroupBy) error
+
 	// PushOrderByNull pushes the special case ORDER By NULL to
 	// all primitives. It's safe to push down this clause because it's
 	// just on optimization hint.

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -65,17 +65,13 @@ type builder interface {
 
 	// MakeDistinct makes the primitive handle the distinct clause.
 	MakeDistinct() error
-	// PushGroupBy makes the primitive handle the group by clause.
+	// PushGroupBy makes the primitive handle the GROUP BY clause.
 	PushGroupBy(sqlparser.GroupBy) error
 
-	// PushOrderByNull pushes the special case ORDER By NULL to
-	// all primitives. It's safe to push down this clause because it's
-	// just on optimization hint.
-	PushOrderByNull()
-
-	// PushOrderByRand pushes the special case ORDER BY RAND() to
-	// all primitives.
-	PushOrderByRand()
+	// PushOrderBy pushes the ORDER BY clause. It returns the
+	// the current primitive or a replacement if a new one was
+	// created.
+	PushOrderBy(sqlparser.OrderBy) (builder, error)
 
 	// SetUpperLimit is an optimization hint that tells that primitive
 	// that it does not need to return more than the specified number of rows.

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -112,7 +112,11 @@ func (pb *primitiveBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTabl
 		if !ok {
 			var err error
 			pb.bldr, pb.st, err = newSubquery(tableExpr.As, spb.bldr)
-			return err
+			if err != nil {
+				return err
+			}
+			pb.bldr.Reorder(0)
+			return nil
 		}
 
 		// Since a route is more versatile than a subquery, we

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -177,6 +177,16 @@ func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *res
 	return rc, len(jb.resultColumns) - 1, nil
 }
 
+// MakeDistinct satisfies the builder interface.
+func (jb *join) MakeDistinct() error {
+	return errors.New("join.MakeDistinct: unreachable")
+}
+
+// PushGroupBy satisfies the builder interface.
+func (jb *join) PushGroupBy(_ sqlparser.GroupBy) error {
+	return errors.New("join.PushGroupBy: unreachable")
+}
+
 // PushOrderByNull satisfies the builder interface.
 func (jb *join) PushOrderByNull() {
 	jb.Left.PushOrderByNull()

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -179,24 +179,88 @@ func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *res
 
 // MakeDistinct satisfies the builder interface.
 func (jb *join) MakeDistinct() error {
-	return errors.New("join.MakeDistinct: unreachable")
+	return errors.New("unsupported: distinct on cross-shard join")
 }
 
 // PushGroupBy satisfies the builder interface.
 func (jb *join) PushGroupBy(_ sqlparser.GroupBy) error {
-	return errors.New("join.PushGroupBy: unreachable")
+	return errors.New("unupported: group by on cross-shard join")
 }
 
-// PushOrderByNull satisfies the builder interface.
-func (jb *join) PushOrderByNull() {
-	jb.Left.PushOrderByNull()
-	jb.Right.PushOrderByNull()
-}
+// PushOrderBy satisfies the builder interface.
+func (jb *join) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	isSpecial := false
+	switch len(orderBy) {
+	case 0:
+		isSpecial = true
+	case 1:
+		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {
+			isSpecial = true
+		} else if f, ok := orderBy[0].Expr.(*sqlparser.FuncExpr); ok {
+			if f.Name.Lowered() == "rand" {
+				isSpecial = true
+			}
+		}
+	}
+	if isSpecial {
+		l, err := jb.Left.PushOrderBy(orderBy)
+		if err != nil {
+			return nil, err
+		}
+		jb.Left = l
+		r, err := jb.Right.PushOrderBy(orderBy)
+		if err != nil {
+			return nil, err
+		}
+		jb.Right = r
+		return jb, nil
+	}
 
-// PushOrderByRand satisfies the builder interface.
-func (jb *join) PushOrderByRand() {
-	jb.Left.PushOrderByRand()
-	jb.Right.PushOrderByRand()
+	for _, order := range orderBy {
+		if node, ok := order.Expr.(*sqlparser.SQLVal); ok {
+			// This block handles constructs that use ordinals for 'ORDER BY'. For example:
+			// SELECT a, b, c FROM t1, t2 ORDER BY 1, 2, 3.
+			num, err := ResultFromNumber(jb.ResultColumns(), node)
+			if err != nil {
+				return nil, err
+			}
+			if jb.ResultColumns()[num].column.Origin().Order() > jb.Left.Order() {
+				return nil, errors.New("unsupported: order by spans across shards")
+			}
+		} else {
+			// Analyze column references within the expression to make sure they all
+			// go to the left.
+			err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+				switch node := node.(type) {
+				case *sqlparser.ColName:
+					if node.Metadata.(*column).Origin().Order() > jb.Left.Order() {
+						return false, errors.New("unsupported: order by spans across shards")
+					}
+				case *sqlparser.Subquery:
+					// Unreachable because ResolveSymbols perfoms this check up above.
+					return false, errors.New("unsupported: order by has subquery")
+				}
+				return true, nil
+			}, order.Expr)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// There were no errors. We can push the order by to the left-most route.
+	l, err := jb.Left.PushOrderBy(orderBy)
+	if err != nil {
+		return nil, err
+	}
+	jb.Left = l
+	// Still need to push an empty order by to the right.
+	r, err := jb.Right.PushOrderBy(nil)
+	if err != nil {
+		return nil, err
+	}
+	jb.Right = r
+	return jb, nil
 }
 
 // SetUpperLimit satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planbuilder
 
 import (
+	"errors"
 	"fmt"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -74,32 +75,32 @@ func (l *limit) ResultColumns() []*resultColumn {
 
 // PushFilter satisfies the builder interface.
 func (l *limit) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
-	panic("BUG: unreachable")
+	return errors.New("limit.PushFilter: unreachable")
 }
 
 // PushSelect satisfies the builder interface.
 func (l *limit) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
-	panic("BUG: unreachable")
+	return nil, 0, errors.New("limit.PushSelect: unreachable")
 }
 
 // MakeDistinct satisfies the builder interface.
 func (l *limit) MakeDistinct() error {
-	panic("BUG: unreachable")
+	return errors.New("limit.MakeDistinct: unreachable")
 }
 
-// SetGroupBy satisfies the builder interface.
-func (l *limit) SetGroupBy(groupBy sqlparser.GroupBy) (builder, error) {
-	panic("BUG: unreachable")
+// PushGroupBy satisfies the builder interface.
+func (l *limit) PushGroupBy(_ sqlparser.GroupBy) error {
+	return errors.New("limit.PushGroupBy: unreachable")
 }
 
 // PushOrderByNull satisfies the builder interface.
 func (l *limit) PushOrderByNull() {
-	panic("BUG: unreachable")
+	// Unreachable.
 }
 
 // PushOrderByRand satisfies the builder interface.
 func (l *limit) PushOrderByRand() {
-	panic("BUG: unreachable")
+	// Unreachable.
 }
 
 // SetLimit sets the limit for the primitive. It calls the underlying

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -24,6 +24,8 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+var _ builder = (*limit)(nil)
+
 // limit is the builder for engine.Limit.
 // This gets built if a limit needs to be applied
 // after rows are returned from an underlying
@@ -39,7 +41,6 @@ type limit struct {
 // newLimit builds a new limit.
 func newLimit(bldr builder) *limit {
 	return &limit{
-		order:         bldr.Order() + 1,
 		resultColumns: bldr.ResultColumns(),
 		input:         bldr,
 		elimit:        &engine.Limit{},
@@ -93,14 +94,12 @@ func (l *limit) PushGroupBy(_ sqlparser.GroupBy) error {
 	return errors.New("limit.PushGroupBy: unreachable")
 }
 
-// PushOrderByNull satisfies the builder interface.
-func (l *limit) PushOrderByNull() {
-	// Unreachable.
-}
-
-// PushOrderByRand satisfies the builder interface.
-func (l *limit) PushOrderByRand() {
-	// Unreachable.
+// PushGroupBy satisfies the builder interface.
+func (l *limit) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	if len(orderBy) == 0 {
+		return l, nil
+	}
+	return nil, errors.New("limit.PushOrderBy: unreachable")
 }
 
 // SetLimit sets the limit for the primitive. It calls the underlying

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -26,7 +26,7 @@ import (
 var _ builder = (*mergeSort)(nil)
 
 // mergeSort is a pseudo-primitive. It amends the
-// the underlying Route to performa a merge sort.
+// the underlying Route to perform a merge sort.
 // It's differentiated as a separate primitive
 // because some operations cannot be pushed down,
 // which would otherwise be possible with a simple route.
@@ -90,9 +90,9 @@ func (ms *mergeSort) PushGroupBy(groupBy sqlparser.GroupBy) error {
 	return ms.input.PushGroupBy(groupBy)
 }
 
-// PushGroupBy satisfies the builder interface.
+// PushOrderBy satisfies the builder interface.
 // A merge sort is created due to the push of an ORDER BY clause.
-// So, the function should never get called.
+// So, this function should never get called.
 func (ms *mergeSort) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 	return nil, errors.New("mergeSort.PushOrderBy: unreachable")
 }

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"errors"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+var _ builder = (*mergeSort)(nil)
+
+// mergeSort is a pseudo-primitive. It amends the
+// the underlying Route to performa a merge sort.
+// It's differentiated as a separate primitive
+// because some operations cannot be pushed down,
+// which would otherwise be possible with a simple route.
+// Since ORDER BY happens near the end of the SQL processing,
+// most functions of this primitive are unreachable.
+type mergeSort struct {
+	order int
+	input *route
+}
+
+// newMergeSort builds a new mergeSort.
+func newMergeSort(rb *route) *mergeSort {
+	return &mergeSort{
+		input: rb,
+	}
+}
+
+// Order satisfies the builder interface.
+func (ms *mergeSort) Order() int {
+	return ms.order
+}
+
+// Reorder satisfies the builder interface.
+func (ms *mergeSort) Reorder(order int) {
+	ms.input.Reorder(order)
+	ms.order = ms.input.Order() + 1
+}
+
+// Primitive satisfies the builder interface.
+func (ms *mergeSort) Primitive() engine.Primitive {
+	return ms.input.Primitive()
+}
+
+// First satisfies the builder interface.
+func (ms *mergeSort) First() builder {
+	return ms.input.First()
+}
+
+// ResultColumns satisfies the builder interface.
+func (ms *mergeSort) ResultColumns() []*resultColumn {
+	return ms.input.ResultColumns()
+}
+
+// PushFilter satisfies the builder interface.
+func (ms *mergeSort) PushFilter(pb *primitiveBuilder, expr sqlparser.Expr, whereType string, origin builder) error {
+	return ms.input.PushFilter(pb, expr, whereType, origin)
+}
+
+// PushSelect satisfies the builder interface.
+func (ms *mergeSort) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+	return ms.input.PushSelect(expr, origin)
+}
+
+// MakeDistinct satisfies the builder interface.
+func (ms *mergeSort) MakeDistinct() error {
+	return ms.input.MakeDistinct()
+}
+
+// PushGroupBy satisfies the builder interface.
+func (ms *mergeSort) PushGroupBy(groupBy sqlparser.GroupBy) error {
+	return ms.input.PushGroupBy(groupBy)
+}
+
+// PushGroupBy satisfies the builder interface.
+// A merge sort is created due to the push of an ORDER BY clause.
+// So, the function should never get called.
+func (ms *mergeSort) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	return nil, errors.New("mergeSort.PushOrderBy: unreachable")
+}
+
+// SetUpperLimit satisfies the builder interface.
+func (ms *mergeSort) SetUpperLimit(count *sqlparser.SQLVal) {
+	ms.input.SetUpperLimit(count)
+}
+
+// PushMisc satisfies the builder interface.
+func (ms *mergeSort) PushMisc(sel *sqlparser.Select) {
+	ms.input.PushMisc(sel)
+}
+
+// Wireup satisfies the builder interface.
+func (ms *mergeSort) Wireup(bldr builder, jt *jointab) error {
+	return ms.input.Wireup(bldr, jt)
+}
+
+// SupplyVar satisfies the builder interface.
+func (ms *mergeSort) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	ms.input.SupplyVar(from, to, col, varname)
+}
+
+// SupplyCol satisfies the builder interface.
+func (ms *mergeSort) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	return ms.input.SupplyCol(col)
+}

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -17,16 +17,13 @@ limitations under the License.
 package planbuilder
 
 import (
-	"errors"
-	"fmt"
-
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 // This file has functions to analyze postprocessing
 // clauses like ORDER BY, etc.
 
-// pushGroupBy processes the group by clause. It resolves all symbols,
+// pushGroupBy processes the group by clause. It resolves all symbols
 // and ensures that there are no subqueries.
 func (pb *primitiveBuilder) pushGroupBy(sel *sqlparser.Select) error {
 	if sel.Distinct != "" {
@@ -40,82 +37,25 @@ func (pb *primitiveBuilder) pushGroupBy(sel *sqlparser.Select) error {
 		return nil
 	}
 	if err := pb.st.ResolveSymbols(sel.GroupBy); err != nil {
-		return fmt.Errorf("unsupported: in group by: %v", err)
+		return err
 	}
 
 	// We can be here only if the builder could handle a group by.
 	return pb.bldr.PushGroupBy(sel.GroupBy)
 }
 
-// pushOrderBy pushes the order by clause to the appropriate route.
-// In the case of a join, it's only possible to push down if the
-// order by references columns of the left-most route. Otherwise, the
-// function returns an unsupported error.
+// pushOrderBy pushes the order by clause into the primitives.
+// It resolves all symbols and ensures that there are no subqueries.
 func (pb *primitiveBuilder) pushOrderBy(orderBy sqlparser.OrderBy) error {
-	if oa, ok := pb.bldr.(*orderedAggregate); ok {
-		return oa.PushOrderBy(pb, orderBy)
+	if err := pb.st.ResolveSymbols(orderBy); err != nil {
+		return err
 	}
-
-	switch len(orderBy) {
-	case 0:
-		return nil
-	case 1:
-		// Special handling for ORDER BY NULL. Push it everywhere.
-		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {
-			pb.bldr.PushOrderByNull()
-			return nil
-		} else if f, ok := orderBy[0].Expr.(*sqlparser.FuncExpr); ok {
-			if f.Name.Lowered() == "rand" {
-				pb.bldr.PushOrderByRand()
-				return nil
-			}
-		}
+	bldr, err := pb.bldr.PushOrderBy(orderBy)
+	if err != nil {
+		return err
 	}
-
-	firstRB, ok := pb.bldr.First().(*route)
-	if !ok {
-		return errors.New("unsupported: cannot order by on a cross-shard subquery")
-	}
-	for _, order := range orderBy {
-		if node, ok := order.Expr.(*sqlparser.SQLVal); ok {
-			// This block handles constructs that use ordinals for 'ORDER BY'. For example:
-			// SELECT a, b, c FROM t1, t2 ORDER BY 1, 2, 3.
-			num, err := ResultFromNumber(pb.st.ResultColumns, node)
-			if err != nil {
-				return err
-			}
-			target := pb.st.ResultColumns[num].column.Origin()
-			if target != firstRB {
-				return errors.New("unsupported: order by spans across shards")
-			}
-		} else {
-			// Analyze column references within the expression to make sure they all
-			// go to the same route.
-			err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-				switch node := node.(type) {
-				case *sqlparser.ColName:
-					target, _, err := pb.st.Find(node)
-					if err != nil {
-						return false, err
-					}
-					if target != firstRB {
-						return false, errors.New("unsupported: order by spans across shards")
-					}
-				case *sqlparser.Subquery:
-					return false, errors.New("unsupported: order by has subquery")
-				}
-				return true, nil
-			}, order.Expr)
-			if err != nil {
-				return err
-			}
-		}
-
-		// There were no errors. We can push the order by to the left-most route.
-		if err := firstRB.PushOrderBy(order); err != nil {
-			return err
-		}
-	}
+	pb.bldr = bldr
+	pb.bldr.Reorder(0)
 	return nil
 }
 

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -101,14 +101,14 @@ func (ps *pulloutSubquery) PushGroupBy(groupBy sqlparser.GroupBy) error {
 	return ps.underlying.PushGroupBy(groupBy)
 }
 
-// PushOrderByNull satisfies the builder interface.
-func (ps *pulloutSubquery) PushOrderByNull() {
-	ps.underlying.PushOrderByNull()
-}
-
-// PushOrderByRand satisfies the builder interface.
-func (ps *pulloutSubquery) PushOrderByRand() {
-	ps.underlying.PushOrderByRand()
+// PushOrderBy satisfies the builder interface.
+func (ps *pulloutSubquery) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	bldr, err := ps.underlying.PushOrderBy(orderBy)
+	if err != nil {
+		return nil, err
+	}
+	ps.underlying = bldr
+	return ps, nil
 }
 
 // SetUpperLimit satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -91,6 +91,16 @@ func (ps *pulloutSubquery) PushSelect(expr *sqlparser.AliasedExpr, origin builde
 	return ps.underlying.PushSelect(expr, origin)
 }
 
+// MakeDistinct satisfies the builder interface.
+func (ps *pulloutSubquery) MakeDistinct() error {
+	return ps.underlying.MakeDistinct()
+}
+
+// PushGroupBy satisfies the builder interface.
+func (ps *pulloutSubquery) PushGroupBy(groupBy sqlparser.GroupBy) error {
+	return ps.underlying.PushGroupBy(groupBy)
+}
+
 // PushOrderByNull satisfies the builder interface.
 func (ps *pulloutSubquery) PushOrderByNull() {
 	ps.underlying.PushOrderByNull()

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -155,8 +155,8 @@ func (rb *route) MakeDistinct() error {
 	return nil
 }
 
-// SetGroupBy sets the GROUP BY clause for the route.
-func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) error {
+// PushGroupBy sets the GROUP BY clause for the route.
+func (rb *route) PushGroupBy(groupBy sqlparser.GroupBy) error {
 	rb.Select.(*sqlparser.Select).GroupBy = groupBy
 	return nil
 }

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -223,7 +223,7 @@ func (rb *route) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 
 		rb.Select.AddOrder(order)
 	}
-	return rb, nil
+	return newMergeSort(rb), nil
 }
 
 // SetLimit adds a LIMIT clause to the route.

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -121,20 +121,20 @@ func (sq *subquery) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resu
 
 // MakeDistinct satisfies the builder interface.
 func (sq *subquery) MakeDistinct() error {
-	return errors.New("subquery.MakeDistinct: unreachable")
+	return errors.New("unsupported: distinct on cross-shard subquery")
 }
 
 // PushGroupBy satisfies the builder interface.
 func (sq *subquery) PushGroupBy(_ sqlparser.GroupBy) error {
-	return errors.New("subquery.PushGroupBy: unreachable")
+	return errors.New("unupported: group by on cross-shard subquery")
 }
 
-// PushOrderByNull satisfies the builder interface.
-func (sq *subquery) PushOrderByNull() {
-}
-
-// PushOrderByRand satisfies the builder interface.
-func (sq *subquery) PushOrderByRand() {
+// PushOrderBy satisfies the builder interface.
+func (sq *subquery) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	if len(orderBy) == 0 {
+		return sq, nil
+	}
+	return nil, errors.New("unsupported: order by on cross-shard subquery")
 }
 
 // SetUpperLimit satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -45,7 +45,6 @@ type subquery struct {
 // newSubquery builds a new subquery.
 func newSubquery(alias sqlparser.TableIdent, bldr builder) (*subquery, *symtab, error) {
 	sq := &subquery{
-		order:     bldr.Order() + 1,
 		input:     bldr,
 		esubquery: &engine.Subquery{},
 	}
@@ -118,6 +117,16 @@ func (sq *subquery) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resu
 	sq.resultColumns = append(sq.resultColumns, rc)
 
 	return rc, len(sq.resultColumns) - 1, nil
+}
+
+// MakeDistinct satisfies the builder interface.
+func (sq *subquery) MakeDistinct() error {
+	return errors.New("subquery.MakeDistinct: unreachable")
+}
+
+// PushGroupBy satisfies the builder interface.
+func (sq *subquery) PushGroupBy(_ sqlparser.GroupBy) error {
+	return errors.New("subquery.PushGroupBy: unreachable")
 }
 
 // PushOrderByNull satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -126,7 +126,7 @@ func (sq *subquery) MakeDistinct() error {
 
 // PushGroupBy satisfies the builder interface.
 func (sq *subquery) PushGroupBy(_ sqlparser.GroupBy) error {
-	return errors.New("unupported: group by on cross-shard subquery")
+	return errors.New("unsupported: group by on cross-shard subquery")
 }
 
 // PushOrderBy satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -406,7 +406,7 @@ func (st *symtab) ResolveSymbols(node sqlparser.SQLNode) error {
 				return false, err
 			}
 		case *sqlparser.Subquery:
-			return false, errors.New("subqueries disallowed")
+			return false, errors.New("unsupported: subqueries disallowed in GROUP or ORDER BY")
 		}
 		return true, nil
 	}, node)

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -922,7 +922,7 @@
 
 # invalid order by column numner for scatter
 "select col, count(*) from user group by col order by 5 limit 10"
-"invalid order by: column number out of range: 5"
+"column number out of range: 5"
 
 # aggregate with limit
 "select col, count(*) from user group by col limit 10"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -515,7 +515,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select col from user order by rand()",
+    "Query": "select col from user order by RAND()",
     "FieldQuery": "select col from user where 1 != 1"
   }
 }
@@ -532,7 +532,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by rand()",
+      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by RAND()",
       "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [1]
@@ -543,7 +543,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select music.col3 from music where music.id = :user_id order by rand()",
+      "Query": "select music.col3 from music where music.id = :user_id order by RAND()",
       "FieldQuery": "select music.col3 from music where 1 != 1",
       "Vindex": "music_user_map",
       "Values": [":user_id"]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -175,6 +175,10 @@
 "select user.id from user, user_extra group by id"
 "unsupported: cross-shard query with aggregates"
 
+# if subquery scatter and ordering, then we don't allow outer constructs to be pushed down.
+"select count(*) from (select col, user_extra.extra from user join user_extra on user.id = user_extra.user_id order by user_extra.extra) a"
+"unsupported: cross-shard query with aggregates"
+
 # subqueries not supported in group by
 "select id from user group by id, (select id from user_extra)"
 "unsupported: subqueries disallowed in GROUP or ORDER BY"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -53,7 +53,7 @@
 
 # order by on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t order by id"
-"unsupported: cannot order by on a cross-shard subquery"
+"unsupported: order by on cross-shard subquery"
 
 # order by on a cross-shard query. Note: this is only a problem when an order by column is from the second table
 "select user.col1 as a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
@@ -137,7 +137,7 @@
 
 # scatter aggregate symtab lookup error
 "select id, b as id, count(*) from user order by id"
-"invalid order by: ambiguous symbol reference: id"
+"ambiguous symbol reference: id"
 
 # scatter aggregate with ambiguous aliases
 "select distinct a, b as a from user"
@@ -177,7 +177,7 @@
 
 # subqueries not supported in group by
 "select id from user group by id, (select id from user_extra)"
-"unsupported: in group by: subqueries disallowed"
+"unsupported: subqueries disallowed in GROUP or ORDER BY"
 
 # Order by uses cross-shard expression
 "select id from user order by id+1"
@@ -201,7 +201,7 @@
 
 # Order by has subqueries
 "select id from unsharded order by (select id from unsharded)"
-"unsupported: order by has subquery"
+"unsupported: subqueries disallowed in GROUP or ORDER BY"
 
 # subqueries in update
 "update user set col = (select id from unsharded)"

--- a/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
@@ -329,30 +329,5 @@
   }
 }
 
-# limit and order by null clauses
-"select keyspace_id from user_index where id = :id order by null limit 1"
-{
-  "Original": "select keyspace_id from user_index where id = :id order by null limit 1",
-  "Instructions": {
-    "Opcode": "Limit",
-    "Count": 1,
-    "Offset": null,
-    "Input": {
-      "Opcode": "VindexMap",
-      "Fields": [
-        {
-          "name": "keyspace_id",
-          "type": 10262
-        }
-      ],
-      "Cols": [
-        1
-      ],
-      "Vindex": "user_index",
-      "Value": ":id"
-    }
-  }
-}
-
 "select none from user_index where id = :id"
 "symbol none not found in table or subquery"

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -152,20 +152,20 @@ func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *re
 
 // MakeDistinct satisfies the builder interface.
 func (vf *vindexFunc) MakeDistinct() error {
-	return errors.New("vindexFunc.MakeDistinct: unreachable")
+	return errors.New("unsupported: distinct on vindex function")
 }
 
 // PushGroupBy satisfies the builder interface.
 func (vf *vindexFunc) PushGroupBy(_ sqlparser.GroupBy) error {
-	return errors.New("vindexFunc.PushGroupBy: unreachable")
+	return errors.New("unupported: group by on vindex function")
 }
 
-// PushOrderByNull satisfies the builder interface.
-func (vf *vindexFunc) PushOrderByNull() {
-}
-
-// PushOrderByRand satisfies the builder interface.
-func (vf *vindexFunc) PushOrderByRand() {
+// PushOrderBy satisfies the builder interface.
+func (vf *vindexFunc) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	if len(orderBy) == 0 {
+		return vf, nil
+	}
+	return nil, errors.New("unsupported: order by on vindex function")
 }
 
 // SetUpperLimit satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -150,6 +150,16 @@ func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *re
 	return rc, len(vf.resultColumns) - 1, nil
 }
 
+// MakeDistinct satisfies the builder interface.
+func (vf *vindexFunc) MakeDistinct() error {
+	return errors.New("vindexFunc.MakeDistinct: unreachable")
+}
+
+// PushGroupBy satisfies the builder interface.
+func (vf *vindexFunc) PushGroupBy(_ sqlparser.GroupBy) error {
+	return errors.New("vindexFunc.PushGroupBy: unreachable")
+}
+
 // PushOrderByNull satisfies the builder interface.
 func (vf *vindexFunc) PushOrderByNull() {
 }
@@ -175,7 +185,7 @@ func (vf *vindexFunc) Wireup(bldr builder, jt *jointab) error {
 func (vf *vindexFunc) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
 	// vindexFunc is an atomic primitive. So, SupplyVar cannot be
 	// called on it.
-	panic("BUG: route is an atomic node.")
+	panic("BUG: vindexFunc is an atomic node.")
 }
 
 // SupplyCol satisfies the builder interface.


### PR DESCRIPTION
Previously group by and order by constructs were treated as special case. The new change extends the builder interface and requires all primitives to implement the corresponding push functions.

This approach allows for primitives to be composed more easily because of the fact that we don't special case these constructs any more.

This also fixes #4851. The above changes make it easy to introduce a new mergeSort pseudo primitive that differentiates regular routes from those that perform a merge-sort. This prevents push-down of some constructs that were previously (incorrectly) allowed.