### PR TITLE
Added MariaDB103 as a flavor to the vttablet-up script

### DIFF
--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -47,6 +47,9 @@ case "$MYSQL_FLAVOR" in
   "MariaDB")
     export EXTRA_MY_CNF=$EXTRA_MY_CNF:$VTROOT/config/mycnf/master_mariadb.cnf
     ;;
+  "MariaDB103")
+    export EXTRA_MY_CNF=$EXTRA_MY_CNF:$VTROOT/config/mycnf/master_mariadb103.cnf
+    ;;
   *)
     echo "Please set MYSQL_FLAVOR to MySQL56 or MariaDB."
     exit 1


### PR DESCRIPTION
I added MariaDB103 as a valid flavor to the vttablet-up.sh script in examples/local so users that install the latest MariaDB can get up and running with the local tutorial.