### PR TITLE
Cat error log when mysqld fails to start

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -684,18 +684,18 @@ func (mysqld *Mysqld) Init(ctx context.Context, cnf *Mycnf, initDBSQLFile string
 // This helps prevent cases where the error log is symlinked to /dev/stderr etc,
 // In which case the user can manually open the file.
 func readTailOfMysqldErrorLog(fileName string) string {
-	file, err := os.Open(fileName)
-	defer file.Close()
-	if err != nil {
-		return fmt.Sprintf("could not open mysql error log (%v): %v", fileName, err)
-	}
-	fileInfo, err := file.Stat()
+	fileInfo, err := os.Stat(fileName)
 	if err != nil {
 		return fmt.Sprintf("could not stat mysql error log (%v): %v", fileName, err)
 	}
 	if !fileInfo.Mode().IsRegular() {
 		return fmt.Sprintf("mysql error log file is not a regular file: %v", fileName)
 	}
+	file, err := os.Open(fileName)
+	if err != nil {
+		return fmt.Sprintf("could not open mysql error log (%v): %v", fileName, err)
+	}
+	defer file.Close()
 	startPos := int64(0)
 	if fileInfo.Size() > maxLogFileSampleSize {
 		startPos = fileInfo.Size() - maxLogFileSampleSize

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -726,7 +726,6 @@ func (mysqld *Mysqld) installDataDir(cnf *Mycnf) error {
 			"--basedir=" + mysqlBaseDir,
 			"--initialize-insecure", // Use empty 'root'@'localhost' password.
 		}
-
 		if _, _, err = execCmd(mysqldPath, args, nil, mysqlRoot, nil); err != nil {
 			log.Errorf("mysqld --initialize-insecure failed: %v %s", err, readTailOfMysqldErrorLog(cnf.ErrorLogPath))
 			return err


### PR DESCRIPTION
I have debugged a number of user issues, where the underlying cause is written to the mysqld error log.. but the user does not realize they have to read this log. Examples include:

- Executing the local example as root (mysql will fail to run as root by default).
- Breaking the mysqld config file, and then running bootstrap
- Not enough memory
- File permission errors.

Here is an example showing this feature with a bad my.cnf file:

```
morgo@morgox1:~/vitess/src/vitess.io/vitess$ ./launch-my-vitess.sh 
13148 etcd
13208 vtctld
13344 vttablet
13345 vttablet
13346 vttablet
Fri 18 Oct 2019 01:09:24 PM MDT: Building source tree
enter etcd2 env
add /vitess/global
add /vitess/zone1
add zone1 CellInfo
etcd start done...
enter etcd2 env
Starting vtctld...
Access vtctld web UI at http://morgox1:15000
Send commands with: vtctlclient -server morgox1:15999 ...
enter etcd2 env
Starting MySQL for tablet zone1-0000000100...
Starting MySQL for tablet zone1-0000000101...
Starting MySQL for tablet zone1-0000000102...
E1018 13:09:42.503935   14244 mysqld.go:721] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: 2019-10-18T19:09:40.823725Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2019-10-18T19:09:40.823757Z 0 [Warning] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
2019-10-18T19:09:40.823761Z 0 [Warning] 'NO_AUTO_CREATE_USER' sql mode was not set.
2019-10-18T19:09:40.929999Z 0 [Warning] InnoDB: New log files created, LSN=45790
2019-10-18T19:09:41.020525Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2019-10-18T19:09:41.074136Z 0 [ERROR] unknown option '--totally-bs-option'
2019-10-18T19:09:41.074192Z 0 [ERROR] Aborting

E1018 13:09:42.504435   14244 mysqlctl.go:254] failed init mysql: /usr/sbin/mysqld: exit status 1, output: 
E1018 13:09:42.542678   14246 mysqld.go:721] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: 2019-10-18T19:09:40.821143Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2019-10-18T19:09:40.821178Z 0 [Warning] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
2019-10-18T19:09:40.821182Z 0 [Warning] 'NO_AUTO_CREATE_USER' sql mode was not set.
2019-10-18T19:09:40.930012Z 0 [Warning] InnoDB: New log files created, LSN=45790
2019-10-18T19:09:41.016395Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2019-10-18T19:09:41.018450Z 0 [ERROR] unknown option '--totally-bs-option'
2019-10-18T19:09:41.018469Z 0 [ERROR] Aborting

E1018 13:09:42.543442   14246 mysqlctl.go:254] failed init mysql: /usr/sbin/mysqld: exit status 1, output: 
E1018 13:09:42.547948   14243 mysqld.go:721] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: 2019-10-18T19:09:40.823291Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2019-10-18T19:09:40.823319Z 0 [Warning] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
2019-10-18T19:09:40.823322Z 0 [Warning] 'NO_AUTO_CREATE_USER' sql mode was not set.
2019-10-18T19:09:40.930012Z 0 [Warning] InnoDB: New log files created, LSN=45790
2019-10-18T19:09:41.020525Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2019-10-18T19:09:41.022838Z 0 [ERROR] unknown option '--totally-bs-option'
2019-10-18T19:09:41.022855Z 0 [ERROR] Aborting

E1018 13:09:42.548560   14243 mysqlctl.go:254] failed init mysql: /usr/sbin/mysqld: exit status 1, output: 
Starting vttablet for zone1-0000000100...
Access tablet zone1-0000000100 at http://morgox1:15100/debug/status
Starting vttablet for zone1-0000000101...
Access tablet zone1-0000000101 at http://morgox1:15101/debug/status
Starting vttablet for zone1-0000000102...
Access tablet zone1-0000000102 at http://morgox1:15102/debug/status
W1018 13:09:57.609002   14419 main.go:64] W1018 19:09:57.607113 reparent.go:182] master-elect tablet zone1-0000000100 is not the shard master, proceeding anyway as -force was used
W1018 13:09:57.610764   14419 main.go:64] W1018 19:09:57.607923 reparent.go:188] master-elect tablet zone1-0000000100 is not a master in the shard, proceeding anyway as -force was used

```


Signed-off-by: Morgan Tocker <tocker@gmail.com>