### PR TITLE
Create Region JSON Vindex

### DIFF
--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vindexes
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"io/ioutil"

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -38,9 +38,11 @@ func init() {
 // RegionMap is used to store mapping of country to region
 type RegionMap map[string]uint64
 
-// RegionJson defines a vindex that uses a lookup table.
-// The table is expected to define the id column as unique. It's
-// Unique and a Lookup.
+// RegionJson is a multi-column unique vindex
+// The first column is used to lookup the prefix part of the keyspace id, the second column is hashed,
+// and the two values are combined to produce the keyspace id.
+// RegionJson can be used for geo-partitioning because the first column can denote a region,
+// and it will dictate the shard range for that region.
 type RegionJson struct {
 	name        string
 	regionMap   RegionMap

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -41,8 +41,9 @@ type RegionMap map[string]uint64
 // The table is expected to define the id column as unique. It's
 // Unique and a Lookup.
 type RegionJson struct {
-	regionMap RegionMap
-	*RegionExperimental
+	name        string
+	regionMap   RegionMap
+	regionBytes int
 }
 
 // NewRegionJson creates a RegionJson vindex.
@@ -62,18 +63,9 @@ func NewRegionJson(name string, m map[string]string) (Vindex, error) {
 		return nil, err
 	}
 
-	vindex, err := NewRegionExperimental(name, m)
-	if err != nil {
-		// Unreachable.
-		return nil, err
-	}
-	re := vindex.(*RegionExperimental)
-	if len(re.ConsistentLookupUnique.lkp.FromColumns) != 2 {
-		return nil, fmt.Errorf("two columns are required for region_experimental: %v", re.ConsistentLookupUnique.lkp.FromColumns)
-	}
 	return &RegionJson{
-		regionMap:          rmap,
-		RegionExperimental: re,
+		name:      name,
+		regionMap: rmap,
 	}, nil
 }
 
@@ -124,6 +116,20 @@ func (rv *RegionJson) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]
 		destinations = append(destinations, key.DestinationKeyspaceID(dest))
 	}
 	return destinations, nil
+}
+
+// Verify satisfies MultiColumn
+func (rv *RegionJson) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	result := make([]bool, len(rowsColValues))
+	destinations, _ := rv.Map(vcursor, rowsColValues)
+	for i, dest := range destinations {
+		destksid, ok := dest.(key.DestinationKeyspaceID)
+		if !ok {
+			continue
+		}
+		result[i] = bytes.Equal([]byte(destksid), ksids[i])
+	}
+	return result, nil
 }
 
 // NeedVCursor satisfies the Vindex interface.

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -48,7 +48,7 @@ type RegionJson struct {
 }
 
 // NewRegionJson creates a RegionJson vindex.
-// The supplied map requires all the fields of "region_experimental".
+// The supplied map requires all the fields of "RegionExperimental".
 // Additionally, it requires a region_map argument representing the path to a json file
 // containing a map of country to region.
 func NewRegionJson(name string, m map[string]string) (Vindex, error) {
@@ -133,7 +133,7 @@ func (rv *RegionJson) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, 
 	return result, nil
 }
 
-// NeedVCursor staisfies the Vindex interface.
+// NeedVCursor satisfies the Vindex interface.
 func (rv *RegionJson) NeedsVCursor() bool {
 	return false
 }

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vindexes
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"io/ioutil"

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -101,6 +101,7 @@ func (rv *RegionJson) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]
 		}
 		h := vhash(hn)
 
+		rn, ok := rv.regionMap[row[1].ToString()]
 		if !ok {
 			destinations = append(destinations, key.DestinationNone{})
 			continue

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -42,7 +42,7 @@ type RegionMap map[string]uint64
 // The table is expected to define the id column as unique. It's
 // Unique and a Lookup.
 type RegionJson struct {
-	regionMap   RegionMap
+	regionMap RegionMap
 	*RegionExperimental
 }
 

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -101,11 +101,6 @@ func (rv *RegionJson) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]
 		}
 		h := vhash(hn)
 
-		log.Infof("Region map: %v", rv.regionMap)
-		// Compute region prefix.
-		log.Infof("Country: %v", row[1].ToString())
-		rn, ok := rv.regionMap[row[1].ToString()]
-		log.Infof("Found region %v, true/false: %v", rn, ok)
 		if !ok {
 			destinations = append(destinations, key.DestinationNone{})
 			continue

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -28,30 +28,30 @@ import (
 )
 
 var (
-	_ MultiColumn = (*RegionVindex)(nil)
+	_ MultiColumn = (*RegionJson)(nil)
 )
 
 func init() {
-	Register("region_vindex", NewRegionVindex)
+	Register("region_json", NewRegionJson)
 }
 
 // RegionMap is used to store mapping of country to region
 type RegionMap map[string]uint64
 
-// RegionVindex defines a vindex that uses a lookup table.
+// RegionJson defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // Unique and a Lookup.
-type RegionVindex struct {
+type RegionJson struct {
 	name        string
 	regionMap   RegionMap
 	regionBytes int
 }
 
-// NewRegionVindex creates a RegionVindex vindex.
+// NewRegionJson creates a RegionJson vindex.
 // The supplied map requires all the fields of "region_experimental".
 // Additionally, it requires a region_map argument representing the path to a json file
 // containing a map of country to region.
-func NewRegionVindex(name string, m map[string]string) (Vindex, error) {
+func NewRegionJson(name string, m map[string]string) (Vindex, error) {
 	rmPath := m["region_map"]
 	rmap := make(map[string]uint64)
 	data, err := ioutil.ReadFile(rmPath)
@@ -64,29 +64,29 @@ func NewRegionVindex(name string, m map[string]string) (Vindex, error) {
 		return nil, err
 	}
 
-	return &RegionVindex{
+	return &RegionJson{
 		name:      name,
 		regionMap: rmap,
 	}, nil
 }
 
 // String returns the name of the vindex.
-func (rv *RegionVindex) String() string {
+func (rv *RegionJson) String() string {
 	return rv.name
 }
 
 // Cost returns the cost of this index as 1.
-func (rv *RegionVindex) Cost() int {
+func (rv *RegionJson) Cost() int {
 	return 1
 }
 
 // IsUnique returns true since the Vindex is unique.
-func (rv *RegionVindex) IsUnique() bool {
+func (rv *RegionJson) IsUnique() bool {
 	return true
 }
 
 // Map satisfies MultiColumn.
-func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
+func (rv *RegionJson) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
 	destinations := make([]key.Destination, 0, len(rowsColValues))
 	for _, row := range rowsColValues {
 		if len(row) != 2 {
@@ -124,7 +124,7 @@ func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) (
 }
 
 // Verify satisfies MultiColumn
-func (rv *RegionVindex) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
+func (rv *RegionJson) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	result := make([]bool, len(rowsColValues))
 	destinations, _ := rv.Map(vcursor, rowsColValues)
 	for i, dest := range destinations {
@@ -138,6 +138,6 @@ func (rv *RegionVindex) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value
 }
 
 // NeedVCursor staisfies the Vindex interface.
-func (rv *RegionVindex) NeedsVCursor() bool {
+func (rv *RegionJson) NeedsVCursor() bool {
 	return false
 }

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -19,7 +19,6 @@ package vindexes
 import (
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -124,6 +123,6 @@ func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) (
 }
 
 // NeedVCursor staisfies the Vindex interface.
-func (rv *RegionVindex) NeedVCursor() bool {
+func (rv *RegionVindex) NeedsVCursor() bool {
 	return false
 }

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vindexes
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"io/ioutil"

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -122,6 +122,20 @@ func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) (
 	return destinations, nil
 }
 
+// Verify satisfies MultiColumn
+func (rv *RegionVindex) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]bytes) ([]bool, error) {
+	result := make([]bool, len(rowsColValues))
+	destinations, _ := rv.Map(vcursor, rowsColValues)
+	for i, dest := range destinations {
+		destksid, ok := dest.(key.DestinationKeyspaceID)
+		if !ok {
+			continue
+		}
+		result[i] = bytes.Equal([]byte(destksid), ksids[i])
+	}
+	return result, nil
+}
+
 // NeedVCursor staisfies the Vindex interface.
 func (rv *RegionVindex) NeedsVCursor() bool {
 	return false

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	_ MultiColumn   = (*RegionVindex)(nil)
+	_ MultiColumn = (*RegionVindex)(nil)
 )
 
 func init() {
@@ -82,7 +82,7 @@ func (rv *RegionVindex) Cost() int {
 
 // IsUnique returns true since the Vindex is unique.
 func (rv *RegionVindex) IsUnique() bool {
-	return true;
+	return true
 }
 
 // Map satisfies MultiColumn.

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -124,7 +124,7 @@ func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) (
 }
 
 // Verify satisfies MultiColumn
-func (rv *RegionVindex) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]bytes) ([]bool, error) {
+func (rv *RegionVindex) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	result := make([]bool, len(rowsColValues))
 	destinations, _ := rv.Map(vcursor, rowsColValues)
 	for i, dest := range destinations {

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -121,3 +121,8 @@ func (rv *RegionVindex) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) (
 	}
 	return destinations, nil
 }
+
+// NeedVCursor staisfies the Vindex interface.
+func (rv *RegionVindex) NeedVCursor() bool {
+	return false
+}

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -44,6 +44,7 @@ type RegionMap map[string]uint64
 type RegionVindex struct {
 	name        string
 	regionMap   RegionMap
+	regionBytes int
 }
 
 // NewRegionVindex creates a RegionVindex vindex.

--- a/go/vt/vtgate/vindexes/region_vindex.go
+++ b/go/vt/vtgate/vindexes/region_vindex.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
+)
+
+var (
+	_ Vindex        = (*RegionVindex)(nil)
+	_ Lookup        = (*RegionVindex)(nil)
+	_ WantOwnerInfo = (*RegionVindex)(nil)
+	_ MultiColumn   = (*RegionVindex)(nil)
+)
+
+func init() {
+	Register("region_vindex", NewRegionVindex)
+}
+
+// RegionMap is used to store mapping of country to region
+type RegionMap map[string]uint64
+
+// RegionVindex defines a vindex that uses a lookup table.
+// The table is expected to define the id column as unique. It's
+// Unique and a Lookup.
+type RegionVindex struct {
+	regionMap RegionMap
+	*RegionExperimental
+}
+
+// NewRegionVindex creates a RegionVindex vindex.
+// The supplied map requires all the fields of "region_experimental".
+// Additionally, it requires a region_map argument representing the path to a json file
+// containing a map of country to region.
+func NewRegionVindex(name string, m map[string]string) (Vindex, error) {
+	rmPath := m["region_map"]
+	rmap := make(map[string]uint64)
+	data, err := ioutil.ReadFile(rmPath)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("Loaded Region map from: %s", rmPath)
+	err = json.Unmarshal(data, &rmap)
+	if err != nil {
+		return nil, err
+	}
+
+	vindex, err := NewRegionExperimental(name, m)
+	if err != nil {
+		// Unreachable.
+		return nil, err
+	}
+	re := vindex.(*RegionExperimental)
+	if len(re.ConsistentLookupUnique.lkp.FromColumns) != 2 {
+		return nil, fmt.Errorf("two columns are required for region_experimental: %v", re.ConsistentLookupUnique.lkp.FromColumns)
+	}
+	return &RegionVindex{
+		regionMap:          rmap,
+		RegionExperimental: re,
+	}, nil
+}
+
+// MapMulti satisfies MultiColumn.
+func (rv *RegionVindex) MapMulti(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
+	destinations := make([]key.Destination, 0, len(rowsColValues))
+	for _, row := range rowsColValues {
+		if len(row) != 2 {
+			destinations = append(destinations, key.DestinationNone{})
+			continue
+		}
+		// Compute hash.
+		hn, err := sqltypes.ToUint64(row[0])
+		if err != nil {
+			destinations = append(destinations, key.DestinationNone{})
+			continue
+		}
+		h := vhash(hn)
+
+		log.Infof("Region map: %v", rv.regionMap)
+		// Compute region prefix.
+		log.Infof("Country: %v", row[1].ToString())
+		rn, ok := rv.regionMap[row[1].ToString()]
+		log.Infof("Found region %v, true/false: %v", rn, ok)
+		if !ok {
+			destinations = append(destinations, key.DestinationNone{})
+			continue
+		}
+		r := make([]byte, 2)
+		binary.BigEndian.PutUint16(r, uint16(rn))
+
+		// Concatenate and add to destinations.
+		if rv.regionBytes == 1 {
+			r = r[1:]
+		}
+		dest := append(r, h...)
+		destinations = append(destinations, key.DestinationKeyspaceID(dest))
+	}
+	return destinations, nil
+}


### PR DESCRIPTION
Adds the `region_vindex` (as `region_json`) created for a Vitess conference demo (https://github.com/planetscale/vitess/blob/ds-kcn19-demo/go/vt/vtgate/vindexes/region_vindex.go), with modifications so it works with the latest Vitess version.