### PR TITLE
messager: add special support for time_expires, min/maxBackoff

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -170,6 +170,8 @@ type messageManager struct {
 	fieldResult  *sqltypes.Result
 	ackWaitTime  time.Duration
 	purgeAfter   time.Duration
+	minBackoff   time.Duration
+	maxBackoff   time.Duration
 	batchSize    int
 	pollerTicks  *timer.Timer
 	purgeTicks   *timer.Timer
@@ -214,6 +216,8 @@ func newMessageManager(tsv TabletService, table *schema.Table, conns *connpool.P
 		},
 		ackWaitTime:  table.MessageInfo.AckWaitDuration,
 		purgeAfter:   table.MessageInfo.PurgeAfterDuration,
+		minBackoff:   table.MessageInfo.MinBackoff,
+		maxBackoff:   table.MessageInfo.MaxBackoff,
 		batchSize:    table.MessageInfo.BatchSize,
 		cache:        newCache(table.MessageInfo.CacheSize),
 		pollerTicks:  timer.NewTimer(table.MessageInfo.PollInterval),
@@ -235,9 +239,18 @@ func newMessageManager(tsv TabletService, table *schema.Table, conns *connpool.P
 	mm.ackQuery = sqlparser.BuildParsedQuery(
 		"update %v set time_acked = %a, time_next = null where id in %a and time_acked is null",
 		mm.name, ":time_acked", "::ids")
-	mm.postponeQuery = sqlparser.BuildParsedQuery(
-		"update %v set time_next = %a+(%a<<epoch), epoch = epoch+1 where id in %a and time_acked is null",
-		mm.name, ":time_now", ":wait_time", "::ids")
+
+	// if a maxBackoff is set, incorporate it into the update statement
+	if mm.maxBackoff > 0 {
+		mm.postponeQuery = sqlparser.BuildParsedQuery(
+			"update %v set time_next = %a+if(%a<<epoch > %a, %a, %a<<epoch), epoch = epoch+1 where id in %a and time_acked is null",
+			mm.name, ":time_now", ":min_backoff", ":max_backoff", ":max_backoff", ":min_backoff", "::ids")
+	} else {
+		mm.postponeQuery = sqlparser.BuildParsedQuery(
+			"update %v set time_next = %a+(%a<<epoch), epoch = epoch+1 where id in %a and time_acked is null",
+			mm.name, ":time_now", ":min_backoff", "::ids")
+	}
+
 	mm.purgeQuery = sqlparser.BuildParsedQuery(
 		"delete from %v where time_scheduled < %a and time_acked is not null limit 500",
 		mm.name, ":time_scheduled")
@@ -681,11 +694,18 @@ func (mm *messageManager) GeneratePostponeQuery(ids []string) (string, map[strin
 			Value: []byte(id),
 		})
 	}
-	return mm.postponeQuery.Query, map[string]*querypb.BindVariable{
-		"time_now":  sqltypes.Int64BindVariable(time.Now().UnixNano()),
-		"wait_time": sqltypes.Int64BindVariable(int64(mm.ackWaitTime)),
-		"ids":       idbvs,
+
+	bvs := map[string]*querypb.BindVariable{
+		"time_now":    sqltypes.Int64BindVariable(time.Now().UnixNano()),
+		"min_backoff": sqltypes.Int64BindVariable(int64(mm.minBackoff)),
+		"ids":         idbvs,
 	}
+
+	if mm.maxBackoff > 0 {
+		bvs["max_backoff"] = sqltypes.Int64BindVariable(int64(mm.maxBackoff))
+	}
+
+	return mm.postponeQuery.Query, bvs
 }
 
 // GeneratePurgeQuery returns the query and bind vars for purging messages.

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -174,6 +174,15 @@ func loadMessageInfo(ta *Table, comment string) error {
 	if ta.MessageInfo.PollInterval, err = getDuration(keyvals, "vt_poller_interval"); err != nil {
 		return err
 	}
+
+	// errors are ignored because these fields are optional and 0 is the default value
+	ta.MessageInfo.MinBackoff, _ = getDuration(keyvals, "vt_min_backoff")
+	// the original default minimum backoff was based on ack wait timeout, so this preserves that
+	if ta.MessageInfo.MinBackoff == 0 {
+		ta.MessageInfo.MinBackoff = ta.MessageInfo.AckWaitDuration
+	}
+	ta.MessageInfo.MaxBackoff, _ = getDuration(keyvals, "vt_max_backoff")
+
 	if strings.Contains(comment, "vt_include_time_expires") {
 		ta.MessageInfo.IncludeTimeExpires = true
 	}

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -174,6 +174,9 @@ func loadMessageInfo(ta *Table, comment string) error {
 	if ta.MessageInfo.PollInterval, err = getDuration(keyvals, "vt_poller_interval"); err != nil {
 		return err
 	}
+	if strings.Contains(comment, "vt_include_time_expires") {
+		ta.MessageInfo.IncludeTimeExpires = true
+	}
 	for _, col := range orderedColumns {
 		num := ta.FindColumn(sqlparser.NewColIdent(col))
 		if num == -1 {

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -139,6 +139,14 @@ type MessageInfo struct {
 	// PollInterval specifies the polling frequency to
 	// look for messages to be sent.
 	PollInterval time.Duration
+
+	// MinBackoff specifies the shortest duration message manager
+	// should wait before rescheduling a message
+	MinBackoff time.Duration
+
+	// MaxBackoff specifies the longest duration message manager
+	// should wait before rescheduling a message
+	MaxBackoff time.Duration
 }
 
 // NewTable creates a new Table.

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -109,6 +109,11 @@ type MessageInfo struct {
 	// returned for subscribers.
 	Fields []*querypb.Field
 
+	// IncludeTimeExpires defines whether the user wants the
+	// message manager to send the receiver the time that the message
+	// will expire and be postponed, helping to prevent duplicates.
+	IncludeTimeExpires bool
+
 	// Optional topic to subscribe to. Any messages
 	// published to the topic will be added to this table.
 	Topic string


### PR DESCRIPTION
As a consumer of Vitess messages, it is currently impossible to know whether or not a message has expired or is about to expire. This PR provides a backwards compatible way for the actual message expiration time to be sent with the query results as a special cased pseudo field, configured with a table level comment.

While in the code, I also added the ability to set min and max backoff durations for exponential backoff. After enough attempts, message attempts can get pushed out for days, which is usually undesirable. 

If this approach is acceptable, I'll go ahead and add tests.