### PR TITLE
make TabletExternallyReparented more robust

### DIFF
--- a/go/vt/vttablet/tabletmanager/healthcheck_test.go
+++ b/go/vt/vttablet/tabletmanager/healthcheck_test.go
@@ -38,6 +38,9 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+
+	// needed so that grpc client is registered
+	_ "vitess.io/vitess/go/vt/vttablet/grpctmclient"
 )
 
 func TestHealthRecordDeduplication(t *testing.T) {
@@ -717,7 +720,7 @@ func TestStateChangeImmediateHealthBroadcast(t *testing.T) {
 	// Run TER to turn us into a proper master, wait for it to finish.
 	agent.HealthReporter.(*fakeHealthCheck).reportReplicationDelay = 19 * time.Second
 	if err := agent.TabletExternallyReparented(ctx, "unused_id"); err != nil {
-		t.Fatal(err)
+		t.Fatalf("TabletExternallyReparented failed: %v", err)
 	}
 	<-agent.finalizeReparentCtx.Done()
 	ti, err := agent.TopoServer.GetTablet(ctx, tabletAlias)

--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
@@ -269,7 +269,7 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 	for tab := range tabletsToRefresh {
 		log.Infof("finalizeTabletExternallyReparented: Refresh state for tablet: %v", topoproto.TabletAliasString(tab.Alias))
 		wg.Add(1)
-		go func(tablet *topodatapb.Tablet) {
+		go func(tablet topodatapb.Tablet) {
 			defer wg.Done()
 
 			// Tell the old master(s) to re-read its tablet record and change its state.
@@ -277,10 +277,10 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 			// for it to make sure that an old master tablet is not stuck in the MASTER
 			// state.
 			tmc := tmclient.NewTabletManagerClient()
-			if err := tmc.RefreshState(ctx, tablet); err != nil {
+			if err := tmc.RefreshState(ctx, &tablet); err != nil {
 				log.Warningf("Error calling RefreshState on old master %v: %v", topoproto.TabletAliasString(tablet.Alias), err)
 			}
-		}(&tab)
+		}(tab)
 	}
 	wg.Wait()
 	if errs.HasErrors() {

--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
@@ -206,6 +206,11 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 	// here anymore. The lock was only to ensure that the global shard record
 	// didn't get modified between the time when we read it and the time when we
 	// write it back. Now we use an update loop pattern to do that instead.
+
+	// We also used to do this in parallel with RefreshState on the old master
+	// we don't do that any more. we want to update the shard record first
+	// and only then attempt to refresh the old master because it is possible
+	// that the old master is unreachable
 	event.DispatchUpdate(ev, "updating global shard record")
 	log.Infof("finalizeTabletExternallyReparented: updating global shard record if needed")
 	_, err = agent.TopoServer.UpdateShardFields(ctx, masterTablet.Keyspace, masterTablet.Shard, func(currentSi *topo.ShardInfo) error {

--- a/go/vt/wrangler/testlib/reparent_external_test.go
+++ b/go/vt/wrangler/testlib/reparent_external_test.go
@@ -326,6 +326,15 @@ func TestTabletExternallyReparentedImpostorMaster(t *testing.T) {
 		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
 	}
 
+	// check the impostor also claims to be master
+	tablet, err = ts.GetTablet(ctx, badSlave.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", badSlave.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
+	}
+
 	// On the elected master, we will respond to
 	// TabletActionSlaveWasPromoted.
 	newMaster.StartActionLoop(t, wr)
@@ -352,6 +361,98 @@ func TestTabletExternallyReparentedImpostorMaster(t *testing.T) {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
 	waitForExternalReparent(t, "TestTabletExternallyReparentedImpostorMaster: good case", waitID)
+
+	// check the new master is really master
+	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// check the old master was converted to replica
+	tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_REPLICA {
+		t.Fatalf("old master should be replica but is: %v", tablet.Type)
+	}
+
+	// check the impostor master was converted to replica
+	tablet, err = ts.GetTablet(ctx, badSlave.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", badSlave.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_REPLICA {
+		t.Fatalf("bad slave should be replica but is: %v", tablet.Type)
+	}
+}
+
+func TestTabletExternallyReparentedFailedImpostorMaster(t *testing.T) {
+	tabletmanager.SetReparentFlags(2 * time.Second /* finalizeTimeout */)
+
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1", "cell2")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, a new master, and a bad slave.
+	badSlave := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_MASTER, nil)
+	// do this after badSlave so that the shard record has the expected master
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil, ForceInitTablet())
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+
+	// check the old master is really master
+	tablet, err := ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// check the impostor also claims to be master
+	tablet, err = ts.GetTablet(ctx, badSlave.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", badSlave.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted.
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted.
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	// Reparent to a replica, and pretend the impostor master is not responding.
+
+	// The reparent should work as expected here
+	tmc := tmclient.NewTabletManagerClient()
+	ti, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
+	waitID := makeWaitID()
+	if err := tmc.TabletExternallyReparented(context.Background(), ti.Tablet, waitID); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+	waitForExternalReparent(t, "TestTabletExternallyReparentedImpostorMaster: good case", waitID)
+
+	// check the new master is really master
+	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
 
 	// check the old master was converted to replica
 	tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)

--- a/go/vt/wrangler/testlib/reparent_external_test.go
+++ b/go/vt/wrangler/testlib/reparent_external_test.go
@@ -300,7 +300,7 @@ func TestTabletExternallyReparentedFailedOldMaster(t *testing.T) {
 		t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_REPLICA {
-		t.Fatalf("old master should be spare but is: %v", tablet.Type)
+		t.Fatalf("old master should be replica but is: %v", tablet.Type)
 	}
 }
 


### PR DESCRIPTION
This is an attempt to fix some problems found by @sougou and @enisoc 
TabletExternallyReparented should set the type to REPLICA not only on the current "oldMaster" but also on any lingering old masters from previous unsuccessful reparents.

Changes in this PR (edited from the list written by @enisoc below)
* Remove the short circuit on the shard record being up-to-date. This ensures future TER calls will try to do cleanup even if the shard record has already been updated. 
* Update the shard record as soon as the new and old master tablet records have been updated. This ensures that everyone knows who the new master is even if we fail to update some of the impostors, which in the context of TER is only a best-effort cleanup.
* In parallel with updating the shard record, we should immediately start trying to refresh the old master, since ensuring it knows it's not master is the next most important thing.
* Only after all that do we start trying to do best-effort cleanup of impostors: listing tablets for the shard, updating tablet records, and refreshing tablets.

When is TER is marked as finished vs failed?
* if the global shard record was updated correctly AND the old master and new master tablet records were updated correctly AND any lingering old masters have had their tablet records updated correctly, then TER is marked as finished. If the topo is healthy, there is no reason for any of these to fail.
* if any of these fails, then it is marked as failed. re-running TER is safe and might make more progress than a previous attempt.
* if the old master(s) have not refreshed their state correctly, we only log a warning (along with the error from the call to RefreshState), we don't mark TER as failed. This is only expected to happen if that particular tablet is unreachable. However, you do need to watch for if and when the old tablets come back online. An automated fix to this situation is planned for a future PR (Issue #5173)

Signed-off-by: deepthi <deepthi@planetscale.com>