### PR TITLE
Allow start local cluster using a provided tablet host name

### DIFF
--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -152,6 +152,8 @@ func parseFlags() (config vttest.Config, env vttest.Environment, err error) {
 	flag.StringVar(&config.TransactionMode, "transaction_mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
 	flag.Float64Var(&config.TransactionTimeout, "queryserver-config-transaction-timeout", 0, "query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value")
 
+	flag.StringVar(&config.TabletHostName, "tablet_hostname", "localhost", "The hostname to use for the tablet otherwise it will be derived from OS' hostname")
+
 	flag.Parse()
 
 	if basePort != 0 {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -101,6 +101,9 @@ type Config struct {
 	TransactionMode string
 
 	TransactionTimeout float64
+
+	// The host name to use for the table otherwise it will be resolved from the local hostname
+	TabletHostName string
 }
 
 // InitSchemas is a shortcut for tests that just want to setup a single

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -240,6 +240,9 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	if args.TransactionTimeout != 0 {
 		vt.ExtraArgs = append(vt.ExtraArgs, "-queryserver-config-transaction-timeout", fmt.Sprintf("%f", args.TransactionTimeout))
 	}
+	if args.TabletHostName != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-tablet_hostname", args.TabletHostName}...)
+	}
 
 	if socket != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{


### PR DESCRIPTION
This helps fix a name resolution problem when initializing the tablet. If flag "tablet_hostname" is not provided it will be derived from the OS' hostname. The way it is implemented there is not guarantee that ```net.LookupHost(os.HostName())``` will return a valid IP for certain local env dns configs, i.e, in Mac OS X, hostname can be configured using the system's resolver which is not used by ```net.LookupHost```

Reference: init_tablet.go:151

Signed-off-by: Karel Alfonso Sague <kalfonso@squareup.com>