### PR TITLE
v3: support overlapping multi-column vindexes

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -1172,6 +1172,41 @@
   }
 }
 
+# insert for overlapped vindex columns
+"insert overlap_vindex (kid, column_a, column_b) VALUES (1,2,3)"
+{
+  "Original": "insert overlap_vindex (kid, column_a, column_b) VALUES (1,2,3)",
+  "Instructions": {
+    "Opcode": "InsertSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "insert into overlap_vindex(kid, column_a, column_b) values (:_kid0, :_column_a0, 3)",
+    "Values": [
+      [
+        [
+          1
+        ]
+      ],
+      [
+        [
+          2
+        ],
+        [
+          1
+        ]
+      ]
+    ],
+    "Table": "overlap_vindex",
+    "Prefix": "insert into overlap_vindex(kid, column_a, column_b) values ",
+    "Mid": [
+      "(:_kid0, :_column_a0, 3)"
+    ]
+  }
+}
+
+
 # insert multiple rows in a multi column vindex table
 "insert multicolvin (column_a, column_b, column_c, kid) VALUES (1,2,3,4), (5,6,7,8)"
 {

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -26,6 +26,10 @@
           "type": "lookup_test",
           "owner": "multicolvin"
         },
+        "cola_kid_map": {
+          "type": "lookup_test",
+          "owner": "overlap_vindex"
+        },
         "name_user_map": {
           "type": "multi",
           "owner": "user"
@@ -162,6 +166,18 @@
             {
               "columns": ["column_b", "column_c"],
               "name": "colb_colc_map"
+            }
+          ]
+        },
+        "overlap_vindex": {
+          "column_vindexes": [
+            {
+              "column": "kid",
+              "name": "kid_index"
+            },
+            {
+              "columns": ["column_a", "kid"],
+              "name": "cola_kid_map"
             }
           ]
         },


### PR DESCRIPTION
There exist use cases where one needs vindexes with overlapping columns. In such scenarios, the extraction of values cannot be done simultaneously with the substitution of bindvars. If so, the first vindex will substitute its bindvar name to replace an existing value, and then a subsequent vindex may pick up the previously substituted value instead of the original value.

With this logic change, we pull all necessary values out of the insert values in the first pass, and substitutes those values with bind var names in a separate pass.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>