### PR TITLE
Add ability to process vschema migrations during vttestserver startup

### DIFF
--- a/go/cmd/vttestserver/data/schema/app_customer/v001__create_customer_table.sql
+++ b/go/cmd/vttestserver/data/schema/app_customer/v001__create_customer_table.sql
@@ -1,0 +1,7 @@
+create table customers (
+  id bigint,
+  name varchar(64),
+  age SMALLINT,
+  primary key (id)
+) Engine=InnoDB;
+

--- a/go/cmd/vttestserver/data/schema/app_customer/v002__add_customer_vschema.sql
+++ b/go/cmd/vttestserver/data/schema/app_customer/v002__add_customer_vschema.sql
@@ -1,0 +1,1 @@
+alter vschema on customers add vindex hash (id);

--- a/go/cmd/vttestserver/data/schema/app_customer/vschema.json
+++ b/go/cmd/vttestserver/data/schema/app_customer/vschema.json
@@ -1,0 +1,10 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    }
+  },
+  "tables": {
+  }
+}

--- a/go/cmd/vttestserver/data/schema/test_keyspace/v001__create_test_table.sql
+++ b/go/cmd/vttestserver/data/schema/test_keyspace/v001__create_test_table.sql
@@ -1,0 +1,12 @@
+create table test_table (
+  id bigint,
+  name varchar(64),
+  age SMALLINT,
+  percent DECIMAL(5,2),
+  datetime_col DATETIME,
+  timestamp_col TIMESTAMP,
+  date_col DATE,
+  time_col TIME,
+  primary key (id)
+) Engine=InnoDB;
+

--- a/go/cmd/vttestserver/data/schema/test_keyspace/v002__create_hash_vindex.sql
+++ b/go/cmd/vttestserver/data/schema/test_keyspace/v002__create_hash_vindex.sql
@@ -1,0 +1,1 @@
+alter vschema create vindex my_vdx using hash

--- a/go/cmd/vttestserver/data/schema/test_keyspace/v003__add_table_vschema.sql
+++ b/go/cmd/vttestserver/data/schema/test_keyspace/v003__add_table_vschema.sql
@@ -1,0 +1,1 @@
+alter vschema on test_table add vindex my_vdx (id)

--- a/go/cmd/vttestserver/data/schema/test_keyspace/v004__create_test_table1.sql
+++ b/go/cmd/vttestserver/data/schema/test_keyspace/v004__create_test_table1.sql
@@ -1,0 +1,11 @@
+create table test_table1 (
+  id bigint,
+  name varchar(64),
+  age SMALLINT,
+  percent DECIMAL(5,2),
+  datetime_col DATETIME,
+  timestamp_col TIMESTAMP,
+  date_col DATE,
+  time_col TIME,
+  primary key (id)
+) Engine=InnoDB;

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -199,32 +199,34 @@ func parseFlags() (config vttest.Config, env vttest.Environment, err error) {
 }
 
 func main() {
-	config, env, err := parseFlags()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Infof("Starting local cluster...")
-	log.Infof("config: %#v", config)
-
-	cluster := vttest.LocalCluster{
-		Config: config,
-		Env:    env,
-	}
-
-	err = cluster.Setup()
+	cluster := runCluster()
 	defer cluster.TearDown()
-
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	kvconf := cluster.JSONConfig()
 	if err := json.NewEncoder(os.Stdout).Encode(kvconf); err != nil {
 		log.Fatal(err)
 	}
 
+	select {}
+}
+
+func runCluster() vttest.LocalCluster {
+	config, env, err := parseFlags()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("Starting local cluster...")
+	log.Infof("config: %#v", config)
+	cluster := vttest.LocalCluster{
+		Config: config,
+		Env:    env,
+	}
+	err = cluster.Setup()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	log.Info("Local cluster started.")
 
-	select {}
+	return cluster
 }

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"vitess.io/vitess/go/vt/vttest"
+
+	"github.com/golang/protobuf/jsonpb"
+	"vitess.io/vitess/go/vt/proto/logutil"
+	"vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
+)
+
+type columnVindex struct {
+	keyspace   string
+	table      string
+	vindex     string
+	vindexType string
+	column     string
+}
+
+func TestRunsVschemaMigrations(t *testing.T) {
+	schemaDirArg := "-schema_dir=data/schema"
+	webDirArg := "-web_dir=web/vtctld/app"
+	webDir2Arg := "-web_dir2=web/vtctld2/app"
+	tabletHostname := "-tablet_hostname=localhost"
+	keyspaceArg := "-keyspaces=test_keyspace,app_customer"
+	numShardsArg := "-num_shards=2,2"
+
+	os.Args = append(os.Args, []string{schemaDirArg, keyspaceArg, numShardsArg, webDirArg, webDir2Arg, tabletHostname}...)
+
+	cluster := runCluster()
+	defer cluster.TearDown()
+
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
+}
+
+func assertColumnVindex(t *testing.T, cluster vttest.LocalCluster, expected columnVindex) {
+	server := fmt.Sprintf("localhost:%v", cluster.GrpcPort())
+	args := []string{"GetVSchema", expected.keyspace}
+	ctx := context.Background()
+
+	err := vtctlclient.RunCommandAndWait(ctx, server, args, func(e *logutil.Event) {
+		var keyspace vschema.Keyspace
+		if err := jsonpb.UnmarshalString(e.Value, &keyspace); err != nil {
+			t.Error(err)
+		}
+
+		columnVindex := keyspace.Tables[expected.table].ColumnVindexes[0]
+		actualVindex := keyspace.Vindexes[expected.vindex]
+		assertEqual(t, actualVindex.Type, expected.vindexType, "Actual vindex type different from expected")
+		assertEqual(t, columnVindex.Name, expected.vindex, "Actual vindex name different from expected")
+		assertEqual(t, columnVindex.Columns[0], expected.column, "Actual vindex column different from expected")
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func assertEqual(t *testing.T, actual string, expected string, message string) {
+	if actual != expected {
+		t.Errorf("%s: actual %s, expected %s", message, actual, expected)
+	}
+}

--- a/go/vt/vtgate/endtoend/deletetest/delete_test.go
+++ b/go/vt/vtgate/endtoend/deletetest/delete_test.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	cluster     *vttest.LocalCluster
-	vtParams    mysql.ConnParams
-	mysqlParams mysql.ConnParams
-	grpcAddress string
+	cluster        *vttest.LocalCluster
+	vtParams       mysql.ConnParams
+	mysqlParams    mysql.ConnParams
+	grpcAddress    string
+	tabletHostName = flag.String("tablet_hostname", "", "the tablet hostname")
 
 	schema = `
 create table t1(
@@ -133,6 +134,8 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 		defer os.RemoveAll(cfg.SchemaDir)
+
+		cfg.TabletHostName = *tabletHostName
 
 		cluster = &vttest.LocalCluster{
 			Config: cfg,

--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	cluster     *vttest.LocalCluster
-	vtParams    mysql.ConnParams
-	mysqlParams mysql.ConnParams
-	grpcAddress string
+	cluster        *vttest.LocalCluster
+	vtParams       mysql.ConnParams
+	mysqlParams    mysql.ConnParams
+	grpcAddress    string
+	tabletHostName = flag.String("tablet_hostname", "", "the tablet hostname")
 
 	schema = `
 create table t1(
@@ -177,6 +178,8 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 		defer os.RemoveAll(cfg.SchemaDir)
+
+		cfg.TabletHostName = *tabletHostName
 
 		cluster = &vttest.LocalCluster{
 			Config: cfg,


### PR DESCRIPTION
This allows defining vschema changes during testing using "ALTER VSCHEMA" statements which follows a convention "v[0-9]{3}__\\w+" in the specified "schemaDir" while still supporting an initial "vschema.json" file.

The vschema migrations are located in same directory as db migrations to keep same developer experience. The migration is routed to the db or topology based on the content. We're constraining one single vschema migration per file.

Signed-off-by: Karel Alfonso Sague <kalfonso@squareup.com>