### PR TITLE
vtgate_test: round duration before checking

### DIFF
--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -1325,7 +1325,7 @@ func TestVTGateMessageStreamRetry(t *testing.T) {
 	// which should make vtgate wait for 1s (5s/5) and retry.
 	start := time.Now()
 	<-ch
-	duration := time.Since(start)
+	duration := time.Since(start).Round(time.Second)
 	if duration < 1*time.Second || duration > 2*time.Second {
 		t.Errorf("Retry duration should be around 1 second: %v", duration)
 	}


### PR DESCRIPTION
The test sometimes fails in CI with this error:
```
--- FAIL: TestVTGateMessageStreamRetry (1.00s)
##[error]    vtgate_test.go:1330: Retry duration should be around 1 second: 999.675154ms
```
Signed-off-by: deepthi <deepthi@planetscale.com>