### PR TITLE
Move git hooks to start of bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -368,4 +368,4 @@ if [ "$BUILD_PYTHON" == 1 ] ; then
 fi
 
 echo
-echo "bootstrap finished - run 'source dev.build' or 'source build.env' in your shell before building."
+echo "bootstrap finished - run 'source dev.env' or 'source build.env' in your shell before building."


### PR DESCRIPTION
This is a small change to the bootstrap. I moved creating git hooks to the start, and they are not gated by `BUILD_TESTS`.

The motivation for doing this, is that I was doing something naive (and have to assume others are doing this too): the selenium dependency forces the rest of the script to fail. I manually ran the `govendor` and `go get` steps that followed (because I had to), but did not run the git hook code.

In the future we will remove the selenium requirement (and I think later we can remove the `govendor`/`go get` via go modules), but until then this is hopefully an improvement.

*Edit:* some dead code is also removed about number of cores. It is not used anywhere.

Signed-off-by: Morgan Tocker <tocker@gmail.com>