### PR TITLE
Fix vcopier use of time.Timer->Ticker to correctly allow continuous catchup rather than single-time catchup.

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -135,9 +135,9 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 	}()
 
 	// Wait for catchup.
-	tmr := time.NewTimer(1 * time.Second)
+	tkr := time.NewTicker(1 * time.Second)
 	seconds := int64(replicaLagTolerance / time.Second)
-	defer tmr.Stop()
+	defer tkr.Stop()
 	for {
 		sbm := vc.vr.stats.SecondsBehindMaster.Get()
 		if sbm < seconds {
@@ -156,7 +156,7 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 			// Make sure vplayer returns before returning.
 			<-errch
 			return io.EOF
-		case <-tmr.C:
+		case <-tkr.C:
 		}
 	}
 }


### PR DESCRIPTION
time.Timer (single-use timer) was unintentionally used as a continuous ticker, time.Ticker.

This is due to a similarly named vitess type timer.Timer, and thus bad mnemonics.

Signed-off-by: Toliver Jue <toliver@planetscale.com>