### PR TITLE
bootstrap.sh: Remove unused unused command.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -304,7 +304,6 @@ gotools=" \
        golang.org/x/tools/cmd/cover \
        golang.org/x/tools/cmd/goimports \
        golang.org/x/tools/cmd/goyacc \
-       honnef.co/go/tools/cmd/unused \
 "
 echo "Installing dev tools with 'go get'..."
 # shellcheck disable=SC2086


### PR DESCRIPTION
The deprecated `unused` command has been removed from the source repository, so this now fails. We no longer use `unused` (as of #4644) so we can just drop the line that tries to install it.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>

Auto-submit: on