### PR TITLE
vrepl: improve some failure handling

### DIFF
--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -52,7 +52,7 @@ func (client *client) Dial(tablet *topodatapb.Tablet) error {
 	if err != nil {
 		return err
 	}
-	client.cc, err = grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
+	client.cc, err = grpcclient.Dial(addr, grpcclient.FailFast(true), opt)
 	if err != nil {
 		return err
 	}

--- a/go/vt/discovery/utils.go
+++ b/go/vt/discovery/utils.go
@@ -30,7 +30,7 @@ func RemoveUnhealthyTablets(tabletStatsList []TabletStats) []TabletStats {
 		// source and destination, and the source is not serving (disabled by
 		// TabletControl). When we switch the tablet to 'worker', it will
 		// go back to serving state.
-		if ts.Stats == nil || ts.Stats.HealthError != "" || IsReplicationLagHigh(&ts) {
+		if ts.Stats == nil || ts.Stats.HealthError != "" || ts.LastError != nil || IsReplicationLagHigh(&ts) {
 			continue
 		}
 		result = append(result, ts)

--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
@@ -103,7 +103,7 @@ func (vsClient *TabletVStreamerClient) Open(ctx context.Context) (err error) {
 	}
 	vsClient.isOpen = true
 
-	vsClient.tsQueryService, err = tabletconn.GetDialer()(vsClient.tablet, grpcclient.FailFast(false))
+	vsClient.tsQueryService, err = tabletconn.GetDialer()(vsClient.tablet, grpcclient.FailFast(true))
 	return err
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client_test.go
@@ -26,9 +26,6 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/vt/vttablet/queryservice"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -40,10 +37,7 @@ func TestTabletVStreamerClientOpen(t *testing.T) {
 	defer deleteTablet(tablet)
 
 	type fields struct {
-		isOpen         bool
-		tablet         *topodatapb.Tablet
-		target         *querypb.Target
-		tsQueryService queryservice.QueryService
+		tablet *topodatapb.Tablet
 	}
 	type args struct {
 		ctx context.Context
@@ -100,10 +94,7 @@ func TestTabletVStreamerClientClose(t *testing.T) {
 	defer deleteTablet(tablet)
 
 	type fields struct {
-		isOpen         bool
-		tablet         *topodatapb.Tablet
-		target         *querypb.Target
-		tsQueryService queryservice.QueryService
+		tablet *topodatapb.Tablet
 	}
 	type args struct {
 		ctx context.Context
@@ -296,7 +287,6 @@ func TestNewMySQLVStreamerClient(t *testing.T) {
 
 func TestMySQLVStreamerClientOpen(t *testing.T) {
 	type fields struct {
-		isOpen           bool
 		sourceConnParams *mysql.ConnParams
 	}
 	type args struct {
@@ -365,8 +355,6 @@ func TestMySQLVStreamerClientClose(t *testing.T) {
 	type fields struct {
 		isOpen           bool
 		sourceConnParams *mysql.ConnParams
-		vsEngine         *vstreamer.Engine
-		sourceSe         *schema.Engine
 	}
 	type args struct {
 		ctx context.Context

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -81,16 +81,16 @@ func TestUpdateVSchema(t *testing.T) {
 
 	// We have to start at least one stream to start the vschema watcher.
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	cancel()
 	filter := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
 			Match: "/.*/",
 		}},
 	}
-
-	_ = startStream(ctx, t, filter, "")
-	cancel()
+	// Stream should terminate immediately due to canceled context.
+	_ = engine.Stream(ctx, "current", filter, func(_ []*binlogdatapb.VEvent) error {
+		return nil
+	})
 
 	startCount := expectUpdateCount(t, 1)
 

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -125,19 +125,19 @@ func (vs *vstreamer) Cancel() {
 func (vs *vstreamer) Stream() error {
 	defer vs.cancel()
 
-	curpos, err := vs.currentPosition()
+	curPos, err := vs.currentPosition()
 	if err != nil {
 		return vterrors.Wrap(err, "could not obtain current position")
 	}
 	if vs.startPos == "current" {
-		vs.pos = curpos
+		vs.pos = curPos
 	} else {
 		pos, err := mysql.DecodePosition(vs.startPos)
 		if err != nil {
 			return vterrors.Wrap(err, "could not decode position")
 		}
-		if !curpos.AtLeast(pos) {
-			return fmt.Errorf("requested position %v is ahead of current position %v", mysql.EncodePosition(pos), mysql.EncodePosition(curpos))
+		if !curPos.AtLeast(pos) {
+			return fmt.Errorf("requested position %v is ahead of current position %v", mysql.EncodePosition(pos), mysql.EncodePosition(curPos))
 		}
 		vs.pos = pos
 	}


### PR DESCRIPTION
Tablet dialers were set to not fail fast. This was causing grpc
to redial the same tablet indefinitely eventhough it was permanently
down. This has now been changed to fail fast.

The tablet picker was only taking health errors into account, which
happens when tablets report themseleves as unhealthy. But if a tablet
is unreachable, we have to check LastError.

It's possible that vrepication can be ahead of a source repica.
In those cases, the vstreamer of the source should fail requests.
There are situations where mysql has unpredictable behavior,
especially if the requested position is one above the current one.

Also fixed some staticcheck errors.
