### PR TITLE
vrepl: handle resharding journal events for those who pull from the sources

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -76,7 +76,7 @@ func TestControllerKeyRange(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: 3306}
 
-	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil)
+	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestControllerTables(t *testing.T) {
 		},
 	}
 
-	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil)
+	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestControllerBadID(t *testing.T) {
 	params := map[string]string{
 		"id": "bad",
 	}
-	_, err := newController(context.Background(), params, nil, nil, nil, "", "", nil)
+	_, err := newController(context.Background(), params, nil, nil, nil, "", "", nil, nil)
 	want := `strconv.Atoi: parsing "bad": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("newController err: %v, want %v", err, want)
@@ -166,7 +166,7 @@ func TestControllerStopped(t *testing.T) {
 		"state": binlogplayer.BlpStopped,
 	}
 
-	ct, err := newController(context.Background(), params, nil, nil, nil, "", "", nil)
+	ct, err := newController(context.Background(), params, nil, nil, nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestControllerOverrides(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: 3306}
 
-	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil)
+	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestControllerCanceledContext(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	ct, err := newController(ctx, params, nil, nil, env.TopoServ, env.Cells[0], "rdonly", nil)
+	ct, err := newController(ctx, params, nil, nil, env.TopoServ, env.Cells[0], "rdonly", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestControllerRetry(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: 3306}
 
-	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil)
+	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "rdonly", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestControllerStopPosition(t *testing.T) {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: 3306}
 
-	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil)
+	ct, err := newController(context.Background(), params, dbClientFactory, mysqld, env.TopoServ, env.Cells[0], "replica", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -461,6 +461,7 @@ func (vre *Engine) transitionJournal(key string) {
 
 	log.Infof("Transitioning for journal:workload %v", key)
 	je := vre.journaler[key]
+	defer delete(vre.journaler, key)
 	// Wait for participating controllers to stop.
 	// Also collect one id reference.
 	refid := 0

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -411,12 +411,17 @@ func (vre *Engine) journalRegister(journal *binlogdatapb.Journal, id int) error 
 		return nil
 	}
 
-	key := fmt.Sprintf("%s:%d", vre.controllers[id].workflow, journal.Id)
+	workflow := vre.controllers[id].workflow
+	key := fmt.Sprintf("%s:%d", workflow, journal.Id)
 	je, ok := vre.journaler[key]
 	if !ok {
 		log.Infof("Journal encountered: %v", journal)
 		controllerSources := make(map[string]bool)
 		for _, ct := range vre.controllers {
+			if ct.workflow != workflow {
+				// Only compare with streams that belong to the current workflow.
+				continue
+			}
 			ks := fmt.Sprintf("%s:%s", ct.source.Keyspace, ct.source.Shard)
 			controllerSources[ks] = true
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -403,7 +403,7 @@ func (vre *Engine) fetchIDs(dbClient binlogplayer.DBClient, selector string) (id
 	return ids, bv, nil
 }
 
-func (vre *Engine) journalRegister(journal *binlogdatapb.Journal, id int) error {
+func (vre *Engine) registerJournal(journal *binlogdatapb.Journal, id int) error {
 	vre.mu.Lock()
 	defer vre.mu.Unlock()
 	if !vre.isOpen {

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/topo"
 )
@@ -82,6 +83,13 @@ type Engine struct {
 	mysqld          mysqlctl.MysqlDaemon
 	dbClientFactory func() binlogplayer.DBClient
 	dbName          string
+
+	journaler map[string]*journalEvent
+}
+
+type journalEvent struct {
+	journal      *binlogdatapb.Journal
+	participants map[string]int
 }
 
 // NewEngine creates a new Engine.
@@ -94,6 +102,7 @@ func NewEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, dbClie
 		mysqld:          mysqld,
 		dbClientFactory: dbClientFactory,
 		dbName:          dbName,
+		journaler:       make(map[string]*journalEvent),
 	}
 	return vre
 }
@@ -187,7 +196,7 @@ func (vre *Engine) initAll() error {
 		return err
 	}
 	for _, row := range rows {
-		ct, err := newController(vre.ctx, row, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil)
+		ct, err := newController(vre.ctx, row, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil, vre)
 		if err != nil {
 			return err
 		}
@@ -280,7 +289,7 @@ func (vre *Engine) Exec(query string) (*sqltypes.Result, error) {
 			if err != nil {
 				return nil, err
 			}
-			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil)
+			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil, vre)
 			if err != nil {
 				return nil, err
 			}
@@ -318,7 +327,7 @@ func (vre *Engine) Exec(query string) (*sqltypes.Result, error) {
 			}
 			// Create a new controller in place of the old one.
 			// For continuity, the new controller inherits the previous stats.
-			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, blpStats[id])
+			ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, blpStats[id], vre)
 			if err != nil {
 				return nil, err
 			}
@@ -392,6 +401,133 @@ func (vre *Engine) fetchIDs(dbClient binlogplayer.DBClient, selector string) (id
 	}
 	bv = map[string]*querypb.BindVariable{"ids": bvval}
 	return ids, bv, nil
+}
+
+func (vre *Engine) journalRegister(journal *binlogdatapb.Journal, id int) error {
+	vre.mu.Lock()
+	defer vre.mu.Unlock()
+	if !vre.isOpen {
+		// Unreachable.
+		return nil
+	}
+
+	key := fmt.Sprintf("%s:%d", vre.controllers[id].workflow, journal.Id)
+	je, ok := vre.journaler[key]
+	if !ok {
+		log.Infof("Journal encountered: %v", journal)
+		controllerSources := make(map[string]bool)
+		for _, ct := range vre.controllers {
+			ks := fmt.Sprintf("%s:%s", ct.source.Keyspace, ct.source.Shard)
+			controllerSources[ks] = true
+		}
+		je = &journalEvent{
+			journal:      journal,
+			participants: make(map[string]int),
+		}
+		for _, jks := range journal.Participants {
+			ks := fmt.Sprintf("%s:%s", jks.Keyspace, jks.Shard)
+			if _, ok := controllerSources[ks]; !ok {
+				return fmt.Errorf("cannot redirect on journal: not all sources are present in this workflow: missing %v", ks)
+			}
+			je.participants[ks] = 0
+		}
+		vre.journaler[key] = je
+	}
+
+	ks := fmt.Sprintf("%s:%s", vre.controllers[id].source.Keyspace, vre.controllers[id].source.Shard)
+	log.Infof("Registering id %v against %v", id, ks)
+	je.participants[ks] = id
+	for _, pid := range je.participants {
+		if pid == 0 {
+			// Still need to wait.
+			return nil
+		}
+	}
+	go vre.transitionJournal(key)
+	return nil
+}
+
+func (vre *Engine) transitionJournal(key string) {
+	vre.mu.Lock()
+	defer vre.mu.Unlock()
+	if !vre.isOpen {
+		return
+	}
+
+	log.Infof("Transitioning for journal:workload %v", key)
+	je := vre.journaler[key]
+	// Wait for participating controllers to stop.
+	// Also collect one id reference.
+	refid := 0
+	for _, id := range je.participants {
+		refid = id
+		vre.controllers[id].Stop()
+	}
+
+	dbClient := vre.dbClientFactory()
+	if err := dbClient.Connect(); err != nil {
+		log.Errorf("transitionJournal: unable to connect to the database: %v", err)
+		return
+	}
+	defer dbClient.Close()
+
+	if err := dbClient.Begin(); err != nil {
+		log.Errorf("transitionJournal: %v", err)
+		return
+	}
+
+	params, err := readRow(dbClient, refid)
+	if err != nil {
+		log.Errorf("transitionJournal: %v", err)
+		return
+	}
+	var newids []int
+	for _, sgtid := range je.journal.ShardGtids {
+		bls := vre.controllers[refid].source
+		bls.Keyspace, bls.Shard = sgtid.Keyspace, sgtid.Shard
+		query := fmt.Sprintf("insert into _vt.vreplication "+
+			"(workflow, source, pos, max_tps, max_replication_lag, tablet_types, time_updated, transaction_timestamp, state, db_name) "+
+			"values (%v, %v, %v, %v, %v, %v, %v, 0, '%v', %v)",
+			encodeString(params["workflow"]), encodeString(bls.String()), encodeString(sgtid.Gtid), params["max_tps"], params["max_replication_lag"], encodeString(params["tablet_types"]), time.Now().Unix(), binlogplayer.BlpRunning, encodeString(vre.dbName))
+		qr, err := vre.executeFetchMaybeCreateTable(dbClient, query, 1)
+		if err != nil {
+			log.Errorf("transitionJournal: %v", err)
+			return
+		}
+		log.Infof("Created stream: %v for %v", qr.InsertID, sgtid)
+		newids = append(newids, int(qr.InsertID))
+	}
+	for _, id := range je.participants {
+		_, err := vre.executeFetchMaybeCreateTable(dbClient, binlogplayer.DeleteVReplication(uint32(id)), 1)
+		if err != nil {
+			log.Errorf("transitionJournal: %v", err)
+			return
+		}
+		log.Infof("Deleted stream: %v", id)
+	}
+	if err := dbClient.Commit(); err != nil {
+		log.Errorf("transitionJournal: %v", err)
+		return
+	}
+
+	for _, id := range je.participants {
+		delete(vre.controllers, id)
+	}
+
+	for _, id := range newids {
+		params, err := readRow(dbClient, id)
+		if err != nil {
+			log.Errorf("transitionJournal: %v", err)
+			return
+		}
+		ct, err := newController(vre.ctx, params, vre.dbClientFactory, vre.mysqld, vre.ts, vre.cell, *tabletTypesStr, nil, vre)
+		if err != nil {
+			log.Errorf("transitionJournal: %v", err)
+			return
+		}
+		vre.controllers[id] = ct
+	}
+	log.Infof("Completed transition for journal:workload %v", key)
 }
 
 // WaitForPos waits for the replication to reach the specified position.

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -19,6 +19,7 @@ package vreplication
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -145,6 +146,26 @@ func addTablet(id int) *topodatapb.Tablet {
 	return tablet
 }
 
+func addOtherTablet(id int, keyspace, shard string) *topodatapb.Tablet {
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: env.Cells[0],
+			Uid:  uint32(id),
+		},
+		Keyspace: keyspace,
+		Shard:    shard,
+		KeyRange: &topodatapb.KeyRange{},
+		Type:     topodatapb.TabletType_REPLICA,
+		PortMap: map[string]int32{
+			"test": int32(id),
+		},
+	}
+	if err := env.TopoServ.CreateTablet(context.Background(), tablet); err != nil {
+		panic(err)
+	}
+	return tablet
+}
+
 func deleteTablet(tablet *topodatapb.Tablet) {
 	env.TopoServ.DeleteTablet(context.Background(), tablet.Alias)
 	// This is not automatically removed from shard replication, which results in log spam.
@@ -174,6 +195,10 @@ func (ftc *fakeTabletConn) StreamHealth(ctx context.Context, callback func(*quer
 
 // VStream directly calls into the pre-initialized engine.
 func (ftc *fakeTabletConn) VStream(ctx context.Context, target *querypb.Target, startPos string, filter *binlogdatapb.Filter, send func([]*binlogdatapb.VEvent) error) error {
+	if target.Keyspace != "vttest" {
+		<-ctx.Done()
+		return io.EOF
+	}
 	return streamerEngine.Stream(ctx, startPos, filter, send)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -63,6 +63,7 @@ func TestJournalOneToOne(t *testing.T) {
 	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
 
 	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
 		"begin",
 		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"0\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10'`,
 		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
@@ -121,6 +122,7 @@ func TestJournalOneToMany(t *testing.T) {
 	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
 
 	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
 		"begin",
 		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"-80\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-5'`,
 		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"80-\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:5-10'`,
@@ -177,6 +179,7 @@ func TestJournalTablePresent(t *testing.T) {
 	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
 
 	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
 		"begin",
 		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"0\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10'`,
 		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
@@ -288,6 +291,7 @@ func TestJournalTableMixed(t *testing.T) {
 	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
 
 	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
 		"/update _vt.vreplication set state='Stopped', message='unable to handle journal event: tables were partially matched' where id",
 	})
 

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+func TestJournalOneToOne(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	_, firstID := startVReplication(t, filter, binlogdatapb.OnDDLAction_IGNORE, "")
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_SHARDS,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{createReshardingJournalTable, query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	expectDBClientQueries(t, []string{
+		"begin",
+		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"0\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10'`,
+		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
+		"commit",
+		"/update _vt.vreplication set state='Running', message='' where id.*",
+	})
+
+	// Delete all vreplication streams. There should be only one, but we don't know its id.
+	if _, err := playerEngine.Exec("delete from _vt.vreplication"); err != nil {
+		t.Fatal(err)
+	}
+	expectDeleteQueries(t)
+}
+
+func TestJournalOneToMany(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "-80"))
+	defer deleteTablet(addOtherTablet(102, "other_keyspace", "80-"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	_, firstID := startVReplication(t, filter, binlogdatapb.OnDDLAction_IGNORE, "")
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_SHARDS,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "-80",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-5",
+		}, {
+			Keyspace: "other_keyspace",
+			Shard:    "80-",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:5-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{createReshardingJournalTable, query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	expectDBClientQueries(t, []string{
+		"begin",
+		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"-80\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-5'`,
+		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"80-\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:5-10'`,
+		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
+		"commit",
+		"/update _vt.vreplication set state='Running', message='' where id.*",
+		"/update _vt.vreplication set state='Running', message='' where id.*",
+	})
+
+	// Delete all vreplication streams. There should be only one, but we don't know its id.
+	if _, err := playerEngine.Exec("delete from _vt.vreplication"); err != nil {
+		t.Fatal(err)
+	}
+	expectDeleteQueries(t)
+}
+
+func TestJournalTablePresent(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	_, firstID := startVReplication(t, filter, binlogdatapb.OnDDLAction_IGNORE, "")
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_TABLES,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		Tables: []string{"t"},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{createReshardingJournalTable, query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	expectDBClientQueries(t, []string{
+		"begin",
+		`/insert into _vt.vreplication.*workflow, source, pos.*values.*'test', 'keyspace:\\"other_keyspace\\" shard:\\"0\\.*'MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10'`,
+		fmt.Sprintf("delete from _vt.vreplication where id=%d", firstID),
+		"commit",
+		"/update _vt.vreplication set state='Running', message='' where id.*",
+	})
+
+	// Delete all vreplication streams. There should be only one, but we don't know its id.
+	if _, err := playerEngine.Exec("delete from _vt.vreplication"); err != nil {
+		t.Fatal(err)
+	}
+	expectDeleteQueries(t)
+}
+
+func TestJournalTableNotPresent(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	_, _ = startVReplication(t, filter, binlogdatapb.OnDDLAction_IGNORE, "")
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_TABLES,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		Tables: []string{"t1"},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{createReshardingJournalTable, query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	// Wait for a heartbeat based update to confirm that the existing vreplication was not transitioned.
+	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set pos=",
+	})
+
+	// Delete all vreplication streams. There should be only one, but we don't know its id.
+	if _, err := playerEngine.Exec("delete from _vt.vreplication"); err != nil {
+		t.Fatal(err)
+	}
+	expectDeleteQueries(t)
+}
+
+func TestJournalTableMixed(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		"create table t1(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+		fmt.Sprintf("create table %s.t1(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}, {
+			Match: "t1",
+		}},
+	}
+	_, _ = startVReplication(t, filter, binlogdatapb.OnDDLAction_IGNORE, "")
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_TABLES,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		Tables: []string{"t"},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{createReshardingJournalTable, query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	expectDBClientQueries(t, []string{
+		"/update _vt.vreplication set state='Stopped', message='unable to handle journal event: tables were partially matched' where id",
+	})
+
+	// Delete all vreplication streams. There should be only one, but we don't know its id.
+	if _, err := playerEngine.Exec("delete from _vt.vreplication"); err != nil {
+		t.Fatal(err)
+	}
+	expectDeleteQueries(t)
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -144,7 +144,8 @@ func (vp *vplayer) fetchAndApply(ctx context.Context) error {
 			<-streamErr
 		}()
 		// If the apply thread ends with io.EOF, it means either the Engine
-		// is shutting down and canceled the context, or stop position was reached.
+		// is shutting down and canceled the context, or stop position was reached,
+		// or a journal event was encountered.
 		// If so, we return nil which will cause the controller to not retry.
 		if err == io.EOF {
 			return nil
@@ -412,15 +413,29 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 			for _, table := range event.Journal.Tables {
 				jtables[table] = true
 			}
+			found := false
+			notFound := false
 			for tableName := range vp.replicatorPlan.TablePlans {
-				if _, ok := jtables[tableName]; !ok {
-					if err := vp.vr.setState(binlogplayer.BlpStopped, fmt.Sprintf("unable to continue stream: %v is absent in the journal", tableName)); err != nil {
-						return err
-					}
-					return io.EOF
+				if _, ok := jtables[tableName]; ok {
+					found = true
+				} else {
+					notFound = true
 				}
 			}
+			switch {
+			case found && notFound:
+				// Some were found and some were not found. We can't handle this.
+				if err := vp.vr.setState(binlogplayer.BlpStopped, "unable to handle journal event: tables were partially matched"); err != nil {
+					return err
+				}
+				return io.EOF
+			case notFound:
+				// None were found. Ignore journal.
+				return nil
+			}
+			// All were found. We must register journal.
 		}
+
 		if err := vp.vr.vre.journalRegister(event.Journal, int(vp.vr.id)); err != nil {
 			if err := vp.vr.setState(binlogplayer.BlpStopped, err.Error()); err != nil {
 				return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -46,6 +46,7 @@ var (
 )
 
 type vreplicator struct {
+	vre          *Engine
 	id           uint32
 	source       *binlogdatapb.BinlogSource
 	sourceTablet *topodatapb.Tablet
@@ -57,8 +58,9 @@ type vreplicator struct {
 	tableKeys map[string][]string
 }
 
-func newVReplicator(id uint32, source *binlogdatapb.BinlogSource, sourceTablet *topodatapb.Tablet, stats *binlogplayer.Stats, dbClient binlogplayer.DBClient, mysqld mysqlctl.MysqlDaemon) *vreplicator {
+func newVReplicator(id uint32, source *binlogdatapb.BinlogSource, sourceTablet *topodatapb.Tablet, stats *binlogplayer.Stats, dbClient binlogplayer.DBClient, mysqld mysqlctl.MysqlDaemon, vre *Engine) *vreplicator {
 	return &vreplicator{
+		vre:          vre,
 		id:           id,
 		source:       source,
 		sourceTablet: sourceTablet,

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -80,7 +80,7 @@ func (vr *vreplicator) Replicate(ctx context.Context) error {
 	for {
 		settings, numTablesToCopy, err := vr.readSettings(ctx)
 		if err != nil {
-			return fmt.Errorf("error reading VReplication settings: %v", err)
+			return err
 		}
 		// If any of the operations below changed state to Stopped, we should return.
 		if settings.State == binlogplayer.BlpStopped {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -306,6 +306,17 @@ func (se *Engine) Reload(ctx context.Context) error {
 	return rec.Error()
 }
 
+// LoadTableBasic loads a table with minimal info. This is used by vstreamer
+// to load _vt.resharding_journal.
+func (se *Engine) LoadTableBasic(ctx context.Context, tableName string) (*Table, error) {
+	conn, err := se.conns.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+	return LoadTableBasic(conn, tableName)
+}
+
 func (se *Engine) mysqlTime(ctx context.Context, conn *connpool.DBConn) (int64, error) {
 	tm, err := conn.Exec(ctx, "select unix_timestamp()", 1, false)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -54,6 +54,15 @@ func LoadTable(conn *connpool.DBConn, tableName string, tableType string, commen
 	return ta, nil
 }
 
+// LoadTableBaisc creates a Table with just the column info loaded.
+func LoadTableBasic(conn *connpool.DBConn, tableName string) (*Table, error) {
+	ta := NewTable(tableName)
+	if err := fetchColumns(ta, conn, tableName); err != nil {
+		return nil, err
+	}
+	return ta, nil
+}
+
 func fetchColumns(ta *Table, conn *connpool.DBConn, sqlTableName string) error {
 	qr, err := conn.Exec(tabletenv.LocalContext(), fmt.Sprintf("select * from %s where 1 != 1", sqlTableName), 0, true)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -340,106 +340,27 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 	case ev.IsTableMap():
 		// This is very frequent. It precedes every row event.
 		id := ev.TableID(vs.format)
+		if _, ok := vs.plans[id]; ok {
+			return nil, nil
+		}
 		tm, err := ev.TableMap(vs.format)
 		if err != nil {
 			return nil, err
 		}
-		// We have to build a plan only for new ids.
-		if _, ok := vs.plans[id]; ok || id == vs.journalTableID {
-			return nil, nil
-		}
 		if tm.Database == "_vt" && tm.Name == "resharding_journal" {
-			st, err := vs.se.LoadTableBasic(vs.ctx, "_vt.resharding_journal")
-			if err != nil {
-				return nil, err
-			}
-			// Partially duplicated code from below.
-			if len(st.Columns) < len(tm.Types) {
-				return nil, fmt.Errorf("cannot determine table columns for %s: event has %d columns, current schema has %d: %#v", tm.Name, len(tm.Types), len(st.Columns), ev)
-			}
-			table := &Table{
-				Name:    "_vt.resharding_journal",
-				Columns: st.Columns[:len(tm.Types)],
-			}
-			plan, err := buildREPlan(table, nil, "")
-			if err != nil {
-				return nil, err
-			}
-			vs.plans[id] = &streamerPlan{
-				Plan:     plan,
-				TableMap: tm,
-			}
-			vs.journalTableID = id
-			return nil, nil
+			return nil, vs.buildJournalPlan(id, tm)
 		}
 		if tm.Database != "" && tm.Database != vs.cp.DbName {
 			vs.plans[id] = nil
 			return nil, nil
 		}
-		tableName := tm.Name
-		var cols []schema.TableColumn
-		for i, typ := range tm.Types {
-			t, err := sqltypes.MySQLToType(int64(typ), 0)
-			if err != nil {
-				return nil, fmt.Errorf("unsupported type: %d, position: %d", typ, i)
-			}
-			cols = append(cols, schema.TableColumn{
-				Name: sqlparser.NewColIdent(fmt.Sprintf("@%d", i+1)),
-				Type: t,
-			})
-		}
-		st := vs.se.GetTable(sqlparser.NewTableIdent(tm.Name))
-		if st == nil {
-			if vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
-				return nil, fmt.Errorf("unknown table %v in schema", tm.Name)
-			}
-		} else {
-			if len(st.Columns) < len(tm.Types) && vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
-				return nil, fmt.Errorf("cannot determine table columns for %s: event has %d columns, current schema has %d: %#v", tm.Name, len(tm.Types), len(st.Columns), ev)
-			}
-			tableName = st.Name.String()
-			// check if the schema returned by schema.Engine matches with row.
-			schemaMatch := true
-			if len(tm.Types) <= len(st.Columns) {
-				for i := range tm.Types {
-					t := cols[i].Type
-					if !sqltypes.AreTypesEquivalent(t, st.Columns[i].Type) {
-						schemaMatch = false
-						break
-					}
-				}
-			} else {
-				schemaMatch = false
-			}
-			if schemaMatch {
-				// Columns should be truncated to match those in tm.
-				cols = st.Columns[:len(tm.Types)]
-			}
-		}
-
-		table := &Table{
-			Name:    tableName,
-			Columns: cols,
-		}
-		plan, err := buildPlan(table, vs.kschema, vs.filter)
+		vevent, err := vs.buildTablePlan(id, tm)
 		if err != nil {
 			return nil, err
 		}
-		if plan == nil {
-			vs.plans[id] = nil
-			return nil, nil
+		if vevent != nil {
+			vevents = append(vevents, vevent)
 		}
-		vs.plans[id] = &streamerPlan{
-			Plan:     plan,
-			TableMap: tm,
-		}
-		vevents = append(vevents, &binlogdatapb.VEvent{
-			Type: binlogdatapb.VEventType_FIELD,
-			FieldEvent: &binlogdatapb.FieldEvent{
-				TableName: plan.Table.Name,
-				Fields:    plan.fields(),
-			},
-		})
 	case ev.IsWriteRows() || ev.IsDeleteRows() || ev.IsUpdateRows():
 		// The existence of before and after images can be used to
 		// identify statememt types. It's also possible that the
@@ -456,87 +377,178 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 			return nil, err
 		}
 		if id == vs.journalTableID {
-		nextrow:
-			for _, row := range rows.Rows {
-				afterOK, afterValues, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns)
-				if err != nil {
-					return nil, err
-				}
-				if !afterOK {
-					continue
-				}
-				for i, fld := range plan.fields() {
-					switch fld.Name {
-					case "db_name":
-						if afterValues[i].ToString() != vs.cp.DbName {
-							continue nextrow
-						}
-					case "val":
-						journal := &binlogdatapb.Journal{}
-						if err := proto.UnmarshalText(afterValues[i].ToString(), journal); err != nil {
-							return nil, err
-						}
-						switch journal.MigrationType {
-						case binlogdatapb.MigrationType_SHARDS:
-							vevents = append(vevents, &binlogdatapb.VEvent{
-								Type:    binlogdatapb.VEventType_JOURNAL,
-								Journal: journal,
-							})
-						case binlogdatapb.MigrationType_TABLES:
-							matched := false
-							for _, table := range journal.Tables {
-								tname := sqlparser.TableName{Name: sqlparser.NewTableIdent(table)}
-								if tableMatches(tname, "", vs.filter) {
-									matched = true
-								}
-							}
-							if matched {
-								vevents = append(vevents, &binlogdatapb.VEvent{
-									Type:    binlogdatapb.VEventType_JOURNAL,
-									Journal: journal,
-								})
-							}
-						}
-					}
-				}
-			}
+			vevents, err = vs.processJounalEvent(vevents, plan, rows)
 		} else {
-			rowChanges := make([]*binlogdatapb.RowChange, 0, len(rows.Rows))
-			for _, row := range rows.Rows {
-				beforeOK, beforeValues, err := vs.extractRowAndFilter(plan, row.Identify, rows.IdentifyColumns, row.NullIdentifyColumns)
-				if err != nil {
-					return nil, err
-				}
-				afterOK, afterValues, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns)
-				if err != nil {
-					return nil, err
-				}
-				if !beforeOK && !afterOK {
-					continue
-				}
-				rowChange := &binlogdatapb.RowChange{}
-				if beforeOK {
-					rowChange.Before = sqltypes.RowToProto3(beforeValues)
-				}
-				if afterOK {
-					rowChange.After = sqltypes.RowToProto3(afterValues)
-				}
-				rowChanges = append(rowChanges, rowChange)
-			}
-			if len(rowChanges) != 0 {
-				vevents = append(vevents, &binlogdatapb.VEvent{
-					Type: binlogdatapb.VEventType_ROW,
-					RowEvent: &binlogdatapb.RowEvent{
-						TableName:  plan.Table.Name,
-						RowChanges: rowChanges,
-					},
-				})
-			}
+			vevents, err = vs.processRowEvent(vevents, plan, rows)
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 	for _, vevent := range vevents {
 		vevent.Timestamp = int64(ev.Timestamp())
 		vevent.CurrentTime = time.Now().UnixNano()
+	}
+	return vevents, nil
+}
+
+func (vs *vstreamer) buildJournalPlan(id uint64, tm *mysql.TableMap) error {
+	st, err := vs.se.LoadTableBasic(vs.ctx, "_vt.resharding_journal")
+	if err != nil {
+		return err
+	}
+	if len(st.Columns) < len(tm.Types) {
+		return fmt.Errorf("cannot determine table columns for %s: event has %v, schema as %v", tm.Name, tm.Types, st.Columns)
+	}
+	table := &Table{
+		Name:    "_vt.resharding_journal",
+		Columns: st.Columns[:len(tm.Types)],
+	}
+	plan, err := buildREPlan(table, nil, "")
+	if err != nil {
+		return err
+	}
+	vs.plans[id] = &streamerPlan{
+		Plan:     plan,
+		TableMap: tm,
+	}
+	vs.journalTableID = id
+	return nil
+}
+
+func (vs *vstreamer) buildTablePlan(id uint64, tm *mysql.TableMap) (*binlogdatapb.VEvent, error) {
+	cols, err := vs.buildTableColumns(id, tm)
+	if err != nil {
+		return nil, err
+	}
+
+	table := &Table{
+		Name:    tm.Name,
+		Columns: cols,
+	}
+	plan, err := buildPlan(table, vs.kschema, vs.filter)
+	if err != nil {
+		return nil, err
+	}
+	if plan == nil {
+		vs.plans[id] = nil
+		return nil, nil
+	}
+	vs.plans[id] = &streamerPlan{
+		Plan:     plan,
+		TableMap: tm,
+	}
+	return &binlogdatapb.VEvent{
+		Type: binlogdatapb.VEventType_FIELD,
+		FieldEvent: &binlogdatapb.FieldEvent{
+			TableName: plan.Table.Name,
+			Fields:    plan.fields(),
+		},
+	}, nil
+}
+
+func (vs *vstreamer) buildTableColumns(id uint64, tm *mysql.TableMap) ([]schema.TableColumn, error) {
+	var cols []schema.TableColumn
+	for i, typ := range tm.Types {
+		t, err := sqltypes.MySQLToType(int64(typ), 0)
+		if err != nil {
+			return nil, fmt.Errorf("unsupported type: %d, position: %d", typ, i)
+		}
+		cols = append(cols, schema.TableColumn{
+			Name: sqlparser.NewColIdent(fmt.Sprintf("@%d", i+1)),
+			Type: t,
+		})
+	}
+
+	st := vs.se.GetTable(sqlparser.NewTableIdent(tm.Name))
+	if st == nil {
+		if vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
+			return nil, fmt.Errorf("unknown table %v in schema", tm.Name)
+		}
+		return cols, nil
+	}
+
+	if len(st.Columns) < len(tm.Types) {
+		if vs.filter.FieldEventMode == binlogdatapb.Filter_ERR_ON_MISMATCH {
+			return nil, fmt.Errorf("cannot determine table columns for %s: event has %v, schema as %v", tm.Name, tm.Types, st.Columns)
+		}
+		return cols, nil
+	}
+
+	// check if the schema returned by schema.Engine matches with row.
+	for i := range tm.Types {
+		if !sqltypes.AreTypesEquivalent(cols[i].Type, st.Columns[i].Type) {
+			return cols, nil
+		}
+	}
+
+	// Columns should be truncated to match those in tm.
+	cols = st.Columns[:len(tm.Types)]
+	return cols, nil
+}
+
+func (vs *vstreamer) processJounalEvent(vevents []*binlogdatapb.VEvent, plan *streamerPlan, rows mysql.Rows) ([]*binlogdatapb.VEvent, error) {
+nextrow:
+	for _, row := range rows.Rows {
+		afterOK, afterValues, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns)
+		if err != nil {
+			return nil, err
+		}
+		if !afterOK {
+			continue
+		}
+		for i, fld := range plan.fields() {
+			switch fld.Name {
+			case "db_name":
+				if afterValues[i].ToString() != vs.cp.DbName {
+					continue nextrow
+				}
+			case "val":
+				journal := &binlogdatapb.Journal{}
+				if err := proto.UnmarshalText(afterValues[i].ToString(), journal); err != nil {
+					return nil, err
+				}
+				vevents = append(vevents, &binlogdatapb.VEvent{
+					Type:    binlogdatapb.VEventType_JOURNAL,
+					Journal: journal,
+				})
+			}
+		}
+	}
+	return vevents, nil
+}
+
+func (vs *vstreamer) processRowEvent(vevents []*binlogdatapb.VEvent, plan *streamerPlan, rows mysql.Rows) ([]*binlogdatapb.VEvent, error) {
+	rowChanges := make([]*binlogdatapb.RowChange, 0, len(rows.Rows))
+	for _, row := range rows.Rows {
+		beforeOK, beforeValues, err := vs.extractRowAndFilter(plan, row.Identify, rows.IdentifyColumns, row.NullIdentifyColumns)
+		if err != nil {
+			return nil, err
+		}
+		afterOK, afterValues, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns)
+		if err != nil {
+			return nil, err
+		}
+		if !beforeOK && !afterOK {
+			continue
+		}
+		rowChange := &binlogdatapb.RowChange{}
+		if beforeOK {
+			rowChange.Before = sqltypes.RowToProto3(beforeValues)
+		}
+		if afterOK {
+			rowChange.After = sqltypes.RowToProto3(afterValues)
+		}
+		rowChanges = append(rowChanges, rowChange)
+	}
+	if len(rowChanges) != 0 {
+		vevents = append(vevents, &binlogdatapb.VEvent{
+			Type: binlogdatapb.VEventType_ROW,
+			RowEvent: &binlogdatapb.RowEvent{
+				TableName:  plan.Table.Name,
+				RowChanges: rowChanges,
+			},
+		})
 	}
 	return vevents, nil
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -843,9 +843,9 @@ func TestJournal(t *testing.T) {
 		},
 		// External table events don't get sent.
 		output: [][]string{{
-			`gtid|begin`,
-			`gtid|begin`,
+			`begin`,
 			`type:JOURNAL journal:<id:1 migration_type:SHARDS > `,
+			`gtid`,
 			`commit`,
 		}},
 	}}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -849,7 +849,7 @@ func TestJournal(t *testing.T) {
 			`commit`,
 		}},
 	}}
-	runCases(t, nil, testcases)
+	runCases(t, nil, testcases, "")
 }
 
 func TestMinimalMode(t *testing.T) {


### PR DESCRIPTION
If there is a resharding or table migrate event, then any streams that were previously pulling from the sources have to be changed to pull from targets. This change handles these migrations.