### PR TITLE
Fix PlannedReparentShard unit tests

### DIFF
--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -131,6 +131,7 @@ func TestAPI(t *testing.T) {
 		{"GET", "shards/ks1/", "", `["-80","80-"]`},
 		{"GET", "shards/ks1/-80", "", `{
 				"master_alias": null,
+				"master_term_start_time":null,
 				"key_range": {
 					"start": null,
 					"end":"gA=="

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -576,11 +576,10 @@ func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topo
 
 	// if needed, wait until we get the replicated row, or our
 	// context times out
-	if !shouldbeReplicating || timeCreatedNS == 0 {
-		return nil
-	}
-	if err := agent.MysqlDaemon.WaitForReparentJournal(ctx, timeCreatedNS); err != nil {
-		return err
+	if shouldbeReplicating && timeCreatedNS != 0 {
+		if err := agent.MysqlDaemon.WaitForReparentJournal(ctx, timeCreatedNS); err != nil {
+			return err
+		}
 	}
 	if typeChanged {
 		if err := agent.refreshTablet(ctx, "SetMaster"); err != nil {

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -67,12 +67,15 @@ func (agent *ActionAgent) shardSyncLoop(ctx context.Context) {
 		select {
 		case <-notifyChan:
 			// Something may have changed in the tablet state.
+			log.Info("Change to tablet state")
 		case <-retryChan:
 			// It's time to retry a previous failed sync attempt.
+			log.Info("Retry sync")
 		case event := <-shardWatch.watchChan:
 			// Something may have changed in the shard record.
 			// We don't use the watch event except to know that we should
 			// re-read the shard record, and to know if the watch dies.
+			log.Info("Change in shard record")
 			if event.Err != nil {
 				// The watch failed. Stop it so we start a new one if needed.
 				log.Errorf("Shard watch failed: %v", event.Err)

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -81,6 +81,9 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
+		// we end up calling SetMaster twice on the old master
+		"FAKE SET MASTER",
+		"START SLAVE",
 	}
 	oldMaster.StartActionLoop(t, wr)
 	defer oldMaster.StopActionLoop(t)
@@ -103,7 +106,7 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 		t.Fatalf("PlannedReparentShard failed: %v", err)
 	}
 
-	// // check what was run
+	// check what was run
 	if err := newMaster.FakeMysqlDaemon.CheckSuperQueryList(); err != nil {
 		t.Errorf("newMaster.FakeMysqlDaemon.CheckSuperQueryList failed: %v", err)
 	}
@@ -126,8 +129,8 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 		t.Errorf("oldMaster...QueryServiceControl not serving")
 	}
 
-	// // verify the old master was told to start replicating (and not
-	// // the slave that wasn't replicating in the first place)
+	// verify the old master was told to start replicating (and not
+	// the slave that wasn't replicating in the first place)
 	if !oldMaster.FakeMysqlDaemon.Replicating {
 		t.Errorf("oldMaster.FakeMysqlDaemon.Replicating not set")
 	}
@@ -186,6 +189,9 @@ func TestPlannedReparentShard(t *testing.T) {
 	oldMaster.FakeMysqlDaemon.CurrentMasterPosition = newMaster.FakeMysqlDaemon.WaitMasterPosition
 	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+		// we end up calling SetMaster twice on the old master
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}


### PR DESCRIPTION
The expected result needed to be updated (because we now call SetMaster twice) + a tiny fix in SetMaster.
I went ahead and removed the block of code in PRS that was updating the shard's MasterAlias, even though with it in place, PRS still works as expected. IOW, ShardSync is working idempotently, as desired.
It also seems like SetMaster already works idempotently as well, at least in the unit tests.
Nice work @enisoc!

Signed-off-by: deepthi <deepthi@planetscale.com>