### PR TITLE
fix flakiness of TestMessageManagerSend

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -219,6 +219,16 @@ func TestMessageManagerSend(t *testing.T) {
 		t.Errorf("Postpone: %s, want %v", got, want)
 	}
 
+	// Wait while the receiver is marked as busy.
+	for {
+		mm.mu.Lock()
+		busy := mm.receivers[0].busy
+		mm.mu.Unlock()
+		if !busy {
+			break
+		}
+	}
+
 	// Verify item has been removed from cache.
 	// Need to obtain lock to prevent data race.
 	mm.cache.mu.Lock()


### PR DESCRIPTION
This PR is to fix #5652 .

The absence of an entry in `inFlight cache` is checked [here](https://github.com/vitessio/vitess/blob/6228dabf92c1305837cf8ecb54b8388237b419a7/go/vt/vttablet/tabletserver/messager/message_manager_test.go#L229), and sometimes, the check occurred before the cache is cleared [here](https://github.com/vitessio/vitess/blob/6228dabf92c1305837cf8ecb54b8388237b419a7/go/vt/vttablet/tabletserver/messager/message_manager.go#L475).

This PR fixes the problem by adding wait for the clean-up process to happen.