### PR TITLE
Examples: search for mysqld instead of mysqld_safe

### DIFF
--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -20,11 +20,11 @@ vtctld_web_port=15000
 # Set up environment.
 export VTTOP=${VTTOP-$VTROOT/src/vitess.io/vitess}
 
-# Try to find mysqld_safe on PATH.
+# Try to find mysqld on PATH.
 if [ -z "$VT_MYSQL_ROOT" ]; then
-  mysql_path=`which mysqld_safe`
+  mysql_path=`which mysqld`
   if [ -z "$mysql_path" ]; then
-    echo "Can't guess location of mysqld_safe. Please set VT_MYSQL_ROOT so it can be found at \$VT_MYSQL_ROOT/bin/mysqld_safe."
+    echo "Can't guess location of mysqld. Please set VT_MYSQL_ROOT manually."
     exit 1
   fi
   export VT_MYSQL_ROOT=$(dirname `dirname $mysql_path`)


### PR DESCRIPTION
Fixes #5359

mysqld_safe is not available in newer packages, and thus the example fails to autodetect `VT_MYSQL_ROOT`.

Signed-off-by: Morgan Tocker <tocker@gmail.com>