### PR TITLE
vstreamer: send immediate GTID on "current"

### DIFF
--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -1256,7 +1256,7 @@ func (m *Journal) GetSourceWorkflows() []string {
 type VEvent struct {
 	Type VEventType `protobuf:"varint,1,opt,name=type,proto3,enum=binlogdata.VEventType" json:"type,omitempty"`
 	// Timestamp is the binlog timestamp in seconds.
-	// It's set for all events.
+	// The value should be ignored if 0.
 	Timestamp int64 `protobuf:"varint,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	// Gtid is set if the event type is GTID.
 	Gtid string `protobuf:"bytes,3,opt,name=gtid,proto3" json:"gtid,omitempty"`

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -154,6 +154,15 @@ func (vs *vstreamer) Stream() error {
 	}
 	if vs.startPos == "current" {
 		vs.pos = curPos
+		vevents := []*binlogdatapb.VEvent{{
+			Type: binlogdatapb.VEventType_GTID,
+			Gtid: mysql.EncodePosition(vs.pos),
+		}, {
+			Type: binlogdatapb.VEventType_OTHER,
+		}}
+		if err := vs.send(vevents); err != nil {
+			return wrapError(err, vs.pos)
+		}
 	} else {
 		pos, err := mysql.DecodePosition(vs.startPos)
 		if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -1144,7 +1144,7 @@ func runCases(t *testing.T, filter *binlogdatapb.Filter, testcases []testcase, p
 	// If position is 'current', we wait for a heartbeat to be
 	// sure the vstreamer has started.
 	if position == "current" {
-		<-ch
+		expectLog(ctx, t, "current pos", ch, [][]string{{`gtid`, `type:OTHER `}})
 	}
 
 	for _, tcase := range testcases {
@@ -1212,9 +1212,6 @@ func expectLog(ctx context.Context, t *testing.T, input interface{}, ch <-chan [
 					t.Fatalf("%v (%d): event: %v, want commit", input, i, evs[i])
 				}
 			default:
-				if evs[i].Timestamp == 0 {
-					t.Fatalf("evs[%d].Timestamp: 0, want non-zero", i)
-				}
 				evs[i].Timestamp = 0
 				if got := fmt.Sprintf("%v", evs[i]); got != want {
 					t.Fatalf("%v (%d): event:\n%q, want\n%q", input, i, got, want)

--- a/proto/binlogdata.proto
+++ b/proto/binlogdata.proto
@@ -320,7 +320,7 @@ message Journal {
 message VEvent {
   VEventType type = 1;
   // Timestamp is the binlog timestamp in seconds.
-  // It's set for all events.
+  // The value should be ignored if 0.
   int64 timestamp = 2;
   // Gtid is set if the event type is GTID.
   string gtid = 3;


### PR DESCRIPTION
If the current position is requested as start for vstream, it will
be good to send the actual starting GTID as a separate event before
streaming the rest.

This is particularly useful for messager because it needs to know
its current position from the beginning in order to determine which
events to skip w.r.t to poller position.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>