### PR TITLE
Make the unit race test raise errors

### DIFF
--- a/tools/unit_test_race.sh
+++ b/tools/unit_test_race.sh
@@ -14,39 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-temp_log_file="$(mktemp --suffix .unit_test_race.log)"
-trap '[ -f "$temp_log_file" ] && rm $temp_log_file' EXIT
-
-# Wrapper around go test -race.
-
-# This script exists because the -race test doesn't allow to distinguish
-# between a failed (e.g. flaky) unit test and a found data race.
-# Although Go 1.5 says 'exit status 66' in case of a race, it exits with 1.
-# Therefore, we manually check the output of 'go test' for data races and
-# exit with an error if one was found.
-# TODO(mberlin): Test all packages (go/... instead of go/vt/...) once
-#                go/cgzip is moved into a separate repository. We currently
-#                skip the cgzip package because -race takes >30 sec for it.
+if [[ -z $VT_GO_PARALLEL && -n $VT_GO_PARALLEL_VALUE ]]; then
+  VT_GO_PARALLEL="-p $VT_GO_PARALLEL_VALUE"
+fi
 
 # All Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
+# TODO: This tests ./go/vt/... instead of ./go/... due to a historical reason.
+# When https://github.com/vitessio/vitess/issues/5493 is closed, we should change it.
+
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/vt/... | sort)
 
 # endtoend tests should be in a directory called endtoend
 all_except_e2e_tests=$(echo "$packages_with_tests" | cut -d" " -f1 | grep -v "endtoend")
 
 # Run non endtoend tests.
-echo "$all_except_e2e_tests" | xargs go test $VT_GO_PARALLEL -race 2>&1 | tee $temp_log_file
-if [ ${PIPESTATUS[0]} -ne 0 ]; then
-  if grep "WARNING: DATA RACE" -q $temp_log_file; then
-    echo
-    echo "ERROR: go test -race found a data race. See log above."
-    exit 2
-  fi
+echo "$all_except_e2e_tests" | xargs go test $VT_GO_PARALLEL -race
 
-  echo "ERROR: go test -race found NO data race, but failed. See log above."
+if [ $? -ne 0 ]; then
+  echo "WARNING: POSSIBLE DATA RACE"
+  echo
+  echo "ERROR: go test -race failed. See log above."
   exit 1
 fi
-
-echo
-echo "SUCCESS: No data race was found."


### PR DESCRIPTION
The `unit_test_race.sh` is currently always returning success, even if there are errors.. so we have uncaught races. This refactors it to be more or less the same as `unit_test_runner.sh` (in future they could merge).

There is one historical difference, which meant that unit test race was not testing `go/*`, and only `go/vt/*`. Once https://github.com/vitessio/vitess/issues/5493 is fixed, we can make it test `go/*`.

Signed-off-by: Morgan Tocker <tocker@gmail.com>