### PR TITLE
vtgate plan: auto-expand insert column list

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -531,6 +531,31 @@
   }
 }
 
+# unsharded insert, no col list with auto-inc and authoritative column list
+"insert into unsharded_authoritative values(1,1)"
+{
+  "Original": "insert into unsharded_authoritative values(1,1)",
+  "Instructions": {
+    "Opcode": "InsertUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "insert into unsharded_authoritative(col1, col2) values (:__seq0, 1)",
+    "Table": "unsharded_authoritative",
+    "Generate": {
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select next :n values from seq",
+      "Values": [
+        1
+      ]
+    }
+  }
+}
+
 # sharded upsert with sharding key set to vindex column
 "insert into music(user_id, id) values(1, 2) on duplicate key update user_id = values(user_id)"
 {
@@ -795,13 +820,35 @@
   }
 }
 
-# insert no column list
-"insert into user values(1, 2, 3)"
-"no column list"
-
 # insert with mimatched column list
 "insert into user(id) values (1, 2)"
 "column list doesn't match values"
+
+# insert no column list for sharded authoritative table
+"insert into authoritative values(1, 2, 3)"
+{
+  "Original": "insert into authoritative values(1, 2, 3)",
+  "Instructions": {
+    "Opcode": "InsertSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "insert into authoritative(user_id, col1, col2) values (:_user_id0, 2, 3)",
+    "Values": [
+      [
+        [
+          1
+        ]
+      ]
+    ],
+    "Table": "authoritative",
+    "Prefix": "insert into authoritative(user_id, col1, col2) values ",
+    "Mid": [
+      "(:_user_id0, 2, 3)"
+    ]
+  }
+}
 
 # insert sharded, no values
 "insert into user values()"

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -245,6 +245,21 @@
             "sequence": "seq"
           }
         },
+        "unsharded_authoritative": {
+          "columns": [
+            {
+              "name": "col1"
+            },
+            {
+              "name": "col2"
+            }
+          ],
+          "auto_increment": {
+            "column": "col1",
+            "sequence": "seq"
+          },
+          "column_list_authoritative": true
+        },
         "seq": {
           "type": "sequence"
         }


### PR DESCRIPTION
If the table has authoritative column list, use it to auto-expand
insert columns if they were not supplied.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>