### PR TITLE
option to disable caching field names to avoid schema mismatches

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -521,7 +521,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 
 // execDirect is for reads inside transactions. Always send to MySQL.
 func (qre *QueryExecutor) execDirect(conn *TxConnection) (*sqltypes.Result, error) {
-	if qre.plan.Fields != nil {
+	if qre.tsv.qe.enableQueryPlanFieldCaching && qre.plan.Fields != nil {
 		result, err := qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, "", true, false)
 		if err != nil {
 			return nil, err
@@ -535,7 +535,7 @@ func (qre *QueryExecutor) execDirect(conn *TxConnection) (*sqltypes.Result, erro
 // execSelect sends a query to mysql only if another identical query is not running. Otherwise, it waits and
 // reuses the result. If the plan is missng field info, it sends the query to mysql requesting full info.
 func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
-	if qre.plan.Fields != nil {
+	if qre.tsv.qe.enableQueryPlanFieldCaching && qre.plan.Fields != nil {
 		result, err := qre.qFetch(qre.logStats, qre.plan.FullQuery, qre.bindVars)
 		if err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -105,6 +105,7 @@ func init() {
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flag.BoolVar(&Config.EnableConsolidator, "enable-consolidator", DefaultQsConfig.EnableConsolidator, "This option enables the query consolidator.")
+	flag.BoolVar(&Config.EnableQueryPlanFieldCaching, "enable-query-plan-field-caching", DefaultQsConfig.EnableQueryPlanFieldCaching, "This option fetches & caches fields (columns) when storing query plans")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -179,8 +180,9 @@ type TabletConfig struct {
 	HeartbeatEnable   bool
 	HeartbeatInterval time.Duration
 
-	EnforceStrictTransTables bool
-	EnableConsolidator       bool
+	EnforceStrictTransTables    bool
+	EnableConsolidator          bool
+	EnableQueryPlanFieldCaching bool
 }
 
 // TransactionLimitConfig captures configuration of transaction pool slots
@@ -258,8 +260,9 @@ var DefaultQsConfig = TabletConfig{
 	HeartbeatEnable:   false,
 	HeartbeatInterval: 1 * time.Second,
 
-	EnforceStrictTransTables: true,
-	EnableConsolidator:       true,
+	EnforceStrictTransTables:    true,
+	EnableConsolidator:          true,
+	EnableQueryPlanFieldCaching: true,
 }
 
 // defaultTxThrottlerConfig formats the default throttlerdata.Configuration


### PR DESCRIPTION
We've had several incidents where schema migrations + the query plan cache can combine to return results with the wrong column/field names until the cache is refreshed.

ex:

1. `SELECT * FROM table WHERE id = something` is executed and cached with field names `(foo, bar, baz)`
2. `ptosc` or `ghost` migration completes to drop `bar`
3. `SELECT * FROM table WHERE id = something` is executed again, and the tablet grabs the field names from the cache, which includes `bar`. However, MySQL only returned data for two columns, `(foo, baz)`
4. Client either fails loudly, when the field / row types mismatch, or fails silently when the types can be coerced into the wrong columns (scary!).

From my understanding, this mismatch can happen when:

* A migration is executed out-of-band via a tool like `ghost` or `ptosc` 
* Online DDL is executed against a master, in the brief period of time before the schema-refresh hook after it completes.
* Online DDL is executed against a master, and then replicates to a replica while that replica is serving reads. The replica can return bad results until its query cache is refreshed.

The simplest & most expedient thing I could think of to circumvent this problem entirely is to just stop caching field names with the query plans, which is what this PR enables. Looking for feedback on the changes, and I'm curious if others have run into these issues as well.

Signed-off-by: Paul Hemberger <phemberger@hubspot.com>