### PR TITLE
Add a go fmt check

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -1,0 +1,21 @@
+name: check_formatting
+on: [pull_request]
+jobs:
+
+  build:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Run go fmt
+      run: |
+        gofmt -l . | grep -vF vendor/ && exit 1 || echo "All files formatted correctly"
+


### PR DESCRIPTION
Fixes #5756 

I was hoping to use an existing GitHub action, but since there is a vendor dir with violations, this seemed like the most straight forward way to implement.

Signed-off-by: Morgan Tocker <tocker@gmail.com>