### PR TITLE
Fix relay-log and relay-log-index paths

### DIFF
--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -5,6 +5,8 @@ innodb_data_home_dir = {{.InnodbDataHomeDir}}
 innodb_log_group_home_dir = {{.InnodbLogGroupHomeDir}}
 log-error = {{.ErrorLogPath}}
 log-bin = {{.BinLogPath}}
+relay-log = {{.RelayLogPath}}
+relay-log-index =  {{.RelayLogIndexPath}}
 pid-file = {{.PidFile}}
 port = {{.MysqlPort}}
 

--- a/go/vt/mysqlctl/rice-box.go
+++ b/go/vt/mysqlctl/rice-box.go
@@ -29,9 +29,9 @@ func init() {
 	}
 	file6 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/default.cnf",
-		FileModTime: time.Unix(1579019403, 0),
+		FileModTime: time.Unix(1579632282, 0),
 
-		Content: string("# Global configuration that is auto-included for all MySQL/MariaDB versions\n\ndatadir = {{.DataDir}}\ninnodb_data_home_dir = {{.InnodbDataHomeDir}}\ninnodb_log_group_home_dir = {{.InnodbLogGroupHomeDir}}\nlog-error = {{.ErrorLogPath}}\nlog-bin = {{.BinLogPath}}\npid-file = {{.PidFile}}\nport = {{.MysqlPort}}\n\n# all db instances should start in read-only mode - once the db is started and\n# fully functional, we'll push it into read-write mode\nread-only\nserver-id = {{.ServerID}}\n\n# all db instances should skip the slave startup - that way we can do any\n# additional configuration (like enabling semi-sync) before we connect to\n# the master.\nskip_slave_start\nslave_load_tmpdir = {{.SlaveLoadTmpDir}}\nsocket = {{.SocketFile}}\ntmpdir = {{.TmpDir}}\n\nslow-query-log-file = {{.SlowLogPath}}\n\n# These are sensible defaults that apply to all MySQL/MariaDB versions\n\nlong_query_time = 2\nslow-query-log\nskip-name-resolve\nconnect_timeout = 30\ninnodb_lock_wait_timeout = 20\nmax_allowed_packet = 64M\nmax_connections = 500\n\n\n"),
+		Content: string("# Global configuration that is auto-included for all MySQL/MariaDB versions\n\ndatadir = {{.DataDir}}\ninnodb_data_home_dir = {{.InnodbDataHomeDir}}\ninnodb_log_group_home_dir = {{.InnodbLogGroupHomeDir}}\nlog-error = {{.ErrorLogPath}}\nlog-bin = {{.BinLogPath}}\nrelay-log = {{.RelayLogPath}}\nrelay-log-index =  {{.RelayLogIndexPath}}\npid-file = {{.PidFile}}\nport = {{.MysqlPort}}\n\n# all db instances should start in read-only mode - once the db is started and\n# fully functional, we'll push it into read-write mode\nread-only\nserver-id = {{.ServerID}}\n\n# all db instances should skip the slave startup - that way we can do any\n# additional configuration (like enabling semi-sync) before we connect to\n# the master.\nskip_slave_start\nslave_load_tmpdir = {{.SlaveLoadTmpDir}}\nsocket = {{.SocketFile}}\ntmpdir = {{.TmpDir}}\n\nslow-query-log-file = {{.SlowLogPath}}\n\n# These are sensible defaults that apply to all MySQL/MariaDB versions\n\nlong_query_time = 2\nslow-query-log\nskip-name-resolve\nconnect_timeout = 30\ninnodb_lock_wait_timeout = 20\nmax_allowed_packet = 64M\nmax_connections = 500\n\n\n"),
 	}
 	file7 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb100.cnf",
@@ -113,7 +113,7 @@ func init() {
 	}
 	dir4 := &embedded.EmbeddedDir{
 		Filename:   "mycnf",
-		DirModTime: time.Unix(1579019403, 0),
+		DirModTime: time.Unix(1579632282, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			file5, // "mycnf/default-fast.cnf"
 			file6, // "mycnf/default.cnf"


### PR DESCRIPTION
The relay-log and relay-log-index paths were dropped by https://github.com/vitessio/vitess/pull/5326

This includes them back.

The `replica.cnf` file previously contained the following:
```
# replica.cnf - reserved for future tuning

relay-log = {{.RelayLogPath}}
relay-log-index =  {{.RelayLogIndexPath}}
relay-log-info-file =  {{.RelayLogInfoPath}}
master-info-file = {{.MasterInfoFile}}

# required if this master is chained
# probably safe to turn on all the time at the expense of some disk I/O
# note: this is in the master conf too
log-slave-updates

#slave_compressed_protocol
```

I have not reverted `relay-log-info-file`, `master-info-file` as these conflict with the table info repositories which were also configured. Depending on the order the config files were merged, this may have lead to non-deterministic behavior.

Signed-off-by: Morgan Tocker <tocker@gmail.com>