### PR TITLE
only rewrite database() against dual

### DIFF
--- a/go/test/endtoend/tabletmanager/dbnameoverride/tablet_master_test.go
+++ b/go/test/endtoend/tabletmanager/dbnameoverride/tablet_master_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package master
+
+import (
+	"context"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/mysql"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	hostname        = "localhost"
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	sqlSchema       = `
+	create table t1(
+		id bigint,
+		value varchar(16),
+		primary key(id)
+	) Engine=InnoDB;
+`
+
+	vSchema = `
+	{
+    "sharded": true,
+    "vindexes": {
+      "hash": {
+        "type": "hash"
+      }
+    },
+    "tables": {
+      "t1": {
+        "column_vindexes": [
+          {
+            "column": "id",
+            "name": "hash"
+          }
+        ]
+      }
+    }
+  }`
+)
+
+const dbName = "myDbName"
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Set extra tablet args for lock timeout
+		clusterInstance.VtTabletExtraArgs = []string{
+			"-init_db_name_override", dbName,
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+
+		if err = clusterInstance.StartUnshardedKeyspace(*keyspace, 1, false); err != nil {
+			return 1
+		}
+
+		if err = clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestDbNameOverride(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+	qr, err := conn.ExecuteFetch("SELECT database() FROM information_schema.tables WHERE table_schema = database()", 1000, true)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(qr.Rows), "did not get enough rows back")
+	require.Equal(t, strings.ToLower(dbName), qr.Rows[0][0].ToString())
+}

--- a/go/test/endtoend/tabletmanager/dbnameoverride/tablet_master_test.go
+++ b/go/test/endtoend/tabletmanager/dbnameoverride/tablet_master_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"flag"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -116,5 +115,5 @@ func TestDbNameOverride(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 1, len(qr.Rows), "did not get enough rows back")
-	require.Equal(t, strings.ToLower(dbName), qr.Rows[0][0].ToString())
+	require.Equal(t, dbName, qr.Rows[0][0].ToString())
 }

--- a/go/vt/sqlparser/expression_rewriting_test.go
+++ b/go/vt/sqlparser/expression_rewriting_test.go
@@ -55,14 +55,19 @@ func TestRewrites(in *testing.T) {
 			db:       true, liid: true,
 		},
 		{
-			in:       "select (select database() from test) from test",
-			expected: "select (select :__vtdbname as `database()` from test) as `(select database() from test)` from test",
+			in:       "select (select database() from dual) from dual",
+			expected: "select (select :__vtdbname as `database()` from dual) as `(select database() from dual)` from dual",
 			db:       true, liid: false,
 		},
 		{
 			in:       "select id from user where database()",
-			expected: "select id from user where :__vtdbname",
-			db:       true, liid: false,
+			expected: "select id from user where database()",
+			db:       false, liid: false,
+		},
+		{
+			in:       "select table_name from information_schema.tables where table_schema = database()",
+			expected: "select table_name from information_schema.tables where table_schema = database()",
+			db:       false, liid: false,
 		},
 	}
 
@@ -77,16 +82,10 @@ func TestRewrites(in *testing.T) {
 			expected, err := Parse(tc.expected)
 			require.NoError(t, err)
 
-			s := toString(expected)
-			require.Equal(t, s, toString(result.AST))
+			s := String(expected)
+			require.Equal(t, s, String(result.AST))
 			require.Equal(t, tc.liid, result.NeedLastInsertID, "should need last insert id")
 			require.Equal(t, tc.db, result.NeedDatabase, "should need database name")
 		})
 	}
-}
-
-func toString(node SQLNode) string {
-	buf := NewTrackedBuffer(nil)
-	node.Format(buf)
-	return buf.String()
 }

--- a/go/vt/sqlparser/expression_rewriting_test.go
+++ b/go/vt/sqlparser/expression_rewriting_test.go
@@ -45,6 +45,11 @@ func TestRewrites(in *testing.T) {
 			db:       true, liid: false,
 		},
 		{
+			in:       "SELECT database() from test",
+			expected: "SELECT database() from test",
+			db:       false, liid: false,
+		},
+		{
 			in:       "SELECT last_insert_id() as test",
 			expected: "SELECT :__lastInsertId as test",
 			db:       false, liid: true,
@@ -53,6 +58,16 @@ func TestRewrites(in *testing.T) {
 			in:       "SELECT last_insert_id() + database()",
 			expected: "SELECT :__lastInsertId + :__vtdbname as `last_insert_id() + database()`",
 			db:       true, liid: true,
+		},
+		{
+			in:       "select (select database()) from test",
+			expected: "select (select database() from dual) from test",
+			db:       false, liid: false,
+		},
+		{
+			in:       "select (select database() from dual) from test",
+			expected: "select (select database() from dual) from test",
+			db:       false, liid: false,
 		},
 		{
 			in:       "select (select database() from dual) from dual",

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -282,7 +282,6 @@ func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql
 			sql = comments.Leading + normalized + comments.Trailing
 			if rewriteResult.NeedDatabase {
 				keyspace, _, _, _ := e.ParseDestinationTarget(safeSession.TargetString)
-				log.Warningf("This is the keyspace name: ---> %v", keyspace)
 				if keyspace == "" {
 					bindVars[sqlparser.DBVarName] = sqltypes.NullBindVariable
 				} else {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1078,7 +1078,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select id from user where :__vtdbname",
+    "Query": "select id from user where database()",
     "FieldQuery": "select id from user where 1 != 1",
     "Table": "user"
   }


### PR DESCRIPTION
When we implemented handling of `database()` to map to keyspace_name, we didn't consider cases where the expression is part of a query that is being sent to a tablet instead of being handled in vtgate.

So a query like `select database()` would return the keyspace name (which is correct), but a query like `select table_name from information_schema.tables where table_schema = database()` would not work as expected because the table_schema doesn't match the keyspace name.

This is a stopgap fix until we fully implement information_schema.

Adapted from #5787 with unit test fixes and more tests.
cc @systay 