### PR TITLE
xtrabackup: Better support for large datasets

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -339,7 +339,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, cnf *Mycnf, my
 }
 
 // backupFiles finds the list of files to backup, and creates the backup.
-func (be *BuiltinBackupEngine) backupFiles(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, replicationPosition mysql.Position, backupConcurrency int, hookExtraEnv map[string]string) (err error) {
+func (be *BuiltinBackupEngine) backupFiles(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, replicationPosition mysql.Position, backupConcurrency int, hookExtraEnv map[string]string) (finalErr error) {
 	// Get the files to backup.
 	fes, err := findFilesToBackup(cnf)
 	if err != nil {
@@ -381,8 +381,8 @@ func (be *BuiltinBackupEngine) backupFiles(ctx context.Context, cnf *Mycnf, mysq
 		return vterrors.Wrapf(err, "cannot add %v to backup", backupManifest)
 	}
 	defer func() {
-		if closeErr := wc.Close(); err == nil {
-			err = closeErr
+		if closeErr := wc.Close(); finalErr == nil {
+			finalErr = closeErr
 		}
 	}()
 
@@ -405,10 +405,9 @@ func (be *BuiltinBackupEngine) backupFiles(ctx context.Context, cnf *Mycnf, mysq
 }
 
 // backupFile backs up an individual file.
-func (be *BuiltinBackupEngine) backupFile(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, fe *FileEntry, name string, hookExtraEnv map[string]string) (err error) {
+func (be *BuiltinBackupEngine) backupFile(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, fe *FileEntry, name string, hookExtraEnv map[string]string) (finalErr error) {
 	// Open the source file for reading.
-	var source *os.File
-	source, err = fe.open(cnf, true)
+	source, err := fe.open(cnf, true)
 	if err != nil {
 		return err
 	}
@@ -427,11 +426,11 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, cnf *Mycnf, mysql
 	}
 	defer func(name, fileName string) {
 		if rerr := wc.Close(); rerr != nil {
-			if err != nil {
+			if finalErr != nil {
 				// We already have an error, just log this one.
 				logger.Errorf2(rerr, "failed to close file %v,%v", name, fe.Name)
 			} else {
-				err = rerr
+				finalErr = rerr
 			}
 		}
 	}(name, fe.Name)
@@ -577,10 +576,9 @@ func (be *BuiltinBackupEngine) restoreFiles(ctx context.Context, cnf *Mycnf, bh 
 }
 
 // restoreFile restores an individual file.
-func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, cnf *Mycnf, bh backupstorage.BackupHandle, fe *FileEntry, transformHook string, compress bool, name string, hookExtraEnv map[string]string) (err error) {
+func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, cnf *Mycnf, bh backupstorage.BackupHandle, fe *FileEntry, transformHook string, compress bool, name string, hookExtraEnv map[string]string) (finalErr error) {
 	// Open the source file for reading.
-	var source io.ReadCloser
-	source, err = bh.ReadFile(ctx, name)
+	source, err := bh.ReadFile(ctx, name)
 	if err != nil {
 		return vterrors.Wrap(err, "can't open source file for reading")
 	}
@@ -593,11 +591,11 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, cnf *Mycnf, bh b
 	}
 	defer func() {
 		if cerr := dstFile.Close(); cerr != nil {
-			if err != nil {
+			if finalErr != nil {
 				// We already have an error, just log this one.
 				log.Errorf("failed to close file %v: %v", name, cerr)
 			} else {
-				err = vterrors.Wrap(err, "failed to close destination file")
+				finalErr = vterrors.Wrap(cerr, "failed to close destination file")
 			}
 		}
 	}()
@@ -631,11 +629,11 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, cnf *Mycnf, bh b
 		}
 		defer func() {
 			if cerr := gz.Close(); cerr != nil {
-				if err != nil {
+				if finalErr != nil {
 					// We already have an error, just log this one.
 					log.Errorf("failed to close gzip decompressor %v: %v", name, cerr)
 				} else {
-					err = vterrors.Wrap(err, "failed to close gzip decompressor")
+					finalErr = vterrors.Wrap(err, "failed to close gzip decompressor")
 				}
 			}
 		}()

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -468,7 +468,7 @@ func (be *XtrabackupEngine) extractFiles(
 		if *xbstreamRestoreFlags != "" {
 			flagsToExec = append(flagsToExec, strings.Fields(*xbstreamRestoreFlags)...)
 		}
-		flagsToExec = append(flagsToExec, "-C", tempDir, "-x")
+		flagsToExec = append(flagsToExec, "-C", tempDir, "-xv")
 		xbstreamCmd := exec.CommandContext(ctx, xbstreamProgram, flagsToExec...)
 		logger.Infof("Executing xbstream cmd: %v %v", xbstreamProgram, flagsToExec)
 		xbstreamCmd.Stdin = reader

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -318,7 +318,7 @@ func (be *XtrabackupEngine) restoreFromBackup(ctx context.Context, cnf *Mycnf, b
 	}
 
 	if err := be.extractFiles(ctx, logger, bh, !bm.SkipCompress, be.backupFileName(), tempDir); err != nil {
-		logger.Errorf("error restoring backup file %v:%v", be.backupFileName(), err)
+		logger.Errorf("error restoring backup file %v: %v", be.backupFileName(), err)
 		return err
 	}
 
@@ -433,7 +433,7 @@ func (be *XtrabackupEngine) extractFiles(
 	case streamModeTar:
 		// now extract the files by running tar
 		// error if we can't find tar
-		flagsToExec := []string{"-C", tempDir, "-xi"}
+		flagsToExec := []string{"-C", tempDir, "-xiv"}
 		tarCmd := exec.CommandContext(ctx, "tar", flagsToExec...)
 		logger.Infof("Executing tar cmd with flags %v", flagsToExec)
 		tarCmd.Stdin = reader

--- a/test/backup.py
+++ b/test/backup.py
@@ -31,6 +31,7 @@ from mysql_flavor import mysql_flavor
 
 use_mysqlctld = False
 use_xtrabackup = False
+xtrabackup_stripes = 0
 stream_mode = 'tar'
 tablet_master = None
 tablet_replica1 = None
@@ -48,6 +49,7 @@ def setUpModule():
                    '-xtrabackup_stream_mode',
                    stream_mode,
                    '-xtrabackup_user=vt_dba',
+                   '-xtrabackup_stripes=%d' % (xtrabackup_stripes),
                    '-xtrabackup_backup_flags',
                    '--password=VtDbaPass']
 
@@ -539,7 +541,7 @@ class TestBackup(unittest.TestCase):
   def test_terminated_restore(self):
     stop_restore_msg = 'Copying file 10'
     if use_xtrabackup:
-      stop_restore_msg = 'Restore: Preparing the files'
+      stop_restore_msg = 'Restore: Preparing'
     def _terminated_restore(t):
       for e in utils.vtctld_connection.execute_vtctl_command(
           ['RestoreFromBackup', t.tablet_alias]):

--- a/test/xtrabackup_xbstream.py
+++ b/test/xtrabackup_xbstream.py
@@ -23,4 +23,5 @@ import utils
 if __name__ == '__main__':
   backup.use_xtrabackup = True
   backup.stream_mode = 'xbstream'
+  backup.xtrabackup_stripes = 8
   utils.main(backup)


### PR DESCRIPTION
Changes to improve the Vitess xtrabackup integration for use with large datasets:

* Stream stderr in the background instead of waiting until the end. This is needed for long-running backups so that the xtrabackup process doesn't block after the write buffer fills up. It's also nice for checking in on progress during a long upload.
* Use `move-back` instead of `copy-back` so the disk doesn't need 2x the space to restore. We download backups from remote storage on every restore, so there's no need to keep a copy of the original downloaded files on local disk.
* Store stream mode (tar vs xbstream) in the manifest so going forward it will be possible to restore from either one, regardless of the current flag setting for creating new backups.
* Support optional data striping to parallelize compression/decompression and file upload/download. The striping parameters are stored in the manifest so the flags for new backups don't have to match in order to restore an old one.

Fixes #5063

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>