### PR TITLE
Update vagrant bootstrap to install pip

### DIFF
--- a/vagrant-scripts/bootstrap_vm.sh
+++ b/vagrant-scripts/bootstrap_vm.sh
@@ -23,6 +23,7 @@ apt-get install -y make \
                    python-dev \
                    python-virtualenv \
                    python-mysqldb \
+                   python-pip \
                    libssl-dev \
                    g++ \
                    mercurial \


### PR DESCRIPTION
Following the [vagrant instructions](https://vitess.io/docs/get-started/vagrant/), `vagrant up` ends in an error: 

```
    default: + pip install mysql-connector-python
    default: /tmp/vagrant-shell: line 37: pip: command not found
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

This PR updates the vagrant bootstrap to install the `python-pip` package to install pip. After this change, a fresh `vagrant up` will complete successfully.