### PR TITLE
Don't recheck mysqld port if it was provided explicitly.

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -151,6 +151,11 @@ type ActionAgent struct {
 	// It is protected by actionMutex.
 	gotMysqlPort bool
 
+	// mysqlAdvertisePort is the port to publish for our own mysqld in the
+	// tablet record. If this is greater than 0, we simply advertise this value
+	// instead of asking mysqld what port it's serving on.
+	mysqlAdvertisePort int32
+
 	// initReplication remembers whether an action has initialized
 	// replication.  It is protected by actionMutex.
 	initReplication bool
@@ -273,6 +278,12 @@ func NewActionAgent(
 	if appConfig := dbcfgs.AppWithDB(); appConfig.Host != "" {
 		mysqlHost = appConfig.Host
 		mysqlPort = int32(appConfig.Port)
+
+		// Remember this port as the advertise port. When we're connecting over
+		// host:port, it doesn't make sense to ask mysqld for its port after
+		// connecting. We should just tell others to use the same port we were
+		// told to use, in case it's a proxy.
+		agent.mysqlAdvertisePort = mysqlPort
 	} else {
 		// Assume unix socket was specified and try to get the port from mysqld
 		var err error
@@ -724,14 +735,24 @@ func (agent *ActionAgent) hookExtraEnv() map[string]string {
 // The actionMutex lock must be held when calling this function.
 func (agent *ActionAgent) checkTabletMysqlPort(ctx context.Context, tablet *topodatapb.Tablet) *topodatapb.Tablet {
 	agent.checkLock()
-	mport, err := agent.MysqlDaemon.GetMysqlPort()
-	if err != nil {
-		// Only log the first time, so we don't spam the logs.
-		if !agent.waitingForMysql {
-			log.Warningf("Cannot get current mysql port, not checking it (will retry at healthcheck interval): %v", err)
-			agent.waitingForMysql = true
+
+	var mport int32
+
+	// If we have stored an advertise port, just assume that.
+	// Otherwise, ask mysqld (presumably over unix socket) what its port is.
+	if agent.mysqlAdvertisePort > 0 {
+		mport = agent.mysqlAdvertisePort
+	} else {
+		var err error
+		mport, err = agent.MysqlDaemon.GetMysqlPort()
+		if err != nil {
+			// Only log the first time, so we don't spam the logs.
+			if !agent.waitingForMysql {
+				log.Warningf("Cannot get current mysql port, not checking it (will retry at healthcheck interval): %v", err)
+				agent.waitingForMysql = true
+			}
+			return nil
 		}
-		return nil
 	}
 
 	if mport == topoproto.MysqlPort(tablet) {


### PR DESCRIPTION
At startup, we already avoid asking mysqld for its port if we were given
the port in DB configs. However, we would forget this port when we later
trigger a recheck of the MySQL port.

It's important to trust the port that was given to us because it might
be different from the port that mysqld is actually serving on, such as
in the case that the host we were given is actually a proxy.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>