### PR TITLE
Include all proto for the java build

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -86,13 +86,6 @@
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protobuf.protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <protoSourceRoot>../../proto</protoSourceRoot>
-          <includes>
-            <include>query.proto</include>
-            <include>topodata.proto</include>
-            <include>vtgate.proto</include>
-            <include>vtrpc.proto</include>
-            <include>vttest.proto</include>
-          </includes>
         </configuration>
         <executions>
           <execution>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -104,13 +104,6 @@
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <protoSourceRoot>../../proto</protoSourceRoot>
-          <includes>
-            <include>query.proto</include>
-            <include>topodata.proto</include>
-            <include>vtgate.proto</include>
-            <include>vtrpc.proto</include>
-            <include>vtgateservice.proto</include>
-          </includes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
https://www.xolstice.org/protobuf-maven-plugin/compile-mojo.html#includes

Removing the include will include all `*.proto` files.

Signed-off-by: Leo Xuzhang Lin <llin@hubspot.com>

cc @deepthi 