### PR TITLE
Update mark down file hyperlink format

### DIFF
--- a/doc/internal/ReleaseInstructions.md
+++ b/doc/internal/ReleaseInstructions.md
@@ -1,7 +1,6 @@
 # Release Instructions
 
-This page describes the steps for cutting a new [open source release]
-(https://github.com/vitessio/vitess/releases).
+This page describes the steps for cutting a new [open source release](https://github.com/vitessio/vitess/releases).
 
 ## Versioning
 
@@ -14,8 +13,7 @@ backward-incompatible way -- for example, when removing deprecated interfaces.
 
 Our public API includes (but is not limited to):
 
-*   The VTGate [RPC interfaces]
-    (https://github.com/vitessio/vitess/tree/master/proto).
+*   The VTGate [RPC interfaces](https://github.com/vitessio/vitess/tree/master/proto).
 *   The interfaces exposed by the VTGate client library in each language.
 
 Care must also be taken when changing the format of any data stored by a live
@@ -62,8 +60,7 @@ and tag the following items under it:
 
 ## Release Branches
 
-Each minor release level (X.Y) should have a [release branch]
-(https://github.com/vitessio/vitess/branches/all?query=release) named
+Each minor release level (X.Y) should have a [release branch](https://github.com/vitessio/vitess/branches/all?query=release) named
 `release-X.Y`. This branch should diverge from `master` when the code freeze for
 that release is declared, after which point only bugfix PRs should be
 cherrypicked onto the branch. All other activity on `master` will go out with a
@@ -261,8 +258,7 @@ git push upstream vX.Y.Z
 notes. Use the GitHub [Compare](https://github.com/vitessio/vitess/compare) tool
 to see all the commits since the last release.
 
-Then send an announcement on the [vitess-announce]
-(https://groups.google.com/forum/#!forum/vitess-announce) list.
+Then send an announcement on the [vitess-announce](https://groups.google.com/forum/#!forum/vitess-announce) list.
 
 ## Bump Java SNAPSHOT version
 


### PR DESCRIPTION
Signed-off-by: xichengliudui <liuduidui@beyondcent.com>

Similar to the following example:

[google home] (http://google.com/) -> [google home](http://google.com/)

there's a space in the middle, which is not right