### PR TITLE
mysql: flush buffer on inactivity

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -185,6 +187,19 @@ func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.R
 					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(c.UserData.Get().Username)),
 				},
 			},
+		})
+	case "50ms delay":
+		callback(&sqltypes.Result{
+			Fields: []*querypb.Field{{
+				Name: "result",
+				Type: querypb.Type_VARCHAR,
+			}},
+		})
+		time.Sleep(50 * time.Millisecond)
+		callback(&sqltypes.Result{
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("delayed")),
+			}},
 		})
 	default:
 		if strings.HasPrefix(query, benchmarkQueryPrefix) {
@@ -1367,4 +1382,49 @@ func TestParseConnAttrs(t *testing.T) {
 			t.Fatalf("Error reading key %s from connection attributes: attrs: %-v", k, attrs)
 		}
 	}
+}
+
+func TestServerFlush(t *testing.T) {
+	defer func(saved time.Duration) { *mysqlServerFlushDelay = saved }(*mysqlServerFlushDelay)
+	*mysqlServerFlushDelay = 10 * time.Millisecond
+
+	th := &testHandler{}
+
+	l, err := NewListener("tcp", ":0", &AuthServerNone{}, th, 0, 0, false)
+	require.NoError(t, err)
+	defer l.Close()
+	go l.Accept()
+
+	host, port := getHostPort(t, l.Addr())
+	params := &ConnParams{
+		Host: host,
+		Port: port,
+	}
+
+	c, err := Connect(context.Background(), params)
+	require.NoError(t, err)
+	defer c.Close()
+
+	start := time.Now()
+	err = c.ExecuteStreamFetch("50ms delay")
+	require.NoError(t, err)
+
+	flds, err := c.Fields()
+	require.NoError(t, err)
+	if duration, want := time.Since(start), 20*time.Millisecond; duration < *mysqlServerFlushDelay || duration > want {
+		t.Errorf("duration: %v, want between %v and %v", duration, *mysqlServerFlushDelay, want)
+	}
+	want1 := []*querypb.Field{{
+		Name: "result",
+		Type: querypb.Type_VARCHAR,
+	}}
+	assert.Equal(t, want1, flds)
+
+	row, err := c.FetchNext()
+	require.NoError(t, err)
+	if duration, want := time.Since(start), 50*time.Millisecond; duration < want {
+		t.Errorf("duration: %v, want > %v", duration, want)
+	}
+	want2 := []sqltypes.Value{sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("delayed"))}
+	assert.Equal(t, want2, row)
 }


### PR DESCRIPTION
The mysql server uses buffered I/O. This works fine if the results
are streamed all at once. But if the streaming is intermitent, like
in the case of messages, the client may not get timely responses.

This new change flushes any unsent data if no other data is sent
within mysql_server_flush_delay (100ms).

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>