### PR TITLE
test case run into docker

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -75,7 +75,15 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 		"--initial-cluster", fmt.Sprintf("%s=%s", topo.Name, topo.PeerURL),
 	)
 
-	errFile, _ := os.Create(path.Join(topo.DataDirectory, "topo-stderr.txt"))
+	err = createDirectory(topo.DataDirectory, 0700)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	errFile, err := os.Create(path.Join(topo.DataDirectory, "topo-stderr.txt"))
+	if err != nil {
+		return err
+	}
+
 	topo.proc.Stderr = errFile
 
 	topo.proc.Env = append(topo.proc.Env, os.Environ()...)


### PR DESCRIPTION
Testcase was failing at Add Cell info.

while it was trying to create cell in etcd it was failing because of invalid error file.
error file was invalid because process was not able to create the error file and there was no check in the error of file creation.

process was not able to create file because the etcd data directory was not avaiable at that time.