### PR TITLE
Log when we fail to accept a conn

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -55,6 +55,7 @@ var (
 	timings    = stats.NewTimings("MysqlServerTimings", "MySQL server timings", "operation")
 	connCount  = stats.NewGauge("MysqlServerConnCount", "Active MySQL server connections")
 	connAccept = stats.NewCounter("MysqlServerConnAccepted", "Connections accepted by MySQL server")
+	connRefuse = stats.NewCounter("MysqlServerConnRefused", "Connections refused by MySQL server")
 	connSlow   = stats.NewCounter("MysqlServerConnSlow", "Connections that took more than the configured mysql_slow_connect_warn_threshold to establish")
 
 	connCountByTLSVer = stats.NewGaugesWithSingleLabel("MysqlServerConnCountByTLSVer", "Active MySQL server connections by TLS version", "tls")
@@ -248,6 +249,7 @@ func (l *Listener) Accept() {
 		conn, err := l.listener.Accept()
 		if err != nil {
 			// Close() was probably called.
+			connRefuse.Add(1)
 			return
 		}
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -587,6 +587,7 @@ func TestServer(t *testing.T) {
 	initialTimingCounts := timings.Counts()
 	initialConnAccept := connAccept.Get()
 	initialConnSlow := connSlow.Get()
+	initialconnRefuse := connRefuse.Get()
 
 	// Run an 'error' command.
 	th.SetErr(NewSQLError(ERUnknownComError, SSUnknownComError, "forced query error"))
@@ -606,6 +607,9 @@ func TestServer(t *testing.T) {
 	}
 	if connSlow.Get()-initialConnSlow != 1 {
 		t.Errorf("Expected ConnSlow delta=1, got %d", connSlow.Get()-initialConnSlow)
+	}
+	if connRefuse.Get()-initialconnRefuse != 0 {
+		t.Errorf("Expected connRefuse delta=0, got %d", connRefuse.Get()-initialconnRefuse)
 	}
 
 	expectedTimingDeltas := map[string]int64{
@@ -643,6 +647,9 @@ func TestServer(t *testing.T) {
 	}
 	if connSlow.Get()-initialConnSlow != 1 {
 		t.Errorf("Expected ConnSlow delta=1, got %d", connSlow.Get()-initialConnSlow)
+	}
+	if connRefuse.Get()-initialconnRefuse != 0 {
+		t.Errorf("Expected connRefuse delta=0, got %d", connRefuse.Get()-initialconnRefuse)
 	}
 
 	// Run a 'select rows' command with results.
@@ -1299,6 +1306,7 @@ func TestListenerShutdown(t *testing.T) {
 		Uname: "user1",
 		Pass:  "password1",
 	}
+	initialconnRefuse := connRefuse.Get()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1313,6 +1321,10 @@ func TestListenerShutdown(t *testing.T) {
 	}
 
 	l.Shutdown()
+
+	if connRefuse.Get()-initialconnRefuse != 1 {
+		t.Errorf("Expected connRefuse delta=1, got %d", connRefuse.Get()-initialconnRefuse)
+	}
 
 	if err := conn.Ping(); err != nil {
 		sqlErr, ok := err.(*SQLError)


### PR DESCRIPTION
### Overview
This PR introduces a new counter that will track failures when attempting to accept connections to enable greater visibility into these error states. 

#### Testing 
Test cases were added to existing unit tests to ensure that we were incrementing the new `connClose` counter as intended. 