### PR TITLE
vtgate sql: in-memory sorting

### DIFF
--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -182,7 +182,7 @@ func (sh *sortHeap) Less(i, j int) bool {
 			continue
 		}
 		// This is equivalent to:
-		//if !sj.reverse {
+		//if !sh.reverse {
 		//	if order.Desc {
 		//		cmp = -cmp
 		//	}

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -164,10 +164,12 @@ type sortHeap struct {
 	err     error
 }
 
+// Len satisfies sort.Interface and heap.Interface.
 func (sh *sortHeap) Len() int {
 	return len(sh.rows)
 }
 
+// Less satisfies sort.Interface and heap.Interface.
 func (sh *sortHeap) Less(i, j int) bool {
 	for _, order := range sh.orderBy {
 		if sh.err != nil {
@@ -199,14 +201,17 @@ func (sh *sortHeap) Less(i, j int) bool {
 	return true
 }
 
+// Swap satisfies sort.Interface and heap.Interface.
 func (sh *sortHeap) Swap(i, j int) {
 	sh.rows[i], sh.rows[j] = sh.rows[j], sh.rows[i]
 }
 
+// Push satisfies heap.Interface.
 func (sh *sortHeap) Push(x interface{}) {
 	sh.rows = append(sh.rows, x.([]sqltypes.Value))
 }
 
+// Pop satisfies heap.Interface.
 func (sh *sortHeap) Pop() interface{} {
 	n := len(sh.rows)
 	x := sh.rows[n-1]

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"container/heap"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var _ Primitive = (*MemorySort)(nil)
+
+// MemorySort is a primitive that performs in-memory sorting.
+type MemorySort struct {
+	UpperLimit sqltypes.PlanValue
+	OrderBy    []OrderbyParams
+	Input      Primitive
+}
+
+// MarshalJSON serializes the MemorySort into a JSON representation.
+// It's used for testing and diagnostics.
+func (ms *MemorySort) MarshalJSON() ([]byte, error) {
+	marshalMemorySort := struct {
+		Opcode  string
+		MaxRows sqltypes.PlanValue
+		OrderBy []OrderbyParams
+		Input   Primitive
+	}{
+		Opcode:  "MemorySort",
+		MaxRows: ms.UpperLimit,
+		OrderBy: ms.OrderBy,
+		Input:   ms.Input,
+	}
+	return json.Marshal(marshalMemorySort)
+}
+
+// RouteType returns a description of the query routing type used by the primitive.
+func (ms *MemorySort) RouteType() string {
+	return ms.Input.RouteType()
+}
+
+// Execute satisfies the Primtive interface.
+func (ms *MemorySort) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	count, err := ms.fetchCount(bindVars)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := ms.Input.Execute(vcursor, bindVars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+	sh := &sortHeap{
+		rows:    result.Rows,
+		orderBy: ms.OrderBy,
+	}
+	sort.Sort(sh)
+	if sh.err != nil {
+		return nil, sh.err
+	}
+	result.Rows = sh.rows
+	if len(result.Rows) > count {
+		result.Rows = result.Rows[:count]
+		result.RowsAffected = uint64(count)
+	}
+	return result, nil
+}
+
+// StreamExecute satisfies the Primtive interface.
+func (ms *MemorySort) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	count, err := ms.fetchCount(bindVars)
+	if err != nil {
+		return err
+	}
+
+	sh := &sortHeap{
+		orderBy: ms.OrderBy,
+	}
+	err = ms.Input.StreamExecute(vcursor, bindVars, wantfields, func(qr *sqltypes.Result) error {
+		if len(qr.Fields) != 0 {
+			if err := callback(&sqltypes.Result{Fields: qr.Fields}); err != nil {
+				return err
+			}
+		}
+		for _, row := range qr.Rows {
+			heap.Push(sh, streamRow{row: row})
+		}
+		for len(sh.rows) > count {
+			_ = heap.Pop(sh)
+		}
+		if len(sh.rows) > vcursor.MaxMemoryRows() {
+			return fmt.Errorf("in-memory row count exceeded allowed limit of %d", vcursor.MaxMemoryRows())
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if sh.err != nil {
+		return sh.err
+	}
+	sort.Sort(sh)
+	if sh.err != nil {
+		return sh.err
+	}
+	return callback(&sqltypes.Result{Rows: sh.rows})
+}
+
+// GetFields satisfies the Primtive interface.
+func (ms *MemorySort) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return ms.Input.GetFields(vcursor, bindVars)
+}
+
+func (ms *MemorySort) fetchCount(bindVars map[string]*querypb.BindVariable) (int, error) {
+	resolved, err := ms.UpperLimit.ResolveValue(bindVars)
+	if err != nil {
+		return 0, err
+	}
+	num, err := sqltypes.ToUint64(resolved)
+	if err != nil {
+		return 0, err
+	}
+	count := int(num)
+	if count < 0 {
+		return 0, fmt.Errorf("requested limit is out of range: %v", num)
+	}
+	return count, nil
+}
+
+// sortHeap is sorted based on the orderBy params.
+// Implementation is similar to scatterHeap
+type sortHeap struct {
+	rows    [][]sqltypes.Value
+	orderBy []OrderbyParams
+	err     error
+}
+
+func (sh *sortHeap) Len() int {
+	return len(sh.rows)
+}
+
+func (sh *sortHeap) Less(i, j int) bool {
+	for _, order := range sh.orderBy {
+		if sh.err != nil {
+			return true
+		}
+		cmp, err := sqltypes.NullsafeCompare(sh.rows[i][order.Col], sh.rows[j][order.Col])
+		if err != nil {
+			sh.err = err
+			return true
+		}
+		if cmp == 0 {
+			continue
+		}
+		if order.Desc {
+			cmp = -cmp
+		}
+		return cmp < 0
+	}
+	return true
+}
+
+func (sh *sortHeap) Swap(i, j int) {
+	sh.rows[i], sh.rows[j] = sh.rows[j], sh.rows[i]
+}
+
+func (sh *sortHeap) Push(x interface{}) {
+	sh.rows = append(sh.rows, x.([]sqltypes.Value))
+}
+
+func (sh *sortHeap) Pop() interface{} {
+	n := len(sh.rows)
+	x := sh.rows[n-1]
+	sh.rows = sh.rows[:n-1]
+	return x
+}

--- a/go/vt/vtgate/engine/memory_sort_test.go
+++ b/go/vt/vtgate/engine/memory_sort_test.go
@@ -164,7 +164,7 @@ func TestMemorySortStreamExecute(t *testing.T) {
 	}
 }
 
-func TestMemoerySortGetFields(t *testing.T) {
+func TestMemorySortGetFields(t *testing.T) {
 	result := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
 			"col1|col2",

--- a/go/vt/vtgate/engine/memory_sort_test.go
+++ b/go/vt/vtgate/engine/memory_sort_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func TestMemorySortExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|c2",
+		"varbinary|decimal",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"b|2",
+			"a|1",
+			"c|4",
+			"c|3",
+		)},
+	}
+
+	ms := &MemorySort{
+		OrderBy: []OrderbyParams{{
+			Col: 1,
+		}},
+		Input: fp,
+	}
+
+	result, err := ms.Execute(nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResult := sqltypes.MakeTestResult(
+		fields,
+		"a|1",
+		"a|1",
+		"b|2",
+		"c|3",
+		"c|4",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", result, wantResult)
+	}
+
+	fp.rewind()
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewValArg([]byte(":__upper_limit")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms.UpperLimit = upperlimit
+	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
+
+	result, err = ms.Execute(nil, bv, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResult = sqltypes.MakeTestResult(
+		fields,
+		"a|1",
+		"a|1",
+		"b|2",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", result, wantResult)
+	}
+}
+
+func TestMemorySortStreamExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|c2",
+		"varbinary|decimal",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"b|2",
+			"a|1",
+			"c|4",
+			"c|3",
+		)},
+	}
+
+	ms := &MemorySort{
+		OrderBy: []OrderbyParams{{
+			Col: 1,
+		}},
+		Input: fp,
+	}
+
+	var results []*sqltypes.Result
+	err := ms.StreamExecute(noopVCursor{}, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResults := sqltypes.MakeTestStreamingResults(
+		fields,
+		"a|1",
+		"a|1",
+		"b|2",
+		"c|3",
+		"c|4",
+	)
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", results, wantResults)
+	}
+
+	fp.rewind()
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewValArg([]byte(":__upper_limit")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms.UpperLimit = upperlimit
+	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
+
+	results = nil
+	err = ms.StreamExecute(noopVCursor{}, bv, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResults = sqltypes.MakeTestStreamingResults(
+		fields,
+		"a|1",
+		"a|1",
+		"b|2",
+	)
+	if !reflect.DeepEqual(results, wantResults) {
+		r, _ := json.Marshal(results)
+		w, _ := json.Marshal(wantResults)
+		t.Errorf("oa.Execute:\n%s, want\n%s", r, w)
+	}
+}
+
+func TestMemoerySortGetFields(t *testing.T) {
+	result := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1|col2",
+			"int64|varchar",
+		),
+	)
+	fp := &fakePrimitive{results: []*sqltypes.Result{result}}
+
+	ms := &MemorySort{Input: fp}
+
+	got, err := ms.GetFields(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, result) {
+		t.Errorf("l.GetFields:\n%v, want\n%v", got, result)
+	}
+}
+
+func TestMemorySortMultiColumn(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|c2",
+		"varbinary|decimal",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"b|2",
+			"b|1",
+			"c|4",
+			"c|3",
+		)},
+	}
+
+	ms := &MemorySort{
+		OrderBy: []OrderbyParams{{
+			Col: 1,
+		}, {
+			Col:  0,
+			Desc: true,
+		}},
+		Input: fp,
+	}
+
+	result, err := ms.Execute(nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResult := sqltypes.MakeTestResult(
+		fields,
+		"b|1",
+		"a|1",
+		"b|2",
+		"c|3",
+		"c|4",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", result, wantResult)
+	}
+
+	fp.rewind()
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewValArg([]byte(":__upper_limit")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms.UpperLimit = upperlimit
+	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
+
+	result, err = ms.Execute(nil, bv, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantResult = sqltypes.MakeTestResult(
+		fields,
+		"b|1",
+		"a|1",
+		"b|2",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", result, wantResult)
+	}
+}
+
+func TestMemorySortMaxMemoryRows(t *testing.T) {
+	save := testMaxMemoryRows
+	testMaxMemoryRows = 3
+	defer func() { testMaxMemoryRows = save }()
+
+	fields := sqltypes.MakeTestFields(
+		"c1|c2",
+		"varbinary|decimal",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"b|2",
+			"a|1",
+			"c|4",
+			"c|3",
+		)},
+	}
+
+	ms := &MemorySort{
+		OrderBy: []OrderbyParams{{
+			Col: 1,
+		}},
+		Input: fp,
+	}
+
+	err := ms.StreamExecute(noopVCursor{}, nil, false, func(qr *sqltypes.Result) error {
+		return nil
+	})
+	want := "in-memory row count exceeded allowed limit of 3"
+	if err == nil || err.Error() != want {
+		t.Errorf("StreamExecute err: %v, want %v", err, want)
+	}
+}
+
+func TestMemorySortExecuteNoVarChar(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|c2",
+		"varchar|decimal",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"b|2",
+			"a|1",
+			"c|4",
+			"c|3",
+		)},
+	}
+
+	ms := &MemorySort{
+		OrderBy: []OrderbyParams{{
+			Col: 0,
+		}},
+		Input: fp,
+	}
+
+	_, err := ms.Execute(nil, nil, false)
+	want := "types are not comparable: VARCHAR vs VARCHAR"
+	if err == nil || err.Error() != want {
+		t.Errorf("Execute err: %v, want %v", err, want)
+	}
+
+	fp.rewind()
+	err = ms.StreamExecute(noopVCursor{}, nil, false, func(qr *sqltypes.Result) error {
+		return nil
+	})
+	if err == nil || err.Error() != want {
+		t.Errorf("StreamExecute err: %v, want %v", err, want)
+	}
+}

--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -190,10 +190,12 @@ type scatterHeap struct {
 	err     error
 }
 
+// Len satisfies sort.Interface and heap.Interface.
 func (sh *scatterHeap) Len() int {
 	return len(sh.rows)
 }
 
+// Less satisfies sort.Interface and heap.Interface.
 func (sh *scatterHeap) Less(i, j int) bool {
 	for _, order := range sh.orderBy {
 		if sh.err != nil {
@@ -215,14 +217,17 @@ func (sh *scatterHeap) Less(i, j int) bool {
 	return true
 }
 
+// Swap satisfies sort.Interface and heap.Interface.
 func (sh *scatterHeap) Swap(i, j int) {
 	sh.rows[i], sh.rows[j] = sh.rows[j], sh.rows[i]
 }
 
+// Push satisfies heap.Interface.
 func (sh *scatterHeap) Push(x interface{}) {
 	sh.rows = append(sh.rows, x.(streamRow))
 }
 
+// Pop satisfies heap.Interface.
 func (sh *scatterHeap) Pop() interface{} {
 	n := len(sh.rows)
 	x := sh.rows[n-1]

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -85,15 +85,15 @@ type Plan struct {
 	// Mutex to protect the stats
 	mu sync.Mutex
 	// Count of times this plan was executed
-	ExecCount uint64
+	ExecCount uint64 `json:",omitempty"`
 	// Total execution time
-	ExecTime time.Duration
+	ExecTime time.Duration `json:",omitempty"`
 	// Total number of shard queries
-	ShardQueries uint64
+	ShardQueries uint64 `json:",omitempty"`
 	// Total number of rows
-	Rows uint64
+	Rows uint64 `json:",omitempty"`
 	// Total number of errors
-	Errors uint64
+	Errors uint64 `json:",omitempty"`
 }
 
 // AddStats updates the plan execution statistics

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -96,9 +96,6 @@ func (l *limit) PushGroupBy(_ sqlparser.GroupBy) error {
 
 // PushGroupBy satisfies the builder interface.
 func (l *limit) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
-	if len(orderBy) == 0 {
-		return l, nil
-	}
 	return nil, errors.New("limit.PushOrderBy: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/memory_sort.go
+++ b/go/vt/vtgate/planbuilder/memory_sort.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"errors"
+	"fmt"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+var _ builder = (*memorySort)(nil)
+
+// memorySort is the builder for engine.Limit.
+// This gets built if a limit needs to be applied
+// after rows are returned from an underlying
+// operation. Since a limit is the final operation
+// of a SELECT, most pushes are not applicable.
+type memorySort struct {
+	order         int
+	resultColumns []*resultColumn
+	input         builder
+	eMemorySort   *engine.MemorySort
+}
+
+// newMemorySort builds a new memorySort.
+func newMemorySort(bldr builder, orderBy sqlparser.OrderBy) (*memorySort, error) {
+	ms := &memorySort{
+		resultColumns: bldr.ResultColumns(),
+		input:         bldr,
+		eMemorySort:   &engine.MemorySort{},
+	}
+	for _, order := range orderBy {
+		colnum := -1
+		switch expr := order.Expr.(type) {
+		case *sqlparser.SQLVal:
+			var err error
+			if colnum, err = ResultFromNumber(ms.ResultColumns(), expr); err != nil {
+				return nil, err
+			}
+		case *sqlparser.ColName:
+			c := expr.Metadata.(*column)
+			for i, rc := range ms.ResultColumns() {
+				if rc.column == c {
+					colnum = i
+					break
+				}
+			}
+		default:
+			return nil, fmt.Errorf("unsupported: memory sort: complex order by expression: %s", sqlparser.String(expr))
+		}
+		// If column is not found, then the order by is referencing
+		// a column that's not on the select list.
+		if colnum == -1 {
+			return nil, fmt.Errorf("unsupported: memory sort: order by must reference a column in the select list: %s", sqlparser.String(order))
+		}
+		ob := engine.OrderbyParams{
+			Col:  colnum,
+			Desc: order.Direction == sqlparser.DescScr,
+		}
+		ms.eMemorySort.OrderBy = append(ms.eMemorySort.OrderBy, ob)
+	}
+	return ms, nil
+}
+
+// Order satisfies the builder interface.
+func (ms *memorySort) Order() int {
+	return ms.order
+}
+
+// Reorder satisfies the builder interface.
+func (ms *memorySort) Reorder(order int) {
+	ms.input.Reorder(order)
+	ms.order = ms.input.Order() + 1
+}
+
+// Primitive satisfies the builder interface.
+func (ms *memorySort) Primitive() engine.Primitive {
+	ms.eMemorySort.Input = ms.input.Primitive()
+	return ms.eMemorySort
+}
+
+// First satisfies the builder interface.
+func (ms *memorySort) First() builder {
+	return ms.input.First()
+}
+
+// ResultColumns satisfies the builder interface.
+func (ms *memorySort) ResultColumns() []*resultColumn {
+	return ms.resultColumns
+}
+
+// PushFilter satisfies the builder interface.
+func (ms *memorySort) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType string, _ builder) error {
+	return errors.New("memorySort.PushFilter: unreachable")
+}
+
+// PushSelect satisfies the builder interface.
+func (ms *memorySort) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+	return nil, 0, errors.New("memorySort.PushSelect: unreachable")
+}
+
+// MakeDistinct satisfies the builder interface.
+func (ms *memorySort) MakeDistinct() error {
+	return errors.New("memorySort.MakeDistinct: unreachable")
+}
+
+// PushGroupBy satisfies the builder interface.
+func (ms *memorySort) PushGroupBy(_ sqlparser.GroupBy) error {
+	return errors.New("memorySort.PushGroupBy: unreachable")
+}
+
+// PushGroupBy satisfies the builder interface.
+func (ms *memorySort) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
+	return nil, errors.New("memorySort.PushOrderBy: unreachable")
+}
+
+// SetLimit satisfies the builder interface.
+func (ms *memorySort) SetLimit(limit *sqlparser.Limit) error {
+	return errors.New("memorySort.Limit: unreachable")
+}
+
+// SetUpperLimit satisfies the builder interface.
+// This is a no-op because we actually call SetLimit for this primitive.
+// In the future, we may have to honor this call for subqueries.
+func (ms *memorySort) SetUpperLimit(count *sqlparser.SQLVal) {
+	ms.eMemorySort.UpperLimit, _ = sqlparser.NewPlanValue(count)
+}
+
+// PushMisc satisfies the builder interface.
+func (ms *memorySort) PushMisc(sel *sqlparser.Select) {
+	ms.input.PushMisc(sel)
+}
+
+// Wireup satisfies the builder interface.
+func (ms *memorySort) Wireup(bldr builder, jt *jointab) error {
+	return ms.input.Wireup(bldr, jt)
+}
+
+// SupplyVar satisfies the builder interface.
+func (ms *memorySort) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	ms.input.SupplyVar(from, to, col, varname)
+}
+
+// SupplyCol satisfies the builder interface.
+func (ms *memorySort) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	panic("BUG: nothing should depend on ORDER BY")
+}

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -467,7 +467,7 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) (builder, err
 			if err != nil {
 				return nil, err
 			}
-			orderByCol = oa.input.ResultColumns()[num].column
+			orderByCol = oa.resultColumns[num].column
 		case *sqlparser.ColName:
 			orderByCol = expr.Metadata.(*column)
 		default:
@@ -477,19 +477,17 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) (builder, err
 		// Match orderByCol against the group by columns.
 		found := false
 		for j, key := range oa.eaggr.Keys {
-			inputForKey := oa.input.ResultColumns()[key]
-			if inputForKey.column != orderByCol {
+			if oa.resultColumns[key].column != orderByCol {
 				continue
 			}
 
 			found = true
 			referenced[j] = true
+			selOrderBy = append(selOrderBy, order)
 			break
 		}
 		if !found {
 			postSort = true
-		} else {
-			selOrderBy = append(selOrderBy, order)
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -456,6 +456,8 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) (builder, err
 
 	// referenced tracks the keys referenced by the order by clause.
 	referenced := make([]bool, len(oa.eaggr.Keys))
+	postSort := false
+	selOrderBy := make(sqlparser.OrderBy, 0, len(orderBy))
 	for _, order := range orderBy {
 		// Identify the order by column.
 		var orderByCol *column
@@ -485,7 +487,9 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) (builder, err
 			break
 		}
 		if !found {
-			return nil, fmt.Errorf("unsupported: in scatter query: order by column must reference group by expression: %v", sqlparser.String(order))
+			postSort = true
+		} else {
+			selOrderBy = append(selOrderBy, order)
 		}
 	}
 
@@ -499,21 +503,26 @@ func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) (builder, err
 		if err != nil {
 			return nil, fmt.Errorf("generating order by clause: %v", err)
 		}
-		orderBy = append(orderBy, &sqlparser.Order{Expr: col, Direction: sqlparser.AscScr})
+		selOrderBy = append(selOrderBy, &sqlparser.Order{Expr: col, Direction: sqlparser.AscScr})
 	}
 
 	// Append the distinct aggregate if any.
 	if oa.extraDistinct != nil {
-		orderBy = append(orderBy, &sqlparser.Order{Expr: oa.extraDistinct, Direction: sqlparser.AscScr})
+		selOrderBy = append(selOrderBy, &sqlparser.Order{Expr: oa.extraDistinct, Direction: sqlparser.AscScr})
 	}
 
 	// Push down the order by.
 	// It's ok to push the original AST down because all references
 	// should point to the route. Only aggregate functions are originated
 	// by oa, and we currently don't allow the ORDER BY to reference them.
-	_, err := oa.input.PushOrderBy(orderBy)
+	// TODO(sougou): PushOrderBy will return a mergeSort primitive, which
+	// we should ideally replace oa.input with.
+	_, err := oa.input.PushOrderBy(selOrderBy)
 	if err != nil {
 		return nil, err
+	}
+	if postSort {
+		return newMemorySort(oa, orderBy)
 	}
 	return oa, nil
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -157,6 +157,7 @@ func TestPlan(t *testing.T) {
 	testFile(t, "unsupported_cases.txt", vschema)
 	testFile(t, "vindex_func_cases.txt", vschema)
 	testFile(t, "wireup_cases.txt", vschema)
+	testFile(t, "memory_sort_cases.txt", vschema)
 }
 
 func TestOne(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -1,0 +1,228 @@
+# Test cases in this file follow the code in memory_sort.go.
+
+# scatter aggregate order by references ungrouped column
+"select a, b, count(*) from user group by a order by b"
+{
+  "Original": "select a, b, count(*) from user group by a order by b",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 1,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 2
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select a, b, count(*) from user group by a order by a asc",
+        "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by a",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}
+
+# scatter aggregate order by references aggregate expression
+"select a, b, count(*) k from user group by a order by k"
+{
+  "Original": "select a, b, count(*) k from user group by a order by k",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 2
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select a, b, count(*) as k from user group by a order by a asc",
+        "FieldQuery": "select a, b, count(*) as k from user where 1 != 1 group by a",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}
+
+# scatter aggregate order by references multiple non-group-by expressions
+"select a, b, count(*) k from user group by a order by b, a, k"
+{
+  "Original": "select a, b, count(*) k from user group by a order by b, a, k",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 2
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select a, b, count(*) as k from user group by a order by a asc",
+        "FieldQuery": "select a, b, count(*) as k from user where 1 != 1 group by a",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}
+
+# scatter aggregate with memory sort and limit
+"select a, b, count(*) k from user group by a order by k desc limit 10"
+{
+  "Original": "select a, b, count(*) k from user group by a order by k desc limit 10",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 10,
+    "Offset": null,
+    "Input": {
+      "Opcode": "MemorySort",
+      "MaxRows": ":__upper_limit",
+      "OrderBy": [
+        {
+          "Col": 2,
+          "Desc": true
+        }
+      ],
+      "Input": {
+        "Aggregates": [
+          {
+            "Opcode": "count",
+            "Col": 2
+          }
+        ],
+        "Keys": [
+          0
+        ],
+        "Input": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select a, b, count(*) as k from user group by a order by a asc",
+          "FieldQuery": "select a, b, count(*) as k from user where 1 != 1 group by a",
+          "OrderBy": [
+            {
+              "Col": 0,
+              "Desc": false
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+# scatter aggregate with memory sort and order by number
+"select a, b, count(*) k from user group by a order by 1,3"
+{
+  "Original": "select a, b, count(*) k from user group by a order by 1,3",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 2
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select a, b, count(*) as k from user group by a order by 1 asc",
+        "FieldQuery": "select a, b, count(*) as k from user where 1 != 1 group by a",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -159,7 +159,7 @@
 "select col, count(*) from user group by col order by col+1"
 "unsupported: in scatter query: complex order by expression: col + 1"
 
-# Scatter order by and aggregation: order by column myst reference column from select list
+# Scatter order by and aggregation: order by column must reference column from select list
 "select col, count(*) from user group by col order by c1"
 "unsupported: memory sort: order by must reference a column in the select list: c1 asc"
 

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -159,9 +159,9 @@
 "select col, count(*) from user group by col order by col+1"
 "unsupported: in scatter query: complex order by expression: col + 1"
 
-# scatter aggregate order by does not reference group by
-"select a, b, count(*) from user group by a order by b"
-"unsupported: in scatter query: order by column must reference group by expression: b asc"
+# Scatter order by and aggregation: order by column myst reference column from select list
+"select col, count(*) from user group by col order by c1"
+"unsupported: memory sort: order by must reference a column in the select list: c1 asc"
 
 # Aggregates and joins
 "select count(*) from user join user_extra"


### PR DESCRIPTION
This change introduces a new in-memory sorting primitive. Functionality is as follows:
* It can sort up to the max number of in-memory rows allowed. This is the case even if you're using OLAP (streaming) mode.
* It can efficiently handle the case where there's a LIMIT, as long as the limit is less than the max rows allowed.
* It's currently created only if ordered aggregate cannot handle the ordering. The use case is an ordering by an aggregate column, like COUNT.
* It does not handle TEXT columns yet.

I'm working on making it work for other primitives as well as text columns, which will be in separate PRs.