### PR TITLE
add optional tag-based filtering for query logging

### DIFF
--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -41,8 +41,8 @@ var (
 	// QueryLogFormat controls the format of the query log (either text or json)
 	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
 
-	// FilterTag contains an optional string that must be present in the query for it to be logged
-	FilterTag = flag.String("querylog-filter-tag", "", "string that must be present in the query for it to be logged")
+	// QueryLogFilterTag contains an optional string that must be present in the query for it to be logged
+	QueryLogFilterTag = flag.String("querylog-filter-tag", "", "string that must be present in the query for it to be logged")
 
 	sendCount      = stats.NewCountersWithSingleLabel("StreamlogSend", "stream log send count", "logger_names")
 	deliveredCount = stats.NewCountersWithMultiLabels(
@@ -209,8 +209,8 @@ func GetFormatter(logger *StreamLogger) LogFormatter {
 // ShouldEmitLog returns whether the log with the given SQL query
 // should be emitted or filtered
 func ShouldEmitLog(sql string) bool {
-	if *FilterTag == "" {
+	if *QueryLogFilterTag == "" {
 		return true
 	}
-	return strings.Contains(sql, *FilterTag)
+	return strings.Contains(sql, *QueryLogFilterTag)
 }

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -39,6 +40,9 @@ var (
 
 	// QueryLogFormat controls the format of the query log (either text or json)
 	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
+
+	// FilterTag contains an optional string that must be present in the query for it to be logged
+	FilterTag = flag.String("querylog-filter-tag", "", "string that must be present in the query for it to be logged")
 
 	sendCount      = stats.NewCountersWithSingleLabel("StreamlogSend", "stream log send count", "logger_names")
 	deliveredCount = stats.NewCountersWithMultiLabels(
@@ -200,4 +204,13 @@ func GetFormatter(logger *StreamLogger) LogFormatter {
 		}
 		return fmter.Logf(w, params)
 	}
+}
+
+// ShouldEmitLog returns whether the log with the given SQL query
+// should be emitted or filtered
+func ShouldEmitLog(sql string) bool {
+	if *FilterTag == "" {
+		return true
+	}
+	return strings.Contains(sql, *FilterTag)
 }

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -121,6 +121,10 @@ func (stats *LogStats) RemoteAddrUsername() (string, string) {
 // Logf formats the log record to the given writer, either as
 // tab-separated list of logged fields or as JSON.
 func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
+	if !streamlog.ShouldEmitLog(stats.SQL) {
+		return nil
+	}
+
 	formattedBindVars := "\"[REDACTED]\""
 	if !*streamlog.RedactDebugUIQueries {
 		_, fullBindParams := params["full"]

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -127,7 +127,7 @@ func TestLogStatsFormat(t *testing.T) {
 }
 
 func TestLogStatsFilter(t *testing.T) {
-	defer func() { *streamlog.FilterTag = "" }()
+	defer func() { *streamlog.QueryLogFilterTag = "" }()
 
 	logStats := NewLogStats(context.Background(), "test", "sql1 /* LOG_THIS_QUERY */", map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1)})
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
@@ -140,14 +140,14 @@ func TestLogStatsFilter(t *testing.T) {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
-	*streamlog.FilterTag = "LOG_THIS_QUERY"
+	*streamlog.QueryLogFilterTag = "LOG_THIS_QUERY"
 	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\" ]\t0\t0\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
-	*streamlog.FilterTag = "NOT_THIS_QUERY"
+	*streamlog.QueryLogFilterTag = "NOT_THIS_QUERY"
 	got = testFormat(logStats, url.Values(params))
 	want = ""
 	if got != want {

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
 )
 
@@ -142,6 +143,17 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	close(ch)
 	body, _ = ioutil.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
+
+	// ensure querylogz is not affected by the filter tag
+	*streamlog.FilterTag = "XXX_SKIP_ME"
+	defer func() { *streamlog.FilterTag = "" }()
+	ch = make(chan interface{}, 1)
+	ch <- logStats
+	querylogzHandler(ch, response, req)
+	close(ch)
+	body, _ = ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
+
 }
 
 func checkQuerylogzHasStats(t *testing.T, pattern []string, logStats *LogStats, page []byte) {

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -145,8 +145,8 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 
 	// ensure querylogz is not affected by the filter tag
-	*streamlog.FilterTag = "XXX_SKIP_ME"
-	defer func() { *streamlog.FilterTag = "" }()
+	*streamlog.QueryLogFilterTag = "XXX_SKIP_ME"
+	defer func() { *streamlog.QueryLogFilterTag = "" }()
 	ch = make(chan interface{}, 1)
 	ch <- logStats
 	querylogzHandler(ch, response, req)

--- a/go/vt/vttablet/tabletserver/querylogz_test.go
+++ b/go/vt/vttablet/tabletserver/querylogz_test.go
@@ -151,8 +151,8 @@ func TestQuerylogzHandler(t *testing.T) {
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 
 	// ensure querylogz is not affected by the filter tag
-	*streamlog.FilterTag = "XXX_SKIP_ME"
-	defer func() { *streamlog.FilterTag = "" }()
+	*streamlog.QueryLogFilterTag = "XXX_SKIP_ME"
+	defer func() { *streamlog.QueryLogFilterTag = "" }()
 	ch = make(chan interface{}, 1)
 	ch <- logStats
 	querylogzHandler(ch, response, req)

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -180,6 +180,10 @@ func (stats *LogStats) CallInfo() (string, string) {
 // Logf formats the log record to the given writer, either as
 // tab-separated list of logged fields or as JSON.
 func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
+	if !streamlog.ShouldEmitLog(stats.OriginalSQL) {
+		return nil
+	}
+
 	rewrittenSQL := "[REDACTED]"
 	formattedBindVars := "\"[REDACTED]\""
 

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -150,7 +150,7 @@ func TestLogStatsFormat(t *testing.T) {
 }
 
 func TestLogStatsFilter(t *testing.T) {
-	defer func() { *streamlog.FilterTag = "" }()
+	defer func() { *streamlog.QueryLogFilterTag = "" }()
 
 	logStats := NewLogStats(context.Background(), "test")
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
@@ -168,14 +168,14 @@ func TestLogStatsFilter(t *testing.T) {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
-	*streamlog.FilterTag = "LOG_THIS_QUERY"
+	*streamlog.QueryLogFilterTag = "LOG_THIS_QUERY"
 	got = testFormat(logStats, url.Values(params))
 	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t\t\"sql /* LOG_THIS_QUERY */\"\tmap[intVal:type:INT64 value:\"1\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
-	*streamlog.FilterTag = "NOT_THIS_QUERY"
+	*streamlog.QueryLogFilterTag = "NOT_THIS_QUERY"
 	got = testFormat(logStats, url.Values(params))
 	want = ""
 	if got != want {


### PR DESCRIPTION
## Description
Add optional tag-based filtering for query logging.

## Details
Although the query logging can be very useful for debugging why certain queries are slow, in large deployments the overhead of logging every query can be burdensome and we'd like more control over what is logged.

As a simple enhancement, this PR adds a flag `-querylog-filter-tag` that allows us to specify a string and only emits query logs for queries that contain the specified string.

This allows the application to control logging by including a marker in a trailing comment.
