### PR TITLE
helm: delete mysql.sock.lock in init container

### DIFF
--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -195,6 +195,7 @@ spec:
 
       # remove the old socket file if it is still around
       rm -f /vtdataroot/tabletdata/mysql.sock
+      rm -f /vtdataroot/tabletdata/mysql.sock.lock
 
 {{- end -}}
 


### PR DESCRIPTION
Sometimes if a pod is terminated abruptly, this gets left behind in the PV and prevents MySQL from booting up.