### PR TITLE
Prevent log purging of symlinks

### DIFF
--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -70,7 +70,13 @@ func purgeLogsOnce(now time.Time, dir, program string, ctimeDelta time.Duration,
 		return
 	}
 	for _, file := range files {
-		if current[file] {
+		statInfo, err := os.Lstat(file)
+		if err != nil {
+			// Failed to stat file
+			continue
+		}
+		if current[file] || !statInfo.Mode().IsRegular() {
+			// Do not purge current file or any non-regular files (symlinks etc)
 			continue
 		}
 		purgeFile := false


### PR DESCRIPTION
This prevents purging of current log files, i.e., logs that are pointed to by a symlink such as `vttablet.INFO`. Previously we were allowed to delete the current log file if the underlying log file was low volume and had an mtime that put it beyond the retention period.

Signed-off-by: Adam Saponara <as@php.net>