### PR TITLE
tablet should stay healthy while running xtrabackup

### DIFF
--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -41,6 +41,7 @@ var (
 type BackupEngine interface {
 	ExecuteBackup(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.BackupHandle, backupConcurrency int, hookExtraEnv map[string]string) (bool, error)
 	ExecuteRestore(ctx context.Context, cnf *Mycnf, mysqld MysqlDaemon, logger logutil.Logger, dir string, bhs []backupstorage.BackupHandle, restoreConcurrency int, hookExtraEnv map[string]string) (mysql.Position, error)
+	ShouldDrainForBackup() bool
 }
 
 // BackupEngineMap contains the registered implementations for BackupEngine

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -672,6 +672,12 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, cnf *Mycnf, bh b
 	return nil
 }
 
+// ShouldDrainForBackup satisfies the BackupEngine interface
+// backup requires query service to be stopped, hence true
+func (be *BuiltinBackupEngine) ShouldDrainForBackup() bool {
+	return true
+}
+
 func init() {
 	BackupEngineMap["builtin"] = &BuiltinBackupEngine{}
 }

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -471,6 +471,12 @@ func findReplicationPosition(input, flavor string, logger logutil.Logger) (mysql
 	return replicationPosition, nil
 }
 
+// ShouldDrainForBackup satisfies the BackupEngine interface
+// xtrabackup can run while tablet is serving, hence false
+func (be *XtrabackupEngine) ShouldDrainForBackup() bool {
+	return false
+}
+
 func init() {
 	BackupEngineMap[xtrabackupBackupMethod] = &XtrabackupEngine{}
 }

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -109,6 +109,10 @@ type ActionAgent struct {
 	// only used if exportStats is true.
 	statsTabletTypeCount *stats.CountersWithSingleLabel
 
+	// statsBackupIsRunning is set to true if an online backup is running
+	// not set if an offline backup is running because that is
+	// indicated by tablet_type = BACKUP
+	// only used if exportStats is true
 	statsBackupIsRunning *stats.String
 
 	// batchCtx is given to the agent by its creator, and should be used for

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -109,6 +109,8 @@ type ActionAgent struct {
 	// only used if exportStats is true.
 	statsTabletTypeCount *stats.CountersWithSingleLabel
 
+	statsBackupIsRunning *stats.String
+
 	// batchCtx is given to the agent by its creator, and should be used for
 	// any background tasks spawned by the agent.
 	batchCtx context.Context
@@ -211,6 +213,8 @@ type ActionAgent struct {
 	_lockTablesTimer      *time.Timer
 	// unused
 	//_lockTablesTimeout    *time.Duration
+	// _isOnlineBackupRunning tells us whether there is a non-blocking backup that is currently running
+	_isOnlineBackupRunning bool
 }
 
 // NewActionAgent creates a new ActionAgent and registers all the
@@ -262,6 +266,7 @@ func NewActionAgent(
 	agent.exportStats = true
 	agent.statsTabletType = stats.NewString("TabletType")
 	agent.statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
+	agent.statsBackupIsRunning = stats.NewString("BackupIsRunning")
 
 	var mysqlHost string
 	var mysqlPort int32

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -109,11 +109,9 @@ type ActionAgent struct {
 	// only used if exportStats is true.
 	statsTabletTypeCount *stats.CountersWithSingleLabel
 
-	// statsBackupIsRunning is set to true if an online backup is running
-	// not set if an offline backup is running because that is
-	// indicated by tablet_type = BACKUP
+	// statsBackupIsRunning is set to 1 (true) if a backup is running
 	// only used if exportStats is true
-	statsBackupIsRunning *stats.String
+	statsBackupIsRunning *stats.GaugesWithMultiLabels
 
 	// batchCtx is given to the agent by its creator, and should be used for
 	// any background tasks spawned by the agent.
@@ -215,10 +213,8 @@ type ActionAgent struct {
 	// _lockTablesConnection is used to get and release the table read locks to pause replication
 	_lockTablesConnection *dbconnpool.DBConnection
 	_lockTablesTimer      *time.Timer
-	// unused
-	//_lockTablesTimeout    *time.Duration
-	// _isOnlineBackupRunning tells us whether there is a non-blocking backup that is currently running
-	_isOnlineBackupRunning bool
+	// _isBackupRunning tells us whether there is a backup that is currently running
+	_isBackupRunning bool
 }
 
 // NewActionAgent creates a new ActionAgent and registers all the
@@ -270,7 +266,7 @@ func NewActionAgent(
 	agent.exportStats = true
 	agent.statsTabletType = stats.NewString("TabletType")
 	agent.statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
-	agent.statsBackupIsRunning = stats.NewString("BackupIsRunning")
+	agent.statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
 
 	var mysqlHost string
 	var mysqlPort int32

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -54,7 +54,10 @@ func (agent *ActionAgent) Backup(ctx context.Context, concurrency int, logger lo
 	if err != nil {
 		return err
 	}
-	originalType := tablet.Type
+	if !allowMaster && tablet.Type == topodatapb.TabletType_MASTER {
+		return fmt.Errorf("type MASTER cannot take backup. if you really need to do this, rerun the backup command with -allow_master")
+	}
+	var originalType topodatapb.TabletType
 	if builtin != nil {
 		if err := agent.lock(ctx); err != nil {
 			return err
@@ -65,7 +68,7 @@ func (agent *ActionAgent) Backup(ctx context.Context, concurrency int, logger lo
 		if err != nil {
 			return err
 		}
-
+		originalType = tablet.Type
 		// update our type to BACKUP
 		if _, err := topotools.ChangeType(ctx, agent.TopoServer, tablet.Alias, topodatapb.TabletType_BACKUP); err != nil {
 			return err

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -78,6 +78,9 @@ func (agent *ActionAgent) Backup(ctx context.Context, concurrency int, logger lo
 			return err
 		}
 	} else {
+		if agent._isOnlineBackupRunning {
+			return fmt.Errorf("a backup is already running on tablet: %v", tablet.Alias)
+		}
 		// this means we continue to serve, but let's set _isOnlineBackupRunning to true
 		// have to take the mutex lock before writing to _ fields
 		agent.mutex.Lock()


### PR DESCRIPTION
Fixes #5062.
As documented in the issue, here's how we address this:
- don't take actionMutex lock while running xtrabackup
- introduce a boolean _isBackupRunning
- only allow a backup to start if _isBackupRunning is false
- protect updates to boolean using the mutex lock
- export this boolean to debug/vars so that there is a way for people to know that a backup is running

Signed-off-by: deepthi <deepthi@planetscale.com>