### PR TITLE
Gate Python and Java dependencies

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,6 +24,7 @@
 # 4. Installation of development related steps e.g. creating Git hooks.
 
 BUILD_TESTS=${BUILD_TESTS:-1}
+BUILD_PYTHON=${BUILD_PYTHON:-1}
 
 #
 # 0. Initialization and helper methods.
@@ -48,18 +49,18 @@ function fail() {
 go version &>/dev/null  || fail "Go is not installed or is not on \$PATH"
 [[ "$(go version 2>&1)" =~ go1\.[1-9][1-9] ]] || fail "Go is not version 1.11+"
 
+# Create main directories.
+mkdir -p "$VTROOT/dist"
+mkdir -p "$VTROOT/bin"
+mkdir -p "$VTROOT/lib"
+mkdir -p "$VTROOT/vthook"
+
 # Set up the proper GOPATH for go get below.
 if [ "$BUILD_TESTS" == 1 ] ; then
     source ./dev.env
 else
     source ./build.env
 fi
-
-# Create main directories.
-mkdir -p "$VTROOT/dist"
-mkdir -p "$VTROOT/bin"
-mkdir -p "$VTROOT/lib"
-mkdir -p "$VTROOT/vthook"
 
 if [ "$BUILD_TESTS" == 1 ] ; then
     # Set up required soft links.
@@ -150,7 +151,7 @@ function install_grpc() {
   $PIP install --upgrade grpcio=="$grpcio_ver" grpcio-tools=="$grpcio_ver"
 }
 
-if [ "$BUILD_TESTS" == 1 ] ; then
+if [ "$BUILD_PYTHON" == 1 ] ; then
     install_dep "gRPC" "1.16.0" "$VTROOT/dist/grpc" install_grpc
 fi
 
@@ -253,7 +254,7 @@ function install_pymock() {
   popd >/dev/null
 }
 pymock_version=1.0.1
-if [ "$BUILD_TESTS" == 1 ] ; then
+if [ "$BUILD_PYTHON" == 1 ] ; then
     install_dep "py-mock" "$pymock_version" "$VTROOT/dist/py-mock-$pymock_version" install_pymock
 fi
 
@@ -268,7 +269,7 @@ function install_selenium() {
   # instead of go/dist/selenium/lib/python3.5/site-packages and then can't find module 'pip._vendor.requests'
   PYTHONPATH='' $PIP install selenium
 }
-if [ "$BUILD_TESTS" == 1 ] ; then
+if [ "$BUILD_PYTHON" == 1 ] ; then
     install_dep "Selenium" "latest" "$VTROOT/dist/selenium" install_selenium
 fi
 
@@ -282,7 +283,7 @@ function install_chromedriver() {
   unzip -o -q chromedriver_linux64.zip -d "$dist"
   rm chromedriver_linux64.zip
 }
-if [ "$BUILD_TESTS" == 1 ] ; then
+if [ "$BUILD_PYTHON" == 1 ] ; then
     install_dep "chromedriver" "73.0.3683.20" "$VTROOT/dist/chromedriver" install_chromedriver
 fi
 
@@ -361,7 +362,9 @@ if [ "$BUILD_TESTS" == 1 ] ; then
   echo "$MYSQL_FLAVOR" > "$VTROOT/dist/MYSQL_FLAVOR"
 fi
 
-PYTHONPATH='' $PIP install mysql-connector-python
+if [ "$BUILD_PYTHON" == 1 ] ; then
+  PYTHONPATH='' $PIP install mysql-connector-python
+fi
 
 #
 # 4. Installation of development related steps e.g. creating Git hooks.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,7 @@
 
 BUILD_TESTS=${BUILD_TESTS:-1}
 BUILD_PYTHON=${BUILD_PYTHON:-1}
+BUILD_JAVA=${BUILD_JAVA:-1}
 
 #
 # 0. Initialization and helper methods.
@@ -188,9 +189,11 @@ function install_zookeeper() {
   zip -d "lib/$zk-fatjar.jar" 'META-INF/*.SF' 'META-INF/*.RSA' 'META-INF/*SF' || true # needed for >=3.4.10 <3.5
   rm -rf "$zk" "$zk.tar.gz"
 }
-zk_ver=${ZK_VERSION:-3.4.14}
-install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist/vt-zookeeper-$zk_ver" install_zookeeper
 
+zk_ver=${ZK_VERSION:-3.4.14}
+if [ "$BUILD_JAVA" == 1 ] ; then
+  install_dep "Zookeeper" "$zk_ver" "$VTROOT/dist/vt-zookeeper-$zk_ver" install_zookeeper
+fi
 
 # Download and install etcd, link etcd binary into our root.
 function install_etcd() {


### PR DESCRIPTION
The plan is to remove python dependencies, so this makes the first step of not requiring it for bootstrap. The goal is that a user can do this:

```
BUILD_PYTHON=0 ./bootstrap.sh
source dev.env
make
./tools/unit_test_runner.sh
```

This only runs unit tests, but in future Go-based end-to-end testing is planned.

Signed-off-by: Morgan Tocker <tocker@gmail.com>