### PR TITLE
Java Client: add VStream method to the `VTGateConnection`

### DIFF
--- a/java/client/src/main/java/io/vitess/client/VTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateConnection.java
@@ -36,6 +36,8 @@ import io.vitess.proto.Vtgate.ExecuteResponse;
 import io.vitess.proto.Vtgate.SplitQueryRequest;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
 import io.vitess.proto.Vtgate.StreamExecuteRequest;
+import io.vitess.proto.Vtgate.VStreamRequest;
+import io.vitess.proto.Vtgate.VStreamResponse;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -250,6 +252,26 @@ public class VTGateConnection implements Closeable {
                 return Futures.immediateFuture(response.getSplitsList());
               }
             }, directExecutor()));
+  }
+
+  /**
+   * Starts streaming the vstream binlog events.
+   *
+   * @param ctx Context on user and execution deadline if any.
+   * @param vstreamRequest VStreamRequest containing starting VGtid positions
+   *                       in binlog and optional Filters
+   * @return Streaming iterator over VStream events
+   * @throws SQLException If anything fails on query execution.
+   */
+  StreamIterator<VStreamResponse> getVStream(Context ctx, VStreamRequest vstreamRequest)
+    throws SQLException {
+    VStreamRequest request = vstreamRequest;
+
+    if (ctx.getCallerId() != null) {
+      request = request.toBuilder().setCallerId(ctx.getCallerId()).build();
+    }
+
+    return client.getVStream(ctx, request);
   }
 
   /**


### PR DESCRIPTION
Follow up to @harshit-gangal's comment in https://github.com/vitessio/vitess/pull/4991#issuecomment-514554170 to add the VStream method to the `VTGateConnection`

Signed-off-by: Paul Hemberger <phemberger@hubspot.com>

cc @leoxlin 