### PR TITLE
populate local_metadata after agent has been initialized

### DIFF
--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -261,6 +261,7 @@ func TestIgnoreHealthError(t *testing.T) {
 	tablet := clusterInstance.GetVttabletInstance("replica", 0, "")
 	tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
 	err := tablet.MysqlctlProcess.Start()
+	assert.Nil(t, err)
 
 	// start vttablet process
 	tablet.VttabletProcess = cluster.VttabletProcessInstance(tablet.HTTPPort,

--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/log"
+)
+
+// TestLocalMetadata tests the contents of local_metadata table after vttablet startup
+func TestLocalMetadata(t *testing.T) {
+	// by default tablets are started with -restore_from_backup
+	// so metadata should exist
+	cluster.VerifyLocalMetadata(t, &replicaTablet, keyspaceName, shardName, cell)
+
+	// Create new tablet
+	rTablet := clusterInstance.GetVttabletInstance("replica", 0, "")
+
+	// Init Tablet
+	err := clusterInstance.VtctlclientProcess.InitTablet(rTablet, cell, keyspaceName, hostname, shardName)
+	require.NoError(t, err)
+
+	clusterInstance.VtTabletExtraArgs = []string{
+		"-lock_tables_timeout", "5s",
+		"-init_populate_metadata",
+	}
+	rTablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(rTablet.TabletUID, rTablet.MySQLPort, clusterInstance.TmpDirectory)
+	err = rTablet.MysqlctlProcess.Start()
+	assert.Nil(t, err)
+
+	log.Info(fmt.Sprintf("Started vttablet %v", rTablet))
+	// SupportsBackup=False prevents vttablet from trying to restore
+	// Start vttablet process
+	err = clusterInstance.StartVttablet(rTablet, "SERVING", false, cell, keyspaceName, hostname, shardName)
+	assert.Nil(t, err)
+
+	cluster.VerifyLocalMetadata(t, rTablet, keyspaceName, shardName, cell)
+
+	// Create another new tablet
+	rTablet2 := clusterInstance.GetVttabletInstance("replica", 0, "")
+
+	// Init Tablet
+	err = clusterInstance.VtctlclientProcess.InitTablet(rTablet2, cell, keyspaceName, hostname, shardName)
+	require.NoError(t, err)
+
+	// start with -init_populate_metadata false (default)
+	clusterInstance.VtTabletExtraArgs = []string{
+		"-lock_tables_timeout", "5s",
+	}
+	rTablet2.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(rTablet2.TabletUID, rTablet2.MySQLPort, clusterInstance.TmpDirectory)
+	err = rTablet2.MysqlctlProcess.Start()
+	assert.Nil(t, err)
+
+	log.Info(fmt.Sprintf("Started vttablet %v", rTablet2))
+	// SupportsBackup=False prevents vttablet from trying to restore
+	// Start vttablet process
+	err = clusterInstance.StartVttablet(rTablet2, "SERVING", false, cell, keyspaceName, hostname, shardName)
+	assert.Nil(t, err)
+
+	// check that tablet did _not_ get populated
+	qr, err := rTablet2.VttabletProcess.QueryTablet("select * from _vt.local_metadata", keyspaceName, false)
+	assert.Nil(t, err)
+	assert.Nil(t, qr.Rows)
+
+	// Reset the VtTabletExtraArgs and kill tablets
+	clusterInstance.VtTabletExtraArgs = []string{}
+	killTablets(t, rTablet, rTablet2)
+}

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -82,7 +82,7 @@ const (
 var (
 	tabletHostname       = flag.String("tablet_hostname", "", "if not empty, this hostname will be assumed instead of trying to resolve it")
 	demoteMasterType     = flag.String("demote_master_type", "REPLICA", "the tablet type a demoted master will transition to")
-	initPopulateMetadata = flag.Bool("init_populate_metadata", false, "(init parameter) populate metadata tables")
+	initPopulateMetadata = flag.Bool("init_populate_metadata", false, "(init parameter) populate metadata tables even if restore_from_backup is disabled. If restore_from_backup is enabled, metadata tables are always populated regardless of this flag.")
 )
 
 // ActionAgent is the main class for the agent.
@@ -358,8 +358,16 @@ func NewActionAgent(
 	} else {
 		// optionally populate metadata records
 		if *initPopulateMetadata {
-			// we can use agent.initialTablet here because it is set by Start()
+			// we use initialTablet here because it has the intended tabletType.
+			// the tablet returned by agent.Tablet() will have type UNKNOWN until we call
+			// refreshTablet
 			localMetadata := agent.getLocalMetadataValues(agent.initialTablet.Type)
+			if agent.Cnf != nil { // we are managing mysqld
+				// we'll use batchCtx here because we are still initializing and can't proceed unless this succeeds
+				if err := agent.MysqlDaemon.Wait(batchCtx, agent.Cnf); err != nil {
+					return nil, err
+				}
+			}
 			err := mysqlctl.PopulateMetadataTables(agent.MysqlDaemon, localMetadata, topoproto.TabletDbName(agent.initialTablet))
 			if err != nil {
 				return nil, vterrors.Wrap(err, "failed to -init_populate_metadata")

--- a/go/vt/vttablet/tabletmanager/init_tablet.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet.go
@@ -30,7 +30,6 @@ import (
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
-	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
@@ -40,13 +39,12 @@ import (
 )
 
 var (
-	initDbNameOverride   = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet. Without this flag, the db name defaults to vt_<keyspacename>")
-	initKeyspace         = flag.String("init_keyspace", "", "(init parameter) keyspace to use for this tablet")
-	initShard            = flag.String("init_shard", "", "(init parameter) shard to use for this tablet")
-	initTags             flagutil.StringMapValue
-	initTabletType       = flag.String("init_tablet_type", "", "(init parameter) the tablet type to use for this tablet.")
-	initTimeout          = flag.Duration("init_timeout", 1*time.Minute, "(init parameter) timeout to use for the init phase.")
-	initPopulateMetadata = flag.Bool("init_populate_metadata", false, "(init parameter) populate metadata tables")
+	initDbNameOverride = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet. Without this flag, the db name defaults to vt_<keyspacename>")
+	initKeyspace       = flag.String("init_keyspace", "", "(init parameter) keyspace to use for this tablet")
+	initShard          = flag.String("init_shard", "", "(init parameter) shard to use for this tablet")
+	initTags           flagutil.StringMapValue
+	initTabletType     = flag.String("init_tablet_type", "", "(init parameter) the tablet type to use for this tablet.")
+	initTimeout        = flag.Duration("init_timeout", 1*time.Minute, "(init parameter) timeout to use for the init phase.")
 )
 
 func init() {
@@ -248,14 +246,5 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 	}
 
 	agent.setTablet(tablet)
-	// optionally populate metadata records
-	if *initPopulateMetadata {
-		localMetadata := agent.getLocalMetadataValues(tablet.Type)
-		err := mysqlctl.PopulateMetadataTables(agent.MysqlDaemon, localMetadata, topoproto.TabletDbName(tablet))
-		if err != nil {
-			return vterrors.Wrap(err, "failed to -init_populate_metadata")
-		}
-	}
-
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/init_tablet_test.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet_test.go
@@ -26,7 +26,6 @@ import (
 
 	"vitess.io/vitess/go/history"
 	"vitess.io/vitess/go/mysql/fakesqldb"
-	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
 	"vitess.io/vitess/go/vt/topo"
@@ -173,17 +172,6 @@ func TestInitTablet(t *testing.T) {
 	}
 	db := fakesqldb.New(t)
 	defer db.Close()
-	db.AddQueryPattern(`(SET|CREATE|BEGIN|INSERT|COMMIT|ALTER|UPDATE)\b.*`, &sqltypes.Result{})
-	/*
-		db.AddQuery("SET @@session.sql_log_bin = 0", &sqltypes.Result{})
-		db.AddQuery("CREATE DATABASE IF NOT EXISTS _vt", &sqltypes.Result{})
-		db.AddQueryPattern(`CREATE TABLE IF NOT EXISTS _vt\.local_metadata.*`, &sqltypes.Result{})
-		db.AddQueryPattern(`CREATE TABLE IF NOT EXISTS _vt\.shard_metadata.*`, &sqltypes.Result{})
-		db.AddQuery("BEGIN", &sqltypes.Result{})
-		db.AddQueryPattern(`INSERT INTO _vt.local_metadata.*`, &sqltypes.Result{})
-		db.AddQueryPattern(`INSERT INTO _vt.shard_metadata.*`, &sqltypes.Result{})
-		db.AddQuery("COMMIT", &sqltypes.Result{})
-	*/
 
 	// start with a tablet record that doesn't exist
 	port := int32(1234)
@@ -209,7 +197,6 @@ func TestInitTablet(t *testing.T) {
 	*initKeyspace = "test_keyspace"
 	*initShard = "-C0"
 	*initTabletType = "replica"
-	*initPopulateMetadata = true
 	tabletAlias = &topodatapb.TabletAlias{
 		Cell: "cell1",
 		Uid:  2,


### PR DESCRIPTION
Fixes #5780.
Since `-restore_from_backup` populates local_metadata regardless of the value of `-init_populate_metadata` , we decided to not make it a fatal error if both flags are set.
Instead, the logic to populate local_metadata has been moved to the correct place (out of InitTablet) so that things work correctly if both flags are specified.

Note that we have chosen not to change the behavior of metadata_tables if `-init_populate_metadata` is false in the presence of `-restore_from_backup` because doing so would break backwards compatibility.

cc @guidoiaquinti 

Signed-off-by: deepthi <deepthi@planetscale.com>