### PR TITLE
Add new Dockerfile.mysql57-arm64v8 to support aarch64 

### DIFF
--- a/docker/bootstrap/Dockerfile.mysql57-arm64v8
+++ b/docker/bootstrap/Dockerfile.mysql57-arm64v8
@@ -1,0 +1,40 @@
+FROM vitess/bootstrap:common
+
+# Install MySQL 5.7
+RUN add-apt-repository 'deb http://ftp.debian.org/debian sid main' && \
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libmysqlclient-dev mysql-client-5.7 mysql-server-5.7 \
+cmake \
+apt-utils \
+libaio-dev \
+libncurses5-dev \
+libssl-dev \
+zlib1g-dev \
+libgcrypt11-dev \
+libev-dev \
+libcurl4-gnutls-dev \
+vim-common \
+bison \
+flex \
+wget \
+libdbd-mysql-perl \
+rsync \
+libev4 \
+python3-distutils-extra  && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://github.com/percona/percona-xtrabackup/archive/percona-xtrabackup-2.4.13.tar.gz -P /opt && \
+tar zxf /opt/percona-xtrabackup-2.4.13.tar.gz -C /opt && \
+rm /opt/percona-xtrabackup-2.4.13.tar.gz && \
+cd /opt/percona-xtrabackup-percona-xtrabackup-2.4.13 && \
+mkdir bld && \
+cd bld && \
+cmake .. -DBUILD_CONFIG=xtrabackup_release -DWITH_MAN_PAGES=OFF -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/usr/local && \
+make -j4 && \
+make install
+
+# Bootstrap Vitess
+WORKDIR /vt/src/vitess.io/vitess
+
+ENV PATH="/usr/local/xtrabackup/bin:${PATH}"
+ENV MYSQL_FLAVOR MySQL56
+USER vitess
+RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mysql57-arm64v8
+++ b/docker/bootstrap/Dockerfile.mysql57-arm64v8
@@ -1,39 +1,61 @@
+FROM debian:9 AS builder
+
+WORKDIR /opt
+#Build xtrabackup
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    bison \
+    build-essential \
+    bzr \
+    ca-certificates \
+    cmake \
+    flex \
+    libaio-dev \
+    libcurl4-gnutls-dev \
+    libev-dev \
+    libgcrypt11-dev \
+    libncurses-dev \
+    libtool \
+    mysql-client \
+    vim-common \
+    wget \
+    zlib1g-dev && \
+    wget https://github.com/percona/percona-xtrabackup/archive/percona-xtrabackup-2.4.13.tar.gz \
+        -P /opt && \
+    tar zxf /opt/percona-xtrabackup-2.4.13.tar.gz -C /opt && \
+    rm /opt/percona-xtrabackup-2.4.13.tar.gz && \
+    cd /opt/percona-xtrabackup-percona-xtrabackup-2.4.13 && \
+    mkdir bld && cd bld && \
+    cmake .. -DBUILD_CONFIG=xtrabackup_release -DWITH_MAN_PAGES=OFF \
+        -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/usr/local && \
+    make -j4 && \
+    make install
+
 FROM vitess/bootstrap:common
 
 # Install MySQL 5.7
 RUN add-apt-repository 'deb http://ftp.debian.org/debian sid main' && \
-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libmysqlclient-dev mysql-client-5.7 mysql-server-5.7 \
-cmake \
-apt-utils \
-libaio-dev \
-libncurses5-dev \
-libssl-dev \
-zlib1g-dev \
-libgcrypt11-dev \
-libev-dev \
-libcurl4-gnutls-dev \
-vim-common \
-bison \
-flex \
-wget \
-libdbd-mysql-perl \
-rsync \
-libev4 \
-python3-distutils-extra  && \
-rm -rf /var/lib/apt/lists/* && \
-wget https://github.com/percona/percona-xtrabackup/archive/percona-xtrabackup-2.4.13.tar.gz -P /opt && \
-tar zxf /opt/percona-xtrabackup-2.4.13.tar.gz -C /opt && \
-rm /opt/percona-xtrabackup-2.4.13.tar.gz && \
-cd /opt/percona-xtrabackup-percona-xtrabackup-2.4.13 && \
-mkdir bld && \
-cd bld && \
-cmake .. -DBUILD_CONFIG=xtrabackup_release -DWITH_MAN_PAGES=OFF -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/usr/local && \
-make -j4 && \
-make install
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libmysqlclient-dev \
+    mysql-client-5.7 \
+    mysql-server-5.7 \
+    libdbd-mysql-perl \
+    python3-distutils-extra \
+    rsync \
+    libev4 \
+    libcurl4-openssl-dev \
+    libaio1 && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /usr/local/xtrabackup/bin && \
+    mkdir -p /usr/local/xtrabackup/lib
 
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
-
+COPY --from=builder /usr/local/xtrabackup/bin /usr/local/xtrabackup/bin
+COPY --from=builder /usr/local/xtrabackup/lib /usr/local/xtrabackup/lib
 ENV PATH="/usr/local/xtrabackup/bin:${PATH}"
 ENV MYSQL_FLAVOR MySQL56
 USER vitess

--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -37,4 +37,4 @@ case $flavor in
 	*)
 		;;
 esac
-docker build --no-cache -f docker/bootstrap/Dockerfile.$flavor$arch_ext -t vitess/bootstrap:$flavor .
+docker build --no-cache -f docker/bootstrap/Dockerfile.$flavor$arch_ext -t vitess/bootstrap:$flavor$arch_ex .

--- a/docker/bootstrap/build.sh
+++ b/docker/bootstrap/build.sh
@@ -29,4 +29,12 @@ fi
 # To avoid AUFS permission issues, files must allow access by "other"
 chmod -R o=g *
 
-docker build --no-cache -f docker/bootstrap/Dockerfile.$flavor -t vitess/bootstrap:$flavor .
+case $flavor in
+	mysql57)
+		arch=$(uname -m)
+		[ "$arch" == "aarch64" ] && arch_ext='-arm64v8'
+		;;
+	*)
+		;;
+esac
+docker build --no-cache -f docker/bootstrap/Dockerfile.$flavor$arch_ext -t vitess/bootstrap:$flavor .


### PR DESCRIPTION
Add new Dockerfile.mysql57-arm64v8 to support aarch64 

The mysql and xtrabackup installed in Dockerfile.mysql57 doesn't work
for aarch64. So the new Dockerfile.mysql57-arm64v8 for aarch64 is added

Change-Id: Icbb1c06b9066eac7786eccb62b5dc3737650b17e
Signed-off-by: Jiamei.Xie <Jiamei.Xie@arm.com>