### PR TITLE
move t.Fatalf into same goroutine in vtworkerclienttest

### DIFF
--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -129,10 +129,14 @@ func commandErrorsBecauseBusy(t *testing.T, client vtworkerclient.Client, server
 	blockCommandStarted := make(chan struct{})
 	var errorCodeCheck error
 	wg.Add(1)
+	errChan := make(chan error, 1)
+	defer close(errChan)
 	go func() {
+		defer wg.Done()
 		stream, err := client.ExecuteVtworkerCommand(ctx, []string{"Block"})
 		if err != nil {
-			t.Fatalf("Block command should not have failed: %v", err)
+			errChan <- err
+			return
 		}
 
 		firstLineReceived := false
@@ -154,7 +158,6 @@ func commandErrorsBecauseBusy(t *testing.T, client vtworkerclient.Client, server
 				close(blockCommandStarted)
 			}
 		}
-		wg.Done()
 	}()
 
 	// Try to run a second, concurrent vtworker command.
@@ -177,6 +180,9 @@ func commandErrorsBecauseBusy(t *testing.T, client vtworkerclient.Client, server
 	cancel()
 
 	wg.Wait()
+	if err := <-errChan; err != nil {
+		t.Fatalf("Block command should not have failed: %v", err)
+	}
 	if errorCodeCheck != nil {
 		t.Fatalf("Block command did not return the CANCELED error code: %v", errorCodeCheck)
 	}

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -138,6 +138,8 @@ func commandErrorsBecauseBusy(t *testing.T, client vtworkerclient.Client, server
 			errChan <- err
 			close(blockCommandStarted)
 			return
+		} else {
+			errChan <- nil
 		}
 
 		firstLineReceived := false

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -136,6 +136,7 @@ func commandErrorsBecauseBusy(t *testing.T, client vtworkerclient.Client, server
 		stream, err := client.ExecuteVtworkerCommand(ctx, []string{"Block"})
 		if err != nil {
 			errChan <- err
+			close(blockCommandStarted)
 			return
 		}
 


### PR DESCRIPTION
`T.Fatalf` should be run in the same goroutine.
`wg.Done` should be defered to be called in anycondition, or it will dead lock.