### PR TITLE
vitessdriver: add ability to set custom gRPC dial options

### DIFF
--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"errors"
 
+	"google.golang.org/grpc"
+	"vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
@@ -76,6 +78,11 @@ func OpenWithConfiguration(c Configuration) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(c.GRPCDialOptions) != 0 {
+		vtgateconn.RegisterDialer(c.Protocol, grpcvtgateconn.DialWithOpts(context.TODO(), c.GRPCDialOptions...))
+	}
+
 	return sql.Open("vitess", json)
 }
 
@@ -139,6 +146,13 @@ type Configuration struct {
 	// This setting has no effect if ConvertDatetime is not set.
 	// Default: UTC
 	DefaultLocation string
+
+	// GRPCDialOptions registers a new vtgateconn dialer with these dial options using the
+	// protocol as the key. This may overwrite the default grpcvtgateconn dial option
+	// if a custom one hasn't been specified in the config.
+	//
+	// Default: none
+	GRPCDialOptions []grpc.DialOption `json:"-"`
 }
 
 // toJSON converts Configuration to the JSON string which is required by the

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -79,7 +79,8 @@ func TestOpen(t *testing.T) {
 			connStr: fmt.Sprintf(`{"address": "%s", "target": "@replica", "timeout": %d}`, testAddress, int64(30*time.Second)),
 			conn: &conn{
 				Configuration: Configuration{
-					Target: "@replica",
+					Protocol: "grpc",
+					Target:   "@replica",
 				},
 				convert: &converter{
 					location: time.UTC,
@@ -90,7 +91,9 @@ func TestOpen(t *testing.T) {
 			desc:    "Open() (defaults omitted)",
 			connStr: fmt.Sprintf(`{"address": "%s", "timeout": %d}`, testAddress, int64(30*time.Second)),
 			conn: &conn{
-				Configuration: Configuration{},
+				Configuration: Configuration{
+					Protocol: "grpc",
+				},
 				convert: &converter{
 					location: time.UTC,
 				},
@@ -116,6 +119,7 @@ func TestOpen(t *testing.T) {
 				testAddress, int64(30*time.Second)),
 			conn: &conn{
 				Configuration: Configuration{
+					Protocol:        "grpc",
 					DefaultLocation: "America/Los_Angeles",
 				},
 				convert: &converter{

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -54,19 +54,30 @@ type vtgateConn struct {
 }
 
 func dial(ctx context.Context, addr string) (vtgateconn.Impl, error) {
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
-	if err != nil {
-		return nil, err
+	return DialWithOpts(ctx)(ctx, addr)
+}
+
+// DialWithOpts allows for custom dial options to be set on a vtgateConn.
+func DialWithOpts(ctx context.Context, opts ...grpc.DialOption) vtgateconn.DialerFunc {
+	return func(ctx context.Context, address string) (vtgateconn.Impl, error) {
+		opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, opt)
+
+		cc, err := grpcclient.Dial(address, grpcclient.FailFast(false), opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		c := vtgateservicepb.NewVitessClient(cc)
+		return &vtgateConn{
+			cc: cc,
+			c:  c,
+		}, nil
 	}
-	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
-	if err != nil {
-		return nil, err
-	}
-	c := vtgateservicepb.NewVitessClient(cc)
-	return &vtgateConn{
-		cc: cc,
-		c:  c,
-	}, nil
 }
 
 func (conn *vtgateConn) Execute(ctx context.Context, session *vtgatepb.Session, query string, bindVars map[string]*querypb.BindVariable) (*vtgatepb.Session, *sqltypes.Result, error) {


### PR DESCRIPTION
This will allow users to set custom gRPC dial options in the driver configuration. We needed this so we could increase the max message receive size.

Signed-off-by: Derrick Laird <swampdonk@gmail.com>