### PR TITLE
vrepl: refactor vdiff for readability and add comments

### DIFF
--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file has the logic for performing merge-sorts of scatter queries.
-
 package engine
 
 import (

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -25,48 +25,41 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/srvtopo"
 )
 
 // TestMergeSortNormal tests the normal flow of a merge
 // sort where all shards return ascending rows.
 func TestMergeSortNormal(t *testing.T) {
 	idColFields := sqltypes.MakeTestFields("id|col", "int32|varchar")
-	vc := &streamVCursor{
-		shardResults: map[string]*shardResult{
-			"0": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"1|a",
-				"7|g",
-			)},
-			"1": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"2|b",
-				"---",
-				"3|c",
-			)},
-			"2": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"4|d",
-				"6|f",
-			)},
-			"3": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"4|d",
-				"---",
-				"8|h",
-			)},
-		},
-	}
+	shardResults := []*shardResult{{
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"1|a",
+			"7|g",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"2|b",
+			"---",
+			"3|c",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"4|d",
+			"6|f",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"4|d",
+			"---",
+			"8|h",
+		),
+	}}
 	orderBy := []OrderbyParams{{
 		Col: 0,
 	}}
-	rss := []*srvtopo.ResolvedShard{
-		{Target: &querypb.Target{Shard: "0"}},
-		{Target: &querypb.Target{Shard: "1"}},
-		{Target: &querypb.Target{Shard: "2"}},
-		{Target: &querypb.Target{Shard: "3"}},
-	}
-	bvs := []map[string]*querypb.BindVariable{nil, nil, nil, nil}
 
 	var results []*sqltypes.Result
-	err := MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error {
+	err := testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -99,42 +92,36 @@ func TestMergeSortNormal(t *testing.T) {
 // sort where all shards return descending rows.
 func TestMergeSortDescending(t *testing.T) {
 	idColFields := sqltypes.MakeTestFields("id|col", "int32|varchar")
-	vc := &streamVCursor{
-		shardResults: map[string]*shardResult{
-			"0": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"7|g",
-				"1|a",
-			)},
-			"1": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"3|c",
-				"---",
-				"2|b",
-			)},
-			"2": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"6|f",
-				"4|d",
-			)},
-			"3": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"8|h",
-				"---",
-				"4|d",
-			)},
-		},
-	}
+	shardResults := []*shardResult{{
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"7|g",
+			"1|a",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"3|c",
+			"---",
+			"2|b",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"6|f",
+			"4|d",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"8|h",
+			"---",
+			"4|d",
+		),
+	}}
 	orderBy := []OrderbyParams{{
 		Col:  0,
 		Desc: true,
 	}}
-	rss := []*srvtopo.ResolvedShard{
-		{Target: &querypb.Target{Shard: "0"}},
-		{Target: &querypb.Target{Shard: "1"}},
-		{Target: &querypb.Target{Shard: "2"}},
-		{Target: &querypb.Target{Shard: "3"}},
-	}
-	bvs := []map[string]*querypb.BindVariable{nil, nil, nil, nil}
 
 	var results []*sqltypes.Result
-	err := MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error {
+	err := testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -165,33 +152,27 @@ func TestMergeSortDescending(t *testing.T) {
 
 func TestMergeSortEmptyResults(t *testing.T) {
 	idColFields := sqltypes.MakeTestFields("id|col", "int32|varchar")
-	vc := &streamVCursor{
-		shardResults: map[string]*shardResult{
-			"0": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"1|a",
-				"7|g",
-			)},
-			"1": {results: sqltypes.MakeTestStreamingResults(idColFields)},
-			"2": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"4|d",
-				"6|f",
-			)},
-			"3": {results: sqltypes.MakeTestStreamingResults(idColFields)},
-		},
-	}
+	shardResults := []*shardResult{{
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"1|a",
+			"7|g",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"4|d",
+			"6|f",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields),
+	}}
 	orderBy := []OrderbyParams{{
 		Col: 0,
 	}}
-	rss := []*srvtopo.ResolvedShard{
-		{Target: &querypb.Target{Shard: "0"}},
-		{Target: &querypb.Target{Shard: "1"}},
-		{Target: &querypb.Target{Shard: "2"}},
-		{Target: &querypb.Target{Shard: "3"}},
-	}
-	bvs := []map[string]*querypb.BindVariable{nil, nil, nil, nil}
 
 	var results []*sqltypes.Result
-	err := MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error {
+	err := testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
 		return nil
 	})
@@ -215,22 +196,15 @@ func TestMergeSortEmptyResults(t *testing.T) {
 // TestMergeSortResultFailures tests failures at various
 // stages of result return.
 func TestMergeSortResultFailures(t *testing.T) {
-	vc := &streamVCursor{
-		shardResults: make(map[string]*shardResult),
-	}
 	orderBy := []OrderbyParams{{
 		Col: 0,
 	}}
-	rss := []*srvtopo.ResolvedShard{
-		{Target: &querypb.Target{Shard: "0"}},
-	}
-	bvs := []map[string]*querypb.BindVariable{nil}
 
 	// Test early error.
-	vc.shardResults["0"] = &shardResult{
+	shardResults := []*shardResult{{
 		sendErr: errors.New("early error"),
-	}
-	err := MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error { return nil })
+	}}
+	err := testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error { return nil })
 	want := "early error"
 	if err == nil || err.Error() != want {
 		t.Errorf("MergeSort(): %v, want %v", err, want)
@@ -238,22 +212,22 @@ func TestMergeSortResultFailures(t *testing.T) {
 
 	// Test fail after fields.
 	idFields := sqltypes.MakeTestFields("id", "int32")
-	vc.shardResults["0"] = &shardResult{
+	shardResults = []*shardResult{{
 		results: sqltypes.MakeTestStreamingResults(idFields),
 		sendErr: errors.New("fail after fields"),
-	}
-	err = MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error { return nil })
+	}}
+	err = testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error { return nil })
 	want = "fail after fields"
 	if err == nil || err.Error() != want {
 		t.Errorf("MergeSort(): %v, want %v", err, want)
 	}
 
 	// Test fail after first row.
-	vc.shardResults["0"] = &shardResult{
+	shardResults = []*shardResult{{
 		results: sqltypes.MakeTestStreamingResults(idFields, "1"),
 		sendErr: errors.New("fail after first row"),
-	}
-	err = MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error { return nil })
+	}}
+	err = testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error { return nil })
 	want = "fail after first row"
 	if err == nil || err.Error() != want {
 		t.Errorf("MergeSort(): %v, want %v", err, want)
@@ -264,26 +238,20 @@ func TestMergeSortDataFailures(t *testing.T) {
 	// The first row being bad fails in a different code path than
 	// the case of subsequent rows. So, test the two cases separately.
 	idColFields := sqltypes.MakeTestFields("id|col", "int32|varchar")
-	vc := &streamVCursor{
-		shardResults: map[string]*shardResult{
-			"0": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"1|a",
-			)},
-			"1": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"2.1|b",
-			)},
-		},
-	}
+	shardResults := []*shardResult{{
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"1|a",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"2.1|b",
+		),
+	}}
 	orderBy := []OrderbyParams{{
 		Col: 0,
 	}}
-	rss := []*srvtopo.ResolvedShard{
-		{Target: &querypb.Target{Shard: "0"}},
-		{Target: &querypb.Target{Shard: "1"}},
-	}
-	bvs := []map[string]*querypb.BindVariable{nil, nil}
 
-	err := MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error { return nil })
+	err := testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error { return nil })
 	want := `strconv.ParseInt: parsing "2.1": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("MergeSort(): %v, want %v", err, want)
@@ -291,50 +259,48 @@ func TestMergeSortDataFailures(t *testing.T) {
 
 	// Create a new VCursor because the previous MergeSort will still
 	// have lingering goroutines that can cause data race.
-	vc = &streamVCursor{
-		shardResults: map[string]*shardResult{
-			"0": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"1|a",
-				"1.1|a",
-			)},
-			"1": {results: sqltypes.MakeTestStreamingResults(idColFields,
-				"2|b",
-			)},
-		},
-	}
-	err = MergeSort(vc, "", orderBy, rss, bvs, func(qr *sqltypes.Result) error { return nil })
+	shardResults = []*shardResult{{
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"1|a",
+			"1.1|a",
+		),
+	}, {
+		results: sqltypes.MakeTestStreamingResults(idColFields,
+			"2|b",
+		),
+	}}
+	err = testMergeSort(shardResults, orderBy, func(qr *sqltypes.Result) error { return nil })
 	want = `strconv.ParseInt: parsing "1.1": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("MergeSort(): %v, want %v", err, want)
 	}
 }
 
+func testMergeSort(shardResults []*shardResult, orderBy []OrderbyParams, callback func(qr *sqltypes.Result) error) error {
+	prims := make([]StreamExecuter, 0, len(shardResults))
+	for _, sr := range shardResults {
+		prims = append(prims, sr)
+	}
+	ms := MergeSort{
+		Primitives: prims,
+		OrderBy:    orderBy,
+	}
+	return ms.StreamExecute(noopVCursor{}, nil, true, callback)
+}
+
 type shardResult struct {
+	// shardRoute helps us avoid redefining the Primitive functions.
+	shardRoute
+
 	results []*sqltypes.Result
-	// sendErr is sent at the end of the stream if it's set.
 	sendErr error
 }
 
-// streamVCursor fakes a VCursor that supports
-// a single-shard streaming query through StreamExecuteMulti.
-type streamVCursor struct {
-	noopVCursor
-
-	shardResults map[string]*shardResult
-}
-
-// StreamExecuteMulti streams a result from the specified shard.
-// The shard is specified by the only entry in shardVars. At the
-// end of a stream, if sendErr is set, that error is returned.
-func (t *streamVCursor) StreamExecuteMulti(query string, rss []*srvtopo.ResolvedShard, bindVars []map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error {
-	shard := rss[0].Target.Shard
-	for _, r := range t.shardResults[shard].results {
+func (sr *shardResult) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	for _, r := range sr.results {
 		if err := callback(r); err != nil {
 			return err
 		}
 	}
-	if t.shardResults[shard].sendErr != nil {
-		return t.shardResults[shard].sendErr
-	}
-	return nil
+	return sr.sendErr
 }

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -277,7 +277,7 @@ func TestMergeSortDataFailures(t *testing.T) {
 }
 
 func testMergeSort(shardResults []*shardResult, orderBy []OrderbyParams, callback func(qr *sqltypes.Result) error) error {
-	prims := make([]StreamExecuter, 0, len(shardResults))
+	prims := make([]StreamExecutor, 0, len(shardResults))
 	for _, sr := range shardResults {
 		prims = append(prims, sr)
 	}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -333,6 +333,8 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 			return callback(qr.Truncate(route.TruncateColumnCount))
 		})
 	}
+
+	// There is an order by. We have to merge-sort.
 	prims := make([]StreamExecuter, 0, len(rss))
 	for i, rs := range rss {
 		prims = append(prims, &shardRoute{
@@ -345,7 +347,6 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 		Primitives: prims,
 		OrderBy:    route.OrderBy,
 	}
-
 	return ms.StreamExecute(vcursor, bindVars, wantfields, func(qr *sqltypes.Result) error {
 		return callback(qr.Truncate(route.TruncateColumnCount))
 	})

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -335,7 +335,7 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 	}
 
 	// There is an order by. We have to merge-sort.
-	prims := make([]StreamExecuter, 0, len(rss))
+	prims := make([]StreamExecutor, 0, len(rss))
 	for i, rs := range rss {
 		prims = append(prims, &shardRoute{
 			query: route.Query,

--- a/go/vt/vtgate/engine/shard_route.go
+++ b/go/vt/vtgate/engine/shard_route.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
+)
+
+var _ StreamExecuter = (*shardRoute)(nil)
+
+// shardRoute is an internal primitive used by Route
+// for performing merge sorts.
+type shardRoute struct {
+	query string
+	rs    *srvtopo.ResolvedShard
+	bv    map[string]*querypb.BindVariable
+}
+
+// StreamExecute performs a streaming exec.
+func (sr *shardRoute) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	return vcursor.StreamExecuteMulti(sr.query, []*srvtopo.ResolvedShard{sr.rs}, []map[string]*querypb.BindVariable{sr.bv}, callback)
+}

--- a/go/vt/vtgate/engine/shard_route.go
+++ b/go/vt/vtgate/engine/shard_route.go
@@ -22,7 +22,7 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 )
 
-var _ StreamExecuter = (*shardRoute)(nil)
+var _ StreamExecutor = (*shardRoute)(nil)
 
 // shardRoute is an internal primitive used by Route
 // for performing merge sorts.

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -91,7 +91,7 @@ type tableDiffer struct {
 
 // shardStreamer streams rows from one shard. This works for
 // the source as well as the target.
-// shardStreamer satisfies engine.StreamExecuter, and can be
+// shardStreamer satisfies engine.StreamExecutor, and can be
 // added to Primitives of engine.MergeSort.
 // shardStreamer is a member of vdiff, and gets reused by
 // every tableDiffer. A new result channel gets instantiated
@@ -386,7 +386,7 @@ func (df *vdiff) buildTablePlan(table *tabletmanagerdatapb.TableDefinition, quer
 
 // newMergeSorter creates an engine.MergeSort based on the shard streamers and pk columns.
 func newMergeSorter(participants map[string]*shardStreamer, comparePKs []int) *engine.MergeSort {
-	prims := make([]engine.StreamExecuter, 0, len(participants))
+	prims := make([]engine.StreamExecutor, 0, len(participants))
 	for _, participant := range participants {
 		prims = append(prims, participant)
 	}

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -74,8 +74,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -89,8 +89,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -104,8 +104,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -119,8 +119,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c2, c1 from t1 order by c1 asc",
 			compareCols:      []int{0, -1},
 			comparePKs:       []int{1},
-			sourcePrimitive:  newMergeSorter([]int{1}),
-			targetPrimitive:  newMergeSorter([]int{1}),
+			sourcePrimitive:  newMergeSorter(nil, []int{1}),
+			targetPrimitive:  newMergeSorter(nil, []int{1}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -134,8 +134,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// non-pk text column.
@@ -150,8 +150,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, textcol, weight_string(textcol) from nonpktext order by c1 asc",
 			compareCols:      []int{-1, 2},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// non-pk text column, different order.
@@ -166,8 +166,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select textcol, c1, weight_string(textcol) from nonpktext order by c1 asc",
 			compareCols:      []int{2, -1},
 			comparePKs:       []int{1},
-			sourcePrimitive:  newMergeSorter([]int{1}),
-			targetPrimitive:  newMergeSorter([]int{1}),
+			sourcePrimitive:  newMergeSorter(nil, []int{1}),
+			targetPrimitive:  newMergeSorter(nil, []int{1}),
 		},
 	}, {
 		// pk text column.
@@ -182,8 +182,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select textcol, c2, weight_string(textcol) from pktext order by textcol asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter([]int{2}),
-			targetPrimitive:  newMergeSorter([]int{2}),
+			sourcePrimitive:  newMergeSorter(nil, []int{2}),
+			targetPrimitive:  newMergeSorter(nil, []int{2}),
 		},
 	}, {
 		// pk text column, different order.
@@ -198,8 +198,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c2, textcol, weight_string(textcol) from pktext order by textcol asc",
 			compareCols:      []int{0, -1},
 			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter([]int{2}),
-			targetPrimitive:  newMergeSorter([]int{2}),
+			sourcePrimitive:  newMergeSorter(nil, []int{2}),
+			targetPrimitive:  newMergeSorter(nil, []int{2}),
 		},
 	}, {
 		// text column as expression.
@@ -214,8 +214,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c2, textcol, weight_string(textcol) from pktext order by textcol asc",
 			compareCols:      []int{0, -1},
 			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter([]int{2}),
-			targetPrimitive:  newMergeSorter([]int{2}),
+			sourcePrimitive:  newMergeSorter(nil, []int{2}),
+			targetPrimitive:  newMergeSorter(nil, []int{2}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -228,8 +228,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from multipk order by c1 asc, c2 asc",
 			compareCols:      []int{-1, -1},
 			comparePKs:       []int{0, 1},
-			sourcePrimitive:  newMergeSorter([]int{0, 1}),
-			targetPrimitive:  newMergeSorter([]int{0, 1}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0, 1}),
+			targetPrimitive:  newMergeSorter(nil, []int{0, 1}),
 		},
 	}, {
 		// in_keyrange
@@ -244,8 +244,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// in_keyrange on RHS of AND.
@@ -261,8 +261,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// in_keyrange on LHS of AND.
@@ -278,8 +278,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// in_keyrange on cascaded AND expression
@@ -295,8 +295,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// in_keyrange parenthesized
@@ -312,8 +312,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// group by
@@ -328,8 +328,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter([]int{0}),
-			targetPrimitive:  newMergeSorter([]int{0}),
+			sourcePrimitive:  newMergeSorter(nil, []int{0}),
+			targetPrimitive:  newMergeSorter(nil, []int{0}),
 		},
 	}, {
 		// aggregations
@@ -353,17 +353,18 @@ func TestVDiffPlanSuccess(t *testing.T) {
 					Col:    3,
 				}},
 				Keys:  []int{0},
-				Input: newMergeSorter([]int{0}),
+				Input: newMergeSorter(nil, []int{0}),
 			},
-			targetPrimitive: newMergeSorter([]int{0}),
+			targetPrimitive: newMergeSorter(nil, []int{0}),
 		},
 	}}
 	for _, tcase := range testcases {
 		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-		differs, err := buildVDiffPlan(context.Background(), filter, schm)
+		df := &vdiff{}
+		err := df.buildVDiffPlan(context.Background(), filter, schm)
 		require.NoError(t, err, tcase.input)
-		require.Equal(t, 1, len(differs), tcase.input)
-		assert.Equal(t, tcase.td, differs[tcase.table], tcase.input)
+		require.Equal(t, 1, len(df.differs), tcase.input)
+		assert.Equal(t, tcase.td, df.differs[tcase.table], tcase.input)
 	}
 }
 
@@ -413,7 +414,8 @@ func TestVDiffPlanFailure(t *testing.T) {
 	}}
 	for _, tcase := range testcases {
 		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-		_, err := buildVDiffPlan(context.Background(), filter, schm)
+		df := &vdiff{}
+		err := df.buildVDiffPlan(context.Background(), filter, schm)
 		assert.EqualError(t, err, tcase.err, tcase.input)
 	}
 }


### PR DESCRIPTION
MergeSort as a function that required a VCursor that performed
scatter queries was hard to use from outside of the engine code.

In the new change, MergeSort is a Primitive that directly drives
other sub-Primitives. This greatly simplifies the vdiff code,
removing the need for a mergeSorter and a resultStreamer.