### PR TITLE
sequences: fix panic on bad sequence name

### DIFF
--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -351,13 +351,18 @@ func resolveAutoIncrement(source *vschemapb.SrvVSchema, vschema *VSchema) {
 			if t == nil || table.AutoIncrement == nil {
 				continue
 			}
-			t.AutoIncrement = &AutoIncrement{Column: sqlparser.NewColIdent(table.AutoIncrement.Column)}
 			seq, err := vschema.findQualified(table.AutoIncrement.Sequence)
 			if err != nil {
+				// Better to remove the table than to leave it partially initialized.
+				delete(ksvschema.Tables, tname)
+				delete(vschema.uniqueTables, tname)
 				ksvschema.Error = fmt.Errorf("cannot resolve sequence %s: %v", table.AutoIncrement.Sequence, err)
 				continue
 			}
-			t.AutoIncrement.Sequence = seq
+			t.AutoIncrement = &AutoIncrement{
+				Column:   sqlparser.NewColIdent(table.AutoIncrement.Column),
+				Sequence: seq,
+			}
 		}
 	}
 }

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -1806,10 +1806,8 @@ func TestBadSequence(t *testing.T) {
 	if err == nil || err.Error() != want {
 		t.Errorf("BuildVSchema: %v, want %v", err, want)
 	}
-
-	t1Seq := got.Keyspaces["sharded"].Tables["t1"].AutoIncrement.Sequence
-	if t1Seq != nil {
-		t.Errorf("BuildVSchema: unexpected sequence for table t1: %v", t1Seq)
+	if t1 := got.Keyspaces["sharded"].Tables["t1"]; t1 != nil {
+		t.Errorf("BuildVSchema: table t1 must not be present in the keyspace: %v", t1)
 	}
 
 	// Verify that a failure to set up a sequence for t1 doesn't prevent setting up
@@ -1855,6 +1853,9 @@ func TestBadSequenceName(t *testing.T) {
 	want := "cannot resolve sequence a.b.seq: table a.b.seq not found"
 	if err == nil || err.Error() != want {
 		t.Errorf("BuildVSchema: %v, want %v", err, want)
+	}
+	if t1 := got.Keyspaces["sharded"].Tables["t1"]; t1 != nil {
+		t.Errorf("BuildVSchema: table t1 must not be present in the keyspace: %v", t1)
 	}
 }
 


### PR DESCRIPTION
Fixes #5339

If a sequence table is not found, then the referring table is
removed from the VSchema to prevent it from being partially
initialized.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>