### PR TITLE
Fix RemoveShardCell

### DIFF
--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -353,7 +353,9 @@ func (ts *Server) DeleteSrvKeyspacePartitions(ctx context.Context, keyspace stri
 					for _, si := range shards {
 						found := false
 						for _, shardReference := range partition.GetShardReferences() {
-							if key.KeyRangeEqual(shardReference.GetKeyRange(), si.GetKeyRange()) {
+							// Use shard name rather than key range so it works
+							// for both range-based and non-range-based shards.
+							if shardReference.GetName() == si.ShardName() {
 								found = true
 							}
 						}
@@ -361,7 +363,9 @@ func (ts *Server) DeleteSrvKeyspacePartitions(ctx context.Context, keyspace stri
 						if found {
 							shardReferences := make([]*topodatapb.ShardReference, 0)
 							for _, shardReference := range partition.GetShardReferences() {
-								if !key.KeyRangeEqual(shardReference.GetKeyRange(), si.GetKeyRange()) {
+								// Use shard name rather than key range so it works
+								// for both range-based and non-range-based shards.
+								if shardReference.GetName() != si.ShardName() {
 									shardReferences = append(shardReferences, shardReference)
 								}
 							}

--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -330,14 +330,14 @@ func (wr *Wrangler) RemoveShardCell(ctx context.Context, keyspace, shard, cell s
 	}
 	defer unlock(&err)
 
-	if err = wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_RDONLY, shardServingCells); err != nil {
+	if err = wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_RDONLY, []string{cell}); err != nil {
 		return err
 	}
 
-	if err = wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_REPLICA, shardServingCells); err != nil {
+	if err = wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_REPLICA, []string{cell}); err != nil {
 		return err
 	}
-	return wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_MASTER, shardServingCells)
+	return wr.ts.DeleteSrvKeyspacePartitions(ctx, keyspace, []*topo.ShardInfo{shardInfo}, topodatapb.TabletType_MASTER, []string{cell})
 }
 
 // SourceShardDelete will delete a SourceShard inside a shard, by index.

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -331,6 +331,12 @@ class TestKeyspace(unittest.TestCase):
       self.assertEqual(len(partition['shard_references']), 1,
           'RemoveShardCell should have removed one shard from the target cell: ' +
           json.dumps(srv_keyspace))
+    # Make sure the shard is still serving in test_ca.
+    srv_keyspace = utils.run_vtctl_json(['GetSrvKeyspace', 'test_ca', 'test_delete_keyspace'])
+    for partition in srv_keyspace['partitions']:
+      self.assertEqual(len(partition['shard_references']), 2,
+          'RemoveShardCell should not have changed other cells: ' +
+          json.dumps(srv_keyspace))
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_delete_keyspace'])
 
     utils.run_vtctl(['GetKeyspace', 'test_delete_keyspace'])


### PR DESCRIPTION
This fixes two bugs in the RemoveShardCell command:

* For non-range-based shards, it would remove all non-range-based shards from serving instead of just one shard.
* For any type of shard, it would remove the given shard from serving in all cells instead of just in one cell.