### PR TITLE
Unit tests for wrangler version of TabletExternallyReparented

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -165,19 +165,19 @@ type ActionAgent struct {
 	// It's only set once in NewActionAgent() and never modified after that.
 	orc *orcClient
 
-	// shardSyncChan is a channel for informing the shard sync goroutine that
+	// mutex protects all the following fields (that start with '_'),
+	// only hold the mutex to update the fields, nothing else.
+	mutex sync.Mutex
+
+	// _shardSyncChan is a channel for informing the shard sync goroutine that
 	// it should wake up and recheck the tablet state, to make sure it and the
 	// shard record are in sync.
 	//
 	// Call agent.notifyShardSync() instead of sending directly to this channel.
-	shardSyncChan chan struct{}
+	_shardSyncChan chan struct{}
 
-	// shardSyncCancel is the function to stop the background shard sync goroutine.
-	shardSyncCancel context.CancelFunc
-
-	// mutex protects all the following fields (that start with '_'),
-	// only hold the mutex to update the fields, nothing else.
-	mutex sync.Mutex
+	// _shardSyncCancel is the function to stop the background shard sync goroutine.
+	_shardSyncCancel context.CancelFunc
 
 	// _tablet has the Tablet record we last read from the topology server.
 	_tablet *topodatapb.Tablet

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -242,9 +242,7 @@ func (agent *ActionAgent) startShardSync() {
 func (agent *ActionAgent) stopShardSync() {
 	agent.mutex.Lock()
 	if agent._shardSyncCancel != nil {
-		agent.mutex.Unlock()
 		agent._shardSyncCancel()
-		agent.mutex.Lock()
 		agent._shardSyncCancel = nil
 		agent._shardSyncChan = nil
 	}
@@ -254,11 +252,11 @@ func (agent *ActionAgent) stopShardSync() {
 func (agent *ActionAgent) notifyShardSync() {
 	// If this is called before the shard sync is started, do nothing.
 	agent.mutex.Lock()
+	defer agent.mutex.Unlock()
+
 	if agent._shardSyncChan == nil {
-		agent.mutex.Unlock()
 		return
 	}
-	agent.mutex.Unlock()
 
 	// Try to send. If the channel buffer is full, it means a notification is
 	// already pending, so we don't need to do anything.

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -1,0 +1,468 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testlib
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+	"vitess.io/vitess/go/vt/wrangler"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+// The tests in this package test the wrangler version of TabletExternallyReparented
+// This is the one that is now called by the vtctl command
+
+// TestTabletExternallyReparentedBasic tests the base cases for TER
+func TestTabletExternallyReparentedBasic(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+	vp := NewVtctlPipe(t, ts)
+	defer vp.Close()
+
+	// Create an old master, a new master, two good replicas, one bad replica
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted.
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	// First test: reparent to the same master, make sure it works
+	// as expected.
+	if err := vp.Run([]string{"TabletExternallyReparented", topoproto.TabletAliasString(oldMaster.Tablet.Alias)}); err != nil {
+		t.Fatalf("TabletExternallyReparented(same master) should have worked: %v", err)
+	}
+
+	// check the old master is still master
+	tablet, err := ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
+	}
+
+	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+
+	// This tests the good case, where everything works as planned
+	t.Logf("TabletExternallyReparented(new master) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+
+	// check the new master is master
+	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// We have to wait for shard sync to do its magic in the background
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+loop:
+	for {
+		select {
+		case <-timer.C:
+			// we timed out
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+		default:
+			// check the old master was converted to replica
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			if tablet.Type != topodatapb.TabletType_REPLICA {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break loop
+			}
+		}
+	}
+}
+
+func TestTabletExternallyReparentedToSlave(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, a new master, two good replicas, one bad replica
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	newMaster.FakeMysqlDaemon.ReadOnly = true
+	newMaster.FakeMysqlDaemon.Replicating = true
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted.
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	// Second test: reparent to a replica, and pretend the old
+	// master is still good to go.
+	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+
+	// This tests a bad case: the new designated master is a slave at mysql level,
+	// but we should do what we're told anyway.
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) error: %v", err)
+	}
+
+	// check that newMaster is master
+	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// We have to wait for shard sync to do its magic in the background
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+loop:
+	for {
+		select {
+		case <-timer.C:
+			// we timed out
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+		default:
+			// check the old master was converted to replica
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			if tablet.Type != topodatapb.TabletType_REPLICA {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break loop
+			}
+		}
+	}
+}
+
+// TestTabletExternallyReparentedWithDifferentMysqlPort makes sure
+// that if mysql is restarted on the master-elect tablet and has a different
+// port, we pick it up correctly.
+func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, a new master, two good replicas, one bad replica
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+	// Now we're restarting mysql on a different port, 3301->3303
+	// but without updating the Tablet record in topology.
+
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted, so we need a MysqlDaemon
+	// that returns no master, and the new port (as returned by mysql)
+	newMaster.FakeMysqlDaemon.MysqlPort = 3303
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted and point to the new mysql port
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	// On the good replicas, we will respond to
+	// TabletActionSlaveWasRestarted and point to the new mysql port
+	goodReplica.StartActionLoop(t, wr)
+	defer goodReplica.StopActionLoop(t)
+
+	// This tests the good case, where everything works as planned
+	t.Logf("TabletExternallyReparented(new master) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+	// check the new master is master
+	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// We have to wait for shard sync to do its magic in the background
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+loop:
+	for {
+		select {
+		case <-timer.C:
+			// we timed out
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+		default:
+			// check the old master was converted to replica
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			if tablet.Type != topodatapb.TabletType_REPLICA {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break loop
+			}
+		}
+	}
+}
+
+// TestTabletExternallyReparentedContinueOnUnexpectedMaster makes sure
+// that we ignore mysql's master if the flag is set
+func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, a new master, two good replicas, one bad replica
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted, so we need a MysqlDaemon
+	// that returns no master, and the new port (as returned by mysql)
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted and point to a bad host
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	// On the good replica, we will respond to
+	// TabletActionSlaveWasRestarted and point to a bad host
+	goodReplica.StartActionLoop(t, wr)
+	defer goodReplica.StopActionLoop(t)
+
+	// This tests the good case, where everything works as planned
+	t.Logf("TabletExternallyReparented(new master) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+	// check the new master is master
+	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+	// We have to wait for shard sync to do its magic in the background
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+loop:
+	for {
+		select {
+		case <-timer.C:
+			// we timed out
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+		default:
+			// check the old master was converted to replica
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			if tablet.Type != topodatapb.TabletType_REPLICA {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break loop
+			}
+		}
+	}
+}
+
+func TestTabletExternallyReparentedRerun(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, a new master, and a good replica.
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+	// On the elected master, we will respond to
+	// TabletActionSlaveWasPromoted.
+	newMaster.StartActionLoop(t, wr)
+	defer newMaster.StopActionLoop(t)
+
+	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+		"FAKE SET MASTER",
+		"START SLAVE",
+	}
+	// On the old master, we will only respond to
+	// TabletActionSlaveWasRestarted.
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
+	goodReplica.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	// On the good replica, we will respond to
+	// TabletActionSlaveWasRestarted.
+	goodReplica.StartActionLoop(t, wr)
+	defer goodReplica.StopActionLoop(t)
+
+	// The reparent should work as expected here
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+
+	// check the new master is master
+	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+	// We have to wait for shard sync to do its magic in the background
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+loop:
+	for {
+		select {
+		case <-timer.C:
+			// we timed out
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+		default:
+			// check the old master was converted to replica
+			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			if err != nil {
+				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			}
+			if tablet.Type != topodatapb.TabletType_REPLICA {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				break loop
+			}
+		}
+	}
+
+	// run TER again and make sure the master is still correct
+	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+
+	// check the new master is still master
+	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+	}
+	if tablet.Type != topodatapb.TabletType_MASTER {
+		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+	}
+
+}

--- a/go/vt/wrangler/testlib/find_tablet_test.go
+++ b/go/vt/wrangler/testlib/find_tablet_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testlib
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+	"vitess.io/vitess/go/vt/wrangler"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestFindTablet(t *testing.T) {
+	tabletmanager.SetReparentFlags(time.Minute /* finalizeTimeout */)
+
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1", "cell2")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+
+	// Create an old master, two good slaves
+	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	goodSlave1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
+	goodSlave2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
+
+	// Build keyspace graph
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1", "cell2"})
+	if err != nil {
+		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
+	}
+
+	// make sure we can find the tablets
+	// even with a datacenter being down.
+	tabletMap, err := ts.GetTabletMapForShardByCell(ctx, "test_keyspace", "0", []string{"cell1"})
+	if err != nil {
+		t.Fatalf("GetTabletMapForShardByCell should have worked but got: %v", err)
+	}
+	master, err := topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
+	if err != nil || !topoproto.TabletAliasEqual(master, oldMaster.Tablet.Alias) {
+		t.Fatalf("FindTabletByHostAndPort(master) failed: %v %v", err, master)
+	}
+	slave1, err := topotools.FindTabletByHostAndPort(tabletMap, goodSlave1.Tablet.Hostname, "vt", goodSlave1.Tablet.PortMap["vt"])
+	if err != nil || !topoproto.TabletAliasEqual(slave1, goodSlave1.Tablet.Alias) {
+		t.Fatalf("FindTabletByHostAndPort(slave1) failed: %v %v", err, master)
+	}
+	slave2, err := topotools.FindTabletByHostAndPort(tabletMap, goodSlave2.Tablet.Hostname, "vt", goodSlave2.Tablet.PortMap["vt"])
+	if !topo.IsErrType(err, topo.NoNode) {
+		t.Fatalf("FindTabletByHostAndPort(slave2) worked: %v %v", err, slave2)
+	}
+
+	// Make sure the master is not exported in other cells
+	tabletMap, _ = ts.GetTabletMapForShardByCell(ctx, "test_keyspace", "0", []string{"cell2"})
+	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
+	if !topo.IsErrType(err, topo.NoNode) {
+		t.Fatalf("FindTabletByHostAndPort(master) worked in cell2: %v %v", err, master)
+	}
+
+	// Get tablet map for all cells.  If there were to be failures talking to local cells, this will return the tablet map
+	// and forward a partial result error
+	tabletMap, err = ts.GetTabletMapForShard(ctx, "test_keyspace", "0")
+	if err != nil {
+		t.Fatalf("GetTabletMapForShard should nil but got: %v", err)
+	}
+	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
+	if err != nil || !topoproto.TabletAliasEqual(master, oldMaster.Tablet.Alias) {
+		t.Fatalf("FindTabletByHostAndPort(master) failed: %v %v", err, master)
+	}
+
+}


### PR DESCRIPTION
NOTE: This PR is targeting the `reparent-refactor` feature branch, not `master`.

Duplicated relevant RPC tests for wrangler.
Moved unrelated tests to a different file, fixed RPC tests to not error out during SetMaster.

Signed-off-by: deepthi <deepthi@planetscale.com>