### PR TITLE
fix(examples): fix the undefined flags in example yaml

### DIFF
--- a/examples/helm/203_vertical_split.yaml
+++ b/examples/helm/203_vertical_split.yaml
@@ -36,7 +36,7 @@ jobs:
   - name: "vertical-split"
     kind: "vtworker"
     cell: "zone1"
-    command: "VerticalSplitClone -min_rdonly_tablets=1 -tables=customer,corder customer/0"
+    command: "VerticalSplitClone -min_healthy_tablets=1 -tables=customer,corder customer/0"
 
 etcd:
   replicas: 1


### PR DESCRIPTION
Job vtworker-vertical-split failed to start as "flag provided but not defined: -min_rdonly_tablets".
Correct flag should be min_healthy_tablets in VerticalSplitClone command.

Signed-off-by: maaaace <fuheming@huawei.com>