### PR TITLE
Fix contrib guide

### DIFF
--- a/build.env
+++ b/build.env
@@ -37,4 +37,5 @@ if [[ "$VTTOP" == "${VTTOP/\/src\/vitess.io\/vitess/}" ]]; then
   echo "WARNING: VTTOP($VTTOP) does not contain src/vitess.io/vitess"
 fi
 
+export GOBIN="$VTROOT/bin"
 export GO111MODULE=on


### PR DESCRIPTION
A couple of weeks back I changed the build so it can use go from anywhere, and reduce some of the ceremony around how Vitess builds.

This had a side-effect where `make` would build Vitess in `$GOPATH/bin`. Some of the scripts still look for these binaries in `$VTROOT/bin` and not in `$PATH` (which they really should). This is a quick fix to ensure builds go to `$VTROOT/bin`.

There was a breakage in the steps to the contributing guides, which is now fixed.

Signed-off-by: Morgan Tocker <tocker@gmail.com>