### PR TITLE
Fix off-by-1 error for row_differ counting rows processed, not counting empty iteration.

### DIFF
--- a/go/vt/worker/row_differ.go
+++ b/go/vt/worker/row_differ.go
@@ -165,11 +165,11 @@ func (rd *RowDiffer2) Diff() (DiffReport, error) {
 			}
 			advanceRight = false
 		}
-		dr.processedRows++
 		if left == nil && right == nil {
 			// No more rows from either side. We're done.
 			break
 		}
+		dr.processedRows++
 		if left == nil {
 			// No more rows on the left side.
 			// We know we have at least one row on the right side left.


### PR DESCRIPTION
Signed-off-by: Toliver Jue <toliver@planetscale.com>