### PR TITLE
make sqlparser/parse_test.go nicer to work with

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1526,7 +1526,7 @@ func TestValid(t *testing.T) {
 }
 
 // Ensure there is no corruption from using a pooled yyParserImpl in Parse.
-func TestValidParallel(t *testing.T) {
+func TestParallelValid(t *testing.T) {
 	parallelism := 100
 	numIters := 1000
 
@@ -2616,10 +2616,10 @@ func TestSkipToEnd(t *testing.T) {
 func TestParseDjangoQueries(t *testing.T) {
 
 	file, err := os.Open("./test_queries/django_queries.txt")
-	defer file.Close()
 	if err != nil {
 		t.Errorf(" Error: %v", err)
 	}
+	defer file.Close()
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {


### PR DESCRIPTION
A file close was done before error checking, and the TestValidParallel name
collided with TestValid when typing in `go test -run TestValid`.

Signed-off-by: Jeff Hodges <jeff@somethingsimilar.com>