### PR TITLE
Change default TOPO to etcd2

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -23,10 +23,10 @@ set -e
 script_root=$(dirname "${BASH_SOURCE}")
 
 # start topo server
-if [ "${TOPO}" = "etcd2" ]; then
-    CELL=zone1 "$script_root/etcd-up.sh"
-else
+if [ "${TOPO}" = "zk2" ]; then
     CELL=zone1 "$script_root/zk-up.sh"
+else
+    CELL=zone1 "$script_root/etcd-up.sh"
 fi
 
 # start vtctld

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -30,10 +30,10 @@ CELL=zone1 UID_BASE=300 "$script_root/vttablet-down.sh"
 CELL=zone1 UID_BASE=400 "$script_root/vttablet-down.sh"
 ./vtctld-down.sh
 
-if [ "${TOPO}" = "etcd2" ]; then
-    CELL=zone1 "$script_root/etcd-down.sh"
-else
+if [ "${TOPO}" = "zk2" ]; then
     CELL=zone1 "$script_root/zk-down.sh"
+else
+    CELL=zone1 "$script_root/etcd-down.sh"
 fi
 
 rm -r $VTDATAROOT/*

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -39,22 +39,7 @@ if [ -z "$MYSQL_FLAVOR" ]; then
   export MYSQL_FLAVOR=MySQL56
 fi
 
-if [ "${TOPO}" = "etcd2" ]; then
-    echo "enter etcd2 env"
-
-    case $(uname) in
-      Linux)  etcd_platform=linux;;
-      Darwin) etcd_platform=darwin;;
-    esac
-
-    ETCD_SERVER="localhost:2379"
-    ETCD_VERSION=$(cat "${VTROOT}/dist/etcd/.installed_version")
-    ETCD_BINDIR="${VTROOT}/dist/etcd/etcd-${ETCD_VERSION}-${etcd_platform}-amd64/"
-    TOPOLOGY_FLAGS="-topo_implementation etcd2 -topo_global_server_address $ETCD_SERVER -topo_global_root /vitess/global"
-
-    mkdir -p "${VTDATAROOT}/tmp"
-    mkdir -p "${VTDATAROOT}/etcd"
-else
+if [ "${TOPO}" = "zk2" ]; then
     # Each ZooKeeper server needs a list of all servers in the quorum.
     # Since we're running them all locally, we need to give them unique ports.
     # In a real deployment, these should be on different machines, and their
@@ -76,6 +61,19 @@ else
     TOPOLOGY_FLAGS="-topo_implementation zk2 -topo_global_server_address ${ZK_SERVER} -topo_global_root /vitess/global"
 
     mkdir -p $VTDATAROOT/tmp
+else
+    echo "enter etcd2 env"
+
+    case $(uname) in
+      Linux)  etcd_platform=linux;;
+      Darwin) etcd_platform=darwin;;
+    esac
+
+    ETCD_SERVER="localhost:2379"
+    ETCD_VERSION=$(cat "${VTROOT}/dist/etcd/.installed_version")
+    ETCD_BINDIR="${VTROOT}/dist/etcd/etcd-${ETCD_VERSION}-${etcd_platform}-amd64/"
+    TOPOLOGY_FLAGS="-topo_implementation etcd2 -topo_global_server_address $ETCD_SERVER -topo_global_root /vitess/global"
+
+    mkdir -p "${VTDATAROOT}/tmp"
+    mkdir -p "${VTDATAROOT}/etcd"
 fi
-
-

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -18,6 +18,7 @@
 
 # timeout in seconds (for each step, not overall)
 timeout=30
+export TOPO=zk2
 
 cd $VTTOP/examples/local
 


### PR DESCRIPTION
This PR changes the default TOPO to etcd.  While zookeeper, etcd, consul are all supported, the motivation for defaulting to etcd is as follows:

* etcd has fewer dependencies than zookeeper. This makes it easier for new users to get started with Vitess, since they do not require ant or a JRE installed.
* etcd is a fellow cncf project.

Fixes #4983

Signed-off-by: Morgan Tocker <tocker@gmail.com>