### PR TITLE
Instead of failing when trying to skip updates, fallback on slower mode

### DIFF
--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -307,10 +307,8 @@ func (lu *clCommon) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []b
 	equal := true
 	for i := range oldValues {
 		result, err := sqltypes.NullsafeCompare(oldValues[i], newValues[i])
-		if err != nil {
-			return err
-		}
-		if result != 0 {
+		// errors from NullsafeCompare can be ignored. if they are real problems, we'll see them in the Create/Update
+		if err != nil || result != 0 {
 			equal = false
 			break
 		}


### PR DESCRIPTION
When updating consistent lookup vindexes, we see if anything really did change,
before updating the vindex. If nothing changes, we can skip updating the vindex.

Sometimes, we encounter errors when checking if we can shortcut the updates.
Instead of passing on there errors, we'll now fall back on the slower mode and execute the update.

Signed-off-by: Andres Taylor <andres@planetscale.com>