### PR TITLE
Force search /usr/sbin for mysqld

### DIFF
--- a/go/vt/env/env.go
+++ b/go/vt/env/env.go
@@ -18,6 +18,7 @@ package env
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -70,7 +71,11 @@ func VtMysqlRoot() (string, error) {
 		return root, nil
 	}
 
-	// otherwise let's use the mysqld in the PATH
+	// otherwise let's look for mysqld in the PATH.
+	// ensure that /usr/sbin is included, as it might not be by default
+	// This is the default location for mysqld from packages.
+	newPath := fmt.Sprintf("/usr/sbin:%s", os.Getenv("PATH"))
+	os.Setenv("PATH", newPath)
 	path, err := exec.LookPath("mysqld")
 	if err != nil {
 		return "", errors.New("VT_MYSQL_ROOT is not set and no mysqld could be found in your PATH")


### PR DESCRIPTION
This is not the most elegant patch, but it's quite possible that a user's `PATH` does not include `/usr/sbin`. This is the default location for mysqld, and we don't strictly need to be a super-user to run it, because we use different directories and ports to the default.

---

I manually tested this on an Ubuntu 19.10 VM by removing `/sbin` and `/usr/sbin` from `PATH`, and it was able to run the local example.

This issue was reported by Emi & @PrismaPhonic. It is technically a regression of https://github.com/vitessio/vitess/pull/5488 which removed the following lines from `dev.env`:

```
# mysql install location. Please set based on your environment.
# Build will not work if this is incorrect.

if [[ "$VT_MYSQL_ROOT" == "" ]]; then
  if [[ "$(which mysql)" == "" ]]; then
     echo "WARNING: VT_MYSQL_ROOT unset because mysql not found. Did you install a client package?"
  else
    VT_MYSQL_ROOT=$(dirname "$(dirname "$(which mysql)")")
    export VT_MYSQL_ROOT
  fi
fi

```

Technically this was looking at the path for the mysql client though, and did not guarantee that the server package was installed. It is the server package which is needed, so overall this is an improvement, but longer term there should be a dependency-check. I am working on one in https://github.com/vitessio/vitess/pull/5382 but it will take some time to complete before merging.

Signed-off-by: Morgan Tocker <tocker@gmail.com>