### PR TITLE
Change the short code for the GPG key into longer key

### DIFF
--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 5.7
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
-    for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && break; done && \
+    for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
     echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \


### PR DESCRIPTION
There are collisions for most of the popular keys. Change the short gpg id into longer gpg-id

Signed-off-by: Jiamei.Xie <Jiamei.Xie@arm.com>