### PR TITLE
messages: add support for topics that route inserts to multiple subscriber message tables

### DIFF
--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -251,6 +251,27 @@ var tableACLConfig = `{
       "admins": ["dev"]
     },
     {
+      "name": "test_topic",
+      "table_names_or_prefixes": ["test_topic"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_topic_subscriber_1",
+      "table_names_or_prefixes": ["vitess_topic_subscriber_1"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
+      "name": "vitess_topic_subscriber_2",
+      "table_names_or_prefixes": ["vitess_topic_subscriber_2"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
       "name": "vitess_acl_unmatched",
       "table_names_or_prefixes": ["vitess_acl_unmatched"],
       "readers": ["dev"],

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -69,6 +69,8 @@ const (
 	PlanInsertSubquery
 	// PlanUpsertPK is for insert ... on duplicate key constructs.
 	PlanUpsertPK
+	// PlanInsertTopic is for inserting into message topics.
+	PlanInsertTopic
 	// PlanInsertMessage is for inserting into message tables.
 	PlanInsertMessage
 	// PlanSet is for SET statements.
@@ -100,6 +102,7 @@ var planName = [NumPlans]string{
 	"INSERT_PK",
 	"INSERT_SUBQUERY",
 	"UPSERT_PK",
+	"INSERT_TOPIC",
 	"INSERT_MESSAGE",
 	"SET",
 	"DDL",
@@ -153,6 +156,7 @@ const (
 	ReasonUpsertMultiRow
 	ReasonReplace
 	ReasonMultiTable
+	ReasonTopic
 	NumReasons
 )
 
@@ -167,6 +171,7 @@ var reasonName = [NumReasons]string{
 	"UPSERT_MULTI_ROW",
 	"REPLACE",
 	"MULTI_TABLE",
+	"TOPIC",
 }
 
 // String returns a string representation of a ReasonType.

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -958,6 +958,51 @@ options:PassthroughDMLs
   "PKValues": [[1, 3], [2, 4]]
 }
 
+# topic insert with time_scheduled specified
+"insert into test_topic(time_scheduled, id, message) values(1, 2, 'aa')"
+{
+  "PlanID": "INSERT_TOPIC",
+  "Reason": "TOPIC",
+  "TableName": "test_topic",
+  "Permissions": [
+    {
+      "TableName": "test_topic",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "insert into test_topic(time_scheduled, id, message) values (1, 2, 'aa')"
+}
+
+# topic update
+"update test_topic set time_next = 1 where id = 1"
+{
+  "PlanID": "PASS_DML",
+  "Reason": "TOPIC",
+  "TableName": "test_topic",
+  "Permissions": [
+    {
+      "TableName": "test_topic",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update test_topic set time_next = 1 where id = 1"
+}
+
+# topic delete
+"delete from test_topic where id = 1"
+{
+  "PlanID": "PASS_DML",
+  "Reason": "TOPIC",
+  "TableName": "test_topic",
+  "Permissions": [
+    {
+      "TableName": "test_topic",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "delete from test_topic where id = 1"
+}
+
 # message insert with time_scheduled specified
 "insert into msg(time_scheduled, id, message) values(1, 2, 'aa')"
 {

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -975,33 +975,11 @@ options:PassthroughDMLs
 
 # topic update
 "update test_topic set time_next = 1 where id = 1"
-{
-  "PlanID": "PASS_DML",
-  "Reason": "TOPIC",
-  "TableName": "test_topic",
-  "Permissions": [
-    {
-      "TableName": "test_topic",
-      "Role": 1
-    }
-  ],
-  "FullQuery": "update test_topic set time_next = 1 where id = 1"
-}
+"updates not allowed on topics"
 
 # topic delete
 "delete from test_topic where id = 1"
-{
-  "PlanID": "PASS_DML",
-  "Reason": "TOPIC",
-  "TableName": "test_topic",
-  "Permissions": [
-    {
-      "TableName": "test_topic",
-      "Role": 1
-    }
-  ],
-  "FullQuery": "delete from test_topic where id = 1"
-}
+"deletes not allowed on topics"
 
 # message insert with time_scheduled specified
 "insert into msg(time_scheduled, id, message) values(1, 2, 'aa')"

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
@@ -356,6 +356,65 @@
     "Type": 2
   },
   {
+    "Name": "msg1_with_topic",
+    "Columns": [
+      {
+        "Name": "time_scheduled"
+      },
+      {
+        "Name": "id"
+      },
+      {
+        "Name": "time_next"
+      },
+      {
+        "Name": "epoch"
+      },
+      {
+        "Name": "time_created"
+      },
+      {
+        "Name": "time_acked"
+      },
+      {
+        "Name": "message"
+      }
+    ],
+    "Indexes": [
+      {
+        "Name": "PRIMARY",
+        "Unique": true,
+        "Columns": [
+          "time_scheduled",
+          "id"
+        ],
+        "Cardinality": [
+          1
+        ],
+        "DataColumns": [
+        ]
+      }
+    ],
+    "PKColumns": [
+      0,
+      1
+    ],
+    "Type": 2,
+    "MessageInfo": {
+      "Topic": "test_topic"
+    }
+  },
+  {
+    "Name": "test_topic",
+    "TopicInfo": {
+      "Subscribers": [
+        {
+          "Name": "msg1_with_topic"
+        }
+      ]
+    }
+  },
+  {
     "Name": "dual",
     "Type": 0
   }

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -267,29 +266,13 @@ func TestCreateOrUpdateTable(t *testing.T) {
 			mysql.BaseShowTablesRow(existingTable, false, ""),
 		},
 	})
-	i := 0
-	se.RegisterNotifier("test", func(schema map[string]*Table, created, altered, dropped []string) {
-		switch i {
-		case 0:
-			if len(created) != 5 {
-				t.Errorf("callback 0: %v, want len of 5\n", created)
-			}
-		case 1:
-			want := []string{"test_table_01"}
-			if !reflect.DeepEqual(altered, want) {
-				t.Errorf("callback 0: %v, want %v\n", created, want)
-			}
-		default:
-			t.Fatal("unexpected")
-		}
-		i++
-	})
-	defer se.UnregisterNotifier("test")
-	if err := se.tableWasCreatedOrAltered(context.Background(), "test_table_01"); err != nil {
+
+	wasCreated, err := se.tableWasCreatedOrAltered(context.Background(), existingTable)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if i < 2 {
-		t.Error("Notifier did not get called")
+	if wasCreated {
+		t.Error("wanted wasCreated == false")
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -157,12 +157,8 @@ func loadMessageInfo(ta *Table, comment string) error {
 		keyvals[kv[0]] = kv[1]
 	}
 	var err error
-	if ta.MessageInfo.Topic, err = getString(keyvals, "vt_topic"); err != nil {
-		// the topic is an optional value
-		if err.Error() != "attribute vt_topic not specified for message table" {
-			return err
-		}
-	}
+	ta.MessageInfo.Topic = getTopic(keyvals)
+
 	if ta.MessageInfo.AckWaitDuration, err = getDuration(keyvals, "vt_ack_wait"); err != nil {
 		return err
 	}
@@ -246,10 +242,6 @@ func getNum(in map[string]string, key string) (int, error) {
 	return v, nil
 }
 
-func getString(in map[string]string, key string) (string, error) {
-	sv := in[key]
-	if sv == "" {
-		return "", fmt.Errorf("attribute %s not specified for message table", key)
-	}
-	return sv, nil
+func getTopic(in map[string]string) string {
+	return in["vt_topic"]
 }

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -239,3 +239,11 @@ func getNum(in map[string]string, key string) (int, error) {
 	}
 	return v, nil
 }
+
+func getString(in map[string]string, key string) (string, error) {
+	sv := in[key]
+	if sv == "" {
+		return "", fmt.Errorf("attribute %s not specified for message table", key)
+	}
+	return sv, nil
+}

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -157,6 +157,12 @@ func loadMessageInfo(ta *Table, comment string) error {
 		keyvals[kv[0]] = kv[1]
 	}
 	var err error
+	if ta.MessageInfo.Topic, err = getString(keyvals, "vt_topic"); err != nil {
+		// the topic is an optional value
+		if err.Error() != "attribute vt_topic not specified for message table" {
+			return err
+		}
+	}
 	if ta.MessageInfo.AckWaitDuration, err = getDuration(keyvals, "vt_ack_wait"); err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -68,6 +68,9 @@ type Table struct {
 	// MessageInfo contains info for message tables.
 	MessageInfo *MessageInfo
 
+	// TopicInfo contains info for message topics.
+	TopicInfo *TopicInfo
+
 	// These vars can be accessed concurrently.
 	TableRows     sync2.AtomicInt64
 	DataLength    sync2.AtomicInt64
@@ -87,6 +90,13 @@ type SequenceInfo struct {
 	LastVal int64
 }
 
+// TopicInfo contains info specific to message topics.
+type TopicInfo struct {
+	// Subscribers links to all the message tables
+	// subscribed to this topic
+	Subscribers []*Table
+}
+
 // MessageInfo contains info specific to message tables.
 type MessageInfo struct {
 	// IDPKIndex is the index of the ID column
@@ -98,6 +108,10 @@ type MessageInfo struct {
 	// Fields stores the field info to be
 	// returned for subscribers.
 	Fields []*querypb.Field
+
+	// Optional topic to subscribe to. Any messages
+	// published to the topic will be added to this table.
+	Topic string
 
 	// AckWaitDuration specifies how long to wait after
 	// the message was first sent. The back-off doubles
@@ -199,6 +213,14 @@ func (ta *Table) SetMysqlStats(tr, dl, il, df, mdl sqltypes.Value) {
 // HasPrimary returns true if the table has a primary key.
 func (ta *Table) HasPrimary() bool {
 	return len(ta.Indexes) != 0 && ta.Indexes[0].Name.EqualString("primary")
+}
+
+// IsTopic returns true if TopicInfo is not nil.
+func (ta *Table) IsTopic() bool {
+	if ta.TopicInfo == nil {
+		return false
+	}
+	return true
 }
 
 // UniqueIndexes returns the number of unique indexes on the table

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1010,7 +1010,7 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 			if err != nil {
 				return err
 			}
-			if plan.Reason == planbuilder.ReasonTopic {
+			if plan.PlanID == planbuilder.PlanInsertTopic {
 				result, err = tsv.topicExecute(ctx, query, comments, bindVariables, transactionID, options, plan, logStats)
 			} else {
 				result, err = tsv.qreExecute(ctx, query, comments, bindVariables, transactionID, options, plan, logStats)
@@ -1023,12 +1023,6 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 }
 
 func (tsv *TabletServer) topicExecute(ctx context.Context, query string, comments sqlparser.MarginComments, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, plan *TabletPlan, logStats *tabletenv.LogStats) (result *sqltypes.Result, err error) {
-	if plan.PlanID != planbuilder.PlanInsertTopic {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Only inserts allowed on topics")
-	}
-
-	// choose InsertMessage as the new PlanID
-	plan.PlanID = planbuilder.PlanInsertMessage
 	for _, subscriber := range plan.Table.TopicInfo.Subscribers {
 		// replace the topic name with the subscribed message table name
 		newQuery := strings.Replace(query, plan.Table.Name.String(), subscriber.Name.String(), -1)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1010,28 +1010,62 @@ func (tsv *TabletServer) Execute(ctx context.Context, target *querypb.Target, sq
 			if err != nil {
 				return err
 			}
-			qre := &QueryExecutor{
-				query:          query,
-				marginComments: comments,
-				bindVars:       bindVariables,
-				transactionID:  transactionID,
-				options:        options,
-				plan:           plan,
-				ctx:            ctx,
-				logStats:       logStats,
-				tsv:            tsv,
+			if plan.Reason == planbuilder.ReasonTopic {
+				result, err = tsv.topicExecute(ctx, query, comments, bindVariables, transactionID, options, plan, logStats)
+			} else {
+				result, err = tsv.qreExecute(ctx, query, comments, bindVariables, transactionID, options, plan, logStats)
 			}
-			extras := tsv.watcher.ComputeExtras(options)
-			result, err = qre.Execute()
-			if err != nil {
-				return err
-			}
-			result.Extras = extras
-			result = result.StripMetadata(sqltypes.IncludeFieldsOrDefault(options))
-			return nil
+
+			return err
 		},
 	)
 	return result, err
+}
+
+func (tsv *TabletServer) topicExecute(ctx context.Context, query string, comments sqlparser.MarginComments, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, plan *TabletPlan, logStats *tabletenv.LogStats) (result *sqltypes.Result, err error) {
+	if plan.PlanID != planbuilder.PlanInsertTopic {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Only inserts allowed on topics")
+	}
+
+	// choose InsertMessage as the new PlanID
+	plan.PlanID = planbuilder.PlanInsertMessage
+	for _, subscriber := range plan.Table.TopicInfo.Subscribers {
+		// replace the topic name with the subscribed message table name
+		newQuery := strings.Replace(query, plan.Table.Name.String(), subscriber.Name.String(), -1)
+		var newPlan *TabletPlan
+		newPlan, err = tsv.qe.GetPlan(ctx, logStats, newQuery, skipQueryPlanCache(options))
+		if err != nil {
+			return nil, err
+		}
+
+		// because there isn't an option to return multiple results, only the last
+		// message table result is returned
+		result, err = tsv.qreExecute(ctx, newQuery, comments, bindVariables, transactionID, options, newPlan, logStats)
+	}
+	return result, err
+}
+
+func (tsv *TabletServer) qreExecute(ctx context.Context, query string, comments sqlparser.MarginComments, bindVariables map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, plan *TabletPlan, logStats *tabletenv.LogStats) (result *sqltypes.Result, err error) {
+	qre := &QueryExecutor{
+		query:          query,
+		marginComments: comments,
+		bindVars:       bindVariables,
+		transactionID:  transactionID,
+		options:        options,
+		plan:           plan,
+		ctx:            ctx,
+		logStats:       logStats,
+		tsv:            tsv,
+	}
+	extras := tsv.watcher.ComputeExtras(options)
+	result, err = qre.Execute()
+	if err != nil {
+		return nil, err
+	}
+	result.Extras = extras
+	result = result.StripMetadata(sqltypes.IncludeFieldsOrDefault(options))
+
+	return result, nil
 }
 
 // StreamExecute executes the query and streams the result.


### PR DESCRIPTION
This is an alternative approach to #4956 to solve #4940. Instead of having topics separate from tables, it adds topics as pseudo tables.