### PR TITLE
Disable unit_race due to flakiness

### DIFF
--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -1,5 +1,4 @@
 name: unit_race
-on: [push, pull_request]
 jobs:
 
   build:


### PR DESCRIPTION
Backstory:
- unit_race was "enabled" but always returned success until 4 days ago, when I discovered it was broken https://github.com/vitessio/vitess/pull/5499
- The flakiness has been reported as issues. The main one is https://github.com/vitessio/vitess/issues/5530

The flakiness is just too severe for now, so I propose we disable the test while we wait on fixes. It won't put us in any worse of a position than 4 days ago.

Signed-off-by: Morgan Tocker <tocker@gmail.com>