### PR TITLE
vrepl: improve row and result streamers

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -126,7 +126,7 @@ func buildReplicatorPlan(filter *binlogdatapb.Filter, tableKeys map[string][]str
 	return plan, nil
 }
 
-// MatchTable is similar to tableMatches defined in vstreamer.
+// MatchTable is similar to tableMatches and buildPlan defined in vstreamer/planbuilder.go.
 func MatchTable(tableName string, filter *binlogdatapb.Filter) (*binlogdatapb.Rule, error) {
 	for _, rule := range filter.Rules {
 		switch {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -22,7 +22,6 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -43,6 +42,14 @@ func NewRowStreamer(ctx context.Context, cp *mysql.ConnParams, se *schema.Engine
 	return newRowStreamer(ctx, cp, se, query, lastpk, &localVSchema{vschema: &vindexes.VSchema{}}, send)
 }
 
+// rowStreamer is used for copying the existing rows of a table
+// before vreplication begins streaming binlogs. The rowStreamer
+// responds to a request with the GTID position as of which it
+// streams the rows of a table. This allows vreplication to synchronize
+// its events as of the returned GTID before adding the new rows.
+// For every set of rows sent, the last pk value is also sent.
+// This allows for the streaming to be resumed based on the last
+// pk value processed.
 type rowStreamer struct {
 	ctx    context.Context
 	cancel func()
@@ -88,7 +95,7 @@ func (rs *rowStreamer) Stream() error {
 		return err
 	}
 
-	conn, err := rs.mysqlConnect()
+	conn, err := snapshotConnect(rs.ctx, rs.cp)
 	if err != nil {
 		return err
 	}
@@ -114,6 +121,10 @@ func (rs *rowStreamer) buildPlan() error {
 		Name:    st.Name.String(),
 		Columns: st.Columns,
 	}
+	// The plan we build is identical to the one for vstreamer.
+	// This is because the row format of a read is identical
+	// to the row format of a binlog event. So, the same
+	// filtering will work.
 	rs.plan, err = buildTablePlan(ti, rs.vschema, rs.query)
 	if err != nil {
 		return err
@@ -147,6 +158,7 @@ func buildPKColumns(st *schema.Table) ([]int, error) {
 
 func (rs *rowStreamer) buildSelect() (string, error) {
 	buf := sqlparser.NewTrackedBuffer(nil)
+	// We could have used select *, but being explicit is more predictable.
 	buf.Myprintf("select ")
 	prefix := ""
 	for _, col := range rs.plan.Table.Columns {
@@ -160,6 +172,11 @@ func (rs *rowStreamer) buildSelect() (string, error) {
 		}
 		buf.WriteString(" where ")
 		prefix := ""
+		// This loop handles the case for composite pks. For example,
+		// if lastpk was (1,2), the where clause would be:
+		// (col1 = 1 and col2 > 2) or (col1 > 1).
+		// A tuple inequality like (col1,col2) > (1,2) ends up
+		// being a full table scan for mysql.
 		for lastcol := len(rs.pkColumns) - 1; lastcol >= 0; lastcol-- {
 			buf.Myprintf("%s(", prefix)
 			prefix = " or "
@@ -182,8 +199,9 @@ func (rs *rowStreamer) buildSelect() (string, error) {
 	return buf.String(), nil
 }
 
-func (rs *rowStreamer) streamQuery(conn *mysql.Conn, send func(*binlogdatapb.VStreamRowsResponse) error) error {
-	gtid, err := rs.startStreaming(conn)
+func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.VStreamRowsResponse) error) error {
+	log.Infof("Streaming query: %v\n", rs.sendQuery)
+	gtid, err := conn.streamWithSnapshot(rs.ctx, rs.plan.Table.Name, rs.sendQuery)
 	if err != nil {
 		return err
 	}
@@ -227,9 +245,12 @@ func (rs *rowStreamer) streamQuery(conn *mysql.Conn, send func(*binlogdatapb.VSt
 		if row == nil {
 			break
 		}
+		// Compute lastpk here, because we'll neeed it
+		// at the end after the loop exits.
 		for i, pk := range rs.pkColumns {
 			lastpk[i] = row[pk]
 		}
+		// Reuse the vstreamer's filter.
 		ok, filtered, err := rs.plan.filter(row)
 		if err != nil {
 			return err
@@ -249,7 +270,7 @@ func (rs *rowStreamer) streamQuery(conn *mysql.Conn, send func(*binlogdatapb.VSt
 			}
 			// empty the rows so we start over, but we keep the
 			// same capacity
-			response.Rows = response.Rows[:0]
+			response.Rows = nil
 			byteCount = 0
 		}
 	}
@@ -263,45 +284,4 @@ func (rs *rowStreamer) streamQuery(conn *mysql.Conn, send func(*binlogdatapb.VSt
 	}
 
 	return nil
-}
-
-func (rs *rowStreamer) startStreaming(conn *mysql.Conn) (string, error) {
-	lockConn, err := rs.mysqlConnect()
-	if err != nil {
-		return "", err
-	}
-	// To be safe, always unlock tables, even if lock tables might fail.
-	defer func() {
-		_, err := lockConn.ExecuteFetch("unlock tables", 0, false)
-		if err != nil {
-			log.Warning("Unlock tables failed: %v", err)
-		} else {
-			log.Infof("Tables unlocked", rs.plan.Table.Name)
-		}
-		lockConn.Close()
-	}()
-
-	log.Infof("Locking table %s for copying", rs.plan.Table.Name)
-	if _, err := lockConn.ExecuteFetch(fmt.Sprintf("lock tables %s read", sqlparser.String(sqlparser.NewTableIdent(rs.plan.Table.Name))), 0, false); err != nil {
-		return "", err
-	}
-	pos, err := lockConn.MasterPosition()
-	if err != nil {
-		return "", err
-	}
-
-	log.Infof("Streaming query: %v\n", rs.sendQuery)
-	if err := conn.ExecuteStreamFetch(rs.sendQuery); err != nil {
-		return "", err
-	}
-
-	return mysql.EncodePosition(pos), nil
-}
-
-func (rs *rowStreamer) mysqlConnect() (*mysql.Conn, error) {
-	cp, err := dbconfigs.WithCredentials(rs.cp)
-	if err != nil {
-		return nil, err
-	}
-	return mysql.Connect(rs.ctx, cp)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamer
+
+import (
+	"context"
+	"fmt"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// snapshotConn is wrapper on mysql.Conn capable of
+// reading a table along with a gtid snapshot.
+type snapshotConn struct {
+	*mysql.Conn
+	cp *mysql.ConnParams
+}
+
+func snapshotConnect(ctx context.Context, cp *mysql.ConnParams) (*snapshotConn, error) {
+	mconn, err := mysqlConnect(ctx, cp)
+	if err != nil {
+		return nil, err
+	}
+	return &snapshotConn{
+		Conn: mconn,
+		cp:   cp,
+	}, nil
+}
+
+// startSnapshot starts a streaming query with a snapshot view of the specified table.
+// It returns the gtid of the time when the snapshot was taken.
+func (conn *snapshotConn) streamWithSnapshot(ctx context.Context, table, query string) (gtid string, err error) {
+	gtid, err = conn.startSnapshot(ctx, table)
+	if err != nil {
+		return "", err
+	}
+	if err := conn.ExecuteStreamFetch(query); err != nil {
+		return "", err
+	}
+	return gtid, nil
+}
+
+// snapshot performs the snapshotting.
+func (conn *snapshotConn) startSnapshot(ctx context.Context, table string) (gtid string, err error) {
+	lockConn, err := mysqlConnect(ctx, conn.cp)
+	if err != nil {
+		return "", err
+	}
+	// To be safe, always unlock tables, even if lock tables might fail.
+	defer func() {
+		_, err := lockConn.ExecuteFetch("unlock tables", 0, false)
+		if err != nil {
+			log.Warning("Unlock tables failed: %v", err)
+		} else {
+			log.Infof("Tables unlocked: %v", table)
+		}
+		lockConn.Close()
+	}()
+
+	tableIdent := sqlparser.String(sqlparser.NewTableIdent(table))
+
+	log.Infof("Locking table %s for copying", table)
+	if _, err := lockConn.ExecuteFetch(fmt.Sprintf("lock tables %s read", tableIdent), 1, false); err != nil {
+		return "", err
+	}
+	mpos, err := lockConn.MasterPosition()
+	if err != nil {
+		return "", err
+	}
+
+	// Starting a transaction now will allow us to start the read later,
+	// which will happen after we release the lock on the table.
+	if _, err := conn.ExecuteFetch("set transaction isolation level repeatable read", 1, false); err != nil {
+		return "", err
+	}
+	if _, err := conn.ExecuteFetch("start transaction read only", 1, false); err != nil {
+		return "", err
+	}
+	// For the transaction to really start, we have to perform a read.
+	if _, err := conn.ExecuteFetch(fmt.Sprintf("select 1 from %s limit 1", tableIdent), 1, false); err != nil {
+		return "", err
+	}
+	return mysql.EncodePosition(mpos), nil
+}
+
+// Close rollsback any open transactions and closes the connection.
+func (conn *snapshotConn) Close() {
+	_, _ = conn.ExecuteFetch("rollback", 1, false)
+	conn.Conn.Close()
+}
+
+func mysqlConnect(ctx context.Context, cp *mysql.ConnParams) (*mysql.Conn, error) {
+	cp, err := dbconfigs.WithCredentials(cp)
+	if err != nil {
+		return nil, err
+	}
+	return mysql.Connect(ctx, cp)
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vstreamer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/sqltypes"
+)
+
+func TestStartSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	execStatements(t, []string{
+		"create table t1(id int, val varbinary(128), primary key(id))",
+		"insert into t1 values (1, 'aaa')",
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+	})
+
+	ctx := context.Background()
+	conn, err := snapshotConnect(ctx, engine.cp)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	conn.startSnapshot(ctx, "t1")
+
+	// This second row should not be in the result.
+	execStatement(t, "insert into t1 values(2, 'bbb')")
+
+	wantqr := &sqltypes.Result{
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewInt32(1), sqltypes.NewVarBinary("aaa")},
+		},
+		RowsAffected: 1,
+	}
+	qr, err := conn.ExecuteFetch("select * from t1", 10, false)
+	require.NoError(t, err)
+	assert.Equal(t, wantqr, qr)
+}


### PR DESCRIPTION
The new implementation starts a transaction after locking the
tables instead of issuing the read query. This guarantees that
we'll release the table locks immediately. Otherwise, there's
no guarantee about when the first results will be returned.

Also, the logic to do the snapshotting has been moved into
a reusable connection wrapper, which is a more elegant approach.

Also added more comments to vstreamer.go
