### PR TITLE
change topo_implementation default value

### DIFF
--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -145,7 +145,7 @@ type cellsToAliasesMap struct {
 
 var (
 	// topoImplementation is the flag for which implementation to use.
-	topoImplementation = flag.String("topo_implementation", "etcd2", "the topology implementation to use")
+	topoImplementation = flag.String("topo_implementation", "", "the topology implementation to use")
 
 	// topoGlobalServerAddress is the address of the global topology
 	// server.

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -145,7 +145,7 @@ type cellsToAliasesMap struct {
 
 var (
 	// topoImplementation is the flag for which implementation to use.
-	topoImplementation = flag.String("topo_implementation", "zookeeper", "the topology implementation to use")
+	topoImplementation = flag.String("topo_implementation", "etcd2", "the topology implementation to use")
 
 	// topoGlobalServerAddress is the address of the global topology
 	// server.


### PR DESCRIPTION
`topo_implementation` accepts value `etcd2` or `zk2`, the default value of `topo_implementation` in `go/vt/topo/server.go` is `zookeeper`.
Change the default value `zookeeper` to `etcd2`.


Signed-off-by: Gang.Shen <gang.shen@woqutech.com>