### PR TITLE
Fix invocation of deferred function for loading schema.

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -113,7 +113,7 @@ func (se *Engine) Open() error {
 		return nil
 	}
 	start := time.Now()
-	defer log.Infof("Time taken to load the schema: %v", time.Since(start))
+	defer func() { log.Infof("Time taken to load the schema: %v", time.Since(start)) }()
 	ctx := tabletenv.LocalContext()
 	dbaParams := se.dbconfigs.DbaWithDB()
 	se.conns.Open(dbaParams, dbaParams, dbaParams)


### PR DESCRIPTION
Golang's defer's arguments are evaluated immediately. Thus the time.Since(start) was being resolved immediately, rather than at the end of function execution.

FYI this changes the times shown in the logs from a few nanoseconds to a few milliseconds in a small test setup.