### PR TITLE
vreplication: code improvement

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -17,10 +17,14 @@ limitations under the License.
 package vreplication
 
 import (
+	"io"
 	"time"
 
+	"golang.org/x/net/context"
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/log"
 )
 
 // vdbClient is a wrapper on binlogplayer.DBClient.
@@ -83,17 +87,48 @@ func (vc *vdbClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, 
 	return vc.DBClient.ExecuteFetch(query, maxrows)
 }
 
-func (vc *vdbClient) Retry() error {
+// Execute is ExecuteFetch without the maxrows.
+func (vc *vdbClient) Execute(query string) (*sqltypes.Result, error) {
+	return vc.ExecuteFetch(query, 100000)
+}
+
+func (vc *vdbClient) ExecuteWithRetry(ctx context.Context, query string) (*sqltypes.Result, error) {
+	qr, err := vc.Execute(query)
+	for err != nil {
+		if sqlErr, ok := err.(*mysql.SQLError); ok && sqlErr.Number() == mysql.ERLockDeadlock || sqlErr.Number() == mysql.ERLockWaitTimeout {
+			log.Infof("retryable error: %v, waiting for %v and retrying", sqlErr, dbLockRetryDelay)
+			if err := vc.Rollback(); err != nil {
+				return nil, err
+			}
+			time.Sleep(dbLockRetryDelay)
+			// Check context here. Otherwise this can become an infinite loop.
+			select {
+			case <-ctx.Done():
+				return nil, io.EOF
+			default:
+			}
+			qr, err = vc.Retry()
+			continue
+		}
+		return qr, err
+	}
+	return qr, nil
+}
+
+func (vc *vdbClient) Retry() (*sqltypes.Result, error) {
+	var qr *sqltypes.Result
 	for _, q := range vc.queries {
 		if q == "begin" {
 			if err := vc.Begin(); err != nil {
-				return err
+				return nil, err
 			}
 			continue
 		}
-		if _, err := vc.DBClient.ExecuteFetch(q, 10000); err != nil {
-			return err
+		result, err := vc.DBClient.ExecuteFetch(q, 100000)
+		if err != nil {
+			return nil, err
 		}
+		qr = result
 	}
-	return nil
+	return qr, nil
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -89,7 +89,8 @@ func (vc *vdbClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, 
 
 // Execute is ExecuteFetch without the maxrows.
 func (vc *vdbClient) Execute(query string) (*sqltypes.Result, error) {
-	return vc.ExecuteFetch(query, 100000)
+	// Number of rows should never exceed relayLogMaxSize.
+	return vc.ExecuteFetch(query, relayLogMaxSize)
 }
 
 func (vc *vdbClient) ExecuteWithRetry(ctx context.Context, query string) (*sqltypes.Result, error) {
@@ -124,7 +125,8 @@ func (vc *vdbClient) Retry() (*sqltypes.Result, error) {
 			}
 			continue
 		}
-		result, err := vc.DBClient.ExecuteFetch(q, 100000)
+		// Number of rows should never exceed relayLogMaxSize.
+		result, err := vc.DBClient.ExecuteFetch(q, relayLogMaxSize)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -176,8 +176,8 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 		return fmt.Errorf("unexpected event on table %s", rowEvent.TableName)
 	}
 	for _, change := range rowEvent.RowChanges {
-		err := tplan.applyChange(change, func(sql string) error {
-			return vp.exec(ctx, sql)
+		_, err := tplan.applyChange(change, func(sql string) (*sqltypes.Result, error) {
+			return vp.vr.dbClient.ExecuteWithRetry(ctx, sql)
 		})
 		if err != nil {
 			return err
@@ -188,7 +188,7 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 
 func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 	update := binlogplayer.GenerateUpdatePos(vp.vr.id, vp.pos, time.Now().Unix(), ts)
-	if _, err := vp.vr.dbClient.ExecuteFetch(update, 0); err != nil {
+	if _, err := vp.vr.dbClient.Execute(update); err != nil {
 		vp.vr.dbClient.Rollback()
 		return false, fmt.Errorf("error %v updating position", err)
 	}
@@ -204,30 +204,6 @@ func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 		}
 	}
 	return posReached, nil
-}
-
-func (vp *vplayer) exec(ctx context.Context, sql string) error {
-	defer vp.vr.stats.Timings.Record("query", time.Now())
-	_, err := vp.vr.dbClient.ExecuteFetch(sql, 0)
-	for err != nil {
-		if sqlErr, ok := err.(*mysql.SQLError); ok && sqlErr.Number() == mysql.ERLockDeadlock || sqlErr.Number() == mysql.ERLockWaitTimeout {
-			log.Infof("retryable error: %v, waiting for %v and retrying", sqlErr, dbLockRetryDelay)
-			if err := vp.vr.dbClient.Rollback(); err != nil {
-				return err
-			}
-			time.Sleep(dbLockRetryDelay)
-			// Check context here. Otherwise this can become an infinite loop.
-			select {
-			case <-ctx.Done():
-				return io.EOF
-			default:
-			}
-			err = vp.vr.dbClient.Retry()
-			continue
-		}
-		return err
-	}
-	return nil
 }
 
 func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
@@ -400,7 +376,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 			}
 			return io.EOF
 		case binlogdatapb.OnDDLAction_EXEC:
-			if err := vp.exec(ctx, event.Ddl); err != nil {
+			if _, err := vp.vr.dbClient.ExecuteWithRetry(ctx, event.Ddl); err != nil {
 				return err
 			}
 			posReached, err := vp.updatePos(event.Timestamp)
@@ -411,7 +387,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 				return io.EOF
 			}
 		case binlogdatapb.OnDDLAction_EXEC_IGNORE:
-			if err := vp.exec(ctx, event.Ddl); err != nil {
+			if _, err := vp.vr.dbClient.ExecuteWithRetry(ctx, event.Ddl); err != nil {
 				log.Infof("Ignoring error: %v for DDL: %s", err, event.Ddl)
 			}
 			posReached, err := vp.updatePos(event.Timestamp)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -134,7 +134,7 @@ func (vr *vreplicator) readSettings(ctx context.Context) (settings binlogplayer.
 	}
 
 	query := fmt.Sprintf("select count(*) from _vt.copy_state where vrepl_id=%d", vr.id)
-	qr, err := vr.dbClient.ExecuteFetch(query, 10)
+	qr, err := vr.dbClient.Execute(query)
 	if err != nil {
 		// If it's a not found error, create it.
 		merr, isSQLErr := err.(*mysql.SQLError)
@@ -143,13 +143,13 @@ func (vr *vreplicator) readSettings(ctx context.Context) (settings binlogplayer.
 		}
 		log.Info("Looks like _vt.copy_state table may not exist. Trying to create... ")
 		for _, query := range CreateCopyState {
-			if _, merr := vr.dbClient.ExecuteFetch(query, 0); merr != nil {
+			if _, merr := vr.dbClient.Execute(query); merr != nil {
 				log.Errorf("Failed to ensure _vt.copy_state table exists: %v", merr)
 				return settings, numTablesToCopy, err
 			}
 		}
 		// Redo the read.
-		qr, err = vr.dbClient.ExecuteFetch(query, 10)
+		qr, err = vr.dbClient.Execute(query)
 		if err != nil {
 			return settings, numTablesToCopy, err
 		}
@@ -170,7 +170,7 @@ func (vr *vreplicator) setMessage(message string) error {
 		Message: message,
 	})
 	query := fmt.Sprintf("update _vt.vreplication set message=%v where id=%v", encodeString(message), vr.id)
-	if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
+	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}
 	return nil


### PR DESCRIPTION
Returning queries to execute is a bad pattern, and bloats code.
This new pattern delegates the generation and execution to a
single function. Much cleaner code.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>