### PR TITLE
Docker-compose client.sh fails on permissions

### DIFF
--- a/examples/compose/client.sh
+++ b/examples/compose/client.sh
@@ -25,4 +25,4 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # This is a convenience script to run the client.go script
-exec $tty docker-compose exec ${CS:-vtgate} go run ${script:-/script/client.go} -server=vtgate:15999
+exec $tty docker-compose exec -u root ${CS:-vtgate} go run ${script:-/script/client.go} -server=vtgate:15999


### PR DESCRIPTION
Vitess/base is built using root and pkg/cache is mostly root, but default user later changed to vitess, so using example client.go fails on /go/pkg/cache permissions; this fixes it without changing docker image, and localised just to this shell script