### PR TITLE
docker: Add sysstat and strace to vitess/lite.

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -31,6 +31,8 @@ BASE_PACKAGES=(
     libtcmalloc-minimal4
     procps
     rsync
+    strace
+    sysstat
     wget
 )
 


### PR DESCRIPTION
These are useful for diagnostics on running containers.