### PR TITLE
fix mysql_install_db search path for MySQL 5.6

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -453,7 +453,7 @@ func execCmd(name string, args, env []string, dir string, input io.Reader) (cmd 
 // binaryPath does a limited path lookup for a command,
 // searching only within sbin and bin in the given root.
 func binaryPath(root, binary string) (string, error) {
-	subdirs := []string{"sbin", "bin", "libexec"}
+	subdirs := []string{"sbin", "bin", "libexec", "scripts"}
 	for _, subdir := range subdirs {
 		binPath := path.Join(root, subdir, binary)
 		if _, err := os.Stat(binPath); err == nil {


### PR DESCRIPTION
The generic tarballs for MySQL 5.6 will locate mysql_install_db in `scripts/`. This moves in MySQL 5.7 to `bin`, which is correctly found. We should handle both locations.

Fixes #4975

Signed-off-by: Morgan Tocker <tocker@gmail.com>