### PR TITLE
Rebalance Travis tests

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -599,7 +599,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 2,
 			"RetryMax": 0,
 			"Tags": []
 		},
@@ -608,7 +608,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 1,
+			"Shard": 3,
 			"RetryMax": 0,
 			"Tags": []
 		}


### PR DESCRIPTION
Due to tests migrating to Go and being run in GitHub actions, shards 2 and 3 have been finishing quicker than the other shards.  example: https://travis-ci.org/vitessio/vitess/builds/627204960?utm_source=github_status&utm_medium=notification

There are additional tests being moved all the time, so this just makes a small balance change.

Signed-off-by: Morgan Tocker <tocker@gmail.com>