### PR TITLE
Disable prepared statements test

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -267,6 +267,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"prepared_statement": {
+			"File": "prepared_statement_test.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 4,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
 			"Args": [],

--- a/test/config.json
+++ b/test/config.json
@@ -267,15 +267,6 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
-		"prepared_statement": {
-			"File": "prepared_statement_test.py",
-			"Args": [],
-			"Command": [],
-			"Manual": false,
-			"Shard": 4,
-			"RetryMax": 0,
-			"Tags": []
-		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
 			"Args": [],


### PR DESCRIPTION
I could not get it to work while bootstrapping the docker images and
then running the test suite (it works fine using the Docker image
published on Docker Hub).

I discussed with others, and with prepared_statements marked
experimental, we will disable the tests for now so that the 4.0 branch
can start based on a passing testsuite.