### PR TITLE
test.go: Re-enable clean-up of docker test dirs.

### DIFF
--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -211,9 +211,9 @@ fi
 # Clean up host dir mounted VTDATAROOT
 if [[ -n "$hostdir" ]]; then
   # Use Docker user to clean up first, to avoid permission errors.
-  #docker run --name=rm_$testid -v $hostdir:/vt/vtdataroot $image bash -c 'rm -rf /vt/vtdataroot/*'
+  docker run --name=rm_$testid -v $hostdir:/vt/vtdataroot $image bash -c 'rm -rf /vt/vtdataroot/*'
   docker rm -f rm_$testid &>/dev/null
-  #rm -rf $hostdir
+  rm -rf $hostdir
 fi
 
 # If requested, create the cache image.


### PR DESCRIPTION
I don't see any reason this was disabled so I assume it was checked in by accident as part of an unrelated PR (#4410).

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>