### PR TITLE
Add read-only security_policy to block admin HTTP endpoints.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/gorilla/websocket v0.0.0-20160912153041-2d1e4548da23
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
@@ -48,6 +49,8 @@ require (
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20160115111002-cca8bbc07984
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go/acl/acl.go
+++ b/go/acl/acl.go
@@ -18,6 +18,21 @@ limitations under the License.
 // It allows you to register multiple security policies for enforcing
 // ACLs for users or HTTP requests. The specific policy to use must be
 // specified from a command line argument and cannot be changed on-the-fly.
+//
+// For actual authentication and authorization, you would need to implement your
+// own policy as a package that calls RegisterPolicy(), and compile it into all
+// Vitess binaries that you use.
+//
+// By default (when no security_policy is specified), everyone is allowed to do
+// anything.
+//
+// For convenience, there are two other built-in policies that also do NOT do
+// any authentication, but allow you to globally disable some roles entirely:
+//   * `deny-all` disallows all roles for everyone. Note that access is still
+//     allowed to endpoints that are considered "public" (no ACL check at all).
+//   * `read-only` allows anyone to act as DEBUGGING or MONITORING, but no one
+//     is allowed to act as ADMIN. It also disallows any other custom roles that
+//     are requested.
 package acl
 
 import (
@@ -39,7 +54,7 @@ const (
 )
 
 var (
-	securityPolicy = flag.String("security_policy", "", "security policy to enforce for URLs")
+	securityPolicy = flag.String("security_policy", "", "the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)")
 	policies       = make(map[string]Policy)
 	once           sync.Once
 	currentPolicy  Policy
@@ -69,13 +84,16 @@ func RegisterPolicy(name string, policy Policy) {
 
 func savePolicy() {
 	if *securityPolicy == "" {
+		// Setting the policy to nil means Allow All from Anyone.
+		currentPolicy = nil
 		return
 	}
-	currentPolicy = policies[*securityPolicy]
-	if currentPolicy == nil {
-		log.Warningf("policy %s not found, using fallback policy", *securityPolicy)
-		currentPolicy = FallbackPolicy{}
+	if policy, ok := policies[*securityPolicy]; ok {
+		currentPolicy = policy
+		return
 	}
+	log.Warningf("security_policy %q not found; using fallback policy (deny-all)", *securityPolicy)
+	currentPolicy = denyAllPolicy{}
 }
 
 // CheckAccessActor uses the current security policy to

--- a/go/acl/acl_test.go
+++ b/go/acl/acl_test.go
@@ -40,6 +40,10 @@ func (tp TestPolicy) CheckAccessHTTP(req *http.Request, role string) error {
 
 func init() {
 	RegisterPolicy("test", TestPolicy{})
+
+	// Run the `once` so it doesn't run during testing,
+	// since we need to override the currentPolicy.
+	once.Do(savePolicy)
 }
 
 func TestSimplePolicy(t *testing.T) {

--- a/go/acl/deny_all_policy.go
+++ b/go/acl/deny_all_policy.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acl
+
+import (
+	"errors"
+	"net/http"
+)
+
+var errDenyAll = errors.New("not allowed: deny-all security_policy enforced")
+
+// denyAllPolicy rejects all access.
+type denyAllPolicy struct{}
+
+// CheckAccessActor disallows all actor access.
+func (denyAllPolicy) CheckAccessActor(actor, role string) error {
+	return errDenyAll
+}
+
+// CheckAccessHTTP disallows all HTTP access.
+func (denyAllPolicy) CheckAccessHTTP(req *http.Request, role string) error {
+	return errDenyAll
+}
+
+func init() {
+	RegisterPolicy("deny-all", denyAllPolicy{})
+}

--- a/go/acl/read_only_policy.go
+++ b/go/acl/read_only_policy.go
@@ -21,19 +21,32 @@ import (
 	"net/http"
 )
 
-var errFallback = errors.New("not allowed: fallback policy")
+var errReadOnly = errors.New("not allowed: read-only security_policy enforced")
 
-// FallbackPolicy is the policy that's used if the
-// requested policy cannot be found. It rejects all
-// access.
-type FallbackPolicy struct{}
+// readOnlyPolicy allows DEBUGGING and MONITORING roles for everyone,
+// while denying any other roles (e.g. ADMIN) for everyone.
+type readOnlyPolicy struct{}
 
 // CheckAccessActor disallows all actor access.
-func (fp FallbackPolicy) CheckAccessActor(actor, role string) error {
-	return errFallback
+func (readOnlyPolicy) CheckAccessActor(actor, role string) error {
+	switch role {
+	case DEBUGGING, MONITORING:
+		return nil
+	default:
+		return errReadOnly
+	}
 }
 
 // CheckAccessHTTP disallows all HTTP access.
-func (fp FallbackPolicy) CheckAccessHTTP(req *http.Request, role string) error {
-	return errFallback
+func (readOnlyPolicy) CheckAccessHTTP(req *http.Request, role string) error {
+	switch role {
+	case DEBUGGING, MONITORING:
+		return nil
+	default:
+		return errReadOnly
+	}
+}
+
+func init() {
+	RegisterPolicy("read-only", readOnlyPolicy{})
 }

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -685,14 +685,81 @@ class TestTabletManager(unittest.TestCase):
     # And done.
     tablet.kill_tablets([tablet_62344, tablet_62044])
 
-  def test_fallback_policy(self):
+  def test_fallback_security_policy(self):
     tablet_62344.create_db('vt_test_keyspace')
     tablet_62344.init_tablet('master', 'test_keyspace', '0')
+
+    # Requesting an unregistered security_policy should fall back to deny-all.
     tablet_62344.start_vttablet(security_policy='bogus')
+
+    # It should deny ADMIN role.
+    f = urllib.urlopen('http://localhost:%d/streamqueryz/terminate' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    # It should deny MONITORING role.
+    f = urllib.urlopen('http://localhost:%d/debug/health' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    # It should deny DEBUGGING role.
     f = urllib.urlopen('http://localhost:%d/queryz' % int(tablet_62344.port))
     response = f.read()
     f.close()
     self.assertIn('not allowed', response)
+
+    tablet_62344.kill_vttablet()
+
+  def test_deny_all_security_policy(self):
+    tablet_62344.create_db('vt_test_keyspace')
+    tablet_62344.init_tablet('master', 'test_keyspace', '0')
+    tablet_62344.start_vttablet(security_policy='deny-all')
+
+    # It should deny ADMIN role.
+    f = urllib.urlopen('http://localhost:%d/streamqueryz/terminate' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    # It should deny MONITORING role.
+    f = urllib.urlopen('http://localhost:%d/debug/health' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    # It should deny DEBUGGING role.
+    f = urllib.urlopen('http://localhost:%d/queryz' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    tablet_62344.kill_vttablet()
+
+  def test_read_only_security_policy(self):
+    tablet_62344.create_db('vt_test_keyspace')
+    tablet_62344.init_tablet('master', 'test_keyspace', '0')
+    tablet_62344.start_vttablet(security_policy='read-only')
+
+    # It should deny ADMIN role.
+    f = urllib.urlopen('http://localhost:%d/streamqueryz/terminate' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertIn('not allowed', response)
+
+    # It should allow MONITORING role.
+    f = urllib.urlopen('http://localhost:%d/debug/health' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertNotIn('not allowed', response)
+
+    # It should allow DEBUGGING role.
+    f = urllib.urlopen('http://localhost:%d/queryz' % int(tablet_62344.port))
+    response = f.read()
+    f.close()
+    self.assertNotIn('not allowed', response)
+
     tablet_62344.kill_vttablet()
 
   def test_ignore_health_error(self):


### PR DESCRIPTION
Previously, the only built-in policies available were effectively
"allow all" and "deny all". Anything else required writing a custom
plugin.

This adds a new built-in policy called `read-only` that does NOT do any
authentication, but allows anyone to query HTTP endpoints designated as
requiring the DEBUGGING or MONITORING roles, while denying everyone
access to ADMIN endpoints.

The default when no policy is specified remains "allow all".
The fallback policy remains "deny all" when an unknown, non-empty
policy name is requested. In addition, you can now explicitly request
the `deny-all` policy without having to engage fallback by providing an
invalid policy name.

Note that security_policy only applies to HTTP endpoints. It does NOT
affect gRPC calls, nor SQL queries. Also, the security_policy flag
must be set individually on every process (e.g. vttablet, vtgate, vtctld)
and only applies to endpoints served directly by that one process.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>