### PR TITLE
Update slack links to use alias

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,4 +6,4 @@ about: If you have a question, please check out our other community resources in
 Issues on GitHub are intended to be related to bugs or feature requests, so we recommend using our other community resources instead of asking here.
 
 - [Vitess User Guide](https://vitess.io/user-guide/introduction/)
-- Any other questions can be asked in the community [Slack workspace](https://join.slack.com/t/vitess/shared_invite/enQtMzIxMDMyMzA0NzA1LTYxMjk2M2M2NjAwNGY0ODljY2E1MjBlZjRkMmZmNDVkZTBhNDUxNzNkOGM4YmEzNWEwOTE2NjJiY2QyZjZjYTE)
+- Any other questions can be asked in the community [Slack workspace](https://vitess.io/slack)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ask questions in the
 discussion forum.
 
 For topics that are better discussed live, please join the
-[Vitess Slack](https://join.slack.com/t/vitess/shared_invite/enQtMzIxMDMyMzA0NzA1LTYxMjk2M2M2NjAwNGY0ODljY2E1MjBlZjRkMmZmNDVkZTBhNDUxNzNkOGM4YmEzNWEwOTE2NjJiY2QyZjZjYTE) workspace.
+[Vitess Slack](https://vitess.io/slack) workspace.
 
 Subscribe to
 [vitess-announce@googlegroups.com](https://groups.google.com/forum/#!forum/vitess-announce)


### PR DESCRIPTION
This makes use of the new alias added in https://github.com/vitessio/website/pull/367

Signed-off-by: Morgan Tocker <tocker@gmail.com>