### PR TITLE
 Keep the lowest cost vindex for each column if there are multiple ones

### DIFF
--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -130,7 +130,9 @@ func (st *symtab) AddVSchemaTable(alias sqlparser.TableName, vschemaTables []*vi
 					if vindexMap == nil {
 						vindexMap = make(map[*column]vindexes.Vindex)
 					}
-					vindexMap[col] = cv.Vindex
+					if vindexMap[col] == nil || vindexMap[col].Cost() > cv.Vindex.Cost() {
+						vindexMap[col] = cv.Vindex
+					}
 				}
 			}
 		}

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -66,6 +66,14 @@
         "hash_dup": {
           "type": "hash_test",
           "owner": "user"
+        },
+        "vindex1": {
+          "type": "hash_test",
+          "owner": "samecolvin"
+        },
+        "vindex2": {
+          "type": "lookup_test",
+          "owner": "samecolvin"
         }
       },
       "tables": {
@@ -166,6 +174,24 @@
             },
             {
               "name": "col2"
+            }
+          ],
+          "column_list_authoritative": true
+        },
+        "samecolvin": {
+          "column_vindexes": [
+            {
+              "column": "col",
+              "name": "vindex1"
+            },
+            {
+              "column": "col",
+              "name": "vindex2"
+            }
+          ],
+          "columns": [
+            {
+              "name": "col"
             }
           ],
           "column_list_authoritative": true

--- a/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/vindex_func_cases.txt
@@ -331,3 +331,22 @@
 
 "select none from user_index where id = :id"
 "symbol none not found in table or subquery"
+
+"select * from samecolvin where col = :col"
+{
+  "Original": "select * from samecolvin where col = :col",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select col from samecolvin where col = :col",
+    "FieldQuery": "select col from samecolvin where 1 != 1",
+    "Vindex": "vindex1",
+    "Values": [
+      ":col"
+    ],
+    "Table": "samecolvin"
+  }
+}


### PR DESCRIPTION
If the same column having multiple vindex, choose the one with lowest cost. Not the last one in ColumnVindex's order