### PR TITLE
Improve stability of dependency fetches

### DIFF
--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget ant openjdk-8-jdk
         sudo service mysql stop
         sudo service etcd stop

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Get dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
         sudo service mysql stop
         sudo service etcd stop


### PR DESCRIPTION
There might be cases where an apt-get install fails because a package returns a 404. It is typically because there has been a security fix + updated packages, but the apt cache is out of date.

Signed-off-by: Morgan Tocker <tocker@gmail.com>