### PR TITLE
Change bad client handshake logging from err to info. 

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -296,7 +296,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	if err != nil {
 		// Don't log EOF errors. They cause too much spam, same as main read loop.
 		if err != io.EOF {
-			log.Errorf("Cannot read client handshake response from %s: %v", c, err)
+                        log.Infof("Cannot read client handshake response from %s: %v, it may not be a valid MySQL client", c, err)
 		}
 		return
 	}

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -296,7 +296,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	if err != nil {
 		// Don't log EOF errors. They cause too much spam, same as main read loop.
 		if err != io.EOF {
-                        log.Infof("Cannot read client handshake response from %s: %v, it may not be a valid MySQL client", c, err)
+			log.Infof("Cannot read client handshake response from %s: %v, it may not be a valid MySQL client", c, err)
 		}
 		return
 	}


### PR DESCRIPTION
Addresses #5191

This changes logging of bad handshakes from error to info. It also adds a bit of detail to the log message to indicate it may be from a non-mysql connection attempt.

[new PR because I am bad at git]

/cc @morgo 

Signed-off-by: Dan Rogart <drogart@github.com>