### PR TITLE
Don't set RestorePosition in local_metadata.

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -26,7 +26,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
@@ -319,7 +318,8 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 
 	// Add backupTime and restorePosition to LocalMetadata
 	params.LocalMetadata["RestoredBackupTime"] = manifest.BackupTime
-	params.LocalMetadata["RestorePosition"] = mysql.EncodePosition(manifest.Position)
+	// TODO(deepthi): Uncomment this when the table is fixed to fit replication positions.
+	//params.LocalMetadata["RestorePosition"] = mysql.EncodePosition(manifest.Position)
 
 	// Populate local_metadata before starting without --skip-networking,
 	// so it's there before we start announcing ourselves.

--- a/test/recovery.py
+++ b/test/recovery.py
@@ -263,7 +263,8 @@ class TestRecovery(unittest.TestCase):
     self.assertEqual(metadata['Alias'], 'test_nj-0000062346')
     self.assertEqual(metadata['ClusterAlias'], 'recovery_keyspace.0')
     self.assertEqual(metadata['DataCenter'], 'test_nj')
-    self.assertEqual(metadata['RestorePosition'], master_pos)
+    # TODO(deepthi): Uncomment this when RestorePosition is fixed.
+    #self.assertEqual(metadata['RestorePosition'], master_pos)
     logging.debug('RestoredBackupTime: %s', str(metadata['RestoredBackupTime']))
     gotTime = datetime.strptime(metadata['RestoredBackupTime'], '%Y-%m-%dT%H:%M:%SZ')
     self.assertEqual(gotTime, expectedTime)


### PR DESCRIPTION
This temporarily stops setting the RestorePosition in local_metadata
because the table's value column is not big enough to fit typical
replication positions, and therefore tablets are blocked from restoring.

We plan to re-enable RestorePosition after altering the local_metadata
table to make the value column big enough.

This is a temporary mitigation for #5377.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>