### PR TITLE
vrepl: fix materializer bug

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -565,7 +565,7 @@ func (mz *materializer) generateInserts(ctx context.Context) (string, error) {
 				}
 				vindexName := fmt.Sprintf("%s.%s", mz.ms.TargetKeyspace, cv.Name)
 				subExprs = append(subExprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewStrVal([]byte(vindexName))})
-				subExprs = append(subExprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewStrVal([]byte("'{{.keyrange}}'"))})
+				subExprs = append(subExprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewStrVal([]byte("{{.keyrange}}"))})
 				sel.Where = &sqlparser.Where{
 					Type: sqlparser.WhereStr,
 					Expr: &sqlparser.FuncExpr{


### PR DESCRIPTION
The keyrange was getting quoted twice. @rohit-nayak-ps and I
discovered this while running some manual tests. This can
be best tested with end to end tests, which are coming soon.
This is why the unit tests are not affected by this change.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>