### PR TITLE
Redact password from error log

### DIFF
--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -72,7 +72,7 @@ func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbcon
 	for _, query := range queryList {
 		log.Infof("exec %v", redactMasterPassword(query))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
-			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), err.Error())
+			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 		}
 	}
 	return nil


### PR DESCRIPTION
# Desc

* Mysql could have the master password in the error log. Make sure it gets redacted here too. 

# Test

* I validated this fix in our environment and verified that password gets redacted as expected. 