### PR TITLE
This adds systemd unit files to run Vitess and an example

### DIFF
--- a/config/systemd/cell@.service
+++ b/config/systemd/cell@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Vitess Service to Configure a Cell
+Requires=network.service
+
+[Service]
+Environment="VTROOT=/vt"
+EnvironmentFile=/etc/vitess/conf/vtctld-%i.conf
+Type=oneshot
+User=vitess
+ExecStart=/bin/bash -c '${VTROOT}/bin/vtctl \
+    -topo_implementation ${TOPO_IMPLEMENTATION} \
+    -topo_global_root ${TOPO_GLOBAL_ROOT} \
+    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+    AddCellInfo \
+    -root ${CELL_ROOT} \
+    -server_address ${CELL_TOPO_SERVER} \
+    %i'
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=vtctld@%i.service

--- a/config/systemd/etcd.service
+++ b/config/systemd/etcd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=etcd service
+Documentation=https://github.com/etcd-io/etcd
+After=network.target
+
+[Service]
+User=etcd
+Type=notify
+Environment=ETCD_DATA_DIR=/var/lib/etcd
+Environment=ETCD_NAME=%m
+ExecStart=/usr/local/bin/etcd \
+   --listen-client-urls http://0.0.0.0:2379 \
+   --advertise-client-urls http://%H:2379 \
+   --listen-peer-urls http://0.0.0.0:2380
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/mysqlctld@.service
+++ b/config/systemd/mysqlctld@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Mysqlctld Service
+Requires=network.service
+
+[Service]
+Environment="VTROOT=/vt"
+Environment="USER=vitess"
+Environment="MYSQL_FLAVOR=MySQL56"
+Environment="VT_MYSQL_ROOT=/usr"
+Environment="MYSQL_PORT=3306"
+Environment="EXTRA_MYSQLCTLD_FLAGS=-alsologtostderr"
+
+EnvironmentFile=/etc/vitess/conf/vttablet-%i.conf
+Type=simple
+Restart=always
+WorkingDirectory=/vt
+User=vitess
+ExecStart=/bin/bash -c '${VTROOT}/bin/mysqlctld \
+     -alsologtostderr \
+     -log_dir ${VTROOT}/tmp \
+     -tablet_uid %i \
+     -init_db_sql_file ${VTROOT}/config/init_db.sql \
+     -mysql_port ${MYSQL_PORT} \
+     ${EXTRA_MYSQLCTLD_FLAGS}'
+
+[Install]
+WantedBy=vitess-cluster.target

--- a/config/systemd/vitess-cluster.target
+++ b/config/systemd/vitess-cluster.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Vitess cluster Mode
+Requires=network.service

--- a/config/systemd/vtctld@.service
+++ b/config/systemd/vtctld@.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Vitess Control Daemon Service
+Requires=network.service
+
+[Service]
+Environment="VTROOT=/vt"
+Environment="USER=vitess"
+Environment="VTCTLD_PORT=15000"
+Environment="GRPC_PORT=15999"
+Environment="EXTRA_VTCTLD_FLAGS=-alsologtostderr"
+EnvironmentFile=/etc/vitess/conf/vtctld-%i.conf
+Type=simple
+Restart=always
+WorkingDirectory=/vt
+User=vitess
+ExecStartPre=/bin/bash -c "${TOPO_PREPARE_COMMAND}"
+ExecStart=/bin/bash -c '${VTROOT}/bin/vtctld \
+    -enable_realtime_stats \
+    -workflow_manager_use_election \
+    -service_map "grpc-vtctl" \
+    -workflow_manager_init \
+    -enable_queries \
+    -cell %i \
+    -log_dir ${VTROOT}/tmp \
+    -port ${VTCTLD_PORT} \
+    -grpc_port ${GRPC_PORT} \
+    -topo_implementation ${TOPO_IMPLEMENTATION} \
+    -topo_global_root ${TOPO_GLOBAL_ROOT} \
+    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+    -web_dir ${VTROOT}/src/vitess.io/vitess/web/vtctld \
+    -web_dir2 ${VTROOT}/src/vitess.io/vitess/web/vtctld2/app \
+    ${EXTRA_VTCTLD_FLAGS}'
+
+[Install]
+WantedBy=vitess-cluster.target

--- a/config/systemd/vtgate@.service
+++ b/config/systemd/vtgate@.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Vitess Gateway Service
+Requires=network.service
+
+[Service]
+Environment="VTROOT=/vt"
+Environment="USER=vitess"
+Environment="VTGATE_PORT=15001"
+Environment="MYSQL_PORT=3306"
+Environment="GRPC_PORT=15991"
+Environment="VTGATE_BUFFER_DURATION=0m10s"
+
+EnvironmentFile=/etc/vitess/conf/vtgate.conf
+Type=simple
+Restart=always
+WorkingDirectory=/vt
+User=vitess
+ExecStart=/bin/bash -c '${VTROOT}/bin/vtgate \
+    -gateway_implementation discoverygateway \
+    -service_map "grpc-vtgateservice" \
+    -tablet_types_to_wait MASTER,REPLICA \
+    -alsologtostderr \
+    -enable_buffer \
+    -buffer_max_failover_duration ${VTGATE_BUFFER_DURATION} \
+    -cell ${CELL} \
+    -cells_to_watch ${CELL}${ADDITIONAL_CELLS} \
+    -mysql_server_port ${MYSQL_PORT} \
+    -grpc_port ${GRPC_PORT} \
+    -port ${VTGATE_PORT} \
+    -topo_implementation ${TOPO_IMPLEMENTATION} \
+    -topo_global_root ${TOPO_GLOBAL_ROOT} \
+    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+    ${EXTRA_VTGATE_FLAGS}'
+
+[Install]
+WantedBy=vitess-cluster.target

--- a/config/systemd/vttablet@.service
+++ b/config/systemd/vttablet@.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Vitess Tablet
+Requires=mysqlctld@%i.service
+
+[Service]
+Environment="VTROOT=/vt"
+Environment="USER=vitess"
+Environment="TABLET_TYPE=replica"
+Environment="TABLET_PORT=15002"
+Environment="GRPC_PORT=16002"
+Environment="MYSQL_PORT=3306"
+Environment="MYSQL_FLAVOR=MySQL56"
+Environment="EXTRA_VTTABLET_FLAGS=-alsologtostderr"
+
+EnvironmentFile=/etc/vitess/conf/vttablet-%i.conf
+Type=simple
+Restart=always
+WorkingDirectory=/vt
+User=vitess
+ExecStart=/bin/bash -c '${VTROOT}/bin/vttablet \
+    -tablet_hostname "%H" \
+    -service_map "grpc-queryservice,grpc-tabletmanager,grpc-updatestream" \
+    -binlog_use_v3_resharding_mode \
+    -enable_replication_reporter \
+    -health_check_interval 5s \
+    -alsologtostderr \
+    -init_keyspace ${KEYSPACE} \
+    -init_shard ${SHARD}\
+    -init_tablet_type ${TABLET_TYPE} \
+    -mycnf_mysql_port ${MYSQL_PORT} \
+    -port ${TABLET_PORT} \
+    -grpc_port ${GRPC_PORT} \
+    -tablet-path ${CELL}-%i \
+    -log_dir ${VTROOT}/tmp \
+    -topo_implementation ${TOPO_IMPLEMENTATION} \
+    -topo_global_root ${TOPO_GLOBAL_ROOT} \
+    -topo_global_server_address ${TOPO_GLOBAL_SERVER_ADDRESS} \
+    ${EXTRA_VTTABLET_FLAGS}'
+
+[Install]
+WantedBy=vitess-cluster.target

--- a/examples/terraform/distro.sh
+++ b/examples/terraform/distro.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This script will create a vitess_distro.tgz file to be used with a terraform deploy
+
+tar cfvz vitess_distro.tgz $GOPATH/src/vitess.io/vitess/config $GOPATH/src/vitess.io/vitess/web $GOPATH/src/vitess.io/vitess/build $GOPATH/bin/vt* $GOPATH/bin/mysqlctl*

--- a/examples/terraform/ec2/loadbalancer.tf
+++ b/examples/terraform/ec2/loadbalancer.tf
@@ -1,0 +1,67 @@
+resource "aws_lb" "vitess" {
+  name="vitess-${var.cluster-name}"
+  load_balancer_type = "network"
+  subnets = ["${data.aws_subnet_ids.all.ids}"]
+  enable_cross_zone_load_balancing = true
+  
+  tags = {
+    Cluster = "${var.cluster-name}"
+  }  
+}
+
+resource "aws_lb_target_group" "vtgate" {
+  name = "vitess-${var.cluster-name}-vtgate-tg"
+  vpc_id = "${data.aws_vpc.default.id}"  
+  target_type = "instance"
+  protocol = "TCP"
+  port = "3306"
+}
+
+resource "aws_lb_listener" "vtgate" {
+  load_balancer_arn = "${aws_lb.vitess.arn}"
+  port = "3306"
+  protocol =  "TCP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.vtgate.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "vtgate-ui" {
+  name = "vitess-${var.cluster-name}-vtgate-ui-tg"
+  vpc_id = "${data.aws_vpc.default.id}"  
+  target_type = "instance"
+  protocol = "TCP"
+  port = "15001"
+}
+
+resource "aws_lb_listener" "vtgate-ui" {
+  load_balancer_arn = "${aws_lb.vitess.arn}"
+  port = "15001"
+  protocol =  "TCP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.vtgate-ui.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "vtctld" {
+  name = "vitess-${var.cluster-name}-vtctld-tg"
+  vpc_id = "${data.aws_vpc.default.id}"
+  target_type = "instance"
+  protocol = "TCP"
+  port = "15000"
+}
+
+resource "aws_lb_listener" "vtctld" {
+  load_balancer_arn = "${aws_lb.vitess.arn}"
+  port = "15000"
+  protocol =  "TCP"
+
+  default_action {
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.vtctld.arn}"
+  }
+}

--- a/examples/terraform/ec2/main.tf
+++ b/examples/terraform/ec2/main.tf
@@ -1,0 +1,122 @@
+variable "region" {
+  default="us-west-1"
+}
+
+variable "instance-type" {
+  default="t3.medium"
+}
+
+variable "cluster-name" {
+  default="vitess"
+}
+
+variable "keyspace-name" {
+  default="messagedb"
+}
+
+variable "mysql-user" {
+  default="mysql_user"
+}
+
+variable "mysql-password" {
+  default="mysql_password"
+}
+
+variable "public-key" {}
+
+locals{
+  cell-name="${replace(var.region,"-","")}"
+}
+
+provider "aws" {
+  region="${var.region}"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [
+      "amzn2-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+
+  filter {
+    name = "owner-alias"
+    values = [
+      "amazon",
+    ]
+  }
+}
+
+resource "aws_key_pair" "key" {
+  key_name = "yubikey"
+  public_key = "${var.public-key}"
+}
+
+resource "aws_security_group" "default" {
+  name = "${var.cluster-name}-default"
+  description = "A security group for the vitess hosts"
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+resource "aws_security_group_rule" "egress-all" {
+  type="egress"
+  from_port=0
+  to_port=0
+  protocol = "-1"
+  cidr_blocks =["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "internal" {
+  type="ingress"
+  from_port=0
+  to_port=0
+  protocol = "-1"
+
+  security_group_id = "${aws_security_group.default.id}"
+  source_security_group_id = "${aws_security_group.default.id}"  
+}
+
+resource "aws_security_group_rule" "inbound-ssh" {
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "inbound-mysql" {
+  type = "ingress"
+  from_port = 3306
+  to_port = 3306
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "inbound-vitess" {
+  type = "ingress"
+  from_port = 15000
+  to_port = 19000
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.default.id}"
+}
+

--- a/examples/terraform/ec2/modules/tablet.tf
+++ b/examples/terraform/ec2/modules/tablet.tf
@@ -1,0 +1,190 @@
+variable "config-map" {
+  type = object({
+    name = string
+    ami = string
+    instance-type = string
+    key-name = string
+    security-groups = list(string)
+    mysql-user = string
+    mysql-password = string
+    etcd-address = string
+    
+  })
+  description = "A configuration object to group common components
+"
+}
+
+variable "cell" {
+}
+
+variable "keyspace" {
+}
+
+variable "shard" {
+}
+
+variable "with-vtgate" {
+  default=true
+}
+
+resource "aws_instance" "tablet" {
+  ami           = "${var.config-map.ami}"
+  instance_type = "${var.config-map.instance-type}"
+  key_name = "${var.config-map.key-name}"
+  vpc_security_group_ids = "${var.config-amp.security-groups}"
+  
+  tags = {
+    Name = "${var.config-map.name}-vttablet"
+    Cluster = "${var.config-map.name}"
+    Component = "vttablet,vtgate"
+  }
+  
+  provisioner "file" {
+    source="vitess_distro.tgz"
+    destination="/tmp/vitess_distro.tgz"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+{
+	"${var.config-map.mysql-user}": [
+		{
+			"Password": "${var.config-map.mysql-password}",
+			"UserData": "${var.config-map.mysql-user}"
+		}
+	]
+}
+EOT
+    destination = "/tmp/userdata.json"
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+  
+  provisioner "file" {
+    content= <<EOT
+CELL=${var.cell}
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.config-map.name}
+TOPO_GLOBAL_SERVER_ADDRESS=${var.config-map.etcd-address}
+
+EXTRA_VTGATE_FLAGS="-mysql_auth_server_impl static -mysql_auth_server_static_file=/etc/vitess/userdata.json"
+EOT
+    destination="/tmp/vtgate.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+CELL=${var.cell-name}
+KEYSPACE=${var.keyspace}
+SHARD="-"
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+GRPC_PORT=16002
+TABLET_PORT=17002
+MYSQL_PORT=18002
+MYSQL_FLAVOR=MariaDB103
+VT_MYSQL_ROOT=/usr
+EOT
+    destination="/tmp/vttablet-1001.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+CELL=${local.cell-name}
+KEYSPACE=${var.keyspace-name}
+SHARD="-"
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+GRPC_PORT=16003
+TABLET_PORT=17003
+MYSQL_PORT=18003
+MYSQL_FLAVOR=MariaDB103
+VT_MYSQL_ROOT=/usr
+EOT
+    destination="/tmp/vttablet-1002.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+  
+  provisioner "file" {
+    content= <<EOT
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOT
+    destination="/tmp/MariaDB.repo"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo useradd vitess",
+      "sudo mv /tmp/MariaDB.repo /etc/yum.repos.d/",
+      "sudo rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB",
+      "sudo yum install -y MariaDB-server galera MariaDB-client MariaDB-shared MariaDB-backup MariaDB-common",
+      "curl -L https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz -o - | sudo tar xfvz - -C /usr/local/bin/ --strip-components=1 etcd-v3.3.12-linux-amd64/etcdctl etcd-v3.3.12-linux-amd64/etcd",
+      "sudo mkdir /vt",
+      "sudo tar xfvz /tmp/vitess_distro.tgz -C /vt",
+      "sudo cp /vt/src/vitess.io/vitess/config/systemd/* /etc/systemd/system/",
+      "sudo mkdir -p /etc/vitess/conf",
+      "sudo mv /tmp/vtgate.conf /tmp/vttablet-1001.conf /tmp/vttablet-1002.conf /etc/vitess/conf/",
+      "sudo mv /tmp/userdata.json /etc/vitess/",      
+      "sudo chown -R vitess:vitess /vt",
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable vtgate@1.service",
+      "sudo systemctl enable mysqlctld@1001.service",
+      "sudo systemctl enable mysqlctld@1002.service",
+      "sudo systemctl enable vttablet@1001.service",
+      "sudo systemctl enable vttablet@1002.service",                  
+      "sudo systemctl enable vitess-cluster.target",
+      "sudo systemctl start vitess-cluster.target"
+    ]
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+}
+
+resource "aws_lb_target_group_attachment" "vtgate-1000" {
+  target_group_arn="${aws_lb_target_group.vtgate.arn}"
+  target_id = "${aws_instance.vttablet-1000.id}"
+  port = 3306
+}
+
+resource "aws_lb_target_group_attachment" "vtgate-ui-1000" {
+  target_group_arn="${aws_lb_target_group.vtgate-ui.arn}"
+  target_id = "${aws_instance.vttablet-1000.id}"
+  port = 15001
+}

--- a/examples/terraform/ec2/vtctld.tf
+++ b/examples/terraform/ec2/vtctld.tf
@@ -1,0 +1,105 @@
+resource "aws_network_interface" "vtctld" {
+  subnet_id="${data.aws_subnet_ids.all.ids[0]}"
+  security_groups = ["${aws_security_group.default.id}"]  
+}
+
+resource "aws_eip" "vtctld" {
+  vpc=true
+  network_interface="${aws_network_interface.vtctld.id}"
+}
+
+resource "aws_instance" "vtctld" {
+  ami           = "${data.aws_ami.amazon_linux.id}"
+  instance_type = "${var.instance-type}"
+  key_name = "${aws_key_pair.key.key_name}"
+  
+  tags = {
+    Name = "${var.cluster-name}-vtctld"
+    Cluster = "${var.cluster-name}"
+    Component = "vtctld"
+  }
+
+  network_interface {
+    device_index            = 0
+    network_interface_id    = "${aws_network_interface.vtctld.id}"
+  }
+  
+  provisioner "file" {
+    source="vitess_distro.tgz"
+    destination="/tmp/vitess_distro.tgz"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+CELL_ROOT=/vitess/${var.cluster-name}/${local.cell-name}
+CELL_TOPO_SERVER=${aws_eip.vtctld.private_dns}:2379
+EOT
+    destination="/tmp/vtctld-${local.cell-name}.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOT
+    destination="/tmp/MariaDB.repo"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo useradd vitess",
+      "sudo useradd etcd",
+      "sudo mkdir /var/lib/etcd",
+      "sudo chown -R etcd:etcd /var/lib/etcd",
+      "sudo mv /tmp/MariaDB.repo /etc/yum.repos.d/",
+      "sudo rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB",
+      "sudo yum install -y MariaDB-server galera MariaDB-client MariaDB-shared MariaDB-backup MariaDB-common",
+      "curl -L https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz -o - | sudo tar xfvz - -C /usr/local/bin/ --strip-components=1 etcd-v3.3.12-linux-amd64/etcdctl etcd-v3.3.12-linux-amd64/etcd",
+      "sudo mkdir /vt",
+      "sudo tar xfvz /tmp/vitess_distro.tgz -C /vt",
+      "sudo cp /vt/src/vitess.io/vitess/config/systemd/* /etc/systemd/system/",
+      "sudo mkdir -p /etc/vitess/conf",
+      "sudo mv /tmp/vtctld-${local.cell-name}.conf /etc/vitess/conf/",
+      "sudo chown -R vitess:vitess /vt",
+      "sudo systemctl daemon-reload",
+      "sudo systemctl start etcd.service",
+      "sudo systemctl enable vtctld@${local.cell-name}.service",
+      "sudo systemctl enable cell@${local.cell-name}.service",
+      "sudo systemctl enable vitess-cluster.target",
+      "sudo systemctl start vitess-cluster.target"
+    ]
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+}
+
+resource "aws_lb_target_group_attachment" "vtctld-1" {
+  target_group_arn="${aws_lb_target_group.vtctld.arn}"
+  target_id = "${aws_instance.vtctld.id}"
+  port = 15000
+}

--- a/examples/terraform/ec2/vttablet.tf
+++ b/examples/terraform/ec2/vttablet.tf
@@ -1,0 +1,161 @@
+resource "aws_instance" "vttablet-1000" {
+  ami           = "${data.aws_ami.amazon_linux.id}"
+  instance_type = "${var.instance-type}"
+  key_name = "${aws_key_pair.key.key_name}"
+  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  
+  tags = {
+    Name = "${var.cluster-name}-vttablet"
+    Cluster = "${var.cluster-name}"
+    Component = "vttablet,vtgate"
+  }
+  
+  provisioner "file" {
+    source="vitess_distro.tgz"
+    destination="/tmp/vitess_distro.tgz"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+{
+	"${var.mysql-user}": [
+		{
+			"Password": "${var.mysql-password}",
+			"UserData": "${var.mysql-user}"
+		}
+	]
+}
+EOT
+    destination = "/tmp/userdata.json"
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+  
+  provisioner "file" {
+    content= <<EOT
+CELL=${local.cell-name}
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+EXTRA_VTGATE_FLAGS="-mysql_auth_server_impl static -mysql_auth_server_static_file=/etc/vitess/userdata.json"
+EOT
+    destination="/tmp/vtgate.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+CELL=${local.cell-name}
+KEYSPACE=${var.keyspace-name}
+SHARD="-"
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+GRPC_PORT=16002
+TABLET_PORT=17002
+MYSQL_PORT=18002
+MYSQL_FLAVOR=MariaDB103
+VT_MYSQL_ROOT=/usr
+EOT
+    destination="/tmp/vttablet-1001.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+
+  provisioner "file" {
+    content= <<EOT
+CELL=${local.cell-name}
+KEYSPACE=${var.keyspace-name}
+SHARD="-"
+TOPO_IMPLEMENTATION=etcd2
+TOPO_GLOBAL_ROOT=/vitess/${var.cluster-name}
+TOPO_GLOBAL_SERVER_ADDRESS=${aws_eip.vtctld.private_dns}:2379
+
+GRPC_PORT=16003
+TABLET_PORT=17003
+MYSQL_PORT=18003
+MYSQL_FLAVOR=MariaDB103
+VT_MYSQL_ROOT=/usr
+EOT
+    destination="/tmp/vttablet-1002.conf"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }    
+  }
+  
+  provisioner "file" {
+    content= <<EOT
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOT
+    destination="/tmp/MariaDB.repo"
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo useradd vitess",
+      "sudo mv /tmp/MariaDB.repo /etc/yum.repos.d/",
+      "sudo rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB",
+      "sudo yum install -y MariaDB-server galera MariaDB-client MariaDB-shared MariaDB-backup MariaDB-common",
+      "curl -L https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz -o - | sudo tar xfvz - -C /usr/local/bin/ --strip-components=1 etcd-v3.3.12-linux-amd64/etcdctl etcd-v3.3.12-linux-amd64/etcd",
+      "sudo mkdir /vt",
+      "sudo tar xfvz /tmp/vitess_distro.tgz -C /vt",
+      "sudo cp /vt/src/vitess.io/vitess/config/systemd/* /etc/systemd/system/",
+      "sudo mkdir -p /etc/vitess/conf",
+      "sudo mv /tmp/vtgate.conf /tmp/vttablet-1001.conf /tmp/vttablet-1002.conf /etc/vitess/conf/",
+      "sudo mv /tmp/userdata.json /etc/vitess/",      
+      "sudo chown -R vitess:vitess /vt",
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable vtgate@1.service",
+      "sudo systemctl enable mysqlctld@1001.service",
+      "sudo systemctl enable mysqlctld@1002.service",
+      "sudo systemctl enable vttablet@1001.service",
+      "sudo systemctl enable vttablet@1002.service",                  
+      "sudo systemctl enable vitess-cluster.target",
+      "sudo systemctl start vitess-cluster.target"
+    ]
+
+    connection {
+      type = "ssh"
+      user = "ec2-user"
+    }
+  }
+}
+
+resource "aws_lb_target_group_attachment" "vtgate-1000" {
+  target_group_arn="${aws_lb_target_group.vtgate.arn}"
+  target_id = "${aws_instance.vttablet-1000.id}"
+  port = 3306
+}
+
+resource "aws_lb_target_group_attachment" "vtgate-ui-1000" {
+  target_group_arn="${aws_lb_target_group.vtgate-ui.arn}"
+  target_id = "${aws_instance.vttablet-1000.id}"
+  port = 15001
+}


### PR DESCRIPTION
This adds in vitess systemd unit files. These unit files need
configuration and enabling on the system they are being used on. An
example using terraform to create AWS infrastructure and configure the
tablets is provided in the examples folder

Signed-off-by: Dan Kozlowski <koz@planetscale.com>