### PR TITLE
Fix master branch

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -81,14 +81,3 @@ export PKG_CONFIG_PATH
 alias gt='cd $GOTOP'
 alias pt='cd $PYTOP'
 alias vt='cd $VTTOP'
-
-# Etcd path.
-case $(uname) in
-  Linux)  etcd_platform=linux;;
-  Darwin) etcd_platform=darwin;;
-esac
-
-ETCD_VERSION=$(cat "${VTROOT}/dist/etcd/.installed_version")
-ETCD_BINDIR="${VTROOT}/dist/etcd/etcd-${ETCD_VERSION}-${etcd_platform}-amd64/"
-PATH=$(prepend_path "$PATH" "$ETCD_BINDIR")
-export PATH


### PR DESCRIPTION
The test broke because of the interaction between two PRs:  https://github.com/vitessio/vitess/pull/5346 and https://github.com/vitessio/vitess/pull/5427

This restores the intended behavior, which is that Vitess does not package etcd and looks for it in the `$PATH`.

Signed-off-by: Morgan Tocker <tocker@gmail.com>