### PR TITLE
Re-enable MySQL 8.0 unit test

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [percona56, mysql57, mariadb101, mariadb102, mariadb103]
+        name: [percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103]
 
     steps:
     - name: Set up Go
@@ -19,41 +19,52 @@ jobs:
 
     - name: Get dependencies
       run: |
+        export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
 
         if [ ${{matrix.name}} = "mysql57" ]; then
           sudo apt-get install -y mysql-server mysql-client
         else
           # Uninstall likely installed MySQL first
-          sudo apt-get remove -y mysql-server mysql-client
-          
+          sudo systemctl stop apparmor
+          sudo apt-get remove -y --purge mysql-server mysql-client mysql-common
+          sudo apt-get -y autoremove
+          sudo apt-get -y autoclean
+          sudo deluser mysql
+          sudo rm -rf /var/lib/mysql
+          sudo rm -rf /etc/mysql
+ 
           if [ ${{matrix.name}} = "percona56" ]; then
             sudo rm -rf /var/lib/mysql
             sudo apt install -y gnupg2
             wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
             sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
             sudo apt update
-            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y percona-server-server-5.6 percona-server-client-5.6  
+            sudo apt-get install -y percona-server-server-5.6 percona-server-client-5.6  
           elif [ ${{matrix.name}} = "mysql80" ]; then
             wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.14-1_all.deb
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections 
-            sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+            sudo dpkg -i mysql-apt-config*
             sudo apt-get update
-            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+            sudo apt-get install -y mysql-server mysql-client
           elif [ ${{matrix.name}} = "mariadb101" ]; then
-            sudo apt install -y mariadb-server mariadb-client
+            sudo apt-get install -y software-properties-common
+            sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
+            sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu bionic main'
+            sudo apt update
+            sudo apt install -y mariadb-server
           elif [ ${{matrix.name}} = "mariadb102" ]; then
             sudo apt-get install -y software-properties-common
             sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
             sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu bionic main'
             sudo apt update
-            sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
+            sudo apt install -y mariadb-server
           elif [ ${{matrix.name}} = "mariadb103" ]; then
             sudo apt-get install -y software-properties-common
             sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
             sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu bionic main'
             sudo apt update
-            sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
+            sudo apt install -y mariadb-server
           fi
         fi
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -27,7 +27,7 @@ jobs:
         else
           # Uninstall likely installed MySQL first
           sudo systemctl stop apparmor
-          sudo apt-get remove -y --purge mysql-server mysql-client mysql-common
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
           sudo apt-get -y autoremove
           sudo apt-get -y autoclean
           sudo deluser mysql
@@ -40,31 +40,31 @@ jobs:
             wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
             sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
             sudo apt update
-            sudo apt-get install -y percona-server-server-5.6 percona-server-client-5.6  
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y percona-server-server-5.6 percona-server-client-5.6  
           elif [ ${{matrix.name}} = "mysql80" ]; then
             wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.14-1_all.deb
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections 
-            sudo dpkg -i mysql-apt-config*
+            sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
             sudo apt-get update
-            sudo apt-get install -y mysql-server mysql-client
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
           elif [ ${{matrix.name}} = "mariadb101" ]; then
             sudo apt-get install -y software-properties-common
             sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
             sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu bionic main'
             sudo apt update
-            sudo apt install -y mariadb-server
+            sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
           elif [ ${{matrix.name}} = "mariadb102" ]; then
             sudo apt-get install -y software-properties-common
             sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
             sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu bionic main'
             sudo apt update
-            sudo apt install -y mariadb-server
+            sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
           elif [ ${{matrix.name}} = "mariadb103" ]; then
             sudo apt-get install -y software-properties-common
             sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
             sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu bionic main'
             sudo apt update
-            sudo apt install -y mariadb-server
+            sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
           fi
         fi
 


### PR DESCRIPTION
Re-enable MySQL 8.0 unit test + fetch MariaDB 10.1 from MariaDB repos (works more consistently)

Signed-off-by: Morgan Tocker <tocker@gmail.com>