### PR TITLE
helm/vitess/templates/_vtctld.tpl: Revert web_dir changes

### DIFF
--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -90,6 +90,8 @@ spec:
 
               eval exec /vt/bin/vtctld $(cat <<END_OF_COMMAND
                 -cell={{$cellClean | quote}}
+                -web_dir="/vt/web/vtctld"
+                -web_dir2="/vt/web/vtctld2/app"
                 -workflow_manager_init
                 -workflow_manager_use_election
                 -logtostderr=true


### PR DESCRIPTION
Fixes #5720 until we can push a helm v2.0 release alongside 5.0. 
See [this comment](https://github.com/vitessio/vitess/issues/5720#issuecomment-576463020).

CC @derekperkins @morgo @rohit-nayak-ps 

Signed-off-by: Gary Edgar <gary@planetscale.com>

