### PR TITLE
Add jemalloc and tcmalloc to the image build.

### DIFF
--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
       libmysqlclient20 \
       mysql-client \
       mysql-server \
+      libjemalloc1 \
+      libtcmalloc-minimal4 \
  && wget https://www.percona.com/downloads/XtraBackup/Percona-XtraBackup-2.4.13/binary/debian/stretch/x86_64/percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb \
  && dpkg -i percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb \
  && rm -f percona-xtrabackup-24_2.4.13-1.stretch_amd64.deb \


### PR DESCRIPTION
Not used by default.  To use:
  * Set LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4
  * or  LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
in your container startup environment.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>