### PR TITLE
routing rules: fix TODO

### DIFF
--- a/go/vt/vtgate/planbuilder/symtab_test.go
+++ b/go/vt/vtgate/planbuilder/symtab_test.go
@@ -17,14 +17,14 @@ limitations under the License.
 package planbuilder
 
 import (
+	"encoding/json"
 	"testing"
 
-	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
-func TestSymtabAddVindexTable(t *testing.T) {
+func TestSymtabAddVSchemaTable(t *testing.T) {
 	tname := sqlparser.TableName{Name: sqlparser.NewTableIdent("t")}
 	rb := &route{}
 
@@ -32,18 +32,20 @@ func TestSymtabAddVindexTable(t *testing.T) {
 		in            []*vindexes.Table
 		authoritative bool
 		vindexes      [][]string
+		err           string
 	}{{
+		// Single table.
 		in: []*vindexes.Table{{
 			Columns: []vindexes.Column{{
 				Name: sqlparser.NewColIdent("C1"),
 			}, {
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{}},
 	}, {
+		// Column vindex specified.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("C1")},
@@ -52,12 +54,12 @@ func TestSymtabAddVindexTable(t *testing.T) {
 				Name: sqlparser.NewColIdent("C1"),
 			}, {
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{"c1"}},
 	}, {
+		// Multi-column vindex.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{
@@ -69,12 +71,12 @@ func TestSymtabAddVindexTable(t *testing.T) {
 				Name: sqlparser.NewColIdent("C1"),
 			}, {
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{"c1"}},
 	}, {
+		// AutoIncrement.
 		in: []*vindexes.Table{{
 			AutoIncrement: &vindexes.AutoIncrement{
 				Column: sqlparser.NewColIdent("C1"),
@@ -83,24 +85,24 @@ func TestSymtabAddVindexTable(t *testing.T) {
 				Name: sqlparser.NewColIdent("C1"),
 			}, {
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{}},
 	}, {
+		// Column vindex specifies a column not in list.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("C1")},
 			}},
 			Columns: []vindexes.Column{{
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{"c1"}},
 	}, {
+		// Column vindex specifies columns with none in list.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{
@@ -112,47 +114,32 @@ func TestSymtabAddVindexTable(t *testing.T) {
 		authoritative: false,
 		vindexes:      [][]string{{"c1"}},
 	}, {
+		// AutoIncrement specifies a column not in list.
 		in: []*vindexes.Table{{
 			AutoIncrement: &vindexes.AutoIncrement{
 				Column: sqlparser.NewColIdent("C1"),
 			},
 			Columns: []vindexes.Column{{
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{}},
 	}, {
+		// Two tables.
 		in: []*vindexes.Table{{
 			Columns: []vindexes.Column{{
 				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
 			}},
 		}, {
 			Columns: []vindexes.Column{{
 				Name: sqlparser.NewColIdent("C1"),
-				Type: sqltypes.VarChar,
 			}},
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{}, {}},
 	}, {
-		in: []*vindexes.Table{{
-			Columns: []vindexes.Column{{
-				Name: sqlparser.NewColIdent("C2"),
-				Type: sqltypes.VarChar,
-			}},
-		}, {
-			Columns: []vindexes.Column{{
-				Name: sqlparser.NewColIdent("C1"),
-				Type: sqltypes.VarChar,
-			}},
-			ColumnListAuthoritative: true,
-		}},
-		authoritative: true,
-		vindexes:      [][]string{{}, {}},
-	}, {
+		// Two tables, with column vindexes.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{
@@ -169,6 +156,7 @@ func TestSymtabAddVindexTable(t *testing.T) {
 		authoritative: false,
 		vindexes:      [][]string{{"c1"}, {"c2"}},
 	}, {
+		// One table with two column vindexes.
 		in: []*vindexes.Table{{
 			ColumnVindexes: []*vindexes.ColumnVindex{{
 				Columns: []sqlparser.ColIdent{
@@ -182,35 +170,133 @@ func TestSymtabAddVindexTable(t *testing.T) {
 		}},
 		authoritative: false,
 		vindexes:      [][]string{{"c1", "c2"}, {}},
+	}, {
+		// First table is authoritative.
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+			}},
+			ColumnListAuthoritative: true,
+		}, {
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+		}},
+		authoritative: true,
+		vindexes:      [][]string{{}, {}},
+	}, {
+		// Both tables are authoritative.
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+			}},
+			ColumnListAuthoritative: true,
+		}, {
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+			ColumnListAuthoritative: true,
+		}},
+		authoritative: true,
+		vindexes:      [][]string{{}, {}},
+	}, {
+		// Second table is authoritative.
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+			}},
+		}, {
+			Name: sqlparser.NewTableIdent("t1"),
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+			ColumnListAuthoritative: true,
+		}},
+		authoritative: true,
+		vindexes:      [][]string{{}, {}},
+		err:           "intermixing of authoritative and non-authoritative tables not allowed: t1",
+	}, {
+		// Cannot add to authoritative table (column list).
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+			ColumnListAuthoritative: true,
+		}, {
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C2"),
+			}},
+		}},
+		err: "column C2 not found in t",
+	}, {
+		// Cannot add to authoritative table (column vindex).
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+			ColumnListAuthoritative: true,
+		}, {
+			ColumnVindexes: []*vindexes.ColumnVindex{{
+				Columns: []sqlparser.ColIdent{
+					sqlparser.NewColIdent("C2"),
+				},
+			}},
+		}},
+		err: "column C2 not found in t",
+	}, {
+		// Cannot add to authoritative table (autoinc).
+		in: []*vindexes.Table{{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}},
+			ColumnListAuthoritative: true,
+		}, {
+			AutoIncrement: &vindexes.AutoIncrement{
+				Column: sqlparser.NewColIdent("C2"),
+			},
+		}},
+		err: "column C2 not found in t",
 	}}
 
 	out := []string{"c1", "c2"}
 	for _, tcase := range tcases {
 		st := newSymtab()
 		vindexMaps, err := st.AddVSchemaTable(tname, tcase.in, rb)
+		tcasein, _ := json.Marshal(tcase.in)
 		if err != nil {
-			t.Error(err)
+			if err.Error() != tcase.err {
+				t.Errorf("st.AddVSchemaTable(%s) err: %v, want %s", tcasein, err, tcase.err)
+			}
+			continue
+		} else if tcase.err != "" {
+			t.Errorf("st.AddVSchemaTable(%s) succeeded, want error: %s", tcasein, tcase.err)
 			continue
 		}
 		tab := st.tables[tname]
 		for _, col := range out {
 			if tab.columns[col] == nil {
-				t.Errorf("st.AddVSchemaTable(%+v): column %s not found", tcase.in, col)
+				t.Errorf("st.AddVSchemaTable(%s): column %s not found", tcasein, col)
 			}
 		}
 		for i, cols := range tcase.vindexes {
 			for _, col := range cols {
 				c := tab.columns[col]
 				if c == nil {
-					t.Errorf("st.AddVSchemaTable(%+v): column %s not found", tcase.in, col)
+					t.Errorf("st.AddVSchemaTable(%s): column %s not found", tcasein, col)
 				}
 				if _, ok := vindexMaps[i][c]; !ok {
-					t.Errorf("st.AddVSchemaTable(%+v).vindexMap[%d]: column %s not found", tcase.in, i, col)
+					t.Errorf("st.AddVSchemaTable(%s).vindexMap[%d]: column %s not found", tcasein, i, col)
 				}
 			}
 		}
 		if tab.isAuthoritative != tcase.authoritative {
-			t.Errorf("st.AddVSchemaTable(%+v).authoritative: %v want %v", tcase.in, tab.isAuthoritative, tcase.authoritative)
+			t.Errorf("st.AddVSchemaTable(%s).authoritative: %v want %v", tcasein, tab.isAuthoritative, tcase.authoritative)
 		}
 	}
 }


### PR DESCRIPTION
Tables with authoritative columns are now handled correctly.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>