### PR TITLE
Fix vtexplain race by waiting around for the fakesqldb tabletserver

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -205,6 +205,7 @@ func (db *DB) Close() {
 	db.listener.Close()
 	db.acceptWG.Wait()
 
+	db.WaitForClose(250 * time.Millisecond)
 	db.CloseAllConnections()
 
 	tmpDir := path.Dir(db.socketFile)
@@ -213,7 +214,7 @@ func (db *DB) Close() {
 
 // CloseAllConnections can be used to provoke MySQL client errors for open
 // connections.
-// Make sure to call WaitForShutdown() as well.
+// Make sure to call WaitForClose() as well.
 func (db *DB) CloseAllConnections() {
 	db.mu.Lock()
 	defer db.mu.Unlock()


### PR DESCRIPTION
instances to exit cleanly.  Fixes #5474


I have tested this, and WaitForClose will typically have to wait only a few milliseconds before all the tablets have exited cleanly, even with `-shards 64`