### PR TITLE
tests: deflake migrater

### DIFF
--- a/go/vt/wrangler/migrater.go
+++ b/go/vt/wrangler/migrater.go
@@ -370,6 +370,10 @@ func (wr *Wrangler) buildMigrationTargets(ctx context.Context, targetKeyspace, w
 		if err != nil {
 			return nil, false, err
 		}
+		if targetsi.MasterAlias == nil {
+			// This can happen if bad inputs are given.
+			return nil, false, fmt.Errorf("shard %v:%v doesn't have a master set", targetKeyspace, targetShard)
+		}
 		targetMaster, err := wr.ts.GetTablet(ctx, targetsi.MasterAlias)
 		if err != nil {
 			return nil, false, err


### PR DESCRIPTION
Fixes #5616
After tablets are initialized, the shard master gets updated
asynchronoysly. Sometimes, the test races ahead of that update and
panics.

Test is now changed to wait for shard masters to be udpated, and
there's no defensive code in case the master is not set.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>