### PR TITLE
Add option for TLS enabled etcd server connections.

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,11 +18,13 @@ jobs:
     - name: Get dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget ant openjdk-8-jdk
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ curl git wget ant openjdk-8-jdk
         sudo service mysql stop
-        sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        mkdir -p dist bin
+        curl -L https://github.com/coreos/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz | tar -zxC dist
+        mv dist/etcd-v3.3.10-linux-amd64/{etcd,etcdctl} bin/
         go mod download
 
     - name: Run make tools

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/gorilla/websocket v0.0.0-20160912153041-2d1e4548da23
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
@@ -49,6 +50,8 @@ require (
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20160115111002-cca8bbc07984
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -170,12 +170,12 @@ func CreateClientServerCertPairs(root string) ClientServerKeyPairs {
 	serialCounter = serialCounter + 1
 
 	serverName := fmt.Sprintf("server-%s", serverSerial)
-	serverCACommonName := fmt.Sprintf("server-%s-ca", serverSerial)
+	serverCACommonName := fmt.Sprintf("Server %s CA", serverSerial)
 	serverCertName := fmt.Sprintf("server-instance-%s", serverSerial)
 	serverCertCommonName := fmt.Sprintf("server%s.example.com", serverSerial)
 
 	clientName := fmt.Sprintf("clients-%s", serverSerial)
-	clientCACommonName := fmt.Sprintf("clients-%s-ca", serverSerial)
+	clientCACommonName := fmt.Sprintf("Clients %s CA", serverSerial)
 	clientCertName := fmt.Sprintf("client-instance-%s", serverSerial)
 	clientCertCommonName := fmt.Sprintf("Client Instance %s", serverSerial)
 

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -175,7 +175,7 @@ func CreateClientServerCertPairs(root string) ClientServerKeyPairs {
 	serverCertCommonName := fmt.Sprintf("server%s.example.com", serverSerial)
 
 	clientName := fmt.Sprintf("clients-%s", serverSerial)
-	clientCACommonName := fmt.Sprintf("Clients %s CA", serverSerial)
+	clientCACommonName := fmt.Sprintf("clients-%s-ca", serverSerial)
 	clientCertName := fmt.Sprintf("client-instance-%s", serverSerial)
 	clientCertCommonName := fmt.Sprintf("Client Instance %s", serverSerial)
 

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -170,7 +170,7 @@ func CreateClientServerCertPairs(root string) ClientServerKeyPairs {
 	serialCounter = serialCounter + 1
 
 	serverName := fmt.Sprintf("server-%s", serverSerial)
-	serverCACommonName := fmt.Sprintf("Server %s CA", serverSerial)
+	serverCACommonName := fmt.Sprintf("server-%s-ca", serverSerial)
 	serverCertName := fmt.Sprintf("server-instance-%s", serverSerial)
 	serverCertCommonName := fmt.Sprintf("server%s.example.com", serverSerial)
 

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -44,9 +44,9 @@ import (
 )
 
 var (
-	clientCertPath = flag.String("topo_etcd_tls_cert", "", "the client cert to use to connect to the etcd topo server, requires topo_etcd2_tls_key, enables TLS")
-	clientKeyPath  = flag.String("topo_etcd_tls_key", "", "the client key to use to connect to the etcd topo server, enables TLS")
-	clientCaPath   = flag.String("topo_etcd_tls_ca", "", "the ca to use to validate clients when connecting to the etcd topo server")
+	clientCertPath = flag.String("topo_etcd_tls_cert", "", "path to the client cert to use to connect to the etcd topo server, requires topo_etcd_tls_key, enables TLS")
+	clientKeyPath  = flag.String("topo_etcd_tls_key", "", "path to the client key to use to connect to the etcd topo server, enables TLS")
+	serverCaPath   = flag.String("topo_etcd_tls_ca", "", "path to the ca to use to validate the server cert when connecting to the etcd topo server")
 )
 
 // Factory is the consul topo.Factory implementation.

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -44,9 +44,9 @@ import (
 )
 
 var (
-	clientCertPath = flag.String("topo_etcd2_tls_cert", "", "the client cert to use to connect to the etcd topo server, requires topo_etcd2_tls_key, enables TLS")
-	clientKeyPath  = flag.String("topo_etcd2_tls_key", "", "the client key to use to connect to the etcd topo server, enables TLS")
-	clientCaPath   = flag.String("topo_etcd2_tls_ca", "", "the ca to use to validate clients when connecting to the etcd topo server")
+	clientCertPath = flag.String("topo_etcd_tls_cert", "", "the client cert to use to connect to the etcd topo server, requires topo_etcd2_tls_key, enables TLS")
+	clientKeyPath  = flag.String("topo_etcd_tls_key", "", "the client key to use to connect to the etcd topo server, enables TLS")
+	clientCaPath   = flag.String("topo_etcd_tls_ca", "", "the ca to use to validate clients when connecting to the etcd topo server")
 )
 
 // Factory is the consul topo.Factory implementation.

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -34,9 +34,7 @@ We follow these conventions within this package:
 package etcd2topo
 
 import (
-	"crypto/tls"
 	"flag"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -92,18 +90,6 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 
 	// If TLS is enabled, attach TLS config info.
 	if certPath != "" && keyPath != "" {
-		// Verify we can load provided cert and key.
-		_, err := tls.LoadX509KeyPair(certPath, keyPath)
-		if err != nil {
-			log.Fatalf("Unable to load cert %v and key %v, err %v", certPath, keyPath, err)
-		}
-
-		// Verify we can open ca cert.
-		_, err = ioutil.ReadFile(caPath)
-		if err != nil {
-			log.Fatalf("Unable to open ca cert %v, err %v", caPath, err)
-		}
-
 		// Safe now to build up TLS info.
 		tlsInfo := transport.TLSInfo{
 			CertFile:      certPath,

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -79,8 +79,9 @@ func (s *Server) Close() {
 	s.cli = nil
 }
 
-// TODO: Rename this to NewServer and change NewServer to a name that signifies it uses the process-wide TLS settings.
 func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Server, error) {
+	// TODO: Rename this to NewServer and change NewServer to a name that signifies it uses the process-wide TLS settings.
+
 	config := clientv3.Config{
 		Endpoints:   strings.Split(serverAddr, ","),
 		DialTimeout: 5 * time.Second,
@@ -113,10 +114,11 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 	}, nil
 }
 
-// TODO: Rename this to a name to signifies this function uses the process-wide TLS settings.
 // NewServer returns a new etcdtopo.Server.
 func NewServer(serverAddr, root string) (*Server, error) {
-	return NewServerWithOpts(serverAddr, root, *clientCertPath, *clientKeyPath, *clientCaPath)
+	// TODO: Rename this to a name to signifies this function uses the process-wide TLS settings.
+
+	return NewServerWithOpts(serverAddr, root, *clientCertPath, *clientKeyPath, *serverCaPath)
 }
 
 func init() {

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -36,10 +36,11 @@ package etcd2topo
 import (
 	"crypto/tls"
 	"flag"
-	"github.com/coreos/etcd/pkg/transport"
 	"io/ioutil"
 	"strings"
 	"time"
+
+	"github.com/coreos/etcd/pkg/transport"
 	"vitess.io/vitess/go/vt/log"
 
 	"github.com/coreos/etcd/clientv3"
@@ -47,9 +48,9 @@ import (
 )
 
 var (
-	certPath = flag.String("topo_etcd2_tls_cert", "", "the cert to use to connect to the etcd topo server, requires topo_etcd2_tls_key, enables TLS")
-	keyPath = flag.String("topo_etcd2_tls_key", "", "the key to use to connect to the etcd topo server, enables TLS")
-	caPath  = flag.String("topo_etcd2_tls_ca", "", "the server ca to use to validate servers when connecting to the etcd topo server")
+	clientCertPath = flag.String("topo_etcd2_tls_cert", "", "the client cert to use to connect to the etcd topo server, requires topo_etcd2_tls_key, enables TLS")
+	clientKeyPath  = flag.String("topo_etcd2_tls_key", "", "the client key to use to connect to the etcd topo server, enables TLS")
+	clientCaPath   = flag.String("topo_etcd2_tls_ca", "", "the ca to use to validate clients when connecting to the etcd topo server")
 )
 
 // Factory is the consul topo.Factory implementation.
@@ -83,9 +84,9 @@ func (s *Server) Close() {
 }
 
 // TODO: Rename this to NewServer and change NewServer to a name that signifies it's global.
-func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *string, caPath *string) (*Server, error){
+func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *string, caPath *string) (*Server, error) {
 	config := clientv3.Config{
-		Endpoints:  strings.Split(serverAddr, ","),
+		Endpoints:   strings.Split(serverAddr, ","),
 		DialTimeout: 5 * time.Second,
 	}
 
@@ -105,8 +106,8 @@ func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *strin
 
 		// Safe now to build up TLS info.
 		tlsInfo := transport.TLSInfo{
-			CertFile:   *certPath,
-			KeyFile:    *keyPath,
+			CertFile:      *certPath,
+			KeyFile:       *keyPath,
 			TrustedCAFile: *caPath,
 		}
 
@@ -131,7 +132,7 @@ func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *strin
 // TODO: Rename this to a name to signifies this is a global etcd server.
 // NewServer returns a new etcdtopo.Server.
 func NewServer(serverAddr, root string) (*Server, error) {
-	return NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath)
+	return NewServerWithOpts(serverAddr, root, clientCertPath, clientKeyPath, clientCaPath)
 }
 
 func init() {

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -84,31 +84,31 @@ func (s *Server) Close() {
 }
 
 // TODO: Rename this to NewServer and change NewServer to a name that signifies it's global.
-func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *string, caPath *string) (*Server, error) {
+func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Server, error) {
 	config := clientv3.Config{
 		Endpoints:   strings.Split(serverAddr, ","),
 		DialTimeout: 5 * time.Second,
 	}
 
 	// If TLS is enabled, attach TLS config info.
-	if *certPath != "" && *keyPath != "" {
+	if certPath != "" && keyPath != "" {
 		// Verify we can load provided cert and key.
-		_, err := tls.LoadX509KeyPair(*certPath, *keyPath)
+		_, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			log.Fatalf("Unable to load cert %v and key %v, err %v", *certPath, *keyPath, err)
+			log.Fatalf("Unable to load cert %v and key %v, err %v", certPath, keyPath, err)
 		}
 
 		// Verify we can open ca cert.
-		_, err = ioutil.ReadFile(*caPath)
+		_, err = ioutil.ReadFile(caPath)
 		if err != nil {
-			log.Fatalf("Unable to open ca cert %v, err %v", *caPath, err)
+			log.Fatalf("Unable to open ca cert %v, err %v", caPath, err)
 		}
 
 		// Safe now to build up TLS info.
 		tlsInfo := transport.TLSInfo{
-			CertFile:      *certPath,
-			KeyFile:       *keyPath,
-			TrustedCAFile: *caPath,
+			CertFile:      certPath,
+			KeyFile:       keyPath,
+			TrustedCAFile: caPath,
 		}
 
 		tlsConfig, err := tlsInfo.ClientConfig()
@@ -132,7 +132,7 @@ func NewServerWithOpts(serverAddr, root string, certPath *string, keyPath *strin
 // TODO: Rename this to a name to signifies this is a global etcd server.
 // NewServer returns a new etcdtopo.Server.
 func NewServer(serverAddr, root string) (*Server, error) {
-	return NewServerWithOpts(serverAddr, root, clientCertPath, clientKeyPath, clientCaPath)
+	return NewServerWithOpts(serverAddr, root, *clientCertPath, *clientKeyPath, *clientCaPath)
 }
 
 func init() {

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -38,10 +38,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/etcd/pkg/transport"
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
 	"vitess.io/vitess/go/vt/topo"
 )
 
@@ -99,7 +97,7 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 
 		tlsConfig, err := tlsInfo.ClientConfig()
 		if err != nil {
-			log.Fatalf("Unable to generate client config, err %v", err)
+			return nil, err
 		}
 		config.TLS = tlsConfig
 	}

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -79,7 +79,7 @@ func (s *Server) Close() {
 	s.cli = nil
 }
 
-// TODO: Rename this to NewServer and change NewServer to a name that signifies it's global.
+// TODO: Rename this to NewServer and change NewServer to a name that signifies it uses the process-wide TLS settings.
 func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Server, error) {
 	config := clientv3.Config{
 		Endpoints:   strings.Split(serverAddr, ","),
@@ -113,7 +113,7 @@ func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Ser
 	}, nil
 }
 
-// TODO: Rename this to a name to signifies this is a global etcd server.
+// TODO: Rename this to a name to signifies this function uses the process-wide TLS settings.
 // NewServer returns a new etcdtopo.Server.
 func NewServer(serverAddr, root string) (*Server, error) {
 	return NewServerWithOpts(serverAddr, root, *clientCertPath, *clientKeyPath, *clientCaPath)

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -140,15 +140,21 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 
 	tlsConfig, err := tlsInfo.ClientConfig()
 
-	// Create a client to connect to the created etcd.
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   []string{clientAddr},
-		TLS:         tlsConfig,
-		DialTimeout: 5 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("newCellClient(%v) failed: %v", clientAddr, err)
+	var cli *clientv3.Client
+	// Create client
+	for {
+		// Create a client to connect to the created etcd.
+		cli, err = clientv3.New(clientv3.Config{
+			Endpoints:   []string{clientAddr},
+			TLS:         tlsConfig,
+			DialTimeout: 5 * time.Second,
+		})
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
+	defer cli.Close()
 
 	// Wait until we can list "/", or timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -188,20 +188,18 @@ func TestEtcd2TLS(t *testing.T) {
 	}
 	defer server.Close()
 
-	client := server.cli
-
 	testCtx := context.Background()
 	testKey := "testkey"
 	testVal := "testval"
-	_, err = client.Put(testCtx, testKey, testVal)
+	_, err = server.Create(testCtx, testKey, []byte(testVal))
 	if err != nil {
 		t.Fatalf("Failed to set key value pair: %v", err)
 	}
-	val, err := client.Get(testCtx, testKey)
+	val, _, err := server.Get(testCtx, testKey)
 	if err != nil {
 		t.Fatalf("Failed to retrieve value at key we just set: %v", err)
 	}
-	if len(val.Kvs) == 1 && string(val.Kvs[0].Value) != testVal {
+	if string(val) != testVal {
 		t.Fatalf("Value returned doesn't match %s, err: %v", testVal, err)
 	}
 }

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -157,7 +157,7 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 		}
 		t.Logf("error establishing client for etcd tls test: %v", err)
 		if time.Since(start) > 60*time.Second {
-			t.Fatalf("Failed to start client for etcd tls test in time.")
+			t.Fatalf("failed to start client for etcd tls test in time")
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -172,7 +172,7 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 			break
 		}
 		if time.Since(start) > 60*time.Second {
-			t.Fatalf("Failed to start etcd daemon in time")
+			t.Fatalf("failed to start etcd daemon in time")
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -185,7 +185,6 @@ func TestEtcd2TLS(t *testing.T) {
 		cmd.Wait()
 		os.RemoveAll(dataDir)
 		server.Close()
-		client.Close()
 	}()
 
 	testCtx := context.Background()

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -157,7 +157,7 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 		}
 		t.Logf("error establishing client for etcd tls test: %v", err)
 		if time.Since(start) > 60*time.Second {
-			t.Fatalf("Failed to start etcd daemon in time")
+			t.Fatalf("Failed to start client for etcd tls test in time.")
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -18,13 +18,14 @@ package etcd2topo
 
 import (
 	"fmt"
-	"github.com/coreos/etcd/pkg/transport"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/coreos/etcd/pkg/transport"
 
 	"golang.org/x/net/context"
 
@@ -37,7 +38,7 @@ import (
 )
 
 var (
-	testKeyPath = "/tmp/testkey.key"
+	testKeyPath  = "/tmp/testkey.key"
 	testCertPath = "/tmp/testcert.crt"
 )
 
@@ -106,7 +107,7 @@ func startEtcdWithTLS(t *testing.T) (*exec.Cmd, string, string) {
 	// Get our two ports to listen to.
 	port := testfiles.GoVtTopoEtcd2topoPort
 	name := "vitess_unit_test"
-	clientAddr := fmt.Sprintf("https://localhost:%v", port)
+	clientAddr := fmt.Sprintf("http://localhost:%v", port)
 	peerAddr := fmt.Sprintf("http://localhost:%v", port+1)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 
@@ -135,8 +136,8 @@ func startEtcdWithTLS(t *testing.T) (*exec.Cmd, string, string) {
 
 	// Safe now to build up TLS info.
 	tlsInfo := transport.TLSInfo{
-		CertFile:   testCertPath,
-		KeyFile:    testKeyPath,
+		CertFile:      testCertPath,
+		KeyFile:       testKeyPath,
 		TrustedCAFile: testCertPath,
 	}
 
@@ -145,7 +146,7 @@ func startEtcdWithTLS(t *testing.T) (*exec.Cmd, string, string) {
 	// Create a client to connect to the created etcd.
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{clientAddr},
-		TLS: tlsConfig,
+		TLS:         tlsConfig,
 		DialTimeout: 5 * time.Second,
 	})
 	if err != nil {
@@ -176,7 +177,7 @@ func TestEtcd2TLS(t *testing.T) {
 	testRoot := fmt.Sprintf("/test-%v", testIndex)
 
 	// Create the server on the new root.
-	server, err := NewServerWithOpts(clientAddr, testRoot, &testCertPath, &testKeyPath, &testCertPath)
+	server, err := NewServerWithOpts(clientAddr, testRoot, testCertPath, testKeyPath, testCertPath)
 	if err != nil {
 		t.Fatalf("NewServerWithOpts failed: %v", err)
 	}
@@ -189,7 +190,6 @@ func TestEtcd2TLS(t *testing.T) {
 		server.Close()
 		client.Close()
 	}()
-
 
 	testCtx := context.Background()
 	testKey := "testkey"

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -126,6 +126,8 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func
 		"-client-cert-auth",
 		"-data-dir", dataDir)
 
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 	err = cmd.Start()
 	if err != nil {
 		t.Fatalf("failed to start etcd: %v", err)


### PR DESCRIPTION
This PR adds the option for TLS enabled etcd server connections, and includes a test to confirm that when an etcd instance has been started with key, and cert, that a client setup with the correct TLS info can connect, put a value on a key, and retrieve that value off the key.