### PR TITLE
tools/make-release-packages.sh: stop packaging web dir

### DIFF
--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -39,7 +39,7 @@ done;
 
 # Copy remaining files, preserving date/permissions
 # But resolving symlinks
-cp -rpfL {config,vthook,web,examples} "${RELEASE_DIR}/"
+cp -rpfL {config,vthook,examples} "${RELEASE_DIR}/"
 
 echo "Follow the binary installation instructions at: https://vitess.io/docs/get-started/local/" > "${RELEASE_DIR}"/README.md
 


### PR DESCRIPTION
Now that web assets are embedded in vtctld (#5597), we no longer need to include the `web` dir in release packages. 

Signed-off-by: Gary Edgar <gary@planetscale.com>