### PR TITLE
log4j upgrade from 1.x to 2.x

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -29,6 +29,11 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
     <!-- Dependencies with limited scope. -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -53,11 +58,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/java/client/src/test/java/io/vitess/client/TestEnv.java
+++ b/java/client/src/test/java/io/vitess/client/TestEnv.java
@@ -78,7 +78,7 @@ public class TestEnv {
     }
     String schemaDir = getTestDataPath() + "/schema";
     List<String> command = new ArrayList<String>();
-    command.add(vtRoot + "/py/vttest/run_local_database.py");
+    command.add(vtRoot + "/py-vtdb/vttest/run_local_database.py");
     command.add("--port");
     command.add(Integer.toString(port));
     command.add("--proto_topo");

--- a/java/client/src/test/java/io/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/io/vitess/client/TestUtil.java
@@ -30,15 +30,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.joda.time.Duration;
 import org.junit.Assert;
 import vttest.Vttest.VTTestTopology;
 
 public class TestUtil {
 
-  static final Logger logger = LogManager.getLogger(TestUtil.class.getName());
+  static final Logger logger = LogManager.getLogger(TestUtil.class);
   public static final String PROPERTY_KEY_CLIENT_TEST_ENV = "vitess.client.testEnv";
   public static final String PROPERTY_KEY_CLIENT_TEST_PORT = "vitess.client.testEnv.portName";
   public static final String PROPERTY_KEY_CLIENT_FACTORY_CLASS = "vitess.client.factory";

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -39,6 +39,11 @@
       <version>2.6</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
     <!-- Dependencies with limited scope. -->
     <dependency>
       <groupId>junit</groupId>

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessDatabaseMetaData.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessDatabaseMetaData.java
@@ -22,7 +22,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.logging.Logger;
 
 /**
  * Created by harshit.gangal on 25/01/16.
@@ -36,8 +35,6 @@ public abstract class VitessDatabaseMetaData implements DatabaseMetaData {
   private static final String PROCEDURE_TERM = "procedure";
   private static final String CATALOG_TERM = "database";
   private static final String DATABASE_PRODUCT_NAME = "MySQL";
-  /* Get actual class name to be printed on */
-  private static Logger logger = Logger.getLogger(VitessDatabaseMetaData.class.getName());
   protected final String quotedId = "`";
   protected VitessConnection connection = null;
 

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
@@ -25,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.logging.Logger;
 
 /**
  * Created by ashudeep.sharma on 15/02/16.
@@ -34,7 +33,6 @@ public class VitessMariaDBDatabaseMetadata extends VitessDatabaseMetaData implem
     DatabaseMetaData {
 
   private static final String DRIVER_NAME = "Vitess MariaDB JDBC Driver";
-  private static Logger logger = Logger.getLogger(VitessMariaDBDatabaseMetadata.class.getName());
 
   public VitessMariaDBDatabaseMetadata(VitessConnection connection) throws SQLException {
     this.setConnection(connection);

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessMySQLDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessMySQLDatabaseMetadata.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
-import java.util.logging.Logger;
 
 /**
  * Created by ashudeep.sharma on 15/02/16.
@@ -50,7 +49,6 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData implemen
     DatabaseMetaData {
 
   private static final String DRIVER_NAME = "Vitess MySQL JDBC Driver";
-  private static Logger logger = Logger.getLogger(VitessMySQLDatabaseMetadata.class.getName());
   private static String mysqlKeywordsThatArentSQL92;
 
   static {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessResultSetMetaData.java
@@ -25,7 +25,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
-import java.util.logging.Logger;
 
 
 /**
@@ -33,8 +32,6 @@ import java.util.logging.Logger;
  */
 public class VitessResultSetMetaData implements ResultSetMetaData {
 
-  /* Get actual class name to be printed on */
-  private static Logger logger = Logger.getLogger(VitessResultSetMetaData.class.getName());
   private List<FieldWithMetadata> fields;
 
   public VitessResultSetMetaData(List<FieldWithMetadata> fields) throws SQLException {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -26,6 +26,8 @@ import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.client.grpc.RetryingInterceptorConfig;
 import io.vitess.client.grpc.tls.TlsOptions;
 import io.vitess.util.Constants.Property;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -37,15 +39,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Created by naveen.nahata on 24/02/16.
  */
 public class VitessVTGateManager {
 
-  private static Logger logger = Logger.getLogger(VitessVTGateManager.class.getName());
+  private static Logger logger = LogManager.getLogger(VitessVTGateManager.class);
   /*
   Current implementation have one VTGateConn for ip-port-username combination
   */
@@ -148,15 +148,14 @@ public class VitessVTGateManager {
         }
       }
       if (updatedCount > 0) {
-        logger.info("refreshed " + updatedCount + " vtgate connections due to keystore update");
+        logger.info("refreshed {} vtgate connections due to keystore update", updatedCount);
       }
     }
   }
 
   private static void closeRefreshedConnection(final VTGateConnection old) {
     if (vtgateClosureTimer != null) {
-      logger.info(String
-          .format("%s Closing connection with a %s second delay", old, vtgateClosureDelaySeconds));
+      logger.info("{} Closing connection with a {} second delay", old, vtgateClosureDelaySeconds);
       vtgateClosureTimer.schedule(new TimerTask() {
         @Override
         public void run() {
@@ -170,10 +169,10 @@ public class VitessVTGateManager {
 
   private static void actuallyCloseRefreshedConnection(final VTGateConnection old) {
     try {
-      logger.info(old + " Closing connection because it had been refreshed");
+      logger.info("{} Closing connection because it had been refreshed", old);
       old.close();
     } catch (IOException ioe) {
-      logger.log(Level.WARNING, String.format("Error closing VTGateConnection %s", old), ioe);
+      logger.warn("Error closing VTGateConnection {}", old, ioe);
     }
   }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,6 +76,7 @@
     <protobuf.java.version>3.6.1</protobuf.java.version>
     <protobuf.protoc.version>3.6.1</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
+    <log4j2.version>2.13.0</log4j2.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->
@@ -181,9 +182,14 @@
       </dependency>
 
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Java has a dependency on deprecated log4j 1.x. 
Upgraded to use log4j 2.

There is one Java Hadoop Test failing locally.
Creating PR to check here.

Signed-off-by: Harshit Gangal <harshit.gangal@gmail.com>