### PR TITLE
Allow to demote master vttablet to SPARE instead of REPLICA

### DIFF
--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -192,15 +192,15 @@ func syncShardMaster(ctx context.Context, ts *topo.Server, tablet *topodatapb.Ta
 // We just directly update our tablet type to REPLICA.
 func (agent *ActionAgent) abortMasterTerm(ctx context.Context, masterAlias *topodatapb.TabletAlias) error {
 	masterAliasStr := topoproto.TabletAliasString(masterAlias)
-	log.Warningf("Another tablet (%v) has won master election. Stepping down to REPLICA.", masterAliasStr)
+	log.Warningf("Another tablet (%v) has won master election. Stepping down to %v.", masterAliasStr, agent.DemoteMasterType)
 
 	if *mysqlctl.DisableActiveReparents {
 		// Don't touch anything at the MySQL level. Just update tablet state.
 		log.Infof("Active reparents are disabled; updating tablet state only.")
 		changeTypeCtx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 		defer cancel()
-		if err := agent.ChangeType(changeTypeCtx, topodatapb.TabletType_REPLICA); err != nil {
-			return vterrors.Wrap(err, "failed to change type to REPLICA")
+		if err := agent.ChangeType(changeTypeCtx, agent.DemoteMasterType); err != nil {
+			return vterrors.Wrapf(err, "failed to change type to %v", agent.DemoteMasterType)
 		}
 		return nil
 	}


### PR DESCRIPTION
In our setups we use SPARE tablets to take over MASTER role during reparents or failures. Currently shard sync and external reparent demote MASTER to REPLICA. This change allows to configure the tablet type of a demoted master. SPARE and REPLICA are the only ones allowed. REPLICA is the default one if flag is not set. This can also be achieved with a boolean flag if only SPARE and REPLICA make sense as the only tablet types that can be promoted to master

Signed-off-by: Karel Alfonso Sague <kalfonso@squareup.com>