### PR TITLE
vrepl: support qualified vindex names

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
@@ -27,7 +27,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/grpcclient"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
@@ -187,7 +186,7 @@ func (vsClient *MySQLVStreamerClient) VStream(ctx context.Context, startPos stri
 	if !vsClient.isOpen {
 		return errors.New("can't VStream without opening client")
 	}
-	streamer := vstreamer.NewVStreamer(ctx, vsClient.sourceConnParams, vsClient.sourceSe, startPos, filter, &vindexes.KeyspaceSchema{}, send)
+	streamer := vstreamer.NewVStreamer(ctx, vsClient.sourceConnParams, vsClient.sourceSe, startPos, filter, nil, send)
 	return streamer.Stream()
 }
 
@@ -204,7 +203,7 @@ func (vsClient *MySQLVStreamerClient) VStreamRows(ctx context.Context, query str
 		}
 		row = r.Rows[0]
 	}
-	streamer := vstreamer.NewRowStreamer(ctx, vsClient.sourceConnParams, vsClient.sourceSe, query, row, &vindexes.KeyspaceSchema{}, send)
+	streamer := vstreamer.NewRowStreamer(ctx, vsClient.sourceConnParams, vsClient.sourceSe, query, row, nil, send)
 	return streamer.Stream()
 }
 

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -49,7 +49,7 @@ type Engine struct {
 	// cp is initialized by InitDBConfig
 	cp *mysql.ConnParams
 
-	// mu protects isOpen, streamers, streamIdx and kschema.
+	// mu protects isOpen, streamers, streamIdx and vschema.
 	mu sync.Mutex
 
 	isOpen bool
@@ -61,12 +61,12 @@ type Engine struct {
 	resultStreamers map[int]*resultStreamer
 	streamIdx       int
 
-	// watcherOnce is used for initializing kschema
+	// watcherOnce is used for initializing vschema
 	// and setting up the vschema watch. It's guaranteed that
-	// no stream will start until kschema is initialized by
+	// no stream will start until vschema is initialized by
 	// the first call through watcherOnce.
 	watcherOnce sync.Once
-	kschema     *vindexes.KeyspaceSchema
+	lvschema    *localVSchema
 
 	// The following members are initialized once at the beginning.
 	ts       srvtopo.Server
@@ -83,7 +83,7 @@ func NewEngine(ts srvtopo.Server, se *schema.Engine) *Engine {
 		streamers:       make(map[int]*vstreamer),
 		rowStreamers:    make(map[int]*rowStreamer),
 		resultStreamers: make(map[int]*resultStreamer),
-		kschema:         &vindexes.KeyspaceSchema{},
+		lvschema:        &localVSchema{vschema: &vindexes.VSchema{}},
 		ts:              ts,
 		se:              se,
 	}
@@ -146,15 +146,15 @@ func (vse *Engine) Close() {
 	vse.wg.Wait()
 }
 
-func (vse *Engine) vschema() *vindexes.KeyspaceSchema {
+func (vse *Engine) vschema() *vindexes.VSchema {
 	vse.mu.Lock()
 	defer vse.mu.Unlock()
-	return vse.kschema
+	return vse.lvschema.vschema
 }
 
 // Stream starts a new stream.
 func (vse *Engine) Stream(ctx context.Context, startPos string, filter *binlogdatapb.Filter, send func([]*binlogdatapb.VEvent) error) error {
-	// Ensure kschema is initialized and the watcher is started.
+	// Ensure vschema is initialized and the watcher is started.
 	// Starting of the watcher has to be delayed till the first call to Stream
 	// because this overhead should be incurred only if someone uses this feature.
 	vse.watcherOnce.Do(vse.setWatch)
@@ -166,7 +166,7 @@ func (vse *Engine) Stream(ctx context.Context, startPos string, filter *binlogda
 		if !vse.isOpen {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
-		streamer := NewVStreamer(ctx, vse.cp, vse.se, startPos, filter, vse.kschema, send)
+		streamer := NewVStreamer(ctx, vse.cp, vse.se, startPos, filter, vse.lvschema, send)
 		idx := vse.streamIdx
 		vse.streamers[idx] = streamer
 		vse.streamIdx++
@@ -193,7 +193,7 @@ func (vse *Engine) Stream(ctx context.Context, startPos string, filter *binlogda
 
 // StreamRows streams rows.
 func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltypes.Value, send func(*binlogdatapb.VStreamRowsResponse) error) error {
-	// Ensure kschema is initialized and the watcher is started.
+	// Ensure vschema is initialized and the watcher is started.
 	// Starting of the watcher has to be delayed till the first call to Stream
 	// because this overhead should be incurred only if someone uses this feature.
 	vse.watcherOnce.Do(vse.setWatch)
@@ -206,7 +206,7 @@ func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltyp
 		if !vse.isOpen {
 			return nil, 0, errors.New("VStreamer is not open")
 		}
-		rowStreamer := NewRowStreamer(ctx, vse.cp, vse.se, query, lastpk, vse.kschema, send)
+		rowStreamer := NewRowStreamer(ctx, vse.cp, vse.se, query, lastpk, vse.lvschema, send)
 		idx := vse.streamIdx
 		vse.rowStreamers[idx] = rowStreamer
 		vse.streamIdx++
@@ -273,7 +273,7 @@ func (vse *Engine) ServeHTTP(response http.ResponseWriter, request *http.Request
 	}
 	response.Header().Set("Content-Type", "application/json; charset=utf-8")
 	vs := vse.vschema()
-	if vs == nil || vs.Keyspace == nil {
+	if vs == nil {
 		response.Write([]byte("{}"))
 	}
 	b, err := json.MarshalIndent(vs, "", "  ")
@@ -289,39 +289,39 @@ func (vse *Engine) ServeHTTP(response http.ResponseWriter, request *http.Request
 func (vse *Engine) setWatch() {
 	// WatchSrvVSchema does not return until the inner func has been called at least once.
 	vse.ts.WatchSrvVSchema(context.TODO(), vse.cell, func(v *vschemapb.SrvVSchema, err error) {
-		var kschema *vindexes.KeyspaceSchema
 		switch {
 		case err == nil:
-			kschema, err = vindexes.BuildKeyspaceSchema(v.Keyspaces[vse.keyspace], vse.keyspace)
-			if err != nil {
-				log.Errorf("Error building vschema %s: %v", vse.keyspace, err)
-				vschemaErrors.Add(1)
-				return
-			}
+			// Build vschema down below.
 		case topo.IsErrType(err, topo.NoNode):
-			// No-op.
+			v = nil
 		default:
-			log.Errorf("Error fetching vschema %s: %v", vse.keyspace, err)
+			log.Errorf("Error fetching vschema: %v", err)
 			vschemaErrors.Add(1)
 			return
 		}
-
-		if kschema == nil {
-			kschema = &vindexes.KeyspaceSchema{
-				Keyspace: &vindexes.Keyspace{
-					Name: vse.keyspace,
-				},
+		var vschema *vindexes.VSchema
+		if v != nil {
+			vschema, err = vindexes.BuildVSchema(v)
+			if err != nil {
+				log.Errorf("Error building vschema: %v", err)
+				vschemaErrors.Add(1)
+				return
 			}
+		} else {
+			vschema = &vindexes.VSchema{}
 		}
 
 		// Broadcast the change to all streamers.
 		vse.mu.Lock()
 		defer vse.mu.Unlock()
-		vse.kschema = kschema
-		b, _ := json.MarshalIndent(kschema, "", "  ")
-		log.Infof("Updated KSchema: %s", b)
+		vse.lvschema = &localVSchema{
+			keyspace: vse.keyspace,
+			vschema:  vschema,
+		}
+		b, _ := json.MarshalIndent(vschema, "", "  ")
+		log.Infof("Updated vschema: %s", b)
 		for _, s := range vse.streamers {
-			s.SetKSchema(kschema)
+			s.SetVSchema(vse.lvschema)
 		}
 		vschemaUpdates.Add(1)
 	})

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -100,36 +100,46 @@ func TestUpdateVSchema(t *testing.T) {
 	expectUpdateCount(t, startCount+1)
 
 	want := `{
-  "sharded": true,
-  "tables": {
-    "t1": {
-      "name": "t1",
-      "column_vindexes": [
-        {
-          "columns": [
-            "id1"
+  "routing_rules": {},
+  "keyspaces": {
+    "vttest": {
+      "sharded": true,
+      "tables": {
+        "dual": {
+          "type": "reference",
+          "name": "dual"
+        },
+        "t1": {
+          "name": "t1",
+          "column_vindexes": [
+            {
+              "columns": [
+                "id1"
+              ],
+              "type": "hash",
+              "name": "hash",
+              "vindex": {}
+            }
           ],
-          "type": "hash",
-          "name": "hash",
-          "vindex": {}
+          "ordered": [
+            {
+              "columns": [
+                "id1"
+              ],
+              "type": "hash",
+              "name": "hash",
+              "vindex": {}
+            }
+          ]
         }
-      ],
-      "ordered": [
-        {
-          "columns": [
-            "id1"
-          ],
-          "type": "hash",
-          "name": "hash",
-          "vindex": {}
-        }
-      ]
+      },
+      "vindexes": {
+        "hash": {}
+      }
     }
-  },
-  "vindexes": {
-    "hash": {}
   }
 }`
+
 	b, err := json.MarshalIndent(engine.vschema(), "", "  ")
 	if err != nil {
 		t.Fatal(err)

--- a/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamer
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+// localVSchema provides vschema behavior specific to vstreamer.
+// Tables are searched within keyspace, but vindexes can be referenced
+// outside the current keyspace.
+type localVSchema struct {
+	keyspace string
+	vschema  *vindexes.VSchema
+}
+
+func (lvs *localVSchema) FindTable(tablename string) (*vindexes.Table, error) {
+	ks, ok := lvs.vschema.Keyspaces[lvs.keyspace]
+	if !ok {
+		return nil, fmt.Errorf("keyspace %s not found in vschema", lvs.keyspace)
+	}
+	table := ks.Tables[tablename]
+	if table == nil {
+		return nil, fmt.Errorf("table %s not found", tablename)
+	}
+	return table, nil
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/local_vschema_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/local_vschema_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+var testSrvVSchema = &vschemapb.SrvVSchema{
+	Keyspaces: map[string]*vschemapb.Keyspace{
+		"ks1": {
+			Sharded: true,
+			Vindexes: map[string]*vschemapb.Vindex{
+				"duphash": {
+					Type: "hash",
+				},
+			},
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name:    "duphash",
+						Columns: []string{"id"},
+					}},
+				},
+			},
+		},
+		"ks2": {
+			Sharded: true,
+			Vindexes: map[string]*vschemapb.Vindex{
+				"duphash": {
+					Type: "hash",
+				},
+				"otherhash": {
+					Type: "hash",
+				},
+			},
+		},
+	},
+}
+
+func TestFindTable(t *testing.T) {
+	vschema, err := vindexes.BuildVSchema(testSrvVSchema)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		keyspace  string
+		tablename string
+		err       string
+	}{{
+		keyspace:  "ks1",
+		tablename: "t1",
+		err:       "",
+	}, {
+		keyspace:  "ks1",
+		tablename: "t2",
+		err:       "table t2 not found",
+	}, {
+		keyspace:  "noks",
+		tablename: "t2",
+		err:       "keyspace noks not found in vschema",
+	}}
+	for _, tcase := range testcases {
+		lvs := &localVSchema{
+			keyspace: tcase.keyspace,
+			vschema:  vschema,
+		}
+		table, err := lvs.FindTable(tcase.tablename)
+		if err != nil {
+			assert.EqualError(t, err, tcase.err, tcase.keyspace, tcase.tablename)
+			continue
+		}
+		assert.NoError(t, err, tcase.keyspace, tcase.tablename)
+		assert.Equal(t, table.Name.String(), tcase.tablename, tcase.keyspace, tcase.tablename)
+	}
+}
+
+func TestFindOrCreateVindex(t *testing.T) {
+	vschema, err := vindexes.BuildVSchema(testSrvVSchema)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name string
+		err  string
+	}{{
+		name: "otherhash",
+		err:  "",
+	}, {
+		name: "ks1.duphash",
+		err:  "",
+	}, {
+		name: "hash",
+		err:  "",
+	}, {
+		name: "a.b.c",
+		err:  "invalid vindex name: a.b.c",
+	}, {
+		name: "duphash",
+		err:  "ambiguous vindex reference: duphash",
+	}, {
+		name: "ks1.hash",
+		err:  "vindex ks1.hash not found",
+	}, {
+		name: "none",
+		err:  `vindexType "none" not found`,
+	}}
+	for _, tcase := range testcases {
+		lvs := &localVSchema{
+			keyspace: "ks1",
+			vschema:  vschema,
+		}
+		vindex, err := lvs.FindOrCreateVindex(tcase.name)
+		if err != nil {
+			assert.EqualError(t, err, tcase.err, tcase.name)
+			continue
+		}
+		assert.NoError(t, err, tcase.name)
+		splits := strings.Split(tcase.name, ".")
+		want := splits[len(splits)-1]
+		assert.Equal(t, vindex.String(), want, tcase.name)
+	}
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -424,7 +424,7 @@ func (plan *Plan) analyzeInKeyRange(vschema *localVSchema, exprs sqlparser.Selec
 		if err != nil {
 			return err
 		}
-		plan.Vindex, err = vindexes.CreateVindex(vtype, vtype, map[string]string{})
+		plan.Vindex, err = vschema.FindOrCreateVindex(vtype)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change allows you to use qualified vindex names in the in_keyrange expressions. Example: `in_keyrange(col, 'ks.my_vindex', '-80')`.

The expression can refer to an existing vindex in any keyspace, and we continue to support a straight vindex type as long as it doesn't require additional parameters.