### PR TITLE
Don't lower case keywords

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1774,8 +1774,14 @@ func TestKeywords(t *testing.T) {
 		input:  "select status from t",
 		output: "select `status` from t",
 	}, {
+		input:  "select Status from t",
+		output: "select `Status` from t",
+	}, {
 		input:  "select variables from t",
 		output: "select `variables` from t",
+	}, {
+		input:  "select Variables from t",
+		output: "select `Variables` from t",
 	}}
 
 	for _, tcase := range validSQL {

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -661,7 +661,7 @@ func (tkn *Tokenizer) scanIdentifier(firstByte byte, isDbSystemVariable bool) (i
 	lowered := bytes.ToLower(buffer.Bytes())
 	loweredStr := string(lowered)
 	if keywordID, found := keywords[loweredStr]; found {
-		return keywordID, lowered
+		return keywordID, buffer.Bytes()
 	}
 	// dual must always be case-insensitive
 	if loweredStr == "dual" {

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -19,12 +19,13 @@ package vtexplain
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 var testOutputTempDir string
@@ -142,7 +143,7 @@ func TestErrors(t *testing.T) {
 
 		{
 			SQL: "SELECT * FROM THIS IS NOT SQL",
-			Err: "vtexplain execute error in 'SELECT * FROM THIS IS NOT SQL': syntax error at position 22 near 'is'",
+			Err: "vtexplain execute error in 'SELECT * FROM THIS IS NOT SQL': syntax error at position 22 near 'IS'",
 		},
 
 		{


### PR DESCRIPTION
Before this change, non-reserved keywords would get their case changed when parsed.

```
SELECT Status FROM Table
```

was parsed as:

```
SELECT `status` FROM Table
```
