### PR TITLE
dbconfigs: remove default utf8 from charset

### DIFF
--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -94,7 +94,7 @@ func registerBaseFlags() {
 	flag.StringVar(&baseConfig.UnixSocket, "db_socket", "", "The unix socket to connect on. If this is specifed, host and port will not be used.")
 	flag.StringVar(&baseConfig.Host, "db_host", "", "The host name for the tcp connection.")
 	flag.IntVar(&baseConfig.Port, "db_port", 0, "tcp port")
-	flag.StringVar(&baseConfig.Charset, "db_charset", "utf8", "Character set. Only utf8 or latin1 based character sets are supported.")
+	flag.StringVar(&baseConfig.Charset, "db_charset", "", "Character set. Only utf8 or latin1 based character sets are supported.")
 	flag.Uint64Var(&baseConfig.Flags, "db_flags", 0, "Flag values as defined by MySQL.")
 	flag.StringVar(&baseConfig.SslCa, "db_ssl_ca", "", "connection ssl ca")
 	flag.StringVar(&baseConfig.SslCaPath, "db_ssl_ca_path", "", "connection ssl ca path")


### PR DESCRIPTION
@dasl- @brirams @eeSeeGee @rafael 

Followup fix to #4870: The db charset had a default value of utf8,
which makes it hard to check if the value was actually specified
in the command line signaling an override.

Changing this to blank allows us to disambiguate this situation.
Moreover, I believe MySQL wants to deprecate utf8 in favor of
utf8mb4. So, it's better to not have such a default, or any
default until this matter is settled in the MySQL community.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>