### PR TITLE
messaging: move topic handling to vtgate

### DIFF
--- a/proto/vschema.proto
+++ b/proto/vschema.proto
@@ -64,8 +64,8 @@ message Vindex {
 
 // Table is the table info for a Keyspace.
 message Table {
-  // If the table is a sequence, type must be
-  // "sequence". Otherwise, it should be empty.
+  // If the table is a sequence, type must be "sequence".
+  // If the table is a topic, type must be "topic".
   string type = 1;
   // column_vindexes associates columns to vindexes.
   repeated ColumnVindex column_vindexes = 2;
@@ -83,6 +83,8 @@ message Table {
   // an authoritative list for the table. This allows
   // us to expand 'select *' expressions.
   bool column_list_authoritative = 6;
+  // subscription defines a relationship to a topic table.
+  Subscription subscription = 7;
 }
 
 // ColumnVindex is used to associate a column to a vindex.
@@ -113,4 +115,31 @@ message SrvVSchema {
   // keyspaces is a map of keyspace name -> Keyspace object.
   map<string, Keyspace> keyspaces = 1;
   RoutingRules routing_rules = 2;
+}
+
+// A Subscription defines a table relationship to a topic
+message Subscription {
+  // The topic must match a table of type TOPIC.
+  string topic = 1;
+  // TODO: filters are for a future PR. I am including a rough
+  // design here to help flesh out the reasoning behind including
+  // topic/subscription data in the vschema.
+  //
+  // filters allow messages published to a topic to conditionally
+  // be inserted into the message table. Repeated filters
+  // are ANDed together.
+  repeated SubscriptionFilter filters = 2;
+}
+
+// SubscriptionFilters describe matching rules for subscriptions.
+// https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html
+message SubscriptionFilter {
+  // valid values are "whitelist" or "blacklist"
+  string type = 1;
+  // column references a json column of type map<string, string>
+  Column column = 2;
+  // key references a value in the specified json column
+  string key = 3;
+  // vals specifies valid match values
+  repeated string vals = 4;
 }


### PR DESCRIPTION
I think the design of topics as implemented in #5011 is flawed. Topics are handled at the vttablet level, which has two use cases that cause unexpected data loss and cannot be fixed at the tablet layer:
1. **Single Keyspace**: It should be possible for a messaging table in one keyspace to subscribe to a topic from another keyspace. Currently, the topic won’t be aware of the subscribers from other keyspaces, as that is defined in a table level comment, and so will never fanout.
1. **Requires identical sharding column**: The sharding decision has already been made at the vtgate level, so inserting into subscriber message tables that are sharded differently would result in data integrity problems, since it violates sharding guarantees.

IMO, the correct solution should be handled at vtgate, where it can fanout inserts across keyspaces and maintain data integrity regardless of sharding columns. This has a further benefit of taking a burden off of vttablet, which will come into play as we add more advanced features like subscription filtering (#5180).

In this PR, I am proposing new vschema fields/messages to describe these subscriptions. I have also included a rough draft for what subscription filters might look like, to support the need for subscriptions to live in the vschema. The actual proto definition and implementation details are out of the scope of this PR. I will remove all these fields once the overall design is approved.