### PR TITLE
vrepl: vtctld Migrate command

### DIFF
--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -195,7 +195,6 @@ func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 
 	qr, err := session.Execute(ctx, subFlags.Arg(0), bindVars)
 	if err != nil {
-		//lint:ignore ST1005 function name
 		return fmt.Errorf("execute failed: %v", err)
 	}
 	if *json {
@@ -444,7 +443,6 @@ func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags
 		TabletType: tabletInfo.Tablet.Type,
 	}, subFlags.Arg(1), bindVars, int64(*transactionID), executeOptions)
 	if err != nil {
-		//lint:ignore ST1005 function name
 		return fmt.Errorf("execute failed: %v", err)
 	}
 	if *json {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -312,8 +312,8 @@ var commands = []commandGroup{
 				"[-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>",
 				"Start a Resharding process. Example: Reshard ks.workflow001 '0' '-80,80-'"},
 			{"Migrate", commandMigrate,
-				"[-cell=<cell>] [-tablet_types=<tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <tables>",
-				"Start a table(s) migration."},
+				"[-cell=<cell>] [-tablet_types=<tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
+				`Start a table(s) migration, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{}, "t2":{}}`},
 			{"Materialize", commandMaterialize,
 				`<json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'`,
 				"Performs materialization based on the json spec."},
@@ -1819,15 +1819,15 @@ func commandMigrate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.F
 		return err
 	}
 	if subFlags.NArg() != 3 {
-		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tables")
+		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
 	}
 	if *workflow == "" {
 		return fmt.Errorf("a workflow name must be specified")
 	}
 	source := subFlags.Arg(0)
 	target := subFlags.Arg(1)
-	tables := strings.Split(subFlags.Arg(2), ",")
-	return wr.Migrate(ctx, *workflow, source, target, tables, *cell, *tabletTypes)
+	tableSpecs := subFlags.Arg(2)
+	return wr.Migrate(ctx, *workflow, source, target, tableSpecs, *cell, *tabletTypes)
 }
 
 func commandMaterialize(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -313,7 +313,7 @@ var commands = []commandGroup{
 				"Start a Resharding process. Example: Reshard ks.workflow001 '0' '-80,80-'"},
 			{"Migrate", commandMigrate,
 				"[-cell=<cell>] [-tablet_types=<tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
-				`Start a table(s) migration, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{}, "t2":{}}`},
+				`Start a table(s) migration, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{"column_vindexes": [{""column": "id1", "name": "hash"}]}, "t2":{"column_vindexes": [{""column": "id2", "name": "hash"}]}}`},
 			{"Materialize", commandMaterialize,
 				`<json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'`,
 				"Performs materialization based on the json spec."},
@@ -1818,11 +1818,11 @@ func commandMigrate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.F
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
-	if subFlags.NArg() != 3 {
-		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
-	}
 	if *workflow == "" {
 		return fmt.Errorf("a workflow name must be specified")
+	}
+	if subFlags.NArg() != 3 {
+		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
 	}
 	source := subFlags.Arg(0)
 	target := subFlags.Arg(1)

--- a/go/vt/wrangler/materializer_env_test.go
+++ b/go/vt/wrangler/materializer_env_test.go
@@ -90,6 +90,7 @@ func newTestMaterializerEnv(t *testing.T, ms *vtctldatapb.MaterializeSettings, s
 			}},
 		}
 	}
+	env.expectValidation()
 	return env
 }
 

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package wrangler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,61 @@ import (
 )
 
 const mzUpdateQuery = "update _vt.vreplication set state='Running' where db_name='vt_targetks' and workflow='workflow'"
+
+func TestMigrateTables(t *testing.T) {
+	ms := &vtctldatapb.MaterializeSettings{
+		Workflow:       "workflow",
+		SourceKeyspace: "sourceks",
+		TargetKeyspace: "targetks",
+		TableSettings: []*vtctldatapb.TableMaterializeSettings{{
+			TargetTable:      "t1",
+			SourceExpression: "select * from t1",
+		}},
+	}
+	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
+	defer env.close()
+
+	env.tmc.expectVRQuery(200, insertPrefix, &sqltypes.Result{})
+	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
+
+	ctx := context.Background()
+	err := env.wr.Migrate(ctx, "workflow", "sourceks", "targetks", "t1", "", "")
+	assert.NoError(t, err)
+	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
+	assert.NoError(t, err)
+	got := fmt.Sprintf("%v", vschema)
+	want := `keyspaces:<key:"sourceks" value:<> > keyspaces:<key:"targetks" value:<> > ` +
+		`routing_rules:<rules:<from_table:"t1" to_tables:"sourceks.t1" > rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" > > `
+	assert.Equal(t, got, want)
+}
+
+func TestMigrateVSchema(t *testing.T) {
+	ms := &vtctldatapb.MaterializeSettings{
+		Workflow:       "workflow",
+		SourceKeyspace: "sourceks",
+		TargetKeyspace: "targetks",
+		TableSettings: []*vtctldatapb.TableMaterializeSettings{{
+			TargetTable:      "t1",
+			SourceExpression: "select * from t1",
+		}},
+	}
+	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
+	defer env.close()
+
+	env.tmc.expectVRQuery(200, insertPrefix, &sqltypes.Result{})
+	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
+
+	ctx := context.Background()
+	err := env.wr.Migrate(ctx, "workflow", "sourceks", "targetks", `{"t1":{}}`, "", "")
+	assert.NoError(t, err)
+	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
+	assert.NoError(t, err)
+	got := fmt.Sprintf("%v", vschema)
+	want := `keyspaces:<key:"sourceks" value:<> > ` +
+		`keyspaces:<key:"targetks" value:<tables:<key:"t1" value:<> > > > ` +
+		`routing_rules:<rules:<from_table:"t1" to_tables:"sourceks.t1" > rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" > > `
+	assert.Equal(t, got, want)
+}
 
 func TestMaterializerOneToOne(t *testing.T) {
 	ms := &vtctldatapb.MaterializeSettings{
@@ -48,7 +104,6 @@ func TestMaterializerOneToOne(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -81,7 +136,6 @@ func TestMaterializerManyToOne(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"-80", "80-"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -133,7 +187,6 @@ func TestMaterializerOneToMany(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -189,7 +242,6 @@ func TestMaterializerManyToMany(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -250,7 +302,6 @@ func TestMaterializerMulticolumnVindex(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -289,7 +340,6 @@ func TestMaterializerDeploySchema(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	delete(env.tmc.schema, "targetks.t2")
 
@@ -325,7 +375,6 @@ func TestMaterializerCopySchema(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	delete(env.tmc.schema, "targetks.t1")
 
@@ -381,7 +430,6 @@ func TestMaterializerExplicitColumns(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -440,7 +488,6 @@ func TestMaterializerRenamedColumns(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	env.tmc.expectVRQuery(
 		200,
@@ -483,7 +530,6 @@ func TestMaterializerNoTargetVSchema(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "table t1 not found in vschema for keyspace targetks")
 }
@@ -501,7 +547,6 @@ func TestMaterializerNoDDL(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	delete(env.tmc.schema, "targetks.t1")
 
@@ -568,7 +613,6 @@ func TestMaterializerTableMismatch(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	delete(env.tmc.schema, "targetks.t1")
 
@@ -589,7 +633,6 @@ func TestMaterializerNoSourceTable(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	delete(env.tmc.schema, "targetks.t1")
 	delete(env.tmc.schema, "sourceks.t1")
@@ -611,7 +654,6 @@ func TestMaterializerSyntaxError(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "syntax error at position 4 near 'bad'")
@@ -630,7 +672,6 @@ func TestMaterializerNotASelect(t *testing.T) {
 	}
 	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
 	defer env.close()
-	env.expectValidation()
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "unrecognized statement: update t1 set val=1")
@@ -670,7 +711,6 @@ func TestMaterializerNoGoodVindex(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "could not find a vindex to compute keyspace id for table t1")
@@ -710,7 +750,6 @@ func TestMaterializerComplexVindexExpression(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "vindex column cannot be a complex expression: a + b as c1")
@@ -750,7 +789,6 @@ func TestMaterializerNoVindexInExpression(t *testing.T) {
 	if err := env.topoServ.SaveVSchema(context.Background(), "targetks", vs); err != nil {
 		t.Fatal(err)
 	}
-	env.expectValidation()
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "could not find vindex column c1")

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -54,9 +54,14 @@ func TestMigrateTables(t *testing.T) {
 	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
 	assert.NoError(t, err)
 	got := fmt.Sprintf("%v", vschema)
-	want := `keyspaces:<key:"sourceks" value:<> > keyspaces:<key:"targetks" value:<> > ` +
-		`routing_rules:<rules:<from_table:"t1" to_tables:"sourceks.t1" > rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" > > `
-	assert.Equal(t, got, want)
+	want := []string{
+		`keyspaces:<key:"sourceks" value:<> > keyspaces:<key:"targetks" value:<> >`,
+		`rules:<from_table:"t1" to_tables:"sourceks.t1" >`,
+		`rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" >`,
+	}
+	for _, wantstr := range want {
+		assert.Contains(t, got, wantstr)
+	}
 }
 
 func TestMigrateVSchema(t *testing.T) {
@@ -81,10 +86,14 @@ func TestMigrateVSchema(t *testing.T) {
 	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
 	assert.NoError(t, err)
 	got := fmt.Sprintf("%v", vschema)
-	want := `keyspaces:<key:"sourceks" value:<> > ` +
-		`keyspaces:<key:"targetks" value:<tables:<key:"t1" value:<> > > > ` +
-		`routing_rules:<rules:<from_table:"t1" to_tables:"sourceks.t1" > rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" > > `
-	assert.Equal(t, got, want)
+	want := []string{`keyspaces:<key:"sourceks" value:<> >`,
+		`keyspaces:<key:"targetks" value:<tables:<key:"t1" value:<> > > >`,
+		`rules:<from_table:"t1" to_tables:"sourceks.t1" >`,
+		`rules:<from_table:"targetks.t1" to_tables:"sourceks.t1" >`,
+	}
+	for _, wantstr := range want {
+		assert.Contains(t, got, wantstr)
+	}
 }
 
 func TestMaterializerOneToOne(t *testing.T) {


### PR DESCRIPTION
We reuse the Materialize command to build the command to migrate tables from one keyspace to another. This works from any keyspace to any keyspace, and the MigrateReads and MigrateWrite commands can be used to migrate traffic.