### PR TITLE
Add option to disable per table metrics collection

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -397,6 +397,33 @@ func TestStatsURL(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/debug/schema", nil)
 	response := httptest.NewRecorder()
 	se.ServeHTTP(response, request)
+
+	// Check the status code is what we expect.
+	if status := response.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}
+
+func TestPrometheusStatsURL(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	for query, result := range schematest.Queries() {
+		db.AddQuery(query, result)
+	}
+	se := newEngine(10, 1*time.Second, 1*time.Second, true, db)
+	se.Open()
+	defer se.Close()
+
+	request, _ := http.NewRequest("GET", "/metrics", nil)
+	response := httptest.NewRecorder()
+	se.ServeHTTP(response, request)
+
+	// Check the status code is what we expect.
+	if status := response.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
 }
 
 type dummyChecker struct {


### PR DESCRIPTION
If the user is creating a large number of tables, this could cause a spike in memory.  This change allows the user to turn off any metrics that scale with the number of tables.