### PR TITLE
vtgate sql: distinct aggregates

### DIFF
--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -26,6 +26,9 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
+// TODO(sougou): change these functions to be more permissive.
+// Most string to number conversions should quietly convert to 0.
+
 // numeric represents a numeric value extracted from
 // a Value, used for arithmetic operations.
 type numeric struct {

--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -38,6 +38,8 @@ type numeric struct {
 	fval float64
 }
 
+var zeroBytes = []byte("0")
+
 // NullsafeAdd adds two Values in a null-safe manner. A null value
 // is treated as 0. If both values are null, then a null is returned.
 // If both values are not null, a numeric value is built
@@ -51,10 +53,10 @@ type numeric struct {
 // result is preserved.
 func NullsafeAdd(v1, v2 Value, resultType querypb.Type) (Value, error) {
 	if v1.IsNull() {
-		return v2, nil
+		v1 = MakeTrusted(resultType, zeroBytes)
 	}
 	if v2.IsNull() {
-		return v1, nil
+		v2 = MakeTrusted(resultType, zeroBytes)
 	}
 
 	lv1, err := newNumeric(v1)

--- a/go/sqltypes/arithmetic_test.go
+++ b/go/sqltypes/arithmetic_test.go
@@ -37,16 +37,16 @@ func TestAdd(t *testing.T) {
 		// All nulls.
 		v1:  NULL,
 		v2:  NULL,
-		out: NULL,
+		out: NewInt64(0),
 	}, {
 		// First value null.
-		v1:  NewInt64(1),
+		v1:  NewInt32(1),
 		v2:  NULL,
 		out: NewInt64(1),
 	}, {
 		// Second value null.
 		v1:  NULL,
-		v2:  NewInt64(1),
+		v2:  NewInt32(1),
 		out: NewInt64(1),
 	}, {
 		// Normal case.

--- a/go/vt/vtgate/endtoend/aggr_test.go
+++ b/go/vt/vtgate/endtoend/aggr_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endtoend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+func TestAggregateTypes(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	exec(t, conn, "insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'a',1), (3,'b',1), (4,'c',3), (5,'c',4)")
+	exec(t, conn, "insert into aggr_test(id, val1, val2) values(6,'d',null), (7,'e',null), (8,'e',1)")
+
+	qr := exec(t, conn, "select val1, count(distinct val2), count(*) from aggr_test group by val1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARBINARY("a") INT64(1) INT64(2)] [VARBINARY("b") INT64(1) INT64(1)] [VARBINARY("c") INT64(2) INT64(2)] [VARBINARY("d") INT64(0) INT64(1)] [VARBINARY("e") INT64(1) INT64(2)]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	qr = exec(t, conn, "select val1, sum(distinct val2), sum(val2) from aggr_test group by val1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARBINARY("a") DECIMAL(1) DECIMAL(2)] [VARBINARY("b") DECIMAL(1) DECIMAL(1)] [VARBINARY("c") DECIMAL(7) DECIMAL(7)] [VARBINARY("d") NULL NULL] [VARBINARY("e") DECIMAL(1) DECIMAL(1)]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+}

--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -54,6 +54,13 @@ create table vstream_test(
 	val bigint,
 	primary key(id)
 ) Engine=InnoDB;
+
+create table aggr_test(
+	id bigint,
+	val1 varbinary(16),
+	val2 bigint,
+	primary key(id)
+) Engine=InnoDB;
 `
 
 	vschema = &vschemapb.Keyspace{
@@ -89,6 +96,12 @@ create table vstream_test(
 				}},
 			},
 			"vstream_test": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "id",
+					Name:   "hash",
+				}},
+			},
+			"aggr_test": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "id",
 					Name:   "hash",

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -367,7 +367,7 @@ func TestMerge(t *testing.T) {
 		"1|3|2.8|2|bc",
 	)
 
-	merged, err := oa.merge(fields, r.Rows[0], r.Rows[1])
+	merged, _, err := oa.merge(fields, r.Rows[0], r.Rows[1], sqltypes.NULL)
 	if err != nil {
 		t.Error(err)
 	}
@@ -377,7 +377,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	// swap and retry
-	merged, err = oa.merge(fields, r.Rows[1], r.Rows[0])
+	merged, _, err = oa.merge(fields, r.Rows[1], r.Rows[0], sqltypes.NULL)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -61,7 +61,7 @@ type builder interface {
 	// a resultColumn entry and return it. The top level caller
 	// must accumulate these result columns and set the symtab
 	// after analysis.
-	PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error)
+	PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error)
 
 	// MakeDistinct makes the primitive handle the distinct clause.
 	MakeDistinct() error

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -154,9 +154,9 @@ func (jb *join) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereTyp
 }
 
 // PushSelect satisfies the builder interface.
-func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (jb *join) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
 	if jb.isOnLeft(origin.Order()) {
-		rc, colnum, err = jb.Left.PushSelect(expr, origin)
+		rc, colnum, err = jb.Left.PushSelect(pb, expr, origin)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -167,7 +167,7 @@ func (jb *join) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *res
 			return nil, 0, errors.New("unsupported: cross-shard left join and column expressions")
 		}
 
-		rc, colnum, err = jb.Right.PushSelect(expr, origin)
+		rc, colnum, err = jb.Right.PushSelect(pb, expr, origin)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -183,7 +183,10 @@ func (jb *join) MakeDistinct() error {
 }
 
 // PushGroupBy satisfies the builder interface.
-func (jb *join) PushGroupBy(_ sqlparser.GroupBy) error {
+func (jb *join) PushGroupBy(groupBy sqlparser.GroupBy) error {
+	if (groupBy) == nil {
+		return nil
+	}
 	return errors.New("unupported: group by on cross-shard join")
 }
 

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -80,7 +80,7 @@ func (l *limit) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType stri
 }
 
 // PushSelect satisfies the builder interface.
-func (l *limit) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (l *limit) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
 	return nil, 0, errors.New("limit.PushSelect: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -76,8 +76,8 @@ func (ms *mergeSort) PushFilter(pb *primitiveBuilder, expr sqlparser.Expr, where
 }
 
 // PushSelect satisfies the builder interface.
-func (ms *mergeSort) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
-	return ms.input.PushSelect(expr, origin)
+func (ms *mergeSort) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+	return ms.input.PushSelect(pb, expr, origin)
 }
 
 // MakeDistinct satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -27,20 +27,14 @@ import (
 // and ensures that there are no subqueries.
 func (pb *primitiveBuilder) pushGroupBy(sel *sqlparser.Select) error {
 	if sel.Distinct != "" {
-		// We can be here only if the builder could handle a group by.
 		if err := pb.bldr.MakeDistinct(); err != nil {
 			return err
 		}
 	}
 
-	if len(sel.GroupBy) == 0 {
-		return nil
-	}
 	if err := pb.st.ResolveSymbols(sel.GroupBy); err != nil {
 		return err
 	}
-
-	// We can be here only if the builder could handle a group by.
 	return pb.bldr.PushGroupBy(sel.GroupBy)
 }
 

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -87,8 +87,8 @@ func (ps *pulloutSubquery) PushFilter(pb *primitiveBuilder, filter sqlparser.Exp
 }
 
 // PushSelect satisfies the builder interface.
-func (ps *pulloutSubquery) PushSelect(expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
-	return ps.underlying.PushSelect(expr, origin)
+func (ps *pulloutSubquery) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+	return ps.underlying.PushSelect(pb, expr, origin)
 }
 
 // MakeDistinct satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -124,7 +124,7 @@ func (rb *route) UpdatePlans(pb *primitiveBuilder, filter sqlparser.Expr) {
 }
 
 // PushSelect satisfies the builder interface.
-func (rb *route) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
+func (rb *route) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
 	sel := rb.Select.(*sqlparser.Select)
 	sel.SelectExprs = append(sel.SelectExprs, expr)
 
@@ -468,7 +468,8 @@ func (rb *route) SupplyWeightString(colnum int) (weightColnum int) {
 			},
 		},
 	}
-	_, weightColnum, _ = rb.PushSelect(expr, nil)
+	// It's ok to pass nil for pb and builder because PushSelect doesn't use them.
+	_, weightColnum, _ = rb.PushSelect(nil, expr, nil)
 	rb.weightStrings[rc] = weightColnum
 	return weightColnum
 }

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -194,7 +194,7 @@ func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) 
 				return nil, err
 			}
 			node.Expr = expr
-			rc, _, err := pb.bldr.PushSelect(node, origin)
+			rc, _, err := pb.bldr.PushSelect(pb, node, origin)
 			if err != nil {
 				return nil, err
 			}
@@ -289,7 +289,7 @@ func (pb *primitiveBuilder) expandStar(inrcs []*resultColumn, expr *sqlparser.St
 						As: col,
 					}
 				}
-				rc, _, err := pb.bldr.PushSelect(expr, t.Origin())
+				rc, _, err := pb.bldr.PushSelect(pb, expr, t.Origin())
 				if err != nil {
 					// Unreachable because PushSelect won't fail on ColName.
 					return inrcs, false, err
@@ -316,7 +316,7 @@ func (pb *primitiveBuilder) expandStar(inrcs []*resultColumn, expr *sqlparser.St
 				Qualifier: expr.TableName,
 			},
 		}
-		rc, _, err := pb.bldr.PushSelect(expr, t.Origin())
+		rc, _, err := pb.bldr.PushSelect(pb, expr, t.Origin())
 		if err != nil {
 			// Unreachable because PushSelect won't fail on ColName.
 			return inrcs, false, err

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -102,7 +102,7 @@ func (sq *subquery) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType 
 }
 
 // PushSelect satisfies the builder interface.
-func (sq *subquery) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
+func (sq *subquery) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
 	col, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok {
 		return nil, 0, errors.New("unsupported: expression on results of a cross-shard subquery")

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -125,7 +125,10 @@ func (sq *subquery) MakeDistinct() error {
 }
 
 // PushGroupBy satisfies the builder interface.
-func (sq *subquery) PushGroupBy(_ sqlparser.GroupBy) error {
+func (sq *subquery) PushGroupBy(groupBy sqlparser.GroupBy) error {
+	if (groupBy) == nil {
+		return nil
+	}
 	return errors.New("unsupported: group by on cross-shard subquery")
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -577,6 +577,38 @@
   }
 }
 
+# count with distinct unique vindex
+"select col, count(distinct id) from user group by col"
+{
+  "Original": "select col, count(distinct id) from user group by col",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 1
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col, count(distinct id) from user group by col order by col asc",
+      "FieldQuery": "select col, count(distinct id) from user where 1 != 1 group by col",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
 # count with distinct no unique vindex
 "select col1, count(distinct col2) from user group by col1"
 {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -562,6 +562,199 @@
   }
 }
 
+# count with distinct group by unique vindex
+"select id, count(distinct col) from user group by id"
+{
+  "Original": "select id, count(distinct col) from user group by id",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id, count(distinct col) from user group by id",
+    "FieldQuery": "select id, count(distinct col) from user where 1 != 1 group by id"
+  }
+}
+
+# count with distinct no unique vindex
+"select col1, count(distinct col2) from user group by col1"
+{
+  "Original": "select col1, count(distinct col2) from user group by col1",
+  "Instructions": {
+    "HasDistinct": true,
+    "Aggregates": [
+      {
+        "Opcode": "count_distinct",
+        "Col": 1,
+        "Alias": "count(distinct col2)"
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col1, col2 from user group by col1, col2 order by col1 asc, col2 asc",
+      "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1, col2",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# count with distinct no unique vindex and no group by
+"select count(distinct col2) from user"
+{
+  "Original": "select count(distinct col2) from user",
+  "Instructions": {
+    "HasDistinct": true,
+    "Aggregates": [
+      {
+        "Opcode": "count_distinct",
+        "Col": 0,
+        "Alias": "count(distinct col2)"
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col2 from user group by col2 order by col2 asc",
+      "FieldQuery": "select col2 from user where 1 != 1 group by col2",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# count with distinct no unique vindex, count expression aliased
+"select col1, count(distinct col2) c2 from user group by col1"
+{
+  "Original": "select col1, count(distinct col2) c2 from user group by col1",
+  "Instructions": {
+    "HasDistinct": true,
+    "Aggregates": [
+      {
+        "Opcode": "count_distinct",
+        "Col": 1,
+        "Alias": "c2"
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col1, col2 from user group by col1, col2 order by col1 asc, col2 asc",
+      "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1, col2",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# sum with distinct no unique vindex
+"select col1, sum(distinct col2) from user group by col1"
+{
+  "Original": "select col1, sum(distinct col2) from user group by col1",
+  "Instructions": {
+    "HasDistinct": true,
+    "Aggregates": [
+      {
+        "Opcode": "sum_distinct",
+        "Col": 1,
+        "Alias": "sum(distinct col2)"
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col1, col2 from user group by col1, col2 order by col1 asc, col2 asc",
+      "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1, col2",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# min with distinct no unique vindex. distinct is ignored.
+"select col1, min(distinct col2) from user group by col1"
+{
+  "Original": "select col1, min(distinct col2) from user group by col1",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "min",
+        "Col": 1
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col1, min(distinct col2) from user group by col1 order by col1 asc",
+      "FieldQuery": "select col1, min(distinct col2) from user where 1 != 1 group by col1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
 # scatter aggregate group by aggregate function
 " select count(*) b from user group by b"
 "group by expression cannot reference an aggregate function: b"
@@ -1030,3 +1223,7 @@
 # Group by out of range column number (code is duplicated from symab).
 "select id from user group by 2"
 "column number out of range: 2"
+
+# syntax error detected by planbuilder
+"select count(distinct *) from user"
+"syntax error: count(distinct *)"

--- a/go/vt/vtgate/planbuilder/testdata/onecase.txt
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.txt
@@ -1,6 +1,1 @@
 # Add your test case here for debugging and run go test -run=One.
-"select a, count(distinct b) from user group by a"
-""
-
-"select count(distinct b) a from user"
-""

--- a/go/vt/vtgate/planbuilder/testdata/onecase.txt
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.txt
@@ -1,1 +1,6 @@
 # Add your test case here for debugging and run go test -run=One.
+"select a, count(distinct b) from user group by a"
+""
+
+"select count(distinct b) a from user"
+""

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -131,6 +131,14 @@
 "select 1+count(*) from user"
 "unsupported: in scatter query: complex aggregate expression"
 
+# Multi-value aggregates not supported
+"select count(a,b) from user"
+"unsupported: only one expression allowed inside aggregates: count(a, b)"
+
+# Cannot have more than one aggr(distinct...
+"select count(distinct a), count(distinct b) from user"
+"unsupported: only one distinct aggregation allowed in a select: count(distinct b)"
+
 # scatter aggregate group by doesn't reference select list
 "select id from user group by col"
 "unsupported: in scatter query: group by column must reference column in SELECT list"

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -130,7 +130,7 @@ func (vf *vindexFunc) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, wh
 }
 
 // PushSelect satisfies the builder interface.
-func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
+func (vf *vindexFunc) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
 	// Catch the case where no where clause was specified. If so, the opcode
 	// won't be set.
 	if vf.eVindexFunc.Opcode == engine.VindexNone {

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -156,7 +156,10 @@ func (vf *vindexFunc) MakeDistinct() error {
 }
 
 // PushGroupBy satisfies the builder interface.
-func (vf *vindexFunc) PushGroupBy(_ sqlparser.GroupBy) error {
+func (vf *vindexFunc) PushGroupBy(groupBy sqlparser.GroupBy) error {
+	if (groupBy) == nil {
+		return nil
+	}
 	return errors.New("unupported: group by on vindex function")
 }
 


### PR DESCRIPTION
This change adds support for constructs like `select count(distinct col)...`.

This construct was previously not supported. In fact, usage of such construct could have returned erroneous results.

With this change, we specifically look for the `distinct` construct and change the behavior of the plan generation accordingly:
1. If there is a group by a unique vindex, everything is pushed down like before.
2. If the `distinct` is on a unique vindex, then we push it down, and then merge aggregate the results. The idea is that there are no overlapping values across shards. So, each shard can accurately report the final distinct aggregation.
3. If none of the above, then we push down the inner expression only, and then add it as part of the group and order by clauses. We modify the ordered aggregate primitive to dedup values (coming from multiple shards), and then apply the aggregation.

Limitations:
* Only one value is allowed.
* Only a simple column reference is allowed.
* There cannot be more than one distinct aggregate.

Implementation notes:
Previously, we were only aggregating from pre-aggregated results. With this new change we are aggregating values from original columns. This requires the primitive to generate its own fields for the distinct aggregate, and also perform necessary data type conversions: int64 for counts, and decimal for sums.

MySQL allows distinct for min and max, but seems to ignore the directive. The implementation has been made to match that behavior.

Signature of PushSelect had to be changed to include `pb`. Access to pb is required to see if the distinct sub-expression has a unique vindex.