### PR TITLE
Fix reparent test.

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -76,6 +76,11 @@ func (agent *ActionAgent) ChangeType(ctx context.Context, tabletType topodatapb.
 		return err
 	}
 
+	// If we have been told we're master, update master term start time.
+	if tabletType == topodatapb.TabletType_MASTER {
+		agent.setMasterTermStartTime(time.Now())
+	}
+
 	// let's update our internal state (stop query service and other things)
 	if err := agent.refreshTablet(ctx, "ChangeType"); err != nil {
 		return err

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -193,7 +193,7 @@ func (agent *ActionAgent) abortMasterTerm(ctx context.Context, masterAlias *topo
 	if *mysqlctl.DisableActiveReparents {
 		// Don't touch anything at the MySQL level. Just update tablet state.
 		log.Infof("Active reparents are disabled; updating tablet state only.")
-		return agent.SlaveWasRestarted(ctx, masterAlias)
+		return agent.ChangeType(ctx, topodatapb.TabletType_REPLICA)
 	}
 
 	// Do a full demotion to convert MySQL into a replica.


### PR DESCRIPTION
The new TER in wrangler skipped setting the master term start time.
Now we start a master term if ChangeType() is called with type MASTER.

Also switched shard_sync from SlaveWasRestarted() to ChangeType() after realizing ChangeType() already does what I wanted. SlaveWasRestarted() is a legacy API that actually isn't needed anymore because its purpose is to update topo fields that no longer exist.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>