### PR TITLE
Disable prepared statements test

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -267,15 +267,6 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
-		"prepared_statement": {
-			"File": "prepared_statement_test.py",
-			"Args": [],
-			"Command": [],
-			"Manual": false,
-			"Shard": 4,
-			"RetryMax": 0,
-			"Tags": []
-		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
 			"Args": [],


### PR DESCRIPTION
Disabling the prepared statements test for the release branch.  The test is not currently stable when re-bootstrapping the Docker image.

Prepared statements are an experimental 4.0 feature.

Signed-off-by: Morgan Tocker <tocker@gmail.com>