### PR TITLE
fix wrong spells in vtprocess.go

### DIFF
--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -91,7 +91,7 @@ func (vtp *VtProcess) Address() string {
 	return fmt.Sprintf("localhost:%d", vtp.Port)
 }
 
-// WaitTerminate attemps to gracefully shutdown the Vitess process by sending
+// WaitTerminate attempts to gracefully shutdown the Vitess process by sending
 // a SIGTERM, then wait for up to 10s for it to exit. If the process hasn't
 // exited cleanly after 10s, a SIGKILL is forced and the corresponding exit
 // error is returned to the user


### PR DESCRIPTION
Make the comment more readable