### PR TITLE
Make .gitignore rules safer.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,8 @@ java/*/target
 java/*/bin
 php/vendor
 releases
+/dist/
+/py-vtdb/
+/vthook/
+/bin/
+/vtdataroot/

--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,8 @@ releases
 # Vagrant
 .vagrant
 
-dist/*
-py-vtdb*
-vthook*
-bin*
-
-vtdataroot*
+/dist/
+/py-vtdb/
+/vthook/
+/bin/
+/vtdataroot/


### PR DESCRIPTION
In particular, `bin*` ignores any file anywhere that even starts with "bin", of which we have many (e.g. "binlog_blah").

This change scopes these rules down to only match directories (`/`suffix) at the root of the repo (`/` prefix).

@morgo Can you confirm these scoped-down rules still match the things you intended in #5527?