### PR TITLE
Add mysqlctl support for MariaDB 10.4

### DIFF
--- a/config/mycnf/master_mariadb104.cnf
+++ b/config/mycnf/master_mariadb104.cnf
@@ -1,0 +1,23 @@
+# This file is auto-included when MariaDB 10.4 is detected.
+
+# enable strict mode so it's safe to compare sequence numbers across different server IDs.
+gtid_strict_mode = 1
+innodb_stats_persistent = 0
+
+# Semi-sync replication is required for automated unplanned failover
+# (when the master goes away). Here we just load the plugin so it's
+# available if desired, but it's disabled at startup.
+#
+# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync
+# at the proper time when replication is set up, or when masters are
+# promoted or demoted.
+
+# semi_sync has been merged into master as of mariadb 10.3 so this is no longer needed 
+#plugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so
+
+# When semi-sync is enabled, don't allow fallback to async
+# if you get no ack, or have no slaves. This is necessary to
+# prevent alternate futures when doing a failover in response to
+# a master that becomes unresponsive.
+rpl_semi_sync_master_timeout = 1000000000000000000
+rpl_semi_sync_master_wait_no_slave = 1

--- a/go/vt/mysqlctl/capabilityset.go
+++ b/go/vt/mysqlctl/capabilityset.go
@@ -46,10 +46,16 @@ func (c *capabilitySet) hasMySQLUpgradeInServer() bool {
 func (c *capabilitySet) hasInitializeInServer() bool {
 	return c.isMySQLLike() && c.version.atLeast(serverVersion{Major: 5, Minor: 7, Patch: 0})
 }
+func (c *capabilitySet) hasMaria104InstallDb() bool {
+	return c.isMariaDB() && c.version.atLeast(serverVersion{Major: 10, Minor: 4, Patch: 0})
+}
 
 // IsMySQLLike tests if the server is either MySQL
 // or Percona Server. At least currently, Vitess doesn't
 // make use of any specific Percona Server features.
 func (c *capabilitySet) isMySQLLike() bool {
 	return c.flavor == flavorMySQL || c.flavor == flavorPercona
+}
+func (c *capabilitySet) isMariaDB() bool {
+	return c.flavor == flavorMariaDB
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -742,6 +742,9 @@ func (mysqld *Mysqld) installDataDir(cnf *Mycnf) error {
 		"--defaults-file=" + cnf.path,
 		"--basedir=" + mysqlBaseDir,
 	}
+	if mysqld.capabilities.hasMaria104InstallDb() {
+		args = append(args, "--auth-root-authentication-method=normal")
+	}
 	cmdPath, err := binaryPath(mysqlRoot, "mysql_install_db")
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds mysqlctl support for MariaDB 10.4 bootstrapping (technically it tells mariadb 10.4 to bootstrap the old way). MariaDB 10.4 does not work yet, since it fails somewhere around the force master-elect:

```
+ cd examples/local/
+ ./101_initial_cluster.sh
enter etcd2 env
add /vitess/global
add /vitess/zone1
add zone1 CellInfo
etcd start done...
enter etcd2 env
Starting vtctld...
Access vtctld web UI at http://morgox1:15000
Send commands with: vtctlclient -server morgox1:15999 ...
enter etcd2 env
Starting MySQL for tablet zone1-0000000100...
Starting MySQL for tablet zone1-0000000101...
Starting MySQL for tablet zone1-0000000102...
Starting vttablet for zone1-0000000100...
Access tablet zone1-0000000100 at http://morgox1:15100/debug/status
Starting vttablet for zone1-0000000101...
Access tablet zone1-0000000101 at http://morgox1:15101/debug/status
Starting vttablet for zone1-0000000102...
Access tablet zone1-0000000102 at http://morgox1:15102/debug/status
Waiting for tablets to be listening...
Tablets up!
W1029 13:40:15.140647   10388 main.go:64] W1029 19:40:15.138686 reparent.go:182] master-elect tablet zone1-0000000100 is not the shard master, proceeding anyway as -force was used
W1029 13:40:15.141158   10388 main.go:64] W1029 19:40:15.139772 reparent.go:188] master-elect tablet zone1-0000000100 is not a master in the shard, proceeding anyway as -force was used
E1029 13:40:45.661848   10388 main.go:67] remote error: rpc error: code = Unknown desc = tablet zone1-0000000101 InitSlave failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded;tablet zone1-0000000102 InitSlave failed: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

After this merges, I will update #5362 to say this is no longer a `mysqlctl` issue, but a reparenting issue that needs further investigation.

Signed-off-by: Morgan Tocker <tocker@gmail.com>