### PR TITLE
Fix the etcd run error on aarch64

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -98,6 +98,12 @@ fi
 PKG_CONFIG_PATH=$(prepend_path "$PKG_CONFIG_PATH" "$VTROOT/lib")
 export PKG_CONFIG_PATH
 
+# According to https://github.com/etcd-io/etcd/blob/a621d807f061e1dd635033a8d6bc261461429e27/Documentation/op-guide/supported-platform.md,
+# currently, etcd is unstable on arm64, so ETCD_UNSUPPORTED_ARCH should be set.
+if [ "$(arch)" == aarch64 ]; then
+    export ETCD_UNSUPPORTED_ARCH=arm64
+fi
+
 # Useful aliases. Remove if inconvenient.
 alias gt='cd $GOTOP'
 alias pt='cd $PYTOP'


### PR DESCRIPTION
etcd on unstable or unsupported architectures will print a warning message and immediately exit if the environment variable ETCD_UNSUPPORTED_ARCH is not set to the target architecture.

Change-Id: Ifdd3ed4ae322484477d2db3e2d0eed09e086518f
Signed-off-by: Jiamei.Xie <Jiamei.Xie@arm.com>