### PR TITLE
add basedir when starting mysqld

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -226,7 +226,7 @@ func (mysqld *Mysqld) startNoWait(ctx context.Context, cnf *Mycnf, mysqldArgs ..
 		}
 		arg := []string{
 			"--defaults-file=" + cnf.path,
-			"--basedir" + mysqlBasedir,
+			"--basedir" + mysqlBaseDir,
 		}
 		arg = append(arg, mysqldArgs...)
 		env := []string{os.ExpandEnv("LD_LIBRARY_PATH=$VT_MYSQL_ROOT/lib/mysql")}

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -220,8 +220,14 @@ func (mysqld *Mysqld) startNoWait(ctx context.Context, cnf *Mycnf, mysqldArgs ..
 				return err
 			}
 		}
+		mysqlBaseDir, err := vtenv.VtMysqlBaseDir()
+		if err != nil {
+			return err
+		}
 		arg := []string{
-			"--defaults-file=" + cnf.path}
+			"--defaults-file=" + cnf.path,
+			"--basedir" + mysqlBasedir,
+		}
 		arg = append(arg, mysqldArgs...)
 		env := []string{os.ExpandEnv("LD_LIBRARY_PATH=$VT_MYSQL_ROOT/lib/mysql")}
 


### PR DESCRIPTION
Currently `mysqlctl` does not always specify the basedir when launching mysqld (it does when launching to initialize a datadir, but not for launching mysqld afterward).

This can lead to cases where the plugindir cannot be discovered, and plugins cannot be loaded.

Fixes #4992

Signed-off-by: Morgan Tocker <tocker@gmail.com>