### PR TITLE
check replication lag on state change before starting query service

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -90,7 +89,7 @@ var (
 // - uses the BackupStorage service to store a new backup
 // - shuts down Mysqld during the backup
 // - remember if we were replicating, restore the exact same state
-func Backup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, dir, name string, backupConcurrency int, hookExtraEnv map[string]string) error {
+func Backup(ctx context.Context, dir, name string, params BackupParams) error {
 	// Start the backup with the BackupStorage.
 	bs, err := backupstorage.GetBackupStorage()
 	if err != nil {
@@ -101,6 +100,8 @@ func Backup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.
 	if err != nil {
 		return vterrors.Wrap(err, "StartBackup failed")
 	}
+	// Set params.BackupHandle to the selected backup
+	params.BackupHandle = bh
 
 	be, err := GetBackupEngine()
 	if err != nil {
@@ -108,7 +109,8 @@ func Backup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.
 	}
 
 	// Take the backup, and either AbortBackup or EndBackup.
-	usable, err := be.ExecuteBackup(ctx, cnf, mysqld, logger, bh, backupConcurrency, hookExtraEnv)
+	usable, err := be.ExecuteBackup(ctx, params)
+	logger := params.Logger
 	var finishErr error
 	if usable {
 		finishErr = bh.EndBackup(ctx)
@@ -215,17 +217,16 @@ func removeExistingFiles(cnf *Mycnf) error {
 // Restore is the main entry point for backup restore.  If there is no
 // appropriate backup on the BackupStorage, Restore logs an error
 // and returns ErrNoBackup. Any other error is returned.
-func Restore(
-	ctx context.Context,
-	cnf *Mycnf,
-	mysqld MysqlDaemon,
-	dir string,
-	restoreConcurrency int,
-	hookExtraEnv map[string]string,
-	localMetadata map[string]string,
-	logger logutil.Logger,
-	deleteBeforeRestore bool,
-	dbName string) (mysql.Position, error) {
+func Restore(ctx context.Context, params RestoreParams) (mysql.Position, error) {
+
+	// extract params
+	cnf := params.Cnf
+	mysqld := params.Mysqld
+	logger := params.Logger
+	localMetadata := params.LocalMetadata
+	deleteBeforeRestore := params.DeleteBeforeRestore
+	dbName := params.DbName
+	dir := params.Dir
 
 	rval := mysql.Position{}
 
@@ -290,12 +291,15 @@ func Restore(
 	if err != nil {
 		return rval, err
 	}
+	// Set params.BackupHandle to the selected backup
+	params.BackupHandle = bh
 
 	re, err := GetRestoreEngine(ctx, bh)
 	if err != nil {
 		return mysql.Position{}, vterrors.Wrap(err, "Failed to find restore engine")
 	}
-	if rval, err = re.ExecuteRestore(ctx, cnf, mysqld, logger, dir, bh, restoreConcurrency, hookExtraEnv); err != nil {
+
+	if rval, err = re.ExecuteRestore(ctx, params); err != nil {
 		return rval, err
 	}
 

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -100,8 +100,6 @@ func Backup(ctx context.Context, dir, name string, params BackupParams) error {
 	if err != nil {
 		return vterrors.Wrap(err, "StartBackup failed")
 	}
-	// Set params.BackupHandle to the selected backup
-	params.BackupHandle = bh
 
 	be, err := GetBackupEngine()
 	if err != nil {
@@ -109,7 +107,7 @@ func Backup(ctx context.Context, dir, name string, params BackupParams) error {
 	}
 
 	// Take the backup, and either AbortBackup or EndBackup.
-	usable, err := be.ExecuteBackup(ctx, params)
+	usable, err := be.ExecuteBackup(ctx, params, bh)
 	logger := params.Logger
 	var finishErr error
 	if usable {
@@ -291,15 +289,13 @@ func Restore(ctx context.Context, params RestoreParams) (mysql.Position, error) 
 	if err != nil {
 		return rval, err
 	}
-	// Set params.BackupHandle to the selected backup
-	params.BackupHandle = bh
 
 	re, err := GetRestoreEngine(ctx, bh)
 	if err != nil {
 		return mysql.Position{}, vterrors.Wrap(err, "Failed to find restore engine")
 	}
 
-	if rval, err = re.ExecuteRestore(ctx, params); err != nil {
+	if rval, err = re.ExecuteRestore(ctx, params, bh); err != nil {
 		return rval, err
 	}
 

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
@@ -39,13 +40,40 @@ var (
 
 // BackupEngine is the interface to take a backup with a given engine.
 type BackupEngine interface {
-	ExecuteBackup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, backupConcurrency int, hookExtraEnv map[string]string) (bool, error)
+	ExecuteBackup(ctx context.Context, params BackupParams) (bool, error)
 	ShouldDrainForBackup() bool
+}
+
+// BackupParams is the struct that holds all params passed to ExecuteBackup
+type BackupParams struct {
+	Cnf          *Mycnf
+	Mysqld       MysqlDaemon
+	Logger       logutil.Logger
+	BackupHandle backupstorage.BackupHandle
+	Concurrency  int
+	HookExtraEnv map[string]string
+	TopoServer   *topo.Server
+	Keyspace     string
+	Shard        string
+}
+
+// RestoreParams is the struct that holds all params passed to ExecuteRestore
+type RestoreParams struct {
+	Cnf                 *Mycnf
+	Mysqld              MysqlDaemon
+	Logger              logutil.Logger
+	BackupHandle        backupstorage.BackupHandle
+	Concurrency         int
+	HookExtraEnv        map[string]string
+	LocalMetadata       map[string]string
+	DeleteBeforeRestore bool
+	DbName              string
+	Dir                 string
 }
 
 // RestoreEngine is the interface to restore a backup with a given engine.
 type RestoreEngine interface {
-	ExecuteRestore(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, dir string, bh backupstorage.BackupHandle, restoreConcurrency int, hookExtraEnv map[string]string) (mysql.Position, error)
+	ExecuteRestore(ctx context.Context, params RestoreParams) (mysql.Position, error)
 }
 
 // BackupRestoreEngine is a combination of BackupEngine and RestoreEngine.

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -121,16 +121,11 @@ func closeFile(wc io.WriteCloser, fileName string, logger logutil.Logger, finalE
 
 // ExecuteBackup returns a boolean that indicates if the backup is usable,
 // and an overall error.
-func (be *XtrabackupEngine) ExecuteBackup(ctx context.Context, params BackupParams) (complete bool, finalErr error) {
+func (be *XtrabackupEngine) ExecuteBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (complete bool, finalErr error) {
 	// extract all params from BackupParams
 	cnf := params.Cnf
 	mysqld := params.Mysqld
 	logger := params.Logger
-	bh := params.BackupHandle
-
-	if bh == nil {
-		return false, vterrors.New(vtrpc.Code_INVALID_ARGUMENT, "ExecuteBackup must be called with a valid BackupHandle")
-	}
 
 	if *xtrabackupUser == "" {
 		return false, vterrors.New(vtrpc.Code_INVALID_ARGUMENT, "xtrabackupUser must be specified.")
@@ -372,20 +367,13 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, cnf *Mycnf, logger 
 }
 
 // ExecuteRestore restores from a backup. Any error is returned.
-func (be *XtrabackupEngine) ExecuteRestore(
-	ctx context.Context,
-	params RestoreParams) (mysql.Position, error) {
+func (be *XtrabackupEngine) ExecuteRestore(ctx context.Context, params RestoreParams, bh backupstorage.BackupHandle) (mysql.Position, error) {
 
 	cnf := params.Cnf
 	mysqld := params.Mysqld
 	logger := params.Logger
-	bh := params.BackupHandle
 
 	zeroPosition := mysql.Position{}
-	if bh == nil {
-		return zeroPosition, vterrors.New(vtrpc.Code_INVALID_ARGUMENT, "ExecuteRestore must be called with a valid BackupHandle")
-	}
-
 	var bm xtraBackupManifest
 
 	if err := getBackupManifestInto(ctx, bh, &bm); err != nil {

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -99,7 +99,18 @@ func (agent *ActionAgent) Backup(ctx context.Context, concurrency int, logger lo
 	// now we can run the backup
 	dir := fmt.Sprintf("%v/%v", tablet.Keyspace, tablet.Shard)
 	name := fmt.Sprintf("%v.%v", time.Now().UTC().Format("2006-01-02.150405"), topoproto.TabletAliasString(tablet.Alias))
-	returnErr := mysqlctl.Backup(ctx, agent.Cnf, agent.MysqlDaemon, l, dir, name, concurrency, agent.hookExtraEnv())
+	backupParams := mysqlctl.BackupParams{
+		Cnf:          agent.Cnf,
+		Mysqld:       agent.MysqlDaemon,
+		Logger:       l,
+		Concurrency:  concurrency,
+		HookExtraEnv: agent.hookExtraEnv(),
+		TopoServer:   agent.TopoServer,
+		Keyspace:     tablet.Keyspace,
+		Shard:        tablet.Shard,
+	}
+
+	returnErr := mysqlctl.Backup(ctx, dir, name, backupParams)
 
 	if engine.ShouldDrainForBackup() {
 		bgCtx := context.Background()

--- a/go/vt/vttablet/tabletmanager/state_change.go
+++ b/go/vt/vttablet/tabletmanager/state_change.go
@@ -203,7 +203,10 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 	// we're going to use it.
 	var shardInfo *topo.ShardInfo
 	var err error
+	// this is just for logging
 	var disallowQueryReason string
+	// this is actually used to set state
+	var disallowQueryService string
 	var blacklistedTables []string
 	updateBlacklistedTables := true
 	if allowQuery {
@@ -212,23 +215,26 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 			log.Errorf("Cannot read shard for this tablet %v, might have inaccurate SourceShards and TabletControls: %v", newTablet.Alias, err)
 			updateBlacklistedTables = false
 		} else {
-			if newTablet.Type == topodatapb.TabletType_MASTER {
-				if len(shardInfo.SourceShards) > 0 {
-					allowQuery = false
-					disallowQueryReason = "master tablet with filtered replication on"
-				}
+			if oldTablet.Type == topodatapb.TabletType_RESTORE {
+				// always start as NON-SERVING after a restore because
+				// healthcheck has not been initialized yet
+				allowQuery = false
+				// setting disallowQueryService permanently turns off query service
+				// since we want it to be temporary (until tablet is healthy) we don't set it
+				// disallowQueryReason is only used for logging
+				disallowQueryReason = "after restore from backup"
 			} else {
-				if oldTablet.Type == topodatapb.TabletType_RESTORE {
-					// always start as NON-SERVING after a restore because
-					// healthcheck has not been initialized yet
-					allowQuery = false
-					disallowQueryReason = "After restore from backup"
+				if newTablet.Type == topodatapb.TabletType_MASTER {
+					if len(shardInfo.SourceShards) > 0 {
+						allowQuery = false
+						disallowQueryReason = "master tablet with filtered replication on"
+						disallowQueryService = disallowQueryReason
+					}
 				} else {
 					replicationDelay, healthErr := agent.HealthReporter.Report(true, true)
-					log.Infof("4426: replication delay during changeCallback: %v", replicationDelay)
 					if healthErr != nil {
 						allowQuery = false
-						disallowQueryReason = "Unable to get health"
+						disallowQueryReason = "unable to get health"
 					} else {
 						agent.mutex.Lock()
 						agent._replicationDelay = replicationDelay
@@ -255,6 +261,7 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 							if tabletControl.QueryServiceDisabled {
 								allowQuery = false
 								disallowQueryReason = "TabletControl.DisableQueryService set"
+								disallowQueryService = disallowQueryReason
 							}
 							break
 						}
@@ -270,8 +277,9 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 		}
 	} else {
 		disallowQueryReason = fmt.Sprintf("not a serving tablet type(%v)", newTablet.Type)
+		disallowQueryService = disallowQueryReason
 	}
-	agent.setServicesDesiredState(disallowQueryReason, runUpdateStream)
+	agent.setServicesDesiredState(disallowQueryService, runUpdateStream)
 	if updateBlacklistedTables {
 		if err := agent.loadBlacklistRules(newTablet, blacklistedTables); err != nil {
 			// FIXME(alainjobart) how to handle this error?


### PR DESCRIPTION
Fixes #4426 
- check replication delay on replica during state_change before setting it to SERVING
- restored tablets should always start as NOT_SERVING
- SecondsBehindMaster from `SHOW SLAVE STATUS` gets set to 0 when replication is stopped and restarted. Implemented logic in backup/restore to ensure that either replication has caught up to master, or has progressed from last known position before this can be trusted to compute replication delay.

Signed-off-by: deepthi <deepthi@planetscale.com>