### PR TITLE
Add some info-level logging to help debug vreplication

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -179,10 +179,12 @@ func (ct *controller) runBlp(ctx context.Context) (err error) {
 	}
 	defer dbClient.Close()
 
+	log.Infof("trying to find a tablet eligible for vreplication. stream id: %v", ct.id)
 	tablet, err := ct.tabletPicker.PickForStreaming(ctx)
 	if err != nil {
 		return err
 	}
+	log.Infof("found a tablet eligible for vreplication. stream id: %v  tablet: %s", ct.id, tablet.Alias.String())
 	ct.sourceTablet.Set(tablet.Alias.String())
 
 	switch {


### PR DESCRIPTION
issues when a tablet of the correct type or for the keyspace
is not available, and we end up waiting indefinitely in waitForTablets.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>