### PR TITLE
Convert non-python tests to GitHub actions

### DIFF
--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -1,4 +1,4 @@
-name: Local Example
+name: check_make_parser
 on: [push, pull_request]
 jobs:
 
@@ -30,12 +30,8 @@ jobs:
         cp .github/bootstrap.sh .
         ./bootstrap.sh
 
-    - name: Build
-      run: |
-        GOBIN=$PWD/bin make build
-
-    - name: Run Local Example
+    - name: check_make_parser
       run: |
         export PATH=$PWD/bin:$PATH
-        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD test/local_example.sh
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD tools/check_make_parser.sh
 

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -1,4 +1,4 @@
-name: e2e Test Cluster
+name: cluster_endtoend
 on: [push, pull_request]
 jobs:
 
@@ -34,8 +34,8 @@ jobs:
       run: |
         GOBIN=$PWD/bin make build
 
-    - name: Run e2e test cluster
+    - name: cluster_endtoend
       run: |
         export PATH=$PWD/bin:$PATH
         source ./dev.env
-        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD tools/e2e_test_cluster.sh
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD make e2e_test_cluster

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -1,0 +1,41 @@
+name: e2e_race
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run bootstrap.sh
+      run: |
+        echo "Copying new bootstrap over location of legacy one."
+        cp .github/bootstrap.sh .
+        ./bootstrap.sh
+
+    - name: Build
+      run: |
+        GOBIN=$PWD/bin make build
+
+    - name: e2e_race
+      run: |
+        export PATH=$PWD/bin:$PATH
+        source ./dev.env
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD make e2e_test_race

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -1,0 +1,42 @@
+name: endtoend
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run bootstrap.sh
+      run: |
+        echo "Copying new bootstrap over location of legacy one."
+        cp .github/bootstrap.sh .
+        ./bootstrap.sh
+
+    - name: Build
+      run: |
+        GOBIN=$PWD/bin make build
+
+    - name: endtoend
+      run: |
+        export PATH=$PWD/bin:$PATH
+        source ./dev.env
+        mkdir -p /tmp/vtdataroot
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD tools/e2e_test_runner.sh

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -1,0 +1,41 @@
+name: local_example
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run bootstrap.sh
+      run: |
+        echo "Copying new bootstrap over location of legacy one."
+        cp .github/bootstrap.sh .
+        ./bootstrap.sh
+
+    - name: Build
+      run: |
+        GOBIN=$PWD/bin make build
+
+    - name: local_example
+      run: |
+        export PATH=$PWD/bin:$PATH
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD test/local_example.sh
+

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,40 @@
+name: unit
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+
+    - name: Check out code
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget ant openjdk-8-jdk
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run bootstrap.sh
+      run: |
+        VTTOP=$PWD VTROOT=$PWD BUILD_PYTHON=0 ./bootstrap.sh
+
+    - name: Build
+      run: |
+        GOBIN=$PWD/bin make build
+
+    - name: unit
+      run: |
+        export PATH=$PWD/bin:$PATH
+        source ./dev.env
+        mkdir -p /tmp/vtdataroot
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD tools/unit_test_runner.sh

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -1,0 +1,41 @@
+name: unit_race
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+    - name: Run bootstrap.sh
+      run: |
+        echo "Copying new bootstrap over location of legacy one."
+        cp .github/bootstrap.sh .
+        ./bootstrap.sh
+
+    - name: Build
+      run: |
+        GOBIN=$PWD/bin make build
+
+    - name: unit_race
+      run: |
+        export PATH=$PWD/bin:$PATH
+        source ./dev.env
+        VTDATAROOT=/tmp/vtdataroot VTTOP=$PWD VTROOT=$PWD make unit_test_race

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/env"
 	"vitess.io/vitess/go/vt/servenv"
 )
 
@@ -37,12 +36,8 @@ func TestMycnf(t *testing.T) {
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
-	root, err := env.VtRoot()
-	if err != nil {
-		t.Errorf("err: %v", err)
-	}
 	cnfTemplatePaths := []string{
-		path.Join(root, "src/vitess.io/vitess/config/mycnf/default.cnf"),
+		path.Join(os.Getenv("VTTOP"), "/config/mycnf/default.cnf"),
 	}
 	data, err := cnf.makeMycnf(cnfTemplatePaths)
 	if err != nil {

--- a/test/config.json
+++ b/test/config.json
@@ -94,7 +94,7 @@
 				"tools/check_make_parser.sh"
 			],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 5,
 			"RetryMax": 1,
 			"Tags": []
 		},
@@ -212,7 +212,7 @@
 				"test/local_example.sh"
 			],
 			"Manual": false,
-			"Shard": 3,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -418,7 +418,7 @@
 				"tools/e2e_test_runner.sh"
 			],
 			"Manual": false,
-			"Shard": 3,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -442,7 +442,7 @@
 				"e2e_test_race"
 			],
 			"Manual": false,
-			"Shard": 1,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -453,7 +453,7 @@
 				"tools/unit_test_runner.sh"
 			],
 			"Manual": false,
-			"Shard": 0,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -465,7 +465,7 @@
 				"unit_test_race"
 			],
 			"Manual": false,
-			"Shard": 3,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": []
 		},


### PR DESCRIPTION
I have not heard any negative feedback about GitHub actions, since converting local-example a few weeks ago.

This moves all other tests that don't use Python 2.7 to GitHub actions. Note that `unit` is still installing zookeeper and consul from the bootstrap script. I intend to fix this later, so we can get out of the business of distributing zk/consul in our packages, and instead rely on them as system components.

`unit` also currently requires go 1.12. There is a problem with client TLS authentication in go 1.13 which will need to be investigated.

Signed-off-by: Morgan Tocker <tocker@gmail.com>