### PR TITLE
fix docker pre-fetch of go modules

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -52,18 +52,20 @@ ENV USER vitess
 ENV GO111MODULE on
 
 # Copy files needed for bootstrap
-COPY bootstrap.sh dev.env build.env /vt/src/vitess.io/vitess/
+COPY bootstrap.sh dev.env build.env go.mod go.sum /vt/src/vitess.io/vitess/
 COPY config /vt/src/vitess.io/vitess/config
 COPY third_party /vt/src/vitess.io/vitess/third_party
 COPY tools /vt/src/vitess.io/vitess/tools
 COPY travis /vt/src/vitess.io/vitess/travis
 
-RUN go mod download
-
 # Create vitess user
 RUN groupadd -r vitess && useradd -r -g vitess vitess && \
     mkdir -p /vt/vtdataroot /home/vitess && \
     chown -R vitess:vitess /vt /home/vitess
+
+# Download vendored Go dependencies
+RUN cd /vt/src/vitess.io/vitess && \
+ su vitess -c "/usr/local/go/bin/go mod download"
 
 # Create mount point for actual data (e.g. MySQL data dir)
 VOLUME /vt/vtdataroot


### PR DESCRIPTION
There was a bug in #5109 where go modules were not being prefetched correctly. Reported by @dweitzman 

I tested this with `make docker_bootstrap && make docker_test flavor=mysql57`. I manually observed the `go mod download` phase, and checked that it did not return instantly (which would indicate there is no download happening).

Signed-off-by: Morgan Tocker <tocker@gmail.com>