### PR TITLE
tests: deflake vstreamer

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -53,6 +54,14 @@ type VStreamer interface {
 func NewVStreamer(ctx context.Context, cp *mysql.ConnParams, se *schema.Engine, startPos string, filter *binlogdatapb.Filter, send func([]*binlogdatapb.VEvent) error) VStreamer {
 	return newVStreamer(ctx, cp, se, startPos, filter, &localVSchema{vschema: &vindexes.VSchema{}}, send)
 }
+
+// vschemaUpdateCount is for testing only.
+// vstreamer is a mutex free data structure. So, it's not safe to access its members
+// from a test. Since VSchema gets updated asynchronously, there's no way for a test
+// to wait for it. Instead, the code that updates the vschema increments this atomic
+// counter, which will let the tests poll for it to change.
+// TODO(sougou): find a better way for this.
+var vschemaUpdateCount sync2.AtomicInt64
 
 type vstreamer struct {
 	ctx    context.Context
@@ -237,6 +246,8 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 			if err := vs.rebuildPlans(); err != nil {
 				return err
 			}
+			// Increment this counter for testing.
+			vschemaUpdateCount.Add(1)
 		case <-ctx.Done():
 			return nil
 		case <-timer.C:


### PR DESCRIPTION
Found another flaky use case around VSchema updates.
The current fix is simple, but slightly hacky. We'll have to look
alternatives later if it becomes a hindrance.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>