### PR TITLE
vrepl: truncate messages to column length

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -508,7 +508,7 @@ func AlterVReplicationTable() []string {
 
 // SetVReplicationState updates the state in the _vt.vreplication table.
 func SetVReplicationState(dbClient DBClient, uid uint32, state, message string) error {
-	query := fmt.Sprintf("update _vt.vreplication set state='%v', message=%v where id=%v", state, encodeString(message), uid)
+	query := fmt.Sprintf("update _vt.vreplication set state='%v', message=%v where id=%v", state, encodeString(MessageTruncate(message)), uid)
 	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
 		return fmt.Errorf("could not set state: %v: %v", query, err)
 	}
@@ -613,12 +613,21 @@ func StartVReplicationUntil(uid uint32, pos string) string {
 func StopVReplication(uid uint32, message string) string {
 	return fmt.Sprintf(
 		"update _vt.vreplication set state='%v', message=%v where id=%v",
-		BlpStopped, encodeString(message), uid)
+		BlpStopped, encodeString(MessageTruncate(message)), uid)
 }
 
 // DeleteVReplication returns a statement to delete the replication.
 func DeleteVReplication(uid uint32) string {
 	return fmt.Sprintf("delete from _vt.vreplication where id=%v", uid)
+}
+
+// MessageTruncate truncates the message string to a safe length.
+func MessageTruncate(msg string) string {
+	// message length is 1000 bytes.
+	if len(msg) > 950 {
+		return msg[:950] + "..."
+	}
+	return msg
 }
 
 func encodeString(in string) string {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -158,7 +158,7 @@ func (vr *vreplicator) setMessage(message string) error {
 		Time:    time.Now(),
 		Message: message,
 	})
-	query := fmt.Sprintf("update _vt.vreplication set message=%v where id=%v", encodeString(message), vr.id)
+	query := fmt.Sprintf("update _vt.vreplication set message=%v where id=%v", encodeString(binlogplayer.MessageTruncate(message)), vr.id)
 	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}


### PR DESCRIPTION
If an error message is too long, then it won't get recorded
and no one will know what happened.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>