### PR TITLE
vtgate sql: enforce a max row count limit

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -35,12 +35,18 @@ import (
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
 
+var testMaxMemoryRows = 100
+
 // noopVCursor is used to build other vcursors.
 type noopVCursor struct {
 }
 
 func (t noopVCursor) Context() context.Context {
 	return context.Background()
+}
+
+func (t noopVCursor) MaxMemoryRows() int {
+	return testMaxMemoryRows
 }
 
 func (t noopVCursor) SetContextTimeout(timeout time.Duration) context.CancelFunc {

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -88,6 +88,9 @@ func (jn *Join) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariab
 		} else {
 			result.RowsAffected += uint64(len(rresult.Rows))
 		}
+		if len(result.Rows) > vcursor.MaxMemoryRows() {
+			return nil, fmt.Errorf("in-memory row count exceeded allowed limit of %d", vcursor.MaxMemoryRows())
+		}
 	}
 	return result, nil
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -45,6 +45,9 @@ type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
 
+	// MaxMemoryRows returns the maxMemoryRows flag value.
+	MaxMemoryRows() int
+
 	// SetContextTimeout updates the context and sets a timeout.
 	SetContextTimeout(timeout time.Duration) context.CancelFunc
 

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -75,6 +75,11 @@ func (vc *vcursorImpl) Context() context.Context {
 	return vc.ctx
 }
 
+// MaxMemoryRows returns the maxMemoryRows flag value.
+func (vc *vcursorImpl) MaxMemoryRows() int {
+	return *maxMemoryRows
+}
+
 // SetContextTimeout updates context and sets a timeout.
 func (vc *vcursorImpl) SetContextTimeout(timeout time.Duration) context.CancelFunc {
 	ctx, cancel := context.WithTimeout(vc.ctx, timeout)

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -60,6 +60,7 @@ var (
 	streamBufferSize    = flag.Int("stream_buffer_size", 32*1024, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
 	queryPlanCacheSize  = flag.Int64("gate_query_cache_size", 10000, "gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
 	disableLocalGateway = flag.Bool("disable_local_gateway", false, "if specified, this process will not route any queries to local tablets in the local cell")
+	maxMemoryRows       = flag.Int("max_memory_rows", 30000, "Maximum number of rows that will be held in memory for intermediate results as well as the final result.")
 )
 
 func getTxMode() vtgatepb.TransactionMode {


### PR DESCRIPTION
I've been claiming that vtgate had a max row count limit.
It turns out that I never actually implemented it.
So, here's the implementation.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>