### PR TITLE
Add better dependency checking

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,6 +17,8 @@
 
 ### This file is executed by 'make tools'. You do not need to execute it directly.
 
+source ./dev.env
+
 # Outline of this file.
 # 0. Initialization and helper methods.
 # 1. Installation of dependencies.
@@ -29,16 +31,7 @@ BUILD_CONSUL=${BUILD_CONSUL:-1}
 # 0. Initialization and helper methods.
 #
 
-function fail() {
-  echo "ERROR: $1"
-  exit 1
-}
-
 [[ "$(dirname "$0")" = "." ]] || fail "bootstrap.sh must be run from its current directory"
-
-# Create main directories.
-
-source ./dev.env
 
 # install_dep is a helper function to generalize the download and installation of dependencies.
 #

--- a/build.env
+++ b/build.env
@@ -16,8 +16,8 @@
 
 source ./tools/shell_functions.inc
 
-go version &>/dev/null  || fail "Go is not installed or is not on \$PATH"
-goversion_min 1.12 || fail "Go is not version 1.12+"
+go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.12 || fail "Go is not version 1.12+. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -21,11 +21,7 @@ set -e
 
 # shellcheck disable=SC2128
 script_root=$(dirname "${BASH_SOURCE}")
-
-if [[ $EUID -eq 0 ]]; then
-   echo "This script refuses to be run as root. Please switch to a regular user."
-   exit 1
-fi
+source "${script_root}/env.sh"
 
 # start topo server
 if [ "${TOPO}" = "zk2" ]; then

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -23,12 +23,23 @@ function fail() {
   exit 1
 }
 
+if [[ $EUID -eq 0 ]]; then
+  fail "This script refuses to be run as root. Please switch to a regular user."
+fi
+
+for binary in mysqld etcd etcdctl curl vtctlclient vttablet vtgate vtctld mysqlctl; do
+  command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/docs/get-started/local/ for install instructions."
+done;
+
+if [ -z "$VTROOT" ]; then
+  fail "VTROOT is not set. See https://vitess.io/docs/get-started/local/ for install instructions."
+fi
+
 if [ "${TOPO}" = "zk2" ]; then
     # Each ZooKeeper server needs a list of all servers in the quorum.
     # Since we're running them all locally, we need to give them unique ports.
     # In a real deployment, these should be on different machines, and their
     # respective hostnames should be given.
-    echo "enter zk2 env"
     zkcfg=(\
         "1@$hostname:28881:38881:21811" \
         "2@$hostname:28882:38882:21812" \
@@ -46,8 +57,6 @@ if [ "${TOPO}" = "zk2" ]; then
 
     mkdir -p $VTDATAROOT/tmp
 else
-    echo "enter etcd2 env"
-
     ETCD_SERVER="localhost:2379"
     TOPOLOGY_FLAGS="-topo_implementation etcd2 -topo_global_server_address $ETCD_SERVER -topo_global_root /vitess/global"
 

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -27,6 +27,8 @@ if [[ $EUID -eq 0 ]]; then
   fail "This script refuses to be run as root. Please switch to a regular user."
 fi
 
+# mysqld might be in /usr/sbin which will not be in the default PATH
+PATH="/usr/sbin:$PATH"
 for binary in mysqld etcd etcdctl curl vtctlclient vttablet vtgate vtctld mysqlctl; do
   command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/docs/get-started/local/ for install instructions."
 done;

--- a/tools/dependency_check.sh
+++ b/tools/dependency_check.sh
@@ -22,6 +22,8 @@ function fail() {
 }
 
 # These binaries are required to 'make test'
+# mysqld might be in /usr/sbin which will not be in the default PATH
+PATH="/usr/sbin:$PATH"
 for binary in mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
   command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/contributing/build-from-source for install instructions."
 done;

--- a/tools/dependency_check.sh
+++ b/tools/dependency_check.sh
@@ -23,5 +23,5 @@ function fail() {
 
 # These binaries are required to 'make test'
 for binary in mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
-  command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. Run see https://vitess.io/contributing/build-from-source for install instructions."
+  command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/contributing/build-from-source for install instructions."
 done;

--- a/tools/dependency_check.sh
+++ b/tools/dependency_check.sh
@@ -21,6 +21,7 @@ function fail() {
   exit 1
 }
 
-for binary in mysqld consul etcd etcdctl zksrv.sh; do
-  command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. Run 'make tools' to install dependencies."
+# These binaries are required to 'make test'
+for binary in mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
+  command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. Run see https://vitess.io/contributing/build-from-source for install instructions."
 done;

--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -60,3 +60,9 @@ function prepend_path() {
   # Return path variable unchanged.
   echo "$1"
 }
+
+function fail() {
+  echo "ERROR: $1"
+  exit 1
+}
+


### PR DESCRIPTION
This adds dependency checking for both the local example, and the dependency check used by 'make test'. It should help reduce some of the common problems when running local examples.

Signed-off-by: Morgan Tocker <tocker@gmail.com>