### PR TITLE
Initial take at supporting topics in messaging

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -317,10 +317,20 @@ func analyzeInsert(ins *sqlparser.Insert, tables map[string]*schema.Table) (plan
 		return plan, nil
 	}
 	tableName := sqlparser.GetTableName(ins.Table)
-	if tableName.IsEmpty() {
+	switch {
+	case tableName.IsTopic():
+		msgTables := getTopicTables()
+		for _, t := range msgTables {
+			// recursively run inserts
+		}
+		plan.Reason = ReasonTopic
+		return plan, nil
+
+	case tableName.IsEmpty():
 		plan.Reason = ReasonTable
 		return plan, nil
 	}
+
 	table, tableErr := plan.setTable(tableName, tables)
 
 	switch {

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -154,6 +154,7 @@ const (
 	ReasonReplace
 	ReasonMultiTable
 	NumReasons
+	ReasonTopic
 )
 
 // Must exactly match order of reason constants.

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -157,6 +157,12 @@ func loadMessageInfo(ta *Table, comment string) error {
 		keyvals[kv[0]] = kv[1]
 	}
 	var err error
+	if ta.MessageInfo.Topic, err = getString(keyvals, "vt_topic"); err != nil {
+		// the topic is an optional value
+		if err.Error() != "attribute vt_topic not specified for message table" {
+			return err
+		}
+	}
 	if ta.MessageInfo.AckWaitDuration, err = getDuration(keyvals, "vt_ack_wait"); err != nil {
 		return err
 	}
@@ -238,4 +244,12 @@ func getNum(in map[string]string, key string) (int, error) {
 		return 0, err
 	}
 	return v, nil
+}
+
+func getString(in map[string]string, key string) (string, error) {
+	sv := in[key]
+	if sv == "" {
+		return 0, fmt.Errorf("attribute %s not specified for message table", key)
+	}
+	return sv, nil
 }

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -99,6 +99,10 @@ type MessageInfo struct {
 	// returned for subscribers.
 	Fields []*querypb.Field
 
+	// Optional topic to subscribe to. Any messages
+	// published to the topic will be added to this table.
+	Topic string
+
 	// AckWaitDuration specifies how long to wait after
 	// the message was first sent. The back-off doubles
 	// every attempt.


### PR DESCRIPTION
This isn't functional, but should describe well enough the approach I am suggesting. With minimal changes to the existing flow, it stores a map of topics on the engine. Then on inserts, it checks to see if the table name references a topic. If so, it recursively replaces the insert statement table with each of the subscribed message table names. Topics are insert only. Updates and deletes only happen on the individual message tables.

Fixes #4940 