### PR TITLE
Mount on /private/var/run/syslog in OSX for syslog

### DIFF
--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -129,7 +129,11 @@ chmod -R o=g .
 # "Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted"
 args="$args --cap-add=SYS_ADMIN"
 
-args="$args -v /dev/log:/dev/log"
+if [[ "$(uname)" = "Darwin" ]]; then
+  args="$args -v /private/var/run/syslog:/dev/log"
+else
+  args="$args -v /dev/log:/dev/log"
+fi
 args="$args -v $PWD:/tmp/src"
 
 # Share maven dependency cache so they don't have to be redownloaded every time.


### PR DESCRIPTION
Not really sure if this is the best solution. In mac, `/var` (the soft links) can't be mounted from docker directly and therefore either `/var/run/syslog` as mentioned. 

Ref: #5772 

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>