### PR TITLE
vtbackup: Stop slave before trying to change master address.

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -376,8 +376,8 @@ func startReplication(ctx context.Context, mysqld mysqlctl.MysqlDaemon, topoServ
 		return vterrors.Wrapf(err, "Cannot read master tablet %v", si.MasterAlias)
 	}
 
-	// Set master and start slave.
-	if err := mysqld.SetMaster(ctx, topoproto.MysqlHostname(ti.Tablet), int(topoproto.MysqlPort(ti.Tablet)), false /* slaveStopBefore */, true /* slaveStartAfter */); err != nil {
+	// Stop slave (in case we're restarting), set master, and start slave.
+	if err := mysqld.SetMaster(ctx, topoproto.MysqlHostname(ti.Tablet), int(topoproto.MysqlPort(ti.Tablet)), true /* slaveStopBefore */, true /* slaveStartAfter */); err != nil {
 		return vterrors.Wrap(err, "MysqlDaemon.SetMaster failed")
 	}
 	return nil


### PR DESCRIPTION
Otherwise, we get errors like this when we try to restart replication:

```
This operation cannot be performed with running replication threads; run STOP SLAVE FOR CHANNEL '' first (errno 3081) (sqlstate HY000) during query: CHANGE MASTER TO
```

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>