### PR TITLE
vrepl: handle "other" events

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -352,6 +352,15 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		if err := vp.applyRowEvent(ctx, event.RowEvent); err != nil {
 			return err
 		}
+	case binlogdatapb.VEventType_OTHER:
+		// Just update the position.
+		posReached, err := vp.updatePos(event.Timestamp)
+		if err != nil {
+			return err
+		}
+		if posReached {
+			return io.EOF
+		}
 	case binlogdatapb.VEventType_DDL:
 		if vp.vr.dbClient.InTransaction {
 			return fmt.Errorf("unexpected state: DDL encountered in the middle of a transaction: %v", event.Ddl)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -864,6 +864,8 @@ func TestPlayerDDL(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"alter table t1 add column val1 varchar(128)",
 		"/update _vt.vreplication set pos=",
+		// The apply of the DDL on target generates an "other" event.
+		"/update _vt.vreplication set pos=",
 	})
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
@@ -883,6 +885,8 @@ func TestPlayerDDL(t *testing.T) {
 	execStatements(t, []string{"alter table t1 add column val1 varchar(128)"})
 	expectDBClientQueries(t, []string{
 		"alter table t1 add column val1 varchar(128)",
+		"/update _vt.vreplication set pos=",
+		// The apply of the DDL on target generates an "other" event.
 		"/update _vt.vreplication set pos=",
 	})
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
@@ -1303,6 +1307,9 @@ func TestPlayerBatching(t *testing.T) {
 		"alter table t1 add column val2 varbinary(128)",
 		"/update _vt.vreplication set pos=",
 		"alter table t1 drop column val2",
+		"/update _vt.vreplication set pos=",
+		// The apply of the DDLs on target generates two "other" event.
+		"/update _vt.vreplication set pos=",
 		"/update _vt.vreplication set pos=",
 	})
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -114,19 +114,29 @@ func TestStatements(t *testing.T) {
 	}, {
 		// repair, optimize and analyze show up in binlog stream, but ignored by vitess.
 		input: "repair table stream2",
+		output: [][]string{{
+			`gtid`,
+			`type:OTHER `,
+		}},
 	}, {
 		input: "optimize table stream2",
+		output: [][]string{{
+			`gtid`,
+			`type:OTHER `,
+		}},
 	}, {
 		input: "analyze table stream2",
+		output: [][]string{{
+			`gtid`,
+			`type:OTHER `,
+		}},
 	}, {
-		// select, set, show, analyze and describe don't get logged.
+		// select, set, show and describe don't get logged.
 		input: "select * from stream1",
 	}, {
 		input: "set @val=1",
 	}, {
 		input: "show tables",
-	}, {
-		input: "analyze table stream1",
 	}, {
 		input: "describe stream1",
 	}}
@@ -435,9 +445,8 @@ func TestUnsentDDL(t *testing.T) {
 		},
 		// An unsent DDL is sent as an empty transaction.
 		output: [][]string{{
-			`gtid|begin`,
-			`gtid|begin`,
-			`commit`,
+			`gtid`,
+			`type:OTHER `,
 		}},
 	}}
 


### PR DESCRIPTION
While working on filePos flavor, I encountered this issue where
an "other" statement will cause the next GTID to not be immediately
sent. This can cause delays if the target waits for that event.

This is pretty rare for GTID mode. But will likely be more pronounced
for filePos. So, I'm proactively making this fix to make sure we
don't delay sending of GTIDs, even in the case of non-relevant events.

Because of this change, this also means that we don't have to generate
pseudo-gtids. Generating GTIDs outside of transactions, coupled with
OTHER event will make the right thing happen.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>