### PR TITLE
Remove unused util from bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -304,7 +304,6 @@ gotools=" \
        golang.org/x/tools/cmd/cover \
        golang.org/x/tools/cmd/goimports \
        golang.org/x/tools/cmd/goyacc \
-       honnef.co/go/tools/cmd/unused \
 "
 echo "Installing dev tools with 'go get'..."
 # shellcheck disable=SC2086


### PR DESCRIPTION
Trying to fix https://github.com/vitessio/vitess/issues/4892 by just deleting the offending tool

Signed-off-by: Aaron Young <young@squareup.com>