### PR TITLE
Fix Dockerfile.mariadb103

### DIFF
--- a/docker/bootstrap/Dockerfile.mariadb103
+++ b/docker/bootstrap/Dockerfile.mariadb103
@@ -4,8 +4,8 @@ FROM vitess/bootstrap:common
 RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8 \
     && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian stretch main' \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-       mariadb-server \
-       libmariadbclient-dev \
+       mariadb-server-10.3 \
+       libmariadb-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess


### PR DESCRIPTION
It seems that the base distro now includes mariadb 10.1, which means the
package names conflict and it was getting stuck after installing some
dependencies at 10.1 and others at 10.3.

These package names seem to work to force it to use 10.3.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>