### PR TITLE
Healthcheck - limit healthchecks by keyspace

### DIFF
--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -437,3 +437,59 @@ func (fbs *FilterByShard) isIncluded(tablet *topodatapb.Tablet) bool {
 	}
 	return false
 }
+
+// FilterByKeyspace is a TabletRecorder filter that filters tablets by
+// keyspace
+type FilterByKeyspace struct {
+	tr TabletRecorder
+
+	keyspaces map[string]bool
+}
+
+// NewFilterByKeyspace creates a new FilterByKeyspace on top of an existing
+// TabletRecorder. Each filter is a keyspace entry. All tablets that match
+// a keyspace will be forwarded to the underlying TabletRecorder.
+func NewFilterByKeyspace(tr TabletRecorder, selectedKeyspaces []string) *FilterByKeyspace {
+	m := make(map[string]bool)
+	for _, keyspace := range selectedKeyspaces {
+		m[keyspace] = true
+	}
+
+	return &FilterByKeyspace{
+		tr:        tr,
+		keyspaces: m,
+	}
+}
+
+// AddTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) AddTablet(tablet *topodatapb.Tablet, name string) {
+	if fbk.isIncluded(tablet) {
+		fbk.tr.AddTablet(tablet, name)
+	}
+}
+
+// RemoveTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) RemoveTablet(tablet *topodatapb.Tablet) {
+	if fbk.isIncluded(tablet) {
+		fbk.tr.RemoveTablet(tablet)
+	}
+}
+
+// ReplaceTablet is part of the TabletRecorder interface.
+func (fbk *FilterByKeyspace) ReplaceTablet(old *topodatapb.Tablet, new *topodatapb.Tablet, name string) {
+	if old.Keyspace != new.Keyspace {
+		log.Errorf("Error replacing old tablet in %v with new tablet in %v", old.Keyspace, new.Keyspace)
+		return
+	}
+
+	if fbk.isIncluded(new) {
+		fbk.tr.ReplaceTablet(old, new, name)
+	}
+}
+
+// isIncluded returns true if the tablet's keyspace should be
+// forwarded to the underlying TabletRecorder.
+func (fbk *FilterByKeyspace) isIncluded(tablet *topodatapb.Tablet) bool {
+	_, exist := fbk.keyspaces[tablet.Keyspace]
+	return exist
+}

--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -125,6 +125,8 @@ func createDiscoveryGateway(ctx context.Context, hc discovery.HealthCheck, serv 
 				log.Exitf("Cannot parse tablet_filters parameter: %v", err)
 			}
 			tr = fbs
+		} else if len(KeyspacesToWatch) > 0 {
+			tr = discovery.NewFilterByKeyspace(dg.hc, KeyspacesToWatch)
 		}
 
 		ctw := discovery.NewCellTabletsWatcher(ctx, topoServer, tr, c, *refreshInterval, *refreshKnownTablets, *topoReadConcurrency)


### PR DESCRIPTION
### Overview
Currently, vtgates support a `keyspaces_to_watch` flag which can enable data isolation by keyspace. However, vtgates still perform healthchecks against all tablets regardless of the value provided to this flag.  

This PR introduces changes to healthchecks such that when the `keyspaces_to_watch` flag is utilized, vtgates will only maintain healthchecks on tablets in keyspaces that the vtgate has access to. 

--
This closes #5387.
Relevant PR: https://github.com/vitessio/vitess/pull/4420

### Implementation
1. Introduce a new TabletRecorder filter, `FilterByKeyspace`, which will only add tablets from keyspaces that the vtgate has access to
2. Update the discovery gateway to use this filter when values for `keyspaces_to_watch` is passed in

### Testing
In addition to unit testing, I performed the following manual tests:
- Confirmed that vtgates that use the `keyspaces_to_watch` flag were only performing healthchecks on tablets from the desired keyspace
- Confirmed that vtgates that do _not_ use the `keyspaces_to_watch` flag performed health checks on the expected tablets
- Confirmed on a vtctld that various keyspace commands continue to work as expected
- Confirmed that backups continue to work as expected