### PR TITLE
Add log line indicating when WaitForReparentJournal fails

### DIFF
--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/log"
 
 	"golang.org/x/net/context"
 )
@@ -84,6 +85,7 @@ func (mysqld *Mysqld) WaitForReparentJournal(ctx context.Context, timeCreatedNS 
 		t := time.After(100 * time.Millisecond)
 		select {
 		case <-ctx.Done():
+			log.Warning("WaitForReparentJournal failed to see row before timeout.")
 			return ctx.Err()
 		case <-t:
 		}


### PR DESCRIPTION
We've seen `WaitForReparentJournal` fail on some replicas during failover. Add a log line to make this easier to detect.