### PR TITLE
bootstrap.sh: Clear PYTHONPATH for virtualenv in install_selenium.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -248,7 +248,7 @@ function install_selenium() {
   local version="$1"
   local dist="$2"
 
-  $VIRTUALENV "$dist"
+  PYTHONPATH='' $VIRTUALENV "$dist"
   PIP="$dist/bin/pip"
   # PYTHONPATH is removed for `pip install` because otherwise it can pick up go/dist/grpc/usr/local/lib/python2.7/site-packages
   # instead of go/dist/selenium/lib/python3.5/site-packages and then can't find module 'pip._vendor.requests'


### PR DESCRIPTION
This fixes the following error for me:

```
installing Selenium latest
Fatal Python error: initsite: Failed to import the site module
Traceback (most recent call last):
  File "/home/enisoc/vt/src/vitess.io/vitess/dist/py-mock-1.0.1/lib/python2.7/site-packages/site.py", line 73, in <module>
    __boot()
  File "/home/enisoc/vt/src/vitess.io/vitess/dist/py-mock-1.0.1/lib/python2.7/site-packages/site.py", line 26, in __boot
    import imp  # Avoid import loop in Python 3
  File "/usr/lib/python3.7/imp.py", line 27, in <module>
    import tokenize
  File "/usr/lib/python3.7/tokenize.py", line 33, in <module>
    import re
  File "/usr/lib/python3.7/re.py", line 143, in <module>
    class RegexFlag(enum.IntFlag):
AttributeError: module 'enum' has no attribute 'IntFlag'
ERROR: Selenium build failed
```