### PR TITLE
replace strings.TrimRight with strings.TrimSuffix and fix typo

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -51,7 +51,7 @@ Flags available:
     go run vtcompose/vtcompose.go -keyspaceData="test_keyspace:2:1:create_messages.sql,create_tokens.sql:lookup_keyspace;lookup_keyspace:1:1:create_tokens_token_lookup.sql,create_messages_message_lookup.sql"
     ```
 * **externalDbData** - Specifies which databases/keyspaces are external and provides data along with it to connect to the external db.
-    List of `<external_db_name>,<DB_HOST>,<DB_PORT>,<DB_USER>,<DB_PASS>,<DB_CHARSET>` seperated by ';'.  
+    List of `<external_db_name>,<DB_HOST>,<DB_PORT>,<DB_USER>,<DB_PASS>,<DB_CHARSET>` separated by ';'.  
     When using this, make sure to have the external_db_name/keyspace in the `keyspaceData` flag with no schema_file_names specified.  
     ```
     go run vtcompose/vtcompose.go -keyspaces="test:0:2::" -externalDbData="test:192.68.99.101:3306:admin:pass:CHARACTER SET utf8 COLLATE utf8_general_ci"

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -48,7 +48,7 @@ var (
 	mySqlPort      = flag.String("mySqlPort", "15306", "mySql port to be used")
 	cell           = flag.String("cell", "test", "Vitess Cell name")
 	keyspaceData   = flag.String("keyspaceData", "test_keyspace:2:1:create_messages.sql,create_tokens.sql;unsharded_keyspace:0:0:create_dinosaurs.sql,create_eggs.sql", "List of keyspace_name/external_db_name:num_of_shards:num_of_replica_tablets:schema_files:<optional>lookup_keyspace_name separated by ';'")
-	externalDbData = flag.String("externalDbData", "", "List of Data corresponding to external DBs. List of <external_db_name>,<DB_HOST>,<DB_PORT>,<DB_USER>,<DB_PASS>,<DB_CHARSET> seperated by ';'")
+	externalDbData = flag.String("externalDbData", "", "List of Data corresponding to external DBs. List of <external_db_name>,<DB_HOST>,<DB_PORT>,<DB_USER>,<DB_PASS>,<DB_CHARSET> separated by ';'")
 )
 
 type keyspaceInfo struct {

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -177,7 +177,7 @@ func main() {
 
 func fixZkPath(zkPath string) string {
 	if zkPath != "/" {
-		zkPath = strings.TrimRight(zkPath, "/")
+		zkPath = strings.TrimSuffix(zkPath, "/")
 	}
 	return path.Clean(zkPath)
 }

--- a/go/netutil/netutil.go
+++ b/go/netutil/netutil.go
@@ -154,7 +154,7 @@ func FullyQualifiedHostname() (string, error) {
 	//   127.0.0.1	localhost.localdomain localhost
 	// If the FQDN isn't returned by this function, check the order in the entry
 	// in your /etc/hosts file.
-	return strings.TrimRight(resolvedHostnames[0], "."), nil
+	return strings.TrimSuffix(resolvedHostnames[0], "."), nil
 }
 
 // FullyQualifiedHostnameOrPanic is the same as FullyQualifiedHostname


### PR DESCRIPTION
Signed-off-by: tanjunchen <2799194073@qq.com>

In string based trim scenario, we shall always use string based TrimPrefix/TrimSuffix instead of char based TrimLeft/TrimRight.
See the diff here: https://play.golang.org/p/S7cBaoIxPQy

golang:
https://golang.org/pkg/strings/#TrimRight