### PR TITLE
Don't return an error for CONN_ATTR (just log)

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -683,10 +683,8 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []by
 
 	// Decode connection attributes send by the client
 	if clientFlags&CapabilityClientConnAttr != 0 {
-		var err error
-		_, _, err = parseConnAttrs(data, pos)
-		if err != nil {
-			return "", "", nil, err
+		if _, _, err := parseConnAttrs(data, pos); err != nil {
+			log.Warningf("Decode connection attributes send by the client: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

It's related to _Error when connecting from JDBC MariaDB driver_ (https://github.com/vitessio/vitess/issues/4603)

Looks like it's a _MariaDB connector_ (it sends CONN_ATTR in different format), but because we _swallow_ the returned map with attributes, I decided to just log an warning instead of returning the error.
Thanks to this we'll be able to connect to vitess server also via MariaDb connector.