### PR TITLE
Move EnsureVSchema to topo and Added to GetOrCreateShard

### DIFF
--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -331,6 +331,11 @@ func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard string) 
 		return nil, vterrors.Wrapf(err, "CreateKeyspace(%v) failed", keyspace)
 	}
 
+	// make sure a valid vschema has been loaded
+	if err = ts.EnsureVSchema(ctx, keyspace); err != nil {
+		return nil, vterrors.Wrapf(err, "EnsureVSchema(%v) failed", keyspace)
+	}
+
 	// now try to create with the lock, may already exist
 	if err = ts.CreateShard(ctx, keyspace, shard); err != nil && !IsErrType(err, NodeExists) {
 		return nil, vterrors.Wrapf(err, "CreateShard(%v/%v) failed", keyspace, shard)

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"golang.org/x/net/context"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"github.com/golang/protobuf/proto"
@@ -64,6 +65,29 @@ func (ts *Server) GetVSchema(ctx context.Context, keyspace string) (*vschemapb.K
 		return nil, vterrors.Wrapf(err, "bad vschema data: %q", data)
 	}
 	return &vs, nil
+}
+
+// EnsureVschema makes sure that a vschema is present for this keyspace are creates a blank one if it is missing
+func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string) error {
+	vschema, err := ts.GetVSchema(ctx, keyspace)
+	if vschema == nil || IsErrType(err, NoNode) {
+		err = ts.SaveVSchema(ctx, keyspace, &vschemapb.Keyspace{
+			Sharded:  false,
+			Vindexes: make(map[string]*vschemapb.Vindex),
+			Tables:   make(map[string]*vschemapb.Table),
+		})
+		if err != nil {
+			log.Errorf("could not create blank vschema: %v", err)
+			return err
+		}
+	}
+
+	err = ts.RebuildSrvVSchema(ctx, []string{} /* cells */)
+	if err != nil {
+		log.Errorf("could not rebuild SrvVschema after creating keyspace: %v", err)
+		return err
+	}
+	return nil
 }
 
 // SaveRoutingRules saves the routing rules into the topo.

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1580,23 +1580,8 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		err = nil
 	}
 
-	vschema, err := wr.TopoServer().GetVSchema(ctx, keyspace)
-	if !*allowEmptyVSchema && (vschema == nil || topo.IsErrType(err, topo.NoNode)) {
-		err = wr.TopoServer().SaveVSchema(ctx, keyspace, &vschemapb.Keyspace{
-			Sharded:  false,
-			Vindexes: make(map[string]*vschemapb.Vindex),
-			Tables:   make(map[string]*vschemapb.Table),
-		})
-		if err != nil {
-			wr.Logger().Errorf("could not create blank vschema: %v", err)
-			return err
-		}
-	}
-
-	err = wr.TopoServer().RebuildSrvVSchema(ctx, []string{} /* cells */)
-	if err != nil {
-		wr.Logger().Errorf("could not rebuild SrvVschema after creating keyspace: %v", err)
-		return err
+	if !*allowEmptyVSchema {
+		err = wr.TopoServer().EnsureVSchema(ctx, keyspace)
 	}
 
 	return err


### PR DESCRIPTION
CreateKeyspace can be called from vtctl or automatically from GetOrCreateShard. This change refactors the ensure vschema logic to its own function and calls it in both places

Signed-off-by: Dan Kozlowski <koz@planetscale.com>