### PR TITLE
Orc basic auth with vttablet flags

### DIFF
--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -37,6 +37,8 @@ import (
 
 var (
 	orcAddr     = flag.String("orc_api_url", "", "Address of Orchestrator's HTTP API (e.g. http://host:port/api/). Leave empty to disable Orchestrator integration.")
+	orcUser     = flag.String("orc_api_user", "", "(Optional) Basic auth username to authenticate with Orchestrator's HTTP API. Leave empty to disable basic auth.")
+	orcPassword = flag.String("orc_api_password", "", "(Optional) Basic auth password to authenticate with Orchestrator's HTTP API.")
 	orcTimeout  = flag.Duration("orc_timeout", 30*time.Second, "Timeout for calls to Orchestrator's HTTP API")
 	orcInterval = flag.Duration("orc_discover_interval", 0, "How often to ping Orchestrator's HTTP API endpoint to tell it we exist. 0 means never.")
 )
@@ -183,7 +185,11 @@ func (orc *orcClient) apiGet(pathParts ...string) ([]byte, error) {
 	url.Path = path.Join(fullPath...)
 
 	// Note that url.String() will URL-escape the path we gave it above.
-	resp, err := orc.httpClient.Get(url.String())
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if *orcUser != "" {
+		req.SetBasicAuth(*orcUser, *orcPassword)
+	}
+	resp, err := orc.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implement a way to authenticate with Orchestrator via HTTP basic auth by passing the optional flags.

*  `-orc_api_user`
*  `-orc_api_password`

Omitting orc_api_user skips authentication.

This has been tested to work in our k8s-based vitess cluster.

Signed-off-by: Mark Solters <msolters@gmail.com>