### PR TITLE
Load tls certificate and x509 cert pool once per file to reduce memory usage

### DIFF
--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -19,8 +19,12 @@ package vttls
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
+	"strings"
+	"sync"
+
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // Updated list of acceptable cipher suits to address
@@ -51,6 +55,8 @@ func newTLSConfig() *tls.Config {
 	}
 }
 
+var onceByKeys = sync.Map{}
+
 // ClientConfig returns the TLS config to use for a client to
 // connect to a server with the provided parameters.
 func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
@@ -58,24 +64,24 @@ func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
 
 	// Load the client-side cert & key if any.
 	if cert != "" && key != "" {
-		crt, err := tls.LoadX509KeyPair(cert, key)
+		certificates, err := loadTLSCertificate(cert, key)
+
 		if err != nil {
-			return nil, fmt.Errorf("failed to load cert/key: %v", err)
+			return nil, err
 		}
-		config.Certificates = []tls.Certificate{crt}
+
+		config.Certificates = *certificates
 	}
 
 	// Load the server CA if any.
 	if ca != "" {
-		b, err := ioutil.ReadFile(ca)
+		certificatePool, err := loadx509CertPool(ca)
+
 		if err != nil {
-			return nil, fmt.Errorf("failed to read ca file: %v", err)
+			return nil, err
 		}
-		cp := x509.NewCertPool()
-		if !cp.AppendCertsFromPEM(b) {
-			return nil, fmt.Errorf("failed to append certificates")
-		}
-		config.RootCAs = cp
+
+		config.RootCAs = certificatePool
 	}
 
 	// Set the server name if any.
@@ -91,27 +97,109 @@ func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
 func ServerConfig(cert, key, ca string) (*tls.Config, error) {
 	config := newTLSConfig()
 
-	// Load the server cert and key.
-	crt, err := tls.LoadX509KeyPair(cert, key)
+	certificates, err := loadTLSCertificate(cert, key)
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to load cert/key: %v", err)
+		return nil, err
 	}
-	config.Certificates = []tls.Certificate{crt}
+
+	config.Certificates = *certificates
 
 	// if specified, load ca to validate client,
 	// and enforce clients present valid certs.
 	if ca != "" {
-		b, err := ioutil.ReadFile(ca)
+		certificatePool, err := loadx509CertPool(ca)
+
 		if err != nil {
-			return nil, fmt.Errorf("failed to read ca file: %v", err)
+			return nil, err
 		}
-		cp := x509.NewCertPool()
-		if !cp.AppendCertsFromPEM(b) {
-			return nil, fmt.Errorf("failed to append certificates")
-		}
-		config.ClientCAs = cp
+
+		config.ClientCAs = certificatePool
 		config.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
 	return config, nil
+}
+
+var certPools = sync.Map{}
+
+func loadx509CertPool(ca string) (*x509.CertPool, error) {
+	once, _ := onceByKeys.LoadOrStore(ca, &sync.Once{})
+
+	var err error
+	once.(*sync.Once).Do(func() {
+		err = doLoadx509CertPool(ca)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := certPools.Load(ca)
+
+	if !ok {
+		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "Cannot find loaded x509 cert pool for ca: %s", ca)
+	}
+
+	return result.(*x509.CertPool), nil
+}
+
+func doLoadx509CertPool(ca string) error {
+	b, err := ioutil.ReadFile(ca)
+	if err != nil {
+		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to read ca file: %s", ca)
+	}
+
+	cp := x509.NewCertPool()
+	if !cp.AppendCertsFromPEM(b) {
+		return vterrors.Errorf(vtrpc.Code_UNKNOWN, "failed to append certificates")
+	}
+
+	certPools.Store(ca, cp)
+
+	return nil
+}
+
+var tlsCertificates = sync.Map{}
+
+func tlsCertificatesIdentifier(cert, key string) string {
+	return strings.Join([]string{cert, key}, ";")
+}
+
+func loadTLSCertificate(cert, key string) (*[]tls.Certificate, error) {
+	tlsIdentifier := tlsCertificatesIdentifier(cert, key)
+	once, _ := onceByKeys.LoadOrStore(tlsIdentifier, &sync.Once{})
+
+	var err error
+	once.(*sync.Once).Do(func() {
+		err = doLoadTLSCertificate(cert, key)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	result, ok := tlsCertificates.Load(tlsIdentifier)
+
+	if !ok {
+		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "Cannot find loaded tls certificate with cert: %s, key%s", cert, key)
+	}
+
+	return result.(*[]tls.Certificate), nil
+}
+
+func doLoadTLSCertificate(cert, key string) error {
+	tlsIdentifier := tlsCertificatesIdentifier(cert, key)
+
+	var certificate []tls.Certificate
+	// Load the server cert and key.
+	crt, err := tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to load tls certificate, cert %s, key: %s", cert, key)
+	}
+
+	certificate = []tls.Certificate{crt}
+
+	tlsCertificates.Store(tlsIdentifier, &certificate)
+
+	return nil
 }


### PR DESCRIPTION
At the moment when starting connections to mysql database it's creating multiple copies of tls certificates for the same pem file loaded, which is causing memory pressure when loading a big combo certificate (example the combo certificate offered by AWS RDS). 

This PR address the issue by creating only one copy of loaded certificate per file and refer to it, which brings down the memory usage for tls connections.  The image below shows the after(left) vs before(right) comparison via golang's pprof's web interface. 

![image](https://user-images.githubusercontent.com/1623058/68554084-1b5fb600-047a-11ea-8788-d44158d5c567.png)
 

