### PR TITLE
Handle MySQL JDBC driver setCatalog("")

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1286,6 +1286,9 @@ var (
 		input:  "use db",
 		output: "use db",
 	}, {
+		input:  "use ``",
+		output: "use ``",
+	}, {
 		input:  "use duplicate",
 		output: "use `duplicate`",
 	}, {

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -127,7 +127,7 @@ func skipToEnd(yylex interface{}) {
 %left <bytes> JOIN STRAIGHT_JOIN LEFT RIGHT INNER OUTER CROSS NATURAL USE FORCE
 %left <bytes> ON USING
 %token <empty> '(' ',' ')'
-%token <bytes> ID HEX STRING INTEGRAL FLOAT HEXNUM VALUE_ARG LIST_ARG COMMENT COMMENT_KEYWORD BIT_LITERAL
+%token <bytes> ID EMPTY_ID HEX STRING INTEGRAL FLOAT HEXNUM VALUE_ARG LIST_ARG COMMENT COMMENT_KEYWORD BIT_LITERAL
 %token <bytes> NULL TRUE FALSE OFF
 
 // Precedence dictated by mysql. But the vitess grammar is simplified.
@@ -1679,6 +1679,10 @@ use_statement:
   USE table_id
   {
     $$ = &Use{DBName: $2}
+  }
+| USE EMPTY_ID
+  {
+    $$ = &Use{DBName:TableIdent{v:""}}
   }
 | USE
   {

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -711,7 +711,7 @@ func (tkn *Tokenizer) scanLiteralIdentifier() (int, []byte) {
 		tkn.next()
 	}
 	if buffer.Len() == 0 {
-		return LEX_ERROR, buffer.Bytes()
+		return EMPTY_ID, buffer.Bytes()
 	}
 	return ID, buffer.Bytes()
 }


### PR DESCRIPTION
When using the MySQL JDBC driver and you want to switch from shard
targeting back to auto resolving tables you need to use
connection.setCatalog(""). This will send the SQL statement "USE ``"
to the server.