### PR TITLE
Java Netty Version bump to Fix Vulnerability

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,8 +70,8 @@
     <grpc.version>1.16.0</grpc.version>
     <!-- NOTE Netty handler and boring SSL must be kept compatible with grpc
       https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.handler.version>4.1.30.Final</netty.handler.version>
-    <tcnative.boring.ssl.version>2.0.17.Final</tcnative.boring.ssl.version>
+    <netty.handler.version>4.1.45.Final</netty.handler.version>
+    <tcnative.boring.ssl.version>2.0.28.Final</tcnative.boring.ssl.version>
 
     <protobuf.java.version>3.6.1</protobuf.java.version>
     <protobuf.protoc.version>3.6.1</protobuf.protoc.version>


### PR DESCRIPTION
bump netty-handler to 4.1.45.Final and tcnative-boring-ssl to 2.0.28.Final to Fix Vulnerability

Signed-off-by: Harshit Gangal <harshit@planetscale.com>