### PR TITLE
vreplication: refactor table_plan_builder

### DIFF
--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -295,4 +296,11 @@ func ParseShardingSpec(spec string) ([]*topodatapb.KeyRange, error) {
 		old = p
 	}
 	return ranges, nil
+}
+
+var krRegexp = regexp.MustCompile(`^[0-9a-fA-F]*-[0-9a-fA-F]*$`)
+
+// IsKeyRange returns true if the string represents a keyrange.
+func IsKeyRange(kr string) bool {
+	return krRegexp.MatchString(kr)
 }

--- a/go/vt/key/key_test.go
+++ b/go/vt/key/key_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -381,7 +382,7 @@ func BenchmarkUint64KeyString(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for _, key := range keys {
-			key.String()
+			_ = key.String()
 		}
 	}
 }
@@ -433,5 +434,46 @@ func BenchmarkKeyRangesOverlap(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		KeyRangesOverlap(kr1, kr2)
+	}
+}
+
+func TestIsKeyRange(t *testing.T) {
+	testcases := []struct {
+		in  string
+		out bool
+	}{{
+		in:  "-",
+		out: true,
+	}, {
+		in:  "-80",
+		out: true,
+	}, {
+		in:  "40-80",
+		out: true,
+	}, {
+		in:  "80-",
+		out: true,
+	}, {
+		in:  "a0-",
+		out: true,
+	}, {
+		in:  "-A0",
+		out: true,
+	}, {
+		in:  "",
+		out: false,
+	}, {
+		in:  "x-80",
+		out: false,
+	}, {
+		in:  "-80x",
+		out: false,
+	}, {
+		in:  "select",
+		out: false,
+	}}
+
+	for _, tcase := range testcases {
+		assert.Equal(t, IsKeyRange(tcase.in), tcase.out, tcase.in)
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -86,6 +86,44 @@ func TestBuildPlayerPlan(t *testing.T) {
 			},
 		},
 	}, {
+		// Regular with keyrange
+		input: &binlogdatapb.Filter{
+			Rules: []*binlogdatapb.Rule{{
+				Match:  "/.*",
+				Filter: "-80",
+			}},
+		},
+		plan: &TestReplicatorPlan{
+			VStreamFilter: &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{{
+					Match:  "t1",
+					Filter: "select * from t1 where in_keyrange('-80')",
+				}},
+			},
+			TargetTables: []string{"t1"},
+			TablePlans: map[string]*TestTablePlan{
+				"t1": {
+					TargetName: "t1",
+					SendRule:   "t1",
+				},
+			},
+		},
+		planpk: &TestReplicatorPlan{
+			VStreamFilter: &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{{
+					Match:  "t1",
+					Filter: "select * from t1 where in_keyrange('-80')",
+				}},
+			},
+			TargetTables: []string{"t1"},
+			TablePlans: map[string]*TestTablePlan{
+				"t1": {
+					TargetName: "t1",
+					SendRule:   "t1",
+				},
+			},
+		},
+	}, {
 		// '*' expression
 		input: &binlogdatapb.Filter{
 			Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -128,6 +128,7 @@ func mustSendDDL(query mysql.Query, dbname string, filter *binlogdatapb.Filter) 
 	return true
 }
 
+// tableMatches is similar to the one defined in vreplication.
 func tableMatches(table sqlparser.TableName, dbname string, filter *binlogdatapb.Filter) bool {
 	if !table.Qualifier.IsEmpty() && table.Qualifier.String() != dbname {
 		return false


### PR DESCRIPTION
Unify the code path for wildcard and exact table name matches.
The diverging paths have been a source of bugs.

This unification will also help with the next feature that will
allow us to exclude tables in the filtering rules.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>