### PR TITLE
helm: upgrade orchestrator from 3.0.14 to 3.1.1

### DIFF
--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -5,9 +5,9 @@ FROM debian:stretch-slim
 RUN apt-get update && \
    apt-get upgrade -qq && \
    apt-get install wget ca-certificates jq -qq --no-install-recommends && \
-   wget https://github.com/github/orchestrator/releases/download/v3.0.14/orchestrator_3.0.14_amd64.deb && \
-   dpkg -i orchestrator_3.0.14_amd64.deb && \
-   rm orchestrator_3.0.14_amd64.deb && \
+   wget https://github.com/github/orchestrator/releases/download/v3.1.1/orchestrator_3.1.0_amd64.deb && \
+   dpkg -i orchestrator_3.1.0_amd64.deb && \
+   rm orchestrator_3.1.0_amd64.deb && \
    apt-get purge wget -qq && \
    apt-get autoremove -qq && \
    apt-get clean && \

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -379,7 +379,7 @@ pmm:
 # Default values for orchestrator resources
 orchestrator:
   enabled: false
-  image: vitess/orchestrator:3.0.14
+  image: vitess/orchestrator:3.1.1
   replicas: 3
   resources:
     requests:


### PR DESCRIPTION
there was a mixup in the orchestrator release process, hence the inconsistent binary and path matching for 3.1.0 and 3.1.1