### PR TITLE
Add escape and quote to mysql password from mysqlctl/mysqld.go

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1059,6 +1059,7 @@ func (mysqld *Mysqld) executeMysqlScript(connParams *mysql.ConnParams, sql io.Re
 // 'defer os.Remove()' statement.
 func (mysqld *Mysqld) defaultsExtraFile(connParams *mysql.ConnParams) (string, error) {
 	var contents string
+	connParams.Pass = strings.Replace(connParams.Pass, "#", "\\#", -1)
 	if connParams.UnixSocket == "" {
 		contents = fmt.Sprintf(`
 [client]


### PR DESCRIPTION
Fixed #5060 