### PR TITLE
migrater: option to cancel a migration

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -327,7 +327,7 @@ var commands = []commandGroup{
 				"[-cells=c1,c2,...] [-reverse] -workflow=workflow <target keyspace> <tablet type>",
 				"Migrate read traffic for the specified workflow."},
 			{"MigrateWrites", commandMigrateWrites,
-				"[-filtered_replication_wait_time=30s] [-reverse_replication=<true/false>] -workflow=workflow <target keyspace>",
+				"[-filtered_replication_wait_time=30s] [-cancel] [-reverse_replication=false] -workflow=workflow <target keyspace>",
 				"Migrate write traffic for the specified workflow."},
 			{"CancelResharding", commandCancelResharding,
 				"<keyspace/shard>",
@@ -1920,6 +1920,7 @@ func commandMigrateReads(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 func commandMigrateWrites(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "Specifies the maximum time to wait, in seconds, for filtered replication to catch up on master migrations. The migration will be aborted on timeout.")
 	reverseReplication := subFlags.Bool("reverse_replication", true, "Also reverse the replication")
+	cancelMigrate := subFlags.Bool("cancel", false, "Cancel the failed migration and serve from source")
 	workflow := subFlags.String("workflow", "", "Specifies the workflow name")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -1932,7 +1933,7 @@ func commandMigrateWrites(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 	if *workflow == "" {
 		return fmt.Errorf("a -workflow=workflow argument is required")
 	}
-	journalID, err := wr.MigrateWrites(ctx, keyspace, *workflow, *filteredReplicationWaitTime, *reverseReplication)
+	journalID, err := wr.MigrateWrites(ctx, keyspace, *workflow, *filteredReplicationWaitTime, *cancelMigrate, *reverseReplication)
 	if err != nil {
 		return err
 	}

--- a/go/vt/wrangler/migrater.go
+++ b/go/vt/wrangler/migrater.go
@@ -184,7 +184,7 @@ func (wr *Wrangler) MigrateWrites(ctx context.Context, targetKeyspace, workflow 
 	}
 	if !journalsExist {
 		mi.wr.Logger().Infof("No previous journals were found. Proceeding normally.")
-		sm, err := buildStreamMigrater(ctx, mi)
+		sm, err := buildStreamMigrater(ctx, mi, cancelMigrate)
 		if err != nil {
 			mi.wr.Logger().Errorf("buildStreamMigrater failed: %v", err)
 			return 0, err

--- a/go/vt/wrangler/migrater.go
+++ b/go/vt/wrangler/migrater.go
@@ -633,9 +633,11 @@ func (mi *migrater) waitForCatchup(ctx context.Context, filteredReplicationWaitT
 	return mi.forAllUids(func(target *miTarget, uid uint32) error {
 		bls := target.sources[uid]
 		source := mi.sources[bls.Shard]
+		mi.wr.Logger().Infof("waiting for keyspace:shard: %v:%v, position %v", mi.targetKeyspace, target.si.ShardName(), source.position)
 		if err := mi.wr.tmc.VReplicationWaitForPos(ctx, target.master.Tablet, int(uid), source.position); err != nil {
 			return err
 		}
+		mi.wr.Logger().Infof("position for keyspace:shard: %v:%v reached", mi.targetKeyspace, target.si.ShardName())
 		if _, err := mi.wr.tmc.VReplicationExec(ctx, target.master.Tablet, binlogplayer.StopVReplication(uid, "stopped for cutover")); err != nil {
 			return err
 		}

--- a/go/vt/wrangler/migrater.go
+++ b/go/vt/wrangler/migrater.go
@@ -679,7 +679,7 @@ func (mi *migrater) cancelMigration(ctx context.Context, sm *streamMigrater) {
 
 	err = mi.deleteReverseVReplication(ctx)
 	if err != nil {
-		mi.wr.Logger().Errorf("Cancel migration failed: could not restart vreplication: %v", err)
+		mi.wr.Logger().Errorf("Cancel migration failed: could not delete revers vreplication entries: %v", err)
 	}
 }
 

--- a/go/vt/wrangler/migrater_env_test.go
+++ b/go/vt/wrangler/migrater_env_test.go
@@ -453,7 +453,6 @@ func (tme *testShardMigraterEnv) expectCancelMigration() {
 		dbclient.addQuery("select id from _vt.vreplication where db_name = 'vt_ks' and workflow = 'test'", &sqltypes.Result{}, nil)
 	}
 	for _, dbclient := range tme.dbSourceClients {
-		dbclient.addQuery("select id, workflow, source, pos from _vt.vreplication where db_name='vt_ks' and workflow != 'test_reverse'", &sqltypes.Result{}, nil)
 		dbclient.addQuery("select id from _vt.vreplication where db_name = 'vt_ks' and workflow != 'test_reverse'", &sqltypes.Result{}, nil)
 	}
 	tme.expectDeleteReverseVReplication()

--- a/go/vt/wrangler/migrater_env_test.go
+++ b/go/vt/wrangler/migrater_env_test.go
@@ -49,6 +49,10 @@ type testMigraterEnv struct {
 	dbTargetClients []*fakeDBClient
 	allDBClients    []*fakeDBClient
 	targetKeyspace  string
+	sourceShards    []string
+	targetShards    []string
+	sourceKeyRanges []*topodatapb.KeyRange
+	targetKeyRanges []*topodatapb.KeyRange
 }
 
 // testShardMigraterEnv has some convenience functions for adding expected queries.
@@ -56,26 +60,45 @@ type testMigraterEnv struct {
 // Use explicit queries for testing the actual shard migration.
 type testShardMigraterEnv struct {
 	testMigraterEnv
-	sourceShards, targetShards       []string
-	sourceKeyRanges, targetKeyRanges []*topodatapb.KeyRange
 }
 
 func newTestTableMigrater(ctx context.Context, t *testing.T) *testMigraterEnv {
+	return newTestTableMigraterCustom(ctx, t, []string{"-40", "40-"}, []string{"-80", "80-"})
+}
+
+func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards, targetShards []string) *testMigraterEnv {
 	tme := &testMigraterEnv{}
 	tme.ts = memorytopo.NewServer("cell1", "cell2")
 	tme.wr = New(logutil.NewConsoleLogger(), tme.ts, tmclient.NewTabletManagerClient())
-
-	sourceShards := []string{"-40", "40-"}
-	targetShards := []string{"-80", "80-"}
+	tme.sourceShards = sourceShards
+	tme.targetShards = targetShards
 
 	tabletID := 10
 	for _, shard := range sourceShards {
 		tme.sourceMasters = append(tme.sourceMasters, newFakeTablet(t, tme.wr, "cell1", uint32(tabletID), topodatapb.TabletType_MASTER, nil, TabletKeyspaceShard(t, "ks1", shard)))
 		tabletID += 10
+
+		_, sourceKeyRange, err := topo.ValidateShardName(shard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sourceKeyRange == nil {
+			sourceKeyRange = &topodatapb.KeyRange{}
+		}
+		tme.sourceKeyRanges = append(tme.sourceKeyRanges, sourceKeyRange)
 	}
 	for _, shard := range targetShards {
 		tme.targetMasters = append(tme.targetMasters, newFakeTablet(t, tme.wr, "cell1", uint32(tabletID), topodatapb.TabletType_MASTER, nil, TabletKeyspaceShard(t, "ks2", shard)))
 		tabletID += 10
+
+		_, targetKeyRange, err := topo.ValidateShardName(shard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if targetKeyRange == nil {
+			targetKeyRange = &topodatapb.KeyRange{}
+		}
+		tme.targetKeyRanges = append(tme.targetKeyRanges, targetKeyRange)
 	}
 
 	vs := &vschemapb.Keyspace{
@@ -100,11 +123,15 @@ func newTestTableMigrater(ctx context.Context, t *testing.T) *testMigraterEnv {
 			},
 		},
 	}
-	if err := tme.ts.SaveVSchema(ctx, "ks1", vs); err != nil {
-		t.Fatal(err)
+	if len(sourceShards) != 1 {
+		if err := tme.ts.SaveVSchema(ctx, "ks1", vs); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if err := tme.ts.SaveVSchema(ctx, "ks2", vs); err != nil {
-		t.Fatal(err)
+	if len(targetShards) != 1 {
+		if err := tme.ts.SaveVSchema(ctx, "ks2", vs); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := tme.ts.RebuildSrvVSchema(ctx, nil); err != nil {
 		t.Fatal(err)
@@ -396,6 +423,8 @@ func (tme *testShardMigraterEnv) expectCreateJournals() {
 }
 
 func (tme *testShardMigraterEnv) expectStartReverseVReplication() {
+	// NOTE: this is not a faithful reproduction of what should happen.
+	// The ids returned are not accurate.
 	for _, dbclient := range tme.dbSourceClients {
 		dbclient.addQuery("select id from _vt.vreplication where db_name = 'vt_ks'", resultid34, nil)
 		dbclient.addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (3, 4)", &sqltypes.Result{}, nil)

--- a/go/vt/wrangler/migrater_test.go
+++ b/go/vt/wrangler/migrater_test.go
@@ -782,7 +782,7 @@ func TestTableMigrateOneToMany(t *testing.T) {
 	createReverseVReplication()
 
 	createJournals := func() {
-		journal1 := "insert into _vt.resharding_journal.*tables.*t1.*t2.*local_position.*MariaDB/5-456-892.*shard_gtids.*-80.*MariaDB/5-456-893.*80.*MariaDB/5-456-893.*participants.*0"
+		journal1 := "insert into _vt.resharding_journal.*tables.*t1.*t2.*local_position.*MariaDB/5-456-892.*shard_gtids.*80.*MariaDB/5-456-893.*80.*MariaDB/5-456-893.*participants.*0"
 		tme.dbSourceClients[0].addQueryRE(journal1, &sqltypes.Result{}, nil)
 	}
 	createJournals()

--- a/go/vt/wrangler/migrater_test.go
+++ b/go/vt/wrangler/migrater_test.go
@@ -234,7 +234,7 @@ func TestTableMigrateMainflow(t *testing.T) {
 
 	//-------------------------------------------------------------------------------------------------------------------
 	// Can't migrate writes if REPLICA and RDONLY have not fully migrated yet.
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want = "missing tablet type specific routing, read-only traffic must be migrated before migrating writes"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -300,7 +300,7 @@ func TestTableMigrateMainflow(t *testing.T) {
 	}
 	cancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, false, true)
 	want = "DeadlineExceeded"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites(0 timeout) err: %v, must contain %v", err, want)
@@ -415,7 +415,7 @@ func TestTableMigrateMainflow(t *testing.T) {
 	}
 	deleteTargetVReplication()
 
-	journalID, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	journalID, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -548,7 +548,7 @@ func TestShardMigrateMainflow(t *testing.T) {
 
 	//-------------------------------------------------------------------------------------------------------------------
 	// Can't migrate writes if REPLICA and RDONLY have not fully migrated yet.
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want = "cannot migrate MASTER away"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -610,7 +610,7 @@ func TestShardMigrateMainflow(t *testing.T) {
 	}
 	cancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, false, true)
 	want = "DeadlineExceeded"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites(0 timeout) err: %v, must contain %v", err, want)
@@ -707,7 +707,7 @@ func TestShardMigrateMainflow(t *testing.T) {
 	}
 	deleteTargetVReplication()
 
-	journalID, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	journalID, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -808,7 +808,7 @@ func TestMigrateFailJournal(t *testing.T) {
 	tme.dbSourceClients[0].addQueryRE("insert into _vt.resharding_journal", nil, errors.New("journaling intentionally failed"))
 	tme.dbSourceClients[1].addQueryRE("insert into _vt.resharding_journal", nil, errors.New("journaling intentionally failed"))
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "journaling intentionally failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites(0 timeout) err: %v, must contain %v", err, want)
@@ -875,7 +875,7 @@ func TestTableMigrateJournalExists(t *testing.T) {
 	tme.dbTargetClients[1].addQuery("delete from _vt.vreplication where id in (1, 2)", &sqltypes.Result{}, nil)
 	tme.dbTargetClients[1].addQuery("delete from _vt.copy_state where vrepl_id in (1, 2)", &sqltypes.Result{}, nil)
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -945,7 +945,7 @@ func TestShardMigrateJournalExists(t *testing.T) {
 	tme.dbTargetClients[1].addQuery("delete from _vt.vreplication where id in (2)", &sqltypes.Result{}, nil)
 	tme.dbTargetClients[1].addQuery("delete from _vt.copy_state where vrepl_id in (2)", &sqltypes.Result{}, nil)
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -960,6 +960,55 @@ func TestShardMigrateJournalExists(t *testing.T) {
 	checkIsMasterServing(t, tme.ts, "ks:-80", true)
 	checkIsMasterServing(t, tme.ts, "ks:80-", true)
 
+	verifyQueries(t, tme.allDBClients)
+}
+
+func TestTableMigrateCancel(t *testing.T) {
+	ctx := context.Background()
+	tme := newTestTableMigrater(ctx, t)
+	defer tme.stopTablets(t)
+
+	err := tme.wr.MigrateReads(ctx, tme.targetKeyspace, "test", topodatapb.TabletType_RDONLY, nil, DirectionForward)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tme.wr.MigrateReads(ctx, tme.targetKeyspace, "test", topodatapb.TabletType_REPLICA, nil, DirectionForward)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkJournals := func() {
+		tme.dbSourceClients[0].addQuery("select val from _vt.resharding_journal where id=7672494164556733923", &sqltypes.Result{}, nil)
+		tme.dbSourceClients[1].addQuery("select val from _vt.resharding_journal where id=7672494164556733923", &sqltypes.Result{}, nil)
+	}
+	checkJournals()
+
+	deleteReverseReplicaion := func() {
+		tme.dbSourceClients[0].addQuery("select id from _vt.vreplication where db_name = 'vt_ks1' and workflow = 'test_reverse'", resultid34, nil)
+		tme.dbSourceClients[1].addQuery("select id from _vt.vreplication where db_name = 'vt_ks1' and workflow = 'test_reverse'", resultid34, nil)
+		tme.dbSourceClients[0].addQuery("delete from _vt.vreplication where id in (3, 4)", &sqltypes.Result{}, nil)
+		tme.dbSourceClients[1].addQuery("delete from _vt.vreplication where id in (3, 4)", &sqltypes.Result{}, nil)
+		tme.dbSourceClients[0].addQuery("delete from _vt.copy_state where vrepl_id in (3, 4)", &sqltypes.Result{}, nil)
+		tme.dbSourceClients[1].addQuery("delete from _vt.copy_state where vrepl_id in (3, 4)", &sqltypes.Result{}, nil)
+	}
+	cancelMigration := func() {
+		tme.dbTargetClients[0].addQuery("select id from _vt.vreplication where db_name = 'vt_ks2' and workflow = 'test'", resultid12, nil)
+		tme.dbTargetClients[1].addQuery("select id from _vt.vreplication where db_name = 'vt_ks2' and workflow = 'test'", resultid12, nil)
+		tme.dbTargetClients[0].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (1, 2)", &sqltypes.Result{}, nil)
+		tme.dbTargetClients[1].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (1, 2)", &sqltypes.Result{}, nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 1", runningResult(1), nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 2", runningResult(2), nil)
+		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 1", runningResult(1), nil)
+		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 2", runningResult(2), nil)
+
+		deleteReverseReplicaion()
+	}
+	cancelMigration()
+
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	verifyQueries(t, tme.allDBClients)
 }
 
@@ -1061,7 +1110,7 @@ func TestTableMigrateNoReverse(t *testing.T) {
 	}
 	deleteTargetVReplication()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1124,7 +1173,7 @@ func TestMigrateFrozen(t *testing.T) {
 	}
 	deleteTargetVReplication()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 0*time.Second, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/wrangler/stream_migrater_test.go
+++ b/go/vt/wrangler/stream_migrater_test.go
@@ -163,7 +163,7 @@ func TestStreamMigrateMainflow(t *testing.T) {
 	tme.expectStartReverseVReplication()
 	tme.expectDeleteTargetVReplication()
 
-	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true); err != nil {
+	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -330,7 +330,7 @@ func TestStreamMigrateTwoStreams(t *testing.T) {
 	tme.expectStartReverseVReplication()
 	tme.expectDeleteTargetVReplication()
 
-	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true); err != nil {
+	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -462,7 +462,7 @@ func TestStreamMigrateOneToMany(t *testing.T) {
 	tme.expectStartReverseVReplication()
 	tme.expectDeleteTargetVReplication()
 
-	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true); err != nil {
+	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -596,7 +596,7 @@ func TestStreamMigrateManyToOne(t *testing.T) {
 	tme.expectStartReverseVReplication()
 	tme.expectDeleteTargetVReplication()
 
-	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true); err != nil {
+	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -784,7 +784,7 @@ func TestStreamMigrateSyncSuccess(t *testing.T) {
 	tme.expectStartReverseVReplication()
 	tme.expectDeleteTargetVReplication()
 
-	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true); err != nil {
+	if _, err := tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -939,7 +939,7 @@ func TestStreamMigrateSyncFail(t *testing.T) {
 
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "does not match"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites err: %v, want %s", err, want)
@@ -1030,7 +1030,7 @@ func TestStreamMigrateCancel(t *testing.T) {
 	}
 	cancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "intentionally failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites err: %v, want %s", err, want)
@@ -1100,7 +1100,7 @@ func TestStreamMigrateStoppedStreams(t *testing.T) {
 	stopStreams()
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "cannot migrate until all strems are running: 0"
 	if err == nil || err.Error() != want {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -1161,7 +1161,7 @@ func TestStreamMigrateStillCopying(t *testing.T) {
 	stopStreams()
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "cannot migrate while vreplication streams in source shards are still copying: 0"
 	if err == nil || err.Error() != want {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -1221,7 +1221,7 @@ func TestStreamMigrateEmptyWorflow(t *testing.T) {
 	stopStreams()
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "VReplication streams must have named workflows for migration: shard: ks:0, stream: 1"
 	if err == nil || err.Error() != want {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -1281,7 +1281,7 @@ func TestStreamMigrateDupWorflow(t *testing.T) {
 	stopStreams()
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "VReplication stream has the same workflow name as the resharding workflow: shard: ks:0, stream: 1"
 	if err == nil || err.Error() != want {
 		t.Errorf("MigrateWrites err: %v, want %v", err, want)
@@ -1352,7 +1352,7 @@ func TestStreamMigrateStreamsMismatch(t *testing.T) {
 	stopStreams()
 	tme.expectCancelMigration()
 
-	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, true)
+	_, err = tme.wr.MigrateWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, true)
 	want := "streams are mismatched across source shards"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("MigrateWrites err: %v, must contain %v", err, want)

--- a/go/vt/wrangler/stream_migrater_test.go
+++ b/go/vt/wrangler/stream_migrater_test.go
@@ -62,7 +62,7 @@ func TestStreamMigrateMainflow(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -208,7 +208,7 @@ func TestStreamMigrateTwoStreams(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -224,7 +224,7 @@ func TestStreamMigrateTwoStreams(t *testing.T) {
 			}
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -374,7 +374,7 @@ func TestStreamMigrateOneToMany(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -506,7 +506,7 @@ func TestStreamMigrateManyToOne(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -638,7 +638,7 @@ func TestStreamMigrateSyncSuccess(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -671,7 +671,7 @@ func TestStreamMigrateSyncSuccess(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -828,7 +828,7 @@ func TestStreamMigrateSyncFail(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -974,7 +974,7 @@ func TestStreamMigrateCancel(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -1073,7 +1073,7 @@ func TestStreamMigrateStoppedStreams(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -1134,7 +1134,7 @@ func TestStreamMigrateStillCopying(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -1195,7 +1195,7 @@ func TestStreamMigrateEmptyWorflow(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -1255,7 +1255,7 @@ func TestStreamMigrateDupWorflow(t *testing.T) {
 			var rows []string
 			for j, sourceShard := range tme.sourceShards {
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{
@@ -1321,7 +1321,7 @@ func TestStreamMigrateStreamsMismatch(t *testing.T) {
 					continue
 				}
 				bls := &binlogdatapb.BinlogSource{
-					Keyspace: "ks",
+					Keyspace: "ks1",
 					Shard:    sourceShard,
 					Filter: &binlogdatapb.Filter{
 						Rules: []*binlogdatapb.Rule{{


### PR DESCRIPTION
If a MigrateWrites fails, and also fails to undo what it's done. You can explicitly ask for a retry of the cancelation with this new option.