### PR TITLE
fix last pr bug for etcd-operator label reserved

### DIFF
--- a/examples/kubernetes/etcd-service-template.yaml
+++ b/examples/kubernetes/etcd-service-template.yaml
@@ -10,5 +10,5 @@ spec:
     labels:
       component: etcd
       cell: {{cell}}
-      app: vitess
+      application: vitess
     busyboxImage: "busybox:1.28.0-glibc"


### PR DESCRIPTION
Sorry for the last PR [https://github.com/vitessio/vitess/pull/4970](https://github.com/vitessio/vitess/pull/4970)

"app" and "etcd_*" labels are reserved for the internal use of the etcd operator. [https://github.com/coreos/etcd-operator/blob/master/pkg/apis/etcd/v1beta2/cluster.go#L108](https://github.com/coreos/etcd-operator/blob/master/pkg/apis/etcd/v1beta2/cluster.go#L108)

The current version does not work well, so change label app to application. The new code is work well