### PR TITLE
Fix vreplication panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.1 // indirect
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20160115111002-cca8bbc07984
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -102,10 +102,7 @@ func (dc *dbClientImpl) Rollback() error {
 }
 
 func (dc *dbClientImpl) Close() {
-	if dc.dbConn != nil {
-		dc.dbConn.Close()
-		dc.dbConn = nil
-	}
+	dc.dbConn.Close()
 }
 
 func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -368,7 +368,6 @@ func (dbc *realDBClient) Rollback() error {
 
 func (dbc *realDBClient) Close() {
 	dbc.conn.Close()
-	dbc.conn = nil
 }
 
 func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {


### PR DESCRIPTION
Fixes #5752

DBClient was setting the connection to nil after close, which was
causing vreplication to panic because it defers a Rollback on all
connections. The safer thing is to close the connection, but not
set it to nil.

There's no test for DBClient, but I've manually verified that this
won't panic any more.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>