### PR TITLE
vitess/lite: Install config files at the new location.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ install: build
 	mkdir -p "$${PREFIX}/bin"
 	cp "$${VTROOT}/bin/"{mysqlctld,vtctld,vtctlclient,vtgate,vttablet,vtworker,vtbackup} "$${PREFIX}/bin/"
 	# config files
-	cp -R config "$${PREFIX}/"
+	mkdir -p "$${PREFIX}/src/vitess.io/vitess"
+	cp -R config "$${PREFIX}/src/vitess.io/vitess/"
+	# also symlink config files in the old location
+	ln -sf src/vitess.io/vitess/config "$${PREFIX}/config"
 	# vtctld web UI files
 	mkdir -p "$${PREFIX}/src/vitess.io/vitess/web"
 	cp -R web/vtctld "$${PREFIX}/src/vitess.io/vitess/web/"


### PR DESCRIPTION
The expected location of config files has changed, but we were still installing them in the old location. This also adds a symlink from the old location to remain backwards-compatible.

Signed-off-by: Anthony Yeh <enisoc@planetscale.com>