### PR TITLE
vrepl: CreateLookupVindex command with backfill

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-critic/go-critic v0.4.0 // indirect
 	github.com/go-ini/ini v1.12.0 // indirect
-	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/gogo/protobuf v1.3.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/mock v1.3.1

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -312,10 +312,10 @@ var commands = []commandGroup{
 				"[-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>",
 				"Start a Resharding process. Example: Reshard ks.workflow001 '0' '-80,80-'"},
 			{"Migrate", commandMigrate,
-				"[-cell=<cell>] [-tablet_types=<tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
+				"[-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
 				`Start a table(s) migration, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{"column_vindexes": [{""column": "id1", "name": "hash"}]}, "t2":{"column_vindexes": [{""column": "id2", "name": "hash"}]}}`},
 			{"CreateLookupVindex", commandCreateLookupVindex,
-				"[-cell=<cell>] [-tablet_types=<tablet_types>] <keyspace> <json_spec>",
+				"[-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>",
 				`Create and backfill a lookup vindex. the json_spec must contain the vindex and colvindex specs for the new lookup.`},
 			{"Materialize", commandMaterialize,
 				`<json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'`,
@@ -1840,7 +1840,7 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("two arguments are required: keyspace and specs")
+		return fmt.Errorf("two arguments are required: keyspace and json_spec")
 	}
 	keyspace := subFlags.Arg(0)
 	specs := &vschemapb.Keyspace{}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -314,6 +314,9 @@ var commands = []commandGroup{
 			{"Migrate", commandMigrate,
 				"[-cell=<cell>] [-tablet_types=<tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
 				`Start a table(s) migration, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{"column_vindexes": [{""column": "id1", "name": "hash"}]}, "t2":{"column_vindexes": [{""column": "id2", "name": "hash"}]}}`},
+			{"CreateLookupVindex", commandCreateLookupVindex,
+				"[-cell=<cell>] [-tablet_types=<tablet_types>] <keyspace> <json_spec>",
+				`Create and backfill a lookup vindex. the json_spec must contain the vindex and colvindex specs for the new lookup.`},
 			{"Materialize", commandMaterialize,
 				`<json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'`,
 				"Performs materialization based on the json spec."},
@@ -1828,6 +1831,23 @@ func commandMigrate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.F
 	target := subFlags.Arg(1)
 	tableSpecs := subFlags.Arg(2)
 	return wr.Migrate(ctx, *workflow, source, target, tableSpecs, *cell, *tabletTypes)
+}
+
+func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	cell := subFlags.String("cell", "", "Cell to replicate from.")
+	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from.")
+	if err := subFlags.Parse(args); err != nil {
+		return err
+	}
+	if subFlags.NArg() != 2 {
+		return fmt.Errorf("two arguments are required: keyspace and specs")
+	}
+	keyspace := subFlags.Arg(0)
+	specs := &vschemapb.Keyspace{}
+	if err := json2.Unmarshal([]byte(subFlags.Arg(1)), specs); err != nil {
+		return err
+	}
+	return wr.CreateLookupVindex(ctx, keyspace, specs, *cell, *tabletTypes)
 }
 
 func commandMaterialize(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/json2"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -612,6 +613,19 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 		return nil, err
 	}
 	return formal, nil
+}
+
+// ChooseVindexForType chooses the most appropriate vindex for the give type.
+func ChooseVindexForType(typ querypb.Type) (string, error) {
+	switch {
+	case sqltypes.IsIntegral(typ):
+		return "hash", nil
+	case sqltypes.IsText(typ):
+		return "unicode_loose_md5", nil
+	case sqltypes.IsBinary(typ):
+		return "binary_md5", nil
+	}
+	return "", fmt.Errorf("type %v is not recommended for a vindex", typ)
 }
 
 // FindBestColVindex finds the best ColumnVindex for VReplication.

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -820,6 +820,115 @@ func TestVSchemaRoutingRules(t *testing.T) {
 	}
 }
 
+func TestChooseVindexForType(t *testing.T) {
+	testcases := []struct {
+		in  querypb.Type
+		out string
+	}{{
+		in:  sqltypes.Null,
+		out: "",
+	}, {
+		in:  sqltypes.Int8,
+		out: "hash",
+	}, {
+		in:  sqltypes.Uint8,
+		out: "hash",
+	}, {
+		in:  sqltypes.Int16,
+		out: "hash",
+	}, {
+		in:  sqltypes.Uint16,
+		out: "hash",
+	}, {
+		in:  sqltypes.Int24,
+		out: "hash",
+	}, {
+		in:  sqltypes.Uint24,
+		out: "hash",
+	}, {
+		in:  sqltypes.Int32,
+		out: "hash",
+	}, {
+		in:  sqltypes.Uint32,
+		out: "hash",
+	}, {
+		in:  sqltypes.Int64,
+		out: "hash",
+	}, {
+		in:  sqltypes.Uint64,
+		out: "hash",
+	}, {
+		in:  sqltypes.Float32,
+		out: "hash",
+	}, {
+		in:  sqltypes.Float64,
+		out: "",
+	}, {
+		in:  sqltypes.Timestamp,
+		out: "",
+	}, {
+		in:  sqltypes.Date,
+		out: "",
+	}, {
+		in:  sqltypes.Time,
+		out: "",
+	}, {
+		in:  sqltypes.Datetime,
+		out: "",
+	}, {
+		in:  sqltypes.Year,
+		out: "hash",
+	}, {
+		in:  sqltypes.Decimal,
+		out: "",
+	}, {
+		in:  sqltypes.Text,
+		out: "unicode_loose_md5",
+	}, {
+		in:  sqltypes.Blob,
+		out: "binary_md5",
+	}, {
+		in:  sqltypes.VarChar,
+		out: "unicode_loose_md5",
+	}, {
+		in:  sqltypes.VarBinary,
+		out: "binary_md5",
+	}, {
+		in:  sqltypes.Char,
+		out: "unicode_loose_md5",
+	}, {
+		in:  sqltypes.Binary,
+		out: "binary_md5",
+	}, {
+		in:  sqltypes.Bit,
+		out: "",
+	}, {
+		in:  sqltypes.Enum,
+		out: "",
+	}, {
+		in:  sqltypes.Set,
+		out: "",
+	}, {
+		in:  sqltypes.Geometry,
+		out: "",
+	}, {
+		in:  sqltypes.TypeJSON,
+		out: "",
+	}, {
+		in:  sqltypes.Expression,
+		out: "",
+	}}
+
+	for _, tcase := range testcases {
+		out, err := ChooseVindexForType(tcase.in)
+		if out == "" {
+			assert.Error(t, err, tcase.in)
+			continue
+		}
+		assert.Equal(t, out, tcase.out, tcase.in)
+	}
+}
+
 func TestFindBestColVindex(t *testing.T) {
 	testSrvVSchema := &vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -238,7 +238,7 @@ func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, sp
 	if sourceVSchema.Vindexes == nil {
 		sourceVSchema.Vindexes = make(map[string]*vschemapb.Vindex)
 	}
-	// If source and target keyspaces are same, Make vscehmas point to the same object.
+	// If source and target keyspaces are same, Make vschemas point to the same object.
 	if keyspace == targetKeyspace {
 		targetVSchema = sourceVSchema
 	} else {
@@ -263,6 +263,10 @@ func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, sp
 		return nil, nil, nil, fmt.Errorf("source table %s not found in vschema", sourceTableName)
 	}
 	for _, colVindex := range sourceVSchemaTable.ColumnVindexes {
+		// For a conflict, the vindex name and column should match.
+		if colVindex.Name != vindexName {
+			continue
+		}
 		colName := colVindex.Column
 		if len(colVindex.Columns) != 0 {
 			colName = colVindex.Columns[0]

--- a/go/vt/wrangler/materializer_env_test.go
+++ b/go/vt/wrangler/materializer_env_test.go
@@ -90,7 +90,9 @@ func newTestMaterializerEnv(t *testing.T, ms *vtctldatapb.MaterializeSettings, s
 			}},
 		}
 	}
-	env.expectValidation()
+	if ms.Workflow != "" {
+		env.expectValidation()
+	}
 	return env
 }
 

--- a/go/vt/wrangler/materializer_env_test.go
+++ b/go/vt/wrangler/materializer_env_test.go
@@ -67,10 +67,12 @@ func newTestMaterializerEnv(t *testing.T, ms *vtctldatapb.MaterializeSettings, s
 		_ = env.addTablet(tabletID, env.ms.SourceKeyspace, shard, topodatapb.TabletType_MASTER)
 		tabletID += 10
 	}
-	tabletID = 200
-	for _, shard := range targets {
-		_ = env.addTablet(tabletID, env.ms.TargetKeyspace, shard, topodatapb.TabletType_MASTER)
-		tabletID += 10
+	if ms.SourceKeyspace != ms.TargetKeyspace {
+		tabletID = 200
+		for _, shard := range targets {
+			_ = env.addTablet(tabletID, env.ms.TargetKeyspace, shard, topodatapb.TabletType_MASTER)
+			tabletID += 10
+		}
 	}
 
 	for _, ts := range ms.TableSettings {

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -101,6 +101,129 @@ func TestMigrateVSchema(t *testing.T) {
 	}
 }
 
+func TestCreateLookupVindexFull(t *testing.T) {
+	ms := &vtctldatapb.MaterializeSettings{
+		Workflow:       "lkp_vdx",
+		SourceKeyspace: "sourceks",
+		TargetKeyspace: "targetks",
+	}
+	env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
+	defer env.close()
+
+	specs := &vschemapb.Keyspace{
+		Vindexes: map[string]*vschemapb.Vindex{
+			"v": {
+				Type: "lookup_unique",
+				Params: map[string]string{
+					"table": "targetks.lkp",
+					"from":  "c1",
+					"to":    "c2",
+				},
+				Owner: "t1",
+			},
+		},
+		Tables: map[string]*vschemapb.Table{
+			"t1": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Name:   "v",
+					Column: "col2",
+				}},
+			},
+		},
+	}
+	// Dummy sourceSchema
+	sourceSchema := "CREATE TABLE `t1` (\n" +
+		"  `col1` int(11) NOT NULL AUTO_INCREMENT,\n" +
+		"  `col2` int(11) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1"
+
+	sourceVSchema := &vschemapb.Keyspace{
+		Sharded: true,
+		Vindexes: map[string]*vschemapb.Vindex{
+			"hash": {
+				Type: "hash",
+			},
+		},
+		Tables: map[string]*vschemapb.Table{
+			"t1": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Name:   "hash",
+					Column: "col1",
+				}},
+			},
+		},
+	}
+	env.tmc.schema[ms.SourceKeyspace+".t1"] = &tabletmanagerdatapb.SchemaDefinition{
+		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
+			Fields: []*querypb.Field{{
+				Name: "col1",
+				Type: querypb.Type_INT64,
+			}, {
+				Name: "col2",
+				Type: querypb.Type_INT64,
+			}},
+			Schema: sourceSchema,
+		}},
+	}
+	if err := env.topoServ.SaveVSchema(context.Background(), ms.TargetKeyspace, &vschemapb.Keyspace{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.topoServ.SaveVSchema(context.Background(), ms.SourceKeyspace, sourceVSchema); err != nil {
+		t.Fatal(err)
+	}
+
+	env.tmc.expectVRQuery(200, "/CREATE TABLE `lkp`", &sqltypes.Result{})
+	env.tmc.expectVRQuery(200, insertPrefix, &sqltypes.Result{})
+	env.tmc.expectVRQuery(200, "update _vt.vreplication set state='Running' where db_name='vt_targetks' and workflow='lkp_vdx'", &sqltypes.Result{})
+
+	ctx := context.Background()
+	err := env.wr.CreateLookupVindex(ctx, ms.SourceKeyspace, specs, "cell", "MASTER")
+	require.NoError(t, err)
+
+	wantvschema := &vschemapb.Keyspace{
+		Sharded: true,
+		Vindexes: map[string]*vschemapb.Vindex{
+			"hash": {
+				Type: "hash",
+			},
+			"v": {
+				Type: "lookup_unique",
+				Params: map[string]string{
+					"table":      "targetks.lkp",
+					"from":       "c1",
+					"to":         "c2",
+					"write_only": "true",
+				},
+				Owner: "t1",
+			},
+		},
+		Tables: map[string]*vschemapb.Table{
+			"t1": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Name:   "hash",
+					Column: "col1",
+				}, {
+					Name:   "v",
+					Column: "col2",
+				}},
+			},
+		},
+	}
+	vschema, err := env.topoServ.GetVSchema(ctx, ms.SourceKeyspace)
+	require.NoError(t, err)
+	assert.Equal(t, wantvschema, vschema)
+
+	wantvschema = &vschemapb.Keyspace{
+		Tables: map[string]*vschemapb.Table{
+			"lkp": {},
+		},
+	}
+	vschema, err = env.topoServ.GetVSchema(ctx, ms.TargetKeyspace)
+	require.NoError(t, err)
+	assert.Equal(t, wantvschema, vschema)
+}
+
 func TestCreateLookupVindexCreateDDL(t *testing.T) {
 	ms := &vtctldatapb.MaterializeSettings{
 		SourceKeyspace: "sourceks",
@@ -901,6 +1024,272 @@ func TestCreateLookupVindexSameKeyspace(t *testing.T) {
 	}
 }
 
+func TestCreateLookupVindexFailures(t *testing.T) {
+	topoServ := memorytopo.NewServer("cell")
+	wr := New(logutil.NewConsoleLogger(), topoServ, nil)
+
+	unique := map[string]*vschemapb.Vindex{
+		"v": {
+			Type: "lookup_unique",
+			Params: map[string]string{
+				"table": "targetks.t",
+				"from":  "c1",
+				"to":    "c2",
+			},
+		},
+	}
+
+	vs := &vschemapb.Keyspace{
+		Sharded: true,
+		Vindexes: map[string]*vschemapb.Vindex{
+			"other": {
+				Type: "hash",
+			},
+			"v": {
+				Type: "lookup_unique",
+				Params: map[string]string{
+					"table":      "targetks.t",
+					"from":       "c1",
+					"to":         "c2",
+					"write_only": "true",
+				},
+			},
+		},
+		Tables: map[string]*vschemapb.Table{
+			"t1": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "c1",
+					Name:   "v",
+				}},
+			},
+		},
+	}
+	if err := topoServ.SaveVSchema(context.Background(), "sourceks", vs); err != nil {
+		t.Fatal(err)
+	}
+	if err := topoServ.SaveVSchema(context.Background(), "targetks", &vschemapb.Keyspace{}); err != nil {
+		t.Fatal(err)
+	}
+
+	testcases := []struct {
+		description string
+		input       *vschemapb.Keyspace
+		err         string
+	}{{
+		description: "dup vindex",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v1": {
+					Type: "hash",
+				},
+				"v2": {
+					Type: "hash",
+				},
+			},
+		},
+		err: "only one vindex must be specified in the specs",
+	}, {
+		description: "not a lookup",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "hash",
+				},
+			},
+		},
+		err: "vindex hash is not a lookup type",
+	}, {
+		description: "unqualified table",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "lookup",
+					Params: map[string]string{
+						"table": "t",
+					},
+				},
+			},
+		},
+		err: "vindex 'table' must be <keyspace>.<table>",
+	}, {
+		description: "unique lookup should have only one from column",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "lookup_unique",
+					Params: map[string]string{
+						"table": "targetks.t",
+						"from":  "c1,c2",
+					},
+				},
+			},
+		},
+		err: "unique vindex 'from' should have only one column",
+	}, {
+		description: "non-unique lookup should have more than one column",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "lookup",
+					Params: map[string]string{
+						"table": "targetks.t",
+						"from":  "c1",
+					},
+				},
+			},
+		},
+		err: "non-unique vindex 'from' should have more than one column",
+	}, {
+		description: "vindex not found",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "lookup_noexist",
+					Params: map[string]string{
+						"table": "targetks.t",
+						"from":  "c1,c2",
+					},
+				},
+			},
+		},
+		err: `vindexType "lookup_noexist" not found`,
+	}, {
+		description: "only one table",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+		},
+		err: "exactly one table must be specified in the specs",
+	}, {
+		description: "only one colvindex",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"t1": {},
+			},
+		},
+		err: "exactly one ColumnVindex must be specified for the table",
+	}, {
+		description: "vindex name must match",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name: "other",
+					}},
+				},
+			},
+		},
+		err: "ColumnVindex name must match vindex name: other vs v",
+	}, {
+		description: "owner must match",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"v": {
+					Type: "lookup_unique",
+					Params: map[string]string{
+						"table": "targetks.t",
+						"from":  "c1",
+					},
+					Owner: "otherTable",
+				},
+			},
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name: "v",
+					}},
+				},
+			},
+		},
+		err: "vindex owner must match table name: otherTable vs t1",
+	}, {
+		description: "owner must match",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name: "v",
+					}},
+				},
+			},
+		},
+		err: "at least one column must be specified in ColumnVindexes",
+	}, {
+		description: "columnvindex length mismatch",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name:    "v",
+						Columns: []string{"col1", "col2"},
+					}},
+				},
+			},
+		},
+		err: "length of table columns differes from length of vindex columns",
+	}, {
+		description: "vindex mismatches with what's in vschema",
+		input: &vschemapb.Keyspace{
+			Vindexes: map[string]*vschemapb.Vindex{
+				"other": {
+					Type: "lookup_unique",
+					Params: map[string]string{
+						"table": "targetks.t",
+						"from":  "c1",
+					},
+					Owner: "t1",
+				},
+			},
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name:   "other",
+						Column: "col",
+					}},
+				},
+			},
+		},
+		err: "a conflicting vindex named other already exists in the source vschema",
+	}, {
+		description: "source table not in vschema",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"other": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name:   "v",
+						Column: "col",
+					}},
+				},
+			},
+		},
+		err: "source table other not found in vschema",
+	}, {
+		description: "colvindex already exists in vschema",
+		input: &vschemapb.Keyspace{
+			Vindexes: unique,
+			Tables: map[string]*vschemapb.Table{
+				"t1": {
+					ColumnVindexes: []*vschemapb.ColumnVindex{{
+						Name:   "v",
+						Column: "c1",
+					}},
+				},
+			},
+		},
+		err: "ColumnVindex for table t1 already exists: c1",
+	}}
+	for _, tcase := range testcases {
+		err := wr.CreateLookupVindex(context.Background(), "sourceks", tcase.input, "", "")
+		if !strings.Contains(err.Error(), tcase.err) {
+			t.Errorf("CreateLookupVindex(%s) err: %v, must contain %v", tcase.description, err, tcase.err)
+		}
+	}
+}
+
 func TestMaterializerOneToOne(t *testing.T) {
 	ms := &vtctldatapb.MaterializeSettings{
 		Workflow:       "workflow",
@@ -1633,270 +2022,4 @@ func TestMaterializerNoVindexInExpression(t *testing.T) {
 
 	err := env.wr.Materialize(context.Background(), ms)
 	assert.EqualError(t, err, "could not find vindex column c1")
-}
-
-func TestCreateLookupVindexFailures(t *testing.T) {
-	topoServ := memorytopo.NewServer("cell")
-	wr := New(logutil.NewConsoleLogger(), topoServ, nil)
-
-	unique := map[string]*vschemapb.Vindex{
-		"v": {
-			Type: "lookup_unique",
-			Params: map[string]string{
-				"table": "targetks.t",
-				"from":  "c1",
-				"to":    "c2",
-			},
-		},
-	}
-
-	vs := &vschemapb.Keyspace{
-		Sharded: true,
-		Vindexes: map[string]*vschemapb.Vindex{
-			"other": {
-				Type: "hash",
-			},
-			"v": {
-				Type: "lookup_unique",
-				Params: map[string]string{
-					"table":      "targetks.t",
-					"from":       "c1",
-					"to":         "c2",
-					"write_only": "true",
-				},
-			},
-		},
-		Tables: map[string]*vschemapb.Table{
-			"t1": {
-				ColumnVindexes: []*vschemapb.ColumnVindex{{
-					Column: "c1",
-					Name:   "v",
-				}},
-			},
-		},
-	}
-	if err := topoServ.SaveVSchema(context.Background(), "sourceks", vs); err != nil {
-		t.Fatal(err)
-	}
-	if err := topoServ.SaveVSchema(context.Background(), "targetks", &vschemapb.Keyspace{}); err != nil {
-		t.Fatal(err)
-	}
-
-	testcases := []struct {
-		description string
-		input       *vschemapb.Keyspace
-		err         string
-	}{{
-		description: "dup vindex",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v1": {
-					Type: "hash",
-				},
-				"v2": {
-					Type: "hash",
-				},
-			},
-		},
-		err: "only one vindex must be specified in the specs",
-	}, {
-		description: "not a lookup",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "hash",
-				},
-			},
-		},
-		err: "vindex hash is not a lookup type",
-	}, {
-		description: "unqualified table",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "lookup",
-					Params: map[string]string{
-						"table": "t",
-					},
-				},
-			},
-		},
-		err: "vindex 'table' must be <keyspace>.<table>",
-	}, {
-		description: "unique lookup should have only one from column",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "lookup_unique",
-					Params: map[string]string{
-						"table": "targetks.t",
-						"from":  "c1,c2",
-					},
-				},
-			},
-		},
-		err: "unique vindex 'from' should have only one column",
-	}, {
-		description: "non-unique lookup should have more than one column",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "lookup",
-					Params: map[string]string{
-						"table": "targetks.t",
-						"from":  "c1",
-					},
-				},
-			},
-		},
-		err: "non-unique vindex 'from' should have more than one column",
-	}, {
-		description: "vindex not found",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "lookup_noexist",
-					Params: map[string]string{
-						"table": "targetks.t",
-						"from":  "c1,c2",
-					},
-				},
-			},
-		},
-		err: `vindexType "lookup_noexist" not found`,
-	}, {
-		description: "only one table",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-		},
-		err: "exactly one table must be specified in the specs",
-	}, {
-		description: "only one colvindex",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"t1": {},
-			},
-		},
-		err: "exactly one ColumnVindex must be specified for the table",
-	}, {
-		description: "vindex name must match",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name: "other",
-					}},
-				},
-			},
-		},
-		err: "ColumnVindex name must match vindex name: other vs v",
-	}, {
-		description: "owner must match",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"v": {
-					Type: "lookup_unique",
-					Params: map[string]string{
-						"table": "targetks.t",
-						"from":  "c1",
-					},
-					Owner: "otherTable",
-				},
-			},
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name: "v",
-					}},
-				},
-			},
-		},
-		err: "vindex owner must match table name: otherTable vs t1",
-	}, {
-		description: "owner must match",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name: "v",
-					}},
-				},
-			},
-		},
-		err: "at least one column must be specified in ColumnVindexes",
-	}, {
-		description: "columnvindex length mismatch",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:    "v",
-						Columns: []string{"col1", "col2"},
-					}},
-				},
-			},
-		},
-		err: "length of table columns differes from length of vindex columns",
-	}, {
-		description: "vindex mismatches with what's in vschema",
-		input: &vschemapb.Keyspace{
-			Vindexes: map[string]*vschemapb.Vindex{
-				"other": {
-					Type: "lookup_unique",
-					Params: map[string]string{
-						"table": "targetks.t",
-						"from":  "c1",
-					},
-					Owner: "t1",
-				},
-			},
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "other",
-						Column: "col",
-					}},
-				},
-			},
-		},
-		err: "a conflicting vindex named other already exists in the source vschema",
-	}, {
-		description: "source table not in vschema",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"other": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "v",
-						Column: "col",
-					}},
-				},
-			},
-		},
-		err: "source table other not found in vschema",
-	}, {
-		description: "colvindex already exists in vschema",
-		input: &vschemapb.Keyspace{
-			Vindexes: unique,
-			Tables: map[string]*vschemapb.Table{
-				"t1": {
-					ColumnVindexes: []*vschemapb.ColumnVindex{{
-						Name:   "v",
-						Column: "c1",
-					}},
-				},
-			},
-		},
-		err: "ColumnVindex for table t1 already exists: c1",
-	}}
-	for _, tcase := range testcases {
-		err := wr.CreateLookupVindex(context.Background(), "sourceks", tcase.input, "", "")
-		if !strings.Contains(err.Error(), tcase.err) {
-			t.Errorf("CreateLookupVindex(%s) err: %v, must contain %v", tcase.description, err, tcase.err)
-		}
-	}
 }


### PR DESCRIPTION
This command comes very close to a DDL that can create a lookup vindex on an existing table that already has rows. It will:
* Create a lookup vindex in the vschema in "write_only" mode.
* Change the main table to use it.
* Create the lookup table.
* Create a vschema entry for the lookup table.
* Setup vreplication from main table to lookup for the backfill.

If the table is the "owner", then the vreplication streams are created with "stop_after_copy" option. Otherwise, we assume that it's a "best effort" vindex where the lookup table is continuously populated by the vreplication stream.

The final step of this workflow will come in the next PR as `ExternalizeVindex`, which would remove the "write_only" mode and/or delete the vreplication streams.