### PR TITLE
use English quotes in the comment of vtgate.proto

### DIFF
--- a/proto/vtgate.proto
+++ b/proto/vtgate.proto
@@ -748,7 +748,7 @@ message SplitQueryRequest {
   // SELECT <cols> FROM <table> WHERE <filter>.
   // It must not contain subqueries nor any of the keywords
   // JOIN, GROUP BY, ORDER BY, LIMIT, DISTINCT.
-  // Furthermore, <table> must be a single “concrete” table.
+  // Furthermore, <table> must be a single "concrete" table.
   // It cannot be a view.
   query.BoundQuery query = 3;
 


### PR DESCRIPTION
Hi, 

When I imported `vtgate.proto` to my own proto file and generated a java file for it, I got the following error: `.../io/vitess/proto/Vtgate.java:55353:1: unmappable character for encoding ASCII`. By looking at the source code of `vtgate.proto`, it turned out that the quotes were not ASCII chars. 

This PR fixed the error by replacing the old quotes with the English quotes.