### PR TITLE
vreplication: bug fixes

### DIFF
--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -106,8 +106,8 @@ func PurgeLogs() {
 	}
 	logDir := f.Value.String()
 	program := filepath.Base(os.Args[0])
-	timer := time.NewTimer(*purgeLogsInterval)
-	for range timer.C {
+	ticker := time.NewTicker(*purgeLogsInterval)
+	for range ticker.C {
 		purgeLogsOnce(time.Now(), logDir, program, *keepLogsByCtime, *keepLogsByMtime)
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -322,6 +322,8 @@ func (vre *Engine) WaitForPos(ctx context.Context, id int, pos string) error {
 	}
 	defer dbClient.Close()
 
+	tkr := time.NewTicker(waitRetryTime)
+	defer tkr.Stop()
 	for {
 		qr, err := dbClient.ExecuteFetch(binlogplayer.ReadVReplicationStatus(uint32(id)), 10)
 		switch {
@@ -350,7 +352,7 @@ func (vre *Engine) WaitForPos(ctx context.Context, id int, pos string) error {
 			return ctx.Err()
 		case <-vre.ctx.Done():
 			return fmt.Errorf("vreplication is closing: %v", vre.ctx.Err())
-		case <-time.After(waitRetryTime):
+		case <-tkr.C:
 		}
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -56,7 +56,7 @@ func (rp *ReplicatorPlan) buildExecutionPlan(fieldEvent *binlogdatapb.FieldEvent
 		return &tplanv, nil
 	}
 	// select * construct was used. We need to use the field names.
-	tplan, err := rp.buildFromFields(prelim.TargetName, fieldEvent.Fields)
+	tplan, err := rp.buildFromFields(prelim.TargetName, prelim.Lastpk, fieldEvent.Fields)
 	if err != nil {
 		return nil, err
 	}
@@ -67,9 +67,10 @@ func (rp *ReplicatorPlan) buildExecutionPlan(fieldEvent *binlogdatapb.FieldEvent
 // buildFromFields builds a full TablePlan, but uses the field info as the
 // full column list. This happens when the query used was a 'select *', which
 // requires us to wait for the field info sent by the source.
-func (rp *ReplicatorPlan) buildFromFields(tableName string, fields []*querypb.Field) (*TablePlan, error) {
+func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Result, fields []*querypb.Field) (*TablePlan, error) {
 	tpb := &tablePlanBuilder{
-		name: sqlparser.NewTableIdent(tableName),
+		name:   sqlparser.NewTableIdent(tableName),
+		lastpk: lastpk,
 	}
 	for _, field := range fields {
 		colName := sqlparser.NewColIdent(field.Name)
@@ -118,6 +119,8 @@ type TablePlan struct {
 	TargetName   string
 	SendRule     *binlogdatapb.Rule
 	PKReferences []string
+	// Lastpk is used for delayed generation of replication queries.
+	Lastpk *sqltypes.Result
 	// BulkInsertFront, BulkInsertValues and BulkInsertOnDup are used
 	// by vcopier.
 	BulkInsertFront  *sqlparser.ParsedQuery

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -171,6 +171,7 @@ func buildTablePlan(rule *binlogdatapb.Rule, tableKeys map[string][]string, last
 		tablePlan := &TablePlan{
 			TargetName: rule.Match,
 			SendRule:   sendRule,
+			Lastpk:     lastpk,
 		}
 		return tablePlan, nil
 	}
@@ -228,6 +229,7 @@ func (tpb *tablePlanBuilder) generate(tableKeys map[string][]string) *TablePlan 
 
 	return &TablePlan{
 		TargetName:       tpb.name.String(),
+		Lastpk:           tpb.lastpk,
 		PKReferences:     pkrefs,
 		BulkInsertFront:  tpb.generateInsertPart(sqlparser.NewTrackedBuffer(bvf.formatter)),
 		BulkInsertValues: tpb.generateValuesPart(sqlparser.NewTrackedBuffer(bvf.formatter), bvf),

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -135,9 +135,9 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 	}()
 
 	// Wait for catchup.
-	tmr := time.NewTimer(1 * time.Second)
+	tkr := time.NewTicker(waitRetryTime)
+	defer tkr.Stop()
 	seconds := int64(replicaLagTolerance / time.Second)
-	defer tmr.Stop()
 	for {
 		sbm := vc.vr.stats.SecondsBehindMaster.Get()
 		if sbm < seconds {
@@ -156,7 +156,7 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 			// Make sure vplayer returns before returning.
 			<-errch
 			return io.EOF
-		case <-tmr.C:
+		case <-tkr.C:
 		}
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
 
 func TestPlayerCopyTables(t *testing.T) {
@@ -113,6 +114,138 @@ func TestPlayerCopyTables(t *testing.T) {
 	expectData(t, "yes", [][]string{})
 }
 
+// TestPlayerCopyBigTable ensures the copy-catchup back-and-forth loop works correctly.
+func TestPlayerCopyBigTable(t *testing.T) {
+	defer deleteTablet(addTablet(100, "0", topodatapb.TabletType_REPLICA, true, true))
+
+	savedPacketSize := *vstreamer.PacketSize
+	// PacketSize of 1 byte will send at most one row at a time.
+	*vstreamer.PacketSize = 1
+	defer func() { *vstreamer.PacketSize = savedPacketSize }()
+
+	savedCopyTimeout := copyTimeout
+	// copyTimeout should be low enough to have time to send one row.
+	copyTimeout = 500 * time.Millisecond
+	defer func() { copyTimeout = savedCopyTimeout }()
+
+	savedWaitRetryTime := waitRetryTime
+	// waitRetry time shoulw be very low to cause the wait loop to execute multipel times.
+	waitRetryTime = 10 * time.Millisecond
+	defer func() { waitRetryTime = savedWaitRetryTime }()
+
+	execStatements(t, []string{
+		"create table src(id int, val varbinary(128), primary key(id))",
+		"insert into src values(1, 'aaa'), (2, 'bbb')",
+		fmt.Sprintf("create table %s.dst(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src",
+		fmt.Sprintf("drop table %s.dst", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	count := 0
+	vstreamRowsSendHook = func(ctx context.Context) {
+		defer func() { count++ }()
+		// Allow the first two calls to go through: field info and one row.
+		if count <= 1 {
+			return
+		}
+		// Insert a statement to test that catchup gets new events.
+		execStatements(t, []string{
+			"insert into src values(3, 'ccc')",
+		})
+		// Wait for context to expire and then send the row.
+		// This will cause the copier to abort and go back to catchup mode.
+		<-ctx.Done()
+		// Do this no more than once.
+		vstreamRowsSendHook = nil
+	}
+
+	vstreamRowsHook = func(context.Context) {
+		// Sleeping 50ms guarantees that the catchup wait loop executes multiple times.
+		// This is because waitRetryTime is set to 10ms.
+		time.Sleep(50 * time.Millisecond)
+		// Do this no more than once.
+		vstreamRowsHook = nil
+	}
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst",
+			Filter: "select * from src",
+		}},
+	}
+
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.VReplicationInit, playerEngine.dbName)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDBClientQueries(t, []string{
+			"/delete",
+		})
+	}()
+
+	expectDBClientQueries(t, []string{
+		"/insert into _vt.vreplication",
+		// Create the list of tables to copy and transition to Copying state.
+		"begin",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		"commit",
+		"rollback",
+		// The first fast-forward has no starting point. So, it just saves the current position.
+		"/update _vt.vreplication set pos=",
+		"begin",
+		"insert into dst(id,val) values (1,'aaa')",
+		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
+		"commit",
+		"rollback",
+		// The next catchup executes the new row insert, but will be a no-op.
+		"begin",
+		"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
+		"/update _vt.vreplication set pos=",
+		"commit",
+		// fastForward has nothing to add. Just saves position.
+		"begin",
+		"/update _vt.vreplication set pos=",
+		"commit",
+		// Second row gets copied.
+		"begin",
+		"insert into dst(id,val) values (2,'bbb')",
+		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"2\\" > ' where vrepl_id=.*`,
+		"commit",
+		// Third row copied without going back to catchup state.
+		"begin",
+		"insert into dst(id,val) values (3,'ccc')",
+		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"3\\" > ' where vrepl_id=.*`,
+		"commit",
+		"/delete from _vt.copy_state.*dst",
+		// rollback is a no-op because the delete is autocommitted.
+		"rollback",
+		// Copy is done. Go into running state.
+		"/update _vt.vreplication set state='Running'",
+		// All tables copied. Final catch up followed by Running state.
+	})
+	expectData(t, "dst", [][]string{
+		{"1", "aaa"},
+		{"2", "bbb"},
+		{"3", "ccc"},
+	})
+}
+
 // TestPlayerCopyTableContinuation tests the copy workflow where tables have been partially copied.
 func TestPlayerCopyTableContinuation(t *testing.T) {
 	defer deleteTablet(addTablet(100, "0", topodatapb.TabletType_REPLICA, true, true))
@@ -174,14 +307,13 @@ func TestPlayerCopyTableContinuation(t *testing.T) {
 	})
 
 	// Set a hook to execute statements just before the copy begins from src1.
-	streamRowsHook = func(context.Context) {
+	vstreamRowsHook = func(context.Context) {
 		execStatements(t, []string{
 			"update src1 set val='updated again' where id1 = 3",
 		})
 		// Set it back to nil. Otherwise, this will get executed again when copying not_copied.
-		streamRowsHook = nil
+		vstreamRowsHook = nil
 	}
-	defer func() { streamRowsHook = nil }()
 
 	bls := &binlogdatapb.BinlogSource{
 		Keyspace: env.KeyspaceName,
@@ -419,12 +551,11 @@ func TestPlayerCopyTableCancel(t *testing.T) {
 	defer func() { copyTimeout = saveTimeout }()
 
 	// Set a hook to reset the copy timeout after first call.
-	streamRowsHook = func(ctx context.Context) {
+	vstreamRowsHook = func(ctx context.Context) {
 		<-ctx.Done()
 		copyTimeout = saveTimeout
-		streamRowsHook = nil
+		vstreamRowsHook = nil
 	}
-	defer func() { streamRowsHook = nil }()
 
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"golang.org/x/net/context"
@@ -207,6 +208,10 @@ func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 }
 
 func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
+	// If we're not running, set SecondsBehindMaster to be very high.
+	// TODO(sougou): if we also stored the time of the last event, we
+	// can estimate this value more accurately.
+	defer vp.vr.stats.SecondsBehindMaster.Set(math.MaxInt64)
 	for {
 		items, err := relay.Fetch()
 		if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -235,7 +235,7 @@ func (rs *rowStreamer) streamQuery(conn *mysql.Conn, send func(*binlogdatapb.VSt
 			}
 		}
 
-		if byteCount >= *packetSize {
+		if byteCount >= *PacketSize {
 			response.Lastpk = sqltypes.RowToProto3(lastpk)
 			err = send(response)
 			if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -142,9 +142,9 @@ func TestStreamRowsMultiPacket(t *testing.T) {
 		t.Skip()
 	}
 
-	savedSize := *packetSize
-	*packetSize = 10
-	defer func() { *packetSize = savedSize }()
+	savedSize := *PacketSize
+	*PacketSize = 10
+	defer func() { *PacketSize = savedSize }()
 
 	execStatements(t, []string{
 		"create table t1(id int, val varbinary(128), primary key(id))",
@@ -170,9 +170,9 @@ func TestStreamRowsCancel(t *testing.T) {
 		t.Skip()
 	}
 
-	savedSize := *packetSize
-	*packetSize = 10
-	defer func() { *packetSize = savedSize }()
+	savedSize := *PacketSize
+	*PacketSize = 10
+	defer func() { *PacketSize = savedSize }()
 
 	execStatements(t, []string{
 		"create table t1(id int, val varbinary(128), primary key(id))",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -34,12 +34,13 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
-var packetSize = flag.Int("vstream_packet_size", 30000, "Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount.")
+// PacketSize is the suggested packet size for VReplication streamer.
+var PacketSize = flag.Int("vstream_packet_size", 30000, "Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount.")
 
-// heartbeatTime is set to slightly below 1s, compared to idleTimeout
+// HeartbeatTime is set to slightly below 1s, compared to idleTimeout
 // set by VPlayer at slightly above 1s. This minimizes conflicts
 // between the two timeouts.
-var heartbeatTime = 900 * time.Millisecond
+var HeartbeatTime = 900 * time.Millisecond
 
 type vstreamer struct {
 	ctx    context.Context
@@ -163,7 +164,7 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 					newSize += len(rowChange.After.Values)
 				}
 			}
-			if curSize+newSize > *packetSize {
+			if curSize+newSize > *PacketSize {
 				vevents := bufferedEvents
 				bufferedEvents = []*binlogdatapb.VEvent{vevent}
 				curSize = newSize
@@ -178,10 +179,10 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 	}
 
 	// Main loop: calls bufferAndTransmit as events arrive.
-	timer := time.NewTimer(heartbeatTime)
+	timer := time.NewTimer(HeartbeatTime)
 	defer timer.Stop()
 	for {
-		timer.Reset(heartbeatTime)
+		timer.Reset(HeartbeatTime)
 		// Drain event if timer fired before reset.
 		select {
 		case <-timer.C:

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -454,9 +454,9 @@ func TestBuffering(t *testing.T) {
 		t.Skip()
 	}
 
-	savedSize := *packetSize
-	*packetSize = 10
-	defer func() { *packetSize = savedSize }()
+	savedSize := *PacketSize
+	*PacketSize = 10
+	defer func() { *PacketSize = savedSize }()
 
 	execStatement(t, "create table packet_test(id int, val varbinary(128), primary key(id))")
 	defer execStatement(t, "drop table packet_test")


### PR DESCRIPTION
This PR fixes two bugs found during production testing:

### vreplication: handle copy for wildcards

The catchup code path was ignoring lastpk for wildcard expressions in the filter. This is now fixed.

### vcopier: use ticker instead of timer

The vcopier was using a timer instead of a ticker in its wait loop which caused it to wait forever even if the replication had caught up.
    
The change includes a new test that tests the full copy cycle and ensures that multiple iterations succeed.
    
A similar incorrect usage was found in logutil. That's also been fixed.
