### PR TITLE
tablet query engine: introduce -enable-consolidator-replicas

### DIFF
--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -52,6 +52,21 @@ func NewClient() *QueryClient {
 	}
 }
 
+// NewClientWithTabletType creates a new client for Server with the provided tablet type.
+func NewClientWithTabletType(tabletType topodatapb.TabletType) *QueryClient {
+	targetCopy := Target
+	targetCopy.TabletType = tabletType
+	return &QueryClient{
+		ctx: callerid.NewContext(
+			context.Background(),
+			&vtrpcpb.CallerID{},
+			&querypb.VTGateCallerID{Username: "dev"},
+		),
+		target: targetCopy,
+		server: Server,
+	}
+}
+
 // NewClientWithContext creates a new client for Server with the provided context.
 func NewClientWithContext(ctx context.Context) *QueryClient {
 	return &QueryClient{

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -166,6 +166,7 @@ type QueryEngine struct {
 	strictTransTables bool
 
 	enableConsolidator          bool
+	enableConsolidatorReplicas  bool
 	enableQueryPlanFieldCaching bool
 
 	// Loggers
@@ -206,6 +207,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		checker,
 	)
 	qe.enableConsolidator = config.EnableConsolidator
+	qe.enableConsolidatorReplicas = config.EnableConsolidatorReplicas
 	qe.enableQueryPlanFieldCaching = config.EnableQueryPlanFieldCaching
 	qe.consolidator = sync2.NewConsolidator()
 	qe.txSerializer = txserializer.New(config.EnableHotRowProtectionDryRun,

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -41,6 +41,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
@@ -55,6 +56,7 @@ type QueryExecutor struct {
 	ctx            context.Context
 	logStats       *tabletenv.LogStats
 	tsv            *TabletServer
+	tabletType     topodata.TabletType
 }
 
 var sequenceFields = []*querypb.Field{
@@ -829,7 +831,8 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 	if err != nil {
 		return nil, err
 	}
-	if qre.tsv.qe.enableConsolidator {
+	// Check tablet type.
+	if qre.tsv.qe.enableConsolidator || (qre.tsv.qe.enableConsolidatorReplicas && qre.tabletType != topodata.TabletType_MASTER) {
 		q, original := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 		if original {
 			defer q.Broadcast()

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -105,6 +105,7 @@ func init() {
 
 	flag.BoolVar(&Config.EnforceStrictTransTables, "enforce_strict_trans_tables", DefaultQsConfig.EnforceStrictTransTables, "If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database.")
 	flag.BoolVar(&Config.EnableConsolidator, "enable-consolidator", DefaultQsConfig.EnableConsolidator, "This option enables the query consolidator.")
+	flag.BoolVar(&Config.EnableConsolidatorReplicas, "enable-consolidator-replicas", DefaultQsConfig.EnableConsolidatorReplicas, "This option enables the query consolidator only on replicas.")
 	flag.BoolVar(&Config.EnableQueryPlanFieldCaching, "enable-query-plan-field-caching", DefaultQsConfig.EnableQueryPlanFieldCaching, "This option fetches & caches fields (columns) when storing query plans")
 }
 
@@ -182,6 +183,7 @@ type TabletConfig struct {
 
 	EnforceStrictTransTables    bool
 	EnableConsolidator          bool
+	EnableConsolidatorReplicas  bool
 	EnableQueryPlanFieldCaching bool
 }
 
@@ -262,6 +264,7 @@ var DefaultQsConfig = TabletConfig{
 
 	EnforceStrictTransTables:    true,
 	EnableConsolidator:          true,
+	EnableConsolidatorReplicas:  false,
 	EnableQueryPlanFieldCaching: true,
 }
 


### PR DESCRIPTION
This diff creates the possibility to start a tablet with
"-enable-consolidator=false -enable-consolidator-replicas" so
that query consolidation is enabled only for non-master instance
types.

This allows using the consolidator while keeping the agreement that
OLTP reads from master have read-committed consistency, while replicas
have inconsistent reads.

See #4058