### PR TITLE
fix docker files for xtrabackup

### DIFF
--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -1,7 +1,14 @@
 FROM vitess/bootstrap:common
 
 # Install MariaDB 10
-RUN apt-get update -y \
+RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
+    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-5.7 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
+    apt-get update -y \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       bzip2 \
       mariadb-server \
@@ -9,10 +16,8 @@ RUN apt-get update -y \
       libdbd-mysql-perl \
       rsync \
       libev4 \
- && rm -rf /var/lib/apt/lists/* \
- && wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.13/binary/debian/stretch/x86_64/percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb \
- && dpkg -i percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb \
- && rm -f percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb
+      percona-xtrabackup-24 \
+ && rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -3,12 +3,16 @@ FROM vitess/bootstrap:common
 # Install MySQL 5.6
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver pool.sks-keyservers.net 5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-5.6 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.13/binary/debian/stretch/x86_64/percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    dpkg -i percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    rm -f percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 percona-xtrabackup-24 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -4,12 +4,16 @@ FROM vitess/bootstrap:common
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
     for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-5.7 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.13/binary/debian/stretch/x86_64/percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    dpkg -i percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    rm -f percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 percona-xtrabackup-24 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -3,12 +3,16 @@ FROM vitess/bootstrap:common
 # Install MySQL 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-8.0 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-8.0.4/binary/debian/stretch/x86_64/percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb && \
-    dpkg -i percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb && \
-    rm -f percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev libdbd-mysql-perl rsync libev4 libcurl4-openssl-dev percona-xtrabackup-80 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -10,11 +10,8 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     } | debconf-set-selections && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.13/binary/debian/stretch/x86_64/percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    dpkg -i percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb && \
-    rm -f percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb
+        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 percona-xtrabackup-24 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -11,7 +11,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     apt-get update && \
     apt-get install -y --no-install-recommends \
         percona-server-server-5.7 \
-	libperconaserverclient18.1-dev && \
+	libperconaserverclient18.1-dev percona-xtrabackup-24 && \
     rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -18,10 +18,16 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 	libdbd-mysql-perl \
 	rsync \
 	libev4 \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-8.0.4/binary/debian/stretch/x86_64/percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb \
-    && dpkg -i percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb \
-    && rm -f percona-xtrabackup-80_8.0.4-1.stretch_amd64.deb
+#    && rm -f /etc/apt/sources.list.d/percona.list \
+    && echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list \
+#    { \
+#        echo debconf debconf/frontend select Noninteractive; \
+#        echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
+#        echo percona-server-server-8.0 percona-server-server/root_password_again password 'unused'; \
+#    } | debconf-set-selections \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends percona-xtrabackup-80 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess


### PR DESCRIPTION
We were installing specific minor versions of xtrabackup into our docker images. This led to an incompatibility between the MySQL 8.0 version (8.0.16) and xtrabackup version (8.0.4).
Changed all the bootstrap docker files to fetch the latest version of xtrabackup available in the percona repo for the desired major version (2.4 vs 8.0)

Error log:
```
I0923 21:22:58.584642   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.584856   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.585038   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.585221   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.585388   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.586730   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup: Unknown error 3613
I0923 21:22:58.586760   10902 xtrabackupengine.go:645] prepare stderr: 21:22:58 UTC - mysqld got signal 11 ;
I0923 21:22:58.586763   10902 xtrabackupengine.go:645] prepare stderr: This could be because you hit a bug. It is also possible that this
 binary
I0923 21:22:58.586765   10902 xtrabackupengine.go:645] prepare stderr: or one of the libraries it was linked against is corrupt, improper
ly built,
I0923 21:22:58.586767   10902 xtrabackupengine.go:645] prepare stderr: or misconfigured. This error can also be caused by malfunctioning 
hardware.
I0923 21:22:58.586769   10902 xtrabackupengine.go:645] prepare stderr: Attempting to collect some information that could help diagnose th
e problem.
I0923 21:22:58.586771   10902 xtrabackupengine.go:645] prepare stderr: As this is a crash and something is definitely wrong, the informat
ion
I0923 21:22:58.586773   10902 xtrabackupengine.go:645] prepare stderr: collection process might fail.
I0923 21:22:58.586775   10902 xtrabackupengine.go:645] prepare stderr: 
I0923 21:22:58.586777   10902 xtrabackupengine.go:645] prepare stderr: key_buffer_size=0
I0923 21:22:58.586781   10902 xtrabackupengine.go:645] prepare stderr: read_buffer_size=131072
I0923 21:22:58.586783   10902 xtrabackupengine.go:645] prepare stderr: max_used_connections=0
I0923 21:22:58.586785   10902 xtrabackupengine.go:645] prepare stderr: max_threads=0
I0923 21:22:58.586787   10902 xtrabackupengine.go:645] prepare stderr: thread_count=0
I0923 21:22:58.586789   10902 xtrabackupengine.go:645] prepare stderr: connection_count=0
I0923 21:22:58.586791   10902 xtrabackupengine.go:645] prepare stderr: It is possible that mysqld could use up to 
I0923 21:22:58.586793   10902 xtrabackupengine.go:645] prepare stderr: key_buffer_size + (read_buffer_size + sort_buffer_size)*max_thread
s = 1669 K  bytes of memory
I0923 21:22:58.586795   10902 xtrabackupengine.go:645] prepare stderr: Hope that's ok; if not, decrease some variables in the equation.
I0923 21:22:58.586797   10902 xtrabackupengine.go:645] prepare stderr: 
I0923 21:22:58.586799   10902 xtrabackupengine.go:645] prepare stderr: Thread pointer: 0x0
I0923 21:22:58.586801   10902 xtrabackupengine.go:645] prepare stderr: Attempting backtrace. You can use the following information to fin
d out
I0923 21:22:58.586803   10902 xtrabackupengine.go:645] prepare stderr: where mysqld died. If you see no messages after this, something we
nt
I0923 21:22:58.586805   10902 xtrabackupengine.go:645] prepare stderr: terribly wrong...
I0923 21:22:58.586864   10902 xtrabackupengine.go:645] prepare stderr: stack_bottom = 0 thread_stack 0x46000
I0923 21:22:58.591138   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(my_print_stacktrace(unsigned char*, unsigned long)+0x2e
) [0x556e7fadbdbe]
I0923 21:22:58.591145   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(handle_fatal_signal+0x4c1) [0x556e7ebdd651]
I0923 21:22:58.591150   10902 xtrabackupengine.go:645] prepare stderr: /lib/x86_64-linux-gnu/libpthread.so.0(+0x110e0) [0x7f940be900e0]
I0923 21:22:58.591153   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(dd::get_dd_client(THD*)+0x1) [0x556e7f0785c1]
I0923 21:22:58.591156   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(dd_table_open_on_name(THD*, MDL_ticket**, char const*, 
bool, unsigned long)+0x29d) [0x556e7ed5d48d]
I0923 21:22:58.591160   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(+0xbee856) [0x556e7e7a5856]
I0923 21:22:58.591163   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(+0xbef9ef) [0x556e7e7a69ef]
I0923 21:22:58.591170   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(main+0x6dc) [0x556e7e76874c]
I0923 21:22:58.591179   10902 xtrabackupengine.go:645] prepare stderr: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7f9409b
da2e1]
I0923 21:22:58.591186   10902 xtrabackupengine.go:645] prepare stderr: xtrabackup(_start+0x2a) [0x556e7e795b8a]
I0923 21:22:58.591189   10902 xtrabackupengine.go:645] prepare stderr: 
I0923 21:22:58.591192   10902 xtrabackupengine.go:645] prepare stderr: Please report a bug at https://jira.percona.com/projects/PXB
```
This was fixed in xtrabackup 8.0.6
https://jira.percona.com/browse/PXB-1839

Signed-off-by: deepthi <deepthi@planetscale.com>