### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/go/vt/mysqlctl/metadata_tables.go
+++ b/go/vt/mysqlctl/metadata_tables.go
@@ -61,7 +61,7 @@ var (
 // a per-tablet table that is never replicated. This allows queries
 // against local_metadata to return different values on different tablets,
 // which is used for communicating between Vitess and MySQL-level tools like
-// Orchestrator (http://github.com/github/orchestrator).
+// Orchestrator (https://github.com/github/orchestrator).
 // _vt.shard_metadata is a replicated table with per-shard information, but it's
 // created here to make it easier to create it on databases that were running
 // old version of Vitess, or databases that are getting converted to run under

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,7 +52,7 @@
   <scm>
     <connection>scm:git:git@github.com:vitessio/vitess.git</connection>
     <developerConnection>scm:git:git@github.com:vitessio/vitess.git</developerConnection>
-    <url>http://github.com/vitessio/vitess/tree/master</url>
+    <url>https://github.com/vitessio/vitess/tree/master</url>
   </scm>
   <issueManagement>
     <system>GitHub</system>


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>