### PR TITLE
vreplication: clean-up copy_state correctly

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_plan_test.go
@@ -46,6 +46,12 @@ func TestControllerPlan(t *testing.T) {
 			query:  "insert into _vt.vreplication(workflow, id) values ('', null)",
 		},
 	}, {
+		in: "insert into _vt.resharding_journal values (1)",
+		plan: &controllerPlan{
+			opcode: reshardingJournalQuery,
+			query:  "insert into _vt.resharding_journal values (1)",
+		},
+	}, {
 		in:  "replace into _vt.vreplication values(null)",
 		err: "unsupported construct: replace into _vt.vreplication values (null)",
 	}, {
@@ -85,6 +91,12 @@ func TestControllerPlan(t *testing.T) {
 			id:     1,
 		},
 	}, {
+		in: "update _vt.resharding_journal set col = 1",
+		plan: &controllerPlan{
+			opcode: reshardingJournalQuery,
+			query:  "update _vt.resharding_journal set col = 1",
+		},
+	}, {
 		in:  "update a set state='Running' where id = 1",
 		err: "invalid table name: a",
 	}, {
@@ -116,9 +128,16 @@ func TestControllerPlan(t *testing.T) {
 	}, {
 		in: "delete from _vt.vreplication where id = 1",
 		plan: &controllerPlan{
-			opcode: deleteQuery,
-			query:  "delete from _vt.vreplication where id = 1",
-			id:     1,
+			opcode:       deleteQuery,
+			query:        "delete from _vt.vreplication where id = 1",
+			delCopyState: "delete from _vt.copy_state where vrepl_id = 1",
+			id:           1,
+		},
+	}, {
+		in: "delete from _vt.resharding_journal where id = 1",
+		plan: &controllerPlan{
+			opcode: reshardingJournalQuery,
+			query:  "delete from _vt.resharding_journal where id = 1",
 		},
 	}, {
 		in:  "delete from a where id = 1",
@@ -153,10 +172,22 @@ func TestControllerPlan(t *testing.T) {
 
 		// Select
 	}, {
-		in: "select * from _vt.vreplication where id = 1",
+		in: "select * from _vt.vreplication",
 		plan: &controllerPlan{
 			opcode: selectQuery,
-			query:  "select * from _vt.vreplication where id = 1",
+			query:  "select * from _vt.vreplication",
+		},
+	}, {
+		in: "select * from _vt.resharding_journal",
+		plan: &controllerPlan{
+			opcode: selectQuery,
+			query:  "select * from _vt.resharding_journal",
+		},
+	}, {
+		in: "select * from _vt.copy_state",
+		plan: &controllerPlan{
+			opcode: selectQuery,
+			query:  "select * from _vt.copy_state",
 		},
 	}, {
 		in:  "select * from a",

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -317,7 +317,11 @@ func (vre *Engine) Exec(query string) (*sqltypes.Result, error) {
 			return nil, err
 		}
 		if _, err := dbClient.ExecuteFetch(plan.delCopyState, 10000); err != nil {
-			return nil, err
+			// Legacy vreplication won't create this table. So, ignore table not found error.
+			merr, isSQLErr := err.(*mysql.SQLError)
+			if !isSQLErr || !(merr.Num == mysql.ERNoSuchTable) {
+				return nil, err
+			}
 		}
 		if err := dbClient.Commit(); err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -179,7 +179,10 @@ func TestEngineExec(t *testing.T) {
 
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 	delQuery := "delete from _vt.vreplication where id = 1"
+	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest(delQuery, testDMLResponse, nil)
+	dbClient.ExpectRequest("delete from _vt.copy_state where vrepl_id = 1", nil, nil)
+	dbClient.ExpectRequest("commit", nil, nil)
 
 	qr, err = vre.Exec(delQuery)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -108,7 +108,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		if err := env.Mysqld.ExecuteSuperQueryList(context.Background(), CreateCopyState); err != nil {
+		if err := env.Mysqld.ExecuteSuperQuery(context.Background(), createCopyState); err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)
 			return 1
 		}
@@ -366,6 +366,16 @@ func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Resu
 		globalDBQueries <- query
 	}
 	return qr, err
+}
+
+func expectDeleteQueries(t *testing.T) {
+	t.Helper()
+	expectDBClientQueries(t, []string{
+		"begin",
+		"/delete from _vt.vreplication",
+		"/delete from _vt.copy_state",
+		"commit",
+	})
 }
 
 func expectDBClientQueries(t *testing.T, queries []string) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -1471,9 +1471,7 @@ func startVReplication(t *testing.T, filter *binlogdatapb.Filter, onddl binlogda
 		if _, err := playerEngine.Exec(query); err != nil {
 			t.Fatal(err)
 		}
-		expectDBClientQueries(t, []string{
-			"/delete",
-		})
+		expectDeleteQueries(t)
 	}, int(qr.InsertID)
 }
 

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -117,8 +117,7 @@ func TestMigrateServedFrom(t *testing.T) {
 		sqltypes.NewVarBinary("Running"),
 		sqltypes.NewVarBinary(""),
 	}}}, nil)
-	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
-	dbClient.ExpectRequest("delete from _vt.vreplication where id = 1", &sqltypes.Result{RowsAffected: 1}, nil)
+	expectDeleteVRepl(dbClient)
 
 	// simulate the clone, by fixing the dest shard record
 	if err := vp.Run([]string{"SourceShardAdd", "--tables", "gone1,gone2", "dest/0", "1", "source/0"}); err != nil {


### PR DESCRIPTION
* On delete of a row in _vt.vreplication, we should also cleanup
the copy_state table, because it may have related rows.
* Made workflow into a flag, but mandatory. Otherwise the number
of unnamed arguments are too many and command becomes unreadable.
* Added ability to read from _vt.copy_state using VReplicationExec.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>