### PR TITLE
Bugfix: Helm chart parse error when enabling orchestrator

### DIFF
--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -14,7 +14,7 @@ metadata:
   name: orchestrator-cm
 data:
   orchestrator.conf.json: |-
-     {
+    {
     "ActiveNodeExpireSeconds": 5,
     "ApplyMySQLPromotionAfterMasterFailover": true,
     "AuditLogFile": "/tmp/orchestrator-audit.log",


### PR DESCRIPTION
When enabling orchestrator in the values of the helm chart, I saw the following error:
Error: YAML parse error on vitess/templates/vitess.yaml: error converting YAML to JSON: yaml: line 10: did not find expected key

This was due to an extra space in the orchestrator template.