### PR TITLE
Add golangci-lint with linters disabled

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -298,5 +298,5 @@ if [ "$BUILD_PYTHON" == 1 ] ; then
   PYTHONPATH='' $PIP install mysql-connector-python
 fi
 
-echo
-echo "bootstrap finished - run 'make build' to compile"
+# Install golangci-lint using recommended method
+command -v golangci-lint >/dev/null && echo "golangci-lint already installed" || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -298,5 +298,5 @@ if [ "$BUILD_PYTHON" == 1 ] ; then
   PYTHONPATH='' $PIP install mysql-connector-python
 fi
 
-# Install golangci-lint using recommended method
-command -v golangci-lint >/dev/null && echo "golangci-lint already installed" || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+echo
+echo "bootstrap finished - run 'make build' to compile"

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -17,4 +17,10 @@
 # We will enable it for everything here, but with most of the linters disabled.
 # See: https://github.com/vitessio/vitess/issues/5503
 
+GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
+if [ $? -eq 1 ]; then
+  echo "Downloading golangci-lint..."
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+fi
+
 golangci-lint run --disable=ineffassign,unused,gosimple,staticcheck,errcheck,structcheck,varcheck,deadcode

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2019 The Vitess Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unfortunately golangci-lint does not work well on checking just modified files.
+# We will enable it for everything here, but with most of the linters disabled.
+# See: https://github.com/vitessio/vitess/issues/5503
+
+golangci-lint run --disable=ineffassign,unused,gosimple,staticcheck,errcheck,structcheck,varcheck,deadcode


### PR DESCRIPTION
Part of #5503 

I have added the golangci-lint'er but with all the linters that currently produce errors disabled. It will be difficult to enable them all at once, but should be achievable if we target one at a time.

Signed-off-by: Morgan Tocker <tocker@gmail.com>