### PR TITLE
Bump test timeout from 8 minutes to 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
     #       See: https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts
     # To diagnose stuck tests, add "-follow" to TEST_FLAGS below. Then test.go
     # will print the test's output.
-    - TEST_FLAGS="-docker -use_docker_cache -timeout=8m -print-log"
+    - TEST_FLAGS="-docker -use_docker_cache -timeout=9m -print-log"
   matrix:
     # NOTE: Travis CI schedules up to 5 tests simultaneously.
     #       All our tests should be spread out as evenly as possible across these 5 slots.


### PR DESCRIPTION
A bunch of PRs are failing Travis with either unit or unit_race or both timing out at 8 minutes.
This is a temporary measure while I work on splitting the tests into two smaller suites.

Signed-off-by: deepthi <deepthi@planetscale.com>