### PR TITLE
Disable last 2 travis shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ env:
     - TEST_MATRIX="-shard 0"
     - TEST_MATRIX="-shard 1"
     - TEST_MATRIX="-shard 2"
-    - TEST_MATRIX="-shard 3"
-    - TEST_MATRIX="-shard 4"
 script:
   - go run test.go $TEST_FLAGS $TEST_MATRIX
   # Uncomment the next line to verify the GOMAXPROCS value (should be 2 as of 09/2017).


### PR DESCRIPTION
This disables the last two travis shards, which now have no tests running.

We could rebalance the other tests of course: but the impact is minimal because bootstrap overhead is about 6 minutes anyway.

The advantage of disabling the tests is that multiple PRs can be running through Travis in parallel now.

Signed-off-by: Morgan Tocker <tocker@gmail.com>