### PR TITLE
Vertical split testcase migrated in go

### DIFF
--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -289,11 +289,11 @@ func TestAlias(t *testing.T) {
 
 func waitTillAllTabletsAreHealthyInVtgate(t *testing.T, vtgateInstance cluster.VtgateProcess, shards ...string) {
 	for _, shard := range shards {
-		err := vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard))
+		err := vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard), 1)
 		assert.Nil(t, err)
-		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard))
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard), 1)
 		assert.Nil(t, err)
-		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard))
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard), 1)
 		assert.Nil(t, err)
 	}
 }

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -423,10 +423,10 @@ func (cluster *LocalProcessCluster) WaitForTabletsToHealthyInVtgate() (err error
 	for _, keyspace := range cluster.Keyspaces {
 		for _, shard := range keyspace.Shards {
 			isRdOnlyPresent = false
-			if err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspace.Name, shard.Name)); err != nil {
+			if err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspace.Name, shard.Name), 1); err != nil {
 				return err
 			}
-			if err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspace.Name, shard.Name)); err != nil {
+			if err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspace.Name, shard.Name), 1); err != nil {
 				return err
 			}
 			for _, tablet := range shard.Vttablets {
@@ -435,7 +435,7 @@ func (cluster *LocalProcessCluster) WaitForTabletsToHealthyInVtgate() (err error
 				}
 			}
 			if isRdOnlyPresent {
-				err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspace.Name, shard.Name))
+				err = cluster.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspace.Name, shard.Name), 1)
 			}
 			if err != nil {
 				return err

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -118,6 +118,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.VtTabletExtraArgs,
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
+
 			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {

--- a/go/test/endtoend/sharded/sharded_keyspace_test.go
+++ b/go/test/endtoend/sharded/sharded_keyspace_test.go
@@ -233,6 +233,7 @@ func initCluster(shardNames []string, totalTabletsRequired int) {
 				clusterInstance.VtTabletExtraArgs,
 				clusterInstance.EnableSemiSync)
 			tablet.Alias = tablet.VttabletProcess.TabletPath
+
 			shard.Vttablets = append(shard.Vttablets, tablet)
 		}
 		for _, proc := range mysqlCtlProcessList {

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -239,18 +239,23 @@ func checkStreamHealthEqualsBinlogPlayerVars(t *testing.T, vttablet cluster.Vtta
 }
 
 // CheckBinlogServerVars checks the binlog server variables are correctly exported.
-func CheckBinlogServerVars(t *testing.T, vttablet cluster.Vttablet, minStatement int, minTxn int) {
+func CheckBinlogServerVars(t *testing.T, vttablet cluster.Vttablet, minStatement int, minTxn int, isVerticalSplit bool) {
 	resultMap := vttablet.VttabletProcess.GetVars()
-	assert.Contains(t, resultMap, "UpdateStreamKeyRangeStatements")
-	assert.Contains(t, resultMap, "UpdateStreamKeyRangeTransactions")
+	skey := "UpdateStreamKeyRangeStatements"
+	tkey := "UpdateStreamKeyRangeTransactions"
+	if isVerticalSplit {
+		skey = "UpdateStreamTablesStatements"
+		tkey = "UpdateStreamTablesTransactions"
+	}
+	assert.Contains(t, resultMap, skey)
+	assert.Contains(t, resultMap, tkey)
 	if minStatement > 0 {
-		value := fmt.Sprintf("%v", reflect.ValueOf(resultMap["UpdateStreamKeyRangeStatements"]))
+		value := fmt.Sprintf("%v", reflect.ValueOf(resultMap[skey]))
 		iValue, _ := strconv.Atoi(value)
 		assert.True(t, iValue >= minStatement, fmt.Sprintf("only got %d < %d statements", iValue, minStatement))
 	}
-
 	if minTxn > 0 {
-		value := fmt.Sprintf("%v", reflect.ValueOf(resultMap["UpdateStreamKeyRangeStatements"]))
+		value := fmt.Sprintf("%v", reflect.ValueOf(resultMap[tkey]))
 		iValue, _ := strconv.Atoi(value)
 		assert.True(t, iValue >= minTxn, fmt.Sprintf("only got %d < %d transactions", iValue, minTxn))
 	}

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -341,7 +341,7 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 	assert.Nil(t, err)
 
 	for _, tabletType := range []string{"master", "replica", "rdonly"} {
-		if err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.%s", keyspaceName, shard1.Name, tabletType)); err != nil {
+		if err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.%s", keyspaceName, shard1.Name, tabletType), 1); err != nil {
 			assert.Fail(t, err.Error())
 		}
 	}
@@ -400,12 +400,11 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 
 	// Wait for the endpoints, either local or remote.
 	for _, shard := range []cluster.Shard{shard1, shard21, shard22} {
-
-		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard.Name))
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", keyspaceName, shard.Name), 1)
 		assert.Nil(t, err)
-		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard.Name))
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", keyspaceName, shard.Name), 1)
 		assert.Nil(t, err)
-		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard.Name))
+		err = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard.Name), 1)
 		assert.Nil(t, err)
 	}
 
@@ -493,7 +492,7 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 	sharding.CheckDestinationMaster(t, *shard22.MasterTablet(), []string{shard1Ks}, *ClusterInstance)
 
 	//  check that binlog server exported the stats vars
-	sharding.CheckBinlogServerVars(t, *shard1.Replica(), 0, 0)
+	sharding.CheckBinlogServerVars(t, *shard1.Replica(), 0, 0, false)
 
 	for _, tablet := range []cluster.Vttablet{*shard21.Rdonly(), *shard22.Rdonly()} {
 		err = ClusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", tablet.Alias)
@@ -510,7 +509,7 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 
 	sharding.CheckDestinationMaster(t, *shard21.MasterTablet(), []string{shard1Ks}, *ClusterInstance)
 	sharding.CheckDestinationMaster(t, *shard22.MasterTablet(), []string{shard1Ks}, *ClusterInstance)
-	sharding.CheckBinlogServerVars(t, *shard1.Replica(), 1000, 1000)
+	sharding.CheckBinlogServerVars(t, *shard1.Replica(), 1000, 1000, false)
 
 	err = ClusterInstance.VtctlclientProcess.ExecuteCommand("RunHealthCheck", shard21.Rdonly().Alias)
 	assert.Nil(t, err)
@@ -558,8 +557,8 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 	_ = shard21.Rdonly().VttabletProcess.WaitForTabletType("SERVING")
 	_ = shard22.Rdonly().VttabletProcess.WaitForTabletType("SERVING")
 
-	_ = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard21.Name))
-	_ = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard22.Name))
+	_ = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard21.Name), 1)
+	_ = vtgateInstance.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", keyspaceName, shard22.Name), 1)
 
 	//then serve replica from the split shards
 

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -529,7 +529,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	assert.Nil(t, err)
 
 	// check that binlog server exported the stats vars
-	sharding.CheckBinlogServerVars(t, *shard1Replica1, 0, 0)
+	sharding.CheckBinlogServerVars(t, *shard1Replica1, 0, 0, false)
 
 	// Check that the throttler was enabled.
 	// The stream id is hard-coded as 1, which is the first id generated through auto-inc.
@@ -554,7 +554,8 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	checkMultiShardValues(t, keyspaceName, shardingKeyType)
 	sharding.CheckBinlogPlayerVars(t, *shard2Master, []string{shard1Ks}, 30)
 	sharding.CheckBinlogPlayerVars(t, *shard3Master, []string{shard1Ks}, 30)
-	sharding.CheckBinlogServerVars(t, *shard1Replica1, 100, 100)
+
+	sharding.CheckBinlogServerVars(t, *shard1Replica1, 100, 100, false)
 
 	// use vtworker to compare the data (after health-checking the destination
 	// rdonly tablets so discovery works)
@@ -613,7 +614,8 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	insertLots(100, 100, *shard1Master, tableName, fixedParentID, keyspaceName)
 	log.Debug("Checking 100 percent of data was sent quickly")
 	assert.True(t, checkLotsTimeout(t, 100, 100, tableName, keyspaceName, shardingKeyType))
-	sharding.CheckBinlogServerVars(t, *shard1Replica2, 80, 80)
+
+	sharding.CheckBinlogServerVars(t, *shard1Replica2, 80, 80, false)
 
 	// check we can't migrate the master just yet
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes", shard1Ks, "master")

--- a/go/test/endtoend/sharding/verticalsplit/vertical_split_test.go
+++ b/go/test/endtoend/sharding/verticalsplit/vertical_split_test.go
@@ -1,0 +1,736 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package verticalsplit
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os/exec"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
+
+	"github.com/stretchr/testify/assert"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/sharding"
+	"vitess.io/vitess/go/vt/proto/topodata"
+	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+)
+
+var (
+	clusterInstance      *cluster.LocalProcessCluster
+	sourceKeyspace       = "source_keyspace"
+	destinationKeyspace  = "destination_keyspace"
+	hostname             = "localhost"
+	cellj                = "test_nj"
+	shardName            = "0"
+	createTabletTemplate = `
+		create table %s(
+			id bigint not null,
+			msg varchar(64),
+			primary key (id),
+			index by_msg (msg)
+		) Engine=InnoDB;`
+	createViewTemplate     = "create view %s(id, msg) as select id, msg from %s;"
+	createMoving3NoPkTable = `
+		create table moving3_no_pk (
+			id bigint not null,
+			msg varchar(64)
+		) Engine=InnoDB;`
+	tableArr         = []string{"moving1", "moving2", "staying1", "staying2"}
+	insertIndex      = 0
+	moving1First     int
+	moving2First     int
+	staying1First    int
+	staying2First    int
+	moving3NoPkFirst int
+)
+
+func TestVerticalSplit(t *testing.T) {
+	flag.Parse()
+	code, err := initializeCluster()
+	if err != nil {
+		t.Errorf("setup failed with status code %d", code)
+	}
+	defer teardownCluster()
+
+	// Adding another cell in the same cluster
+	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+"test_ca")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlProcess.AddCellInfo("test_ca")
+	assert.Nil(t, err)
+	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+"test_ny")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlProcess.AddCellInfo("test_ny")
+	assert.Nil(t, err)
+
+	assert.Nil(t, err, "error should be Nil")
+
+	// source keyspace, with 4 tables
+	sourceShard := clusterInstance.Keyspaces[0].Shards[0]
+	sourceMasterTablet := *sourceShard.Vttablets[0]
+	sourceReplicaTablet := *sourceShard.Vttablets[1]
+	sourceRdOnlyTablet1 := *sourceShard.Vttablets[2]
+	sourceRdOnlyTablet2 := *sourceShard.Vttablets[3]
+	sourceKs := fmt.Sprintf("%s/%s", sourceKeyspace, shardName)
+
+	// source tablets init
+	for _, tablet := range []cluster.Vttablet{sourceMasterTablet, sourceReplicaTablet, sourceRdOnlyTablet1, sourceRdOnlyTablet2} {
+		err = clusterInstance.VtctlclientProcess.InitTablet(&tablet, cellj, sourceKeyspace, hostname, sourceShard.Name)
+		assert.Nil(t, err)
+		err = tablet.VttabletProcess.CreateDB(sourceKeyspace)
+		assert.Nil(t, err)
+	}
+
+	// destination keyspace, with just two tables
+	destinationShard := clusterInstance.Keyspaces[1].Shards[0]
+	destinationMasterTablet := *destinationShard.Vttablets[0]
+	destinationReplicaTablet := *destinationShard.Vttablets[1]
+	destinationRdOnlyTablet1 := *destinationShard.Vttablets[2]
+	destinationRdOnlyTablet2 := *destinationShard.Vttablets[3]
+
+	// destination tablets init
+	for _, tablet := range []cluster.Vttablet{destinationMasterTablet, destinationReplicaTablet, destinationRdOnlyTablet1, destinationRdOnlyTablet2} {
+		err = clusterInstance.VtctlclientProcess.InitTablet(&tablet, cellj, destinationKeyspace, hostname, destinationShard.Name)
+		assert.Nil(t, err)
+		err = tablet.VttabletProcess.CreateDB(destinationKeyspace)
+		assert.Nil(t, err)
+	}
+
+	// RebuildKeyspaceGraph source keyspace
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", sourceKeyspace)
+	assert.Nil(t, err)
+
+	// RebuildKeyspaceGraph destination keyspace
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", destinationKeyspace)
+	assert.Nil(t, err)
+
+	// source schema
+	for _, tablet := range []cluster.Vttablet{sourceMasterTablet, sourceReplicaTablet, sourceRdOnlyTablet1, sourceRdOnlyTablet2} {
+		for _, tableName := range tableArr {
+			_, err := tablet.VttabletProcess.QueryTablet(fmt.Sprintf(createTabletTemplate, tableName), sourceKeyspace, true)
+			assert.Nil(t, err)
+		}
+		_, err := tablet.VttabletProcess.QueryTablet(fmt.Sprintf(createViewTemplate, "view1", "moving1"), sourceKeyspace, true)
+		assert.Nil(t, err)
+
+		// RBR (default behaviour) only because Vitess requires the primary key for query rewrites if
+		// it is running with statement based replication.
+		_, err = tablet.VttabletProcess.QueryTablet(createMoving3NoPkTable, sourceKeyspace, true)
+		assert.Nil(t, err)
+	}
+
+	// destination schema
+	// Insert data directly because vtgate would redirect us.
+	for _, tablet := range []cluster.Vttablet{destinationMasterTablet, destinationReplicaTablet, destinationRdOnlyTablet1, destinationRdOnlyTablet2} {
+		_, err = tablet.VttabletProcess.QueryTablet(fmt.Sprintf(createTabletTemplate, "extra1"), destinationKeyspace, true)
+		assert.Nil(t, err)
+	}
+
+	// source and destination master and replica tablets will be started
+	for _, tablet := range []cluster.Vttablet{sourceMasterTablet, sourceReplicaTablet, destinationMasterTablet, destinationReplicaTablet} {
+		_ = tablet.VttabletProcess.Setup()
+	}
+
+	// rdonly tablets will be started
+	for _, tablet := range []cluster.Vttablet{sourceRdOnlyTablet1, sourceRdOnlyTablet2, destinationRdOnlyTablet1, destinationRdOnlyTablet2} {
+		_ = tablet.VttabletProcess.Setup()
+	}
+
+	// check SrvKeyspace
+	ksServedFrom := "ServedFrom(master): source_keyspace\nServedFrom(rdonly): source_keyspace\nServedFrom(replica): source_keyspace\n"
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, ksServedFrom, *clusterInstance)
+
+	// reparent to make the tablets work (we use health check, fix their types)
+	err = clusterInstance.VtctlclientProcess.InitShardMaster(sourceKeyspace, shardName, cellj, sourceMasterTablet.TabletUID)
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.InitShardMaster(destinationKeyspace, shardName, cellj, destinationMasterTablet.TabletUID)
+	assert.Nil(t, err)
+
+	sourceMasterTablet.Type = "master"
+	destinationMasterTablet.Type = "master"
+
+	for _, tablet := range []cluster.Vttablet{sourceReplicaTablet, destinationReplicaTablet} {
+		_ = tablet.VttabletProcess.WaitForTabletType("SERVING")
+		assert.Nil(t, err)
+	}
+	for _, tablet := range []cluster.Vttablet{sourceRdOnlyTablet1, sourceRdOnlyTablet2, destinationRdOnlyTablet1, destinationRdOnlyTablet2} {
+		_ = tablet.VttabletProcess.WaitForTabletType("SERVING")
+		assert.Nil(t, err)
+	}
+
+	for _, tablet := range []cluster.Vttablet{sourceMasterTablet, destinationMasterTablet, sourceReplicaTablet, destinationReplicaTablet, sourceRdOnlyTablet1, sourceRdOnlyTablet2, destinationRdOnlyTablet1, destinationRdOnlyTablet2} {
+		assert.Equal(t, tablet.VttabletProcess.GetTabletStatus(), "SERVING")
+	}
+
+	err = clusterInstance.StartVtgate()
+	assert.Nil(t, err)
+
+	vtParams := mysql.ConnParams{
+		Host: clusterInstance.Hostname,
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", sourceKeyspace, shardName), 1)
+	assert.Nil(t, err)
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", sourceKeyspace, shardName), 1)
+	assert.Nil(t, err)
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", sourceKeyspace, shardName), 2)
+	assert.Nil(t, err)
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", destinationKeyspace, shardName), 1)
+	assert.Nil(t, err)
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.replica", destinationKeyspace, shardName), 1)
+	assert.Nil(t, err)
+	err = clusterInstance.VtgateProcess.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.rdonly", destinationKeyspace, shardName), 2)
+	assert.Nil(t, err)
+
+	// create the schema on the source keyspace, add some values
+	insertInitialValues(t, conn, sourceMasterTablet, destinationMasterTablet)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CopySchemaShard", "--tables", "/moving/,view1", sourceRdOnlyTablet1.Alias, "destination_keyspace/0")
+	assert.Nil(t, err, "CopySchemaShard failed")
+
+	// starting vtworker
+	httpPort := clusterInstance.GetAndReservePort()
+	grpcPort := clusterInstance.GetAndReservePort()
+	clusterInstance.VtworkerProcess = *cluster.VtworkerProcessInstance(
+		httpPort,
+		grpcPort,
+		clusterInstance.TopoPort,
+		clusterInstance.Hostname,
+		clusterInstance.TmpDirectory)
+
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(httpPort, grpcPort,
+		"--cell", cellj,
+		"--command_display_interval", "10ms",
+		"--use_v3_resharding_mode=true",
+		"VerticalSplitClone",
+		"--tables", "/moving/,view1",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_tablets", "1", "destination_keyspace/0")
+	assert.Nil(t, err)
+
+	// test Cancel first
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CancelResharding", "destination_keyspace/0")
+	assert.Nil(t, err)
+	err = destinationMasterTablet.VttabletProcess.WaitForBinLogPlayerCount(0)
+	assert.Nil(t, err)
+	// master should be in serving state after cancel
+	sharding.CheckTabletQueryServices(t, []cluster.Vttablet{destinationMasterTablet}, "SERVING", false, *clusterInstance)
+
+	// redo VerticalSplitClone
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(), clusterInstance.GetAndReservePort(),
+		"--cell", cellj,
+		"--command_display_interval", "10ms",
+		"--use_v3_resharding_mode=true",
+		"VerticalSplitClone",
+		"--tables", "/moving/,view1",
+		"--chunk_count", "10",
+		"--min_rows_per_chunk", "1",
+		"--min_healthy_tablets", "1", "destination_keyspace/0")
+	assert.Nil(t, err)
+
+	// check values are present
+	checkValues(t, &destinationMasterTablet, destinationKeyspace, "vt_destination_keyspace", "moving1", moving1First, 100)
+	checkValues(t, &destinationMasterTablet, destinationKeyspace, "vt_destination_keyspace", "moving2", moving2First, 100)
+	checkValues(t, &destinationMasterTablet, destinationKeyspace, "vt_destination_keyspace", "view1", moving1First, 100)
+	checkValues(t, &destinationMasterTablet, destinationKeyspace, "vt_destination_keyspace", "moving3_no_pk", moving3NoPkFirst, 100)
+
+	// Verify vreplication table entries
+	dbParams := mysql.ConnParams{
+		Uname:      "vt_dba",
+		UnixSocket: path.Join(destinationMasterTablet.VttabletProcess.Directory, "mysql.sock"),
+	}
+	dbParams.DbName = "_vt"
+	dbConn, err := mysql.Connect(ctx, &dbParams)
+	assert.Nil(t, err)
+	qr, err := dbConn.ExecuteFetch("select * from vreplication", 1000, true)
+	assert.Nil(t, err, "error should be Nil")
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), "SplitClone")
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), `keyspace:\"source_keyspace\" shard:\"0\" tables:\"/moving/\" tables:\"view1\`)
+	dbConn.Close()
+
+	// check the binlog player is running and exporting vars
+	sharding.CheckDestinationMaster(t, destinationMasterTablet, []string{sourceKs}, *clusterInstance)
+
+	// check that binlog server exported the stats vars
+	sharding.CheckBinlogServerVars(t, sourceReplicaTablet, 0, 0, true)
+
+	// add values to source, make sure they're replicated
+	moving1FirstAdd1 := insertValues(t, conn, sourceKeyspace, "moving1", 100)
+	_ = insertValues(t, conn, sourceKeyspace, "staying1", 100)
+	moving2FirstAdd1 := insertValues(t, conn, sourceKeyspace, "moving2", 100)
+	checkValuesTimeout(t, destinationMasterTablet, "moving1", moving1FirstAdd1, 100, 30)
+	checkValuesTimeout(t, destinationMasterTablet, "moving2", moving2FirstAdd1, 100, 30)
+	sharding.CheckBinlogPlayerVars(t, destinationMasterTablet, []string{sourceKs}, 30)
+	sharding.CheckBinlogServerVars(t, sourceReplicaTablet, 100, 100, true)
+
+	// use vtworker to compare the data
+	t.Log("Running vtworker VerticalSplitDiff")
+	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
+		clusterInstance.GetAndReservePort(),
+		"--use_v3_resharding_mode=true",
+		"--cell", "test_nj",
+		"VerticalSplitDiff",
+		"--min_healthy_rdonly_tablets", "1",
+		"destination_keyspace/0")
+	assert.Nil(t, err)
+
+	// get status for destination master tablet, make sure we have it all
+	sharding.CheckRunningBinlogPlayer(t, destinationMasterTablet, 700, 300)
+
+	// check query service is off on destination master, as filtered
+	// replication is enabled. Even health check should not interfere.
+	destinationMasterTabletVars := destinationMasterTablet.VttabletProcess.GetVars()
+	assert.NotNil(t, destinationMasterTabletVars)
+	assert.Contains(t, reflect.ValueOf(destinationMasterTabletVars["TabletStateName"]).String(), "NOT_SERVING")
+
+	// check we can't migrate the master just yet
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "destination_keyspace/0", "master")
+	assert.NotNil(t, err)
+
+	// migrate rdonly only in test_ny cell, make sure nothing is migrated
+	// in test_nj
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "--cells=test_ny", "destination_keyspace/0", "rdonly")
+	assert.Nil(t, err)
+
+	// check SrvKeyspace
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, ksServedFrom, *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, nil)
+
+	// migrate test_nj only, using command line manual fix command,
+	// and restore it back.
+	keyspaceJSON, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetKeyspace", "destination_keyspace")
+	assert.Nil(t, err)
+
+	validateKeyspaceJSON(t, keyspaceJSON, []string{"test_ca", "test_nj"})
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetKeyspaceServedFrom", "-source=source_keyspace", "-remove", "-cells=test_nj,test_ca", "destination_keyspace", "rdonly")
+	assert.Nil(t, err)
+
+	// again validating keyspaceJSON
+	keyspaceJSON, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetKeyspace", "destination_keyspace")
+	assert.Nil(t, err)
+
+	validateKeyspaceJSON(t, keyspaceJSON, nil)
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetKeyspaceServedFrom", "-source=source_keyspace", "destination_keyspace", "rdonly")
+	assert.Nil(t, err)
+
+	keyspaceJSON, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetKeyspace", "destination_keyspace")
+	assert.Nil(t, err)
+
+	validateKeyspaceJSON(t, keyspaceJSON, []string{})
+
+	// now serve rdonly from the destination shards
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "destination_keyspace/0", "rdonly")
+	assert.Nil(t, err)
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, "ServedFrom(master): source_keyspace\nServedFrom(replica): source_keyspace\n", *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, []string{"/moving/", "view1"})
+
+	grpcAddress := fmt.Sprintf("%s:%d", "localhost", clusterInstance.VtgateProcess.GrpcPort)
+	gconn, err := vtgateconn.Dial(ctx, grpcAddress)
+	assert.Nil(t, err)
+	defer gconn.Close()
+
+	checkClientConnRedirectionExecuteKeyrange(ctx, t, gconn, destinationKeyspace, []topodata.TabletType{topodata.TabletType_MASTER, topodata.TabletType_REPLICA}, []string{"moving1", "moving2"})
+
+	// then serve replica from the destination shards
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "destination_keyspace/0", "replica")
+	assert.Nil(t, err)
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, "ServedFrom(master): source_keyspace\n", *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, []string{"/moving/", "view1"})
+	checkClientConnRedirectionExecuteKeyrange(ctx, t, gconn, destinationKeyspace, []topodata.TabletType{topodata.TabletType_MASTER}, []string{"moving1", "moving2"})
+
+	// move replica back and forth
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "-reverse", "destination_keyspace/0", "replica")
+	assert.Nil(t, err)
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, "ServedFrom(master): source_keyspace\nServedFrom(replica): source_keyspace\n", *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, []string{"/moving/", "view1"})
+
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "destination_keyspace/0", "replica")
+	assert.Nil(t, err)
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, "ServedFrom(master): source_keyspace\n", *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, nil)
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, []string{"/moving/", "view1"})
+	checkClientConnRedirectionExecuteKeyrange(ctx, t, gconn, destinationKeyspace, []topodata.TabletType{topodata.TabletType_MASTER}, []string{"moving1", "moving2"})
+
+	// Cancel should fail now
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("CancelResharding", "destination_keyspace/0")
+	assert.NotNil(t, err)
+
+	// then serve master from the destination shards
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedFrom", "destination_keyspace/0", "master")
+	checkSrvKeyspaceServedFrom(t, cellj, destinationKeyspace, "", *clusterInstance)
+	checkBlacklistedTables(t, sourceMasterTablet, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceReplicaTablet, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet1, sourceKeyspace, []string{"/moving/", "view1"})
+	checkBlacklistedTables(t, sourceRdOnlyTablet2, sourceKeyspace, []string{"/moving/", "view1"})
+
+	// check the binlog player is gone now
+	_ = destinationMasterTablet.VttabletProcess.WaitForBinLogPlayerCount(0)
+
+	// check the stats are correct
+	checkStats(t)
+
+	// now remove the tables on the source shard. The blacklisted tables
+	// in the source shard won't match any table, make sure that works.
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ApplySchema", "-sql=drop view view1", "source_keyspace")
+	assert.Nil(t, err)
+
+	for _, table := range []string{"moving1", "moving2"} {
+		err = clusterInstance.VtctlclientProcess.ExecuteCommand("ApplySchema", "--sql=drop table "+table, "source_keyspace")
+		assert.Nil(t, err)
+	}
+	for _, tablet := range []cluster.Vttablet{sourceMasterTablet, sourceReplicaTablet, sourceRdOnlyTablet1, sourceRdOnlyTablet2} {
+		err = clusterInstance.VtctlclientProcess.ExecuteCommand("ReloadSchema", tablet.Alias)
+		assert.Nil(t, err)
+	}
+	qr, _ = sourceMasterTablet.VttabletProcess.QueryTablet("select count(1) from staying1", sourceKeyspace, true)
+	assert.Equal(t, 1, len(qr.Rows), fmt.Sprintf("cannot read staying1: got %d", len(qr.Rows)))
+
+	// test SetShardTabletControl
+	verifyVtctlSetShardTabletControl(t)
+
+}
+
+func verifyVtctlSetShardTabletControl(t *testing.T) {
+	// clear the rdonly entry:
+	err := clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "--remove", "source_keyspace/0", "rdonly")
+	assert.Nil(t, err)
+	assertTabletControls(t, clusterInstance, []topodata.TabletType{topodata.TabletType_MASTER, topodata.TabletType_REPLICA})
+
+	// re-add rdonly:
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "--blacklisted_tables=/moving/,view1", "source_keyspace/0", "rdonly")
+	assert.Nil(t, err)
+	assertTabletControls(t, clusterInstance, []topodata.TabletType{topodata.TabletType_MASTER, topodata.TabletType_REPLICA, topodata.TabletType_RDONLY})
+
+	//and then clear all entries:
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "--remove", "source_keyspace/0", "rdonly")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "--remove", "source_keyspace/0", "replica")
+	assert.Nil(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SetShardTabletControl", "--remove", "source_keyspace/0", "master")
+	assert.Nil(t, err)
+
+	shardJSON, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetShard", "source_keyspace/0")
+	var shardJSONData topodata.Shard
+	err = json2.Unmarshal([]byte(shardJSON), &shardJSONData)
+	assert.Empty(t, shardJSONData.TabletControls)
+
+}
+
+func assertTabletControls(t *testing.T, clusterInstance *cluster.LocalProcessCluster, aliases []topodata.TabletType) {
+	shardJSON, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("GetShard", "source_keyspace/0")
+	assert.Nil(t, err)
+	var shardJSONData topodata.Shard
+	err = json2.Unmarshal([]byte(shardJSON), &shardJSONData)
+	assert.Nil(t, err)
+	assert.Equal(t, len(shardJSONData.TabletControls), len(aliases))
+	for _, tc := range shardJSONData.TabletControls {
+		assert.Contains(t, aliases, tc.TabletType)
+		assert.Equal(t, []string{"/moving/", "view1"}, tc.BlacklistedTables)
+	}
+}
+
+func checkStats(t *testing.T) {
+
+	resultMap, err := clusterInstance.VtgateProcess.GetVars()
+	assert.Nil(t, err)
+	resultVtTabletCall := resultMap["VttabletCall"]
+	resultVtTabletCallMap := resultVtTabletCall.(map[string]interface{})
+	resultHistograms := resultVtTabletCallMap["Histograms"]
+	resultHistogramsMap := resultHistograms.(map[string]interface{})
+	resultTablet := resultHistogramsMap["Execute.source_keyspace.0.replica"]
+	resultTableMap := resultTablet.(map[string]interface{})
+	resultCountStr := fmt.Sprintf("%v", reflect.ValueOf(resultTableMap["Count"]))
+	assert.Equal(t, "2", resultCountStr, fmt.Sprintf("unexpected value for VttabletCall(Execute.source_keyspace.0.replica) inside %s", resultCountStr))
+
+	// Verify master reads done by self._check_client_conn_redirection().
+	resultVtgateAPI := resultMap["VtgateApi"]
+	resultVtgateAPIMap := resultVtgateAPI.(map[string]interface{})
+	resultAPIHistograms := resultVtgateAPIMap["Histograms"]
+	resultAPIHistogramsMap := resultAPIHistograms.(map[string]interface{})
+	resultTabletDestination := resultAPIHistogramsMap["ExecuteKeyRanges.destination_keyspace.master"]
+	resultTabletDestinationMap := resultTabletDestination.(map[string]interface{})
+	resultCountStrDestination := fmt.Sprintf("%v", reflect.ValueOf(resultTabletDestinationMap["Count"]))
+	assert.Equal(t, "6", resultCountStrDestination, fmt.Sprintf("unexpected value for VtgateApi(ExecuteKeyRanges.destination_keyspace.master) inside %s)", resultCountStrDestination))
+
+	assert.Empty(t, resultMap["VtgateApiErrorCounts"])
+
+}
+
+func insertInitialValues(t *testing.T, conn *mysql.Conn, sourceMasterTablet cluster.Vttablet, destinationMasterTablet cluster.Vttablet) {
+	moving1First = insertValues(t, conn, sourceKeyspace, "moving1", 100)
+	moving2First = insertValues(t, conn, sourceKeyspace, "moving2", 100)
+	staying1First = insertValues(t, conn, sourceKeyspace, "staying1", 100)
+	staying2First = insertValues(t, conn, sourceKeyspace, "staying2", 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "moving1", moving1First, 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "moving2", moving2First, 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "staying1", staying1First, 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "staying2", staying2First, 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "view1", moving1First, 100)
+
+	moving3NoPkFirst = insertValues(t, conn, sourceKeyspace, "moving3_no_pk", 100)
+	checkValues(t, &sourceMasterTablet, sourceKeyspace, "vt_source_keyspace", "moving3_no_pk", moving3NoPkFirst, 100)
+
+	// Insert data directly because vtgate would redirect us.
+	_, err := destinationMasterTablet.VttabletProcess.QueryTablet(fmt.Sprintf("insert into %s (id, msg) values(%d, 'value %d')", "extra1", 1, 1), destinationKeyspace, true)
+	assert.Nil(t, err)
+	checkValues(t, &destinationMasterTablet, destinationKeyspace, "vt_destination_keyspace", "extra1", 1, 1)
+}
+
+func checkClientConnRedirectionExecuteKeyrange(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn, keyspace string, servedFromDbTypes []topodata.TabletType, movedTables []string) {
+	var testKeyRange = &topodata.KeyRange{
+		Start: []byte{},
+		End:   []byte{},
+	}
+	keyRanges := []*topodata.KeyRange{testKeyRange}
+	// check that the ServedFrom indirection worked correctly.
+	for _, tableType := range servedFromDbTypes {
+		for _, table := range movedTables {
+			_, err := conn.ExecuteKeyRanges(ctx, fmt.Sprintf("select * from %s", table), keyspace, keyRanges, nil, tableType, nil)
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func checkValues(t *testing.T, tablet *cluster.Vttablet, keyspace string, dbname string, table string, first int, count int) {
+	t.Logf("Checking %d values from %s/%s starting at %d", count, dbname, table, first)
+	qr, _ := tablet.VttabletProcess.QueryTablet(fmt.Sprintf("select id, msg from %s where id>=%d order by id limit %d", table, first, count), keyspace, true)
+	assert.Equal(t, count, len(qr.Rows), fmt.Sprintf("got wrong number of rows: %d != %d", len(qr.Rows), count))
+	i := 0
+	for i < count {
+		result, _ := sqltypes.ToInt64(qr.Rows[i][0])
+		assert.Equal(t, int64(first+i), result, fmt.Sprintf("got wrong number of rows: %d != %d", len(qr.Rows), first+i))
+		assert.Contains(t, qr.Rows[i][1].String(), fmt.Sprintf("value %d", first+i), fmt.Sprintf("invalid msg[%d]: 'value %d' != '%s'", i, first+i, qr.Rows[i][1].String()))
+		i++
+	}
+}
+
+func checkValuesTimeout(t *testing.T, tablet cluster.Vttablet, table string, first int, count int, timeoutInSec int) bool {
+	for i := 0; i < timeoutInSec; i-- {
+		qr, err := tablet.VttabletProcess.QueryTablet(fmt.Sprintf("select id, msg from %s where id>=%d order by id limit %d", table, first, count), destinationKeyspace, true)
+		if err != nil {
+			assert.Nil(t, err, "select failed on master tablet")
+		}
+		if len(qr.Rows) == count {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return true
+}
+
+func checkBlacklistedTables(t *testing.T, tablet cluster.Vttablet, keyspace string, expected []string) {
+	tabletStatus := tablet.VttabletProcess.GetStatus()
+	if expected != nil {
+		assert.Contains(t, tabletStatus, fmt.Sprintf("BlacklistedTables: %s", strings.Join(expected, " ")))
+	} else {
+		assert.NotContains(t, tabletStatus, "BlacklistedTables")
+	}
+
+	// check we can or cannot access the tables
+	for _, table := range []string{"moving1", "moving2"} {
+		if expected != nil && strings.Contains(strings.Join(expected, " "), "moving") {
+			// table is blacklisted, should get error
+			err := clusterInstance.VtctlclientProcess.ExecuteCommand("VtTabletExecute", "-json", tablet.Alias, fmt.Sprintf("select count(1) from %s", table))
+			assert.NotNil(t, err, "disallowed due to rule: enforce blacklisted tables")
+		} else {
+			// table is not blacklisted, should just work
+			_, err := tablet.VttabletProcess.QueryTablet(fmt.Sprintf("select count(1) from %s", table), keyspace, true)
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func insertValues(t *testing.T, conn *mysql.Conn, keyspace string, table string, count int) int {
+	result := insertIndex
+	i := 0
+	for i < count {
+		execQuery(t, conn, "begin")
+		execQuery(t, conn, "use `"+keyspace+":0`")
+		execQuery(t, conn, fmt.Sprintf("insert into %s (id, msg) values(%d, 'value %d')", table, insertIndex, insertIndex))
+		execQuery(t, conn, "commit")
+		insertIndex++
+		i++
+	}
+	return result
+}
+
+func teardownCluster() {
+	clusterInstance.Teardown()
+}
+
+func execQuery(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
+	t.Helper()
+	qr, err := conn.ExecuteFetch(query, 1000, true)
+	assert.Nil(t, err)
+	return qr
+}
+
+// CheckSrvKeyspaceServedFrom verifies the servedFrom with expected
+func checkSrvKeyspaceServedFrom(t *testing.T, cell string, ksname string, expected string, ci cluster.LocalProcessCluster) {
+	srvKeyspace := sharding.GetSrvKeyspace(t, cell, ksname, ci)
+	tabletTypeKeyspaceMap := make(map[string]string)
+	result := ""
+	if srvKeyspace.GetServedFrom() != nil {
+		for _, servedFrom := range srvKeyspace.GetServedFrom() {
+			tabletTy := strings.ToLower(servedFrom.GetTabletType().String())
+			tabletTypeKeyspaceMap[tabletTy] = servedFrom.GetKeyspace()
+		}
+	}
+	if tabletTypeKeyspaceMap["master"] != "" {
+		result = result + fmt.Sprintf("ServedFrom(%s): %s\n", "master", tabletTypeKeyspaceMap["master"])
+	}
+	if tabletTypeKeyspaceMap["rdonly"] != "" {
+		result = result + fmt.Sprintf("ServedFrom(%s): %s\n", "rdonly", tabletTypeKeyspaceMap["rdonly"])
+	}
+	if tabletTypeKeyspaceMap["replica"] != "" {
+		result = result + fmt.Sprintf("ServedFrom(%s): %s\n", "replica", tabletTypeKeyspaceMap["replica"])
+	}
+	assert.Equal(t, expected, result, fmt.Sprintf("Mismatch in srv keyspace for cell %s keyspace %s, expected:\n %s\ngot:\n%s", cell, ksname, expected, result))
+	assert.Equal(t, "", srvKeyspace.GetShardingColumnName(), fmt.Sprintf("Got a sharding_column_name in SrvKeyspace: %s", srvKeyspace.GetShardingColumnName()))
+	assert.Equal(t, "UNSET", srvKeyspace.GetShardingColumnType().String(), fmt.Sprintf("Got a sharding_column_type in SrvKeyspace: %s", srvKeyspace.GetShardingColumnType().String()))
+}
+
+func initializeCluster() (int, error) {
+	var mysqlProcesses []*exec.Cmd
+	clusterInstance = &cluster.LocalProcessCluster{Cell: cellj, Hostname: hostname}
+
+	// Start topo server
+	if err := clusterInstance.StartTopo(); err != nil {
+		return 1, err
+	}
+
+	for _, keyspaceStr := range []string{sourceKeyspace, destinationKeyspace} {
+		KeyspacePtr := &cluster.Keyspace{Name: keyspaceStr}
+		keyspace := *KeyspacePtr
+		if keyspaceStr == sourceKeyspace {
+			if err := clusterInstance.VtctlProcess.CreateKeyspace(keyspace.Name); err != nil {
+				return 1, err
+			}
+		} else {
+			if err := clusterInstance.VtctlclientProcess.ExecuteCommand("CreateKeyspace", "--served_from", "master:source_keyspace,replica:source_keyspace,rdonly:source_keyspace", "destination_keyspace"); err != nil {
+				return 1, err
+			}
+		}
+		shard := &cluster.Shard{
+			Name: shardName,
+		}
+		for i := 0; i < 4; i++ {
+			// instantiate vttablet object with reserved ports
+			tabletUID := clusterInstance.GetAndReserveTabletUID()
+			var tablet *cluster.Vttablet = nil
+			if i == 0 {
+				tablet = clusterInstance.GetVttabletInstance("replica", tabletUID, cellj)
+			} else if i == 1 {
+				tablet = clusterInstance.GetVttabletInstance("replica", tabletUID, cellj)
+			} else {
+				tablet = clusterInstance.GetVttabletInstance("rdonly", tabletUID, cellj)
+			}
+			// Start Mysqlctl process
+			tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
+			if proc, err := tablet.MysqlctlProcess.StartProcess(); err != nil {
+				return 1, err
+			} else {
+				mysqlProcesses = append(mysqlProcesses, proc)
+			}
+			// start vttablet process
+			tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,
+				tablet.GrpcPort,
+				tablet.TabletUID,
+				clusterInstance.Cell,
+				shardName,
+				keyspace.Name,
+				clusterInstance.VtctldProcess.Port,
+				tablet.Type,
+				clusterInstance.TopoProcess.Port,
+				clusterInstance.Hostname,
+				clusterInstance.TmpDirectory,
+				clusterInstance.VtTabletExtraArgs,
+				clusterInstance.EnableSemiSync)
+			tablet.Alias = tablet.VttabletProcess.TabletPath
+
+			shard.Vttablets = append(shard.Vttablets, tablet)
+		}
+		keyspace.Shards = append(keyspace.Shards, *shard)
+		clusterInstance.Keyspaces = append(clusterInstance.Keyspaces, keyspace)
+	}
+	for _, proc := range mysqlProcesses {
+		err := proc.Wait()
+		if err != nil {
+			return 1, err
+		}
+	}
+	return 0, nil
+}
+
+func validateKeyspaceJSON(t *testing.T, keyspaceJSON string, cellsArr []string) {
+	var keyspace topodata.Keyspace
+	err := json2.Unmarshal([]byte(keyspaceJSON), &keyspace)
+	assert.Nil(t, err)
+	found := false
+	for _, servedFrom := range keyspace.GetServedFroms() {
+		if strings.ToLower(servedFrom.GetTabletType().String()) == "rdonly" {
+			found = true
+			if cellsArr != nil {
+				if len(cellsArr) > 0 {
+					for _, eachCell := range cellsArr {
+						assert.Contains(t, strings.Join(servedFrom.GetCells(), " "), eachCell)
+					}
+				} else {
+					assert.Equal(t, []string{}, servedFrom.GetCells())
+				}
+			}
+		}
+	}
+	if cellsArr != nil {
+		assert.Equal(t, true, found)
+	} else {
+		assert.Equal(t, false, found)
+	}
+}

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -54,6 +54,7 @@ func TestTabletReshuffle(t *testing.T) {
 
 	//Create new tablet
 	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
+
 	//Init Tablets
 	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
 	require.NoError(t, err)

--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -356,6 +356,7 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 
 	// Wait for replica to catch up to master.
 	waitForReplicationPos(ctx, t, master, replica, 60.0)
+
 	duration := time.Since(start)
 	minUnavailabilityInS := 1.0
 	if duration.Seconds() < minUnavailabilityInS {
@@ -372,7 +373,9 @@ func externalReparenting(ctx context.Context, t *testing.T, clusterInstance *clu
 	}
 
 	// Configure old master to replicate from new master.
+
 	_, gtID := cluster.GetMasterPosition(t, *newMaster, hostname)
+
 	// Use 'localhost' as hostname because Travis CI worker hostnames
 	// are too long for MySQL replication.
 	changeMasterCommands := fmt.Sprintf("RESET SLAVE;SET GLOBAL gtid_slave_pos = '%s';CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d ,MASTER_USER='vt_repl', MASTER_USE_GTID = slave_pos;START SLAVE;", gtID, "localhost", newMaster.MySQLPort)

--- a/test/config.json
+++ b/test/config.json
@@ -481,7 +481,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"worker_test"
@@ -492,7 +492,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 5,
 			"RetryMax": 0,
 			"Tags": [
 				"worker_test"


### PR DESCRIPTION
**Vertical split testcase**
Vertical split endtoend testcase migrated from python and using default RBR mode.

Signed-off-by: saurabh408 <saurabh.408@gmail.com>