### PR TITLE
Upgrade to golang 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ services:
 
 language: go
 go:
-  - 1.12.x
+  - 1.13.x
 go_import_path: vitess.io/vitess
 env:
   global:

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.13-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/test/cluster/keytar/config/vitess_config.yaml
+++ b/test/cluster/keytar/config/vitess_config.yaml
@@ -3,8 +3,8 @@ install:
     - python-mysqldb
   extra:
     - apt-get update
-    - wget https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
-    - tar -C /usr/local -xzf go1.12.7.linux-amd64.tar.gz
+    - wget https://dl.google.com/go/go1.13.linux-amd64.tar.gz
+    - tar -C /usr/local -xzf go1.13.linux-amd64.tar.gz
     - wget https://storage.googleapis.com/kubernetes-helm/helm-v2.1.3-linux-amd64.tar.gz
     - tar -zxvf helm-v2.1.3-linux-amd64.tar.gz
     - pip install numpy

--- a/vagrant-scripts/bootstrap_vm.sh
+++ b/vagrant-scripts/bootstrap_vm.sh
@@ -37,7 +37,7 @@ apt-get install -y make \
 pip install mysql-connector-python
 
 # Install golang
-GO_VER='1.12.7'
+GO_VER='1.13'
 GO_DOWNLOAD_URL='https://dl.google.com/go/'
 GO_FILENAME="go${GO_VER}.linux-amd64.tar.gz"
 wget "${GO_DOWNLOAD_URL}/${GO_FILENAME}" -O "${TMP_DIR}/${GO_FILENAME}"


### PR DESCRIPTION
## Description
Upgrade golang to version 1.13. 
Note: the new official Docker image uses Debian Buster instead of the now deprecated Stretch. 

## Why
New version [has been released](https://golang.org/doc/go1.13). Major changes in core libraries are listed [here](https://golang.org/doc/go1.13#library).

## Test Plan
CI is passing

## Revert Plan
Revert