### PR TITLE
Set unique job names on GitHub workflows.

### DIFF
--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Check Make Parser
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Cluster End-to-End Test
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: End-to-End Test (Race)
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: End-to-End Test
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Local Example Test
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    name: Build
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
 
   build:
-    name: Build
+    name: Unit Test (Race)
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
This seems to be necessary to distinguish between them in branch protection rules.