### PR TITLE
tests: further deflake vstreamer

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/main_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 )
@@ -53,12 +52,6 @@ func TestMain(m *testing.M) {
 		engine.InitDBConfig(env.Dbcfgs.DbaWithDB())
 		engine.Open(env.KeyspaceName, env.Cells[0])
 		defer engine.Close()
-
-		// GH actions machines sometimes exhibit multi-second delays on replication.
-		// So, give a generously high value for heartbeat time for all tests.
-		saveHeartbeat := HeartbeatTime
-		defer func() { HeartbeatTime = saveHeartbeat }()
-		HeartbeatTime = 10 * time.Second
 
 		return m.Run()
 	}()

--- a/tools/unit_test_runner.sh
+++ b/tools/unit_test_runner.sh
@@ -62,7 +62,7 @@ for pkg in $flaky_tests; do
   max_attempts=3
   attempt=1
   # Set a timeout because some tests may deadlock when they flake.
-  until go test -timeout 30s $VT_GO_PARALLEL $pkg -count=1; do
+  until go test -timeout 2m $VT_GO_PARALLEL $pkg -count=1; do
     echo "FAILED (try $attempt/$max_attempts) in $pkg (return code $?). See above for errors."
     if [ $((++attempt)) -gt $max_attempts ]; then
       echo "ERROR: Flaky Go unit tests in package $pkg failed too often (after $max_attempts retries). Please reduce the flakiness."


### PR DESCRIPTION
The previous heartbeat fix can still cause flakyness. This new
change ignores spurious heartbeats instead of using a longer
timer.

Also, I've added a specific test to make sure heartbeats are
working as intended.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>