### PR TITLE
vreplication: fix character set issue

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -194,6 +194,11 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 		if _, err := dbClient.ExecuteFetch("set @@session.time_zone = '+00:00'", 10000); err != nil {
 			return err
 		}
+		// Tables may have varying character sets. To ship the bits without interpreting them
+		// we set the character set to be binary.
+		if _, err := dbClient.ExecuteFetch("set names binary", 10000); err != nil {
+			return err
+		}
 		vreplicator := newVReplicator(ct.id, &ct.source, tablet, ct.blpStats, dbClient, ct.mysqld)
 		return vreplicator.Replicate(ctx)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -464,8 +464,12 @@ func expectNontxQueries(t *testing.T, queries []string) {
 		}
 	}
 }
-
 func expectData(t *testing.T, table string, values [][]string) {
+	t.Helper()
+	customExpectData(t, table, values, env.Mysqld.FetchSuperQuery)
+}
+
+func customExpectData(t *testing.T, table string, values [][]string, exec func(ctx context.Context, query string) (*sqltypes.Result, error)) {
 	t.Helper()
 
 	var query string
@@ -474,7 +478,7 @@ func expectData(t *testing.T, table string, values [][]string) {
 	} else {
 		query = fmt.Sprintf("select * from %s", table)
 	}
-	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), query)
+	qr, err := exec(context.Background(), query)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -82,6 +82,9 @@ func (rs *rowStreamer) Stream() error {
 		return err
 	}
 	defer conn.Close()
+	if _, err := conn.ExecuteFetch("set names binary", 1, false); err != nil {
+		return err
+	}
 	return rs.streamQuery(conn, rs.send)
 }
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -107,6 +107,56 @@ func TestStreamRowsScan(t *testing.T) {
 	checkStream(t, "select * from t3", []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewVarBinary("aaa")}, wantQuery, wantStream)
 }
 
+func TestStreamRowsUnicode(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	execStatements(t, []string{
+		"create table t1(id int, val varchar(128) COLLATE utf8_unicode_ci, primary key(id))",
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+	})
+	engine.se.Reload(context.Background())
+
+	// We need a latin1 connection.
+	conn, err := env.Mysqld.GetDbaConnection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecuteFetch("set names latin1", 10000, false); err != nil {
+		t.Fatal(err)
+	}
+	// This will get "Mojibaked" into the utf8 column.
+	if _, err := conn.ExecuteFetch("insert into t1 values(1, '👍')", 10000, false); err != nil {
+		t.Fatal(err)
+	}
+
+	savecp := *engine.cp
+	// Rowstreamer must override this to "binary"
+	engine.cp.Charset = "latin1"
+	defer func() { engine.cp = &savecp }()
+	err = engine.StreamRows(context.Background(), "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		// Skip fields.
+		if len(rows.Rows) == 0 {
+			return nil
+		}
+		got := fmt.Sprintf("%q", rows.Rows[0].Values)
+		// We should expect a "Mojibaked" version of the string.
+		want := `"1ðŸ‘\u008d"`
+		if got != want {
+			t.Errorf("rows.Rows[0].Values: %s, want %s", got, want)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestStreamRowsKeyRange(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
The latin1 character set performs some conversion, which was
not our previous understanding. This changes vreplication to
use binary character set instead, which is more faithful about
not converting the bits in the database.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>