### PR TITLE
bootstrap.sh: add back etdctl symlink

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -234,7 +234,7 @@ function install_etcd() {
   fi
   rm "$file"
   ln -snf "$dist/etcd-${version}-${platform}-${target}/etcd" "$VTROOT/bin/etcd"
-  ln -snf "$dist/etcd-${version}-${platform}-amd64/etcdctl" "$VTROOT/bin/etcdctl"
+  ln -snf "$dist/etcd-${version}-${platform}-${target}/etcdctl" "$VTROOT/bin/etcdctl"
 }
 which etcd || install_dep "etcd" "v3.3.10" "$VTROOT/dist/etcd" install_etcd
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -234,6 +234,7 @@ function install_etcd() {
   fi
   rm "$file"
   ln -snf "$dist/etcd-${version}-${platform}-${target}/etcd" "$VTROOT/bin/etcd"
+  ln -snf "$dist/etcd-${version}-${platform}-amd64/etcdctl" "$VTROOT/bin/etcdctl"
 }
 which etcd || install_dep "etcd" "v3.3.10" "$VTROOT/dist/etcd" install_etcd
 


### PR DESCRIPTION
If `bootstrap.sh` installs etcd, the local tutorial can encounter this error:
```
./etcd-up.sh: line 35: etcdctl: command not found
./etcd-up.sh: line 39: etcdctl: command not found
```
This adds back the symlink added in https://github.com/vitessio/vitess/commit/ee6a9399e9fdaab54ddcb7bc98b8628ac865d17c

Signed-off-by: Gary Edgar <gary@planetscale.com>