### PR TITLE
Bug Fix: Prepared Statements Bind Variables Nil Error

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -898,8 +898,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 		if stmtID != uint32(0) {
 			defer func() {
 				prepare := c.PrepareData[stmtID]
-				paramsCount := len(prepare.BindVars)
-				prepare.BindVars = make(map[string]*querypb.BindVariable, paramsCount)
+				prepare.BindVars = make(map[string]*querypb.BindVariable, prepare.ParamsCount)
 			}()
 		}
 

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -897,6 +897,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 
 		if stmtID != uint32(0) {
 			defer func() {
+				// Allocate a new bindvar map every time since VTGate.Execute() mutates it.
 				prepare := c.PrepareData[stmtID]
 				prepare.BindVars = make(map[string]*querypb.BindVariable, prepare.ParamsCount)
 			}()

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -898,11 +898,8 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 		if stmtID != uint32(0) {
 			defer func() {
 				prepare := c.PrepareData[stmtID]
-				if prepare.BindVars != nil {
-					for k := range prepare.BindVars {
-						prepare.BindVars[k] = nil
-					}
-				}
+				paramsCount := len(prepare.BindVars)
+				prepare.BindVars = make(map[string]*querypb.BindVariable, paramsCount)
 			}()
 		}
 

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -127,12 +127,11 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 		return nil
 	}
 
-	// FormatBindVariables call might panic so we're going to catch it here and print out the stack trace to help us
-	// debug it better.
+	// FormatBindVariables call might panic so we're going to catch it here
+	// and print out the stack trace for debugging.
 	defer func() {
 		if x := recover(); x != nil {
 			log.Errorf("Uncaught panic:\n%v\n%s", x, tb.Stack(4))
-			log.Fatal()
 		}
 	}()
 

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -18,11 +18,13 @@ package vtgate
 
 import (
 	"fmt"
-	"golang.org/x/net/context"
 	"html/template"
 	"io"
 	"net/url"
 	"time"
+
+	"golang.org/x/net/context"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/tb"


### PR DESCRIPTION
This PR fixes the bind variables nil error first discovered in issue https://github.com/vitessio/vitess/issues/5255.  

The fix involved explicitly setting `BindVars` to an empty map, rather than looping through and setting each `BindVar` to nil in the defer function.  

I also added a `recover` to catch any panics that might happen as a result of nil `BindVars` when using `FormatBindVariables` in `Logf`.