### PR TITLE
Transaction BEGIN statements should use the query timeout rather than…

### DIFF
--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -51,9 +51,6 @@ func TestConfigVars(t *testing.T) {
 		tag string
 		val int
 	}{{
-		tag: "BeginTimeout",
-		val: int(tabletenv.Config.TxPoolTimeout * 1e9),
-	}, {
 		tag: "ConnPoolAvailable",
 		val: tabletenv.Config.PoolSize,
 	}, {
@@ -115,6 +112,9 @@ func TestConfigVars(t *testing.T) {
 		val: tabletenv.Config.TransactionCap,
 	}, {
 		tag: "TransactionPoolTimeout",
+		val: int(tabletenv.Config.TxPoolTimeout * 1e9),
+	}, {
+		tag: "TransactionTimeout",
 		val: int(tabletenv.Config.TransactionTimeout * 1e9),
 	}}
 	for _, tcase := range cases {

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -329,17 +329,11 @@ func TestTxPoolSize(t *testing.T) {
 
 	defer framework.Server.SetTxPoolSize(framework.Server.TxPoolSize())
 	framework.Server.SetTxPoolSize(1)
-	defer framework.Server.BeginTimeout.Set(framework.Server.BeginTimeout.Get())
-	timeout := 1 * time.Millisecond
-	framework.Server.BeginTimeout.Set(timeout)
 	vend := framework.DebugVars()
 	if err := verifyIntValue(vend, "TransactionPoolAvailable", 0); err != nil {
 		t.Error(err)
 	}
 	if err := verifyIntValue(vend, "TransactionPoolCapacity", 1); err != nil {
-		t.Error(err)
-	}
-	if err := verifyIntValue(vend, "BeginTimeout", int(timeout)); err != nil {
 		t.Error(err)
 	}
 
@@ -358,8 +352,16 @@ func TestTxTimeout(t *testing.T) {
 	vstart := framework.DebugVars()
 
 	defer framework.Server.SetTxTimeout(framework.Server.TxTimeout())
-	framework.Server.SetTxTimeout(1 * time.Millisecond)
-	if err := verifyIntValue(framework.DebugVars(), "TransactionPoolTimeout", int(1*time.Millisecond)); err != nil {
+	txTimeout := 1 * time.Millisecond
+	framework.Server.SetTxTimeout(txTimeout)
+	if err := verifyIntValue(framework.DebugVars(), "TransactionTimeout", int(txTimeout)); err != nil {
+		t.Error(err)
+	}
+
+	defer framework.Server.SetTxPoolTimeout(framework.Server.TxPoolTimeout())
+	txPoolTimeout := 2 * time.Millisecond
+	framework.Server.SetTxPoolTimeout(txPoolTimeout)
+	if err := verifyIntValue(framework.DebugVars(), "TransactionPoolTimeout", int(txPoolTimeout)); err != nil {
 		t.Error(err)
 	}
 

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -118,6 +118,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 		config.FoundRowsPoolSize,
 		config.TxPoolPrefillParallelism,
 		time.Duration(config.TransactionTimeout*1e9),
+		time.Duration(config.TxPoolTimeout*1e9),
 		time.Duration(config.IdleTimeout*1e9),
 		config.TxPoolWaiterCap,
 		checker,

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -693,6 +693,7 @@ func newTxPool() *TxPool {
 	poolName := fmt.Sprintf("TestTransactionPool-%d", randID)
 	transactionCap := 300
 	transactionTimeout := time.Duration(30 * time.Second)
+	transactionPoolTimeout := time.Duration(40 * time.Second)
 	waiterCap := 500000
 	idleTimeout := time.Duration(30 * time.Second)
 	limiter := &txlimiter.TxAllowAll{}
@@ -702,6 +703,7 @@ func newTxPool() *TxPool {
 		transactionCap,
 		0,
 		transactionTimeout,
+		transactionPoolTimeout,
 		idleTimeout,
 		waiterCap,
 		DummyChecker,


### PR DESCRIPTION
… the transaction pool timeout. According to docs: "query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1)". When we execute the BEGIN statment, we have already grabbed a connection from the transaction pool. Thus it does not make sense to use the transaction pool timeout here. Furthermore, this makes BEGIN behave more like COMMIT -- they will both use the query timeout now.

At Etsy, we have our TxPoolTimeout set relatively low (one second), whereas we have an unlimited query timeout. We were seeing timeouts occur here for the BEGIN statement: https://github.com/vitessio/vitess/blob/5019c283d828eb94890a93bf852862c74660b4a8/go/vt/vttablet/tabletserver/connpool/dbconn.go#L140

It's still an open question why one second was not enough (it should have been).