### PR TITLE
Less output from Maven

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ site_integration_test:
 
 java_test:
 	go install ./go/cmd/vtgateclienttest ./go/cmd/vtcombo
-	mvn -f java/pom.xml clean verify
+	mvn -f java/pom.xml -B clean verify
 
 install_protoc-gen-go:
 	go install github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
`mvn -B` makes Maven run in batch-mode, where less output is produced (such as download progress, colors and what not)