### PR TITLE
Make packages with cut down binaries list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/gorilla/websocket v0.0.0-20160912153041-2d1e4548da23
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
@@ -49,6 +50,8 @@ require (
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20160115111002-cca8bbc07984
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing/opentracing-go v1.1.0

--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This script builds and packages a Vitess release suitable for creating a new
+# release on https://github.com/vitessio/vitess/releases.
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+# sudo gem install --no-ri --no-rdoc fpm
+
+source build.env
+
+SHORT_REV="$(git rev-parse --short HEAD)"
+VERSION="5.0.0" # tmp
+# TODO: We can discover version from the last tag, we just need to have this setup.
+# TAG_VERSION="$(git describe --tags --dirty --always | sed  s/v//)"
+
+RELEASE_ID="vitess-${VERSION}-${SHORT_REV}"
+RELEASE_DIR="${VTROOT}/releases/${RELEASE_ID}"
+DESCRIPTION='A database clustering system for horizontal scaling of MySQL
+
+Vitess is a database solution for deploying, scaling and managing large
+clusters of MySQL instances. It’s architected to run as effectively in a public
+or private cloud architecture as it does on dedicated hardware. It combines and
+extends many important MySQL features with the scalability of a NoSQL database.'
+
+DEB_FILE="vitess_${VERSION}-${SHORT_REV}_amd64.deb"
+RPM_FILE="vitess-${VERSION}-${SHORT_REV}.x86_64.rpm"
+TAR_FILE="${RELEASE_ID}.tar.gz"
+
+make tools
+make build
+
+mkdir -p releases
+
+# Copy a subset of binaries from issue #5421
+mkdir -p "${RELEASE_DIR}/bin"
+for binary in vttestserver mysqlctl mysqlctld query_analyzer topo2topo vtaclcheck vtbackup vtbench vtclient vtcombo vtctl vtctlclient vtctld vtexplain vtgate vttablet vtworker vtworkerclient zk zkctl zkctld; do 
+ cp "bin/$binary" "${RELEASE_DIR}/bin/"
+done;
+
+# Copy remaining files, preserving date/permissions
+# But resolving symlinks
+cp -rpfL {config,vthook,web,examples} "${RELEASE_DIR}/"
+
+cd "${RELEASE_DIR}/.."
+tar -czf "${TAR_FILE}" "${RELEASE_ID}"
+
+fpm \
+   --force \
+   --input-type dir \
+   --name vitess \
+   --version "${VERSION}" \
+   --url "https://vitess.io/" \
+   --description "${DESCRIPTION}" \
+   --license "Apache License - Version 2.0, January 2004" \
+   --prefix "/vt" \
+   --directories "/vt" \
+   --before-install "$VTROOT/tools/preinstall.sh" \
+   -C "${RELEASE_DIR}" \
+   --package "$(dirname "${RELEASE_DIR}")" \
+   --iteration "${SHORT_REV}" \
+   -t deb --deb-no-default-config-files
+
+fpm \
+   --force \
+   --input-type dir \
+   --name vitess \
+   --version "${VERSION}" \
+   --url "https://vitess.io/" \
+   --description "${DESCRIPTION}" \
+   --license "Apache License - Version 2.0, January 2004" \
+   --prefix "/vt" \
+   --directories "/vt" \
+   --before-install "$VTROOT/tools/preinstall.sh" \
+   -C "${RELEASE_DIR}" \
+   --package "$(dirname "${RELEASE_DIR}")" \
+   --iteration "${SHORT_REV}" \
+   -t rpm
+
+echo ""
+echo "Packages created as of $(date +"%m-%d-%y") at $(date +"%r %Z")"
+echo ""
+echo "Package | SHA256"
+echo "------------ | -------------"
+echo "${TAR_FILE} | $(sha256sum ~/releases/"${TAR_FILE}" | awk '{print $1}')"
+echo "${DEB_FILE} | $(sha256sum ~/releases/"${DEB_FILE}" | awk '{print $1}')"
+echo "${RPM_FILE} | $(sha256sum ~/releases/"${RPM_FILE}" | awk '{print $1}')"

--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -17,12 +17,12 @@ VERSION="5.0.0" # tmp
 
 RELEASE_ID="vitess-${VERSION}-${SHORT_REV}"
 RELEASE_DIR="${VTROOT}/releases/${RELEASE_ID}"
-DESCRIPTION='A database clustering system for horizontal scaling of MySQL
+DESCRIPTION="A database clustering system for horizontal scaling of MySQL
 
 Vitess is a database solution for deploying, scaling and managing large
-clusters of MySQL instances. It’s architected to run as effectively in a public
+clusters of MySQL instances. It's architected to run as effectively in a public
 or private cloud architecture as it does on dedicated hardware. It combines and
-extends many important MySQL features with the scalability of a NoSQL database.'
+extends many important MySQL features with the scalability of a NoSQL database."
 
 DEB_FILE="vitess_${VERSION}-${SHORT_REV}_amd64.deb"
 RPM_FILE="vitess-${VERSION}-${SHORT_REV}.x86_64.rpm"
@@ -83,6 +83,6 @@ echo "Packages created as of $(date +"%m-%d-%y") at $(date +"%r %Z")"
 echo ""
 echo "Package | SHA256"
 echo "------------ | -------------"
-echo "${TAR_FILE} | $(sha256sum ~/releases/"${TAR_FILE}" | awk '{print $1}')"
-echo "${DEB_FILE} | $(sha256sum ~/releases/"${DEB_FILE}" | awk '{print $1}')"
-echo "${RPM_FILE} | $(sha256sum ~/releases/"${RPM_FILE}" | awk '{print $1}')"
+echo "${TAR_FILE} | $(sha256sum "${VTROOT}/releases/${TAR_FILE}" | awk '{print $1}')"
+echo "${DEB_FILE} | $(sha256sum "${VTROOT}/releases/${DEB_FILE}" | awk '{print $1}')"
+echo "${RPM_FILE} | $(sha256sum "${VTROOT}/releases/${RPM_FILE}" | awk '{print $1}')"

--- a/tools/preinstall.sh
+++ b/tools/preinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if ! /usr/bin/getent group vitess >/dev/null ; then
+   groupadd -r vitess
+fi
+
+if ! /usr/bin/getent passwd vitess >/dev/null ; then
+    useradd -r -g vitess vitess
+fi


### PR DESCRIPTION
Fixes #5421

This script makes packages (tar.gz, .deb, .rpm), which as part of #5463 I will followup and plug into a GitHub action that runs whenever a tag of a certain convention is made. The artifacts will be uploaded as a new release draft. All that will be required on human intervention is to paste release notes and hit publish.

Changes:
- lib/dist/pkg are no longer bundled.
- the binaries list is much shorter (via #5421)

Signed-off-by: Morgan Tocker <tocker@gmail.com>