### PR TITLE
Empty results should return a count of 0 but a sum of null.

### DIFF
--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -376,9 +376,9 @@ func (oa *OrderedAggregate) createEmptyRow() ([]sqltypes.Value, error) {
 func createEmptyValueFor(opcode AggregateOpcode) (sqltypes.Value, error) {
 	switch opcode {
 	case AggregateCountDistinct:
-		return sqltypes.NULL, nil
+		return countZero, nil
 	case AggregateSumDistinct:
-		return sumZero, nil
+		return sqltypes.NULL, nil
 	}
 	return sqltypes.NULL, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "unknown aggregation %v", opcode)
 }

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -674,7 +674,7 @@ func TestNoInputAndNoGroupingKeys(t *testing.T) {
 			"count(distinct col2)|sum(distinct col2)",
 			"int64|decimal",
 		),
-		"null|0",
+		"0|null",
 	)
 	assert.Equal(wantResult, result)
 }


### PR DESCRIPTION
Signed-off-by: Michael Pawliszyn <mikepaw@squareup.com>