### PR TITLE
Add /debug/liveness handler for liveness checks.

### DIFF
--- a/go/vt/servenv/liveness.go
+++ b/go/vt/servenv/liveness.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"net/http"
+)
+
+// This file registers a handler that immediately responds with HTTP 200 OK.
+// This can be used as a liveness check to make sure the process can pass a
+// minimum bar of functionality: accept a connection and reply unconditionally.
+// The handler is as simple as possible to avoid false negatives for liveness.
+// If the process is actually making progress, albeit slowly, failing the
+// liveness check and restarting the process will likely only make it fall
+// further behind on its backlog.
+
+func init() {
+	http.HandleFunc("/debug/liveness", func(rw http.ResponseWriter, r *http.Request) {
+		// Do nothing. Return success immediately.
+	})
+}

--- a/go/vt/servenv/liveness_test.go
+++ b/go/vt/servenv/liveness_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLivenessHandler(t *testing.T) {
+	server := httptest.NewServer(nil)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/debug/liveness")
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Make sure we can read the body, even though it's empty.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll: %v", err)
+	}
+	t.Logf("body: %q", body)
+}


### PR DESCRIPTION
This is a handler typically used for server liveness checks. If the server can't execute this simple handler, it probably isn't able to do useful work for other incoming requests that actually ask the server to do something. In that case, the watchdog usually assumes the server process is stuck (deadlocked or livelocked) and restarts it.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>

Closes #4480.