### PR TITLE
mysql: handle db name correctly

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -625,7 +625,7 @@ func (c *Conn) writeHandshakeResponse41(capabilities uint32, scrambledPassword [
 	// DbName, only if server supports it.
 	if params.DbName != "" && (capabilities&CapabilityClientConnectWithDB != 0) {
 		pos = writeNullString(data, pos, params.DbName)
-		c.SchemaName = params.DbName
+		c.schemaName = params.DbName
 	}
 
 	// Assume native client during response

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -110,10 +110,12 @@ type Conn struct {
 	// It is set during the initial handshake.
 	UserData Getter
 
-	// SchemaName is the default database name to use. It is set
+	// schemaName is the default database name to use. It is set
 	// during handshake, and by ComInitDb packets. Both client and
-	// servers maintain it.
-	SchemaName string
+	// servers maintain it. This member is private because it's
+	// non-authoritative: the client can change the schema name
+	// through the 'USE' statement, which will bypass this variable.
+	schemaName string
 
 	// ServerVersion is set during Connect with the server
 	// version.  It is not changed afterwards. It is unused for
@@ -731,7 +733,8 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 	case ComInitDB:
 		db := c.parseComInitDB(data)
 		c.recycleReadPacket()
-		c.SchemaName = db
+		c.schemaName = db
+		handler.ComInitDB(c, db)
 		if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
 			log.Errorf("Error writing ComInitDB result to %s: %v", c, err)
 			return err

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -313,6 +313,10 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 	delete(db.connections, c.ConnectionID)
 }
 
+// ComInitDB is part of the mysql.Handler interface.
+func (db *DB) ComInitDB(c *mysql.Conn, schemaName string) {
+}
+
 // ComQuery is part of the mysql.Handler interface.
 func (db *DB) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	return db.Handler.HandleQuery(c, query, callback)

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -88,6 +88,10 @@ type Handler interface {
 	// ConnectionClosed is called when a connection is closed.
 	ConnectionClosed(c *Conn)
 
+	// InitDB is called once at the beginning to set db name,
+	// and subsequently for every ComInitDB event.
+	ComInitDB(c *Conn, schemaName string)
+
 	// ComQuery is called when a connection receives a query.
 	// Note the contents of the query slice may change after
 	// the first call to callback. So the Handler should not
@@ -447,6 +451,9 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		log.Warningf("Slow connection from %s: %v", c, connectTime)
 	}
 
+	// Set initial db name.
+	l.handler.ComInitDB(c, c.schemaName)
+
 	for {
 		err := c.handleNextCommand(l.handler)
 		if err != nil {
@@ -674,7 +681,7 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []by
 		if !ok {
 			return "", "", nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "parseClientHandshakePacket: can't read dbname")
 		}
-		c.SchemaName = dbname
+		c.schemaName = dbname
 	}
 
 	// authMethod (with default)

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -75,7 +75,9 @@ func (th *testHandler) NewConnection(c *Conn) {
 }
 
 func (th *testHandler) ConnectionClosed(c *Conn) {
+}
 
+func (th *testHandler) ComInitDB(c *Conn, schemaName string) {
 }
 
 func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
@@ -109,7 +111,7 @@ func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.R
 			},
 			Rows: [][]sqltypes.Value{
 				{
-					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(c.SchemaName)),
+					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(c.schemaName)),
 				},
 			},
 		})

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -43,6 +43,9 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
+func (th *testHandler) ComInitDB(c *mysql.Conn, schemaName string) {
+}
+
 func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
 	return nil
 }
@@ -52,7 +55,6 @@ func (th *testHandler) ComPrepare(c *mysql.Conn, q string) ([]*querypb.Field, er
 }
 
 func (th *testHandler) ComResetConnection(c *mysql.Conn) {
-
 }
 
 func (th *testHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {

--- a/go/vt/vtqueryserver/plugin_mysql_server_test.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server_test.go
@@ -40,6 +40,9 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
+func (th *testHandler) ComInitDB(c *mysql.Conn, schemaName string) {
+}
+
 func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
 	return nil
 }


### PR DESCRIPTION
Fixes #5206

The conn schemaname var can get set through a new connection
or a ComInitDB packet. However, a use statement bypasses this
mechanism and gets handled at the vtgate level. This causes
problems because schemaName in the connection disagrees with
TargetString in vtgate.

To fix this, the new scheme calls a new handler function: ComInitDB
every time schemaName is initialized or changed in the connection.
This way, the TargetString remains the authoritative source
for the current db name.

I couldn't write a test for this specific behavior change because
the mysql go client does not implement support for ComInitDB.
But I've verified the things generally work as expected.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>