### PR TITLE
consistent lookup: handle insert ignore

### DIFF
--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/proto/vtgate"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -205,7 +206,7 @@ func (lu *clCommon) IsFunctional() bool {
 
 // Verify returns true if ids maps to ksids.
 func (lu *clCommon) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
-	return lu.lkp.Verify(vcursor, ids, ksidsToValues(ksids))
+	return lu.lkp.VerifyCustom(vcursor, ids, ksidsToValues(ksids), vtgate.CommitOrder_PRE)
 }
 
 // Create reserves the id by inserting it into the vindex table.

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -178,8 +178,8 @@ func TestConsistentLookupVerify(t *testing.T) {
 		t.Error(err)
 	}
 	vc.verifyLog(t, []string{
-		"Execute select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 1} {toc test1}] false",
-		"Execute select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 2} {toc test2}] false",
+		"ExecutePre select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 1} {toc test1}] false",
+		"ExecutePre select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 2} {toc test2}] false",
 	})
 
 	// Test query fail.


### PR DESCRIPTION
Fixes #4974

Insert ignore wasn't working correctly because the verify was using
the normal transaction instead of the 'pre' transaction where the
rows were actually created.

This implementation changes the consistent lookup's Verify function
to also use the 'pre' transaction always.

There is another code path that gets used if the vindex is unowned.
That will also cause a 'pre' transaction to be created. Without this
change, the transaction would have been a normal one. This mildly
affects the commit order, but there should be no material difference.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>