### PR TITLE
vstreamer: bug: use WithCredentials

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -28,6 +28,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/binlog"
+	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -148,7 +149,11 @@ func (vs *vstreamer) Stream() error {
 		return wrapError(err, vs.pos)
 	}
 
-	conn, err := binlog.NewSlaveConnection(vs.cp)
+	cp, err := dbconfigs.WithCredentials(vs.cp)
+	if err != nil {
+		return wrapError(err, vs.pos)
+	}
+	conn, err := binlog.NewSlaveConnection(cp)
 	if err != nil {
 		return wrapError(err, vs.pos)
 	}
@@ -163,7 +168,11 @@ func (vs *vstreamer) Stream() error {
 }
 
 func (vs *vstreamer) currentPosition() (mysql.Position, error) {
-	conn, err := mysql.Connect(vs.ctx, vs.cp)
+	cp, err := dbconfigs.WithCredentials(vs.cp)
+	if err != nil {
+		return mysql.Position{}, err
+	}
+	conn, err := mysql.Connect(vs.ctx, cp)
 	if err != nil {
 		return mysql.Position{}, err
 	}


### PR DESCRIPTION
VStreamer was not prefacing mysql.Connect calls with WithCredentials.
I've now added the calls.

There are no new tests for this because this is not a sustainable
coding pattern. I'll create a separate issue to refactor the code
such that one should not have to remember to call WithCredentials
before every call to mysql.Connect.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>