### PR TITLE
Try to repair replication even if SQL thread is running.

### DIFF
--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -376,7 +376,9 @@ class TestTabletManager(unittest.TestCase):
                      'unexpected master type: %s' % ti['type'])
 
     # stop replication at the mysql level.
-    tablet_62044.mquery('', 'stop slave')
+    # Stop only the IO thread since we shouldn't care
+    # if the SQL thread is running.
+    tablet_62044.mquery('', 'STOP SLAVE IO_THREAD')
     # vttablet replication_reporter should restart it.
     utils.run_vtctl(['RunHealthCheck', tablet_62044.tablet_alias])
     # insert something on the master and wait for it on the slave.

--- a/test/utils.py
+++ b/test/utils.py
@@ -833,7 +833,7 @@ def run_vtctl(clargs, auto_log=False, expect_fail=False,
       logging.debug('vtctl: %s', ' '.join(clargs))
     result = vtctl_client.execute_vtctl_command(vtctld_connection, clargs,
                                                 info_to_debug=True,
-                                                action_timeout=10)
+                                                action_timeout=20)
     return result, ''
 
   raise Exception('Unknown mode: %s', mode)


### PR DESCRIPTION
The fix we attempt (verify the latest master host:port and START SLAVE) is specifically meant to address when the IO thread is stopped. We shouldn't block recovery just because the SQL thread is running.

This situation (IO thread stopped, SQL thread running) happens if the master has moved to a new host:port, but this replica didn't get the message.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>