### PR TITLE
Cleanup some left over code from previous changes

### DIFF
--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -38,11 +38,6 @@ source $script_root/env.sh
 
 init_db_sql_file="$VTROOT/config/init_db.sql"
 
-# Previously this file set EXTRA_MY_CNF based on MYSQL_FLAVOR
-# It now relies on mysqlctl to autodetect
-
-export EXTRA_MY_CNF=$VTROOT/config/mycnf/default-fast.cnf:$VTROOT/config/mycnf/rbr.cnf
-
 mkdir -p $VTDATAROOT/backups
 
 # Start 3 vttablets by default.

--- a/py/vttest/mysql_flavor.py
+++ b/py/vttest/mysql_flavor.py
@@ -99,7 +99,7 @@ def set_mysql_flavor(flavor):
   global __mysql_flavor
 
   # Last default is there because the environment variable might be set to "".
-  flavor = flavor or os.environ.get("MYSQL_FLAVOR", "MariaDB") or "MariaDB"
+  flavor = flavor or os.environ.get("MYSQL_FLAVOR", "MySQL56") or "MySQL56"
 
   # Set the environment variable explicitly in case we're overriding it via
   # command-line flag.

--- a/test/mysql_flavor.py
+++ b/test/mysql_flavor.py
@@ -228,10 +228,10 @@ def set_mysql_flavor(flavor):
   global MYSQL_FLAVOR
 
   if not flavor:
-    flavor = os.environ.get("MYSQL_FLAVOR", "MariaDB")
+    flavor = os.environ.get("MYSQL_FLAVOR", "MySQL56")
     # The environment variable might be set, but equal to "".
     if not flavor:
-      flavor = "MariaDB"
+      flavor = "MySQL56"
 
   v = flavor_map.get(flavor, None)
   if not v:

--- a/test/utils.py
+++ b/test/utils.py
@@ -115,7 +115,7 @@ def add_options(parser):
       help='Leave the global processes running after the test is done.')
   parser.add_option('--mysql-flavor')
   parser.add_option('--protocols-flavor', default='grpc')
-  parser.add_option('--topo-server-flavor', default='zk2')
+  parser.add_option('--topo-server-flavor', default='etcd2')
   parser.add_option('--vtgate-gateway-flavor', default='discoverygateway')
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -115,7 +115,7 @@ def add_options(parser):
       help='Leave the global processes running after the test is done.')
   parser.add_option('--mysql-flavor')
   parser.add_option('--protocols-flavor', default='grpc')
-  parser.add_option('--topo-server-flavor', default='etcd2')
+  parser.add_option('--topo-server-flavor', default='zk2')
   parser.add_option('--vtgate-gateway-flavor', default='discoverygateway')
 
 

--- a/tools/e2e_test_runner.sh
+++ b/tools/e2e_test_runner.sh
@@ -33,9 +33,6 @@ if [[ -z $VT_GO_PARALLEL && -n $VT_GO_PARALLEL_VALUE ]]; then
   VT_GO_PARALLEL="-p $VT_GO_PARALLEL_VALUE"
 fi
 
-# This can be removed once the docker images are rebuilt
-export GO111MODULE=on
-
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)

--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -17,9 +17,6 @@
 temp_log_file="$(mktemp --suffix .unit_test_race.log)"
 trap '[ -f "$temp_log_file" ] && rm $temp_log_file' EXIT
 
-# This can be removed once the docker images are rebuilt
-export GO111MODULE=on
-
 # Wrapper around go test -race.
 
 # This script exists because the -race test doesn't allow to distinguish

--- a/tools/unit_test_runner.sh
+++ b/tools/unit_test_runner.sh
@@ -33,9 +33,6 @@ if [[ -z $VT_GO_PARALLEL && -n $VT_GO_PARALLEL_VALUE ]]; then
   VT_GO_PARALLEL="-p $VT_GO_PARALLEL_VALUE"
 fi
 
-# This can be removed once the docker images are rebuilt
-export GO111MODULE=on
-
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/... | sort)


### PR DESCRIPTION
* Stabilizes the testsuite on "MySQL56" == MySQL 5.7 in modern usage.
* Removes testsuite extra cnf from local examples (it should always be RBR now, and the defaults in default-fast are for testsuites.)
* Removes go111mod lines that should not be required because bootstrap has been re-ran in docker image.

Signed-off-by: Morgan Tocker <tocker@gmail.com>