### PR TITLE
Clean up: Use require.NoError in Tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.1 // indirect
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20160115111002-cca8bbc07984
 	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/tlstest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/mysql"
 
 	"vitess.io/vitess/go/vt/vttest"
@@ -187,9 +188,7 @@ func assertColumnVindex(t *testing.T, cluster vttest.LocalCluster, expected colu
 		assertEqual(t, columnVindex.Name, expected.vindex, "Actual vindex name different from expected")
 		assertEqual(t, columnVindex.Columns[0], expected.column, "Actual vindex column different from expected")
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func assertEqual(t *testing.T, actual string, expected string, message string) {

--- a/go/proc/proc_flaky_test.go
+++ b/go/proc/proc_flaky_test.go
@@ -28,6 +28,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRestart(t *testing.T) {
@@ -65,19 +67,13 @@ func testLaunch(t *testing.T) {
 	cmd2 := launchServer(t, port, 2)
 	defer cmd2.Process.Kill()
 	err = cmd1.Wait()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	testPid(t, port, cmd2.Process.Pid)
 
 	err = syscall.Kill(cmd2.Process.Pid, syscall.SIGTERM)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = cmd2.Wait()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func launchServer(t *testing.T, port string, num int) *exec.Cmd {

--- a/go/sqltypes/bind_variables_test.go
+++ b/go/sqltypes/bind_variables_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -524,9 +525,7 @@ func TestValidateBindVariable(t *testing.T) {
 
 func TestBindVariableToValue(t *testing.T) {
 	v, err := BindVariableToValue(Int64BindVariable(1))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := MakeTrusted(querypb.Type_INT64, []byte("1"))
 	if !reflect.DeepEqual(v, want) {
 		t.Errorf("BindVarToValue(1): %v, want %v", v, want)

--- a/go/vt/binlog/event_streamer_test.go
+++ b/go/vt/binlog/event_streamer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -90,9 +91,7 @@ func TestSetErrors(t *testing.T) {
 	}
 	before := binlogStreamerErrors.Counts()["EventStreamer"]
 	err := evs.transactionToEvent(nil, statements)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	got := binlogStreamerErrors.Counts()["EventStreamer"]
 	if got != before+1 {
 		t.Errorf("got: %v, want: %+v", got, before+1)
@@ -160,9 +159,7 @@ func TestDMLEvent(t *testing.T) {
 		},
 	}
 	err := evs.transactionToEvent(eventToken, statements)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestDDLEvent(t *testing.T) {
@@ -208,7 +205,5 @@ func TestDDLEvent(t *testing.T) {
 		},
 	}
 	err := evs.transactionToEvent(eventToken, statements)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }

--- a/go/vt/dtids/dtids_test.go
+++ b/go/vt/dtids/dtids_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -41,9 +42,7 @@ func TestDTID(t *testing.T) {
 		t.Errorf("generateDTID: %s, want %s", dtid, want)
 	}
 	out, err := ShardSession(dtid)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !proto.Equal(in, out) {
 		t.Errorf("ShardSession: %+v, want %+v", out, in)
 	}
@@ -61,9 +60,7 @@ func TestDTID(t *testing.T) {
 
 func TestTransactionID(t *testing.T) {
 	out, err := TransactionID("aa:0:1")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if out != 1 {
 		t.Errorf("TransactionID(aa:0:1): %d, want 1", out)
 	}

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -24,15 +24,14 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 )
 
 func TestAppend(t *testing.T) {
 	query := "select * from t where a = 1"
 	tree, err := Parse(query)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	var b strings.Builder
 	Append(&b, tree)
 	got := b.String()
@@ -50,9 +49,7 @@ func TestAppend(t *testing.T) {
 
 func TestSelect(t *testing.T) {
 	tree, err := Parse("select * from t where a = 1")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	expr := tree.(*Select).Where.Expr
 
 	sel := &Select{}
@@ -88,9 +85,7 @@ func TestSelect(t *testing.T) {
 
 	// OR clauses must be parenthesized.
 	tree, err = Parse("select * from t where a = 1 or b = 1")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	expr = tree.(*Select).Where.Expr
 	sel = &Select{}
 	sel.AddWhere(expr)
@@ -133,14 +128,10 @@ func TestRemoveHints(t *testing.T) {
 
 func TestAddOrder(t *testing.T) {
 	src, err := Parse("select foo, bar from baz order by foo")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	order := src.(*Select).OrderBy[0]
 	dst, err := Parse("select * from t")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	dst.(*Select).AddOrder(order)
 	buf := NewTrackedBuffer(nil)
 	dst.Format(buf)
@@ -149,9 +140,7 @@ func TestAddOrder(t *testing.T) {
 		t.Errorf("order: %q, want %s", buf.String(), want)
 	}
 	dst, err = Parse("select * from t union select * from s")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	dst.(*Union).AddOrder(order)
 	buf = NewTrackedBuffer(nil)
 	dst.Format(buf)
@@ -163,14 +152,10 @@ func TestAddOrder(t *testing.T) {
 
 func TestSetLimit(t *testing.T) {
 	src, err := Parse("select foo, bar from baz limit 4")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	limit := src.(*Select).Limit
 	dst, err := Parse("select * from t")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	dst.(*Select).SetLimit(limit)
 	buf := NewTrackedBuffer(nil)
 	dst.Format(buf)
@@ -179,9 +164,7 @@ func TestSetLimit(t *testing.T) {
 		t.Errorf("limit: %q, want %s", buf.String(), want)
 	}
 	dst, err = Parse("select * from t union select * from s")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	dst.(*Union).SetLimit(limit)
 	buf = NewTrackedBuffer(nil)
 	dst.Format(buf)
@@ -269,9 +252,7 @@ func TestDDL(t *testing.T) {
 
 func TestSetAutocommitON(t *testing.T) {
 	stmt, err := Parse("SET autocommit=ON")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	s, ok := stmt.(*Set)
 	if !ok {
 		t.Errorf("SET statement is not Set: %T", s)
@@ -296,9 +277,7 @@ func TestSetAutocommitON(t *testing.T) {
 	}
 
 	stmt, err = Parse("SET @@session.autocommit=ON")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	s, ok = stmt.(*Set)
 	if !ok {
 		t.Errorf("SET statement is not Set: %T", s)
@@ -325,9 +304,7 @@ func TestSetAutocommitON(t *testing.T) {
 
 func TestSetAutocommitOFF(t *testing.T) {
 	stmt, err := Parse("SET autocommit=OFF")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	s, ok := stmt.(*Set)
 	if !ok {
 		t.Errorf("SET statement is not Set: %T", s)
@@ -352,9 +329,7 @@ func TestSetAutocommitOFF(t *testing.T) {
 	}
 
 	stmt, err = Parse("SET @@session.autocommit=OFF")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	s, ok = stmt.(*Set)
 	if !ok {
 		t.Errorf("SET statement is not Set: %T", s)

--- a/go/vt/topo/test/vschema.go
+++ b/go/vt/topo/test/vschema.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/topo"
 
@@ -53,9 +54,7 @@ func checkVSchema(t *testing.T, ts *topo.Server) {
 	}
 
 	got, err := ts.GetVSchema(ctx, "test_keyspace")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := &vschemapb.Keyspace{
 		Tables: map[string]*vschemapb.Table{
 			"unsharded": {},
@@ -68,14 +67,10 @@ func checkVSchema(t *testing.T, ts *topo.Server) {
 	err = ts.SaveVSchema(ctx, "test_keyspace", &vschemapb.Keyspace{
 		Sharded: true,
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	got, err = ts.GetVSchema(ctx, "test_keyspace")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = &vschemapb.Keyspace{
 		Sharded: true,
 	}
@@ -113,9 +108,7 @@ func checkRoutingRules(t *testing.T, ts *topo.Server) {
 	}
 
 	got, err := ts.GetRoutingRules(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !proto.Equal(got, want) {
 		t.Errorf("GetRoutingRules: %v, want %v", got, want)
 	}

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -160,9 +161,7 @@ func TestOpen_InvalidJson(t *testing.T) {
 
 func TestBeginIsolation(t *testing.T) {
 	db, err := Open(testAddress, "@master")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 	_, err = db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	want := errIsolationUnsupported.Error()

--- a/go/vt/vitessdriver/rows_test.go
+++ b/go/vt/vitessdriver/rows_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -106,9 +107,7 @@ func TestRows(t *testing.T) {
 	}
 	gotRow := make([]driver.Value, len(wantRow))
 	err := ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %#v, want %#v type: %T", gotRow, wantRow, wantRow[3])
 		logMismatchedTypes(t, gotRow, wantRow)
@@ -122,9 +121,7 @@ func TestRows(t *testing.T) {
 		uint64(18446744073709551615),
 	}
 	err = ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %v, want %v", gotRow, wantRow)
 		logMismatchedTypes(t, gotRow, wantRow)

--- a/go/vt/vitessdriver/streaming_rows_test.go
+++ b/go/vt/vitessdriver/streaming_rows_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -102,9 +103,7 @@ func TestStreamingRows(t *testing.T) {
 	}
 	gotRow := make([]driver.Value, 3)
 	err := ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %v, want %v", gotRow, wantRow)
 	}
@@ -115,9 +114,7 @@ func TestStreamingRows(t *testing.T) {
 		[]byte("value2"),
 	}
 	err = ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %v, want %v", gotRow, wantRow)
 	}
@@ -146,9 +143,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 	}
 	gotRow := make([]driver.Value, 3)
 	err := ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %v, want %v", gotRow, wantRow)
 	}
@@ -216,9 +211,7 @@ func TestStreamingRowsError(t *testing.T) {
 	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after rows")}, &converter{})
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = ri.Next(gotRow)
 	wantErr = "error after rows"
 	if err == nil || !strings.Contains(err.Error(), wantErr) {

--- a/go/vt/vtgate/engine/limit_test.go
+++ b/go/vt/vtgate/engine/limit_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -48,9 +49,7 @@ func TestLimitExecute(t *testing.T) {
 
 	// Test with limit smaller than input.
 	result, err := l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResult := sqltypes.MakeTestResult(
 		fields,
 		"a|1",
@@ -82,9 +81,7 @@ func TestLimitExecute(t *testing.T) {
 	}
 
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, inputResult) {
 		t.Errorf("l.Execute:\n%v, want\n%v", result, wantResult)
 	}
@@ -105,9 +102,7 @@ func TestLimitExecute(t *testing.T) {
 	}
 
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n%v, want\n%v", result, wantResult)
 	}
@@ -133,9 +128,7 @@ func TestLimitExecute(t *testing.T) {
 	}
 
 	result, err = l.Execute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n%v, want\n%v", result, wantResult)
 	}
@@ -168,9 +161,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 
 	// Test with offset 0
 	result, err := l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResult := sqltypes.MakeTestResult(
 		fields,
 		"a|1",
@@ -206,9 +197,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		"c|3",
 	)
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -238,9 +227,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		"c|6",
 	)
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -271,9 +258,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		"c|6",
 	)
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -302,9 +287,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		"c|6",
 	)
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -332,9 +315,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		fields,
 	)
 	result, err = l.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -360,9 +341,7 @@ func TestLimitOffsetExecute(t *testing.T) {
 		Input:  fp,
 	}
 	result, err = l.Execute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(1), "o": sqltypes.Int64BindVariable(1)}, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(result, wantResult) {
 		t.Errorf("l.Execute:\n got %v, want\n%v", result, wantResult)
 	}
@@ -395,9 +374,7 @@ func TestLimitStreamExecute(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResults := sqltypes.MakeTestStreamingResults(
 		fields,
 		"a|1",
@@ -415,9 +392,7 @@ func TestLimitStreamExecute(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(results, wantResults) {
 		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
 	}
@@ -430,9 +405,7 @@ func TestLimitStreamExecute(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResults = sqltypes.MakeTestStreamingResults(
 		fields,
 		"a|1",
@@ -452,9 +425,7 @@ func TestLimitStreamExecute(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// wantResults is same as before.
 	if !reflect.DeepEqual(results, wantResults) {
 		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
@@ -473,9 +444,7 @@ func TestLimitGetFields(t *testing.T) {
 	l := &Limit{Input: fp}
 
 	got, err := l.GetFields(nil, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(got, result) {
 		t.Errorf("l.GetFields:\n%v, want\n%v", got, result)
 	}

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -69,9 +70,7 @@ func TestMergeSortNormal(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Results are returned one row at a time.
 	wantResults := sqltypes.MakeTestStreamingResults(idColFields,
@@ -139,9 +138,7 @@ func TestMergeSortDescending(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Results are returned one row at a time.
 	wantResults := sqltypes.MakeTestStreamingResults(idColFields,
@@ -198,9 +195,7 @@ func TestMergeSortEmptyResults(t *testing.T) {
 		results = append(results, qr)
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Results are returned one row at a time.
 	wantResults := sqltypes.MakeTestStreamingResults(idColFields,

--- a/go/vt/vtgate/engine/pullout_subquery_test.go
+++ b/go/vt/vtgate/engine/pullout_subquery_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -59,9 +60,7 @@ func TestPulloutSubqueryValueGood(t *testing.T) {
 	}
 
 	result, err := ps.Execute(nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	sfp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1"  false`})
 	ufp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1" sq: type:INT64 value:"1"  false`})
 	expectResult(t, "ps.Execute", result, underlyingResult)
@@ -317,9 +316,7 @@ func TestPulloutSubqueryStream(t *testing.T) {
 	}
 
 	result, err := wrapStreamExecute(ps, nil, bindVars, false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	sfp.ExpectLog(t, []string{`Execute aa: type:INT64 value:"1"  false`})
 	ufp.ExpectLog(t, []string{`StreamExecute aa: type:INT64 value:"1" sq: type:INT64 value:"1"  false`})
 	expectResult(t, "ps.StreamExecute", result, underlyingResult)

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -42,9 +42,7 @@ func TestUpdateEqual(t *testing.T) {
 
 	// Update by primary vindex.
 	_, err := executorExec(executor, "update user set a=2 where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -59,9 +57,7 @@ func TestUpdateEqual(t *testing.T) {
 
 	sbc1.Queries = nil
 	_, err = executorExec(executor, "update user set a=2 where id = 3", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "update user set a = 2 where id = 3 /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -78,9 +74,7 @@ func TestUpdateEqual(t *testing.T) {
 	sbc2.Queries = nil
 	sbclookup.SetResults([]*sqltypes.Result{{}})
 	_, err = executorExec(executor, "update music set a=2 where id = 2", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select user_id from music_user_map where music_id = :music_id",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -102,9 +96,7 @@ func TestUpdateEqual(t *testing.T) {
 	sbc2.Queries = nil
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "update user2 set name='myname', lastname='mylastname' where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{
 		{
 			Sql:           "select name, lastname from user2 where id = 1 for update",
@@ -271,9 +263,7 @@ func TestUpdateComments(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 
 	_, err := executorExec(executor, "update user set a=2 where id = 1 /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -291,9 +281,7 @@ func TestUpdateNormalize(t *testing.T) {
 
 	executor.normalize = true
 	_, err := executorExec(executor, "/* leading */ update user set a=2 where id = 1 /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "/* leading */ update user set a = :vtg1 where id = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -312,9 +300,7 @@ func TestUpdateNormalize(t *testing.T) {
 	// Force the query to go to the "wrong" shard and ensure that normalization still happens
 	masterSession.TargetString = "TestExecutor/40-60"
 	_, err = executorExec(executor, "/* leading */ update user set a=2 where id = 1 /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "/* leading */ update user set a = :vtg1 where id = :vtg2 /* trailing *//* vtgate:: filtered_replication_unfriendly */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -346,9 +332,7 @@ func TestDeleteEqual(t *testing.T) {
 		}},
 	}})
 	_, err := executorExec(executor, "delete from user where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "select name from user where id = 1 for update",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -375,9 +359,7 @@ func TestDeleteEqual(t *testing.T) {
 	sbclookup.Queries = nil
 	sbc.SetResults([]*sqltypes.Result{{}})
 	_, err = executorExec(executor, "delete from user where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select name from user where id = 1 for update",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -396,9 +378,7 @@ func TestDeleteEqual(t *testing.T) {
 	sbclookup.Queries = nil
 	sbclookup.SetResults([]*sqltypes.Result{{}})
 	_, err = executorExec(executor, "delete from music where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select user_id from music_user_map where music_id = :music_id",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -416,9 +396,7 @@ func TestDeleteEqual(t *testing.T) {
 	sbclookup.Queries = nil
 	sbclookup.SetResults([]*sqltypes.Result{{}})
 	_, err = executorExec(executor, "delete from user_extra where user_id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra where user_id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -433,9 +411,7 @@ func TestDeleteEqual(t *testing.T) {
 	sbc.Queries = nil
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "delete from user2 where id = 1", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{
 		{
 			Sql:           "select name, lastname from user2 where id = 1 for update",
@@ -469,9 +445,7 @@ func TestDeleteEqual(t *testing.T) {
 func TestUpdateScatter(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 	_, err := executorExec(executor, "update user_extra set col = 2", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Queries get annotatted.
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "update user_extra set col = 2/* vtgate:: filtered_replication_unfriendly */",
@@ -488,9 +462,7 @@ func TestUpdateScatter(t *testing.T) {
 func TestDeleteScatter(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 	_, err := executorExec(executor, "delete from user_extra", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Queries get annotatted.
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra/* vtgate:: filtered_replication_unfriendly */",
@@ -508,9 +480,7 @@ func TestDeleteByDestination(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
 	// This query is not supported in v3, so we know for sure is taking the DeleteByDestination route
 	_, err := executorExec(executor, "delete from `TestExecutor[-]`.user_extra limit 10", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Queries get annotatted.
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra limit 10/* vtgate:: filtered_replication_unfriendly */",
@@ -538,9 +508,7 @@ func TestDeleteComments(t *testing.T) {
 		}},
 	}})
 	_, err := executorExec(executor, "delete from user where id = 1 /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "select name from user where id = 1 for update /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -571,9 +539,7 @@ func TestInsertSharded(t *testing.T) {
 	defer QueryLogger.Unsubscribe(logChan)
 
 	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -605,9 +571,7 @@ func TestInsertSharded(t *testing.T) {
 	sbc1.Queries = nil
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "insert into user(id, v, name) values (3, 2, 'myname2')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -635,9 +599,7 @@ func TestInsertSharded(t *testing.T) {
 
 	sbc1.Queries = nil
 	_, err = executorExec(executor, "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into user2(id, name, lastname) values (:_id0, :_name0, :_lastname0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -711,9 +673,7 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createCustomExecutor(vschema)
 
 	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -781,9 +741,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 	// Sixth row: second shard (because 3 hash maps to 40-60).
 	query := "insert ignore into insert_ignore_test(pv, owned, verify) values (1, 1, 1), (2, 2, 2), (3, 3, 1), (4, 4, 4), (5, 5, 1), (6, 6, 3)"
 	_, err := executorExec(executor, query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv0, :_owned0, :_verify0),(:_pv4, :_owned4, :_verify4) /* vtgate:: keyspace_id:166b40b44aba4bd6,166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -906,9 +864,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 	})
 	query = "insert ignore into insert_ignore_test(pv, owned, verify) values (1, 1, 1)"
 	qr, err := executorExec(executor, query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(qr, &sqltypes.Result{}) {
 		t.Errorf("qr: %v, want empty result", qr)
 	}
@@ -935,9 +891,7 @@ func TestInsertOnDupKey(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 	query := "insert into insert_ignore_test(pv, owned, verify) values (1, 1, 1) on duplicate key update col = 2"
 	_, err := executorExec(executor, query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into insert_ignore_test(pv, owned, verify) values (:_pv0, :_owned0, :_verify0) on duplicate key update col = 2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -979,9 +933,7 @@ func TestInsertComments(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname') /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1019,9 +971,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 		InsertID:     1,
 	}})
 	result, err := executorExec(executor, "insert into user(v, name) values (2, 'myname')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user(v, name, id) values (2, :_name0, :_Id0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1066,9 +1016,7 @@ func TestInsertAutoincSharded(t *testing.T) {
 	}
 	sbc.SetResults([]*sqltypes.Result{wantResult})
 	result, err := executorExec(router, "insert into user_extra(user_id) values (2)", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user_extra(user_id) values (:_user_id0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1086,9 +1034,7 @@ func TestInsertAutoincSharded(t *testing.T) {
 func TestInsertGeneratorUnsharded(t *testing.T) {
 	executor, _, _, sbclookup := createExecutorEnv()
 	result, err := executorExec(executor, "insert into main1(id, name) values (null, 'myname')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
@@ -1123,9 +1069,7 @@ func TestInsertAutoincUnsharded(t *testing.T) {
 	sbclookup.SetResults([]*sqltypes.Result{wantResult})
 
 	result, err := executorExec(router, query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           query,
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -1142,9 +1086,7 @@ func TestInsertLookupOwned(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into music(user_id, id) values (2, 3)", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music(user_id, id) values (:_user_id0, :_id0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1179,9 +1121,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 		InsertID:     1,
 	}})
 	result, err := executorExec(executor, "insert into music(user_id) values (2)", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music(user_id, id) values (:_user_id0, :_id0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1217,9 +1157,7 @@ func TestInsertLookupUnowned(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into music_extra(user_id, music_id) values (2, 3)", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music_extra(user_id, music_id) values (:_user_id0, :_music_id0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1246,9 +1184,7 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into music_extra_reversed(music_id) values (3)", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music_extra_reversed(music_id, user_id) values (:_music_id0, :_user_id0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1317,9 +1253,7 @@ func TestMultiInsertSharded(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 1, 'myname1'),(3, 3, 'myname3')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries1 := []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 1, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1368,9 +1302,7 @@ func TestMultiInsertSharded(t *testing.T) {
 	sbclookup.Queries = nil
 	sbc2.Queries = nil
 	_, err = executorExec(executor, "insert into user(id, v, name) values (1, 1, 'myname1'),(2, 2, 'myname2')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id0, 1, :_name0),(:_Id1, 2, :_name1) /* vtgate:: keyspace_id:166b40b44aba4bd6,06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1407,9 +1339,7 @@ func TestMultiInsertSharded(t *testing.T) {
 	sbclookup.Queries = nil
 	sbc2.Queries = nil
 	_, err = executorExec(executor, "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname'), (3, 'myname2', 'mylastname2')", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into user2(id, name, lastname) values (:_id0, :_name0, :_lastname0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1451,9 +1381,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 		InsertID:     1,
 	}})
 	result, err := executorExec(executor, "insert into music(user_id, name) values (:u, 'myname1'),(:u, 'myname2')", map[string]*querypb.BindVariable{"u": sqltypes.Int64BindVariable(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music(user_id, name, id) values (:_user_id0, 'myname1', :_id0),(:_user_id1, 'myname2', :_id1) /* vtgate:: keyspace_id:06e7ea22ce92708f,06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1502,9 +1430,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 		InsertID:     1,
 	}})
 	result, err := executorExec(executor, "insert into music(id, user_id, name) values (NULL, :u, 'myname1'),(2, :u, 'myname2'), (NULL, :u, 'myname3')", map[string]*querypb.BindVariable{"u": sqltypes.Int64BindVariable(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into music(id, user_id, name) values (:_id0, :_user_id0, 'myname1'),(:_id1, :_user_id1, 'myname2'),(:_id2, :_user_id2, 'myname3') /* vtgate:: keyspace_id:06e7ea22ce92708f,06e7ea22ce92708f,06e7ea22ce92708f */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1588,9 +1514,7 @@ func TestKeyDestRangeQuery(t *testing.T) {
 	masterSession.TargetString = "TestExecutor[40-60]"
 
 	_, err := executorExec(executor, "DELETE FROM sharded_user_msgs LIMIT 1000", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	sql := "DELETE FROM sharded_user_msgs LIMIT 1000"
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           sql + "/* vtgate:: filtered_replication_unfriendly */",
@@ -1609,9 +1533,7 @@ func TestKeyDestRangeQuery(t *testing.T) {
 	masterSession.TargetString = "TestExecutor[-60]"
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	testQueries(t, "sbc1", sbc1, wantQueries)
 	testQueries(t, "sbc1", sbc2, wantQueries)
 
@@ -1622,9 +1544,7 @@ func TestKeyDestRangeQuery(t *testing.T) {
 	masterSession.TargetString = "TestExecutor[-]"
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	testQueries(t, "sbc1", sbc1, wantQueries)
 	testQueries(t, "sbc2", sbc2, wantQueries)
@@ -1640,9 +1560,7 @@ func TestKeyDestRangeQuery(t *testing.T) {
 	}}
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	testQueries(t, "sbc1", sbc1, wantQueries)
 	testQueries(t, "sbc2", sbc2, wantQueries)
@@ -1659,9 +1577,7 @@ func TestKeyDestRangeQuery(t *testing.T) {
 	}}
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	testQueries(t, "sbc1", sbc1, wantQueries)
 	testQueries(t, "sbc2", sbc2, wantQueries)
@@ -1688,9 +1604,7 @@ func TestKeyShardDestQuery(t *testing.T) {
 	masterSession.TargetString = "TestExecutor:40-60"
 
 	_, err := executorExec(executor, "DELETE FROM sharded_user_msgs LIMIT 1000", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	sql := "DELETE FROM sharded_user_msgs LIMIT 1000"
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           sql + "/* vtgate:: filtered_replication_unfriendly */",
@@ -1708,9 +1622,7 @@ func TestKeyShardDestQuery(t *testing.T) {
 	masterSession.TargetString = "TestExecutor:40-60"
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	testQueries(t, "sbc2", sbc2, wantQueries)
 
@@ -1725,9 +1637,7 @@ func TestKeyShardDestQuery(t *testing.T) {
 	}}
 
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	if len(sbc1.Queries) != 0 {
 		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, []*querypb.BoundQuery{})
@@ -1748,9 +1658,7 @@ func TestKeyShardDestQuery(t *testing.T) {
 
 	_, err = executorExec(executor, sql, nil)
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	if len(sbc1.Queries) != 0 {
 		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, []*querypb.BoundQuery{})
@@ -1770,9 +1678,7 @@ func TestKeyShardDestQuery(t *testing.T) {
 		Sql:           sql + "/* vtgate:: filtered_replication_unfriendly */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	if len(sbc1.Queries) != 0 {
 		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, []*querypb.BoundQuery{})
@@ -1796,9 +1702,7 @@ func TestUpdateEqualWithPrepare(t *testing.T) {
 		"a0":  sqltypes.Int64BindVariable(3),
 		"id0": sqltypes.Int64BindVariable(2),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
 
@@ -1823,9 +1727,7 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 		"_name0": sqltypes.BytesBindVariable([]byte("myname")),
 		"__seq0": sqltypes.Int64BindVariable(1),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
 
@@ -1846,9 +1748,7 @@ func TestDeleteEqualWithPrepare(t *testing.T) {
 	_, err := executorPrepare(executor, "delete from user where id = :id0", map[string]*querypb.BindVariable{
 		"id0": sqltypes.Int64BindVariable(1),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
 

--- a/go/vt/vtgate/executor_scatter_stats_test.go
+++ b/go/vt/vtgate/executor_scatter_stats_test.go
@@ -22,7 +22,7 @@ import (
 
 	"net/http/httptest"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 )
@@ -32,11 +32,11 @@ func TestScatterStatsWithNoScatterQuery(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: "@master"})
 
 	_, err := executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, "select * from main1", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err := executor.gatherScatterStats()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(result.Items))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(result.Items))
 }
 
 func TestScatterStatsWithSingleScatterQuery(t *testing.T) {
@@ -44,11 +44,11 @@ func TestScatterStatsWithSingleScatterQuery(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: "@master"})
 
 	_, err := executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, "select * from user", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	result, err := executor.gatherScatterStats()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(result.Items))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result.Items))
 }
 
 func TestScatterStatsHttpWriting(t *testing.T) {
@@ -56,23 +56,23 @@ func TestScatterStatsHttpWriting(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: "@master"})
 
 	_, err := executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, "select * from user", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, "select * from user where Id = 15", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, "select * from user where Id > 15", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	query4 := "select * from user as u1 join  user as u2 on u1.Id = u2.Id"
 	_, err = executor.Execute(context.Background(), "TestExecutorResultsExceeded", session, query4, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 	executor.WriteScatterStats(recorder)
 
 	// Here we are checking that the template was executed correctly.
 	// If it wasn't, instead of html, we'll get an error message
-	assert.Contains(t, recorder.Body.String(), query4)
-	assert.NoError(t, err)
+	require.Contains(t, recorder.Body.String(), query4)
+	require.NoError(t, err)
 }

--- a/go/vt/vtgate/executor_stream_test.go
+++ b/go/vt/vtgate/executor_stream_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
@@ -36,9 +37,7 @@ func TestStreamSQLUnsharded(t *testing.T) {
 
 	sql := "stream * from user_msgs"
 	result, err := executorStreamMessages(executor, sql)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResult := sandboxconn.StreamRowResult
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
@@ -62,9 +61,7 @@ func TestStreamSQLSharded(t *testing.T) {
 
 	sql := "stream * from sharded_user_msgs"
 	result, err := executorStreamMessages(executor, sql)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantResult := &sqltypes.Result{
 		Fields: sandboxconn.SingleRowResult.Fields,
 		Rows: [][]sqltypes.Value{

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -549,9 +549,7 @@ func TestExecutorSetMetadata(t *testing.T) {
 
 	show = "show vitess_metadata variables"
 	gotqr, err = executor.Execute(context.Background(), "TestExecute", session, show, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, wantqr.Fields, gotqr.Fields)
 	assert.ElementsMatch(t, wantqr.Rows, gotqr.Rows)
@@ -748,17 +746,11 @@ func TestExecutorShow(t *testing.T) {
 		}
 	}
 	_, err := executor.Execute(context.Background(), "TestExecute", session, "show variables", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = executor.Execute(context.Background(), "TestExecute", session, "show collation", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = executor.Execute(context.Background(), "TestExecute", session, "show collation where `Charset` = 'utf8' and `Collation` = 'utf8_bin'", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	_, err = executor.Execute(context.Background(), "TestExecute", session, "show tables", nil)
 	if err != errNoKeyspace {
@@ -783,9 +775,7 @@ func TestExecutorShow(t *testing.T) {
 
 	query := fmt.Sprintf("show tables from %v", KsTestUnsharded)
 	qr, err := executor.Execute(context.Background(), "TestExecute", session, query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	if len(sbclookup.Queries) != 1 {
 		t.Errorf("Tablet should have received one 'show' query. Instead received: %v", sbclookup.Queries)
@@ -901,9 +891,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show engines", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Engine", "Support", "Comment", "Transactions", "XA", "Savepoints"),
 		Rows: [][]sqltypes.Value{
@@ -921,9 +909,7 @@ func TestExecutorShow(t *testing.T) {
 		t.Errorf("show engines:\n%+v, want\n%+v", qr, wantqr)
 	}
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show plugins", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Name", "Status", "Type", "Library", "License"),
 		Rows: [][]sqltypes.Value{
@@ -954,9 +940,7 @@ func TestExecutorShow(t *testing.T) {
 		}
 	}
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vitess_shards", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Test SHOW FULL COLUMNS FROM where query has a qualifier
 	_, err = executor.Execute(context.Background(), "TestExecute", session, fmt.Sprintf("show full columns from %v.table1", KsTestUnsharded), nil)
@@ -979,9 +963,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vitess_tablets", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Just test for first & last.
 	qr.Rows = [][]sqltypes.Value{qr.Rows[0], qr.Rows[len(qr.Rows)-1]}
 	wantqr = &sqltypes.Result{
@@ -997,9 +979,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema vindexes", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Keyspace", "Name", "Type", "Params", "Owner"),
 		Rows: [][]sqltypes.Value{
@@ -1021,9 +1001,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema vindexes on TestExecutor.user", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Columns", "Name", "Type", "Params", "Owner"),
 		Rows: [][]sqltypes.Value{
@@ -1050,9 +1028,7 @@ func TestExecutorShow(t *testing.T) {
 
 	session.TargetString = "TestExecutor"
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema vindexes on user", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Columns", "Name", "Type", "Params", "Owner"),
 		Rows: [][]sqltypes.Value{
@@ -1067,9 +1043,7 @@ func TestExecutorShow(t *testing.T) {
 
 	session.TargetString = "TestExecutor"
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema vindexes on user2", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Columns", "Name", "Type", "Params", "Owner"),
 		Rows: [][]sqltypes.Value{
@@ -1089,9 +1063,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show warnings", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Level", Type: sqltypes.VarChar},
@@ -1108,9 +1080,7 @@ func TestExecutorShow(t *testing.T) {
 
 	session.Warnings = []*querypb.QueryWarning{}
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show warnings", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Level", Type: sqltypes.VarChar},
@@ -1129,9 +1099,7 @@ func TestExecutorShow(t *testing.T) {
 		{Code: mysql.EROutOfResources, Message: "ks/-40: query timed out"},
 	}
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show warnings", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Level", Type: sqltypes.VarChar},
@@ -1152,9 +1120,7 @@ func TestExecutorShow(t *testing.T) {
 	// Make sure it still works when one of the keyspaces is in a bad state
 	getSandbox("TestExecutor").SrvKeyspaceMustFail++
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vitess_shards", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// Just test for first & last.
 	qr.Rows = [][]sqltypes.Value{qr.Rows[0], qr.Rows[len(qr.Rows)-1]}
 	wantqr = &sqltypes.Result{
@@ -1171,9 +1137,7 @@ func TestExecutorShow(t *testing.T) {
 
 	session = NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
 	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema tables", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Tables"),
 		Rows: [][]sqltypes.Value{
@@ -1507,9 +1471,7 @@ func TestExecutorAlterVSchemaKeyspace(t *testing.T) {
 
 	stmt := "alter vschema create vindex TestExecutor.test_vindex using hash"
 	_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	_, vindex := waitForVindex(t, "TestExecutor", "test_vindex", vschemaUpdates, executor)
 	assert.Equal(t, vindex.Type, "hash")
@@ -1537,9 +1499,7 @@ func TestExecutorCreateVindexDDL(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: ks})
 	stmt := "alter vschema create vindex test_vindex using hash"
 	_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	_, vindex := waitForVindex(t, ks, "test_vindex", vschemaUpdates, executor)
 	if vindex == nil || vindex.Type != "hash" {
@@ -1615,16 +1575,12 @@ func TestExecutorAddDropVschemaTableDDL(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: ks})
 	stmt := "alter vschema add table test_table"
 	_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_ = waitForVschemaTables(t, ks, append(vschemaTables, "test_table"), executor)
 
 	stmt = "alter vschema add table test_table2"
 	_, err = executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_ = waitForVschemaTables(t, ks, append(vschemaTables, []string{"test_table", "test_table2"}...), executor)
 
 	// Should fail adding a table on a sharded keyspace
@@ -1666,9 +1622,7 @@ func TestExecutorAddSequenceDDL(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: ks})
 	stmt := "alter vschema add sequence test_seq"
 	_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_ = waitForVschemaTables(t, ks, append(vschemaTables, []string{"test_seq"}...), executor)
 	vschema = executor.vm.GetCurrentSrvVschema()
 	table := vschema.Keyspaces[ks].Tables["test_seq"]
@@ -2058,9 +2012,7 @@ func TestExecutorVindexDDLNewKeyspace(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: ksName})
 	stmt := "alter vschema create vindex test_hash using hash"
 	_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -2173,9 +2125,7 @@ func TestExecutorMessageAckSharded(t *testing.T) {
 		Value: []byte("1"),
 	}}
 	count, err := executor.MessageAck(context.Background(), "", "user", ids)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}
@@ -2198,9 +2148,7 @@ func TestExecutorMessageAckSharded(t *testing.T) {
 		Value: []byte("3"),
 	}}
 	count, err = executor.MessageAck(context.Background(), "", "user", ids)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 2 {
 		t.Errorf("count: %d, want 2", count)
 	}
@@ -2251,9 +2199,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	logStats1 := NewLogStats(context.Background(), "Test", "", nil)
 	query1 := "select * from music_user_map where id = 1"
 	plan1, err := r.getPlan(emptyvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSQL := query1 + " /* comment */"
 	if logStats1.SQL != wantSQL {
 		t.Errorf("logstats sql want \"%s\" got \"%s\"", wantSQL, logStats1.SQL)
@@ -2261,9 +2207,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 
 	logStats2 := NewLogStats(context.Background(), "Test", "", nil)
 	plan2, err := r.getPlan(emptyvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats2)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 != plan2 {
 		t.Errorf("getPlan(query1): plans must be equal: %p %p", plan1, plan2)
 	}
@@ -2278,9 +2222,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	}
 	logStats3 := NewLogStats(context.Background(), "Test", "", nil)
 	plan3, err := r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats3)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 == plan3 {
 		t.Errorf("getPlan(query1, ks): plans must not be equal: %p %p", plan1, plan3)
 	}
@@ -2289,9 +2231,7 @@ func TestGetPlanUnnormalized(t *testing.T) {
 	}
 	logStats4 := NewLogStats(context.Background(), "Test", "", nil)
 	plan4, err := r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats4)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan3 != plan4 {
 		t.Errorf("getPlan(query1, ks): plans must be equal: %p %p", plan3, plan4)
 	}
@@ -2313,9 +2253,7 @@ func TestGetPlanCacheUnnormalized(t *testing.T) {
 	query1 := "select * from music_user_map where id = 1"
 	logStats1 := NewLogStats(context.Background(), "Test", "", nil)
 	_, err := r.getPlan(emptyvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, true /* skipQueryPlanCache */, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if r.plans.Size() != 0 {
 		t.Errorf("getPlan() expected cache to have size 0, but got: %b", r.plans.Size())
 	}
@@ -2325,9 +2263,7 @@ func TestGetPlanCacheUnnormalized(t *testing.T) {
 	}
 	logStats2 := NewLogStats(context.Background(), "Test", "", nil)
 	_, err = r.getPlan(emptyvc, query1, makeComments(" /* comment 2 */"), map[string]*querypb.BindVariable{}, false /* skipQueryPlanCache */, logStats2)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if r.plans.Size() != 1 {
 		t.Errorf("getPlan() expected cache to have size 1, but got: %b", r.plans.Size())
 	}
@@ -2343,18 +2279,14 @@ func TestGetPlanCacheUnnormalized(t *testing.T) {
 	query1 = "insert /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ into user(id) values (1), (2)"
 	logStats1 = NewLogStats(context.Background(), "Test", "", nil)
 	_, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if len(r.plans.Keys()) != 0 {
 		t.Errorf("Plan keys should be 0, got: %v", len(r.plans.Keys()))
 	}
 
 	query1 = "insert into user(id) values (1), (2)"
 	_, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if len(r.plans.Keys()) != 1 {
 		t.Errorf("Plan keys should be 1, got: %v", len(r.plans.Keys()))
 	}
@@ -2367,9 +2299,7 @@ func TestGetPlanCacheNormalized(t *testing.T) {
 	query1 := "select * from music_user_map where id = 1"
 	logStats1 := NewLogStats(context.Background(), "Test", "", nil)
 	_, err := r.getPlan(emptyvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, true /* skipQueryPlanCache */, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if r.plans.Size() != 0 {
 		t.Errorf("getPlan() expected cache to have size 0, but got: %b", r.plans.Size())
 	}
@@ -2379,9 +2309,7 @@ func TestGetPlanCacheNormalized(t *testing.T) {
 	}
 	logStats2 := NewLogStats(context.Background(), "Test", "", nil)
 	_, err = r.getPlan(emptyvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false /* skipQueryPlanCache */, logStats2)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if r.plans.Size() != 1 {
 		t.Errorf("getPlan() expected cache to have size 1, but got: %b", r.plans.Size())
 	}
@@ -2397,18 +2325,14 @@ func TestGetPlanCacheNormalized(t *testing.T) {
 	query1 = "insert /*vt+ SKIP_QUERY_PLAN_CACHE=1 */ into user(id) values (1), (2)"
 	logStats1 = NewLogStats(context.Background(), "Test", "", nil)
 	_, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if len(r.plans.Keys()) != 0 {
 		t.Errorf("Plan keys should be 0, got: %v", len(r.plans.Keys()))
 	}
 
 	query1 = "insert into user(id) values (1), (2)"
 	_, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if len(r.plans.Keys()) != 1 {
 		t.Errorf("Plan keys should be 1, got: %v", len(r.plans.Keys()))
 	}
@@ -2425,14 +2349,10 @@ func TestGetPlanNormalized(t *testing.T) {
 	normalized := "select * from music_user_map where id = :vtg1"
 	logStats1 := NewLogStats(context.Background(), "Test", "", nil)
 	plan1, err := r.getPlan(emptyvc, query1, makeComments(" /* comment 1 */"), map[string]*querypb.BindVariable{}, false, logStats1)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	logStats2 := NewLogStats(context.Background(), "Test", "", nil)
 	plan2, err := r.getPlan(emptyvc, query1, makeComments(" /* comment 2 */"), map[string]*querypb.BindVariable{}, false, logStats2)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 != plan2 {
 		t.Errorf("getPlan(query1): plans must be equal: %p %p", plan1, plan2)
 	}
@@ -2454,9 +2374,7 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	logStats3 := NewLogStats(context.Background(), "Test", "", nil)
 	plan3, err := r.getPlan(emptyvc, query2, makeComments(" /* comment 3 */"), map[string]*querypb.BindVariable{}, false, logStats3)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 != plan3 {
 		t.Errorf("getPlan(query2): plans must be equal: %p %p", plan1, plan3)
 	}
@@ -2467,9 +2385,7 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	logStats4 := NewLogStats(context.Background(), "Test", "", nil)
 	plan4, err := r.getPlan(emptyvc, normalized, makeComments(" /* comment 4 */"), map[string]*querypb.BindVariable{}, false, logStats4)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 != plan4 {
 		t.Errorf("getPlan(normalized): plans must be equal: %p %p", plan1, plan4)
 	}
@@ -2480,9 +2396,7 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	logStats5 := NewLogStats(context.Background(), "Test", "", nil)
 	plan3, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment 5 */"), map[string]*querypb.BindVariable{}, false, logStats5)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan1 == plan3 {
 		t.Errorf("getPlan(query1, ks): plans must not be equal: %p %p", plan1, plan3)
 	}
@@ -2493,9 +2407,7 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	logStats6 := NewLogStats(context.Background(), "Test", "", nil)
 	plan4, err = r.getPlan(unshardedvc, query1, makeComments(" /* comment 6 */"), map[string]*querypb.BindVariable{}, false, logStats6)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if plan3 != plan4 {
 		t.Errorf("getPlan(query1, ks): plans must be equal: %p %p", plan3, plan4)
 	}
@@ -2530,9 +2442,7 @@ func TestPassthroughDDL(t *testing.T) {
 	masterSession.TargetString = "TestExecutor"
 
 	_, err := executorExec(executor, "/* leading */ create table passthrough_ddl (col bigint default 123) /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "/* leading */ create table passthrough_ddl (col bigint default 123) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
@@ -2551,9 +2461,7 @@ func TestPassthroughDDL(t *testing.T) {
 	executor.normalize = true
 
 	_, err = executorExec(executor, "/* leading */ create table passthrough_ddl (col bigint default 123) /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if sbc1.Queries != nil {
 		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
 	}
@@ -2568,9 +2476,7 @@ func TestPassthroughDDL(t *testing.T) {
 	executor.normalize = true
 
 	_, err = executorExec(executor, "/* leading */ create table passthrough_ddl (col bigint default 123) /* trailing */", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
 		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
 	}

--- a/go/vt/vtgate/mysql_protocol_test.go
+++ b/go/vt/vtgate/mysql_protocol_test.go
@@ -47,9 +47,7 @@ func TestMySQLProtocolExecute(t *testing.T) {
 	defer c.Close()
 
 	qr, err := c.ExecuteFetch("select id from t1", 10, true /* wantfields */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(sandboxconn.SingleRowResult, qr) {
 		t.Errorf("want \n%+v, got \n%+v", sandboxconn.SingleRowResult, qr)
 	}
@@ -74,14 +72,10 @@ func TestMySQLProtocolStreamExecute(t *testing.T) {
 	defer c.Close()
 
 	_, err = c.ExecuteFetch("set workload='olap'", 1, true /* wantfields */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	qr, err := c.ExecuteFetch("select id from t1", 10, true /* wantfields */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(sandboxconn.SingleRowResult, qr) {
 		t.Errorf("want \n%+v, got \n%+v", sandboxconn.SingleRowResult, qr)
 	}
@@ -167,9 +161,7 @@ func TestMySQLProtocolClientFoundRows(t *testing.T) {
 	defer c.Close()
 
 	qr, err := c.ExecuteFetch("select id from t1", 10, true /* wantfields */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(sandboxconn.SingleRowResult, qr) {
 		t.Errorf("want \n%+v, got \n%+v", sandboxconn.SingleRowResult, qr)
 	}

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 
@@ -40,9 +41,7 @@ func TestQueryzHandler(t *testing.T) {
 	// single shard query
 	sql := "select id from user where id = 1"
 	_, err := executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	result, ok := executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
@@ -53,9 +52,7 @@ func TestQueryzHandler(t *testing.T) {
 	// scatter
 	sql = "select id from user"
 	_, err = executorExec(executor, sql, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	result, ok = executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
@@ -68,9 +65,7 @@ func TestQueryzHandler(t *testing.T) {
 		"id":   sqltypes.Uint64BindVariable(1),
 		"name": sqltypes.BytesBindVariable([]byte("myname")),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	result, ok = executor.plans.Get("@master:" + sql)
 	if !ok {
 		t.Fatalf("couldn't get plan from cache")
@@ -91,9 +86,7 @@ func TestQueryzHandler(t *testing.T) {
 		"name": sqltypes.BytesBindVariable([]byte("myname")),
 	})
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	plan3.ExecTime = time.Duration(100 * time.Millisecond)
 	plan4.ExecTime = time.Duration(200 * time.Millisecond)

--- a/go/vt/vtgate/resolver_test.go
+++ b/go/vt/vtgate/resolver_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
@@ -460,9 +461,7 @@ func TestResolverMessageAckSharded(t *testing.T) {
 		},
 	}
 	count, err := res.MessageAckKeyspaceIds(context.Background(), name, "user", idKeyspaceIDs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 2 {
 		t.Errorf("count: %d, want 2", count)
 	}
@@ -504,9 +503,7 @@ func TestResolverMessageAckUnsharded(t *testing.T) {
 		},
 	}
 	count, err := res.MessageAckKeyspaceIds(context.Background(), KsTestUnsharded, "user", idKeyspaceIDs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 2 {
 		t.Errorf("count: %d, want 2", count)
 	}

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
@@ -589,9 +590,7 @@ func TestScatterConnSingleDB(t *testing.T) {
 	// SingleDb (legacy)
 	session := NewSafeSession(&vtgatepb.Session{InTransaction: true, SingleDb: true})
 	_, err = sc.Execute(context.Background(), "query1", nil, rss0, topodatapb.TabletType_MASTER, session, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = sc.Execute(context.Background(), "query1", nil, rss1, topodatapb.TabletType_MASTER, session, false, nil)
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Multi DB exec: %v, must contain %s", err, want)
@@ -600,9 +599,7 @@ func TestScatterConnSingleDB(t *testing.T) {
 	// TransactionMode_SINGLE in session
 	session = NewSafeSession(&vtgatepb.Session{InTransaction: true, TransactionMode: vtgatepb.TransactionMode_SINGLE})
 	_, err = sc.Execute(context.Background(), "query1", nil, rss0, topodatapb.TabletType_MASTER, session, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = sc.Execute(context.Background(), "query1", nil, rss1, topodatapb.TabletType_MASTER, session, false, nil)
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Multi DB exec: %v, must contain %s", err, want)
@@ -612,9 +609,7 @@ func TestScatterConnSingleDB(t *testing.T) {
 	sc.txConn.mode = vtgatepb.TransactionMode_SINGLE
 	session = NewSafeSession(&vtgatepb.Session{InTransaction: true})
 	_, err = sc.Execute(context.Background(), "query1", nil, rss0, topodatapb.TabletType_MASTER, session, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = sc.Execute(context.Background(), "query1", nil, rss1, topodatapb.TabletType_MASTER, session, false, nil)
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Multi DB exec: %v, must contain %s", err, want)
@@ -624,13 +619,9 @@ func TestScatterConnSingleDB(t *testing.T) {
 	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
 	session = NewSafeSession(&vtgatepb.Session{InTransaction: true})
 	_, err = sc.Execute(context.Background(), "query1", nil, rss0, topodatapb.TabletType_MASTER, session, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = sc.Execute(context.Background(), "query1", nil, rss1, topodatapb.TabletType_MASTER, session, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestAppendResult(t *testing.T) {

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/discovery"
@@ -603,9 +604,7 @@ func TestTxConnResolveOnPrepare(t *testing.T) {
 		}},
 	}}
 	err := sc.txConn.Resolve(context.Background(), dtid)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if c := sbc0.SetRollbackCount.Get(); c != 1 {
 		t.Errorf("sbc0.SetRollbackCount: %d, want 1", c)
 	}
@@ -894,9 +893,7 @@ func TestTxConnMultiGoSessions(t *testing.T) {
 	err = txc.runSessions(input, func(s *vtgatepb.Session_ShardSession) error {
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestTxConnMultiGoTargets(t *testing.T) {
@@ -932,9 +929,7 @@ func TestTxConnMultiGoTargets(t *testing.T) {
 	err = txc.runTargets(input, func(t *querypb.Target) error {
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func newTestTxConnEnv(t *testing.T, name string) (sc *ScatterConn, sbc0, sbc1 *sandboxconn.SandboxConn, rss0, rss1, rss01 []*srvtopo.ResolvedShard) {

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -78,9 +79,7 @@ func TestBinaryVerify(t *testing.T) {
 
 func TestBinaryReverseMap(t *testing.T) {
 	got, err := binOnlyVindex.(Reversible).ReverseMap(nil, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []sqltypes.Value{sqltypes.NewVarBinary("\x00\x00\x00\x00\x00\x00\x00\x01")}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ReverseMap(): %+v, want %+v", got, want)

--- a/go/vt/vtgate/vindexes/binarymd5_test.go
+++ b/go/vt/vtgate/vindexes/binarymd5_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -80,9 +81,7 @@ func TestBinaryMD5Verify(t *testing.T) {
 func TestSQLValue(t *testing.T) {
 	val := sqltypes.NewVarBinary("Test")
 	got, err := binVindex.Map(nil, []sqltypes.Value{val})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	out := string(got[0].(key.DestinationKeyspaceID))
 	want := "\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za["
 	if out != want {

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -72,9 +73,7 @@ func TestConsistentLookupMap(t *testing.T) {
 	vc.AddResult(makeTestResult(2), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceIDs([][]byte{
 			[]byte("1"),
@@ -106,9 +105,7 @@ func TestConsistentLookupMapWriteOnly(t *testing.T) {
 	lookup := createConsistentLookup(t, "consistent_lookup", true)
 
 	got, err := lookup.Map(nil, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyRange{
 			KeyRange: &topodatapb.KeyRange{},
@@ -129,9 +126,7 @@ func TestConsistentLookupUniqueMap(t *testing.T) {
 	vc.AddResult(makeTestResult(1), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationNone{},
 		key.DestinationKeyspaceID([]byte("1")),
@@ -157,9 +152,7 @@ func TestConsistentLookupUniqueMapWriteOnly(t *testing.T) {
 	lookup := createConsistentLookup(t, "consistent_lookup_unique", true)
 
 	got, err := lookup.Map(nil, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyRange{
 			KeyRange: &topodatapb.KeyRange{},
@@ -180,9 +173,7 @@ func TestConsistentLookupMapAbsent(t *testing.T) {
 	vc.AddResult(makeTestResult(0), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationNone{},
 		key.DestinationNone{},
@@ -203,9 +194,7 @@ func TestConsistentLookupVerify(t *testing.T) {
 	vc.AddResult(makeTestResult(1), nil)
 
 	_, err := lookup.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte("test1"), []byte("test2")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	vc.verifyLog(t, []string{
 		"ExecutePre select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 1} {toc test1}] false",
 		"ExecutePre select fromc1 from t where fromc1 = :fromc1 and toc = :toc [{fromc1 2} {toc test2}] false",
@@ -222,9 +211,7 @@ func TestConsistentLookupVerify(t *testing.T) {
 	// Test write_only.
 	lookup = createConsistentLookup(t, "consistent_lookup", true)
 	got, err := lookup.Verify(nil, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte(""), []byte("")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantBools := []bool{true, true}
 	if !reflect.DeepEqual(got, wantBools) {
 		t.Errorf("lookup.Verify(writeOnly): %v, want %v", got, wantBools)

--- a/go/vt/vtgate/vindexes/hash_test.go
+++ b/go/vt/vtgate/vindexes/hash_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -58,9 +59,7 @@ func TestHashMap(t *testing.T) {
 		sqltypes.NewUint64(9223372036854775807),  // 2^63 - 1
 		sqltypes.NewInt64(-9223372036854775808),  // - 2^63
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("\x16k@\xb4J\xbaK\xd6")),
 		key.DestinationKeyspaceID([]byte("\x06\xe7\xea\"Βp\x8f")),
@@ -120,9 +119,7 @@ func TestHashReverseMap(t *testing.T) {
 		[]byte("\xf7}H\xaaݡ\xf1\xbb"),
 		[]byte("\x95\xf8\xa5\xe5\xdd1\xd9\x00"),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	neg1 := int64(-1)
 	negmax := int64(-9223372036854775808)
 	want := []sqltypes.Value{

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -68,9 +69,7 @@ func TestLookupHashUniqueMap(t *testing.T) {
 	vc := &vcursor{numRows: 1}
 
 	got, err := lhu.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("\x16k@\xb4J\xbaK\xd6")),
 		key.DestinationKeyspaceID([]byte("\x16k@\xb4J\xbaK\xd6")),
@@ -81,9 +80,7 @@ func TestLookupHashUniqueMap(t *testing.T) {
 
 	vc.numRows = 0
 	got, err = lhu.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = []key.Destination{
 		key.DestinationNone{},
 		key.DestinationNone{},
@@ -105,9 +102,7 @@ func TestLookupHashUniqueMap(t *testing.T) {
 		"notint",
 	)
 	got, err = lhu.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = []key.Destination{
 		key.DestinationNone{},
 	}
@@ -130,9 +125,7 @@ func TestLookupHashUniqueMapWriteOnly(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lhu.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyRange{
 			KeyRange: &topodatapb.KeyRange{},
@@ -155,9 +148,7 @@ func TestLookupHashUniqueVerify(t *testing.T) {
 	got, err := lhu.Verify(vc,
 		[]sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
 		[][]byte{[]byte("\x16k@\xb4J\xbaK\xd6"), []byte("\x06\xe7\xea\"Βp\x8f")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []bool{true, true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lhu.Verify(match): %v, want %v", got, want)
@@ -165,9 +156,7 @@ func TestLookupHashUniqueVerify(t *testing.T) {
 
 	vc.numRows = 0
 	got, err = lhu.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = []bool{false}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lhu.Verify(mismatch): %v, want %v", got, want)
@@ -185,9 +174,7 @@ func TestLookupHashUniqueVerifyWriteOnly(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lhu.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, [][]byte{[]byte("test")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []bool{true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lhu.Verify: %v, want %v", got, want)
@@ -202,9 +189,7 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lhu.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 1; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
@@ -221,9 +206,7 @@ func TestLookupHashUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lhu.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 1; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
@@ -240,9 +223,7 @@ func TestLookupHashUniqueUpdate(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lhu.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("\x16k@\xb4J\xbaK\xd6"), []sqltypes.Value{sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 2; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 
 	"vitess.io/vitess/go/vt/key"
@@ -137,9 +138,7 @@ func TestLookupNonUniqueMap(t *testing.T) {
 	vc := &vcursor{numRows: 2}
 
 	got, err := lookupNonUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceIDs([][]byte{
 			[]byte("1"),
@@ -193,9 +192,7 @@ func TestLookupNonUniqueMapAutocommit(t *testing.T) {
 	vc := &vcursor{numRows: 2}
 
 	got, err := lookupNonUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceIDs([][]byte{
 			[]byte("1"),
@@ -235,9 +232,7 @@ func TestLookupNonUniqueMapWriteOnly(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lookupNonUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyRange{
 			KeyRange: &topodatapb.KeyRange{},
@@ -256,9 +251,7 @@ func TestLookupNonUniqueMapAbsent(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lookupNonUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationNone{},
 		key.DestinationNone{},
@@ -273,9 +266,7 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
 
 	_, err := lookupNonUnique.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte("test1"), []byte("test2")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "select fromc from t where fromc = :fromc and toc = :toc",
@@ -308,9 +299,7 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 	vc.queries = nil
 
 	got, err := lookupNonUnique.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte(""), []byte("")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if vc.queries != nil {
 		t.Errorf("lookup.Verify(writeOnly), queries: %v, want nil", vc.queries)
 	}
@@ -334,9 +323,7 @@ func TestLookupNonUniqueVerifyAutocommit(t *testing.T) {
 	vc := &vcursor{numRows: 1}
 
 	_, err = lookupNonUnique.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte("test1"), []byte("test2")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "select fromc from t where fromc = :fromc and toc = :toc",
@@ -365,9 +352,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, [][]byte{[]byte("test1"), []byte("test2")}, false /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)",
@@ -385,9 +370,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 	// With ignore.
 	vc.queries = nil
 	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(2)}, {sqltypes.NewInt64(1)}}, [][]byte{[]byte("test2"), []byte("test1")}, true /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries[0].Sql = "insert ignore into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)"
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -432,9 +415,7 @@ func TestLookupNonUniqueCreateAutocommit(t *testing.T) {
 		}},
 		[][]byte{[]byte("test1"), []byte("test2")},
 		false /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "insert into t(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
@@ -461,9 +442,7 @@ func TestLookupNonUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, []byte("test"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "delete from t where fromc = :fromc and toc = :toc",
@@ -509,9 +488,7 @@ func TestLookupNonUniqueDeleteAutocommit(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, []byte("test"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery(nil)
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -524,9 +501,7 @@ func TestLookupNonUniqueUpdate(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupNonUnique.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("test"), []sqltypes.Value{sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "delete from t where fromc = :fromc and toc = :toc",

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -68,9 +69,7 @@ func TestLookupUniqueMap(t *testing.T) {
 	vc := &vcursor{numRows: 1}
 
 	got, err := lookupUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("1")),
 		key.DestinationKeyspaceID([]byte("1")),
@@ -81,9 +80,7 @@ func TestLookupUniqueMap(t *testing.T) {
 
 	vc.numRows = 0
 	got, err = lookupUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = []key.Destination{
 		key.DestinationNone{},
 		key.DestinationNone{},
@@ -114,9 +111,7 @@ func TestLookupUniqueMapWriteOnly(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lookupUnique.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyRange{
 			KeyRange: &topodatapb.KeyRange{},
@@ -135,9 +130,7 @@ func TestLookupUniqueVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
 
 	_, err := lookupUnique.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, [][]byte{[]byte("test")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 1; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
@@ -148,9 +141,7 @@ func TestLookupUniqueVerifyWriteOnly(t *testing.T) {
 	vc := &vcursor{numRows: 0}
 
 	got, err := lookupUnique.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, [][]byte{[]byte("test")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []bool{true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lookupUnique.Verify: %v, want %v", got, want)
@@ -173,9 +164,7 @@ func TestLookupUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
 
 	err = lookupUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("test")}, false /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
 		Sql: "insert into t(from, toc) values(:from0, :toc0)",
@@ -198,9 +187,7 @@ func TestLookupUniqueCreateAutocommit(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("test")}, false /* ignoreMode */)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 1; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
@@ -211,9 +198,7 @@ func TestLookupUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("test"))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 1; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
@@ -224,9 +209,7 @@ func TestLookupUniqueUpdate(t *testing.T) {
 	vc := &vcursor{}
 
 	err := lookupUnique.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("test"), []sqltypes.Value{sqltypes.NewInt64(2)})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got, want := len(vc.queries), 2; got != want {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}

--- a/go/vt/vtgate/vindexes/null_test.go
+++ b/go/vt/vtgate/vindexes/null_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -51,9 +52,7 @@ func TestNullMap(t *testing.T) {
 		sqltypes.NewInt64(5),
 		sqltypes.NewInt64(6),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte{0}),
 		key.DestinationKeyspaceID([]byte{0}),

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -63,9 +63,7 @@ func TestNumericStaticMapMap(t *testing.T) {
 		sqltypes.NewInt64(7),
 		sqltypes.NewInt64(8),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// in the third slice, we expect 2 instead of 3 as numeric_static_map_test.json
 	// has 3 mapped to 2
@@ -93,9 +91,7 @@ func TestNumericStaticMapVerify(t *testing.T) {
 	got, err := numericStaticMap.Verify(nil,
 		[]sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
 		[][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01"), []byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []bool{true, false}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lhu.Verify(match): %v, want %v", got, want)

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -51,9 +52,7 @@ func TestNumericMap(t *testing.T) {
 		sqltypes.NewInt64(7),
 		sqltypes.NewInt64(8),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x01")),
 		key.DestinationKeyspaceID([]byte("\x00\x00\x00\x00\x00\x00\x00\x02")),
@@ -74,9 +73,7 @@ func TestNumericVerify(t *testing.T) {
 	got, err := numeric.Verify(nil,
 		[]sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)},
 		[][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01"), []byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []bool{true, false}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("lhu.Verify(match): %v, want %v", got, want)
@@ -92,9 +89,7 @@ func TestNumericVerify(t *testing.T) {
 
 func TestNumericReverseMap(t *testing.T) {
 	got, err := numeric.(Reversible).ReverseMap(nil, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []sqltypes.Value{sqltypes.NewUint64(1)}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ReverseMap(): %v, want %v", got, want)

--- a/go/vt/vtgate/vindexes/reverse_bits_test.go
+++ b/go/vt/vtgate/vindexes/reverse_bits_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 )
@@ -52,9 +53,7 @@ func TestReverseBitsMap(t *testing.T) {
 		sqltypes.NewInt64(5),
 		sqltypes.NewInt64(6),
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("\x80\x00\x00\x00\x00\x00\x00\x00")),
 		key.DestinationKeyspaceID([]byte("@\x00\x00\x00\x00\x00\x00\x00")),
@@ -91,9 +90,7 @@ func TestReverseBitsVerify(t *testing.T) {
 
 func TestReverseBitsReverseMap(t *testing.T) {
 	got, err := reverseBits.(Reversible).ReverseMap(nil, [][]byte{[]byte("\x80\x00\x00\x00\x00\x00\x00\x00")})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := []sqltypes.Value{sqltypes.NewUint64(uint64(1))}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ReverseMap(): %v, want %v", got, want)

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -207,9 +207,7 @@ func TestUnshardedVSchema(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["unsharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name: "unsharded",
 	}
@@ -264,9 +262,7 @@ func TestVSchemaColumns(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["unsharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name: "unsharded",
 	}
@@ -330,9 +326,7 @@ func TestVSchemaColumnListAuthoritative(t *testing.T) {
 		},
 	}
 	got, err := BuildVSchema(&good)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name: "unsharded",
 	}
@@ -417,9 +411,7 @@ func TestVSchemaPinned(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name:    "sharded",
 		Sharded: true,
@@ -495,9 +487,7 @@ func TestShardedVSchemaOwned(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name:    "sharded",
 		Sharded: true,
@@ -625,9 +615,7 @@ func TestShardedVSchemaOwnerInfo(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	results := []struct {
 		name     string
 		keyspace string
@@ -1062,9 +1050,7 @@ func TestFindVindexForSharding(t *testing.T) {
 		},
 	}
 	res, err := FindVindexForSharding(t1.Name.String(), t1.ColumnVindexes)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(res, t1.ColumnVindexes[0]) {
 		t.Errorf("FindVindexForSharding:\n got\n%v, want\n%v", res, t1.ColumnVindexes[0])
 	}
@@ -1138,9 +1124,7 @@ func TestFindVindexForSharding2(t *testing.T) {
 		},
 	}
 	res, err := FindVindexForSharding(t1.Name.String(), t1.ColumnVindexes)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !reflect.DeepEqual(res, t1.ColumnVindexes[1]) {
 		t.Errorf("FindVindexForSharding:\n got\n%v, want\n%v", res, t1.ColumnVindexes[1])
 	}
@@ -1175,9 +1159,7 @@ func TestShardedVSchemaMultiColumnVindex(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name:    "sharded",
 		Sharded: true,
@@ -1270,9 +1252,7 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name:    "sharded",
 		Sharded: true,
@@ -1592,9 +1572,7 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["ksa"].Error
 	err1 := got.Keyspaces["ksb"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if err1 != nil {
 		t.Error(err1)
 	}
@@ -1895,9 +1873,7 @@ func TestSequence(t *testing.T) {
 	}
 	got, _ := BuildVSchema(&good)
 	err := got.Keyspaces["sharded"].Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err1 := got.Keyspaces["unsharded"].Error
 	if err1 != nil {
 		t.Error(err1)
@@ -2392,9 +2368,7 @@ func TestBuildKeyspaceSchema(t *testing.T) {
 	}
 	got, _ := BuildKeyspaceSchema(good, "ks")
 	err := got.Error
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ks := &Keyspace{
 		Name: "ks",
 	}
@@ -2434,9 +2408,7 @@ func TestValidate(t *testing.T) {
 		},
 	}
 	err := ValidateKeyspace(good)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	bad := &vschemapb.Keyspace{
 		Sharded: true,
 		Vindexes: map[string]*vschemapb.Vindex{

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
@@ -95,9 +96,7 @@ func TestVTGateBegin(t *testing.T) {
 
 	rpcVTGate.txConn.mode = vtgatepb.TransactionMode_SINGLE
 	got, err := rpcVTGate.Begin(context.Background(), true)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSession := &vtgatepb.Session{
 		InTransaction: true,
 		SingleDb:      true,
@@ -114,9 +113,7 @@ func TestVTGateBegin(t *testing.T) {
 
 	rpcVTGate.txConn.mode = vtgatepb.TransactionMode_MULTI
 	got, err = rpcVTGate.Begin(context.Background(), true)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSession = &vtgatepb.Session{
 		InTransaction: true,
 		SingleDb:      true,
@@ -126,9 +123,7 @@ func TestVTGateBegin(t *testing.T) {
 	}
 
 	got, err = rpcVTGate.Begin(context.Background(), false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSession = &vtgatepb.Session{
 		InTransaction: true,
 	}
@@ -138,9 +133,7 @@ func TestVTGateBegin(t *testing.T) {
 
 	rpcVTGate.txConn.mode = vtgatepb.TransactionMode_TWOPC
 	got, err = rpcVTGate.Begin(context.Background(), true)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSession = &vtgatepb.Session{
 		InTransaction: true,
 		SingleDb:      true,
@@ -150,9 +143,7 @@ func TestVTGateBegin(t *testing.T) {
 	}
 
 	got, err = rpcVTGate.Begin(context.Background(), false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantSession = &vtgatepb.Session{
 		InTransaction: true,
 	}
@@ -182,9 +173,7 @@ func TestVTGateCommit(t *testing.T) {
 		InTransaction: true,
 	}
 	err = rpcVTGate.Commit(context.Background(), false, session)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	rpcVTGate.txConn.mode = vtgatepb.TransactionMode_MULTI
 	session = &vtgatepb.Session{
@@ -199,33 +188,25 @@ func TestVTGateCommit(t *testing.T) {
 		InTransaction: true,
 	}
 	err = rpcVTGate.Commit(context.Background(), false, session)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	rpcVTGate.txConn.mode = vtgatepb.TransactionMode_TWOPC
 	session = &vtgatepb.Session{
 		InTransaction: true,
 	}
 	err = rpcVTGate.Commit(context.Background(), true, session)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	session = &vtgatepb.Session{
 		InTransaction: true,
 	}
 	err = rpcVTGate.Commit(context.Background(), false, session)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestVTGateRollbackNil(t *testing.T) {
 	err := rpcVTGate.Rollback(context.Background(), nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestVTGateExecute(t *testing.T) {
@@ -253,9 +234,7 @@ func TestVTGateExecute(t *testing.T) {
 	}
 
 	session, err := rpcVTGate.Begin(context.Background(), false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !session.InTransaction {
 		t.Errorf("want true, got false")
 	}
@@ -1438,9 +1417,7 @@ func TestVTGateMessageAck(t *testing.T) {
 		Value: []byte("2"),
 	}}
 	count, err := rpcVTGate.MessageAck(context.Background(), ks, "msg", ids)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 2 {
 		t.Errorf("MessageAck: %d, want 2", count)
 	}
@@ -1469,9 +1446,7 @@ func TestVTGateMessageAckKeyspaceIds(t *testing.T) {
 		},
 	}
 	count, err := rpcVTGate.MessageAckKeyspaceIds(context.Background(), ks, "msg", idKeyspaceIDs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 2 {
 		t.Errorf("MessageAck: %d, want 2", count)
 	}

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -1126,18 +1127,14 @@ func verifyErrorString(t *testing.T, err error, method string) {
 
 func testBegin(t *testing.T, conn *vtgateconn.VTGateConn) {
 	_, err := conn.Begin(newContext())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func testExecute(t *testing.T, session *vtgateconn.VTGateSession) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := session.Execute(ctx, execCase.execQuery.SQL, execCase.execQuery.BindVariables)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got\n%#v want\n%#v", qr, execCase.result)
 	}
@@ -1168,9 +1165,7 @@ func testExecuteBatch(t *testing.T, session *vtgateconn.VTGateSession) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := session.ExecuteBatch(ctx, []string{execCase.execQuery.SQL}, []map[string]*querypb.BindVariable{execCase.execQuery.BindVariables})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr[0].QueryResult.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got\n%#v want\n%#v", qr, execCase.result)
 	}
@@ -1201,9 +1196,7 @@ func testExecuteShards(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := conn.ExecuteShards(ctx, execCase.shardQuery.SQL, execCase.shardQuery.Keyspace, execCase.shardQuery.Shards, execCase.shardQuery.BindVariables, execCase.shardQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", qr, execCase.result)
 	}
@@ -1234,9 +1227,7 @@ func testExecuteKeyspaceIds(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := conn.ExecuteKeyspaceIds(ctx, execCase.keyspaceIDQuery.SQL, execCase.keyspaceIDQuery.Keyspace, execCase.keyspaceIDQuery.KeyspaceIds, execCase.keyspaceIDQuery.BindVariables, execCase.keyspaceIDQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", qr, execCase.result)
 	}
@@ -1267,9 +1258,7 @@ func testExecuteKeyRanges(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := conn.ExecuteKeyRanges(ctx, execCase.keyRangeQuery.SQL, execCase.keyRangeQuery.Keyspace, execCase.keyRangeQuery.KeyRanges, execCase.keyRangeQuery.BindVariables, execCase.keyRangeQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", qr, execCase.result)
 	}
@@ -1300,9 +1289,7 @@ func testExecuteEntityIds(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	qr, err := conn.ExecuteEntityIds(ctx, execCase.entityIdsQuery.SQL, execCase.entityIdsQuery.Keyspace, execCase.entityIdsQuery.EntityColumnName, execCase.entityIdsQuery.EntityKeyspaceIDs, execCase.entityIdsQuery.BindVariables, execCase.entityIdsQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", qr, execCase.result)
 	}
@@ -1333,9 +1320,7 @@ func testExecuteBatchShards(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	ql, err := conn.ExecuteBatchShards(ctx, execCase.batchQueryShard.Queries, execCase.batchQueryShard.TabletType, execCase.batchQueryShard.AsTransaction, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !ql[0].Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", ql, execCase.result)
 	}
@@ -1368,9 +1353,7 @@ func testExecuteBatchKeyspaceIds(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
 	ql, err := conn.ExecuteBatchKeyspaceIds(ctx, execCase.keyspaceIDBatchQuery.Queries, execCase.keyspaceIDBatchQuery.TabletType, execCase.batchQueryShard.AsTransaction, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !ql[0].Equal(execCase.result) {
 		t.Errorf("Unexpected result from Execute: got %+v want %+v", ql, execCase.result)
 	}
@@ -1729,87 +1712,51 @@ func testTxPass(t *testing.T, conn *vtgateconn.VTGateConn) {
 
 	// ExecuteShards
 	tx, err := conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteShards(ctx, execCase.shardQuery.SQL, execCase.shardQuery.Keyspace, execCase.shardQuery.Shards, execCase.shardQuery.BindVariables, execCase.shardQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ExecuteKeyspaceIds
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteKeyspaceIds(ctx, execCase.keyspaceIDQuery.SQL, execCase.keyspaceIDQuery.Keyspace, execCase.keyspaceIDQuery.KeyspaceIds, execCase.keyspaceIDQuery.BindVariables, execCase.keyspaceIDQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ExecuteKeyRanges
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteKeyRanges(ctx, execCase.keyRangeQuery.SQL, execCase.keyRangeQuery.Keyspace, execCase.keyRangeQuery.KeyRanges, execCase.keyRangeQuery.BindVariables, execCase.keyRangeQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ExecuteEntityIds
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteEntityIds(ctx, execCase.entityIdsQuery.SQL, execCase.entityIdsQuery.Keyspace, execCase.entityIdsQuery.EntityColumnName, execCase.entityIdsQuery.EntityKeyspaceIDs, execCase.entityIdsQuery.BindVariables, execCase.entityIdsQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ExecuteBatchShards
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteBatchShards(ctx, execCase.batchQueryShard.Queries, execCase.batchQueryShard.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ExecuteBatchKeyspaceIds
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tx.ExecuteBatchKeyspaceIds(ctx, execCase.keyspaceIDBatchQuery.Queries, execCase.keyspaceIDBatchQuery.TabletType, testExecuteOptions)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func testResolveTransaction(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -1831,9 +1778,7 @@ func testCommitError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGate
 	tx, err := conn.Begin(ctx)
 	fake.forceBeginSuccess = false
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Commit(ctx)
 	verifyError(t, err, "Commit")
 }
@@ -1845,9 +1790,7 @@ func testRollbackError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGa
 	tx, err := conn.Begin(ctx)
 	fake.forceBeginSuccess = false
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
 	verifyError(t, err, "Rollback")
 }
@@ -1870,9 +1813,7 @@ func testCommitPanic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGate
 	tx, err := conn.Begin(ctx)
 	fake.forceBeginSuccess = false
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Commit(ctx)
 	expectPanic(t, err)
 }
@@ -1884,9 +1825,7 @@ func testRollbackPanic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGa
 	tx, err := conn.Begin(ctx)
 	fake.forceBeginSuccess = false
 
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
 	expectPanic(t, err)
 }
@@ -1899,9 +1838,7 @@ func testResolveTransactionPanic(t *testing.T, conn *vtgateconn.VTGateConn, fake
 func testTxFail(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	tx, err := conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Commit(ctx)
 	want := "commit: session mismatch"
 	if err == nil || !strings.Contains(err.Error(), want) {
@@ -1951,14 +1888,10 @@ func testTxFail(t *testing.T, conn *vtgateconn.VTGateConn) {
 	}
 
 	err = tx.Rollback(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	tx, err = conn.Begin(ctx)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = tx.Rollback(ctx)
 	want = "rollback: session mismatch"
 	if err == nil || !strings.Contains(err.Error(), want) {
@@ -1974,9 +1907,7 @@ func testMessageStream(t *testing.T, conn *vtgateconn.VTGateConn) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func testMessageStreamError(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -2001,9 +1932,7 @@ func testMessageAck(t *testing.T, conn *vtgateconn.VTGateConn) {
 	if got != messageAckRowsAffected {
 		t.Errorf("MessageAck: %d, want %d", got, messageAckRowsAffected)
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func testMessageAckError(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -2024,9 +1953,7 @@ func testMessageAckKeyspaceIds(t *testing.T, conn *vtgateconn.VTGateConn) {
 	if got != messageAckRowsAffected {
 		t.Errorf("MessageAckKeyspaceIds: %d, want %d", got, messageAckRowsAffected)
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func testMessageAckKeyspaceIdsError(t *testing.T, conn *vtgateconn.VTGateConn) {

--- a/go/vt/vttablet/endtoend/message_test.go
+++ b/go/vt/vttablet/endtoend/message_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
 
@@ -104,9 +105,7 @@ func TestMessage(t *testing.T) {
 	got = <-ch
 	// Check time_scheduled separately.
 	scheduled, err := sqltypes.ToInt64(got.Rows[0][1])
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if now := time.Now().UnixNano(); now-scheduled >= int64(10*time.Second) {
 		t.Errorf("scheduled: %v, must be close to %v", scheduled, now)
 	}
@@ -168,9 +167,7 @@ func TestMessage(t *testing.T) {
 
 	// Ack the message.
 	count, err := client.MessageAck("vitess_message", []string{"1"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}
@@ -291,9 +288,7 @@ func TestThreeColMessage(t *testing.T) {
 
 	// Verify Ack.
 	count, err := client.MessageAck("vitess_message3", []string{"1"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}
@@ -404,9 +399,7 @@ func TestMessageAuto(t *testing.T) {
 	}
 
 	_, err = client.MessageAck("vitess_message_auto", []string{"1, 2, 5"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Ensure msg6 is eventually received.
 	got := <-ch
@@ -565,15 +558,11 @@ func TestMessageTopic(t *testing.T) {
 
 	// ack the first subscriber
 	_, err = client.MessageAck("vitess_topic_subscriber_1", []string{"1, 2, 3"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// ack the second subscriber
 	_, err = client.MessageAck("vitess_topic_subscriber_2", []string{"1, 2, 3"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	//
 	// phase 2 tests deleting one of the subscribers and making sure
@@ -658,9 +647,7 @@ func TestMessageTopic(t *testing.T) {
 
 	// ack the second subscriber
 	_, err = client.MessageAck("vitess_topic_subscriber_2", []string{"4, 5, 6"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	//
 	// phase 3 tests deleting the last subscriber and making sure

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -668,9 +669,7 @@ func TestClientFoundRows(t *testing.T) {
 		t.Error(err)
 	}
 	qr, err := client.Execute("update vitess_test set charval='aa' where intval=124", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if qr.RowsAffected != 0 {
 		t.Errorf("Execute(rowsFound==false): %d, want 0", qr.RowsAffected)
 	}
@@ -683,9 +682,7 @@ func TestClientFoundRows(t *testing.T) {
 		t.Error(err)
 	}
 	qr, err = client.Execute("update vitess_test set charval='aa' where intval=124", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if qr.RowsAffected != 1 {
 		t.Errorf("Execute(rowsFound==true): %d, want 1", qr.RowsAffected)
 	}
@@ -713,9 +710,7 @@ func TestLastInsertId(t *testing.T) {
 	}
 
 	qr, err := client.Execute("update vitess_autoinc_seq set sequence=last_insert_id(sequence + 1) where name='foo'", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	insID := res.InsertID
 
@@ -724,9 +719,7 @@ func TestLastInsertId(t *testing.T) {
 	}
 
 	qr, err = client.Execute("select sequence from vitess_autoinc_seq where name = 'foo'", nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	wantCol := sqltypes.NewUint64(insID + uint64(1))
 	if !reflect.DeepEqual(qr.Rows[0][0], wantCol) {

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -551,13 +552,9 @@ func TestMMCommitFlow(t *testing.T) {
 	query := "insert into vitess_test (intval, floatval, charval, binval) " +
 		"values(4, null, null, null)"
 	err := client.Begin(false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = client.Execute(query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	err = client.CreateTransaction("aa", []*querypb.Target{{
 		Keyspace: "test1",
@@ -566,9 +563,7 @@ func TestMMCommitFlow(t *testing.T) {
 		Keyspace: "test2",
 		Shard:    "1",
 	}})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	err = client.CreateTransaction("aa", []*querypb.Target{})
 	want := "Duplicate entry"
@@ -577,9 +572,7 @@ func TestMMCommitFlow(t *testing.T) {
 	}
 
 	err = client.StartCommit("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	err = client.SetRollback("aa", 0)
 	want = "could not transition to ROLLBACK: aa (CallerID: dev)"
@@ -588,9 +581,7 @@ func TestMMCommitFlow(t *testing.T) {
 	}
 
 	info, err := client.ReadTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	info.TimeCreated = 0
 	wantInfo := &querypb.TransactionMetadata{
 		Dtid:  "aa",
@@ -610,14 +601,10 @@ func TestMMCommitFlow(t *testing.T) {
 	}
 
 	err = client.ConcludeTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	info, err = client.ReadTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	wantInfo = &querypb.TransactionMetadata{}
 	if !proto.Equal(info, wantInfo) {
 		t.Errorf("ReadTransaction: %#v, want %#v", info, wantInfo)
@@ -631,13 +618,9 @@ func TestMMRollbackFlow(t *testing.T) {
 	query := "insert into vitess_test (intval, floatval, charval, binval) " +
 		"values(4, null, null, null)"
 	err := client.Begin(false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = client.Execute(query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	err = client.CreateTransaction("aa", []*querypb.Target{{
 		Keyspace: "test1",
@@ -646,20 +629,14 @@ func TestMMRollbackFlow(t *testing.T) {
 		Keyspace: "test2",
 		Shard:    "1",
 	}})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	client.Rollback()
 
 	err = client.SetRollback("aa", 0)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	info, err := client.ReadTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	info.TimeCreated = 0
 	wantInfo := &querypb.TransactionMetadata{
 		Dtid:  "aa",
@@ -679,9 +656,7 @@ func TestMMRollbackFlow(t *testing.T) {
 	}
 
 	err = client.ConcludeTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestWatchdog(t *testing.T) {
@@ -690,13 +665,9 @@ func TestWatchdog(t *testing.T) {
 	query := "insert into vitess_test (intval, floatval, charval, binval) " +
 		"values(4, null, null, null)"
 	err := client.Begin(false)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = client.Execute(query, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	start := time.Now()
 	err = client.CreateTransaction("aa", []*querypb.Target{{
@@ -706,9 +677,7 @@ func TestWatchdog(t *testing.T) {
 		Keyspace: "test2",
 		Shard:    "1",
 	}})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// The watchdog should kick in after 1 second.
 	dtid := <-framework.ResolveChan
@@ -721,13 +690,9 @@ func TestWatchdog(t *testing.T) {
 	}
 
 	err = client.SetRollback("aa", 0)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = client.ConcludeTransaction("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// Make sure the watchdog stops sending messages.
 	// Check twice. Sometimes, a race can still cause

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
@@ -214,9 +215,7 @@ func TestGenerateLoadMessagesQuery(t *testing.T) {
 	}, []string{"t1"}, nil, nil)
 
 	q, err := engine.GenerateLoadMessagesQuery("t1")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := "select time_next, epoch, time_created, id, time_scheduled, message from t1 where :#pk"
 	if q.Query != want {
 		t.Errorf("GenerateLoadMessagesQuery: %s, want %s", q.Query, want)

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/tableacl"
@@ -187,9 +188,7 @@ func TestDDLPlan(t *testing.T) {
 func TestMessageStreamingPlan(t *testing.T) {
 	testSchema := loadSchema("schema_test.json")
 	plan, err := BuildMessageStreaming("msg", testSchema)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	bout, _ := json.Marshal(plan)
 	planJSON := string(bout)
 

--- a/go/vt/vttablet/tabletserver/tabletserver_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_flaky_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -135,9 +136,7 @@ func TestTabletServerInitDBConfig(t *testing.T) {
 	}
 	tsv.setState(StateNotConnected)
 	err = tsv.InitDBConfig(target, dbcfgs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestDecideAction(t *testing.T) {
@@ -149,24 +148,18 @@ func TestDecideAction(t *testing.T) {
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	dbcfgs := testUtils.newDBConfigs(db)
 	err := tsv.InitDBConfig(target, dbcfgs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	tsv.setState(StateNotConnected)
 	action, err := tsv.decideAction(topodatapb.TabletType_MASTER, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionNone {
 		t.Errorf("decideAction: %v, want %v", action, actionNone)
 	}
 
 	tsv.setState(StateNotConnected)
 	action, err = tsv.decideAction(topodatapb.TabletType_MASTER, true, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionFullStart {
 		t.Errorf("decideAction: %v, want %v", action, actionFullStart)
 	}
@@ -176,18 +169,14 @@ func TestDecideAction(t *testing.T) {
 
 	tsv.setState(StateNotServing)
 	action, err = tsv.decideAction(topodatapb.TabletType_MASTER, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionNone {
 		t.Errorf("decideAction: %v, want %v", action, actionNone)
 	}
 
 	tsv.setState(StateNotServing)
 	action, err = tsv.decideAction(topodatapb.TabletType_MASTER, true, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionServeNewType {
 		t.Errorf("decideAction: %v, want %v", action, actionServeNewType)
 	}
@@ -197,9 +186,7 @@ func TestDecideAction(t *testing.T) {
 
 	tsv.setState(StateServing)
 	action, err = tsv.decideAction(topodatapb.TabletType_MASTER, false, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionGracefulStop {
 		t.Errorf("decideAction: %v, want %v", action, actionGracefulStop)
 	}
@@ -209,9 +196,7 @@ func TestDecideAction(t *testing.T) {
 
 	tsv.setState(StateServing)
 	action, err = tsv.decideAction(topodatapb.TabletType_REPLICA, true, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionServeNewType {
 		t.Errorf("decideAction: %v, want %v", action, actionServeNewType)
 	}
@@ -222,9 +207,7 @@ func TestDecideAction(t *testing.T) {
 
 	tsv.setState(StateServing)
 	action, err = tsv.decideAction(topodatapb.TabletType_MASTER, true, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if action != actionNone {
 		t.Errorf("decideAction: %v, want %v", action, actionNone)
 	}
@@ -256,44 +239,34 @@ func TestSetServingType(t *testing.T) {
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	err := tsv.InitDBConfig(target, dbcfgs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	stateChanged, err := tsv.SetServingType(topodatapb.TabletType_REPLICA, false, nil)
 	if stateChanged != false {
 		t.Errorf("SetServingType() should NOT have changed the QueryService state, but did")
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	checkTabletServerState(t, tsv, StateNotConnected)
 
 	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_REPLICA, true, nil)
 	if stateChanged != true {
 		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	checkTabletServerState(t, tsv, StateServing)
 
 	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_RDONLY, true, nil)
 	if stateChanged != true {
 		t.Errorf("SetServingType() should have changed the tablet type, but did not")
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	checkTabletServerState(t, tsv, StateServing)
 
 	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_SPARE, false, nil)
 	if stateChanged != true {
 		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	checkTabletServerState(t, tsv, StateNotServing)
 
 	// Verify that we exit lameduck when SetServingType is called.
@@ -305,9 +278,7 @@ func TestSetServingType(t *testing.T) {
 	if stateChanged != true {
 		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
 	}
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	checkTabletServerState(t, tsv, StateServing)
 	if stateName := tsv.GetState(); stateName != "SERVING" {
 		t.Errorf("GetState: %s, want SERVING", stateName)
@@ -449,9 +420,7 @@ func TestTabletServerReconnect(t *testing.T) {
 		t.Fatalf("TabletServer.StartService should success but get error: %v", err)
 	}
 	_, err = tsv.Execute(context.Background(), &target, query, nil, 0, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// make mysql conn fail
 	db.Close()
@@ -470,13 +439,9 @@ func TestTabletServerReconnect(t *testing.T) {
 	db.AddQuery("select addr from test_table where 1 != 1", &sqltypes.Result{})
 	dbcfgs = testUtils.newDBConfigs(db)
 	err = tsv.StartService(target, dbcfgs)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	_, err = tsv.Execute(context.Background(), &target, query, nil, 0, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestTabletServerTarget(t *testing.T) {
@@ -613,9 +578,7 @@ func TestTabletServerMasterToReplica(t *testing.T) {
 	ctx := context.Background()
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	txid1, err := tsv.Begin(ctx, &target, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if _, err := tsv.Execute(ctx, &target, "update test_table set name = 2 where pk = 1", nil, txid1, nil); err != nil {
 		t.Error(err)
 	}
@@ -623,14 +586,10 @@ func TestTabletServerMasterToReplica(t *testing.T) {
 		t.Error(err)
 	}
 	txid2, err := tsv.Begin(ctx, &target, nil)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	// This makes txid2 busy
 	conn2, err := tsv.te.txPool.Get(txid2, "for query")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	ch := make(chan bool)
 	go func() {
 		tsv.SetServingType(topodatapb.TabletType_REPLICA, true, []topodatapb.TabletType{topodatapb.TabletType_MASTER})
@@ -766,9 +725,7 @@ func TestTabletServerCreateTransaction(t *testing.T) {
 		Keyspace: "t1",
 		Shard:    "0",
 	}})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestTabletServerStartCommit(t *testing.T) {
@@ -782,9 +739,7 @@ func TestTabletServerStartCommit(t *testing.T) {
 	db.AddQuery(commitTransition, &sqltypes.Result{RowsAffected: 1})
 	txid := newTxForPrep(tsv)
 	err := tsv.StartCommit(ctx, &target, txid, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	db.AddQuery(commitTransition, &sqltypes.Result{})
 	txid = newTxForPrep(tsv)
@@ -806,9 +761,7 @@ func TestTabletserverSetRollback(t *testing.T) {
 	db.AddQuery(rollbackTransition, &sqltypes.Result{RowsAffected: 1})
 	txid := newTxForPrep(tsv)
 	err := tsv.SetRollback(ctx, &target, "aa", txid)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	db.AddQuery(rollbackTransition, &sqltypes.Result{})
 	txid = newTxForPrep(tsv)
@@ -828,9 +781,7 @@ func TestTabletServerReadTransaction(t *testing.T) {
 
 	db.AddQuery("select dtid, state, time_created from `_vt`.dt_state where dtid = 'aa'", &sqltypes.Result{})
 	got, err := tsv.ReadTransaction(ctx, &target, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := &querypb.TransactionMetadata{}
 	if !proto.Equal(got, want) {
 		t.Errorf("ReadTransaction: %v, want %v", got, want)
@@ -863,9 +814,7 @@ func TestTabletServerReadTransaction(t *testing.T) {
 		}},
 	})
 	got, err = tsv.ReadTransaction(ctx, &target, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want = &querypb.TransactionMetadata{
 		Dtid:        "aa",
 		State:       querypb.TransactionState_PREPARE,
@@ -899,9 +848,7 @@ func TestTabletServerReadTransaction(t *testing.T) {
 	db.AddQuery("select dtid, state, time_created from `_vt`.dt_state where dtid = 'aa'", txResult)
 	want.State = querypb.TransactionState_COMMIT
 	got, err = tsv.ReadTransaction(ctx, &target, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !proto.Equal(got, want) {
 		t.Errorf("ReadTransaction: %v, want %v", got, want)
 	}
@@ -921,9 +868,7 @@ func TestTabletServerReadTransaction(t *testing.T) {
 	db.AddQuery("select dtid, state, time_created from `_vt`.dt_state where dtid = 'aa'", txResult)
 	want.State = querypb.TransactionState_ROLLBACK
 	got, err = tsv.ReadTransaction(ctx, &target, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if !proto.Equal(got, want) {
 		t.Errorf("ReadTransaction: %v, want %v", got, want)
 	}
@@ -939,9 +884,7 @@ func TestTabletServerConcludeTransaction(t *testing.T) {
 	db.AddQuery("delete from `_vt`.dt_state where dtid = 'aa'", &sqltypes.Result{})
 	db.AddQuery("delete from `_vt`.dt_participant where dtid = 'aa'", &sqltypes.Result{})
 	err := tsv.ConcludeTransaction(ctx, &target, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestTabletServerBeginFail(t *testing.T) {
@@ -2215,9 +2158,7 @@ func TestMessageAck(t *testing.T) {
 	)
 	db.AddQueryPattern("update msg set time_acked = .*", &sqltypes.Result{RowsAffected: 1})
 	count, err := tsv.MessageAck(ctx, &target, "msg", ids)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}
@@ -2258,9 +2199,7 @@ func TestRescheduleMessages(t *testing.T) {
 	)
 	db.AddQueryPattern("update msg set time_next = .*", &sqltypes.Result{RowsAffected: 1})
 	count, err := tsv.PostponeMessages(ctx, &target, "msg", []string{"1", "2"})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}
@@ -2301,9 +2240,7 @@ func TestPurgeMessages(t *testing.T) {
 	)
 	db.AddQuery("delete from msg where (time_scheduled = 1 and id = 1) /* _stream msg (time_scheduled id ) (1 1 ); */", &sqltypes.Result{RowsAffected: 1})
 	count, err := tsv.PurgeMessages(ctx, &target, "msg", 3)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if count != 1 {
 		t.Errorf("count: %d, want 1", count)
 	}

--- a/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_prep_pool_test.go
@@ -18,6 +18,8 @@ package tabletserver
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmptyPrep(t *testing.T) {
@@ -32,13 +34,9 @@ func TestEmptyPrep(t *testing.T) {
 func TestPrepPut(t *testing.T) {
 	pp := NewTxPreparedPool(2)
 	err := pp.Put(nil, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = pp.Put(nil, "bb")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := "prepared transactions exceeded limit: 2"
 	err = pp.Put(nil, "cc")
 	if err == nil || err.Error() != want {
@@ -50,9 +48,7 @@ func TestPrepPut(t *testing.T) {
 		t.Errorf("Put err: %v, want %s", err, want)
 	}
 	_, err = pp.FetchForCommit("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	err = pp.Put(nil, "aa")
 	want = "duplicate DTID in Prepare: aa"
 	if err == nil || err.Error() != want {
@@ -60,9 +56,7 @@ func TestPrepPut(t *testing.T) {
 	}
 	pp.Forget("aa")
 	err = pp.Put(nil, "aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestPrepFetchForRollback(t *testing.T) {
@@ -87,17 +81,13 @@ func TestPrepFetchForCommit(t *testing.T) {
 	pp := NewTxPreparedPool(2)
 	conn := &TxConnection{}
 	got, err := pp.FetchForCommit("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got != nil {
 		t.Errorf("Get(aa): %v, want nil", got)
 	}
 	pp.Put(conn, "aa")
 	got, err = pp.FetchForCommit("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got != conn {
 		t.Errorf("pp.Get(aa): %p, want %p", got, conn)
 	}
@@ -120,9 +110,7 @@ func TestPrepFetchForCommit(t *testing.T) {
 	}
 	pp.Forget("aa")
 	got, err = pp.FetchForCommit("aa")
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	if got != nil {
 		t.Errorf("Get(aa): %v, want nil", got)
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -172,9 +173,7 @@ func TestStreamRowsUnicode(t *testing.T) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestStreamRowsKeyRange(t *testing.T) {


### PR DESCRIPTION
This is just a cleanup suggested by @systay for tests. We will use `require.NoError` in our new code unless suggested otherwise.