### PR TITLE
Better granularity for errors that come out of the transaction pool

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -38,6 +38,9 @@ var (
 	// ErrTimeout is returned if a resource get times out.
 	ErrTimeout = errors.New("resource pool timed out")
 
+	// ErrCtxTimeout is returned if a ctx is already expired by the time the resource pool is used
+	ErrCtxTimeout = errors.New("resource pool context already expired")
+
 	prefillTimeout = 30 * time.Second
 )
 
@@ -198,7 +201,7 @@ func (rp *ResourcePool) get(ctx context.Context) (resource Resource, err error) 
 	// If ctx has already expired, avoid racing with rp's resource channel.
 	select {
 	case <-ctx.Done():
-		return nil, ErrTimeout
+		return nil, ErrCtxTimeout
 	default:
 	}
 

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -639,7 +639,7 @@ func TestExpired(t *testing.T) {
 		p.Put(r)
 	}
 	cancel()
-	want := "resource pool timed out"
+	want := "resource pool context already expired"
 	if err == nil || err.Error() != want {
 		t.Errorf("got %v, want %s", err, want)
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -962,7 +962,7 @@ func TestTabletServerBeginFail(t *testing.T) {
 	defer cancel()
 	tsv.Begin(ctx, &target, nil)
 	_, err = tsv.Begin(ctx, &target, nil)
-	want := "transaction pool connection limit exceeded"
+	want := "transaction pool aborting request due to already expired context"
 	if err == nil || err.Error() != want {
 		t.Fatalf("Begin err: %v, want %v", err, want)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -245,6 +245,9 @@ func (axp *TxPool) Begin(ctx context.Context, options *querypb.ExecuteOptions) (
 		switch err {
 		case connpool.ErrConnPoolClosed:
 			return 0, "", err
+		case pools.ErrCtxTimeout:
+			axp.LogActive()
+			return 0, "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool aborting request due to already expired context")
 		case pools.ErrTimeout:
 			axp.LogActive()
 			return 0, "", vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "transaction pool connection limit exceeded")


### PR DESCRIPTION
### Desc

* In our on going saga to debug gremlins in outliers timeouts, we've noticed that sometimes we get timeout errors from the connection pool that are due to contexts being already expired when they get to the pool. 
* This PR adds a new error that distinguishes between actual timeouts from the
  pool and errors due to contexts being already expired by the time it gets to
  the pool.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>