### PR TITLE
Fixed port in use issue occurs during testcase execution

### DIFF
--- a/go/test/endtoend/backup/backup_test.go
+++ b/go/test/endtoend/backup/backup_test.go
@@ -130,7 +130,7 @@ func TestMasterReplicaSameBackup(t *testing.T) {
 	verifyRestoreTablet(t, replica1, "SERVING")
 
 	// wait for replica1 to catch up.
-	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 3)
+	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 3)
 
 	// This is to test that replicationPosition is processed correctly
 	// while doing backup/restore after a reparent.
@@ -147,7 +147,7 @@ func TestMasterReplicaSameBackup(t *testing.T) {
 	// Force replica1 to restore from backup.
 	verifyRestoreTablet(t, replica1, "SERVING")
 
-	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 4)
+	cluster.VerifyRowsInTablet(t, replica1, keyspaceName, 4)
 	replica2.VttabletProcess.TearDown()
 	restartMasterReplica(t)
 }

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -19,17 +19,22 @@ package cluster
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"time"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
 // DefaultCell : If no cell name is passed, then use following
-const DefaultCell = "zone1"
+const (
+	DefaultCell      = "zone1"
+	DefaultStartPort = 6700
+)
 
 var (
 	keepData = flag.Bool("keep-data", false, "don't delete the per-test VTDATAROOT subfolders")
@@ -498,10 +503,31 @@ func (cluster *LocalProcessCluster) StartVtworker(cell string, extraArgs ...stri
 // GetAndReservePort gives port for required process
 func (cluster *LocalProcessCluster) GetAndReservePort() int {
 	if cluster.nextPortForProcess == 0 {
-		cluster.nextPortForProcess = getRandomNumber(20000, 15000)
+		cluster.nextPortForProcess = getPort()
 	}
 	cluster.nextPortForProcess = cluster.nextPortForProcess + 1
 	return cluster.nextPortForProcess
+}
+
+// getPort checks if we have recent used port info in /tmp/todaytime.port
+// If no, then use a random port and save that port + 200 in the above file
+// If yes, then return that port, and save port + 200 in the same file
+// here, assumptions is 200 ports might be consumed for all tests in a package
+func getPort() int {
+	tmpPortFileName := path.Join(os.TempDir(), time.Now().Format("01022006.port"))
+	var port int
+	if _, err := os.Stat(tmpPortFileName); os.IsNotExist(err) {
+		port = getVtStartPort()
+	} else {
+		result, _ := ioutil.ReadFile(tmpPortFileName)
+		cport, err := strconv.Atoi(string(result))
+		if err != nil || cport > 60000 || cport == 0 {
+			cport = getVtStartPort()
+		}
+		port = cport
+	}
+	ioutil.WriteFile(tmpPortFileName, []byte(fmt.Sprintf("%d", port+200)), 0666)
+	return port
 }
 
 // GetAndReserveTabletUID gives tablet uid
@@ -515,6 +541,17 @@ func (cluster *LocalProcessCluster) GetAndReserveTabletUID() int {
 
 func getRandomNumber(maxNumber int32, baseNumber int) int {
 	return int(rand.Int31n(maxNumber)) + baseNumber
+}
+
+func getVtStartPort() int {
+	osVtPort := os.Getenv("VTPORTSTART")
+	if osVtPort != "" {
+		cport, err := strconv.Atoi(string(osVtPort))
+		if err == nil {
+			return cport
+		}
+	}
+	return DefaultStartPort
 }
 
 // GetVttabletInstance creates a new vttablet object

--- a/test/config.json
+++ b/test/config.json
@@ -451,6 +451,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"clustertest": {
+			"File": "clustertest.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/clustertest"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 11,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"initial_sharding": {
 			"File": "initial_sharding.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/sharding/initialsharding/v3"],


### PR DESCRIPTION
Signed-off-by: Arindam Nayak <arindam.nayak@outlook.com>

With this change, we will save last used port to temp file in temp directory, so that subsequent testcases will start from that port and again save that to temp file. The file will be rotated daily. This way, we should not have any conflict on port. For testcase execution in CI, we don't have to worry about temp file clean up, as it is one time activity.