### PR TITLE
Stop nagging about where go is installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,10 +35,8 @@ function fail() {
 
 [[ "$(dirname "$0")" = "." ]] || fail "bootstrap.sh must be run from its current directory"
 
-go version &>/dev/null  || fail "Go is not installed or is not on \$PATH"
-[[ "$(go version 2>&1)" =~ go1\.[1-9][1-9] ]] || fail "Go is not version 1.11+"
-
 # Create main directories.
+VTROOT="${VTROOT:-${PWD/\/src\/vitess.io\/vitess/}}"
 mkdir -p "$VTROOT/dist"
 mkdir -p "$VTROOT/bin"
 mkdir -p "$VTROOT/lib"
@@ -52,6 +50,9 @@ if [ "$BUILD_TESTS" == 1 ] ; then
 else
     source ./build.env
 fi
+
+go version &>/dev/null  || fail "Go is not installed or is not on \$PATH"
+goversion_min 1.12 || fail "Go is not version 1.12+"
 
 if [ "$BUILD_TESTS" == 1 ] ; then
     # Set up required soft links.

--- a/dev.env
+++ b/dev.env
@@ -55,33 +55,12 @@ export PIP
 command -v virtualenv2 >/dev/null && VIRTUALENV=virtualenv2 || VIRTUALENV=virtualenv
 export VIRTUALENV
 
-# Add the current GOBIN
-if [ "$GOBIN" ]; then
-  PATH=$(prepend_path "$PATH" "$GOBIN")
-fi
-
-# Many tests rely on "go install" and assume GOBIN is really $VTROOT/bin.
-# Make sure these take precedence.
-GOBIN=$VTROOT/bin
-export GOBIN
-PATH=$(prepend_path "$PATH" "$GOBIN")
-
 # Add chromedriver to path for Selenium tests.
 PATH=$(prepend_path "$PATH" "$VTROOT/dist/chromedriver")
 
 # Node path.
 PATH=$(prepend_path "$PATH" "$VTROOT/dist/node/bin")
 export PATH
-
-# GOROOT sanity
-go_bin=$(which go)
-go_env=$(go env | grep GOROOT | cut -f 2 -d\")
-if [[ "$go_bin" != "" && "$go_bin" != "$go_env/bin/go" ]]; then
-  echo "WARNING: \$GOROOT may not be compatible with the used go binary"
-  echo "Please make sure 'go' comes from \$GOROOT/bin"
-  echo "go_env: $go_env"
-  echo "go_bin: $go_bin"
-fi
 
 # mysql install location. Please set based on your environment.
 # Build will not work if this is incorrect.


### PR DESCRIPTION
Fixes #5405 

I have verified with `make docker_bootstrap && go run test.go -pull=false`. Currently, the prepared statements test fails (expected), but the other tests pass.

Signed-off-by: Morgan Tocker <tocker@gmail.com>