### PR TITLE
vreplication: fix bug on stop position

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -118,6 +118,7 @@ func (vre *Engine) Open(ctx context.Context) error {
 	if vre.isOpen {
 		return nil
 	}
+	log.Infof("Starting VReplication engine")
 
 	vre.ctx, vre.cancel = context.WithCancel(ctx)
 	vre.isOpen = true
@@ -219,6 +220,7 @@ func (vre *Engine) Close() {
 	if !vre.isOpen {
 		return
 	}
+	log.Infof("Shutting down VReplication engine")
 
 	vre.cancel()
 	// We still have to wait for all controllers to stop.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -78,6 +78,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 // play is not resumable. If pausePos is set, play returns without updating the vreplication state.
 func (vp *vplayer) play(ctx context.Context) error {
 	if !vp.stopPos.IsZero() && vp.startPos.AtLeast(vp.stopPos) {
+		log.Infof("Stop position %v already reached: %v", vp.startPos, vp.stopPos)
 		if vp.saveStop {
 			return vp.vr.setState(binlogplayer.BlpStopped, fmt.Sprintf("Stop position %v already reached: %v", vp.startPos, vp.stopPos))
 		}
@@ -211,6 +212,7 @@ func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 	vp.vr.stats.SetLastPosition(vp.pos)
 	posReached = !vp.stopPos.IsZero() && vp.pos.AtLeast(vp.stopPos)
 	if posReached {
+		log.Infof("Stopped at position: %v", vp.stopPos)
 		if vp.saveStop {
 			if err := vp.vr.setState(binlogplayer.BlpStopped, fmt.Sprintf("Stopped at position %v", vp.stopPos)); err != nil {
 				return false, err

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -1221,6 +1221,114 @@ func TestPlayerStopPos(t *testing.T) {
 	})
 }
 
+func TestPlayerStopAtOther(t *testing.T) {
+	t.Skip("This test was written to verify a bug fix, but is extremely flaky. Only a manual test is possible")
+
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table t1(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t1(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	// Insert a source row.
+	execStatements(t, []string{
+		"insert into t1 values(1, 'aaa')",
+	})
+	startPos := masterPosition(t)
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, startPos, binlogplayer.BlpStopped, vrepldb)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uint32(qr.InsertID)
+	for q := range globalDBQueries {
+		if strings.HasPrefix(q, "insert into _vt.vreplication") {
+			break
+		}
+	}
+	defer func() {
+		if _, err := playerEngine.Exec(fmt.Sprintf("delete from _vt.vreplication where id = %d", id)); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+	}()
+
+	vconn := &realDBClient{nolog: true}
+	if err := vconn.Connect(); err != nil {
+		t.Error(err)
+	}
+	defer vconn.Close()
+
+	// Insert the same row on the target and lock it.
+	if _, err := vconn.ExecuteFetch("insert into t1 values(1, 'aaa')", 1); err != nil {
+		t.Error(err)
+	}
+	if _, err := vconn.ExecuteFetch("begin", 1); err != nil {
+		t.Error(err)
+	}
+	if _, err := vconn.ExecuteFetch("update t1 set val='bbb' where id=1", 1); err != nil {
+		t.Error(err)
+	}
+
+	// Start a VReplication where the first transaction updates the locked row.
+	// It will cause the apply to wait, which will cause the other two events
+	// to accumulate. The stop position will be on the grant.
+	// We're testing the behavior where an OTHER transaction is part of a batch,
+	// we have to commit its stop position correctly.
+	execStatements(t, []string{
+		"update t1 set val='ccc' where id=1",
+		"insert into t1 values(2, 'ddd')",
+		"grant select on *.* to 'vt_app'@'127.0.0.1'",
+	})
+	stopPos := masterPosition(t)
+	query = binlogplayer.StartVReplicationUntil(id, stopPos)
+	if _, err := playerEngine.Exec(query); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the begin. The update will be blocked.
+	expectDBClientQueries(t, []string{
+		"/update.*'Running'",
+		// Second update is from vreplicator.
+		"/update.*'Running'",
+		"begin",
+	})
+
+	// Give time for the other two transactions to reach the relay log.
+	time.Sleep(100 * time.Millisecond)
+	_, _ = vconn.ExecuteFetch("rollback", 1)
+
+	// This is approximately the expected sequence of updates.
+	expectDBClientQueries(t, []string{
+		"update t1 set val='ccc' where id=1",
+		"/update _vt.vreplication set pos=",
+		"commit",
+		"begin",
+		"insert into t1(id,val) values (2,'ddd')",
+		"/update _vt.vreplication set pos=",
+		"commit",
+		fmt.Sprintf("/update _vt.vreplication set pos='%s'", stopPos),
+		"/update.*'Stopped'",
+	})
+}
+
 func TestPlayerIdleUpdate(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -290,6 +290,7 @@ func (rs *rowStreamer) startStreaming(conn *mysql.Conn) (string, error) {
 		return "", err
 	}
 
+	log.Infof("Streaming query: %v\n", rs.sendQuery)
 	if err := conn.ExecuteStreamFetch(rs.sendQuery); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #5800

The function hasAnother commit is supposed to separate out events
that have to be applied in a transaction from events that are
applied as autocommits. But it was not checking for the OTHER
and JOURNAL events. They should not be batched with regular
transactions.

This caused a bug where a regular transaction occured followed
by an OTHER event. The apply of this event happened assuming
autocommit behavior, but it actually got added to the previous
uncommitted transaction.

If the stop position is reached at this point, vplayer exits
because it thinks the autocommit happened, and the entire
transaction gets rolled back, and the stop position ends
up not being actually reached.

The copier which expects this behavior will then start applying
the next set of rows, but they are not consistent with the current
stop position. This will cause the target to go out of sync.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>