### PR TITLE
Remove binlog statement format config setting

### DIFF
--- a/config/mycnf/default-fast.cnf
+++ b/config/mycnf/default-fast.cnf
@@ -1,7 +1,6 @@
 # basic config parameters for all db instances in the grid
 
 sql_mode = STRICT_TRANS_TABLES
-binlog_format = statement
 character_set_server = utf8
 collation_server = utf8_general_ci
 connect_timeout = 30


### PR DESCRIPTION
When using the Helm charts, the `default-fast.cnf` is pulled in unless you override the `mysqlSize` helm value.
This cnf file sets `binlog_format = statement` which will break things like replication and streams.

This is an attempt to just try removing the setting and checking if the tests will still succeed. Slack thread is: https://vitess.slack.com/archives/C0PQY0PTK/p1571095889094000

This also relates to the issue: https://github.com/vitessio/vitess/issues/4990