### PR TITLE
Enable authorization via mtls client cert attribute

### DIFF
--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -19,8 +19,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 	"testing"
+
+	"vitess.io/vitess/go/vt/tlstest"
 
 	"github.com/stretchr/testify/assert"
 	"vitess.io/vitess/go/mysql"
@@ -42,24 +46,111 @@ type columnVindex struct {
 }
 
 func TestRunsVschemaMigrations(t *testing.T) {
+	cluster, err := startCluster()
+	defer cluster.TearDown()
+	args := os.Args
+	defer resetFlags(args)
+
+	assert.NoError(t, err)
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
+
+	// Add Hash vindex via vtgate execution on table
+	err = addColumnVindex(cluster, "test_keyspace", "alter vschema on test_table1 add vindex my_vdx (id)")
+	assert.NoError(t, err)
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table1", vindex: "my_vdx", vindexType: "hash", column: "id"})
+}
+
+func TestMtlsAuth(t *testing.T) {
+	// Our test root.
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	// Create the certs and configs.
+	tlstest.CreateCA(root)
+	caCert := path.Join(root, "ca-cert.pem")
+
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "vtctld", "vtctld.example.com")
+	cert := path.Join(root, "vtctld-cert.pem")
+	key := path.Join(root, "vtctld-key.pem")
+
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "ClientApp")
+	clientCert := path.Join(root, "client-cert.pem")
+	clientKey := path.Join(root, "client-key.pem")
+
+	// When cluster starts it will apply SQL and VSchema migrations in the configured schema_dir folder
+	// With mtls authorization enabled, the authorized CN must match the certificate's CN
+	cluster, err := startCluster(
+		"-grpc_auth_mode=mtls",
+		fmt.Sprintf("-grpc_key=%s", key),
+		fmt.Sprintf("-grpc_cert=%s", cert),
+		fmt.Sprintf("-grpc_ca=%s", caCert),
+		fmt.Sprintf("-vtctld_grpc_key=%s", clientKey),
+		fmt.Sprintf("-vtctld_grpc_cert=%s", clientCert),
+		fmt.Sprintf("-vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("-grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
+	assert.NoError(t, err)
+	defer cluster.TearDown()
+	args := os.Args
+	defer resetFlags(args)
+
+	// startCluster will apply vschema migrations using vtctl grpc and the clientCert.
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
+	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
+}
+
+func TestMtlsAuthUnaothorizedFails(t *testing.T) {
+	// Our test root.
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	// Create the certs and configs.
+	tlstest.CreateCA(root)
+	caCert := path.Join(root, "ca-cert.pem")
+
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "vtctld", "vtctld.example.com")
+	cert := path.Join(root, "vtctld-cert.pem")
+	key := path.Join(root, "vtctld-key.pem")
+
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "AnotherApp")
+	clientCert := path.Join(root, "client-cert.pem")
+	clientKey := path.Join(root, "client-key.pem")
+
+	// When cluster starts it will apply SQL and VSchema migrations in the configured schema_dir folder
+	// For mtls authorization failure by providing a client certificate with different CN thant the
+	// authorized in the configuration
+	cluster, err := startCluster(
+		"-grpc_auth_mode=mtls",
+		fmt.Sprintf("-grpc_key=%s", key),
+		fmt.Sprintf("-grpc_cert=%s", cert),
+		fmt.Sprintf("-grpc_ca=%s", caCert),
+		fmt.Sprintf("-vtctld_grpc_key=%s", clientKey),
+		fmt.Sprintf("-vtctld_grpc_cert=%s", clientCert),
+		fmt.Sprintf("-vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("-grpc_auth_mtls_allowed_substrings=%s", "CN=ClientApp"))
+	defer cluster.TearDown()
+	args := os.Args
+	defer resetFlags(args)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "code = Unauthenticated desc = client certificate not authorized")
+}
+
+func startCluster(flags ...string) (vttest.LocalCluster, error) {
 	schemaDirArg := "-schema_dir=data/schema"
 	tabletHostname := "-tablet_hostname=localhost"
 	keyspaceArg := "-keyspaces=test_keyspace,app_customer"
 	numShardsArg := "-num_shards=2,2"
 	vschemaDDLAuthorizedUsers := "-vschema_ddl_authorized_users=%"
-
 	os.Args = append(os.Args, []string{schemaDirArg, keyspaceArg, numShardsArg, tabletHostname, vschemaDDLAuthorizedUsers}...)
-
-	cluster := runCluster()
-	defer cluster.TearDown()
-
-	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
-	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
-
-	// Add Hash vindex via vtgate execution on table
-	err := addColumnVindex(cluster, "test_keyspace", "alter vschema on test_table1 add vindex my_vdx (id)")
-	assert.NoError(t, err)
-	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table1", vindex: "my_vdx", vindexType: "hash", column: "id"})
+	os.Args = append(os.Args, flags...)
+	return runCluster()
 }
 
 func addColumnVindex(cluster vttest.LocalCluster, keyspace string, vschemaMigration string) error {
@@ -105,4 +196,8 @@ func assertEqual(t *testing.T, actual string, expected string, message string) {
 	if actual != expected {
 		t.Errorf("%s: actual %s, expected %s", message, actual, expected)
 	}
+}
+
+func resetFlags(args []string) {
+	os.Args = args
 }

--- a/go/vt/servenv/grpc_server_auth_mtls.go
+++ b/go/vt/servenv/grpc_server_auth_mtls.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"flag"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+var (
+	// ClientCertSubstrings list of substrings of at least one of the client certificate names to use during authorization
+	ClientCertSubstrings = flag.String("grpc_auth_mtls_allowed_substrings", "", "List of substrings of at least one of the client certificate names (separated by colon).")
+	// MtlsAuthPlugin implements AuthPlugin interface
+	_ Authenticator = (*MtlsAuthPlugin)(nil)
+)
+
+// MtlsAuthPlugin  implements static username/password authentication for grpc. It contains an array of username/passwords
+// that will be authorized to connect to the grpc server.
+type MtlsAuthPlugin struct {
+	clientCertSubstrings []string
+}
+
+// Authenticate implements Authenticator interface. This method will be used inside a middleware in grpc_server to authenticate
+// incoming requests.
+func (ma *MtlsAuthPlugin) Authenticate(ctx context.Context, fullMethod string) (context.Context, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "no peer connection info")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "not connected via TLS")
+	}
+	for _, substring := range ma.clientCertSubstrings {
+		for _, cert := range tlsInfo.State.PeerCertificates {
+			if strings.Contains(cert.Subject.String(), substring) {
+				return ctx, nil
+			}
+		}
+	}
+	return nil, status.Errorf(codes.Unauthenticated, "client certificate not authorized")
+}
+
+func mtlsAuthPluginInitializer() (Authenticator, error) {
+	mtlsAuthPlugin := &MtlsAuthPlugin{
+		clientCertSubstrings: strings.Split(*ClientCertSubstrings, ":"),
+	}
+	log.Infof("mtls auth plugin have initialized successfully with allowed client cert name substrings of %v", *ClientCertSubstrings)
+	return mtlsAuthPlugin, nil
+}
+
+func init() {
+	RegisterAuthPlugin("mtls", mtlsAuthPluginInitializer)
+}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 
 	"github.com/golang/protobuf/proto"
 )
@@ -236,6 +237,9 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	}
 	if args.TabletHostName != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-tablet_hostname", args.TabletHostName}...)
+	}
+	if *servenv.GRPCAuth == "mtls" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-grpc_auth_mode", *servenv.GRPCAuth, "-grpc_key", *servenv.GRPCKey, "-grpc_cert", *servenv.GRPCCert, "-grpc_ca", *servenv.GRPCCA, "-grpc_auth_mtls_allowed_substrings", *servenv.ClientCertSubstrings}...)
 	}
 	if args.InitWorkflowManager {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-workflow_manager_init"}...)


### PR DESCRIPTION
The purpose of this PR is to enable authorization based on particular certificate subject attribute. When enabled ```-grpc_auth_mode=mtls```, then ```-grpc_auth_mtls_allowed_substrings``` will contain the attribute key/value that will be authorized, i.e "CN=ClientApp"

Signed-off-by: Karel Alfonso Sague <kalfonso@squareup.com>