### PR TITLE
[vagrant-scripts] Set TOPO environment variable to use zookeeper

### DIFF
--- a/vagrant-scripts/vitess/start.sh
+++ b/vagrant-scripts/vitess/start.sh
@@ -9,6 +9,8 @@ export VTDATAROOT=/tmp/vtdata-dev
 export MYSQL_FLAVOR=MySQL56
 cd "$VITESS_WORKSPACE"/examples/local
 export SHARD="-"
+export TOPO="zk2"
+
 ./zk-up.sh
 ./vtctld-up.sh --enable-grpc-static-auth
 ./vttablet-up.sh --enable-grpc-static-auth


### PR DESCRIPTION
I think the defaults for the tutorials changed to etcd as part of [this commit](https://github.com/vitessio/vitess/pull/5003) but the vagrant example is still using zookeeper. This PR sets the appropriate env variable to get that to work.