### PR TITLE
Fix vitessdriver.Open example

### DIFF
--- a/go/vt/vitessdriver/doc.go
+++ b/go/vt/vitessdriver/doc.go
@@ -28,13 +28,12 @@ Example
 Using this SQL driver is as simple as:
 
   import (
-    "time"
     "vitess.io/vitess/go/vt/vitessdriver"
   )
 
   func main() {
     // Connect to vtgate.
-    db, err := vitessdriver.Open("localhost:15991", "keyspace", "master", 30*time.Second)
+    db, err := vitessdriver.Open("localhost:15991", "@master")
 
     // Use "db" via the Golang sql interface.
   }


### PR DESCRIPTION
Current docs are out of date and do not match the signature of vitessdriver.Open.