### PR TITLE
vreplication: more VReplicationExec constructs

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
@@ -210,7 +210,7 @@ func buildDeletePlan(del *sqlparser.Delete) (*controllerPlan, error) {
 		},
 	}
 	buf3 := sqlparser.NewTrackedBuffer(nil)
-	buf3.Myprintf("delete from %s%v", copySateTableName, copyStateWhere)
+	buf3.Myprintf("delete from %s%v", copyStateTableName, copyStateWhere)
 
 	return &controllerPlan{
 		opcode:       deleteQuery,
@@ -222,7 +222,7 @@ func buildDeletePlan(del *sqlparser.Delete) (*controllerPlan, error) {
 
 func buildSelectPlan(sel *sqlparser.Select) (*controllerPlan, error) {
 	switch sqlparser.String(sel.From) {
-	case vreplicationTableName, reshardingJournalTableName, copySateTableName:
+	case vreplicationTableName, reshardingJournalTableName, copyStateTableName:
 		return &controllerPlan{
 			opcode: selectQuery,
 		}, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -48,8 +48,10 @@ var (
 			},
 		},
 	}
-	testDMLResponse = &sqltypes.Result{RowsAffected: 1}
-	testPos         = "MariaDB/0-1-1083"
+	testSelectorResponse1 = &sqltypes.Result{Rows: [][]sqltypes.Value{{sqltypes.NewInt64(1)}}}
+	testSelectorResponse2 = &sqltypes.Result{Rows: [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}}
+	testDMLResponse       = &sqltypes.Result{RowsAffected: 1}
+	testPos               = "MariaDB/0-1-1083"
 )
 
 func TestControllerKeyRange(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -36,7 +36,7 @@ import (
 const (
 	reshardingJournalTableName = "_vt.resharding_journal"
 	vreplicationTableName      = "_vt.vreplication"
-	copySateTableName          = "_vt.copy_state"
+	copyStateTableName         = "_vt.copy_state"
 
 	createReshardingJournalTable = `create table if not exists _vt.resharding_journal(
   id bigint,

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/topo"
 )
 
@@ -269,54 +270,92 @@ func (vre *Engine) Exec(query string) (*sqltypes.Result, error) {
 		if qr.InsertID == 0 {
 			return nil, fmt.Errorf("insert failed to generate an id")
 		}
-		params, err := readRow(dbClient, int(qr.InsertID))
-		if err != nil {
-			return nil, err
+		for id := int(qr.InsertID); id < int(qr.InsertID)+plan.numInserts; id++ {
+			if ct := vre.controllers[id]; ct != nil {
+				// Unreachable. Just a failsafe.
+				ct.Stop()
+				delete(vre.controllers, id)
+			}
+			params, err := readRow(dbClient, id)
+			if err != nil {
+				return nil, err
+			}
+			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil)
+			if err != nil {
+				return nil, err
+			}
+			vre.controllers[id] = ct
 		}
-		// Create a controller for the newly created row.
-		ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil)
-		if err != nil {
-			return nil, err
-		}
-		vre.controllers[int(qr.InsertID)] = ct
 		return qr, nil
 	case updateQuery:
-		var blpStats *binlogplayer.Stats
-		if ct := vre.controllers[plan.id]; ct != nil {
-			// Stop the current controller.
-			ct.Stop()
-			blpStats = ct.blpStats
-		}
-		qr, err := vre.executeFetchMaybeCreateTable(dbClient, plan.query, 1)
+		ids, bv, err := vre.fetchIDs(dbClient, plan.selector)
 		if err != nil {
 			return nil, err
 		}
-		params, err := readRow(dbClient, plan.id)
+		if len(ids) == 0 {
+			return &sqltypes.Result{}, nil
+		}
+		blpStats := make(map[int]*binlogplayer.Stats)
+		for _, id := range ids {
+			if ct := vre.controllers[id]; ct != nil {
+				// Stop the current controller.
+				ct.Stop()
+				blpStats[id] = ct.blpStats
+			}
+		}
+		query, err := plan.applier.GenerateQuery(bv, nil)
 		if err != nil {
 			return nil, err
 		}
-		// Create a new controller in place of the old one.
-		// For continuity, the new controller inherits the previous stats.
-		ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, blpStats)
+		qr, err := vre.executeFetchMaybeCreateTable(dbClient, query, 1)
 		if err != nil {
 			return nil, err
 		}
-		vre.controllers[plan.id] = ct
+		for _, id := range ids {
+			params, err := readRow(dbClient, id)
+			if err != nil {
+				return nil, err
+			}
+			// Create a new controller in place of the old one.
+			// For continuity, the new controller inherits the previous stats.
+			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, blpStats[id])
+			if err != nil {
+				return nil, err
+			}
+			vre.controllers[id] = ct
+		}
 		return qr, nil
 	case deleteQuery:
-		// Stop and delete the current controller.
-		if ct := vre.controllers[plan.id]; ct != nil {
-			ct.Stop()
-			delete(vre.controllers, plan.id)
+		ids, bv, err := vre.fetchIDs(dbClient, plan.selector)
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) == 0 {
+			return &sqltypes.Result{}, nil
+		}
+		// Stop and delete the current controllers.
+		for _, id := range ids {
+			if ct := vre.controllers[id]; ct != nil {
+				ct.Stop()
+				delete(vre.controllers, id)
+			}
 		}
 		if err := dbClient.Begin(); err != nil {
 			return nil, err
 		}
-		qr, err := dbClient.ExecuteFetch(plan.query, 10000)
+		query, err := plan.applier.GenerateQuery(bv, nil)
 		if err != nil {
 			return nil, err
 		}
-		if _, err := dbClient.ExecuteFetch(plan.delCopyState, 10000); err != nil {
+		qr, err := vre.executeFetchMaybeCreateTable(dbClient, query, 1)
+		if err != nil {
+			return nil, err
+		}
+		delQuery, err := plan.delCopyState.GenerateQuery(bv, nil)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := dbClient.ExecuteFetch(delQuery, 10000); err != nil {
 			// Legacy vreplication won't create this table. So, ignore table not found error.
 			merr, isSQLErr := err.(*mysql.SQLError)
 			if !isSQLErr || !(merr.Num == mysql.ERNoSuchTable) {
@@ -332,6 +371,27 @@ func (vre *Engine) Exec(query string) (*sqltypes.Result, error) {
 		return vre.executeFetchMaybeCreateTable(dbClient, plan.query, 10000)
 	}
 	panic("unreachable")
+}
+
+func (vre *Engine) fetchIDs(dbClient binlogplayer.DBClient, selector string) (ids []int, bv map[string]*querypb.BindVariable, err error) {
+	qr, err := dbClient.ExecuteFetch(selector, 10000)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, row := range qr.Rows {
+		id, err := sqltypes.ToInt64(row[0])
+		if err != nil {
+			return nil, nil, err
+		}
+		ids = append(ids, int(id))
+	}
+	bvval, err := sqltypes.BuildBindVariable(ids)
+	if err != nil {
+		// Unreachable.
+		return nil, nil, err
+	}
+	bv = map[string]*querypb.BindVariable{"ids": bvval}
+	return ids, bv, nil
 }
 
 // WaitForPos waits for the replication to reach the specified position.

--- a/go/vt/wrangler/migrater_env_test.go
+++ b/go/vt/wrangler/migrater_env_test.go
@@ -35,8 +35,8 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 )
 
-const vreplQueryks = "select id, source from _vt.vreplication where workflow = 'test' and db_name = 'vt_ks'"
-const vreplQueryks2 = "select id, source from _vt.vreplication where workflow = 'test' and db_name = 'vt_ks2'"
+const vreplQueryks = "select id, source from _vt.vreplication where workflow='test' and db_name='vt_ks'"
+const vreplQueryks2 = "select id, source from _vt.vreplication where workflow='test' and db_name='vt_ks2'"
 
 type testMigraterEnv struct {
 	ts                                           *topo.Server

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -585,8 +585,9 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 
 func expectDeleteVRepl(dbClient *binlogplayer.MockDBClient) {
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
+	dbClient.ExpectRequest("select id from _vt.vreplication where id = 1", &sqltypes.Result{Rows: [][]sqltypes.Value{{sqltypes.NewInt64(1)}}}, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
-	dbClient.ExpectRequest("delete from _vt.vreplication where id = 1", &sqltypes.Result{RowsAffected: 1}, nil)
-	dbClient.ExpectRequest("delete from _vt.copy_state where vrepl_id = 1", nil, nil)
+	dbClient.ExpectRequest("delete from _vt.vreplication where id in (1)", &sqltypes.Result{RowsAffected: 1}, nil)
+	dbClient.ExpectRequest("delete from _vt.copy_state where vrepl_id in (1)", nil, nil)
 	dbClient.ExpectRequest("commit", nil, nil)
 }


### PR DESCRIPTION
Previously, only single row queries were allowed for VReplicationExec.
With this change, queries with arbitrary where clauses are supported.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>