### PR TITLE
DeleteTablet: allow deletion of old master tablet without -allow_master

### DIFF
--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -130,15 +130,16 @@ func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.Ta
 		defer unlock(&err)
 
 		// update the shard record's master
-		_, err = wr.ts.UpdateShardFields(ctx, ti.Keyspace, ti.Shard, func(si *topo.ShardInfo) error {
+		if _, err := wr.ts.UpdateShardFields(ctx, ti.Keyspace, ti.Shard, func(si *topo.ShardInfo) error {
 			if !topoproto.TabletAliasEqual(si.MasterAlias, tabletAlias) {
 				wr.Logger().Warningf("Deleting master %v from shard %v/%v but master in Shard object was %v", topoproto.TabletAliasString(tabletAlias), ti.Keyspace, ti.Shard, topoproto.TabletAliasString(si.MasterAlias))
 				return topo.NewError(topo.NoUpdateNeeded, si.Keyspace()+"/"+si.ShardName())
 			}
 			si.MasterAlias = nil
 			return nil
-		})
-		return err
+		}); err != nil {
+			return err
+		}
 	}
 
 	// remove the record and its replication graph entry


### PR DESCRIPTION
The way we define the true master in DeleteTablet is now consistent with how we define a shard's master, taking into account the shard's MasterAlias and MasterTermStartTime.

Signed-off-by: deepthi <deepthi@planetscale.com>