### PR TITLE
split unit and unit_race between different shards, reduce load on shard 0

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -419,7 +419,7 @@
 				"e2e_test_race"
 			],
 			"Manual": false,
-			"Shard": 0,
+			"Shard": 1,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -442,7 +442,7 @@
 				"unit_test_race"
 			],
 			"Manual": false,
-			"Shard": 0,
+			"Shard": 3,
 			"RetryMax": 0,
 			"Tags": []
 		},


### PR DESCRIPTION
Not a good idea to run unit and unit_race on the same shard because if one fails 3 times, it uses up a lot of time.
Also moved e2e_race to another shard to allow sufficient buffer for unit test retries.

Signed-off-by: deepthi <deepthi@planetscale.com>