### PR TITLE
Fix UpdateCellsAlias.

### DIFF
--- a/go/vt/topo/cells_aliases_test.go
+++ b/go/vt/topo/cells_aliases_test.go
@@ -1,0 +1,66 @@
+package topo
+
+import (
+	"testing"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestOverlappingAlias(t *testing.T) {
+	table := []struct {
+		currentAliases map[string][]string
+		newAliasName   string
+		newAlias       []string
+		want           string
+	}{
+		{
+			currentAliases: map[string][]string{
+				"alias1": {"cell_a", "cell_b"},
+				"alias2": {"cell_c", "cell_d"},
+			},
+			newAliasName: "overlaps_alias1",
+			newAlias:     []string{"cell_x", "cell_b"},
+			want:         "alias1",
+		},
+		{
+			currentAliases: map[string][]string{
+				"alias1": {"cell_a", "cell_b"},
+				"alias2": {"cell_c", "cell_d"},
+			},
+			newAliasName: "overlaps_alias2",
+			newAlias:     []string{"cell_x", "cell_c"},
+			want:         "alias2",
+		},
+		{
+			currentAliases: map[string][]string{
+				"alias1": {"cell_a", "cell_b"},
+				"alias2": {"cell_c", "cell_d"},
+			},
+			newAliasName: "no_overlap",
+			newAlias:     []string{"cell_x", "cell_y"},
+			want:         "",
+		},
+		{
+			currentAliases: map[string][]string{
+				"overlaps_self": {"cell_a", "cell_b"},
+				"alias2":        {"cell_c", "cell_d"},
+			},
+			newAliasName: "overlaps_self",
+			newAlias:     []string{"cell_a", "cell_b", "cell_x"},
+			want:         "",
+		},
+	}
+
+	for _, test := range table {
+		currentAliases := map[string]*topodatapb.CellsAlias{}
+		for name, cells := range test.currentAliases {
+			currentAliases[name] = &topodatapb.CellsAlias{Cells: cells}
+		}
+		newAlias := &topodatapb.CellsAlias{Cells: test.newAlias}
+
+		got := overlappingAlias(currentAliases, test.newAliasName, newAlias)
+		if got != test.want {
+			t.Errorf("overlappingAlias(%v) = %q; want %q", test.newAliasName, got, test.want)
+		}
+	}
+}

--- a/go/vt/vtctl/cells_aliases.go
+++ b/go/vt/vtctl/cells_aliases.go
@@ -39,7 +39,7 @@ func init() {
 		"AddCellsAlias",
 		commandAddCellsAlias,
 		"[-cells <cell,cell2...>] <alias>",
-		"Registers a local topology service in a new cell by creating the CellsAlias with the provided parameters. An alis provides a group cells that replica/rdonly can route. By default, vitess won't route traffic cross cells for replica/rdonly tablets. Aliases provide a way to create groups where this is allowed."})
+		"Defines a group of cells within which replica/rdonly traffic can be routed across cells. Between cells that are not in the same group (alias), only master traffic can be routed."})
 
 	addCommand(cellsAliasesGroupName, command{
 		"UpdateCellsAlias",
@@ -61,7 +61,7 @@ func init() {
 }
 
 func commandAddCellsAlias(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	cellsString := subFlags.String("cells", "", "The address the topology server is using for that cell.")
+	cellsString := subFlags.String("cells", "", "The list of cell names that are members of this alias.")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func commandAddCellsAlias(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 }
 
 func commandUpdateCellsAlias(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	cellsString := subFlags.String("cells", "", "The address the topology server is using for that cell.")
+	cellsString := subFlags.String("cells", "", "The list of cell names that are members of this alias.")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}

--- a/test/cell_aliases.py
+++ b/test/cell_aliases.py
@@ -36,7 +36,7 @@ from vtproto import topodata_pb2
 from vtdb import keyrange_constants
 from vtdb import vtgate_client
 
-use_alias = False
+use_alias = True
 
 # initial shards
 # range '' - 80
@@ -226,9 +226,12 @@ index by_msg (msg)
     utils.apply_vschema(vschema)
 
     # Adds alias so vtgate can route to replica/rdonly tablets that are not in the same cell, but same alias
-
     if use_alias:
       utils.run_vtctl(['AddCellsAlias', '-cells', 'test_nj,test_ny','region_east_coast'], auto_log=True)
+
+      # Check that UpdateCellsAlias is idempotent.
+      utils.run_vtctl(['UpdateCellsAlias', '-cells', 'test_nj,test_ny','region_east_coast'], auto_log=True)
+
       tablet_types_to_wait='MASTER,REPLICA'
     else:
       tablet_types_to_wait='MASTER'


### PR DESCRIPTION
It should allow updates to an alias that overlap with the previous value of that same alias, since the old value is being replaced.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>