### PR TITLE
healthcheck after backup should be run only for offline backups

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -122,9 +122,10 @@ func (agent *ActionAgent) Backup(ctx context.Context, concurrency int, logger lo
 		if err := agent.refreshTablet(bgCtx, "after backup"); err != nil {
 			return err
 		}
+		// and re-run health check to be sure to capture any replication delay
+		// not needed for online backups because it will continue to run per schedule
+		agent.runHealthCheckLocked()
 	}
-	// and re-run health check to be sure to capture any replication delay
-	agent.runHealthCheckLocked()
 
 	return returnErr
 }


### PR DESCRIPTION
This is a follow up to #5066 
Since we no longer take the action lock while running online backups (aka xtrabackup), healthcheck will run on the normal schedule. Hence there is no need to call it explicitly when the backup finishes. Further, healthcheck is supposed to take the action lock before running, so it is incorrect to call `agent.runHealthCheckLocked()` when we are not holding the action lock.

Signed-off-by: deepthi <deepthi@planetscale.com>