### PR TITLE
TER should not demote current master if it is run with current master

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent.go
@@ -165,7 +165,8 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 		}
 	}()
 
-	if !topoproto.TabletAliasIsZero(oldMasterAlias) {
+	// If TER is called twice, then oldMasterAlias is the same as agent.TabletAlias
+	if !topoproto.TabletAliasIsZero(oldMasterAlias) && !topoproto.TabletAliasEqual(oldMasterAlias, agent.TabletAlias) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -237,7 +238,7 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 
 	tmc := tmclient.NewTabletManagerClient()
 	defer tmc.Close()
-	if !topoproto.TabletAliasIsZero(oldMasterAlias) && oldMasterTablet != nil {
+	if !topoproto.TabletAliasIsZero(oldMasterAlias) && !topoproto.TabletAliasEqual(oldMasterAlias, agent.TabletAlias) && oldMasterTablet != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
We found a bug in the changes made in #5151, which can (sometimes) cause the master to be demoted to a replica if TER is run with the same master tablet a second time. This PR fixes that.

Signed-off-by: deepthi <deepthi@planetscale.com>