### PR TITLE
Add flag to wait for backup instead of starting up empty.

### DIFF
--- a/doc/BackupAndRestore.md
+++ b/doc/BackupAndRestore.md
@@ -168,8 +168,16 @@ to restore a backup to that tablet.
 
 As noted in the [Prerequisites](#prerequisites) section, the flag is
 generally enabled all of the time for all of the tablets in a shard.
-If Vitess cannot find a backup in the Backup Storage system, it just
-starts the vttablet as a new tablet.
+By default, if Vitess cannot find a backup in the Backup Storage system,
+the tablet will start up empty. This behavior allows you to bootstrap a new
+shard before any backups exist.
+
+If the `-wait_for_backup_interval` flag is set to a value greater than zero,
+the tablet will instead keep checking for a backup to appear at that interval.
+This can be used to ensure tablets launched concurrently while an initial backup
+is being seeded for the shard (e.g. uploaded from cold storage or created by
+another tablet) will wait until the proper time and then pull the new backup
+when it's ready.
 
 ``` sh
 vttablet ... -backup_storage_implementation=file \

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -55,6 +55,10 @@ var (
 	// ErrNoBackup is returned when there is no backup.
 	ErrNoBackup = errors.New("no available backup")
 
+	// ErrNoCompleteBackup is returned when there is at least one backup,
+	// but none of them are complete.
+	ErrNoCompleteBackup = errors.New("backup(s) found but none are complete")
+
 	// ErrExistingDB is returned when there's already an active DB.
 	ErrExistingDB = errors.New("skipping restore due to existing database")
 

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -543,7 +542,7 @@ func (be *BuiltinBackupEngine) ExecuteRestore(
 		// There is at least one attempted backup, but none could be read.
 		// This implies there is data we ought to have, so it's not safe to start
 		// up empty.
-		return mysql.Position{}, errors.New("backup(s) found but none could be read, unsafe to start up empty, restart to retry restore")
+		return mysql.Position{}, ErrNoCompleteBackup
 	}
 
 	// Starting from here we won't be able to recover if we get stopped by a cancelled

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"io"
 	"io/ioutil"
@@ -268,7 +267,7 @@ func (be *XtrabackupEngine) ExecuteRestore(
 		// There is at least one attempted backup, but none could be read.
 		// This implies there is data we ought to have, so it's not safe to start
 		// up empty.
-		return zeroPosition, errors.New("backup(s) found but none could be read, unsafe to start up empty, restart to retry restore")
+		return zeroPosition, ErrNoCompleteBackup
 	}
 
 	// Starting from here we won't be able to recover if we get stopped by a cancelled

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -303,9 +303,9 @@ func NewActionAgent(
 	// - restoreFromBackup is not set: we initHealthCheck right away
 	if *restoreFromBackup {
 		go func() {
-			// restoreFromBackup wil just be a regular action
+			// restoreFromBackup will just be a regular action
 			// (same as if it was triggered remotely)
-			if err := agent.RestoreData(batchCtx, logutil.NewConsoleLogger(), false /* deleteBeforeRestore */); err != nil {
+			if err := agent.RestoreData(batchCtx, logutil.NewConsoleLogger(), *waitForBackupInterval, false /* deleteBeforeRestore */); err != nil {
 				println(fmt.Sprintf("RestoreFromBackup failed: %v", err))
 				log.Exitf("RestoreFromBackup failed: %v", err)
 			}

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -131,7 +131,7 @@ func (agent *ActionAgent) RestoreFromBackup(ctx context.Context, logger logutil.
 	l := logutil.NewTeeLogger(logutil.NewConsoleLogger(), logger)
 
 	// now we can run restore
-	err = agent.restoreDataLocked(ctx, l, true /* deleteBeforeRestore */)
+	err = agent.restoreDataLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */)
 
 	// re-run health check to be sure to capture any replication delay
 	agent.runHealthCheckLocked()

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -178,7 +178,7 @@ func TestBackupRestore(t *testing.T) {
 		RelayLogInfoPath:      path.Join(root, "relay-log.info"),
 	}
 
-	if err := destTablet.Agent.RestoreData(ctx, logutil.NewConsoleLogger(), false /* deleteBeforeRestore */); err != nil {
+	if err := destTablet.Agent.RestoreData(ctx, logutil.NewConsoleLogger(), 0 /* waitForBackupInterval */, false /* deleteBeforeRestore */); err != nil {
 		t.Fatalf("RestoreData failed: %v", err)
 	}
 


### PR DESCRIPTION
This allows shard bootstrap workflows that start up tablets concurrently while uploading an initial backup. Once the initial backup is complete, the tablets will restore from it and start serving. Without this, the workflow has to wait for the backup to complete before launching any tablets, which makes it slower and more complex.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>