### PR TITLE
vttablet-up and vtgate-up should block until ready

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -34,7 +34,6 @@ CELL=zone1 "$script_root/vtctld-up.sh"
 
 # start vttablets for keyspace commerce
 CELL=zone1 KEYSPACE=commerce UID_BASE=100 "$script_root/vttablet-up.sh"
-sleep 15
 
 # set one of the replicas to master
 ./lvtctl.sh InitShardMaster -force commerce/0 zone1-100

--- a/examples/local/202_customer_tablets.sh
+++ b/examples/local/202_customer_tablets.sh
@@ -24,7 +24,7 @@ set -e
 script_root=$(dirname "${BASH_SOURCE}")
 
 CELL=zone1 KEYSPACE=customer UID_BASE=200 "$script_root/vttablet-up.sh"
-sleep 15
+
 ./lvtctl.sh InitShardMaster -force customer/0 zone1-200
 ./lvtctl.sh CopySchemaShard -tables customer,corder commerce/0 customer/0
 ./lvtctl.sh ApplyVSchema -vschema_file vschema_commerce_vsplit.json commerce

--- a/examples/local/302_new_shards.sh
+++ b/examples/local/302_new_shards.sh
@@ -24,7 +24,7 @@ script_root=$(dirname "${BASH_SOURCE}")
 
 SHARD=-80 CELL=zone1 KEYSPACE=customer UID_BASE=300 "$script_root/vttablet-up.sh"
 SHARD=80- CELL=zone1 KEYSPACE=customer UID_BASE=400 "$script_root/vttablet-up.sh"
-sleep 15
+
 ./lvtctl.sh InitShardMaster -force customer/-80 zone1-300
 ./lvtctl.sh InitShardMaster -force customer/80- zone1-400
 ./lvtctl.sh CopySchemaShard customer/0 customer/-80

--- a/examples/local/client.py
+++ b/examples/local/client.py
@@ -21,8 +21,7 @@ This is a sample for using the Python Vitess client.
 It's a script that inserts some random messages on random pages of the
 guestbook sample app.
 
-Before running this, start up a local example cluster as described in the
-README.md file.
+Before running this, start up a local example cluster.
 
 Then run client.sh, which sets up PYTHONPATH before running client.py:
 vitess/examples/local$ ./client.sh

--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -89,6 +89,16 @@ $VTROOT/bin/vtgate \
   $optional_tls_args \
   > $VTDATAROOT/tmp/vtgate.out 2>&1 &
 
+# Block waiting for vtgate to be listening
+# Not the same as healthy
+
+echo "Waiting for vtgate to be up..."
+while true; do
+ curl -I "http://$hostname:$web_port/debug/status" >/dev/null 2>&1 && break
+ sleep 0.1
+done;
+echo "vtgate is up!"
+
 echo "Access vtgate at http://$hostname:$web_port/debug/status"
 
 disown -a

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -129,4 +129,17 @@ for uid_index in $uids; do
   echo "Access tablet $alias at http://$hostname:$port/debug/status"
 done
 
+# Block waiting for all tablets to be listening
+# Not the same as healthy
+
+echo "Waiting for tablets to be listening..."
+for uid_index in $uids; do
+  port=$[$port_base + $uid_index]
+  while true; do
+   curl -I "http://$hostname:$port/debug/status" >/dev/null 2>&1 && break
+   sleep 0.1
+  done;
+done;
+echo "Tablets up!"
+
 disown -a

--- a/test/client_test.sh
+++ b/test/client_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2019 The Vitess Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This runs client tests. It used to be part of local_example,
+# but has been moved to its own test. It hijacks the public examples scripts
+
+set -xe
+cd "$VTTOP/examples/local"
+
+CELL=test ./etcd-up.sh
+CELL=test ./vtctld-up.sh
+
+CELL=test KEYSPACE=test_keyspace UID_BASE=100 ./vttablet-up.sh
+
+./lvtctl.sh InitShardMaster -force test_keyspace/0 test-100
+
+./lvtctl.sh ApplySchema -sql-file create_test_table.sql test_keyspace
+./lvtctl.sh RebuildVSchemaGraph
+
+CELL=test ./vtgate-up.sh
+
+echo "Run Python client script.."
+./client.sh
+
+echo "Run Go client script..."
+go run client.go -server=localhost:15991
+
+echo "Run Java client script..."
+./client_java.sh
+
+echo "Run JDBC client script..."
+./client_jdbc.sh
+
+# Clean up
+
+./vtgate-down.sh
+CELL=test UID_BASE=100 ./vttablet-down.sh
+./vtctld-down.sh
+CELL=test ./etcd-down.sh
+

--- a/test/config.json
+++ b/test/config.json
@@ -216,6 +216,17 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"client_test": {
+                        "File": "",
+                        "Args": [],
+                        "Command": [
+                                "test/client_test.sh"
+                        ],
+                        "Manual": false,
+                        "Shard": 3,
+                        "RetryMax": 0,
+                        "Tags": []
+		},
 		"merge_sharding": {
 			"File": "merge_sharding.py",
 			"Args": [],

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -15,111 +15,51 @@
 # limitations under the License.
 
 # This test runs through the scripts in examples/local to make sure they work.
+# It should be kept in sync with the steps in https://vitess.io/docs/get-started/local/
+# So we can detect if a regression affecting a tutorial is introduced.
 
-# timeout in seconds (for each step, not overall)
-timeout=30
-export TOPO=zk2
+set -xe
 
-cd $VTTOP/examples/local
+cd "$VTTOP/examples/local"
 
-exitcode=1
+./101_initial_cluster.sh
 
-# Use a minimal number of tablets for the test.
-# This helps with staying under CI resource limits.
-num_tablets=2
-uid_base=100
-cell=test
-TABLETS_UIDS="$(seq 0 $((num_tablets - 1)))"
-export TABLETS_UIDS
+mysql -h 127.0.0.1 -P 15306 < ../common/insert_commerce_data.sql
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_commerce_data.sql
+./201_customer_keyspace.sh
+./202_customer_tablets.sh
+./203_vertical_split.sh
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_customer0_data.sql
 
-teardown() {
-  ./vtgate-down.sh &
-  ./vttablet-down.sh "$TABLETS_UIDS" &
-  ./vtctld-down.sh &
-  ./zk-down.sh &
-  wait
-  exit $exitcode
-}
-trap teardown SIGTERM SIGINT EXIT
+./204_vertical_migrate_replicas.sh
+./205_vertical_migrate_master.sh
+# Expected to fail!
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_commerce_data.sql || echo "Blacklist working as expected"
+./206_clean_commerce.sh
+# Expected to fail!
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_commerce_data.sql || echo "Tables missing as expected"
 
-# Set up servers.
-timeout $timeout ./zk-up.sh || teardown
-timeout $timeout ./vtctld-up.sh || teardown
-timeout $timeout ./vttablet-up.sh || teardown
+./301_customer_sharded.sh
+./302_new_shards.sh
 
-# Retry loop function
-retry_with_timeout() {
-  if [ `date +%s` -gt $[$start + $timeout] ]; then
-    echo "Timeout ($timeout) exceeded"
-    teardown
-  fi
+# Wait for the schema to be targetable before proceeding
+# TODO: Eliminate this race in the examples' scripts
+for shard in "customer/-80" "customer/80-"; do
+ while true; do
+  mysql -h 127.0.0.1 -P 15306 "$shard" -e 'show tables' && break || echo "waiting for shard: $shard!"
+  sleep 1
+ done;
+done;
 
-  echo "Waiting 2 seconds to try again..."
-  sleep 2
-}
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_customer-80_data.sql
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_customer80-_data.sql
 
-# Wait for vttablets to show up in topology.
-# If we don't do this, then vtgate might take up to a minute
-# to notice the new tablets, which is normally fine, but not
-# when we're trying to get through the test ASAP.
-echo "Waiting for $num_tablets tablets to appear in topology..."
-start=`date +%s`
-until [[ $(./lvtctl.sh ListAllTablets test | wc -l) -eq $num_tablets ]]; do
-  retry_with_timeout
-done
+./303_horizontal_split.sh
 
-timeout $timeout ./vtgate-up.sh || teardown
+./304_migrate_replicas.sh
+./305_migrate_master.sh
 
-echo "Initialize shard..."
-start=`date +%s`
-until ./lvtctl.sh InitShardMaster -force test_keyspace/0 test-100; do
-  retry_with_timeout
-done
+mysql -h 127.0.0.1 -P 15306 --table < ../common/select_customer-80_data.sql
 
-# Run manual health check on each tablet.
-# This is not necessary, but it helps make this test more representative of
-# what a human would do. It simulates the case where a periodic health check
-# occurs before the user gets around to running the next command. For example,
-# in that case the health check will make the tablet begin serving prior to the
-# ApplySchema command below. Otherwise, ApplySchema races with the periodic
-# health check.
-echo "Running health check on tablets..."
-start=`date +%s`
-for uid_index in $TABLETS_UIDS; do
-  uid=$[$uid_base + $uid_index]
-  printf -v alias '%s-%010d' $cell $uid
-  ./lvtctl.sh RunHealthCheck $alias
-done
+./401_teardown.sh
 
-echo "Create table..."
-start=`date +%s`
-until ./lvtctl.sh ApplySchema -sql "$(cat create_test_table.sql)" test_keyspace; do
-  retry_with_timeout
-done
-
-echo "Rebuild vschema..."
-start=`date +%s`
-until ./lvtctl.sh RebuildVSchemaGraph; do
-  retry_with_timeout
-done
-
-echo "Run Python client script..."
-# Retry until vtgate is ready.
-start=`date +%s`
-# Test that the client.sh script works with no --server arg,
-# because that's how the tutorial says to run it.
-until ./client.sh ; do
-  retry_with_timeout
-done
-
-echo "Run Go client script..."
-go run client.go -server=localhost:15991 || teardown
-
-echo "Run Java client script..."
-./client_java.sh || teardown
-
-echo "Run JDBC client script..."
-./client_jdbc.sh || teardown
-
-exitcode=0
-teardown


### PR DESCRIPTION
Fixes #5355

shellcheck is temporarily disabled due to https://github.com/vitessio/vitess/issues/5305

No new shellcheck issues should be introduced, but there are existing
problems with vtgate-up.sh and vttablet-up.sh which are not addressed.

**Edit:** I have also refactored the `local_example` test to be split into two. The `local_example` just covers the get-started guide from vitess.io. The {python,go,java,jdbc} client tests are in `client_test`. This was done so that it follows complete logical sense: as we update the get-started guide, we should update the test to be identical.

Signed-off-by: Morgan Tocker <tocker@gmail.com>