### PR TITLE
docker: vitess/k8s: Include all my.cnf template files.

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -41,25 +41,8 @@ COPY --from=base $VTTOP/web /vt/web/
 # copy vitess config
 COPY --from=base $VTTOP/config/init_db.sql /vt/config/
 
-# mysql flavor files for db specific .cnf settings
-COPY --from=base $VTTOP/config/mycnf/master_mysql56.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/master_mysql80.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/master_mariadb.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/master_mariadb103.cnf /vt/config/mycnf/
-
-# settings for different types of instances
-COPY --from=base $VTTOP/config/mycnf/default.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/default-fast.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/master.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/replica.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/rdonly.cnf /vt/config/mycnf/
-COPY --from=base $VTTOP/config/mycnf/backup.cnf /vt/config/mycnf/
-
-# settings to support rbr
-COPY --from=base $VTTOP/config/mycnf/rbr.cnf /vt/config/mycnf/
-
-# recommended production settings
-COPY --from=base $VTTOP/config/mycnf/production.cnf /vt/config/mycnf/
+# my.cnf include files
+COPY --from=base $VTTOP/config/mycnf /vt/config/mycnf
 
 # add vitess user and add permissions
 RUN groupadd -r --gid 2000 vitess && useradd -r -g vitess --uid 1000 vitess && \


### PR DESCRIPTION
There are now a larger set of required templates (since #4987) because we have auto-included files for every minor version (e.g. 5.6 vs 5.7). Just include everything instead of trying to pick and choose.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>