### PR TITLE
Fix broken Vagrant build

### DIFF
--- a/vagrant-scripts/bootstrap_vm.sh
+++ b/vagrant-scripts/bootstrap_vm.sh
@@ -30,7 +30,7 @@ apt-get install -y make \
                    pkg-config \
                    bison \
                    curl \
-                   openjdk-7-jdk \
+                   openjdk-8-jdk \
                    ant \
                    zip \
                    unzip

--- a/vagrant-scripts/vitess/build.sh
+++ b/vagrant-scripts/vitess/build.sh
@@ -10,6 +10,9 @@ export VT_MYSQL_ROOT=/usr
 
 printf "\nBuilding Vitess...\n"
 
+# Stopping on errors makes them easier to see
+set -e
+
 # This is just to make sure the vm can write into these directories
 sudo chown "$(whoami)":"$(whoami)" /vagrant
 sudo chown "$(whoami)":"$(whoami)" /vagrant/src
@@ -26,4 +29,4 @@ source /vagrant/dist/grpc/usr/local/bin/activate
 pip install mysqlclient
 make build
 
-printf "\Build completed\n\n"
+printf "\nBuild completed\n\n"


### PR DESCRIPTION
Although provisioning succeeds, the Vagrant box fails to build Vitess on first `vagrant ssh`. It aborts on a missing Java compiler when trying to build Zookeeper, thus missing plenty of dependencies:

```
BUILD FAILED
/vagrant/dist/vt-zookeeper-3.4.14/zookeeper-3.4.14/build.xml:321: Unable to find a javac compiler;
com.sun.tools.javac.Main is not on the classpath.
Perhaps JAVA_HOME does not point to the JDK.
It is currently set to "/usr/lib/jvm/java-8-openjdk-amd64/jre"

Total time: 1 minute 19 seconds
ERROR: Zookeeper build failed
```

Note the `JAVA_HOME`.

Furthermore, although `bootstrap.sh` aborts, `build.sh` still [continues](https://github.com/vitessio/vitess/blob/44f156dd1920a22a092ab211df482512d7e80da3/vagrant-scripts/vitess/build.sh#L21-L27). This makes the process end with a misleading error on Go dependencies:

```
... <<< Plenty of packages omitted here for brevity >>> ...
go/cmd/zk/zkcmd.go:36:2: cannot find package "golang.org/x/crypto/ssh/terminal" in any of:
        /vagrant/src/vitess.io/vitess/vendor/golang.org/x/crypto/ssh/terminal (vendor tree)
        /usr/local/go/src/golang.org/x/crypto/ssh/terminal (from $GOROOT)
        /vagrant/src/golang.org/x/crypto/ssh/terminal (from $GOPATH)
go/vt/vtgate/vtgateservice/vtgateservice_testing/mock_vtgateservice.go:10:2: cannot find package "github.com/golang/mock/gomock" in any of:
        /vagrant/src/vitess.io/vitess/vendor/github.com/golang/mock/gomock (vendor tree)
        /usr/local/go/src/github.com/golang/mock/gomock (from $GOROOT)
        /vagrant/src/github.com/golang/mock/gomock (from $GOPATH)
Makefile:47: recipe for target 'build' failed
make: *** [build] Error 1
\Build completed
```

This PR changes `openjdk-7-jdk` to `openjdk-8-jdk`, that is now available for the Ubuntu version (see [here](https://github.com/vitessio/vitess/pull/4782/files#r271801024)), matching the version used for Docker. (An example for #4780.) It also makes the build script abort on errors, just like `bootstrap.sh` does. This seems to make #4883 obsolete.