### PR TITLE
update grpc 1.16 to 1.23.0 | protobuf 1.2 to 1.3.2

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -150,7 +150,7 @@ function install_grpc() {
 }
 
 if [ "$BUILD_PYTHON" == 1 ] ; then
-    install_dep "gRPC" "1.16.0" "$VTROOT/dist/grpc" install_grpc
+    install_dep "gRPC" "1.23.0" "$VTROOT/dist/grpc" install_grpc
 fi
 
 # Install protoc.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Define versions which are also used by grpc-client/pom.xml. -->
-    <grpc.version>1.16.0</grpc.version>
+    <grpc.version>1.23.0</grpc.version>
     <!-- NOTE Netty handler and boring SSL must be kept compatible with grpc
       https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
     <netty.handler.version>4.1.30.Final</netty.handler.version>

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -527,10 +527,12 @@
 			"versionExact": "v1.3.2"
 		},
 		{
-			"checksumSHA1": "/vLtyN6HK5twSZIFerD199YTmjk=",
+			"checksumSHA1": "iPZXJz9O67/WHMIgg1zhIZNhajw=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/testdata/multi",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "6c65a5562fc06764971b7c5d05c76c75e84bdbf7",
+			"revisionTime": "2019-07-01T18:22:01Z",
+			"version": "v1.3.2",
+			"versionExact": "v1.3.2"
 		},
 		{
 			"checksumSHA1": "aEiR2m3NGaMGTbUW5P+w5gKFyc8=",
@@ -1687,28 +1689,28 @@
 			"revisionTime": "2019-08-01T16:59:51Z"
 		},
 		{
-			"checksumSHA1": "O6SQTcVdhL+4betKp/7ketCc/AU=",
+			"checksumSHA1": "4Qjz8ReDIfs5OacvsbIwONcqg1w=",
 			"path": "google.golang.org/grpc",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "9KEKKMRAdFnz2sMBXbb33ZLS8Oo=",
+			"checksumSHA1": "5tiVv51BgOdX40/MLyRvKKXPgzo=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "lw+L836hLeH8+//le+C+ycddCCU=",
+			"checksumSHA1": "F7rsfATpHy1yFWGgvW+0q1iqzGY=",
 			"path": "google.golang.org/grpc/balancer/base",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "ZD8cJs3NtFy3pzofoTThBvVVdKU=",
@@ -1727,36 +1729,44 @@
 			"versionExact": "v1.16.0"
 		},
 		{
-			"checksumSHA1": "DJ1AtOk4Pu7bqtUMob95Hw8HPNw=",
+			"checksumSHA1": "cE7mFcyGz0F+EnlTZrzLkhprH/4=",
 			"path": "google.golang.org/grpc/balancer/roundrobin",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "R3tuACGAPyK4lr+oSNt1saUzC0M=",
+			"checksumSHA1": "YyTUFAVju8wgb1s/3azC2CeSbfY=",
+			"path": "google.golang.org/grpc/binarylog/grpc_binarylog_v1",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "e0xLHThZgMNcuR7aFuY+pzuQVVU=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
+			"checksumSHA1": "UgxkVy6e/BMqXrmS21WmcHtdcd4=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "5r6NIQY1c3NjwLtxUOo/BcUOqFo=",
+			"checksumSHA1": "wFNageUqdmmE0U4Zz/mbiDEEXPU=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "RqDVFWVRXNIzSEge/L8JSMskEME=",
@@ -1823,188 +1833,236 @@
 			"versionExact": "v1.16.0"
 		},
 		{
-			"checksumSHA1": "QbufP1o0bXrtd5XecqdRCK/Vl0M=",
-			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "8dea3dc473e90c8179e519d91302d0597c0ca1d1",
-			"revisionTime": "2018-09-11T17:48:51Z",
-			"version": "v1.15.0",
-			"versionExact": "v1.15.0"
+			"checksumSHA1": "hj4XY8K4TjmMZwErpAWaSKFrk2c=",
+			"path": "google.golang.org/grpc/credentials/internal",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "cfLb+pzWB+Glwp82rgfcEST1mv8=",
+			"checksumSHA1": "sFnZthdQsbhUK8DM374dTO521z0=",
+			"path": "google.golang.org/grpc/credentials/oauth",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "puS+9H2qFMoLKCyXxu9nGACNuQk=",
 			"path": "google.golang.org/grpc/encoding",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
 			"path": "google.golang.org/grpc/encoding/proto",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "H7SuPUqbPcdbNqgl+k3ohuwMAwE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
 			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
 			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "ZPPSFisPDz2ANO4FBZIft+fRxyk=",
+			"checksumSHA1": "3hj3attJzO2iqArJeSNEW8diHqo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "QyasSHZlgle+PHSIQ2/p+fr+ihY=",
 			"path": "google.golang.org/grpc/grpclog/glogger",
-			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
-			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.11.2",
-			"versionExact": "v1.11.2"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "LVvnj/+AVrdZMDw0DZ8D/vI24+M=",
+			"checksumSHA1": "K0PObzzd/BphqmUWVKlT5tYTKBk=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "uDJA7QK2iGnEwbd9TPqkLaM+xuU=",
 			"path": "google.golang.org/grpc/internal/backoff",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "V6eyqZJfYh+cX+I/AxPVjkQLjTM=",
+			"checksumSHA1": "k4ITR7VpzDbbf0tRqI6p9xsmPug=",
+			"path": "google.golang.org/grpc/internal/balancerload",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "Wxgih1pu+wvJRT/rCY9WgSMF4w4=",
+			"path": "google.golang.org/grpc/internal/binarylog",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "YtqLJH9Ht2sD5EqAOSqbARDUeXw=",
 			"path": "google.golang.org/grpc/internal/channelz",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "5dFUCEaPjKwza9kwKqgljp8ckU4=",
 			"path": "google.golang.org/grpc/internal/envconfig",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "70gndc/uHwyAl3D45zqp7vyHWlo=",
 			"path": "google.golang.org/grpc/internal/grpcrand",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "0r7S4jTgUIatKqL/8ra0J7Q5iO0=",
+			"checksumSHA1": "psHSfNyU2y9L9zRK+s41e7ScTf4=",
+			"path": "google.golang.org/grpc/internal/grpcsync",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "wTCshPVAgkVAk+4nvDj5Yj6AFp4=",
+			"path": "google.golang.org/grpc/internal/syscall",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "wa2r9RndXlhpxQnK0isQN10ePxU=",
 			"path": "google.golang.org/grpc/internal/transport",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "350+v+N+AuknxomqjND19nR969g=",
+			"checksumSHA1": "cDYDzrrgfj9Y45GDWcXXCrRofp0=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "OjIAi5AzqlQ7kLtdAyjvdgMf6hc=",
+			"checksumSHA1": "0OoJw+Wc7+1Ox5nBbwjgqWW8Xpw=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "VvGBoawND0urmYDy11FT+U1IHtU=",
+			"checksumSHA1": "bk9IupgyMXhqsOBR/dp7ZmRjVEE=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
+			"checksumSHA1": "ltPJN8UyzvWN0H0BvkP2AREujgQ=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "GEq6wwE1qWLmkaM02SjxBmmnHDo=",
+			"checksumSHA1": "Gh13yW3zxiCa1vRGDaWqm1b3/mI=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "grHAHa6Fi3WBsXJpmlEOlRbWWVg=",
+			"checksumSHA1": "GDSzPulWXlL1fSZuT65qIBKhk4E=",
 			"path": "google.golang.org/grpc/resolver/dns",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
+			"checksumSHA1": "voz1mta5+d5bXMGt9SK88Vys2iE=",
 			"path": "google.golang.org/grpc/resolver/passthrough",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
+			"checksumSHA1": "qagX2p0Qp5g2g7FpkNAfMQ94jMo=",
+			"path": "google.golang.org/grpc/serviceconfig",
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
+		},
+		{
+			"checksumSHA1": "3ZPGj/HdfLTiK7I3xPdnqELnHdk=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "hFyBO5vgsMamKhUOSyPCqROk1vo=",
+			"checksumSHA1": "pF8iy9/Pmnt2a8sEAtYtOLQtdHE=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
-			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
+			"checksumSHA1": "HGXDrPBB90iBU4NJ7C1N8MJRkI0=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "2e463a05d100327ca47ac218281906921038fd95",
-			"revisionTime": "2018-10-23T17:37:47Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"revision": "6eaf6f47437a6b4e2153a190160ef39a92c7eceb",
+			"revisionTime": "2019-08-13T19:31:37Z",
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "sg7RY87LaWXaZMj0cuLQQaJJQYo=",
 			"path": "google.golang.org/grpc/transport",
 			"revision": "d89cded64628466c4ab532d1f0ba5c220459ebe8",
 			"revisionTime": "2018-04-04T21:41:50Z",
-			"version": "v1.16.0",
-			"versionExact": "v1.16.0"
+			"version": "v1.23.0",
+			"versionExact": "v1.23.0"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
It has been a long time since we've upgraded these dependencies, so it seems like we should take advantage of bug fixes and hopefully some underlying performance improvements.