### PR TITLE
Add automated release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,40 @@
+# This creates a {tar.gz,deb,rpm} file and uploads it to a release.
+# To trigger this, create a new release.. but make sure that you publish
+# it immediately and do not save it as a DRAFT.
+
+name: Release
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make ruby ruby-dev
+        go mod download
+        sudo gem install --no-ri --no-rdoc fpm
+
+    - name: Make Packages
+      run: |
+        ./tools/make-release-packages.sh
+
+    - name: Upload Files
+      uses: csexton/release-asset-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pattern: "releases/*.{tar.gz,rpm,deb}"
+

--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -11,9 +11,7 @@ set -euo pipefail
 source build.env
 
 SHORT_REV="$(git rev-parse --short HEAD)"
-VERSION="5.0.0" # tmp
-# TODO: We can discover version from the last tag, we just need to have this setup.
-# TAG_VERSION="$(git describe --tags --dirty --always | sed  s/v//)"
+VERSION="$(git describe --tags --dirty --always | sed  s/v//)"
 
 RELEASE_ID="vitess-${VERSION}-${SHORT_REV}"
 RELEASE_DIR="${VTROOT}/releases/${RELEASE_ID}"


### PR DESCRIPTION
Fixes #5463

This adds a GitHub action that hooks on creating a release and produces packages. I have verified it working in [my own fork](https://github.com/morgo/vitess/releases/tag/v5.0.4).

Basically, all we need to do now is go to releases and 'Add new' and make sure we pick a tagname that makes sense. The automation will take about 10 minutes, and then upload the corresponding files.

Signed-off-by: Morgan Tocker <tocker@gmail.com>