### PR TITLE
fix wrong spells in acl.go

### DIFF
--- a/go/vt/tableacl/acl/acl.go
+++ b/go/vt/tableacl/acl/acl.go
@@ -32,7 +32,7 @@ type Factory interface {
 	New(entries []string) (ACL, error)
 }
 
-// DenyAllACL implements ACL interface and alway deny access request.
+// DenyAllACL implements ACL interface and always deny access request.
 type DenyAllACL struct{}
 
 // IsMember implements ACL.IsMember and always return false.
@@ -40,7 +40,7 @@ func (acl DenyAllACL) IsMember(principal *querypb.VTGateCallerID) bool {
 	return false
 }
 
-// AcceptAllACL implements ACL interface and alway accept access request.
+// AcceptAllACL implements ACL interface and always accept access request.
 type AcceptAllACL struct{}
 
 // IsMember implements ACL.IsMember and always return true.


### PR DESCRIPTION
make the comment more readable