### PR TITLE
fix bug in vttablet startup script when '--enable-grpc-static-auth' f…

### DIFF
--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -100,7 +100,7 @@ optional_auth_args=''
 if [ "$1" = "--enable-grpc-static-auth" ];
 then
 	  echo "Enabling Auth with static authentication in grpc"
-    optional_auth_args='-grpc_auth_mode static -grpc_auth_static_password_file ./grpc_static_auth.json'
+    optional_auth_args='-grpc_auth_mode static -grpc_auth_static_password_file ./grpc_static_auth.json -grpc_auth_static_client_creds ./grpc_static_client_auth.json'
 fi
 
 # Start all vttablets in background.


### PR DESCRIPTION
…lag is used

When TabletExeternallyReparented command is used, the RPC call that originates [here](https://github.com/dasl-/vitess/blob/f41656fe71fbc42f8fa087e7a5bc28d817c5a8ea/go/vt/vttablet/tabletmanager/rpc_external_reparent.go#L234) needs the specified creds file.

The fact that these creds were missing meant that we saw this in vttablet logs:
```
W0604 18:29:48.972908    3509 rpc_external_reparent.go:235] Error calling RefreshState on old master test-0000000100: rpc error: code = Unauthenticated desc = username and password must be provided
```

And vtgate logs would thereafter be filled with lines like this:
```
W0604 18:29:50.934781   10236 tablet_stats_cache.go:89] not marking healthy master test-0000000100 as Up for index_test/0 because its externally reparented timestamp is smaller than the highest known timestamp from previous MASTERs test-0000000101: 1559672862 < 1559672988
```