### PR TITLE
vtgate sql: make memorySort more composable

### DIFF
--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vttest"
 
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -57,7 +58,7 @@ create table vstream_test(
 
 create table aggr_test(
 	id bigint,
-	val1 varbinary(16),
+	val1 varchar(16),
 	val2 bigint,
 	primary key(id)
 ) Engine=InnoDB;
@@ -144,6 +145,10 @@ create table t2_id4_idx(
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "id",
 					Name:   "hash",
+				}},
+				Columns: []*vschemapb.Column{{
+					Name: "val1",
+					Type: sqltypes.VarChar,
 				}},
 			},
 		},

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -121,6 +121,11 @@ func (oa *OrderedAggregate) RouteType() string {
 	return oa.Input.RouteType()
 }
 
+// SetTruncateColumnCount sets the truncate column count.
+func (oa *OrderedAggregate) SetTruncateColumnCount(count int) {
+	oa.TruncateColumnCount = count
+}
+
 // Execute is a Primitive function.
 func (oa *OrderedAggregate) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	qr, err := oa.execute(vcursor, bindVars, wantfields)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -201,6 +201,11 @@ func (route *Route) RouteType() string {
 	return routeName[route.Opcode]
 }
 
+// SetTruncateColumnCount sets the truncate column count.
+func (route *Route) SetTruncateColumnCount(count int) {
+	route.TruncateColumnCount = count
+}
+
 // Execute performs a non-streaming exec.
 func (route *Route) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	if route.QueryTimeout != 0 {

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -61,7 +61,7 @@ type builder interface {
 	// a resultColumn entry and return it. The top level caller
 	// must accumulate these result columns and set the symtab
 	// after analysis.
-	PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error)
+	PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error)
 
 	// MakeDistinct makes the primitive handle the distinct clause.
 	MakeDistinct() error
@@ -100,7 +100,7 @@ type builder interface {
 	// is different from PushSelect because it may reuse an existing
 	// resultColumn, whereas PushSelect guarantees the addition of a new
 	// result column and returns a distinct symbol for it.
-	SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int)
+	SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int)
 
 	// Primitive returns the underlying primitive.
 	// This function should only be called after Wireup is finished.
@@ -147,7 +147,7 @@ func (bc *builderCommon) SupplyVar(from, to int, col *sqlparser.ColName, varname
 	bc.input.SupplyVar(from, to, col, varname)
 }
 
-func (bc *builderCommon) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (bc *builderCommon) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	return bc.input.SupplyCol(col)
 }
 

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -209,7 +209,7 @@ func BuildFromStmt(query string, stmt sqlparser.Statement, vschema ContextVSchem
 	case *sqlparser.Rollback:
 		return nil, errors.New("unsupported construct: rollback")
 	default:
-		panic(fmt.Sprintf("BUG: unexpected statement type: %T", stmt))
+		return nil, fmt.Errorf("BUG: unexpected statement type: %T", stmt)
 	}
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -107,6 +107,50 @@ type builder interface {
 	Primitive() engine.Primitive
 }
 
+// builderCommon implements some common functionality of builders.
+// Make sure to override in case behavior needs to be changed.
+type builderCommon struct {
+	order int
+	input builder
+}
+
+func (bc *builderCommon) Order() int {
+	return bc.order
+}
+
+func (bc *builderCommon) Reorder(order int) {
+	bc.input.Reorder(order)
+	bc.order = bc.input.Order() + 1
+}
+
+func (bc *builderCommon) First() builder {
+	return bc.input.First()
+}
+
+func (bc *builderCommon) ResultColumns() []*resultColumn {
+	return bc.input.ResultColumns()
+}
+
+func (bc *builderCommon) SetUpperLimit(count *sqlparser.SQLVal) {
+	bc.input.SetUpperLimit(count)
+}
+
+func (bc *builderCommon) PushMisc(sel *sqlparser.Select) {
+	bc.input.PushMisc(sel)
+}
+
+func (bc *builderCommon) Wireup(bldr builder, jt *jointab) error {
+	return bc.input.Wireup(bldr, jt)
+}
+
+func (bc *builderCommon) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	bc.input.SupplyVar(from, to, col, varname)
+}
+
+func (bc *builderCommon) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	return bc.input.SupplyCol(col)
+}
+
 // ContextVSchema defines the interface for this package to fetch
 // info about tables.
 type ContextVSchema interface {

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -127,7 +127,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 					return false, err
 				}
 			default:
-				panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", node))
+				return false, fmt.Errorf("BUG: unexpected SELECT type: %T", node)
 			}
 			sqi := subqueryInfo{
 				ast:  node,

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -79,7 +79,7 @@ func (pb *primitiveBuilder) processTableExpr(tableExpr sqlparser.TableExpr) erro
 	case *sqlparser.JoinTableExpr:
 		return pb.processJoin(tableExpr)
 	}
-	panic(fmt.Sprintf("BUG: unexpected table expression type: %T", tableExpr))
+	return fmt.Errorf("BUG: unexpected table expression type: %T", tableExpr)
 }
 
 // processAliasedTable produces a builder subtree for the given AliasedTableExpr.
@@ -105,7 +105,7 @@ func (pb *primitiveBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTabl
 				return err
 			}
 		default:
-			panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", stmt))
+			return fmt.Errorf("BUG: unexpected SELECT type: %T", stmt)
 		}
 
 		subroute, ok := spb.bldr.(*route)
@@ -168,7 +168,7 @@ func (pb *primitiveBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTabl
 		pb.bldr, pb.st = rb, st
 		return nil
 	}
-	panic(fmt.Sprintf("BUG: unexpected table expression type: %T", tableExpr.Expr))
+	return fmt.Errorf("BUG: unexpected table expression type: %T", tableExpr.Expr)
 }
 
 // buildTablePrimitive builds a primitive based on the table name.

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -70,7 +70,7 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 	case sqlparser.Values:
 		rows = insertValues
 	default:
-		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", insertValues))
+		return nil, fmt.Errorf("BUG: unexpected construct in insert: %T", insertValues)
 	}
 	if eins.Table.AutoIncrement == nil {
 		eins.Query = generateQuery(ins)
@@ -137,7 +137,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", insertValues))
+		return nil, fmt.Errorf("BUG: unexpected construct in insert: %T", insertValues)
 	}
 	for _, value := range rows {
 		if len(ins.Columns) != len(value) {

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -228,7 +228,7 @@ func (jb *join) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 				return nil, err
 			}
 			if jb.ResultColumns()[num].column.Origin().Order() > jb.Left.Order() {
-				return nil, errors.New("unsupported: order by spans across shards")
+				return newMemorySort(jb, orderBy)
 			}
 		} else {
 			// Analyze column references within the expression to make sure they all
@@ -246,7 +246,7 @@ func (jb *join) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 				return true, nil
 			}, order.Expr)
 			if err != nil {
-				return nil, err
+				return newMemorySort(jb, orderBy)
 			}
 		}
 	}

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -154,24 +154,24 @@ func (jb *join) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, whereTyp
 }
 
 // PushSelect satisfies the builder interface.
-func (jb *join) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (jb *join) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	if jb.isOnLeft(origin.Order()) {
-		rc, colnum, err = jb.Left.PushSelect(pb, expr, origin)
+		rc, colNumber, err = jb.Left.PushSelect(pb, expr, origin)
 		if err != nil {
 			return nil, 0, err
 		}
-		jb.ejoin.Cols = append(jb.ejoin.Cols, -colnum-1)
+		jb.ejoin.Cols = append(jb.ejoin.Cols, -colNumber-1)
 	} else {
 		// Pushing of non-trivial expressions not allowed for RHS of left joins.
 		if _, ok := expr.Expr.(*sqlparser.ColName); !ok && jb.ejoin.Opcode == engine.LeftJoin {
 			return nil, 0, errors.New("unsupported: cross-shard left join and column expressions")
 		}
 
-		rc, colnum, err = jb.Right.PushSelect(pb, expr, origin)
+		rc, colNumber, err = jb.Right.PushSelect(pb, expr, origin)
 		if err != nil {
 			return nil, 0, err
 		}
-		jb.ejoin.Cols = append(jb.ejoin.Cols, colnum+1)
+		jb.ejoin.Cols = append(jb.ejoin.Cols, colNumber+1)
 	}
 	jb.resultColumns = append(jb.resultColumns, rc)
 	return rc, len(jb.resultColumns) - 1, nil
@@ -316,7 +316,7 @@ func (jb *join) SupplyVar(from, to int, col *sqlparser.ColName, varname string) 
 }
 
 // SupplyCol satisfies the builder interface.
-func (jb *join) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (jb *join) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	c := col.Metadata.(*column)
 	for i, rc := range jb.resultColumns {
 		if rc.column == c {

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -56,7 +56,7 @@ func (l *limit) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType stri
 }
 
 // PushSelect satisfies the builder interface.
-func (l *limit) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (l *limit) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	return nil, 0, errors.New("limit.PushSelect: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -32,46 +32,22 @@ var _ builder = (*limit)(nil)
 // operation. Since a limit is the final operation
 // of a SELECT, most pushes are not applicable.
 type limit struct {
-	order         int
-	resultColumns []*resultColumn
-	input         builder
-	elimit        *engine.Limit
+	builderCommon
+	elimit *engine.Limit
 }
 
 // newLimit builds a new limit.
 func newLimit(bldr builder) *limit {
 	return &limit{
-		resultColumns: bldr.ResultColumns(),
-		input:         bldr,
+		builderCommon: builderCommon{input: bldr},
 		elimit:        &engine.Limit{},
 	}
-}
-
-// Order satisfies the builder interface.
-func (l *limit) Order() int {
-	return l.order
-}
-
-// Reorder satisfies the builder interface.
-func (l *limit) Reorder(order int) {
-	l.input.Reorder(order)
-	l.order = l.input.Order() + 1
 }
 
 // Primitive satisfies the builder interface.
 func (l *limit) Primitive() engine.Primitive {
 	l.elimit.Input = l.input.Primitive()
 	return l.elimit
-}
-
-// First satisfies the builder interface.
-func (l *limit) First() builder {
-	return l.input.First()
-}
-
-// ResultColumns satisfies the builder interface.
-func (l *limit) ResultColumns() []*resultColumn {
-	return l.resultColumns
 }
 
 // PushFilter satisfies the builder interface.
@@ -135,24 +111,4 @@ func (l *limit) SetLimit(limit *sqlparser.Limit) error {
 // This is a no-op because we actually call SetLimit for this primitive.
 // In the future, we may have to honor this call for subqueries.
 func (l *limit) SetUpperLimit(count *sqlparser.SQLVal) {
-}
-
-// PushMisc satisfies the builder interface.
-func (l *limit) PushMisc(sel *sqlparser.Select) {
-	l.input.PushMisc(sel)
-}
-
-// Wireup satisfies the builder interface.
-func (l *limit) Wireup(bldr builder, jt *jointab) error {
-	return l.input.Wireup(bldr, jt)
-}
-
-// SupplyVar satisfies the builder interface.
-func (l *limit) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
-	l.input.SupplyVar(from, to, col, varname)
-}
-
-// SupplyCol satisfies the builder interface.
-func (l *limit) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
-	panic("BUG: nothing should depend on LIMIT")
 }

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -39,7 +39,7 @@ type limit struct {
 // newLimit builds a new limit.
 func newLimit(bldr builder) *limit {
 	return &limit{
-		builderCommon: builderCommon{input: bldr},
+		builderCommon: newBuilderCommon(bldr),
 		elimit:        &engine.Limit{},
 	}
 }

--- a/go/vt/vtgate/planbuilder/memory_sort.go
+++ b/go/vt/vtgate/planbuilder/memory_sort.go
@@ -40,7 +40,7 @@ type memorySort struct {
 // newMemorySort builds a new memorySort.
 func newMemorySort(bldr builder, orderBy sqlparser.OrderBy) (*memorySort, error) {
 	ms := &memorySort{
-		builderCommon: builderCommon{input: bldr},
+		builderCommon: newBuilderCommon(bldr),
 		resultColumns: bldr.ResultColumns(),
 		eMemorySort:   &engine.MemorySort{},
 	}

--- a/go/vt/vtgate/planbuilder/memory_sort.go
+++ b/go/vt/vtgate/planbuilder/memory_sort.go
@@ -45,18 +45,18 @@ func newMemorySort(bldr builder, orderBy sqlparser.OrderBy) (*memorySort, error)
 		eMemorySort:   &engine.MemorySort{},
 	}
 	for _, order := range orderBy {
-		colnum := -1
+		colNumber := -1
 		switch expr := order.Expr.(type) {
 		case *sqlparser.SQLVal:
 			var err error
-			if colnum, err = ResultFromNumber(ms.ResultColumns(), expr); err != nil {
+			if colNumber, err = ResultFromNumber(ms.ResultColumns(), expr); err != nil {
 				return nil, err
 			}
 		case *sqlparser.ColName:
 			c := expr.Metadata.(*column)
 			for i, rc := range ms.ResultColumns() {
 				if rc.column == c {
-					colnum = i
+					colNumber = i
 					break
 				}
 			}
@@ -65,11 +65,11 @@ func newMemorySort(bldr builder, orderBy sqlparser.OrderBy) (*memorySort, error)
 		}
 		// If column is not found, then the order by is referencing
 		// a column that's not on the select list.
-		if colnum == -1 {
+		if colNumber == -1 {
 			return nil, fmt.Errorf("unsupported: memory sort: order by must reference a column in the select list: %s", sqlparser.String(order))
 		}
 		ob := engine.OrderbyParams{
-			Col:  colnum,
+			Col:  colNumber,
 			Desc: order.Direction == sqlparser.DescScr,
 		}
 		ms.eMemorySort.OrderBy = append(ms.eMemorySort.OrderBy, ob)
@@ -94,7 +94,7 @@ func (ms *memorySort) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereTyp
 }
 
 // PushSelect satisfies the builder interface.
-func (ms *memorySort) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (ms *memorySort) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	return nil, 0, errors.New("memorySort.PushSelect: unreachable")
 }
 

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -33,41 +33,19 @@ var _ builder = (*mergeSort)(nil)
 // Since ORDER BY happens near the end of the SQL processing,
 // most functions of this primitive are unreachable.
 type mergeSort struct {
-	order int
-	input *route
+	builderCommon
 }
 
 // newMergeSort builds a new mergeSort.
 func newMergeSort(rb *route) *mergeSort {
 	return &mergeSort{
-		input: rb,
+		builderCommon: builderCommon{input: rb},
 	}
-}
-
-// Order satisfies the builder interface.
-func (ms *mergeSort) Order() int {
-	return ms.order
-}
-
-// Reorder satisfies the builder interface.
-func (ms *mergeSort) Reorder(order int) {
-	ms.input.Reorder(order)
-	ms.order = ms.input.Order() + 1
 }
 
 // Primitive satisfies the builder interface.
 func (ms *mergeSort) Primitive() engine.Primitive {
 	return ms.input.Primitive()
-}
-
-// First satisfies the builder interface.
-func (ms *mergeSort) First() builder {
-	return ms.input.First()
-}
-
-// ResultColumns satisfies the builder interface.
-func (ms *mergeSort) ResultColumns() []*resultColumn {
-	return ms.input.ResultColumns()
 }
 
 // PushFilter satisfies the builder interface.
@@ -95,29 +73,4 @@ func (ms *mergeSort) PushGroupBy(groupBy sqlparser.GroupBy) error {
 // So, this function should never get called.
 func (ms *mergeSort) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 	return nil, errors.New("mergeSort.PushOrderBy: unreachable")
-}
-
-// SetUpperLimit satisfies the builder interface.
-func (ms *mergeSort) SetUpperLimit(count *sqlparser.SQLVal) {
-	ms.input.SetUpperLimit(count)
-}
-
-// PushMisc satisfies the builder interface.
-func (ms *mergeSort) PushMisc(sel *sqlparser.Select) {
-	ms.input.PushMisc(sel)
-}
-
-// Wireup satisfies the builder interface.
-func (ms *mergeSort) Wireup(bldr builder, jt *jointab) error {
-	return ms.input.Wireup(bldr, jt)
-}
-
-// SupplyVar satisfies the builder interface.
-func (ms *mergeSort) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
-	ms.input.SupplyVar(from, to, col, varname)
-}
-
-// SupplyCol satisfies the builder interface.
-func (ms *mergeSort) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
-	return ms.input.SupplyCol(col)
 }

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -39,7 +39,7 @@ type mergeSort struct {
 // newMergeSort builds a new mergeSort.
 func newMergeSort(rb *route) *mergeSort {
 	return &mergeSort{
-		builderCommon: builderCommon{input: rb},
+		builderCommon: newBuilderCommon(rb),
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/merge_sort.go
+++ b/go/vt/vtgate/planbuilder/merge_sort.go
@@ -54,7 +54,7 @@ func (ms *mergeSort) PushFilter(pb *primitiveBuilder, expr sqlparser.Expr, where
 }
 
 // PushSelect satisfies the builder interface.
-func (ms *mergeSort) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (ms *mergeSort) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	return ms.input.PushSelect(pb, expr, origin)
 }
 

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -282,7 +282,7 @@ func (oa *orderedAggregate) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, wh
 // MAX sent to the route will not be added to symtab and will not be reachable by
 // others. This functionality depends on the PushOrderBy to request that
 // the rows be correctly ordered.
-func (oa *orderedAggregate) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (oa *orderedAggregate) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	if inner, ok := expr.Expr.(*sqlparser.FuncExpr); ok {
 		if _, ok := engine.SupportedAggregates[inner.Name.Lowered()]; ok {
 			return oa.pushAggr(pb, expr, origin)
@@ -299,7 +299,7 @@ func (oa *orderedAggregate) PushSelect(pb *primitiveBuilder, expr *sqlparser.Ali
 	return innerRC, len(oa.resultColumns) - 1, nil
 }
 
-func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (oa *orderedAggregate) pushAggr(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	funcExpr := expr.Expr.(*sqlparser.FuncExpr)
 	opcode := engine.SupportedAggregates[funcExpr.Name.Lowered()]
 	if len(funcExpr.Exprs) != 1 {
@@ -396,7 +396,7 @@ func (oa *orderedAggregate) MakeDistinct() error {
 
 // PushGroupBy satisfies the builder interface.
 func (oa *orderedAggregate) PushGroupBy(groupBy sqlparser.GroupBy) error {
-	colnum := -1
+	colNumber := -1
 	for _, expr := range groupBy {
 		switch node := expr.(type) {
 		case *sqlparser.ColName:
@@ -406,11 +406,11 @@ func (oa *orderedAggregate) PushGroupBy(groupBy sqlparser.GroupBy) error {
 			}
 			for i, rc := range oa.resultColumns {
 				if rc.column == c {
-					colnum = i
+					colNumber = i
 					break
 				}
 			}
-			if colnum == -1 {
+			if colNumber == -1 {
 				return errors.New("unsupported: in scatter query: group by column must reference column in SELECT list")
 			}
 		case *sqlparser.SQLVal:
@@ -418,11 +418,11 @@ func (oa *orderedAggregate) PushGroupBy(groupBy sqlparser.GroupBy) error {
 			if err != nil {
 				return err
 			}
-			colnum = num
+			colNumber = num
 		default:
 			return errors.New("unsupported: in scatter query: only simple references allowed")
 		}
-		oa.eaggr.Keys = append(oa.eaggr.Keys, colnum)
+		oa.eaggr.Keys = append(oa.eaggr.Keys, colNumber)
 	}
 	// Append the distinct aggregate if any.
 	if oa.extraDistinct != nil {
@@ -541,11 +541,11 @@ func (oa *orderedAggregate) PushMisc(sel *sqlparser.Select) {
 // compare those instead. This is because we currently don't have the
 // ability to mimic mysql's collation behavior.
 func (oa *orderedAggregate) Wireup(bldr builder, jt *jointab) error {
-	for i, colnum := range oa.eaggr.Keys {
-		if sqltypes.IsText(oa.resultColumns[colnum].column.typ) {
+	for i, colNumber := range oa.eaggr.Keys {
+		if sqltypes.IsText(oa.resultColumns[colNumber].column.typ) {
 			// len(oa.resultColumns) does not change. No harm using the value multiple times.
 			oa.eaggr.TruncateColumnCount = len(oa.resultColumns)
-			oa.eaggr.Keys[i] = oa.input.SupplyWeightString(colnum)
+			oa.eaggr.Keys[i] = oa.input.SupplyWeightString(colNumber)
 		}
 	}
 	return oa.input.Wireup(bldr, jt)
@@ -557,6 +557,6 @@ func (oa *orderedAggregate) SupplyVar(from, to int, col *sqlparser.ColName, varn
 }
 
 // SupplyCol satisfies the builder interface.
-func (oa *orderedAggregate) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (oa *orderedAggregate) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	panic("BUG: nothing should depend on orderedAggregate")
 }

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -553,7 +553,7 @@ func (oa *orderedAggregate) Wireup(bldr builder, jt *jointab) error {
 
 // SupplyVar satisfies the builder interface.
 func (oa *orderedAggregate) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
-	panic("BUG: orderedAggregate should only have atomic nodes under it")
+	oa.input.SupplyVar(from, to, col, varname)
 }
 
 // SupplyCol satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -145,3 +145,8 @@ func (ps *pulloutSubquery) SupplyVar(from, to int, col *sqlparser.ColName, varna
 func (ps *pulloutSubquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	return ps.underlying.SupplyCol(col)
 }
+
+// SupplyWeightString satisfies the builder interface.
+func (ps *pulloutSubquery) SupplyWeightString(colNumber int) (weightcolNumber int, err error) {
+	return ps.underlying.SupplyWeightString(colNumber)
+}

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -143,5 +143,5 @@ func (ps *pulloutSubquery) SupplyVar(from, to int, col *sqlparser.ColName, varna
 
 // SupplyCol satisfies the builder interface.
 func (ps *pulloutSubquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
-	panic("BUG: unreachable")
+	return ps.underlying.SupplyCol(col)
 }

--- a/go/vt/vtgate/planbuilder/pullout_subquery.go
+++ b/go/vt/vtgate/planbuilder/pullout_subquery.go
@@ -87,7 +87,7 @@ func (ps *pulloutSubquery) PushFilter(pb *primitiveBuilder, filter sqlparser.Exp
 }
 
 // PushSelect satisfies the builder interface.
-func (ps *pulloutSubquery) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colnum int, err error) {
+func (ps *pulloutSubquery) PushSelect(pb *primitiveBuilder, expr *sqlparser.AliasedExpr, origin builder) (rc *resultColumn, colNumber int, err error) {
 	return ps.underlying.PushSelect(pb, expr, origin)
 }
 
@@ -142,6 +142,6 @@ func (ps *pulloutSubquery) SupplyVar(from, to int, col *sqlparser.ColName, varna
 }
 
 // SupplyCol satisfies the builder interface.
-func (ps *pulloutSubquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (ps *pulloutSubquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	panic("BUG: unreachable")
 }

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -236,7 +236,7 @@ func (pb *primitiveBuilder) pushSelectRoutes(selectExprs sqlparser.SelectExprs) 
 			}
 			resultColumns = append(resultColumns, rb.PushAnonymous(node))
 		default:
-			panic(fmt.Sprintf("BUG: unexpceted select expression type: %T", node))
+			return nil, fmt.Errorf("BUG: unexpceted select expression type: %T", node)
 		}
 	}
 	return resultColumns, nil

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -44,7 +44,7 @@ type subquery struct {
 // newSubquery builds a new subquery.
 func newSubquery(alias sqlparser.TableIdent, bldr builder) (*subquery, *symtab, error) {
 	sq := &subquery{
-		builderCommon: builderCommon{input: bldr},
+		builderCommon: newBuilderCommon(bldr),
 		esubquery:     &engine.Subquery{},
 	}
 

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -125,7 +125,7 @@ func (sq *subquery) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 	if len(orderBy) == 0 {
 		return sq, nil
 	}
-	return nil, errors.New("unsupported: order by on cross-shard subquery")
+	return newMemorySort(sq, orderBy)
 }
 
 // SupplyCol satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -90,14 +90,14 @@ func (sq *subquery) PushFilter(_ *primitiveBuilder, _ sqlparser.Expr, whereType 
 }
 
 // PushSelect satisfies the builder interface.
-func (sq *subquery) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
+func (sq *subquery) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colNumber int, err error) {
 	col, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok {
 		return nil, 0, errors.New("unsupported: expression on results of a cross-shard subquery")
 	}
 
-	// colnum should already be set for subquery columns.
-	inner := col.Metadata.(*column).colnum
+	// colNumber should already be set for subquery columns.
+	inner := col.Metadata.(*column).colNumber
 	sq.esubquery.Cols = append(sq.esubquery.Cols, inner)
 
 	// Build a new column reference to represent the result column.
@@ -129,7 +129,7 @@ func (sq *subquery) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 }
 
 // SupplyCol satisfies the builder interface.
-func (sq *subquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (sq *subquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	c := col.Metadata.(*column)
 	for i, rc := range sq.resultColumns {
 		if rc.column == c {
@@ -137,9 +137,9 @@ func (sq *subquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum 
 		}
 	}
 
-	// columns that reference subqueries will have their colnum set.
+	// columns that reference subqueries will have their colNumber set.
 	// Let's use it here.
-	sq.esubquery.Cols = append(sq.esubquery.Cols, c.colnum)
+	sq.esubquery.Cols = append(sq.esubquery.Cols, c.colNumber)
 	sq.resultColumns = append(sq.resultColumns, &resultColumn{column: c})
 	return rc, len(sq.resultColumns) - 1
 }

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -436,7 +436,7 @@ func (t *table) addColumn(alias sqlparser.ColIdent, c *column) {
 	lowered := alias.Lowered()
 	// Dups are allowed, but first one wins if referenced.
 	if _, ok := t.columns[lowered]; !ok {
-		c.colnum = len(t.columnNames)
+		c.colNumber = len(t.columnNames)
 		t.columns[lowered] = c
 	}
 	t.columnNames = append(t.columnNames, alias)
@@ -457,7 +457,7 @@ func (t *table) mergeColumn(alias sqlparser.ColIdent, c *column) (*column, error
 	if t.isAuthoritative {
 		return nil, fmt.Errorf("column %v not found in %v", sqlparser.String(alias), sqlparser.String(t.alias))
 	}
-	c.colnum = len(t.columnNames)
+	c.colNumber = len(t.columnNames)
 	t.columns[lowered] = c
 	t.columnNames = append(t.columnNames, alias)
 	return c, nil
@@ -478,13 +478,13 @@ func (t *table) Origin() builder {
 //
 // Two columns are equal if their pointer values match.
 //
-// For subquery and vindexFunc, the colnum is also set because
+// For subquery and vindexFunc, the colNumber is also set because
 // the column order is known and unchangeable.
 type column struct {
-	origin builder
-	st     *symtab
-	typ    querypb.Type
-	colnum int
+	origin    builder
+	st        *symtab
+	typ       querypb.Type
+	colNumber int
 }
 
 // Origin returns the route that originates the column.

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -115,7 +115,66 @@
           "Col": 3,
           "Desc": false
         }
-      ]
+      ],
+      "TruncateColumnCount": 5
+    }
+  }
+}
+
+# scatter group by a text column, reuse existing weight_string
+"select count(*) k, a, textcol1, b from user group by a, textcol1, b order by k, textcol1"
+{
+  "Original": "select count(*) k, a, textcol1, b from user group by a, textcol1, b order by k, textcol1",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 4,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 0
+        }
+      ],
+      "Keys": [
+        1,
+        4,
+        3
+      ],
+      "TruncateColumnCount": 5,
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select count(*) as k, a, textcol1, b, weight_string(textcol1) from user group by a, textcol1, b order by textcol1 asc, a asc, b asc",
+        "FieldQuery": "select count(*) as k, a, textcol1, b, weight_string(textcol1) from user where 1 != 1 group by a, textcol1, b",
+        "OrderBy": [
+          {
+            "Col": 4,
+            "Desc": false
+          },
+          {
+            "Col": 1,
+            "Desc": false
+          },
+          {
+            "Col": 3,
+            "Desc": false
+          }
+        ],
+        "TruncateColumnCount": 5
+      }
     }
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -846,6 +846,54 @@
   }
 }
 
+# order by count distinct
+"select col1, count(distinct col2) k from user group by col1 order by k"
+{
+  "Original": "select col1, count(distinct col2) k from user group by col1 order by k",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 1,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "HasDistinct": true,
+      "Aggregates": [
+        {
+          "Opcode": "count_distinct",
+          "Col": 1,
+          "Alias": "k"
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col1, col2 from user group by col1, col2 order by col1 asc, col2 asc",
+        "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1, col2",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          },
+          {
+            "Col": 1,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}
+
 # scatter aggregate group by aggregate function
 " select count(*) b from user group by b"
 "group by expression cannot reference an aggregate function: b"

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -227,6 +227,63 @@
   }
 }
 
+# scatter aggregate with memory sort and order by number, reuse weight_string
+# we have to use a meaningless construct to test this.
+"select textcol1, count(*) k from user group by textcol1 order by textcol1, k, textcol1"
+{
+  "Original": "select textcol1, count(*) k from user group by textcol1 order by textcol1, k, textcol1",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 2,
+        "Desc": false
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 1
+        }
+      ],
+      "Keys": [
+        2
+      ],
+      "TruncateColumnCount": 3,
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select textcol1, count(*) as k, weight_string(textcol1) from user group by textcol1 order by textcol1 asc, textcol1 asc",
+        "FieldQuery": "select textcol1, count(*) as k, weight_string(textcol1) from user where 1 != 1 group by textcol1",
+        "OrderBy": [
+          {
+            "Col": 2,
+            "Desc": false
+          },
+          {
+            "Col": 2,
+            "Desc": false
+          }
+        ],
+        "TruncateColumnCount": 3
+      }
+    }
+  }
+}
+
 # order by on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t order by id"
 {
@@ -383,6 +440,100 @@
       "Vars": {
         "user_id": 2
       }
+    }
+  }
+}
+
+# Order by for join, on text column in LHS.
+"select u.a, u.textcol1, un.col2 from user u join unsharded un order by u.textcol1, un.col2"
+{
+  "Original": "select u.a, u.textcol1, un.col2 from user u join unsharded un order by u.textcol1, un.col2",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select u.a, u.textcol1, weight_string(u.textcol1) from user as u",
+        "FieldQuery": "select u.a, u.textcol1, weight_string(u.textcol1) from user as u where 1 != 1"
+      },
+      "Right": {
+        "Opcode": "SelectUnsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "select un.col2 from unsharded as un",
+        "FieldQuery": "select un.col2 from unsharded as un where 1 != 1"
+      },
+      "Cols": [
+        -1,
+        -2,
+        1,
+        -3
+      ]
+    }
+  }
+}
+
+# Order by for join, on text column in RHS.
+"select u.a, u.textcol1, un.col2 from unsharded un join user u order by u.textcol1, un.col2"
+{
+  "Original": "select u.a, u.textcol1, un.col2 from unsharded un join user u order by u.textcol1, un.col2",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectUnsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "select un.col2 from unsharded as un",
+        "FieldQuery": "select un.col2 from unsharded as un where 1 != 1"
+      },
+      "Right": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select u.a, u.textcol1, weight_string(u.textcol1) from user as u",
+        "FieldQuery": "select u.a, u.textcol1, weight_string(u.textcol1) from user as u where 1 != 1"
+      },
+      "Cols": [
+        1,
+        2,
+        -1,
+        3
+      ]
     }
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -226,3 +226,208 @@
     }
   }
 }
+
+# order by on a cross-shard subquery
+"select id from (select user.id, user.col from user join user_extra) as t order by id"
+{
+  "Original": "select id from (select user.id, user.col from user join user_extra) as t order by id",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Cols": [
+        0
+      ],
+      "Subquery": {
+        "Opcode": "Join",
+        "Left": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select user.id, user.col from user",
+          "FieldQuery": "select user.id, user.col from user where 1 != 1"
+        },
+        "Right": {
+          "Opcode": "SelectScatter",
+          "Keyspace": {
+            "Name": "user",
+            "Sharded": true
+          },
+          "Query": "select 1 from user_extra",
+          "FieldQuery": "select 1 from user_extra where 1 != 1"
+        },
+        "Cols": [
+          -1,
+          -2
+        ]
+      }
+    }
+  }
+}
+
+# order by on a cross-shard query. Note: this happens only when an order by column is from the second table
+"select user.col1 as a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
+{
+  "Original": "select user.col1 as a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select user.col1 as a, user.col2 as b, user.id from user where user.id = 1",
+        "FieldQuery": "select user.col1 as a, user.col2 as b, user.id from user where 1 != 1",
+        "Vindex": "user_index",
+        "Values": [
+          1
+        ]
+      },
+      "Right": {
+        "Opcode": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select music.col3 as c from music where music.id = :user_id",
+        "FieldQuery": "select music.col3 as c from music where 1 != 1",
+        "Vindex": "music_user_map",
+        "Values": [
+          ":user_id"
+        ]
+      },
+      "Cols": [
+        -1,
+        -2,
+        1
+      ],
+      "Vars": {
+        "user_id": 2
+      }
+    }
+  }
+}
+
+# Order by for join, with mixed cross-shard ordering
+"select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by 1 asc, 3 desc, 2 asc"
+{
+  "Original": "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by 1 asc, 3 desc, 2 asc",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": true
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1",
+        "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+        "Vindex": "user_index",
+        "Values": [
+          1
+        ]
+      },
+      "Right": {
+        "Opcode": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select music.col3 from music where music.id = :user_id",
+        "FieldQuery": "select music.col3 from music where 1 != 1",
+        "Vindex": "music_user_map",
+        "Values": [
+          ":user_id"
+        ]
+      },
+      "Cols": [
+        -1,
+        -2,
+        1
+      ],
+      "Vars": {
+        "user_id": 2
+      }
+    }
+  }
+}
+
+# order by for vindex func
+"select id, keyspace_id, range_start, range_end from user_index where id = :id order by range_start"
+{
+  "Original": "select id, keyspace_id, range_start, range_end from user_index where id = :id order by range_start",
+  "Instructions": {
+    "Opcode": "MemorySort",
+    "MaxRows": null,
+    "OrderBy": [
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "id",
+          "type": 10262
+        },
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        },
+        {
+          "name": "range_start",
+          "type": 10262
+        },
+        {
+          "name": "range_end",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    }
+  }
+}

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -51,17 +51,13 @@
 "update `user[-]@replica`.user_metadata set id=2"
 "unsupported: UPDATE statement with a replica target"
 
-# order by on a cross-shard subquery
-"select id from (select user.id, user.col from user join user_extra) as t order by id"
-"unsupported: order by on cross-shard subquery"
-
-# order by on a cross-shard query. Note: this is only a problem when an order by column is from the second table
-"select user.col1 as a, user.col2 b, music.col3 c from user, music where user.id = music.id and user.id = 1 order by c"
-"unsupported: order by spans across shards"
-
 # scatter order by with * expression
 "select * from user order by id"
 "unsupported: in scatter query: order by must reference a column in the select list: id asc"
+
+# order by rand on a cross-shard subquery
+"select id from (select user.id, user.col from user join user_extra) as t order by rand()"
+"unsupported: memory sort: complex order by expression: rand()"
 
 # filtering on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t where id=5"
@@ -195,21 +191,9 @@
 "select id from user order by id+1"
 "unsupported: in scatter query: complex order by expression: id + 1"
 
-# Order by for join, but sequence is too cross-shard
-"select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by 1 asc, 3 desc, 2 asc"
-"unsupported: order by spans across shards"
-
-# Order by and left join
-"select user.col1 as a, user_extra.col2 as b from user left join user_extra on user_extra.user_id = 5 where user.id = 5 order by 1, 2"
-"unsupported: order by spans across shards"
-
 # Order by column number with collate
 "select user.col1 as a from user order by 1 collate utf8_general_ci"
 "unsupported: in scatter query: complex order by expression: 1 collate utf8_general_ci"
-
-# Order by for join, but order by is cross-shard
-"select user.col1 as a, user_extra.col2 as b from user join user_extra on user_extra.user_id = 5 where user.id = 5 order by a+b"
-"unsupported: order by spans across shards"
 
 # Order by has subqueries
 "select id from unsharded order by (select id from unsharded)"

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -65,7 +65,7 @@ func (pb *primitiveBuilder) processPart(part sqlparser.SelectStatement, outer *s
 	case *sqlparser.ParenSelect:
 		return pb.processPart(part.Select, outer)
 	}
-	panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", part))
+	return fmt.Errorf("BUG: unexpected SELECT type: %T", part)
 }
 
 func unionRouteMerge(union *sqlparser.Union, left, right builder) error {

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -168,7 +168,7 @@ func (vf *vindexFunc) PushOrderBy(orderBy sqlparser.OrderBy) (builder, error) {
 	if len(orderBy) == 0 {
 		return vf, nil
 	}
-	return nil, errors.New("unsupported: order by on vindex function")
+	return newMemorySort(vf, orderBy)
 }
 
 // SetUpperLimit satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -130,7 +130,7 @@ func (vf *vindexFunc) PushFilter(pb *primitiveBuilder, filter sqlparser.Expr, wh
 }
 
 // PushSelect satisfies the builder interface.
-func (vf *vindexFunc) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colnum int, err error) {
+func (vf *vindexFunc) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExpr, _ builder) (rc *resultColumn, colNumber int, err error) {
 	// Catch the case where no where clause was specified. If so, the opcode
 	// won't be set.
 	if vf.eVindexFunc.Opcode == engine.VindexNone {
@@ -146,7 +146,7 @@ func (vf *vindexFunc) PushSelect(_ *primitiveBuilder, expr *sqlparser.AliasedExp
 		Name: rc.alias.String(),
 		Type: querypb.Type_VARBINARY,
 	})
-	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, col.Metadata.(*column).colnum)
+	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, col.Metadata.(*column).colNumber)
 	return rc, len(vf.resultColumns) - 1, nil
 }
 
@@ -192,7 +192,7 @@ func (vf *vindexFunc) SupplyVar(from, to int, col *sqlparser.ColName, varname st
 }
 
 // SupplyCol satisfies the builder interface.
-func (vf *vindexFunc) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+func (vf *vindexFunc) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNumber int) {
 	c := col.Metadata.(*column)
 	for i, rc := range vf.resultColumns {
 		if rc.column == c {
@@ -206,8 +206,8 @@ func (vf *vindexFunc) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnu
 		Type: querypb.Type_VARBINARY,
 	})
 
-	// columns that reference vindexFunc will have their colnum set.
+	// columns that reference vindexFunc will have their colNumber set.
 	// Let's use it here.
-	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, c.colnum)
+	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, c.colNumber)
 	return rc, len(vf.resultColumns) - 1
 }

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -211,3 +211,8 @@ func (vf *vindexFunc) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colNu
 	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, c.colNumber)
 	return rc, len(vf.resultColumns) - 1
 }
+
+// SupplyWeightString satisfies the builder interface.
+func (vf *vindexFunc) SupplyWeightString(colNumber int) (weightcolNumber int, err error) {
+	return 0, errors.New("cannot do collation on vindex function")
+}


### PR DESCRIPTION
Removed some tight coupling that existed between various primitives.
In particular, orderedAggregate now points at builder instead of
a route. Also, mergeSort takes on some of the work that route
previously used to do.

Boilerplate code has been moved to builderCommon and resultsBuilder.
Introduced SupplyWeightString as a required function for all primitives.

This is now used by all primitives that need to order by a text column.

The end result: memorySort can now sort by text columns, and it can
be on top of any primitive, like a join, subquery, etc.