### PR TITLE
vreplication: allow multi-value functions

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -277,14 +277,14 @@ func TestBuildPlayerPlan(t *testing.T) {
 		input: &binlogdatapb.Filter{
 			Rules: []*binlogdatapb.Rule{{
 				Match:  "t1",
-				Filter: "select foo(a) as c1, b c2 from t1",
+				Filter: "select foo(a) as c1, foo(a, b) as c2, c c3 from t1",
 			}},
 		},
 		plan: &TestReplicatorPlan{
 			VStreamFilter: &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{
 					Match:  "t1",
-					Filter: "select a, b from t1",
+					Filter: "select a, b, c from t1",
 				}},
 			},
 			TargetTables: []string{"t1"},
@@ -293,10 +293,10 @@ func TestBuildPlayerPlan(t *testing.T) {
 					TargetName:   "t1",
 					SendRule:     "t1",
 					PKReferences: []string{"a"},
-					InsertFront:  "insert into t1(c1,c2)",
-					InsertValues: "(foo(:a_a),:a_b)",
-					Insert:       "insert into t1(c1,c2) values (foo(:a_a),:a_b)",
-					Update:       "update t1 set c2=:a_b where c1=(foo(:b_a))",
+					InsertFront:  "insert into t1(c1,c2,c3)",
+					InsertValues: "(foo(:a_a),foo(:a_a, :a_b),:a_c)",
+					Insert:       "insert into t1(c1,c2,c3) values (foo(:a_a),foo(:a_a, :a_b),:a_c)",
+					Update:       "update t1 set c2=foo(:a_a, :a_b), c3=:a_c where c1=(foo(:b_a))",
 					Delete:       "delete from t1 where c1=(foo(:b_a))",
 				},
 			},
@@ -305,7 +305,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			VStreamFilter: &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{
 					Match:  "t1",
-					Filter: "select a, b, pk1, pk2 from t1",
+					Filter: "select a, b, c, pk1, pk2 from t1",
 				}},
 			},
 			TargetTables: []string{"t1"},
@@ -314,10 +314,10 @@ func TestBuildPlayerPlan(t *testing.T) {
 					TargetName:   "t1",
 					SendRule:     "t1",
 					PKReferences: []string{"a", "pk1", "pk2"},
-					InsertFront:  "insert into t1(c1,c2)",
-					InsertValues: "(foo(:a_a),:a_b)",
-					Insert:       "insert into t1(c1,c2) select foo(:a_a), :a_b from dual where (:a_pk1,:a_pk2) <= (1,'aaa')",
-					Update:       "update t1 set c2=:a_b where c1=(foo(:b_a)) and (:b_pk1,:b_pk2) <= (1,'aaa')",
+					InsertFront:  "insert into t1(c1,c2,c3)",
+					InsertValues: "(foo(:a_a),foo(:a_a, :a_b),:a_c)",
+					Insert:       "insert into t1(c1,c2,c3) select foo(:a_a), foo(:a_a, :a_b), :a_c from dual where (:a_pk1,:a_pk2) <= (1,'aaa')",
+					Update:       "update t1 set c2=foo(:a_a, :a_b), c3=:a_c where c1=(foo(:b_a)) and (:b_pk1,:b_pk2) <= (1,'aaa')",
 					Delete:       "delete from t1 where c1=(foo(:b_a)) and (:b_pk1,:b_pk2) <= (1,'aaa')",
 				},
 			},
@@ -479,6 +479,15 @@ func TestBuildPlayerPlan(t *testing.T) {
 			}},
 		},
 		err: "unexpected: sum(*)",
+	}, {
+		// sum should have only one argument
+		input: &binlogdatapb.Filter{
+			Rules: []*binlogdatapb.Rule{{
+				Match:  "t1",
+				Filter: "select sum(a, b) as c from t1",
+			}},
+		},
+		err: "unexpected: sum(a, b)",
 	}, {
 		// no complex expr in sum
 		input: &binlogdatapb.Filter{

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -289,7 +289,7 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 		references: make(map[string]bool),
 	}
 	if expr, ok := aliased.Expr.(*sqlparser.FuncExpr); ok {
-		if expr.Distinct || len(expr.Exprs) != 1 {
+		if expr.Distinct {
 			return nil, fmt.Errorf("unexpected: %v", sqlparser.String(expr))
 		}
 		if aliased.As.IsEmpty() {
@@ -303,6 +303,9 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 			cexpr.operation = opCount
 			return cexpr, nil
 		case "sum":
+			if len(expr.Exprs) != 1 {
+				return nil, fmt.Errorf("unexpected: %v", sqlparser.String(expr))
+			}
 			aInner, ok := expr.Exprs[0].(*sqlparser.AliasedExpr)
 			if !ok {
 				return nil, fmt.Errorf("unexpected: %v", sqlparser.String(expr))


### PR DESCRIPTION
The previous code (from old behavior) was still disallowing functions
with more than one parameter. That check has been moved to 'sum'
which is the only place where it should be enforced.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>