### PR TITLE
vitessdriver: convert sqltypes.Timestamp to time.Time values

### DIFF
--- a/go/vt/vitessdriver/convert.go
+++ b/go/vt/vitessdriver/convert.go
@@ -31,7 +31,7 @@ type converter struct {
 
 func (cv *converter) ToNative(v sqltypes.Value) (interface{}, error) {
 	switch v.Type() {
-	case sqltypes.Datetime:
+	case sqltypes.Datetime, sqltypes.Timestamp:
 		return DatetimeToNative(v, cv.location)
 	case sqltypes.Date:
 		return DateToNative(v, cv.location)

--- a/go/vt/vitessdriver/convert_test.go
+++ b/go/vt/vitessdriver/convert_test.go
@@ -40,7 +40,7 @@ func TestToNative(t *testing.T) {
 	}, {
 		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Timestamp, "2012-02-24 23:19:43"),
-		out:     []byte("2012-02-24 23:19:43"), // TIMESTAMP is not handled
+		out:     time.Date(2012, 02, 24, 23, 19, 43, 0, time.UTC),
 	}, {
 		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Time, "23:19:43"),


### PR DESCRIPTION
When trying to do a scan into a time.Time type it will fail with error
unsupported Scan, storing driver.Value type []uint8 into type *time.Time

This should remedy this behavior and allow scans into time.Time.

Signed-off-by: Derrick Laird <swampdonk@gmail.com>