### PR TITLE
Endtoend testcases in Go migrated from Python

### DIFF
--- a/go/test/endtoend/binlog/binlog_test.go
+++ b/go/test/endtoend/binlog/binlog_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ This file contains integration tests for the go/vt/binlog package.
+ It sets up filtered replication between two shards and checks how data flows
+ through binlog streamer.
+*/
+
+package binlog
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/proto/query"
+)
+
+var (
+	localCluster *cluster.LocalProcessCluster
+	cell         = "zone1"
+	hostname     = "localhost"
+	keyspaceName = "ks"
+	tableName    = "test_table"
+	sqlSchema    = `
+					create table %s(
+					id bigint(20) unsigned auto_increment,
+					msg varchar(64),
+					primary key (id),
+					index by_msg (msg)
+					) Engine=InnoDB
+`
+	insertSql       = `insert into %s(id,msg) values(%d, "%s")`
+	commonTabletArg = []string{
+		"-vreplication_healthcheck_topology_refresh", "1s",
+		"-vreplication_healthcheck_retry_delay", "1s",
+		"-vreplication_retry_delay", "1s",
+		"-degraded_threshold", "5s",
+		"-lock_tables_timeout", "5s",
+		"-watch_replication_stream",
+		"-enable_replication_reporter",
+		"-serving_state_grace_period", "1s",
+		"-binlog_player_protocol", "grpc",
+		"-enable-autocommit",
+	}
+	vSchema = `
+		{
+		  "sharded": false,
+		  "vindexes": {
+			"hash_index": {
+			  "type": "hash"
+			}
+		  },
+		  "tables": {
+			"%s": {
+			   "column_vindexes": [
+				{
+				  "column": "id",
+				  "name": "hash_index"
+				}
+			  ] 
+			}
+		  }
+		}
+`
+	srcMaster  *cluster.Vttablet
+	srcReplica *cluster.Vttablet
+	srcRdonly  *cluster.Vttablet
+
+	destMaster  *cluster.Vttablet
+	destReplica *cluster.Vttablet
+	destRdonly  *cluster.Vttablet
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitcode, err := func() (int, error) {
+		localCluster = cluster.NewCluster(cell, hostname)
+		defer localCluster.Teardown()
+		os.Setenv("EXTRA_MY_CNF", path.Join(os.Getenv("VTROOT"), "config", "mycnf", "rbr.cnf"))
+		localCluster.Keyspaces = append(localCluster.Keyspaces, cluster.Keyspace{
+			Name: keyspaceName,
+		})
+
+		// Start topo server
+		if err := localCluster.StartTopo(); err != nil {
+			return 1, err
+		}
+
+		srcMaster = localCluster.GetVttabletInstance("master", 0, "")
+		srcReplica = localCluster.GetVttabletInstance("replica", 0, "")
+		srcRdonly = localCluster.GetVttabletInstance("rdonly", 0, "")
+
+		destMaster = localCluster.GetVttabletInstance("master", 0, "")
+		destReplica = localCluster.GetVttabletInstance("replica", 0, "")
+		destRdonly = localCluster.GetVttabletInstance("rdonly", 0, "")
+
+		var mysqlProcs []*exec.Cmd
+		for _, tablet := range []*cluster.Vttablet{srcMaster, srcReplica, srcRdonly, destMaster, destReplica, destRdonly} {
+			tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, localCluster.TmpDirectory)
+			tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,
+				tablet.GrpcPort,
+				tablet.TabletUID,
+				cell,
+				"",
+				keyspaceName,
+				localCluster.VtctldProcess.Port,
+				tablet.Type,
+				localCluster.TopoPort,
+				hostname,
+				localCluster.TmpDirectory,
+				commonTabletArg,
+				true,
+			)
+			tablet.VttabletProcess.SupportsBackup = true
+			proc, err := tablet.MysqlctlProcess.StartProcess()
+			if err != nil {
+				return 1, err
+			}
+			mysqlProcs = append(mysqlProcs, proc)
+		}
+		for _, proc := range mysqlProcs {
+			if err := proc.Wait(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := localCluster.VtctlProcess.CreateKeyspace(keyspaceName); err != nil {
+			return 1, err
+		}
+
+		shard1 := cluster.Shard{
+			Name:      "0",
+			Vttablets: []*cluster.Vttablet{srcMaster, srcReplica, srcRdonly},
+		}
+		for idx := range shard1.Vttablets {
+			shard1.Vttablets[idx].VttabletProcess.Shard = shard1.Name
+		}
+		localCluster.Keyspaces[0].Shards = append(localCluster.Keyspaces[0].Shards, shard1)
+
+		shard2 := cluster.Shard{
+			Name:      "-",
+			Vttablets: []*cluster.Vttablet{destMaster, destReplica, destRdonly},
+		}
+		for idx := range shard2.Vttablets {
+			shard2.Vttablets[idx].VttabletProcess.Shard = shard2.Name
+		}
+		localCluster.Keyspaces[0].Shards = append(localCluster.Keyspaces[0].Shards, shard2)
+
+		for _, tablet := range shard1.Vttablets {
+			if err := localCluster.VtctlclientProcess.InitTablet(tablet, cell, keyspaceName, hostname, shard1.Name); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+		if err := localCluster.VtctlclientProcess.InitShardMaster(keyspaceName, shard1.Name, cell, srcMaster.TabletUID); err != nil {
+			return 1, err
+		}
+
+		if err := localCluster.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(sqlSchema, tableName)); err != nil {
+			return 1, err
+		}
+		if err := localCluster.VtctlclientProcess.ApplyVSchema(keyspaceName, fmt.Sprintf(vSchema, tableName)); err != nil {
+			return 1, err
+		}
+
+		// run a health check on source replica so it responds to discovery
+		// (for binlog players) and on the source rdonlys (for workers)
+		for _, tablet := range []string{srcReplica.Alias, srcRdonly.Alias} {
+			if err := localCluster.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet); err != nil {
+				return 1, err
+			}
+		}
+
+		// Create destination shard (won't be serving as there is no DB)
+		for _, tablet := range shard2.Vttablets {
+			if err := localCluster.VtctlclientProcess.InitTablet(tablet, cell, keyspaceName, hostname, shard2.Name); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := localCluster.VtctlclientProcess.InitShardMaster(keyspaceName, shard2.Name, cell, destMaster.TabletUID); err != nil {
+			return 1, err
+		}
+		_ = localCluster.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+		// Copy schema
+		if err := localCluster.VtctlclientProcess.ExecuteCommand("CopySchemaShard", srcReplica.Alias, fmt.Sprintf("%s/%s", keyspaceName, shard2.Name)); err != nil {
+			return 1, err
+		}
+
+		// run the clone worker (this is a degenerate case, source and destination
+		// both have the full keyrange. Happens to work correctly).
+		localCluster.VtworkerProcess = *cluster.VtworkerProcessInstance(localCluster.GetAndReservePort(),
+			localCluster.GetAndReservePort(),
+			localCluster.TopoPort,
+			localCluster.Hostname,
+			localCluster.TmpDirectory)
+		localCluster.VtworkerProcess.Cell = cell
+		if err := localCluster.VtworkerProcess.ExecuteVtworkerCommand(localCluster.VtworkerProcess.Port,
+			localCluster.VtworkerProcess.GrpcPort, "--use_v3_resharding_mode=true",
+			"SplitClone",
+			"--chunk_count", "10",
+			"--min_rows_per_chunk", "1",
+			"--exclude_tables", "unrelated",
+			"--min_healthy_rdonly_tablets", "1",
+			fmt.Sprintf("%s/%s", keyspaceName, shard1.Name)); err != nil {
+			return 1, err
+		}
+		if err := destMaster.VttabletProcess.WaitForBinLogPlayerCount(1); err != nil {
+			return 1, err
+		}
+		// Wait for dst_replica to be ready.
+		if err := destReplica.VttabletProcess.WaitForBinlogServerState("Enabled"); err != nil {
+			return 1, err
+		}
+		return m.Run(), nil
+	}()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
+	} else {
+		os.Exit(exitcode)
+	}
+}
+
+//  Insert something that will replicate incorrectly if the charset is not
+//  propagated through binlog streamer to the destination.
+
+//  Vitess tablets default to using utf8, so we insert something crazy and
+//  pretend it's latin1. If the binlog player doesn't also pretend it's
+//  latin1, it will be inserted as utf8, which will change its value.
+func TestCharset(t *testing.T) {
+	position, _ := cluster.GetMasterPosition(t, *destReplica, hostname)
+
+	_, err := queryTablet(t, *srcMaster, fmt.Sprintf(insertSql, tableName, 1, "Šṛ́rỏé"), "latin1")
+	assert.Nil(t, err)
+	println("Waiting to get rows in dest master tablet")
+	waitForReplicaEvent(t, position, "1", *destReplica)
+
+	verifyData(t, 1, "latin1", `[UINT64(1) VARCHAR("Šṛ́rỏé")]`)
+}
+
+// Enable binlog_checksum, which will also force a log rotation that should
+// cause binlog streamer to notice the new checksum setting.
+func TestChecksumEnabled(t *testing.T) {
+	position, _ := cluster.GetMasterPosition(t, *destReplica, hostname)
+	_, err := queryTablet(t, *destReplica, "SET @@global.binlog_checksum=1", "")
+	assert.Nil(t, err)
+
+	// Insert something and make sure it comes through intact.
+	_, err = queryTablet(t, *srcMaster, fmt.Sprintf(insertSql, tableName, 2, "value - 2"), "")
+	assert.Nil(t, err)
+
+	//  Look for it using update stream to see if binlog streamer can talk to
+	//  dest_replica, which now has binlog_checksum enabled.
+	waitForReplicaEvent(t, position, "2", *destReplica)
+
+	verifyData(t, 2, "", `[UINT64(2) VARCHAR("value - 2")]`)
+}
+
+// Disable binlog_checksum to make sure we can also talk to a server without
+// checksums enabled, in case they are enabled by default
+func TestChecksumDisabled(t *testing.T) {
+	position, _ := cluster.GetMasterPosition(t, *destReplica, hostname)
+
+	_, err := queryTablet(t, *destReplica, "SET @@global.binlog_checksum=0", "")
+	assert.Nil(t, err)
+
+	// Insert something and make sure it comes through intact.
+	_, err = queryTablet(t, *srcMaster, fmt.Sprintf(insertSql, tableName, 3, "value - 3"), "")
+	assert.Nil(t, err)
+
+	// Look for it using update stream to see if binlog streamer can talk to
+	// dest_replica, which now has binlog_checksum disabled.
+	waitForReplicaEvent(t, position, "3", *destReplica)
+
+	verifyData(t, 3, "", `[UINT64(3) VARCHAR("value - 3")]`)
+}
+
+// Wait for a replica event with the given SQL string.
+func waitForReplicaEvent(t *testing.T, position string, pkKey string, vttablet cluster.Vttablet) {
+	timeout := time.Now().Add(10 * time.Second)
+	for time.Now().Before(timeout) {
+		println("fetching with position " + position)
+		output, err := localCluster.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletUpdateStream", "-position", position, "-count", "1", vttablet.Alias)
+		assert.Nil(t, err)
+
+		var binlogStreamEvent query.StreamEvent
+		err = json.Unmarshal([]byte(output), &binlogStreamEvent)
+		assert.Nil(t, err)
+		for _, statement := range binlogStreamEvent.Statements {
+			if isCurrentRowPresent(*statement, pkKey) {
+				return
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+		position = binlogStreamEvent.EventToken.Position
+	}
+}
+
+func isCurrentRowPresent(statement query.StreamEvent_Statement, pkKey string) bool {
+	if statement.TableName == tableName &&
+		statement.PrimaryKeyFields[0].Name == "id" &&
+		fmt.Sprintf("%s", statement.PrimaryKeyValues[0].Values) == pkKey {
+		return true
+	}
+	return false
+}
+
+func verifyData(t *testing.T, id uint64, charset string, expectedOutput string) {
+	data, err := queryTablet(t, *destMaster, fmt.Sprintf("select id, msg from %s where id = %d", tableName, id), charset)
+	assert.Nil(t, err)
+	assert.NotNil(t, data.Rows)
+	rowFound := assert.Equal(t, len(data.Rows), 1)
+	assert.Equal(t, len(data.Fields), 2)
+	if rowFound {
+		assert.Equal(t, fmt.Sprintf("%v", data.Rows[0]), expectedOutput)
+	}
+}
+
+func queryTablet(t *testing.T, vttablet cluster.Vttablet, query string, charset string) (*sqltypes.Result, error) {
+	dbParams := mysql.ConnParams{
+		Uname:      "vt_dba",
+		UnixSocket: path.Join(vttablet.VttabletProcess.Directory, "mysql.sock"),
+
+		DbName: fmt.Sprintf("vt_%s", keyspaceName),
+	}
+	if charset != "" {
+		dbParams.Charset = charset
+	}
+	ctx := context.Background()
+	dbConn, err := mysql.Connect(ctx, &dbParams)
+	assert.Nil(t, err)
+	defer dbConn.Close()
+	return dbConn.ExecuteFetch(query, 1000, true)
+}

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This test cell aliases feature
+
+We start with no aliases and assert that vtgates can't route to replicas/rondly tablets.
+Then we add an alias, and these tablets should be routable
+*/
+
+package binlog
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/sharding"
+	"vitess.io/vitess/go/vt/proto/topodata"
+)
+
+var (
+	localCluster *cluster.LocalProcessCluster
+	cell1        = "zone1"
+	cell2        = "zone2"
+	hostname     = "localhost"
+	keyspaceName = "ks"
+	tableName    = "test_table"
+	sqlSchema    = `
+					create table %s(
+					id bigint(20) unsigned auto_increment,
+					msg varchar(64),
+					primary key (id),
+					index by_msg (msg)
+					) Engine=InnoDB
+`
+	commonTabletArg = []string{
+		"-vreplication_healthcheck_topology_refresh", "1s",
+		"-vreplication_healthcheck_retry_delay", "1s",
+		"-vreplication_retry_delay", "1s",
+		"-degraded_threshold", "5s",
+		"-lock_tables_timeout", "5s",
+		"-watch_replication_stream",
+		"-enable_replication_reporter",
+		"-serving_state_grace_period", "1s",
+		"-binlog_player_protocol", "grpc",
+		"-enable-autocommit",
+	}
+	vSchema = `
+		{
+		  "sharded": true,
+		  "vindexes": {
+			"hash_index": {
+			  "type": "hash"
+			}
+		  },
+		  "tables": {
+			"%s": {
+			   "column_vindexes": [
+				{
+				  "column": "id",
+				  "name": "hash_index"
+				}
+			  ] 
+			}
+		  }
+		}
+`
+	shard1Master  *cluster.Vttablet
+	shard1Replica *cluster.Vttablet
+	shard1Rdonly  *cluster.Vttablet
+	shard2Master  *cluster.Vttablet
+	shard2Replica *cluster.Vttablet
+	shard2Rdonly  *cluster.Vttablet
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitcode, err := func() (int, error) {
+		localCluster = cluster.NewCluster(cell1, hostname)
+		defer localCluster.Teardown()
+		localCluster.Keyspaces = append(localCluster.Keyspaces, cluster.Keyspace{
+			Name: keyspaceName,
+		})
+
+		// Start topo server
+		if err := localCluster.StartTopo(); err != nil {
+			return 1, err
+		}
+
+		// Adding another cell in the same cluster
+		err := localCluster.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+cell2)
+		if err != nil {
+			return 1, err
+		}
+		err = localCluster.VtctlProcess.AddCellInfo(cell2)
+		if err != nil {
+			return 1, err
+		}
+
+		shard1Master = localCluster.GetVttabletInstance("master", 0, "")
+		shard1Replica = localCluster.GetVttabletInstance("replica", 0, cell2)
+		shard1Rdonly = localCluster.GetVttabletInstance("rdonly", 0, cell2)
+
+		shard2Master = localCluster.GetVttabletInstance("master", 0, "")
+		shard2Replica = localCluster.GetVttabletInstance("replica", 0, cell2)
+		shard2Rdonly = localCluster.GetVttabletInstance("rdonly", 0, cell2)
+
+		var mysqlProcs []*exec.Cmd
+		for _, tablet := range []*cluster.Vttablet{shard1Master, shard1Replica, shard1Rdonly, shard2Master, shard2Replica, shard2Rdonly} {
+			tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, localCluster.TmpDirectory)
+			tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,
+				tablet.GrpcPort,
+				tablet.TabletUID,
+				tablet.Cell,
+				"",
+				keyspaceName,
+				localCluster.VtctldProcess.Port,
+				tablet.Type,
+				localCluster.TopoPort,
+				hostname,
+				localCluster.TmpDirectory,
+				commonTabletArg,
+				true,
+			)
+			tablet.VttabletProcess.SupportsBackup = true
+			proc, err := tablet.MysqlctlProcess.StartProcess()
+			if err != nil {
+				return 1, err
+			}
+			mysqlProcs = append(mysqlProcs, proc)
+		}
+		for _, proc := range mysqlProcs {
+			if err := proc.Wait(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := localCluster.VtctlProcess.CreateKeyspace(keyspaceName); err != nil {
+			return 1, err
+		}
+
+		shard1 := cluster.Shard{
+			Name:      "-80",
+			Vttablets: []*cluster.Vttablet{shard1Master, shard1Replica, shard1Rdonly},
+		}
+		for idx := range shard1.Vttablets {
+			shard1.Vttablets[idx].VttabletProcess.Shard = shard1.Name
+		}
+		localCluster.Keyspaces[0].Shards = append(localCluster.Keyspaces[0].Shards, shard1)
+
+		shard2 := cluster.Shard{
+			Name:      "80-",
+			Vttablets: []*cluster.Vttablet{shard2Master, shard2Replica, shard2Rdonly},
+		}
+		for idx := range shard2.Vttablets {
+			shard2.Vttablets[idx].VttabletProcess.Shard = shard2.Name
+		}
+		localCluster.Keyspaces[0].Shards = append(localCluster.Keyspaces[0].Shards, shard2)
+
+		for _, tablet := range shard1.Vttablets {
+			if err := localCluster.VtctlclientProcess.InitTablet(tablet, tablet.Cell, keyspaceName, hostname, shard1.Name); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.CreateDB(keyspaceName); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+		if err := localCluster.VtctlclientProcess.InitShardMaster(keyspaceName, shard1.Name, shard1Master.Cell, shard1Master.TabletUID); err != nil {
+			return 1, err
+		}
+
+		// run a health check on source replica so it responds to discovery
+		// (for binlog players) and on the source rdonlys (for workers)
+		for _, tablet := range []string{shard1Replica.Alias, shard1Rdonly.Alias} {
+			if err := localCluster.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet); err != nil {
+				return 1, err
+			}
+		}
+
+		for _, tablet := range shard2.Vttablets {
+			if err := localCluster.VtctlclientProcess.InitTablet(tablet, tablet.Cell, keyspaceName, hostname, shard2.Name); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.CreateDB(keyspaceName); err != nil {
+				return 1, err
+			}
+			if err := tablet.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+
+		if err := localCluster.VtctlclientProcess.InitShardMaster(keyspaceName, shard2.Name, shard2Master.Cell, shard2Master.TabletUID); err != nil {
+			return 1, err
+		}
+
+		if err := localCluster.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(sqlSchema, tableName)); err != nil {
+			return 1, err
+		}
+		if err := localCluster.VtctlclientProcess.ApplyVSchema(keyspaceName, fmt.Sprintf(vSchema, tableName)); err != nil {
+			return 1, err
+		}
+
+		_ = localCluster.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+
+		return m.Run(), nil
+	}()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
+	} else {
+		os.Exit(exitcode)
+	}
+}
+
+func TestAlias(t *testing.T) {
+	insertInitialValues(t)
+	err := localCluster.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	assert.Nil(t, err)
+	shard1 := localCluster.Keyspaces[0].Shards[0]
+	shard2 := localCluster.Keyspaces[0].Shards[1]
+	allCells := fmt.Sprintf("%s,%s", cell1, cell2)
+
+	expectedPartitions := map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard1.Name, shard2.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard1.Name, shard2.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard1.Name, shard2.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *localCluster)
+	sharding.CheckSrvKeyspace(t, cell2, keyspaceName, "", 0, expectedPartitions, *localCluster)
+
+	// Adds alias so vtgate can route to replica/rdonly tablets that are not in the same cell, but same alias
+	err = localCluster.VtctlclientProcess.ExecuteCommand("AddCellsAlias",
+		"-cells", allCells,
+		"region_east_coast")
+	assert.Nil(t, err)
+	err = localCluster.VtctlclientProcess.ExecuteCommand("UpdateCellsAlias",
+		"-cells", allCells,
+		"region_east_coast")
+	assert.Nil(t, err)
+
+	vtgateInstance := localCluster.GetVtgateInstance()
+	vtgateInstance.CellsToWatch = allCells
+	vtgateInstance.TabletTypesToWait = "MASTER,REPLICA"
+	err = vtgateInstance.Setup()
+	assert.Nil(t, err)
+	waitTillAllTabletsAreHealthyInVtgate(t, *vtgateInstance, shard1.Name, shard2.Name)
+
+	testQueriesInDifferentTabletType(t, "master", vtgateInstance.GrpcPort, false)
+	testQueriesInDifferentTabletType(t, "replica", vtgateInstance.GrpcPort, false)
+	testQueriesInDifferentTabletType(t, "rdonly", vtgateInstance.GrpcPort, false)
+
+	// now, delete the alias, so that if we run above assertions again, it will fail for replica,rdonly target type
+	err = localCluster.VtctlclientProcess.ExecuteCommand("DeleteCellsAlias",
+		"region_east_coast")
+	assert.Nil(t, err)
+
+	// restarts the vtgate process
+	_ = vtgateInstance.TearDown()
+	vtgateInstance.TabletTypesToWait = "MASTER"
+	err = vtgateInstance.Setup()
+	assert.Nil(t, err)
+
+	// since replica and rdonly tablets of all shards in cell2, the last 2 assertion is expected to fail
+	testQueriesInDifferentTabletType(t, "master", vtgateInstance.GrpcPort, false)
+	testQueriesInDifferentTabletType(t, "replica", vtgateInstance.GrpcPort, true)
+	testQueriesInDifferentTabletType(t, "rdonly", vtgateInstance.GrpcPort, true)
+}
+
+func waitTillAllTabletsAreHealthyInVtgate(t *testing.T, vtgateInstance cluster.VtgateProcess, shards ...string) {
+	for _, shard := range shards {
+		err := vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard))
+		assert.Nil(t, err)
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard))
+		assert.Nil(t, err)
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard))
+		assert.Nil(t, err)
+	}
+}
+
+func testQueriesInDifferentTabletType(t *testing.T, tabletType string, vtgateGrpcPort int, shouldFail bool) {
+	output, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("VtGateExecute", "-json",
+		"-server", fmt.Sprintf("%s:%d", localCluster.Hostname, vtgateGrpcPort),
+		"-target", "@"+tabletType,
+		fmt.Sprintf(`select * from %s`, tableName))
+	if shouldFail {
+		assert.NotNil(t, err)
+		return
+	}
+	assert.Nil(t, err)
+	var result sqltypes.Result
+
+	err = json.Unmarshal([]byte(output), &result)
+	assert.Nil(t, err)
+	assert.Equal(t, len(result.Rows), 3)
+}
+
+func insertInitialValues(t *testing.T) {
+	sharding.InsertToTablet(t,
+		fmt.Sprintf(sharding.InsertTabletTemplateKsID, tableName, 1, "msg1", 1),
+		*shard1Master,
+		keyspaceName,
+		false)
+
+	sharding.InsertToTablet(t,
+		fmt.Sprintf(sharding.InsertTabletTemplateKsID, tableName, 2, "msg2", 2),
+		*shard1Master,
+		keyspaceName,
+		false)
+
+	sharding.InsertToTablet(t,
+		fmt.Sprintf(sharding.InsertTabletTemplateKsID, tableName, 4, "msg4", 4),
+		*shard2Master,
+		keyspaceName,
+		false)
+}

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -92,7 +92,7 @@ func (shard *Shard) MasterTablet() *Vttablet {
 	return shard.Vttablets[0]
 }
 
-// Rdonly gets first rdonly tablet
+// Rdonly get the last tablet which is rdonly
 func (shard *Shard) Rdonly() *Vttablet {
 	for idx, tablet := range shard.Vttablets {
 		if tablet.Type == "rdonly" {
@@ -102,7 +102,8 @@ func (shard *Shard) Rdonly() *Vttablet {
 	return nil
 }
 
-// Replica gets the first replica tablet
+// Replica get the last but one tablet which is replica
+// Mostly we have either 3 tablet setup [master, replica, rdonly]
 func (shard *Shard) Replica() *Vttablet {
 	for idx, tablet := range shard.Vttablets {
 		if tablet.Type == "replica" && idx > 0 {
@@ -481,6 +482,7 @@ func (cluster *LocalProcessCluster) Teardown() {
 	if err := cluster.TopoProcess.TearDown(cluster.Cell, cluster.OriginalVTDATAROOT, cluster.CurrentVTDATAROOT, *keepData); err != nil {
 		log.Errorf("Error in etcd teardown - %s", err.Error())
 	}
+
 }
 
 // StartVtworker starts a vtworker

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -482,7 +482,6 @@ func (cluster *LocalProcessCluster) Teardown() {
 	if err := cluster.TopoProcess.TearDown(cluster.Cell, cluster.OriginalVTDATAROOT, cluster.CurrentVTDATAROOT, *keepData); err != nil {
 		log.Errorf("Error in etcd teardown - %s", err.Error())
 	}
-
 }
 
 // StartVtworker starts a vtworker

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -84,19 +84,19 @@ type Keyspace struct {
 // Shard with associated vttablets
 type Shard struct {
 	Name      string
-	Vttablets []Vttablet
+	Vttablets []*Vttablet
 }
 
 // MasterTablet get the 1st tablet which is master
 func (shard *Shard) MasterTablet() *Vttablet {
-	return &shard.Vttablets[0]
+	return shard.Vttablets[0]
 }
 
 // Rdonly gets first rdonly tablet
 func (shard *Shard) Rdonly() *Vttablet {
 	for idx, tablet := range shard.Vttablets {
 		if tablet.Type == "rdonly" {
-			return &shard.Vttablets[idx]
+			return shard.Vttablets[idx]
 		}
 	}
 	return nil
@@ -106,7 +106,7 @@ func (shard *Shard) Rdonly() *Vttablet {
 func (shard *Shard) Replica() *Vttablet {
 	for idx, tablet := range shard.Vttablets {
 		if tablet.Type == "replica" && idx > 0 {
-			return &shard.Vttablets[idx]
+			return shard.Vttablets[idx]
 		}
 	}
 	return nil
@@ -120,6 +120,7 @@ type Vttablet struct {
 	GrpcPort  int
 	MySQLPort int
 	Alias     string
+	Cell      string
 
 	// background executable processes
 	MysqlctlProcess MysqlctlProcess
@@ -236,7 +237,7 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 				cluster.VtTabletExtraArgs,
 				cluster.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
-			shard.Vttablets = append(shard.Vttablets, *tablet)
+			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 
 		// wait till all mysqlctl is instantiated
@@ -297,6 +298,68 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 
 	log.Info("Done creating keyspace : " + keyspace.Name)
 	return
+}
+
+// LaunchCluster creates the skeleton for a cluster by creating keyspace
+// shards and initializing tablets and mysqlctl processes.
+// This does not start any process and user have to explicitly start all
+// the required services (ex topo, vtgate, mysql and vttablet)
+func (cluster *LocalProcessCluster) LaunchCluster(keyspace *Keyspace, shards []Shard) (err error) {
+
+	log.Info("Starting keyspace : " + keyspace.Name)
+
+	// Create Keyspace
+	err = cluster.VtctlProcess.CreateKeyspace(keyspace.Name)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	// Create shard
+	for _, shard := range shards {
+		for _, tablet := range shard.Vttablets {
+			err = cluster.VtctlclientProcess.InitTablet(tablet, tablet.Cell, keyspace.Name, cluster.Hostname, shard.Name)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+
+			// Setup MysqlctlProcess
+			tablet.MysqlctlProcess = *MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, cluster.TmpDirectory)
+			// Setup VttabletProcess
+			tablet.VttabletProcess = VttabletProcessInstance(
+				tablet.HTTPPort,
+				tablet.GrpcPort,
+				tablet.TabletUID,
+				tablet.Cell,
+				shard.Name,
+				keyspace.Name,
+				cluster.VtctldProcess.Port,
+				tablet.Type,
+				cluster.TopoProcess.Port,
+				cluster.Hostname,
+				cluster.TmpDirectory,
+				cluster.VtTabletExtraArgs,
+				cluster.EnableSemiSync)
+		}
+
+		keyspace.Shards = append(keyspace.Shards, shard)
+	}
+
+	// if the keyspace is present then append the shard info
+	existingKeyspace := false
+	for idx, ks := range cluster.Keyspaces {
+		if ks.Name == keyspace.Name {
+			cluster.Keyspaces[idx].Shards = append(cluster.Keyspaces[idx].Shards, keyspace.Shards...)
+			existingKeyspace = true
+		}
+	}
+	if !existingKeyspace {
+		cluster.Keyspaces = append(cluster.Keyspaces, *keyspace)
+	}
+
+	log.Info("Done launching keyspace : " + keyspace.Name)
+	return err
 }
 
 // StartVtgate starts vtgate
@@ -459,17 +522,21 @@ func getRandomNumber(maxNumber int32, baseNumber int) int {
 }
 
 // GetVttabletInstance creates a new vttablet object
-func (cluster *LocalProcessCluster) GetVttabletInstance(UID int) *Vttablet {
+func (cluster *LocalProcessCluster) GetVttabletInstance(tabletType string, UID int, cell string) *Vttablet {
 	if UID == 0 {
 		UID = cluster.GetAndReserveTabletUID()
+	}
+	if cell == "" {
+		cell = cluster.Cell
 	}
 	return &Vttablet{
 		TabletUID: UID,
 		HTTPPort:  cluster.GetAndReservePort(),
 		GrpcPort:  cluster.GetAndReservePort(),
 		MySQLPort: cluster.GetAndReservePort(),
-		Type:      "replica",
-		Alias:     fmt.Sprintf("%s-%010d", cluster.Cell, UID),
+		Type:      tabletType,
+		Cell:      cell,
+		Alias:     fmt.Sprintf("%s-%010d", cell, UID),
 	}
 }
 

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tabletpb "vitess.io/vitess/go/vt/proto/topodata"
+	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
+)
+
+var (
+	tmClient = tmc.NewClient()
+)
+
+// GetMasterPosition gets the master position of required vttablet
+func GetMasterPosition(t *testing.T, vttablet Vttablet, hostname string) (string, string) {
+	ctx := context.Background()
+	vtablet := getTablet(vttablet.GrpcPort, hostname)
+	pos, err := tmClient.MasterPosition(ctx, vtablet)
+	require.NoError(t, err)
+	gtID := strings.SplitAfter(pos, "/")[1]
+	return pos, gtID
+}
+
+func getTablet(tabletGrpcPort int, hostname string) *tabletpb.Tablet {
+	portMap := make(map[string]int32)
+	portMap["grpc"] = int32(tabletGrpcPort)
+	return &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
+}

--- a/go/test/endtoend/cluster/etcd_process.go
+++ b/go/test/endtoend/cluster/etcd_process.go
@@ -109,6 +109,7 @@ func (etcd *EtcdProcess) TearDown(Cell string, originalVtRoot string, currentRoo
 		_ = os.RemoveAll(currentRoot)
 	}
 	_ = os.Setenv("VTDATAROOT", originalVtRoot)
+
 	select {
 	case <-etcd.exit:
 		etcd.proc = nil

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -76,7 +76,6 @@ func (mysqlctl *MysqlctlProcess) StartProcess() (*exec.Cmd, error) {
 	}
 	tmpProcess.Args = append(tmpProcess.Args, "init",
 		"-init_db_sql_file", mysqlctl.InitDBFile)
-
 	return tmpProcess, tmpProcess.Start()
 }
 
@@ -95,12 +94,10 @@ func (mysqlctl *MysqlctlProcess) StopProcess() (*exec.Cmd, error) {
 		mysqlctl.Binary,
 		"-tablet_uid", fmt.Sprintf("%d", mysqlctl.TabletUID),
 	)
-
 	if len(mysqlctl.ExtraArgs) > 0 {
 		tmpProcess.Args = append(tmpProcess.Args, mysqlctl.ExtraArgs...)
 	}
 	tmpProcess.Args = append(tmpProcess.Args, "shutdown")
-
 	return tmpProcess, tmpProcess.Start()
 }
 
@@ -126,7 +123,6 @@ func MysqlCtlProcessInstance(tabletUID int, mySQLPort int, tmpDirectory string) 
 	mysqlctl.TabletUID = tabletUID
 	return mysqlctl
 }
-
 
 // StartMySQL starts mysqlctl process
 func StartMySQL(ctx context.Context, tablet *Vttablet, username string, tmpDirectory string) error {

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -127,6 +127,7 @@ func MysqlCtlProcessInstance(tabletUID int, mySQLPort int, tmpDirectory string) 
 	return mysqlctl
 }
 
+
 // StartMySQL starts mysqlctl process
 func StartMySQL(ctx context.Context, tablet *Vttablet, username string, tmpDirectory string) error {
 	tablet.MysqlctlProcess = *MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, tmpDirectory)

--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -47,6 +47,7 @@ func (vtctl *VtctlProcess) AddCellInfo(Cell string) (err error) {
 		"-server_address", vtctl.TopoServerAddress,
 		Cell,
 	)
+	log.Info(fmt.Sprintf("Adding Cell into Keyspace with arguments %v", strings.Join(tmpProcess.Args, " ")))
 	return tmpProcess.Run()
 }
 

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -99,7 +99,6 @@ func VtctlClientProcessInstance(hostname string, grpcPort int, tmpDirectory stri
 
 // InitTablet initializes a tablet
 func (vtctlclient *VtctlClientProcess) InitTablet(tablet *Vttablet, cell string, keyspaceName string, hostname string, shardName string) error {
-
 	tabletType := "replica"
 	if tablet.Type == "rdonly" {
 		tabletType = "rdonly"

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -88,6 +88,7 @@ func TestMain(m *testing.M) {
 		if err := clusterForKSTest.StartTopo(); err != nil {
 			return 1
 		}
+
 		if err := clusterForKSTest.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+cell2); err != nil {
 			return 1
 		}

--- a/go/test/endtoend/keyspace/keyspace_test.go
+++ b/go/test/endtoend/keyspace/keyspace_test.go
@@ -261,6 +261,7 @@ func RemoveKeyspaceCell(t *testing.T) {
 
 	//Check that the shard is gone from zone2.
 	srvKeyspaceZone2 := getSrvKeyspace(t, cell2, "test_delete_keyspace_removekscell")
+
 	for _, partition := range srvKeyspaceZone2.Partitions {
 		assert.Equal(t, len(partition.ShardReferences), 1)
 	}
@@ -273,6 +274,7 @@ func RemoveKeyspaceCell(t *testing.T) {
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", "test_delete_keyspace_removekscell")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetKeyspace", "test_delete_keyspace_removekscell")
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetShard", "test_delete_keyspace_removekscell/0")
+
 	_ = clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetTablet", "zone1-0000000100")
 
 	err := clusterForKSTest.VtctlclientProcess.ExecuteCommand("GetTablet", "zone2-0000000100")

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -118,7 +118,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.VtTabletExtraArgs,
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
-
 			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {
@@ -164,4 +163,5 @@ func TestAutoDetect(t *testing.T) {
 
 	//Reset flavor
 	os.Setenv("MYSQL_FLAVOR", sqlFlavor)
+
 }

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -62,9 +62,9 @@ func TestMain(m *testing.M) {
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
 			if tablet.Type == "master" {
-				masterTablet = tablet
+				masterTablet = *tablet
 			} else if tablet.Type != "rdonly" {
-				replicaTablet = tablet
+				replicaTablet = *tablet
 			}
 		}
 
@@ -119,7 +119,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 
-			shard.Vttablets = append(shard.Vttablets, *tablet)
+			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {
 			if err := proc.Wait(); err != nil {

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -234,7 +234,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
 
-			shard.Vttablets = append(shard.Vttablets, *tablet)
+			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {
 			if err := proc.Wait(); err != nil {

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -233,7 +233,6 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.VtTabletExtraArgs,
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
-
 			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -64,8 +65,10 @@ func CheckSrvKeyspace(t *testing.T, cell string, ksname string, shardingCol stri
 	assert.True(t, reflect.DeepEqual(currentPartition, expectedPartition))
 }
 
+
 // GetSrvKeyspace return the Srv Keyspace structure
 func GetSrvKeyspace(t *testing.T, cell string, ksname string, ci cluster.LocalProcessCluster) *topodata.SrvKeyspace {
+
 	output, err := ci.VtctlclientProcess.ExecuteCommandWithOutput("GetSrvKeyspace", cell, ksname)
 	assert.Nil(t, err)
 	var srvKeyspace topodata.SrvKeyspace
@@ -75,6 +78,7 @@ func GetSrvKeyspace(t *testing.T, cell string, ksname string, ci cluster.LocalPr
 	return &srvKeyspace
 }
 
+
 // VerifyTabletHealth checks that the tablet URL is reachable.
 func VerifyTabletHealth(t *testing.T, vttablet cluster.Vttablet, hostname string) {
 	tabletURL := fmt.Sprintf("http://%s:%d/healthz", hostname, vttablet.HTTPPort)
@@ -82,6 +86,7 @@ func VerifyTabletHealth(t *testing.T, vttablet cluster.Vttablet, hostname string
 	assert.Nil(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 }
+
 
 // VerifyReconciliationCounters checks that the reconciliation Counters have the expected values.
 func VerifyReconciliationCounters(t *testing.T, vtworkerURL string, availabilityType string, table string,
@@ -305,6 +310,7 @@ func InsertMultiValues(t *testing.T, tablet cluster.Vttablet, keyspaceName strin
 	InsertToTablet(t, queryStr, tablet, keyspaceName, false)
 }
 
+
 // CheckLotsTimeout waits till all values are inserted
 func CheckLotsTimeout(t *testing.T, vttablet cluster.Vttablet, count uint64, table string, ks string, keyType querypb.Type, pctFound int) bool {
 	timeout := time.Now().Add(10 * time.Second)
@@ -389,6 +395,7 @@ func CheckTabletQueryService(t *testing.T, vttablet cluster.Vttablet, expectedSt
 		assert.Equal(t, tabletStatus, expectedStatus)
 	}
 }
+
 
 // CheckShardQueryServices checks DisableQueryService for all shards
 func CheckShardQueryServices(t *testing.T, ci cluster.LocalProcessCluster, shards []cluster.Shard, cell string,

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -65,10 +64,8 @@ func CheckSrvKeyspace(t *testing.T, cell string, ksname string, shardingCol stri
 	assert.True(t, reflect.DeepEqual(currentPartition, expectedPartition))
 }
 
-
 // GetSrvKeyspace return the Srv Keyspace structure
 func GetSrvKeyspace(t *testing.T, cell string, ksname string, ci cluster.LocalProcessCluster) *topodata.SrvKeyspace {
-
 	output, err := ci.VtctlclientProcess.ExecuteCommandWithOutput("GetSrvKeyspace", cell, ksname)
 	assert.Nil(t, err)
 	var srvKeyspace topodata.SrvKeyspace
@@ -78,7 +75,6 @@ func GetSrvKeyspace(t *testing.T, cell string, ksname string, ci cluster.LocalPr
 	return &srvKeyspace
 }
 
-
 // VerifyTabletHealth checks that the tablet URL is reachable.
 func VerifyTabletHealth(t *testing.T, vttablet cluster.Vttablet, hostname string) {
 	tabletURL := fmt.Sprintf("http://%s:%d/healthz", hostname, vttablet.HTTPPort)
@@ -86,7 +82,6 @@ func VerifyTabletHealth(t *testing.T, vttablet cluster.Vttablet, hostname string
 	assert.Nil(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 }
-
 
 // VerifyReconciliationCounters checks that the reconciliation Counters have the expected values.
 func VerifyReconciliationCounters(t *testing.T, vtworkerURL string, availabilityType string, table string,
@@ -310,7 +305,6 @@ func InsertMultiValues(t *testing.T, tablet cluster.Vttablet, keyspaceName strin
 	InsertToTablet(t, queryStr, tablet, keyspaceName, false)
 }
 
-
 // CheckLotsTimeout waits till all values are inserted
 func CheckLotsTimeout(t *testing.T, vttablet cluster.Vttablet, count uint64, table string, ks string, keyType querypb.Type, pctFound int) bool {
 	timeout := time.Now().Add(10 * time.Second)
@@ -395,7 +389,6 @@ func CheckTabletQueryService(t *testing.T, vttablet cluster.Vttablet, expectedSt
 		assert.Equal(t, tabletStatus, expectedStatus)
 	}
 }
-
 
 // CheckShardQueryServices checks DisableQueryService for all shards
 func CheckShardQueryServices(t *testing.T, ci cluster.LocalProcessCluster, shards []cluster.Shard, cell string,

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -400,6 +400,7 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 
 	// Wait for the endpoints, either local or remote.
 	for _, shard := range []cluster.Shard{shard1, shard21, shard22} {
+
 		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard.Name))
 		assert.Nil(t, err)
 		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard.Name))
@@ -414,7 +415,6 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard1.Name}
 	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard1.Name}
 	checkSrvKeyspaceForSharding(t, keyspaceName, expectedPartitions)
-
 
 	err = ClusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard",
 		"--exclude_tables", "unrelated",

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -415,6 +415,7 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard1.Name}
 	checkSrvKeyspaceForSharding(t, keyspaceName, expectedPartitions)
 
+
 	err = ClusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard",
 		"--exclude_tables", "unrelated",
 		shard1.Rdonly().Alias, fmt.Sprintf("%s/%s", keyspaceName, shard21.Name))

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -1,0 +1,1280 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resharding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/mysql"
+
+	"github.com/prometheus/common/log"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/sharding"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/proto/topodata"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// ClusterInstance instance to be used for test with different params
+	clusterInstance      *cluster.LocalProcessCluster
+	hostname             = "localhost"
+	keyspaceName         = "ks"
+	cell1                = "zone1"
+	cell2                = "zone2"
+	createTabletTemplate = `
+							create table %s(
+							custom_ksid_col %s not null,
+							msg varchar(64),
+							id bigint not null,
+							parent_id bigint not null,
+							primary key (parent_id, id),
+							index by_msg (msg)
+							) Engine=InnoDB;
+							`
+	createTableBindataTemplate = `
+							create table %s(
+							custom_ksid_col %s not null,
+							id bigint not null,
+							parent_id bigint not null,
+							msg bit(8),
+							primary key (parent_id, id),
+							index by_msg (msg)
+							) Engine=InnoDB;
+							`
+	createViewTemplate = `
+		create view %s (parent_id, id, msg, custom_ksid_col) as select parent_id, id, msg, custom_ksid_col from %s;
+		`
+	createTimestampTable = `
+							create table timestamps(
+							id int not null,
+							time_milli bigint(20) unsigned not null,
+							custom_ksid_col %s not null,
+							primary key (id)
+							) Engine=InnoDB;
+							`
+	// Make sure that clone and diff work with tables which have no primary key.
+	// Work with RBR only
+	createNoPkTable = `
+							create table no_pk(
+							custom_ksid_col %s not null,
+							msg varchar(64),
+							id bigint not null,
+							parent_id bigint not null
+							) Engine=InnoDB;
+							`
+	createUnrelatedTable = `
+							create table unrelated(
+							custom_ksid_col bigint not null,
+							name varchar(64),
+							primary key (name)
+							) Engine=InnoDB;
+							`
+	fixedParentID = 86
+	tableName     = "resharding1"
+	vSchema       = `
+							{
+							  "sharded": true,
+							  "vindexes": {
+								"hash_index": {
+								  "type": "hash"
+								}
+							  },
+							  "tables": {
+								"resharding1": {
+								   "column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								},
+                                "resharding2": {
+								   "column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								},
+                                "resharding3": {
+								   "column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								},
+								"no_pk": {
+								   "column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								},
+								"timestamps": {
+								   "column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								},
+								"unrelated": {
+									"column_vindexes": [
+									{
+									  "column": "custom_ksid_col",
+									  "name": "hash_index"
+									}
+								  ] 
+								}
+							  }
+							}
+						`
+
+	// initial shards
+	// range '' - 80  &  range 80 - ''
+	shard0 = &cluster.Shard{Name: "-80"}
+	shard1 = &cluster.Shard{Name: "80-"}
+
+	// split shards
+	// range 80 - c0    &   range c0 - ''
+	shard2 = &cluster.Shard{Name: "80-c0"}
+	shard3 = &cluster.Shard{Name: "c0-"}
+
+	// Sharding keys
+	key1 uint64 = 1152921504606846976  // Key redirect to shard 0
+	key2 uint64 = 14987979559889010688 // key redirect to shard 1 (& 2 after Resharding)
+	key3 uint64 = 10376293541461622784 // Key redirect to shard 1 (& 3 after Resharding)
+	key4 uint64 = 10376293541461622789 // Key redirect to shard 1 (& 3 after Resharding)
+	key5 uint64 = 14987979559889010670 // key redirect to shard 1 (& 2 after Resharding)
+	key6 uint64 = 17293822569102704640
+
+	// insertTabletTemplateKsID common insert format
+	insertTabletTemplateKsID = `insert into %s (parent_id, id, msg, custom_ksid_col) values (%d, %d, '%s', %d) /* vtgate:: keyspace_id:%d */ /* id:%d */`
+)
+
+// TestResharding - main test with accepts different params for various test
+func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
+	clusterInstance = cluster.NewCluster(cell1, hostname)
+	defer clusterInstance.Teardown()
+
+	// Launch keyspace
+	keyspace := &cluster.Keyspace{Name: keyspaceName}
+
+	// Start topo server
+	err := clusterInstance.StartTopo()
+	assert.Nil(t, err)
+
+	// Adding another cell in the same cluster
+	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+cell2)
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlProcess.AddCellInfo(cell2)
+	assert.Nil(t, err)
+
+	// Defining all the tablets
+	shard0Master := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard0Replica := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard0RdonlyZ2 := clusterInstance.GetVttabletInstance("rdonly", 0, cell2)
+
+	shard1Master := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard1Replica1 := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard1Replica2 := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard1Rdonly := clusterInstance.GetVttabletInstance("rdonly", 0, "")
+	shard1RdonlyZ2 := clusterInstance.GetVttabletInstance("rdonly", 0, cell2)
+
+	shard2Master := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard2Replica1 := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard2Replica2 := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard2Rdonly := clusterInstance.GetVttabletInstance("rdonly", 0, "")
+
+	shard3Master := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard3Replica := clusterInstance.GetVttabletInstance("replica", 0, "")
+	shard3Rdonly := clusterInstance.GetVttabletInstance("rdonly", 0, "")
+
+	shard0.Vttablets = []*cluster.Vttablet{shard0Master, shard0Replica, shard0RdonlyZ2}
+	shard1.Vttablets = []*cluster.Vttablet{shard1Master, shard1Replica1, shard1Replica2, shard1Rdonly, shard1RdonlyZ2}
+	shard2.Vttablets = []*cluster.Vttablet{shard2Master, shard2Replica1, shard2Replica2, shard2Rdonly}
+	shard3.Vttablets = []*cluster.Vttablet{shard3Master, shard3Replica, shard3Rdonly}
+
+	clusterInstance.VtTabletExtraArgs = []string{
+		"-vreplication_healthcheck_topology_refresh", "1s",
+		"-vreplication_healthcheck_retry_delay", "1s",
+		"-vreplication_retry_delay", "1s",
+		"-degraded_threshold", "5s",
+		"-lock_tables_timeout", "5s",
+		"-watch_replication_stream",
+		"-enable_semi_sync",
+		"-enable_replication_reporter",
+		"-enable-tx-throttler",
+		"-binlog_use_v3_resharding_mode=true",
+	}
+
+	shardingColumnType := "bigint(20) unsigned"
+	shardingKeyType := querypb.Type_UINT64
+
+	if useVarbinaryShardingKeyType {
+		shardingColumnType = "varbinary(64)"
+		shardingKeyType = querypb.Type_VARBINARY
+	}
+
+	// Initialize Cluster
+	err = clusterInstance.LaunchCluster(keyspace, []cluster.Shard{*shard0, *shard1, *shard2, *shard3})
+	assert.Nil(t, err)
+	assert.Equal(t, len(clusterInstance.Keyspaces[0].Shards), 4)
+
+	//Start MySql
+	var mysqlCtlProcessList []*exec.Cmd
+	for _, shard := range clusterInstance.Keyspaces[0].Shards {
+		for _, tablet := range shard.Vttablets {
+			fmt.Println("Starting MySql for tablet ", tablet.Alias)
+			if proc, err := tablet.MysqlctlProcess.StartProcess(); err != nil {
+				t.Fatal(err)
+			} else {
+				mysqlCtlProcessList = append(mysqlCtlProcessList, proc)
+			}
+		}
+	}
+
+	// Wait for mysql processes to start
+	for _, proc := range mysqlCtlProcessList {
+		if err := proc.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Rebuild keyspace Graph
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	assert.Nil(t, err)
+
+	// Get Keyspace and verify the structure
+	srvKeyspace := sharding.GetSrvKeyspace(t, cell1, keyspaceName, *clusterInstance)
+	assert.Equal(t, "", srvKeyspace.GetShardingColumnName())
+
+	//Start Tablets and Wait for the Process
+	for _, shard := range clusterInstance.Keyspaces[0].Shards {
+		for _, tablet := range shard.Vttablets {
+			// Start the tablet
+			err = tablet.VttabletProcess.Setup()
+			assert.Nil(t, err)
+
+			// Create Database
+			_, err = tablet.VttabletProcess.QueryTablet(fmt.Sprintf("create database vt_%s",
+				keyspace.Name), keyspace.Name, false)
+			assert.Nil(t, err)
+		}
+	}
+
+	// Init Shard Master
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("InitShardMaster",
+		"-force", fmt.Sprintf("%s/%s", keyspaceName, shard0.Name), shard0Master.Alias)
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("InitShardMaster",
+		"-force", fmt.Sprintf("%s/%s", keyspaceName, shard1.Name), shard1Master.Alias)
+	assert.Nil(t, err)
+
+	// Init Shard Master on Split Shards
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("InitShardMaster",
+		"-force", fmt.Sprintf("%s/%s", keyspaceName, shard2.Name), shard2Master.Alias)
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("InitShardMaster",
+		"-force", fmt.Sprintf("%s/%s", keyspaceName, shard3.Name), shard3Master.Alias)
+	assert.Nil(t, err)
+
+	// Wait for tablets to come in Service state
+	err = shard0Master.VttabletProcess.WaitForTabletType("SERVING")
+	assert.Nil(t, err)
+	err = shard1Master.VttabletProcess.WaitForTabletType("SERVING")
+	assert.Nil(t, err)
+	err = shard2Master.VttabletProcess.WaitForTabletType("SERVING")
+	assert.Nil(t, err)
+	err = shard3Master.VttabletProcess.WaitForTabletType("SERVING")
+	assert.Nil(t, err)
+
+	// keyspace/shard name fields
+	shard0Ks := fmt.Sprintf("%s/%s", keyspaceName, shard0.Name)
+	shard1Ks := fmt.Sprintf("%s/%s", keyspaceName, shard1.Name)
+	shard2Ks := fmt.Sprintf("%s/%s", keyspaceName, shard2.Name)
+	shard3Ks := fmt.Sprintf("%s/%s", keyspaceName, shard3.Name)
+
+	// check for shards
+	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("FindAllShardsInKeyspace", keyspaceName)
+	assert.Nil(t, err)
+	resultMap := make(map[string]interface{})
+	err = json.Unmarshal([]byte(result), &resultMap)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(resultMap), "No of shards should be 4")
+
+	// Apply Schema
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createTabletTemplate, "resharding1", shardingColumnType))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createTabletTemplate, "resharding2", shardingColumnType))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createTableBindataTemplate, "resharding3", shardingColumnType))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createViewTemplate, "view1", "resharding3"))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createNoPkTable, shardingColumnType))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, fmt.Sprintf(createTimestampTable, shardingColumnType))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ApplySchema(keyspaceName, createUnrelatedTable)
+	assert.Nil(t, err)
+
+	// Apply VSchema
+	err = clusterInstance.VtctlclientProcess.ApplyVSchema(keyspaceName, vSchema)
+	assert.Nil(t, err)
+
+	// Insert Data
+	insertStartupValues(t)
+
+	// run a health check on source replicas so they respond to discovery
+	// (for binlog players) and on the source rdonlys (for workers)
+	for _, shard := range keyspace.Shards {
+		for _, tablet := range shard.Vttablets {
+			err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet.Alias)
+			assert.Nil(t, err)
+		}
+	}
+
+	// Rebuild keyspace Graph
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	assert.Nil(t, err)
+
+	// check srv keyspace
+	expectedPartitions := map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard1.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	// disable shard1Replica2, so we're sure filtered replication will go from shard1Replica1
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Replica2.Alias, "spare")
+	assert.Nil(t, err)
+
+	err = shard1Replica2.VttabletProcess.WaitForTabletType("NOT_SERVING")
+	assert.Nil(t, err)
+
+	// we need to create the schema, and the worker will do data copying
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard", "--exclude_tables", "unrelated",
+		shard1.Rdonly().Alias, fmt.Sprintf("%s/%s", keyspaceName, shard2.Name))
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard", "--exclude_tables", "unrelated",
+		shard1.Rdonly().Alias, fmt.Sprintf("%s/%s", keyspaceName, shard3.Name))
+	assert.Nil(t, err)
+
+	// Run vtworker as daemon for the following SplitClone commands. -use_v3_resharding_mode default is true
+	err = clusterInstance.StartVtworker(cell1, "--command_display_interval", "10ms")
+	assert.Nil(t, err)
+
+	// Copy the data from the source to the destination shards.
+	// --max_tps is only specified to enable the throttler and ensure that the
+	// code is executed. But the intent here is not to throttle the test, hence
+	// the rate limit is set very high.
+
+	// Initial clone (online).
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("SplitClone",
+		"--offline=false",
+		"--exclude_tables", "unrelated",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_rdonly_tablets", "1",
+		"--max_tps", "9999",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	// Check values in the split shard
+	checkValues(t, *shard2.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, true, tableName, fixedParentID, keyspaceName, shardingKeyType)
+	checkValues(t, *shard3.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, false, tableName, fixedParentID, keyspaceName, shardingKeyType)
+
+	// Reset vtworker such that we can run the next command.
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("Reset")
+	assert.Nil(t, err)
+
+	// Test the correct handling of keyspace_id changes which happen after the first clone.
+	sql := fmt.Sprintf("update resharding1 set custom_ksid_col=%d WHERE id=2", key3)
+	_, err = shard1Master.VttabletProcess.QueryTablet(sql, keyspaceName, true)
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("SplitClone",
+		"--offline=false",
+		"--exclude_tables", "unrelated",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_rdonly_tablets", "1",
+		"--max_tps", "9999",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	checkValues(t, *shard2.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key3)},
+		2, false, tableName, fixedParentID, keyspaceName, shardingKeyType)
+	checkValues(t, *shard3.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key3)},
+		2, true, tableName, fixedParentID, keyspaceName, shardingKeyType)
+
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("Reset")
+	assert.Nil(t, err)
+
+	// Move row 2 back to shard 2 from shard 3 by changing the keyspace_id again
+	sql = fmt.Sprintf("update resharding1 set custom_ksid_col=%d WHERE id=2", key2)
+	_, err = shard1Master.VttabletProcess.QueryTablet(sql, keyspaceName, true)
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("SplitClone",
+		"--offline=false",
+		"--exclude_tables", "unrelated",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_rdonly_tablets", "1",
+		"--max_tps", "9999",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	checkValues(t, *shard2.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, true, tableName, fixedParentID, keyspaceName, shardingKeyType)
+	checkValues(t, *shard3.MasterTablet(), []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, false, tableName, fixedParentID, keyspaceName, shardingKeyType)
+
+	// Reset vtworker such that we can run the next command.
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("Reset")
+	assert.Nil(t, err)
+
+	// Modify the destination shard. SplitClone will revert the changes.
+
+	// Delete row 2 (provokes an insert).
+	_, err = shard2Master.VttabletProcess.QueryTablet("delete from resharding1 where id=2", keyspaceName, true)
+	assert.Nil(t, err)
+	// Update row 3 (provokes an update).
+	_, err = shard3Master.VttabletProcess.QueryTablet("update resharding1 set msg='msg-not-3' where id=3", keyspaceName, true)
+	assert.Nil(t, err)
+
+	// Insert row 4 and 5 (provokes a delete).
+	insertValue(t, shard3.MasterTablet(), keyspaceName, tableName, 4, "msg4", key3)
+	insertValue(t, shard3.MasterTablet(), keyspaceName, tableName, 5, "msg5", key3)
+
+	err = clusterInstance.VtworkerProcess.ExecuteCommand("SplitClone",
+		"--exclude_tables", "unrelated",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_rdonly_tablets", "1",
+		"--max_tps", "9999",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	// Change tablet, which was taken offline, back to rdonly.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Rdonly.Alias, "rdonly")
+	assert.Nil(t, err)
+
+	// Terminate worker daemon because it is no longer needed.
+	err = clusterInstance.VtworkerProcess.TearDown()
+	assert.Nil(t, err)
+
+	// Check startup values
+	checkStartupValues(t, shardingKeyType)
+
+	// check the schema too
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ValidateSchemaKeyspace", "--exclude_tables=unrelated", keyspaceName)
+	assert.Nil(t, err)
+
+	// Verify vreplication table entries
+	qr, err := shard2Master.VttabletProcess.QueryTabletWithDB("select * from vreplication", "_vt")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), "SplitClone")
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), `"keyspace:\"ks\" shard:\"80-\" key_range:<start:\"\\200\" end:\"\\300\" > "`)
+
+	qr, err = shard3.MasterTablet().VttabletProcess.QueryTabletWithDB("select * from vreplication", "_vt")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), "SplitClone")
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), `"keyspace:\"ks\" shard:\"80-\" key_range:<start:\"\\300\" > "`)
+
+	// check the binlog players are running and exporting vars
+	sharding.CheckDestinationMaster(t, *shard2Master, []string{shard1Ks}, *clusterInstance)
+	sharding.CheckDestinationMaster(t, *shard3Master, []string{shard1Ks}, *clusterInstance)
+
+	// When the binlog players/filtered replication is turned on, the query
+	// service must be turned off on the destination masters.
+	// The tested behavior is a safeguard to prevent that somebody can
+	// accidentally modify data on the destination masters while they are not
+	// migrated yet and the source shards are still the source of truth.
+	err = shard2Master.VttabletProcess.WaitForTabletType("NOT_SERVING")
+	assert.Nil(t, err)
+	err = shard3Master.VttabletProcess.WaitForTabletType("NOT_SERVING")
+	assert.Nil(t, err)
+
+	// check that binlog server exported the stats vars
+	sharding.CheckBinlogServerVars(t, *shard1Replica1, 0, 0)
+
+	// Check that the throttler was enabled.
+	// The stream id is hard-coded as 1, which is the first id generated through auto-inc.
+	sharding.CheckThrottlerService(t, fmt.Sprintf("%s:%d", hostname, shard2Master.GrpcPort),
+		[]string{"BinlogPlayer/1"}, 9999, *clusterInstance)
+	sharding.CheckThrottlerService(t, fmt.Sprintf("%s:%d", hostname, shard3Master.GrpcPort),
+		[]string{"BinlogPlayer/1"}, 9999, *clusterInstance)
+
+	// testing filtered replication: insert a bunch of data on shard 1, check we get most of it after a few seconds,
+	// wait for binlog server timeout, check we get all of it.
+	log.Debug("Inserting lots of data on source shard")
+	insertLots(100, 0, *shard1Master, tableName, fixedParentID, keyspaceName)
+	log.Debug("Executing MultiValue Insert Queries")
+	execMultiShardDmls(t, keyspaceName)
+
+	// Checking 100 percent of data is sent quickly
+	assert.True(t, checkLotsTimeout(t, 100, 0, tableName, keyspaceName, shardingKeyType))
+	// Checking no data was sent the wrong way
+	checkLotsNotPresent(t, 100, 0, tableName, keyspaceName, shardingKeyType)
+
+	// Checking MultiValue Insert Queries
+	checkMultiShardValues(t, keyspaceName, shardingKeyType)
+	sharding.CheckBinlogPlayerVars(t, *shard2Master, []string{shard1Ks}, 30)
+	sharding.CheckBinlogPlayerVars(t, *shard3Master, []string{shard1Ks}, 30)
+	sharding.CheckBinlogServerVars(t, *shard1Replica1, 100, 100)
+
+	// use vtworker to compare the data (after health-checking the destination
+	// rdonly tablets so discovery works)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", shard3Rdonly.Alias)
+	assert.Nil(t, err)
+
+	// use vtworker to compare the data
+	clusterInstance.VtworkerProcess.Cell = cell1
+
+	// Compare using SplitDiff
+	log.Debug("Running vtworker SplitDiff")
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
+		clusterInstance.GetAndReservePort(),
+		"--use_v3_resharding_mode=true",
+		"SplitDiff",
+		"--exclude_tables", "unrelated",
+		"--min_healthy_rdonly_tablets", "1",
+		shard3Ks)
+	assert.Nil(t, err)
+
+	// Compare using MultiSplitDiff
+	log.Debug("Running vtworker MultiSplitDiff")
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
+		clusterInstance.GetAndReservePort(),
+		"--use_v3_resharding_mode=true",
+		"MultiSplitDiff",
+		"--exclude_tables", "unrelated",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Rdonly.Alias, "rdonly")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard3Rdonly.Alias, "rdonly")
+	assert.Nil(t, err)
+
+	// get status for destination master tablets, make sure we have it all
+	sharding.CheckRunningBinlogPlayer(t, *shard2Master, 436, 216)
+	sharding.CheckRunningBinlogPlayer(t, *shard3Master, 456, 216)
+
+	// tests a failover switching serving to a different replica
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Replica2.Alias, "replica")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Replica1.Alias, "spare")
+	assert.Nil(t, err)
+
+	err = shard1Replica2.VttabletProcess.WaitForTabletType("SERVING")
+	assert.Nil(t, err)
+	err = shard1Replica1.VttabletProcess.WaitForTabletType("NOT_SERVING")
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", shard1Replica2.Alias)
+	assert.Nil(t, err)
+
+	// test data goes through again
+	log.Debug("Inserting lots of data on source shard")
+	insertLots(100, 100, *shard1Master, tableName, fixedParentID, keyspaceName)
+	log.Debug("Checking 100 percent of data was sent quickly")
+	assert.True(t, checkLotsTimeout(t, 100, 100, tableName, keyspaceName, shardingKeyType))
+	sharding.CheckBinlogServerVars(t, *shard1Replica2, 80, 80)
+
+	// check we can't migrate the master just yet
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes", shard1Ks, "master")
+	assert.NotNil(t, err, "MigrateServedTypes should fail")
+
+	// check query service is off on master 2 and master 3, as filtered replication is enabled.
+	// Even health check that is enabled on master 3 should not interfere (we run it to be sure).
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", shard3Master.Alias)
+	assert.Nil(t, err)
+
+	for _, master := range []cluster.Vttablet{*shard2Master, *shard3Master} {
+		sharding.CheckTabletQueryService(t, master, "NOT_SERVING", false, *clusterInstance)
+		streamHealth, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
+			"VtTabletStreamHealth",
+			"-count", "1", master.Alias)
+		assert.Nil(t, err)
+		log.Debug("Got health: ", streamHealth)
+
+		var streamHealthResponse querypb.StreamHealthResponse
+		err = json.Unmarshal([]byte(streamHealth), &streamHealthResponse)
+		assert.Nil(t, err)
+		assert.Equal(t, streamHealthResponse.Serving, false)
+		assert.NotNil(t, streamHealthResponse.RealtimeStats)
+
+	}
+
+	// check the destination master 3 is healthy, even though its query
+	// service is not running (if not healthy this would exception out)
+	sharding.VerifyTabletHealth(t, *shard3Master, hostname)
+
+	// now serve rdonly from the split shards, in cell1 only
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes", fmt.Sprintf("--cells=%s", cell1),
+		shard1Ks, "rdonly")
+	assert.Nil(t, err)
+
+	// check srv keyspace
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard1.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	// Cell 2 is not affected
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard1.Name}
+	sharding.CheckSrvKeyspace(t, cell2, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	sharding.CheckTabletQueryService(t, *shard0RdonlyZ2, "SERVING", false, *clusterInstance)
+	sharding.CheckTabletQueryService(t, *shard1RdonlyZ2, "SERVING", false, *clusterInstance)
+	sharding.CheckTabletQueryService(t, *shard1Rdonly, "NOT_SERVING", true, *clusterInstance)
+
+	// Shouldn't be able to rebuild keyspace graph while migration is on going
+	// (i.e there are records that have tablet controls set)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	assert.NotNil(t, err, "Error expected")
+
+	// rerun migrate to ensure it doesn't fail
+	// skip refresh to make it go faster
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes",
+		fmt.Sprintf("--cells=%s", cell1),
+		"-skip-refresh-state=true",
+		shard1Ks, "rdonly")
+	assert.Nil(t, err)
+
+	// now serve rdonly from the split shards, everywhere
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes",
+		shard1Ks, "rdonly")
+	assert.Nil(t, err)
+
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard1.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+	// Cell 2 is also changed
+	sharding.CheckSrvKeyspace(t, cell2, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	sharding.CheckTabletQueryService(t, *shard0RdonlyZ2, "SERVING", false, *clusterInstance)
+	sharding.CheckTabletQueryService(t, *shard1RdonlyZ2, "NOT_SERVING", true, *clusterInstance)
+	sharding.CheckTabletQueryService(t, *shard1Rdonly, "NOT_SERVING", true, *clusterInstance)
+
+	// rerun migrate to ensure it doesn't fail
+	// skip refresh to make it go faster
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes",
+		"-skip-refresh-state=true",
+		shard1Ks, "rdonly")
+	assert.Nil(t, err)
+
+	// then serve replica from the split shards
+	destinationShards := []cluster.Shard{*shard2, *shard3}
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes", shard1Ks, "replica")
+	assert.Nil(t, err)
+
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard2.Name, shard3.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	// move replica back and forth
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes", "-reverse",
+		shard1Ks, "replica")
+	assert.Nil(t, err)
+
+	// After a backwards migration, queryservice should be enabled on
+	// source and disabled on destinations
+	sharding.CheckTabletQueryService(t, *shard1Replica2, "SERVING", false, *clusterInstance)
+
+	// Destination tablets would have query service disabled for other reasons than the migration,
+	// so check the shard record instead of the tablets directly.
+	sharding.CheckShardQueryServices(t, *clusterInstance, destinationShards, cell1, keyspaceName,
+		topodata.TabletType_REPLICA, false)
+	sharding.CheckShardQueryServices(t, *clusterInstance, destinationShards, cell2, keyspaceName,
+		topodata.TabletType_REPLICA, false)
+
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard1.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes", shard1Ks, "replica")
+	assert.Nil(t, err)
+	// After a forwards migration, queryservice should be disabled on
+	// source and enabled on destinations
+	sharding.CheckTabletQueryService(t, *shard1Replica2, "NOT_SERVING", true, *clusterInstance)
+	// Destination tablets would have query service disabled for other reasons than the migration,
+	// so check the shard record instead of the tablets directly
+	sharding.CheckShardQueryServices(t, *clusterInstance, destinationShards, cell1, keyspaceName,
+		topodata.TabletType_REPLICA, true)
+	sharding.CheckShardQueryServices(t, *clusterInstance, destinationShards, cell2, keyspaceName,
+		topodata.TabletType_REPLICA, true)
+
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard2.Name, shard3.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	// reparent shard2 to shard2Replica1, then insert more data and see it flow through still
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("PlannedReparentShard", "-keyspace_shard", shard2Ks,
+		"-new_master", shard2Replica1.Alias)
+	assert.Nil(t, err)
+
+	// update our test variables to point at the new master
+	tmp := shard2Master
+	shard2Master = shard2Replica1
+	shard2Replica1 = tmp
+
+	// Insert another set of the data and see it flow through
+	insertLots(100, 200, *shard1.MasterTablet(), tableName, fixedParentID, keyspaceName)
+	// Checking 100 percent of data is sent fairly quickly
+	assert.True(t, checkLotsTimeout(t, 100, 200, tableName, keyspaceName, shardingKeyType))
+
+	// Compare using SplitDiff
+	log.Debug("Running vtworker SplitDiff")
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
+		clusterInstance.GetAndReservePort(),
+		"--use_v3_resharding_mode=true",
+		"SplitDiff",
+		"--exclude_tables", "unrelated",
+		"--min_healthy_rdonly_tablets", "1",
+		shard3Ks)
+	assert.Nil(t, err)
+
+	// Compare using MultiSplitDiff
+	log.Debug("Running vtworker MultiSplitDiff")
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
+		clusterInstance.GetAndReservePort(),
+		"--use_v3_resharding_mode=true",
+		"MultiSplitDiff",
+		"--exclude_tables", "unrelated",
+		shard1Ks)
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Rdonly.Alias, "rdonly")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard3Rdonly.Alias, "rdonly")
+	assert.Nil(t, err)
+
+	// going to migrate the master now
+
+	// mock with the SourceShard records to test 'vtctl SourceShardDelete'  and 'vtctl SourceShardAdd'
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SourceShardDelete", shard3Ks, "1")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SourceShardAdd", "--key_range=80-",
+		shard3Ks, "1", shard1Ks)
+	assert.Nil(t, err)
+
+	// CancelResharding should fail because migration has started.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CancelResharding", shard1Ks, "1")
+	assert.NotNil(t, err)
+
+	// do a Migrate that will fail waiting for replication
+	// which should cause the Migrate to be canceled and the source
+	// master to be serving again.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes",
+		"-filtered_replication_wait_time", "0s", shard1Ks, "master")
+	assert.NotNil(t, err)
+
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard1.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard2.Name, shard3.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	sharding.CheckTabletQueryService(t, *shard1Master, "SERVING", false, *clusterInstance)
+
+	// sabotage master migration and make it fail in an unfinished state.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl",
+		"-blacklisted_tables=t",
+		shard3Ks, "master")
+	assert.Nil(t, err)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes",
+		shard1Ks, "master")
+	assert.NotNil(t, err)
+
+	// Query service is disabled in source shard as failure occurred after point of no return
+	sharding.CheckTabletQueryService(t, *shard1Master, "NOT_SERVING", true, *clusterInstance)
+
+	// Global topology records should not change as migration did not succeed
+	shardInfo := sharding.GetShardInfo(t, shard1Ks, *clusterInstance)
+	assert.True(t, shardInfo.GetIsMasterServing(), "source shards should be set in destination shard")
+
+	shardInfo = sharding.GetShardInfo(t, shard3Ks, *clusterInstance)
+	assert.Equal(t, 1, len(shardInfo.GetSourceShards()), "source shards should be set in destination shard")
+	assert.False(t, shardInfo.GetIsMasterServing(), "source shards should be set in destination shard")
+
+	shardInfo = sharding.GetShardInfo(t, shard2Ks, *clusterInstance)
+	assert.Equal(t, 1, len(shardInfo.GetSourceShards()), "source shards should be set in destination shard")
+	assert.False(t, shardInfo.GetIsMasterServing(), "source shards should be set in destination shard")
+
+	// remove sabotage, but make it fail early. This should not result in the source master serving,
+	// because this failure is past the point of no return.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "-blacklisted_tables=t",
+		"-remove", shard3Ks, "master")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes",
+		"-filtered_replication_wait_time", "0s", shard1Ks, "master")
+	assert.NotNil(t, err)
+
+	sharding.CheckTabletQueryService(t, *shard1Master, "NOT_SERVING", true, *clusterInstance)
+
+	// do the migration that's expected to succeed
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes",
+		shard1Ks, "master")
+	assert.Nil(t, err)
+	expectedPartitions = map[topodata.TabletType][]string{}
+	expectedPartitions[topodata.TabletType_MASTER] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_RDONLY] = []string{shard0.Name, shard2.Name, shard3.Name}
+	expectedPartitions[topodata.TabletType_REPLICA] = []string{shard0.Name, shard2.Name, shard3.Name}
+	sharding.CheckSrvKeyspace(t, cell1, keyspaceName, "", 0, expectedPartitions, *clusterInstance)
+
+	sharding.CheckTabletQueryService(t, *shard1Master, "NOT_SERVING", true, *clusterInstance)
+
+	// check destination shards are serving
+	sharding.CheckTabletQueryService(t, *shard2Master, "SERVING", false, *clusterInstance)
+	sharding.CheckTabletQueryService(t, *shard3Master, "SERVING", false, *clusterInstance)
+
+	// check the binlog players are gone now
+	err = shard2Master.VttabletProcess.WaitForBinLogPlayerCount(0)
+	assert.Nil(t, err)
+	err = shard3Master.VttabletProcess.WaitForBinLogPlayerCount(0)
+	assert.Nil(t, err)
+
+	// test reverse_replication
+	// start with inserting a row in each destination shard
+	insertValue(t, shard2Master, keyspaceName, "resharding2", 2, "msg2", key2)
+	insertValue(t, shard3Master, keyspaceName, "resharding2", 3, "msg3", key3)
+
+	// ensure the rows are not present yet
+	checkValues(t, *shard1Master, []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, false, "resharding2", fixedParentID, keyspaceName, shardingKeyType)
+	checkValues(t, *shard1Master, []string{"INT64(86)", "INT64(3)", `VARCHAR("msg3")`, fmt.Sprintf("UINT64(%d)", key3)},
+		3, false, "resharding2", fixedParentID, keyspaceName, shardingKeyType)
+
+	// repeat the migration with reverse_replication
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes", "-reverse_replication=true",
+		shard1Ks, "master")
+	assert.Nil(t, err)
+	// look for the rows in the original master after a short wait
+	time.Sleep(1 * time.Second)
+	checkValues(t, *shard1Master, []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+		2, true, "resharding2", fixedParentID, keyspaceName, shardingKeyType)
+	checkValues(t, *shard1Master, []string{"INT64(86)", "INT64(3)", `VARCHAR("msg3")`, fmt.Sprintf("UINT64(%d)", key3)},
+		3, true, "resharding2", fixedParentID, keyspaceName, shardingKeyType)
+
+	// retry the migration to ensure it now fails
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand(
+		"MigrateServedTypes",
+		"-reverse_replication=true",
+		shard1Ks, "master")
+	assert.NotNil(t, err)
+
+	// CancelResharding should now succeed
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CancelResharding", shard1Ks)
+	assert.Nil(t, err)
+	err = shard1Master.VttabletProcess.WaitForBinLogPlayerCount(0)
+	assert.Nil(t, err)
+
+	// delete the original tablets in the original shard
+	for _, tablet := range []cluster.Vttablet{*shard1Master, *shard1Replica1, *shard1Replica2, *shard1Rdonly, *shard1RdonlyZ2} {
+		_ = tablet.MysqlctlProcess.Stop()
+		_ = tablet.VttabletProcess.TearDown()
+	}
+
+	for _, tablet := range []cluster.Vttablet{*shard1Replica1, *shard1Replica2, *shard1Rdonly, *shard1RdonlyZ2} {
+		err = clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteTablet", tablet.Alias)
+		assert.Nil(t, err)
+	}
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteTablet", "-allow_master", shard1Master.Alias)
+	assert.Nil(t, err)
+
+	// rebuild the serving graph, all mentions of the old shards should be gone
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	assert.Nil(t, err)
+
+	// test RemoveShardCell
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RemoveShardCell", shard0Ks, cell1)
+	assert.NotNil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RemoveShardCell", shard1Ks, cell1)
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RemoveShardCell", shard1Ks, cell2)
+	assert.Nil(t, err)
+
+	shardInfo = sharding.GetShardInfo(t, shard1Ks, *clusterInstance)
+	assert.Empty(t, shardInfo.GetTabletControls(), "cells not in shard ")
+
+	// delete the original shard
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteShard", shard1Ks)
+	assert.Nil(t, err)
+
+	// make sure we can't delete the destination shard now that it's serving
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteShard", shard2Ks)
+	assert.NotNil(t, err)
+
+}
+
+func insertStartupValues(t *testing.T) {
+	insertSQL := fmt.Sprintf(insertTabletTemplateKsID, "resharding1", fixedParentID, 1, "msg1", key1, key1, 1)
+	sharding.InsertToTablet(t, insertSQL, *shard0.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "resharding1", fixedParentID, 2, "msg2", key2, key2, 2)
+	sharding.InsertToTablet(t, insertSQL, *shard1.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "resharding1", fixedParentID, 3, "msg3", key3, key3, 3)
+	sharding.InsertToTablet(t, insertSQL, *shard1.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "resharding3", fixedParentID, 1, "a", key1, key1, 1)
+	sharding.InsertToTablet(t, insertSQL, *shard0.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "resharding3", fixedParentID, 2, "b", key2, key2, 2)
+	sharding.InsertToTablet(t, insertSQL, *shard1.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "resharding3", fixedParentID, 3, "c", key3, key3, 3)
+	sharding.InsertToTablet(t, insertSQL, *shard1.MasterTablet(), keyspaceName, false)
+
+	insertSQL = fmt.Sprintf(insertTabletTemplateKsID, "no_pk", fixedParentID, 1, "msg1", key5, key5, 1)
+	sharding.InsertToTablet(t, insertSQL, *shard1.MasterTablet(), keyspaceName, false)
+}
+
+func insertValue(t *testing.T, tablet *cluster.Vttablet, keyspaceName string, tableName string, id int, msg string, ksID uint64) {
+	insertSQL := fmt.Sprintf(insertTabletTemplateKsID, tableName, fixedParentID, id, msg, ksID, ksID, id)
+	sharding.InsertToTablet(t, insertSQL, *tablet, keyspaceName, false)
+}
+
+func execMultiShardDmls(t *testing.T, keyspaceName string) {
+	ids := []int{10000001, 10000002, 10000003}
+	msgs := []string{"msg-id10000001", "msg-id10000002", "msg-id10000003"}
+	ksIds := []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding1", fixedParentID, ids, msgs, ksIds)
+
+	ids = []int{10000004, 10000005}
+	msgs = []string{"msg-id10000004", "msg-id10000005"}
+	ksIds = []uint64{key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding1", fixedParentID, ids, msgs, ksIds)
+
+	ids = []int{10000011, 10000012, 10000013}
+	msgs = []string{"msg-id10000011", "msg-id10000012", "msg-id10000013"}
+	ksIds = []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding1", fixedParentID, ids, msgs, ksIds)
+
+	// This update targets two shards.
+	sql := `update resharding1 set msg="update1" where parent_id=86 and id in (10000011,10000012)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+	// This update targets one shard.
+	sql = `update resharding1 set msg="update1" where parent_id=86 and id in (10000013)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+	ids = []int{10000014, 10000015, 10000016}
+	msgs = []string{"msg-id10000014", "msg-id10000015", "msg-id10000016"}
+	ksIds = []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding1", fixedParentID, ids, msgs, ksIds)
+
+	// This delete targets two shards.
+	sql = `delete from resharding1 where parent_id =86 and id in (10000014, 10000015)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+	// This delete targets one shard.
+	sql = `delete from resharding1 where parent_id =86 and id in (10000016)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+	// repeat DMLs for table with msg as bit(8)
+	ids = []int{10000001, 10000002, 10000003}
+	msgs = []string{"a", "b", "c"}
+	ksIds = []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding3", fixedParentID, ids, msgs, ksIds)
+
+	ids = []int{10000004, 10000005}
+	msgs = []string{"d", "e"}
+	ksIds = []uint64{key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding3", fixedParentID, ids, msgs, ksIds)
+
+	ids = []int{10000011, 10000012, 10000013}
+	msgs = []string{"k", "l", "m"}
+	ksIds = []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding3", fixedParentID, ids, msgs, ksIds)
+
+	// This update targets two shards.
+	sql = `update resharding3 set msg="g" where parent_id=86 and id in (10000011, 10000012)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+	// This update targets one shard.
+	sql = `update resharding3 set msg="h" where parent_id=86 and id in (10000013)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+	ids = []int{10000014, 10000015, 10000016}
+	msgs = []string{"n", "o", "p"}
+	ksIds = []uint64{key2, key3, key4}
+	sharding.InsertMultiValues(t, *shard1.MasterTablet(), keyspaceName, "resharding3", fixedParentID, ids, msgs, ksIds)
+
+	// This delete targets two shards.
+	sql = `delete from resharding3 where parent_id =86 and id in (10000014, 10000015)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+	// This delete targets one shard.
+	sql = `delete from resharding3 where parent_id =86 and id in (10000016)`
+	_, _ = shard1.MasterTablet().VttabletProcess.QueryTablet(sql, keyspaceName, true)
+
+}
+
+func checkStartupValues(t *testing.T, shardingKeyType querypb.Type) {
+	// check first value is in the right shard
+	for _, tablet := range shard2.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+			2, true, "resharding1", fixedParentID, keyspaceName, shardingKeyType)
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(2)", `BIT("b")`, fmt.Sprintf("UINT64(%d)", key2)},
+			2, true, "resharding3", fixedParentID, keyspaceName, shardingKeyType)
+	}
+	for _, tablet := range shard3.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(2)", `VARCHAR("msg2")`, fmt.Sprintf("UINT64(%d)", key2)},
+			2, false, "resharding1", fixedParentID, keyspaceName, shardingKeyType)
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(2)", `BIT("b")`, fmt.Sprintf("UINT64(%d)", key2)},
+			2, false, "resharding3", fixedParentID, keyspaceName, shardingKeyType)
+	}
+	// check first value is in the right shard
+	for _, tablet := range shard2.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(3)", `VARCHAR("msg3")`, fmt.Sprintf("UINT64(%d)", key3)},
+			3, false, "resharding1", fixedParentID, keyspaceName, shardingKeyType)
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(3)", `BIT("c")`, fmt.Sprintf("UINT64(%d)", key3)},
+			3, false, "resharding3", fixedParentID, keyspaceName, shardingKeyType)
+	}
+	for _, tablet := range shard3.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(3)", `VARCHAR("msg3")`, fmt.Sprintf("UINT64(%d)", key3)},
+			3, true, "resharding1", fixedParentID, keyspaceName, shardingKeyType)
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(3)", `BIT("c")`, fmt.Sprintf("UINT64(%d)", key3)},
+			3, true, "resharding3", fixedParentID, keyspaceName, shardingKeyType)
+	}
+
+	// Check for no_pk table
+	for _, tablet := range shard2.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(1)", `VARCHAR("msg1")`, fmt.Sprintf("UINT64(%d)", key5)},
+			1, true, "no_pk", fixedParentID, keyspaceName, shardingKeyType)
+	}
+	for _, tablet := range shard3.Vttablets {
+		checkValues(t, *tablet, []string{"INT64(86)", "INT64(1)", `BIT("msg1")`, fmt.Sprintf("UINT64(%d)", key5)},
+			1, false, "no_pk", fixedParentID, keyspaceName, shardingKeyType)
+	}
+}
+
+// checkLotsNotPresent verifies that no rows should be present in vttablet
+func checkLotsNotPresent(t *testing.T, count uint64, base uint64, table string, keyspaceName string, keyType querypb.Type) {
+	var i uint64
+	//var count uint64 = 1000
+	for i = 0; i < count; i++ {
+		assert.False(t, checkValues(t, *shard3.Vttablets[1], []string{"INT64(86)",
+			fmt.Sprintf("INT64(%d)", 10000+base+i),
+			fmt.Sprintf(`VARCHAR("msg-range1-%d")`, 10000+base+i),
+			fmt.Sprintf("UINT64(%d)", key5)},
+			10000+base+i, false, table, fixedParentID, keyspaceName, keyType))
+
+		assert.False(t, checkValues(t, *shard2.Vttablets[2], []string{"INT64(86)",
+			fmt.Sprintf("INT64(%d)", 20000+base+i),
+			fmt.Sprintf(`VARCHAR("msg-range2-%d")`, 20000+base+i),
+			fmt.Sprintf("UINT64(%d)", key4)},
+			20000+base+i, false, table, fixedParentID, keyspaceName, keyType))
+	}
+}
+
+// checkLotsTimeout waits till all values are inserted
+func checkLotsTimeout(t *testing.T, count uint64, base uint64, table string, keyspaceName string, keyType querypb.Type) bool {
+	timeout := time.Now().Add(10 * time.Second)
+	for time.Now().Before(timeout) {
+		percentFound := checkLots(t, count, base, table, keyspaceName, keyType)
+		if percentFound == 100 {
+			return true
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return false
+}
+
+func checkLots(t *testing.T, count uint64, base uint64, table string, keyspaceName string, keyType querypb.Type) float32 {
+	var isFound bool
+	var totalFound int
+	var i uint64
+	for i = 0; i < count; i++ {
+		isFound = checkValues(t, *shard2.Vttablets[2], []string{"INT64(86)",
+			fmt.Sprintf("INT64(%d)", 10000+base+i),
+			fmt.Sprintf(`VARCHAR("msg-range1-%d")`, 10000+base+i),
+			fmt.Sprintf("UINT64(%d)", key5)},
+			10000+base+i, true, table, fixedParentID, keyspaceName, keyType)
+		if isFound {
+			totalFound++
+		}
+
+		isFound = checkValues(t, *shard3.Vttablets[1], []string{"INT64(86)",
+			fmt.Sprintf("INT64(%d)", 20000+base+i),
+			fmt.Sprintf(`VARCHAR("msg-range2-%d")`, 20000+base+i),
+			fmt.Sprintf("UINT64(%d)", key4)},
+			20000+base+i, true, table, fixedParentID, keyspaceName, keyType)
+		if isFound {
+			totalFound++
+		}
+	}
+	return float32(totalFound * 100 / int(count) / 2)
+}
+
+func checkValues(t *testing.T, vttablet cluster.Vttablet, values []string, id uint64, exists bool, tableName string, parentID int, ks string, keyType querypb.Type) bool {
+	query := fmt.Sprintf("select parent_id, id, msg, custom_ksid_col from %s where parent_id = %d and id = %d", tableName, parentID, id)
+	result, err := vttablet.VttabletProcess.QueryTablet(query, ks, true)
+	assert.Nil(t, err)
+	isFound := false
+	if exists && len(result.Rows) > 0 {
+		isFound = assert.Equal(t, result.Rows[0][0].String(), values[0])
+		isFound = isFound && assert.Equal(t, result.Rows[0][1].String(), values[1])
+		isFound = isFound && assert.Equal(t, result.Rows[0][2].String(), values[2])
+		if keyType == querypb.Type_VARBINARY {
+			r := strings.NewReplacer("UINT64(", "VARBINARY(\"", ")", "\")")
+			expected := r.Replace(values[3])
+			isFound = isFound && assert.Equal(t, result.Rows[0][3].String(), expected)
+		} else {
+			isFound = isFound && assert.Equal(t, result.Rows[0][3].String(), values[3])
+		}
+
+	} else {
+		assert.Equal(t, len(result.Rows), 0)
+	}
+	return isFound
+}
+
+func checkMultiShardValues(t *testing.T, keyspaceName string, keyType querypb.Type) {
+	//Shard2 master, replica1 and replica 2
+	shard2Tablets := []cluster.Vttablet{*shard2.Vttablets[0], *shard2.Vttablets[1], *shard2.Vttablets[2]}
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000001, "msg-id10000001", key2, true)
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000002, "msg-id10000002", key3, false)
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000003, "msg-id10000003", key4, false)
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000004, "msg-id10000004", key3, false)
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000005, "msg-id10000005", key4, false)
+
+	//Shard 3 master and replica
+	shard3Tablets := []cluster.Vttablet{*shard3.Vttablets[0], *shard3.Vttablets[1]}
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000001, "msg-id10000001", key2, false)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000002, "msg-id10000002", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000003, "msg-id10000003", key4, true)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000004, "msg-id10000004", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000005, "msg-id10000005", key4, true)
+
+	// Updated values
+	checkMultiDbs(t, shard2Tablets, "resharding1", keyspaceName, keyType, 10000011, "update1", key2, true)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000012, "update1", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding1", keyspaceName, keyType, 10000013, "update2", key4, true)
+
+	allTablets := []cluster.Vttablet{*shard2.Vttablets[0], *shard2.Vttablets[1], *shard2.Vttablets[2], *shard3.Vttablets[0], *shard3.Vttablets[1]}
+	checkMultiDbs(t, allTablets, "resharding1", keyspaceName, keyType, 10000014, "msg-id10000014", key2, false)
+	checkMultiDbs(t, allTablets, "resharding1", keyspaceName, keyType, 10000015, "msg-id10000015", key3, false)
+	checkMultiDbs(t, allTablets, "resharding1", keyspaceName, keyType, 10000016, "msg-id10000016", key6, false)
+
+	// checks for bit(8) table
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000001, "a", key2, true)
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000002, "b", key3, false)
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000003, "c", key4, false)
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000004, "d", key3, false)
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000005, "e", key4, false)
+
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000001, "a", key2, false)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000002, "b", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000003, "c", key4, true)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000004, "d", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000005, "e", key4, true)
+
+	// updated values
+	checkMultiDbs(t, shard2Tablets, "resharding3", keyspaceName, keyType, 10000011, "g", key2, true)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000012, "g", key3, true)
+	checkMultiDbs(t, shard3Tablets, "resharding3", keyspaceName, keyType, 10000013, "h", key4, true)
+
+	checkMultiDbs(t, allTablets, "resharding3", keyspaceName, keyType, 10000014, "n", key2, false)
+	checkMultiDbs(t, allTablets, "resharding3", keyspaceName, keyType, 10000015, "o", key3, false)
+	checkMultiDbs(t, allTablets, "resharding3", keyspaceName, keyType, 10000016, "p", key6, false)
+
+}
+
+// checkMultiDbs checks the row in multiple dbs
+func checkMultiDbs(t *testing.T, vttablets []cluster.Vttablet, tableName string, keyspaceName string,
+	keyType querypb.Type, id int, msg string, ksID uint64, presentInDb bool) {
+	for _, tablet := range vttablets {
+		checkValues(t, tablet, []string{"INT64(86)",
+			fmt.Sprintf("INT64(%d)", id),
+			fmt.Sprintf(`VARCHAR("%s")`, msg),
+			fmt.Sprintf("UINT64(%d)", ksID)},
+			ksID, presentInDb, tableName, fixedParentID, keyspaceName, keyType)
+	}
+}
+
+// insertLots inserts multiple values to vttablet
+func insertLots(count uint64, base uint64, vttablet cluster.Vttablet, table string, parentID int, ks string) {
+	ctx := context.Background()
+	dbParams := mysql.ConnParams{
+		Uname:      "vt_dba",
+		UnixSocket: path.Join(vttablet.VttabletProcess.Directory, "mysql.sock"),
+		DbName:     "vt_" + ks,
+	}
+	dbConn, _ := mysql.Connect(ctx, &dbParams)
+	defer dbConn.Close()
+
+	var query1, query2 string
+	var i uint64
+	for i = 0; i < count; i++ {
+		query1 = fmt.Sprintf(insertTabletTemplateKsID, table, parentID, 10000+base+i,
+			fmt.Sprintf("msg-range1-%d", 10000+base+i), key5, key5, 10000+base+i)
+		query2 = fmt.Sprintf(insertTabletTemplateKsID, table, parentID, 20000+base+i,
+			fmt.Sprintf("msg-range2-%d", 20000+base+i), key4, key4, 20000+base+i)
+
+		insertToTabletUsingSameConn(query1, vttablet, ks, dbConn)
+		insertToTabletUsingSameConn(query2, vttablet, ks, dbConn)
+	}
+}
+
+// insertToTabletUsingSameConn inserts a single row to vttablet using existing connection
+func insertToTabletUsingSameConn(query string, vttablet cluster.Vttablet, ks string, dbConn *mysql.Conn) {
+	_, err := dbConn.ExecuteFetch(query, 1000, true)
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/go/test/endtoend/sharding/resharding/string/resharding_string_test.go
+++ b/go/test/endtoend/sharding/resharding/string/resharding_string_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"testing"
+
+	sharding "vitess.io/vitess/go/test/endtoend/sharding/resharding"
+)
+
+// TestReshardingString - using a VARBINARY column for resharding.
+func TestReshardingString(t *testing.T) {
+	sharding.TestResharding(t, true)
+
+}

--- a/go/test/endtoend/sharding/resharding/v3/resharding_v3_test.go
+++ b/go/test/endtoend/sharding/resharding/v3/resharding_v3_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"testing"
+
+	sharding "vitess.io/vitess/go/test/endtoend/sharding/resharding"
+)
+
+// TestV3ReSharding - main tests resharding using a INT column
+func TestV3ReSharding(t *testing.T) {
+	sharding.TestResharding(t, false)
+
+}

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -63,6 +63,7 @@ func TestTabletCommands(t *testing.T) {
 	// make sure direct dba queries work
 	sql = "select * from t1"
 	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", "-json", masterTablet.Alias, sql)
+
 	assert.Nil(t, err)
 	assertExecuteFetch(t, result)
 

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -57,11 +57,13 @@ func TestTabletCommands(t *testing.T) {
 		sql,
 	}
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(args...)
+	assert.Nil(t, err)
 	assertExcludeFields(t, result)
 
 	// make sure direct dba queries work
 	sql = "select * from t1"
 	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", "-json", masterTablet.Alias, sql)
+	assert.Nil(t, err)
 	assertExecuteFetch(t, result)
 
 	// check Ping / RefreshState / RefreshStateByShard
@@ -143,6 +145,7 @@ func assertExecuteFetch(t *testing.T, qr string) {
 func TestActionAndTimeout(t *testing.T) {
 
 	err := clusterInstance.VtctlclientProcess.ExecuteCommand("Sleep", masterTablet.Alias, "5s")
+	assert.Nil(t, err)
 	time.Sleep(1 * time.Second)
 
 	// try a frontend RefreshState that should timeout as the tablet is busy running the other one

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -63,7 +63,6 @@ func TestTabletCommands(t *testing.T) {
 	// make sure direct dba queries work
 	sql = "select * from t1"
 	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("ExecuteFetchAsDba", "-json", masterTablet.Alias, sql)
-
 	assert.Nil(t, err)
 	assertExecuteFetch(t, result)
 

--- a/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
+++ b/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
@@ -61,7 +61,7 @@ func TestTopoCustomRule(t *testing.T) {
 	}
 
 	// Start a new Tablet
-	rTablet := clusterInstance.GetVttabletInstance(replicaUID)
+	rTablet := clusterInstance.GetVttabletInstance("replica", replicaUID, "")
 
 	// Init Tablets
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
@@ -80,6 +80,7 @@ func TestTopoCustomRule(t *testing.T) {
 
 	// Verify that query is working
 	result, err := vtctlExec("select id, value from t1", rTablet.Alias)
+	assert.Nil(t, err)
 	resultMap := make(map[string]interface{})
 	err = json.Unmarshal([]byte(result), &resultMap)
 	require.NoError(t, err)

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -37,7 +37,6 @@ import (
 var (
 	clusterInstance     *cluster.LocalProcessCluster
 	tmClient            *tmc.Client
-	vtParams            mysql.ConnParams
 	masterTabletParams  mysql.ConnParams
 	replicaTabletParams mysql.ConnParams
 	masterTablet        cluster.Vttablet
@@ -125,11 +124,11 @@ func TestMain(m *testing.M) {
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
 			if tablet.Type == "master" {
-				masterTablet = tablet
+				masterTablet = *tablet
 			} else if tablet.Type != "rdonly" {
-				replicaTablet = tablet
+				replicaTablet = *tablet
 			} else {
-				rdonlyTablet = tablet
+				rdonlyTablet = *tablet
 			}
 		}
 
@@ -137,12 +136,12 @@ func TestMain(m *testing.M) {
 		masterTabletParams = mysql.ConnParams{
 			Uname:      username,
 			DbName:     dbName,
-			UnixSocket: fmt.Sprintf(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", masterTablet.TabletUID))),
+			UnixSocket: path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", masterTablet.TabletUID)),
 		}
 		replicaTabletParams = mysql.ConnParams{
 			Uname:      username,
 			DbName:     dbName,
-			UnixSocket: fmt.Sprintf(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", replicaTablet.TabletUID))),
+			UnixSocket: path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", replicaTablet.TabletUID)),
 		}
 
 		// create tablet manager client

--- a/go/test/endtoend/tabletmanager/qps_test.go
+++ b/go/test/endtoend/tabletmanager/qps_test.go
@@ -69,7 +69,7 @@ func TestQPS(t *testing.T) {
 	timeout := time.Now().Add(12 * time.Second)
 	for time.Now().Before(timeout) {
 		result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "-count", "1", masterTablet.Alias)
-
+		assert.Nil(t, err)
 		var streamHealthResponse querypb.StreamHealthResponse
 
 		err = json.Unmarshal([]byte(result), &streamHealthResponse)

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -54,8 +54,6 @@ func TestTabletReshuffle(t *testing.T) {
 
 	//Create new tablet
 	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
-
-
 	//Init Tablets
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
 	require.NoError(t, err)
@@ -98,7 +96,7 @@ func TestHealthCheck(t *testing.T) {
 	ctx := context.Background()
 
 	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
-  
+
 	// Start Mysql Processes and return connection
 	replicaConn, err := cluster.StartMySQLAndGetConnection(ctx, rTablet, username, clusterInstance.TmpDirectory)
 	assert.Nil(t, err)

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -55,6 +55,7 @@ func TestTabletReshuffle(t *testing.T) {
 	//Create new tablet
 	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
 
+
 	//Init Tablets
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
 	require.NoError(t, err)
@@ -66,7 +67,7 @@ func TestTabletReshuffle(t *testing.T) {
 		"-mycnf_server_id", fmt.Sprintf("%d", rTablet.TabletUID),
 		"-db_socket", fmt.Sprintf("%s/mysql.sock", masterTablet.VttabletProcess.Directory),
 	}
-	// SupportBackup=False prevents vttablet from trying to restore
+	// SupportsBackup=False prevents vttablet from trying to restore
 	// Start vttablet process
 	err = clusterInstance.StartVttablet(rTablet, "SERVING", false, cell, keyspaceName, hostname, shardName)
 	assert.Nil(t, err)
@@ -97,10 +98,11 @@ func TestHealthCheck(t *testing.T) {
 	ctx := context.Background()
 
 	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
-
+  
 	// Start Mysql Processes and return connection
 	replicaConn, err := cluster.StartMySQLAndGetConnection(ctx, rTablet, username, clusterInstance.TmpDirectory)
 	assert.Nil(t, err)
+
 	defer replicaConn.Close()
 
 	// Create database in mysql

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -53,7 +53,7 @@ func TestTabletReshuffle(t *testing.T) {
 	checkDataOnReplica(t, replicaConn, `[[VARCHAR("a")] [VARCHAR("b")]]`)
 
 	//Create new tablet
-	rTablet := clusterInstance.GetVttabletInstance(0)
+	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
 
 	//Init Tablets
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
@@ -80,6 +80,7 @@ func TestTabletReshuffle(t *testing.T) {
 		sql,
 	}
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(args...)
+	assert.Nil(t, err)
 	assertExcludeFields(t, result)
 
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Backup", rTablet.Alias)
@@ -95,7 +96,7 @@ func TestHealthCheck(t *testing.T) {
 	// (for the replica, we let vttablet do the InitTablet)
 	ctx := context.Background()
 
-	rTablet := clusterInstance.GetVttabletInstance(0)
+	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
 
 	// Start Mysql Processes and return connection
 	replicaConn, err := cluster.StartMySQLAndGetConnection(ctx, rTablet, username, clusterInstance.TmpDirectory)
@@ -107,10 +108,11 @@ func TestHealthCheck(t *testing.T) {
 
 	//Init Replica Tablet
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
+	assert.Nil(t, err)
 
 	// start vttablet process, should be in SERVING state as we already have a master
 	err = clusterInstance.StartVttablet(rTablet, "SERVING", false, cell, keyspaceName, hostname, shardName)
-	assert.Nil(t, err, "error should be Nil")
+	assert.Nil(t, err)
 
 	masterConn, err := mysql.Connect(ctx, &masterTabletParams)
 	require.NoError(t, err)
@@ -144,6 +146,7 @@ func TestHealthCheck(t *testing.T) {
 
 	// now test VtTabletStreamHealth returns the right thing
 	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "-count", "2", rTablet.Alias)
+	assert.Nil(t, err)
 	scanner := bufio.NewScanner(strings.NewReader(result))
 	for scanner.Scan() {
 		// fmt.Println() // Println will add back the final '\n'
@@ -253,7 +256,7 @@ func waitForTabletStatus(tablet cluster.Vttablet, status string) error {
 
 func TestIgnoreHealthError(t *testing.T) {
 	ctx := context.Background()
-	mTablet := clusterInstance.GetVttabletInstance(masterUID)
+	mTablet := clusterInstance.GetVttabletInstance("replica", masterUID, "")
 
 	//Init Tablets
 	err := clusterInstance.VtctlclientProcess.InitTablet(mTablet, cell, keyspaceName, hostname, shardName)
@@ -261,8 +264,8 @@ func TestIgnoreHealthError(t *testing.T) {
 
 	// Start Mysql Processes
 	masterConn, err := cluster.StartMySQLAndGetConnection(ctx, mTablet, username, clusterInstance.TmpDirectory)
-	defer masterConn.Close()
 	assert.Nil(t, err)
+	defer masterConn.Close()
 
 	mTablet.MysqlctlProcess.Stop()
 	// Clean dir for mysql files

--- a/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestFallbackSecurityPolicy(t *testing.T) {
 	ctx := context.Background()
-	mTablet := clusterInstance.GetVttabletInstance(masterUID)
+	mTablet := clusterInstance.GetVttabletInstance("replica", masterUID, "")
 
 	//Init Tablets
 	err := clusterInstance.VtctlclientProcess.InitTablet(mTablet, cell, keyspaceName, hostname, shardName)
@@ -66,6 +66,7 @@ func assertNotAllowedURLTest(t *testing.T, url string) {
 	assert.Nil(t, err)
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 	defer resp.Body.Close()
 
 	assert.True(t, resp.StatusCode > 400)
@@ -77,6 +78,7 @@ func assertAllowedURLTest(t *testing.T, url string) {
 	assert.Nil(t, err)
 
 	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
 	defer resp.Body.Close()
 
 	assert.NotContains(t, string(body), "Access denied: not allowed")
@@ -84,7 +86,7 @@ func assertAllowedURLTest(t *testing.T, url string) {
 
 func TestDenyAllSecurityPolicy(t *testing.T) {
 	ctx := context.Background()
-	mTablet := clusterInstance.GetVttabletInstance(masterUID)
+	mTablet := clusterInstance.GetVttabletInstance("replica", masterUID, "")
 
 	//Init Tablets
 	err := clusterInstance.VtctlclientProcess.InitTablet(mTablet, cell, keyspaceName, hostname, shardName)
@@ -119,7 +121,7 @@ func TestDenyAllSecurityPolicy(t *testing.T) {
 
 func TestReadOnlySecurityPolicy(t *testing.T) {
 	ctx := context.Background()
-	mTablet := clusterInstance.GetVttabletInstance(0)
+	mTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
 
 	//Init Tablets
 	err := clusterInstance.VtctlclientProcess.InitTablet(mTablet, cell, keyspaceName, hostname, shardName)

--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -48,8 +48,6 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
-	tabletpb "vitess.io/vitess/go/vt/proto/topodata"
-	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
 )
 
 var (
@@ -64,8 +62,7 @@ var (
 		msg VARCHAR(64) NOT NULL,
 		PRIMARY KEY (id)
 	) Engine=InnoDB;`
-	wg       = &sync.WaitGroup{}
-	tmClient = tmc.NewClient()
+	wg = &sync.WaitGroup{}
 )
 
 const (
@@ -74,7 +71,6 @@ const (
 	demoteMasterQuery          = "SET GLOBAL read_only = ON;FLUSH TABLES WITH READ LOCK;UNLOCK TABLES;"
 	disableSemiSyncMasterQuery = "SET GLOBAL rpl_semi_sync_master_enabled = 0"
 	enableSemiSyncMasterQuery  = "SET GLOBAL rpl_semi_sync_master_enabled = 1"
-	masterPositionQuery        = "SELECT @@GLOBAL.gtid_executed;"
 	promoteSlaveQuery          = "STOP SLAVE;RESET SLAVE ALL;SET GLOBAL read_only = OFF;"
 )
 
@@ -360,7 +356,6 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 
 	// Wait for replica to catch up to master.
 	waitForReplicationPos(ctx, t, master, replica, 60.0)
-
 	duration := time.Since(start)
 	minUnavailabilityInS := 1.0
 	if duration.Seconds() < minUnavailabilityInS {
@@ -377,7 +372,7 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 	}
 
 	// Configure old master to replicate from new master.
-	_, gtID := getMasterPosition(ctx, t, newMaster)
+	_, gtID := cluster.GetMasterPosition(t, *newMaster, hostname)
 
 	// Use 'localhost' as hostname because Travis CI worker hostnames
 	// are too long for MySQL replication.
@@ -389,23 +384,15 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 }
 
 func waitForReplicationPos(ctx context.Context, t *testing.T, tabletA *cluster.Vttablet, tabletB *cluster.Vttablet, timeout float64) {
-	replicationPosA, _ := getMasterPosition(ctx, t, tabletA)
+	replicationPosA, _ := cluster.GetMasterPosition(t, *tabletA, hostname)
 	for {
-		replicationPosB, _ := getMasterPosition(ctx, t, tabletB)
+		replicationPosB, _ := cluster.GetMasterPosition(t, *tabletB, hostname)
 		if positionAtLeast(t, tabletA, replicationPosB, replicationPosA) {
 			break
 		}
 		msg := fmt.Sprintf("%s's replication position to catch up to %s's;currently at: %s, waiting to catch up to: %s", tabletB.Alias, tabletA.Alias, replicationPosB, replicationPosA)
 		waitStep(t, msg, timeout, 0.01)
 	}
-}
-
-func getMasterPosition(ctx context.Context, t *testing.T, tablet *cluster.Vttablet) (string, string) {
-	vtablet := getTablet(tablet.GrpcPort)
-	newPos, err := tmClient.MasterPosition(ctx, vtablet)
-	require.NoError(t, err)
-	gtID := strings.SplitAfter(newPos, "/")[1]
-	return newPos, gtID
 }
 
 func positionAtLeast(t *testing.T, tablet *cluster.Vttablet, a string, b string) bool {
@@ -425,10 +412,4 @@ func waitStep(t *testing.T, msg string, timeout float64, sleepTime float64) floa
 	}
 	time.Sleep(time.Duration(sleepTime) * time.Second)
 	return timeout
-}
-
-func getTablet(tabletGrpcPort int) *tabletpb.Tablet {
-	portMap := make(map[string]int32)
-	portMap["grpc"] = int32(tabletGrpcPort)
-	return &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
 }

--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -43,9 +43,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -360,7 +359,7 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 	}
 
 	// Wait for replica to catch up to master.
-	waitForReplicationPos(ctx, t, &master, &replica, 60.0)
+	waitForReplicationPos(ctx, t, master, replica, 60.0)
 
 	duration := time.Since(start)
 	minUnavailabilityInS := 1.0
@@ -378,7 +377,7 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 	}
 
 	// Configure old master to replicate from new master.
-	_, gtID := getMasterPosition(ctx, t, &newMaster)
+	_, gtID := getMasterPosition(ctx, t, newMaster)
 
 	// Use 'localhost' as hostname because Travis CI worker hostnames
 	// are too long for MySQL replication.

--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -373,7 +373,6 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 
 	// Configure old master to replicate from new master.
 	_, gtID := cluster.GetMasterPosition(t, *newMaster, hostname)
-
 	// Use 'localhost' as hostname because Travis CI worker hostnames
 	// are too long for MySQL replication.
 	changeMasterCommands := fmt.Sprintf("RESET SLAVE;SET GLOBAL gtid_slave_pos = '%s';CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d ,MASTER_USER='vt_repl', MASTER_USE_GTID = slave_pos;START SLAVE;", gtID, "localhost", newMaster.MySQLPort)

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -220,7 +220,7 @@ func checkTables(t *testing.T, count int) {
 }
 
 // checkTablesCount checks the number of tables in the given tablet
-func checkTablesCount(t *testing.T, tablet cluster.Vttablet, count int) {
+func checkTablesCount(t *testing.T, tablet *cluster.Vttablet, count int) {
 	queryResult, err := tablet.VttabletProcess.QueryTablet("show tables;", keyspaceName, true)
 	assert.Nil(t, err)
 	assert.Equal(t, len(queryResult.Rows), count)

--- a/test/config.json
+++ b/test/config.json
@@ -308,7 +308,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 2,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"worker_test"
@@ -319,7 +319,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 2,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"worker_test"
@@ -330,7 +330,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 3,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"worker_test"

--- a/test/config.json
+++ b/test/config.json
@@ -70,7 +70,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"site_test"
@@ -81,7 +81,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"site_test"


### PR DESCRIPTION
**Resharding**
- All the test cases are converted in V3 mode and now using default RBR mode.
- Addition: Running SplitDiff & MultiSplitDiff in the same test to save time.

**Binlog** 
Migrated [binlog.py](https://github.com/planetscale/vitess/blob/master/test/binlog.py) to go testcase

**Cell Alias**
Migrated [cell_alias and cell_no_alias](https://github.com/vitessio/vitess/blob/master/test/cell_aliases.py) to Go testcase
