### PR TITLE
migrater: handle tables based on the vschema info

### DIFF
--- a/go/vt/wrangler/migrater.go
+++ b/go/vt/wrangler/migrater.go
@@ -117,6 +117,7 @@ func (wr *Wrangler) MigrateReads(ctx context.Context, targetKeyspace, workflow s
 			mi.wr.Logger().Errorf("migrateTableReads failed: %v", err)
 			return err
 		}
+		return nil
 	}
 	if err := mi.migrateShardReads(ctx, cells, servedType, direction); err != nil {
 		mi.wr.Logger().Errorf("migrateShardReads failed: %v", err)

--- a/go/vt/wrangler/migrater_env_test.go
+++ b/go/vt/wrangler/migrater_env_test.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vschema"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -197,7 +198,34 @@ func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targe
 		tme.targetKeyRanges = append(tme.targetKeyRanges, targetKeyRange)
 	}
 
-	vs := &vschemapb.Keyspace{Sharded: true}
+	vs := &vschemapb.Keyspace{
+		Sharded: true,
+		Vindexes: map[string]*vschema.Vindex{
+			"thash": {
+				Type: "hash",
+			},
+		},
+		Tables: map[string]*vschema.Table{
+			"t1": {
+				ColumnVindexes: []*vschema.ColumnVindex{{
+					Columns: []string{"c1"},
+					Name:    "thash",
+				}},
+			},
+			"t2": {
+				ColumnVindexes: []*vschema.ColumnVindex{{
+					Columns: []string{"c1"},
+					Name:    "thash",
+				}},
+			},
+			"t3": {
+				ColumnVindexes: []*vschema.ColumnVindex{{
+					Columns: []string{"c1"},
+					Name:    "thash",
+				}},
+			},
+		},
+	}
 	if err := tme.ts.SaveVSchema(ctx, "ks", vs); err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/wrangler/stream_migrater.go
+++ b/go/vt/wrangler/stream_migrater.go
@@ -337,6 +337,8 @@ const (
 	reference
 )
 
+// templatizeRule replaces keyrange values with {{.}}.
+// This can then be used by go's template package to substitute other keyrange values.
 func (sm *streamMigrater) templatize(ctx context.Context, tabletStreams []*vrStream) ([]*vrStream, error) {
 	tabletStreams = copyTabletStreams(tabletStreams)
 	var shardedStreams []*vrStream


### PR DESCRIPTION
The previous method of identifying reference tables was not completely reliable: it used the absence of a keyrange constraint in the filtering rules. However, this may not be the case if a target keyspace is being converted from unsharded to sharded.

The new way to identify reference tables is by looking at the vschema. This is a more unambiguous way of identifying such tables.