### PR TITLE
Remove parenthesis from the AST

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -174,8 +174,6 @@ func SplitAndExpression(filters []Expr, node Expr) []Expr {
 	case *AndExpr:
 		filters = SplitAndExpression(filters, node.Left)
 		return SplitAndExpression(filters, node.Right)
-	case *ParenExpr:
-		return SplitAndExpression(filters, node.Expr)
 	}
 	return append(filters, node)
 }

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -404,26 +404,12 @@ func TestNewPlanValue(t *testing.T) {
 		},
 	}, {
 		in: ValTuple{
-			&ParenExpr{Expr: &SQLVal{
-				Type: ValArg,
-				Val:  []byte(":valarg"),
-			}},
-		},
-		err: "expression is too complex",
-	}, {
-		in: ValTuple{
 			ListArg("::list"),
 		},
 		err: "unsupported: nested lists",
 	}, {
 		in:  &NullVal{},
 		out: sqltypes.PlanValue{},
-	}, {
-		in: &ParenExpr{Expr: &SQLVal{
-			Type: ValArg,
-			Val:  []byte(":valarg"),
-		}},
-		err: "expression is too complex",
 	}}
 	for _, tc := range tcases {
 		got, err := NewPlanValue(tc.in)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -536,7 +536,7 @@ type (
 	// RangeCond represents a BETWEEN or a NOT BETWEEN expression.
 	RangeCond struct {
 		Operator string
-		Expr     Expr
+		Left     Expr
 		From, To Expr
 	}
 
@@ -809,7 +809,7 @@ type TableIdent struct {
 
 // Format formats the node.
 func (node *Select) Format(buf *TrackedBuffer) {
-	buf.Myprintf("select %v%s%s%s%v from %v%v%v%v%v%v%s",
+	buf.astPrintf(node, "select %v%s%s%s%v from %v%v%v%v%v%v%s",
 		node.Comments, node.Cache, node.Distinct, node.Hints, node.SelectExprs,
 		node.From, node.Where,
 		node.GroupBy, node.Having, node.OrderBy,
@@ -818,24 +818,24 @@ func (node *Select) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *ParenSelect) Format(buf *TrackedBuffer) {
-	buf.Myprintf("(%v)", node.Select)
+	buf.astPrintf(node, "(%v)", node.Select)
 }
 
 // Format formats the node.
 func (node *Union) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v %s %v%v%v%s", node.Left, node.Type, node.Right,
+	buf.astPrintf(node, "%v %s %v%v%v%s", node.Left, node.Type, node.Right,
 		node.OrderBy, node.Limit, node.Lock)
 }
 
 // Format formats the node.
 func (node *Stream) Format(buf *TrackedBuffer) {
-	buf.Myprintf("stream %v%v from %v",
+	buf.astPrintf(node, "stream %v%v from %v",
 		node.Comments, node.SelectExpr, node.Table)
 }
 
 // Format formats the node.
 func (node *Insert) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s %v%sinto %v%v%v %v%v",
+	buf.astPrintf(node, "%s %v%sinto %v%v%v %v%v",
 		node.Action,
 		node.Comments, node.Ignore,
 		node.Table, node.Partitions, node.Columns, node.Rows, node.OnDup)
@@ -843,26 +843,26 @@ func (node *Insert) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *Update) Format(buf *TrackedBuffer) {
-	buf.Myprintf("update %v%s%v set %v%v%v%v",
+	buf.astPrintf(node, "update %v%s%v set %v%v%v%v",
 		node.Comments, node.Ignore, node.TableExprs,
 		node.Exprs, node.Where, node.OrderBy, node.Limit)
 }
 
 // Format formats the node.
 func (node *Delete) Format(buf *TrackedBuffer) {
-	buf.Myprintf("delete %v", node.Comments)
+	buf.astPrintf(node, "delete %v", node.Comments)
 	if node.Targets != nil {
-		buf.Myprintf("%v ", node.Targets)
+		buf.astPrintf(node, "%v ", node.Targets)
 	}
-	buf.Myprintf("from %v%v%v%v%v", node.TableExprs, node.Partitions, node.Where, node.OrderBy, node.Limit)
+	buf.astPrintf(node, "from %v%v%v%v%v", node.TableExprs, node.Partitions, node.Where, node.OrderBy, node.Limit)
 }
 
 // Format formats the node.
 func (node *Set) Format(buf *TrackedBuffer) {
 	if node.Scope == "" {
-		buf.Myprintf("set %v%v", node.Comments, node.Exprs)
+		buf.astPrintf(node, "set %v%v", node.Comments, node.Exprs)
 	} else {
-		buf.Myprintf("set %v%s %v", node.Comments, node.Scope, node.Exprs)
+		buf.astPrintf(node, "set %v%s %v", node.Comments, node.Scope, node.Exprs)
 	}
 }
 
@@ -885,79 +885,79 @@ func (node *DDL) Format(buf *TrackedBuffer) {
 	switch node.Action {
 	case CreateStr:
 		if node.OptLike != nil {
-			buf.Myprintf("%s table %v %v", node.Action, node.Table, node.OptLike)
+			buf.astPrintf(node, "%s table %v %v", node.Action, node.Table, node.OptLike)
 		} else if node.TableSpec != nil {
-			buf.Myprintf("%s table %v %v", node.Action, node.Table, node.TableSpec)
+			buf.astPrintf(node, "%s table %v %v", node.Action, node.Table, node.TableSpec)
 		} else {
-			buf.Myprintf("%s table %v", node.Action, node.Table)
+			buf.astPrintf(node, "%s table %v", node.Action, node.Table)
 		}
 	case DropStr:
 		exists := ""
 		if node.IfExists {
 			exists = " if exists"
 		}
-		buf.Myprintf("%s table%s %v", node.Action, exists, node.FromTables)
+		buf.astPrintf(node, "%s table%s %v", node.Action, exists, node.FromTables)
 	case RenameStr:
-		buf.Myprintf("%s table %v to %v", node.Action, node.FromTables[0], node.ToTables[0])
+		buf.astPrintf(node, "%s table %v to %v", node.Action, node.FromTables[0], node.ToTables[0])
 		for i := 1; i < len(node.FromTables); i++ {
-			buf.Myprintf(", %v to %v", node.FromTables[i], node.ToTables[i])
+			buf.astPrintf(node, ", %v to %v", node.FromTables[i], node.ToTables[i])
 		}
 	case AlterStr:
 		if node.PartitionSpec != nil {
-			buf.Myprintf("%s table %v %v", node.Action, node.Table, node.PartitionSpec)
+			buf.astPrintf(node, "%s table %v %v", node.Action, node.Table, node.PartitionSpec)
 		} else {
-			buf.Myprintf("%s table %v", node.Action, node.Table)
+			buf.astPrintf(node, "%s table %v", node.Action, node.Table)
 		}
 	case FlushStr:
-		buf.Myprintf("%s", node.Action)
+		buf.astPrintf(node, "%s", node.Action)
 	case CreateVindexStr:
-		buf.Myprintf("alter vschema create vindex %v %v", node.Table, node.VindexSpec)
+		buf.astPrintf(node, "alter vschema create vindex %v %v", node.Table, node.VindexSpec)
 	case DropVindexStr:
-		buf.Myprintf("alter vschema drop vindex %v", node.Table)
+		buf.astPrintf(node, "alter vschema drop vindex %v", node.Table)
 	case AddVschemaTableStr:
-		buf.Myprintf("alter vschema add table %v", node.Table)
+		buf.astPrintf(node, "alter vschema add table %v", node.Table)
 	case DropVschemaTableStr:
-		buf.Myprintf("alter vschema drop table %v", node.Table)
+		buf.astPrintf(node, "alter vschema drop table %v", node.Table)
 	case AddColVindexStr:
-		buf.Myprintf("alter vschema on %v add vindex %v (", node.Table, node.VindexSpec.Name)
+		buf.astPrintf(node, "alter vschema on %v add vindex %v (", node.Table, node.VindexSpec.Name)
 		for i, col := range node.VindexCols {
 			if i != 0 {
-				buf.Myprintf(", %v", col)
+				buf.astPrintf(node, ", %v", col)
 			} else {
-				buf.Myprintf("%v", col)
+				buf.astPrintf(node, "%v", col)
 			}
 		}
-		buf.Myprintf(")")
+		buf.astPrintf(node, ")")
 		if node.VindexSpec.Type.String() != "" {
-			buf.Myprintf(" %v", node.VindexSpec)
+			buf.astPrintf(node, " %v", node.VindexSpec)
 		}
 	case DropColVindexStr:
-		buf.Myprintf("alter vschema on %v drop vindex %v", node.Table, node.VindexSpec.Name)
+		buf.astPrintf(node, "alter vschema on %v drop vindex %v", node.Table, node.VindexSpec.Name)
 	case AddSequenceStr:
-		buf.Myprintf("alter vschema add sequence %v", node.Table)
+		buf.astPrintf(node, "alter vschema add sequence %v", node.Table)
 	case AddAutoIncStr:
-		buf.Myprintf("alter vschema on %v add auto_increment %v", node.Table, node.AutoIncSpec)
+		buf.astPrintf(node, "alter vschema on %v add auto_increment %v", node.Table, node.AutoIncSpec)
 	default:
-		buf.Myprintf("%s table %v", node.Action, node.Table)
+		buf.astPrintf(node, "%s table %v", node.Action, node.Table)
 	}
 }
 
 // Format formats the node.
 func (node *OptLike) Format(buf *TrackedBuffer) {
-	buf.Myprintf("like %v", node.LikeTable)
+	buf.astPrintf(node, "like %v", node.LikeTable)
 }
 
 // Format formats the node.
 func (node *PartitionSpec) Format(buf *TrackedBuffer) {
 	switch node.Action {
 	case ReorganizeStr:
-		buf.Myprintf("%s %v into (", node.Action, node.Name)
+		buf.astPrintf(node, "%s %v into (", node.Action, node.Name)
 		var prefix string
 		for _, pd := range node.Definitions {
-			buf.Myprintf("%s%v", prefix, pd)
+			buf.astPrintf(node, "%s%v", prefix, pd)
 			prefix = ", "
 		}
-		buf.Myprintf(")")
+		buf.astPrintf(node, ")")
 	default:
 		panic("unimplemented")
 	}
@@ -966,50 +966,50 @@ func (node *PartitionSpec) Format(buf *TrackedBuffer) {
 // Format formats the node
 func (node *PartitionDefinition) Format(buf *TrackedBuffer) {
 	if !node.Maxvalue {
-		buf.Myprintf("partition %v values less than (%v)", node.Name, node.Limit)
+		buf.astPrintf(node, "partition %v values less than (%v)", node.Name, node.Limit)
 	} else {
-		buf.Myprintf("partition %v values less than (maxvalue)", node.Name)
+		buf.astPrintf(node, "partition %v values less than (maxvalue)", node.Name)
 	}
 }
 
 // Format formats the node.
 func (ts *TableSpec) Format(buf *TrackedBuffer) {
-	buf.Myprintf("(\n")
+	buf.astPrintf(ts, "(\n")
 	for i, col := range ts.Columns {
 		if i == 0 {
-			buf.Myprintf("\t%v", col)
+			buf.astPrintf(ts, "\t%v", col)
 		} else {
-			buf.Myprintf(",\n\t%v", col)
+			buf.astPrintf(ts, ",\n\t%v", col)
 		}
 	}
 	for _, idx := range ts.Indexes {
-		buf.Myprintf(",\n\t%v", idx)
+		buf.astPrintf(ts, ",\n\t%v", idx)
 	}
 	for _, c := range ts.Constraints {
-		buf.Myprintf(",\n\t%v", c)
+		buf.astPrintf(ts, ",\n\t%v", c)
 	}
 
-	buf.Myprintf("\n)%s", strings.Replace(ts.Options, ", ", ",\n  ", -1))
+	buf.astPrintf(ts, "\n)%s", strings.Replace(ts.Options, ", ", ",\n  ", -1))
 }
 
 // Format formats the node.
 func (col *ColumnDefinition) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v %v", col.Name, &col.Type)
+	buf.astPrintf(col, "%v %v", col.Name, &col.Type)
 }
 
 // Format returns a canonical string representation of the type and all relevant options
 func (ct *ColumnType) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s", ct.Type)
+	buf.astPrintf(ct, "%s", ct.Type)
 
 	if ct.Length != nil && ct.Scale != nil {
-		buf.Myprintf("(%v,%v)", ct.Length, ct.Scale)
+		buf.astPrintf(ct, "(%v,%v)", ct.Length, ct.Scale)
 
 	} else if ct.Length != nil {
-		buf.Myprintf("(%v)", ct.Length)
+		buf.astPrintf(ct, "(%v)", ct.Length)
 	}
 
 	if ct.EnumValues != nil {
-		buf.Myprintf("(%s)", strings.Join(ct.EnumValues, ", "))
+		buf.astPrintf(ct, "(%s)", strings.Join(ct.EnumValues, ", "))
 	}
 
 	opts := make([]string, 0, 16)
@@ -1057,31 +1057,31 @@ func (ct *ColumnType) Format(buf *TrackedBuffer) {
 	}
 
 	if len(opts) != 0 {
-		buf.Myprintf(" %s", strings.Join(opts, " "))
+		buf.astPrintf(ct, " %s", strings.Join(opts, " "))
 	}
 }
 
 // Format formats the node.
 func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v (", idx.Info)
+	buf.astPrintf(idx, "%v (", idx.Info)
 	for i, col := range idx.Columns {
 		if i != 0 {
-			buf.Myprintf(", %v", col.Column)
+			buf.astPrintf(idx, ", %v", col.Column)
 		} else {
-			buf.Myprintf("%v", col.Column)
+			buf.astPrintf(idx, "%v", col.Column)
 		}
 		if col.Length != nil {
-			buf.Myprintf("(%v)", col.Length)
+			buf.astPrintf(idx, "(%v)", col.Length)
 		}
 	}
-	buf.Myprintf(")")
+	buf.astPrintf(idx, ")")
 
 	for _, opt := range idx.Options {
-		buf.Myprintf(" %s", opt.Name)
+		buf.astPrintf(idx, " %s", opt.Name)
 		if opt.Using != "" {
-			buf.Myprintf(" %s", opt.Using)
+			buf.astPrintf(idx, " %s", opt.Using)
 		} else {
-			buf.Myprintf(" %v", opt.Value)
+			buf.astPrintf(idx, " %v", opt.Value)
 		}
 	}
 }
@@ -1089,48 +1089,48 @@ func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (ii *IndexInfo) Format(buf *TrackedBuffer) {
 	if ii.Primary {
-		buf.Myprintf("%s", ii.Type)
+		buf.astPrintf(ii, "%s", ii.Type)
 	} else {
-		buf.Myprintf("%s", ii.Type)
+		buf.astPrintf(ii, "%s", ii.Type)
 		if !ii.Name.IsEmpty() {
-			buf.Myprintf(" %v", ii.Name)
+			buf.astPrintf(ii, " %v", ii.Name)
 		}
 	}
 }
 
 // Format formats the node.
 func (node *AutoIncSpec) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v ", node.Column)
-	buf.Myprintf("using %v", node.Sequence)
+	buf.astPrintf(node, "%v ", node.Column)
+	buf.astPrintf(node, "using %v", node.Sequence)
 }
 
 // Format formats the node. The "CREATE VINDEX" preamble was formatted in
 // the containing DDL node Format, so this just prints the type, any
 // parameters, and optionally the owner
 func (node *VindexSpec) Format(buf *TrackedBuffer) {
-	buf.Myprintf("using %v", node.Type)
+	buf.astPrintf(node, "using %v", node.Type)
 
 	numParams := len(node.Params)
 	if numParams != 0 {
-		buf.Myprintf(" with ")
+		buf.astPrintf(node, " with ")
 		for i, p := range node.Params {
 			if i != 0 {
-				buf.Myprintf(", ")
+				buf.astPrintf(node, ", ")
 			}
-			buf.Myprintf("%v", p)
+			buf.astPrintf(node, "%v", p)
 		}
 	}
 }
 
 // Format formats the node.
 func (node VindexParam) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s=%s", node.Key.String(), node.Val)
+	buf.astPrintf(node, "%s=%s", node.Key.String(), node.Val)
 }
 
 // Format formats the node.
 func (c *ConstraintDefinition) Format(buf *TrackedBuffer) {
 	if c.Name != "" {
-		buf.Myprintf("constraint %s ", c.Name)
+		buf.astPrintf(c, "constraint %s ", c.Name)
 	}
 	c.Details.Format(buf)
 }
@@ -1153,12 +1153,12 @@ func (a ReferenceAction) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (f *ForeignKeyDefinition) Format(buf *TrackedBuffer) {
-	buf.Myprintf("foreign key %v references %v %v", f.Source, f.ReferencedTable, f.ReferencedColumns)
+	buf.astPrintf(f, "foreign key %v references %v %v", f.Source, f.ReferencedTable, f.ReferencedColumns)
 	if f.OnDelete != DefaultAction {
-		buf.Myprintf(" on delete %v", f.OnDelete)
+		buf.astPrintf(f, " on delete %v", f.OnDelete)
 	}
 	if f.OnUpdate != DefaultAction {
-		buf.Myprintf(" on update %v", f.OnUpdate)
+		buf.astPrintf(f, " on update %v", f.OnUpdate)
 	}
 }
 
@@ -1167,32 +1167,32 @@ func (node *Show) Format(buf *TrackedBuffer) {
 	nodeType := strings.ToLower(node.Type)
 	if (nodeType == "tables" || nodeType == "columns" || nodeType == "fields" || nodeType == "index" || nodeType == "keys") && node.ShowTablesOpt != nil {
 		opt := node.ShowTablesOpt
-		buf.Myprintf("show %s%s", opt.Full, nodeType)
+		buf.astPrintf(node, "show %s%s", opt.Full, nodeType)
 		if (nodeType == "columns" || nodeType == "fields" || nodeType == "index" || nodeType == "keys") && node.HasOnTable() {
-			buf.Myprintf(" from %v", node.OnTable)
+			buf.astPrintf(node, " from %v", node.OnTable)
 		}
 		if opt.DbName != "" {
-			buf.Myprintf(" from %s", opt.DbName)
+			buf.astPrintf(node, " from %s", opt.DbName)
 		}
-		buf.Myprintf("%v", opt.Filter)
+		buf.astPrintf(node, "%v", opt.Filter)
 		return
 	}
 	if node.Scope == "" {
-		buf.Myprintf("show %s", nodeType)
+		buf.astPrintf(node, "show %s", nodeType)
 	} else {
-		buf.Myprintf("show %s %s", node.Scope, nodeType)
+		buf.astPrintf(node, "show %s %s", node.Scope, nodeType)
 	}
 	if node.HasOnTable() {
-		buf.Myprintf(" on %v", node.OnTable)
+		buf.astPrintf(node, " on %v", node.OnTable)
 	}
 	if nodeType == "collation" && node.ShowCollationFilterOpt != nil {
-		buf.Myprintf(" where %v", *node.ShowCollationFilterOpt)
+		buf.astPrintf(node, " where %v", *node.ShowCollationFilterOpt)
 	}
 	if nodeType == "charset" && node.ShowTablesOpt != nil {
-		buf.Myprintf("%v", node.ShowTablesOpt.Filter)
+		buf.astPrintf(node, "%v", node.ShowTablesOpt.Filter)
 	}
 	if node.HasTable() {
-		buf.Myprintf(" %v", node.Table)
+		buf.astPrintf(node, " %v", node.Table)
 	}
 }
 
@@ -1202,18 +1202,18 @@ func (node *ShowFilter) Format(buf *TrackedBuffer) {
 		return
 	}
 	if node.Like != "" {
-		buf.Myprintf(" like '%s'", node.Like)
+		buf.astPrintf(node, " like '%s'", node.Like)
 	} else {
-		buf.Myprintf(" where %v", node.Filter)
+		buf.astPrintf(node, " where %v", node.Filter)
 	}
 }
 
 // Format formats the node.
 func (node *Use) Format(buf *TrackedBuffer) {
 	if node.DBName.v != "" {
-		buf.Myprintf("use %v", node.DBName)
+		buf.astPrintf(node, "use %v", node.DBName)
 	} else {
-		buf.Myprintf("use")
+		buf.astPrintf(node, "use")
 	}
 }
 
@@ -1245,7 +1245,7 @@ func (node *OtherAdmin) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node Comments) Format(buf *TrackedBuffer) {
 	for _, c := range node {
-		buf.Myprintf("%s ", c)
+		buf.astPrintf(node, "%s ", c)
 	}
 }
 
@@ -1253,7 +1253,7 @@ func (node Comments) Format(buf *TrackedBuffer) {
 func (node SelectExprs) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1261,22 +1261,22 @@ func (node SelectExprs) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *StarExpr) Format(buf *TrackedBuffer) {
 	if !node.TableName.IsEmpty() {
-		buf.Myprintf("%v.", node.TableName)
+		buf.astPrintf(node, "%v.", node.TableName)
 	}
-	buf.Myprintf("*")
+	buf.astPrintf(node, "*")
 }
 
 // Format formats the node.
 func (node *AliasedExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v", node.Expr)
+	buf.astPrintf(node, "%v", node.Expr)
 	if !node.As.IsEmpty() {
-		buf.Myprintf(" as %v", node.As)
+		buf.astPrintf(node, " as %v", node.As)
 	}
 }
 
 // Format formats the node.
 func (node Nextval) Format(buf *TrackedBuffer) {
-	buf.Myprintf("next %v values", node.Expr)
+	buf.astPrintf(node, "next %v values", node.Expr)
 }
 
 // Format formats the node.
@@ -1286,7 +1286,7 @@ func (node Columns) Format(buf *TrackedBuffer) {
 	}
 	prefix := "("
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 	buf.WriteString(")")
@@ -1299,7 +1299,7 @@ func (node Partitions) Format(buf *TrackedBuffer) {
 	}
 	prefix := " partition ("
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 	buf.WriteString(")")
@@ -1309,20 +1309,20 @@ func (node Partitions) Format(buf *TrackedBuffer) {
 func (node TableExprs) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
 
 // Format formats the node.
 func (node *AliasedTableExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v%v", node.Expr, node.Partitions)
+	buf.astPrintf(node, "%v%v", node.Expr, node.Partitions)
 	if !node.As.IsEmpty() {
-		buf.Myprintf(" as %v", node.As)
+		buf.astPrintf(node, " as %v", node.As)
 	}
 	if node.Hints != nil {
 		// Hint node provides the space padding.
-		buf.Myprintf("%v", node.Hints)
+		buf.astPrintf(node, "%v", node.Hints)
 	}
 }
 
@@ -1330,7 +1330,7 @@ func (node *AliasedTableExpr) Format(buf *TrackedBuffer) {
 func (node TableNames) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1341,43 +1341,43 @@ func (node TableName) Format(buf *TrackedBuffer) {
 		return
 	}
 	if !node.Qualifier.IsEmpty() {
-		buf.Myprintf("%v.", node.Qualifier)
+		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
-	buf.Myprintf("%v", node.Name)
+	buf.astPrintf(node, "%v", node.Name)
 }
 
 // Format formats the node.
 func (node *ParenTableExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("(%v)", node.Exprs)
+	buf.astPrintf(node, "(%v)", node.Exprs)
 }
 
 // Format formats the node.
 func (node JoinCondition) Format(buf *TrackedBuffer) {
 	if node.On != nil {
-		buf.Myprintf(" on %v", node.On)
+		buf.astPrintf(node, " on %v", node.On)
 	}
 	if node.Using != nil {
-		buf.Myprintf(" using %v", node.Using)
+		buf.astPrintf(node, " using %v", node.Using)
 	}
 }
 
 // Format formats the node.
 func (node *JoinTableExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v %s %v%v", node.LeftExpr, node.Join, node.RightExpr, node.Condition)
+	buf.astPrintf(node, "%v %s %v%v", node.LeftExpr, node.Join, node.RightExpr, node.Condition)
 }
 
 // Format formats the node.
 func (node *IndexHints) Format(buf *TrackedBuffer) {
-	buf.Myprintf(" %sindex ", node.Type)
+	buf.astPrintf(node, " %sindex ", node.Type)
 	if len(node.Indexes) == 0 {
-		buf.Myprintf("()")
+		buf.astPrintf(node, "()")
 	} else {
 		prefix := "("
 		for _, n := range node.Indexes {
-			buf.Myprintf("%s%v", prefix, n)
+			buf.astPrintf(node, "%s%v", prefix, n)
 			prefix = ", "
 		}
-		buf.Myprintf(")")
+		buf.astPrintf(node, ")")
 	}
 }
 
@@ -1386,66 +1386,54 @@ func (node *Where) Format(buf *TrackedBuffer) {
 	if node == nil || node.Expr == nil {
 		return
 	}
-	buf.Myprintf(" %s %v", node.Type, node.Expr)
+	buf.astPrintf(node, " %s %v", node.Type, node.Expr)
 }
 
 // Format formats the node.
 func (node Exprs) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
 
 // Format formats the node.
 func (node *AndExpr) Format(buf *TrackedBuffer) {
-	printWithParensIfNeeded(node, node.Left, buf)
-	buf.WriteString(" and ")
-	printWithParensIfNeeded(node, node.Right, buf)
+	buf.astPrintf(node, "%v and %v", node.Left, node.Right)
 }
 
 // Format formats the node.
 func (node *OrExpr) Format(buf *TrackedBuffer) {
-	printWithParensIfNeeded(node, node.Left, buf)
-	buf.WriteString(" or ")
-	printWithParensIfNeeded(node, node.Right, buf)
+	buf.astPrintf(node, "%v or %v", node.Left, node.Right)
 }
 
 // Format formats the node.
 func (node *NotExpr) Format(buf *TrackedBuffer) {
-	buf.WriteString("not ")
-	printWithParensIfNeeded(node, node.Expr, buf)
+	buf.astPrintf(node, "not %v", node.Expr)
 }
 
 // Format formats the node.
 func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
-	printWithParensIfNeeded(node, node.Left, buf)
-	buf.Myprintf(" %s ", node.Operator)
-	printWithParensIfNeeded(node, node.Right, buf)
-
+	buf.astPrintf(node, "%v %s %v", node.Left, node.Operator, node.Right)
 	if node.Escape != nil {
-		buf.Myprintf(" escape %v", node.Escape)
+		buf.astPrintf(node, " escape %v", node.Escape)
 	}
 }
 
 // Format formats the node.
 func (node *RangeCond) Format(buf *TrackedBuffer) {
-	printWithParensIfNeeded(node, node.Expr, buf)
-	buf.Myprintf(" %s ", node.Operator)
-	printWithParensIfNeeded(node, node.From, buf)
-	buf.WriteString(" and ")
-	printWithParensIfNeeded(node, node.To, buf)
+	buf.astPrintf(node, "%v %s %v and %v", node.Left, node.Operator, node.From, node.To)
 }
 
 // Format formats the node.
 func (node *IsExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v %s", node.Expr, node.Operator)
+	buf.astPrintf(node, "%v %s", node.Expr, node.Operator)
 }
 
 // Format formats the node.
 func (node *ExistsExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("exists %v", node.Subquery)
+	buf.astPrintf(node, "exists %v", node.Subquery)
 }
 
 // Format formats the node.
@@ -1454,11 +1442,11 @@ func (node *SQLVal) Format(buf *TrackedBuffer) {
 	case StrVal:
 		sqltypes.MakeTrusted(sqltypes.VarBinary, node.Val).EncodeSQL(buf)
 	case IntVal, FloatVal, HexNum:
-		buf.Myprintf("%s", []byte(node.Val))
+		buf.astPrintf(node, "%s", node.Val)
 	case HexVal:
-		buf.Myprintf("X'%s'", []byte(node.Val))
+		buf.astPrintf(node, "X'%s'", node.Val)
 	case BitVal:
-		buf.Myprintf("B'%s'", []byte(node.Val))
+		buf.astPrintf(node, "B'%s'", node.Val)
 	case ValArg:
 		buf.WriteArg(string(node.Val))
 	default:
@@ -1468,34 +1456,34 @@ func (node *SQLVal) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *NullVal) Format(buf *TrackedBuffer) {
-	buf.Myprintf("null")
+	buf.astPrintf(node, "null")
 }
 
 // Format formats the node.
 func (node BoolVal) Format(buf *TrackedBuffer) {
 	if node {
-		buf.Myprintf("true")
+		buf.astPrintf(node, "true")
 	} else {
-		buf.Myprintf("false")
+		buf.astPrintf(node, "false")
 	}
 }
 
 // Format formats the node.
 func (node *ColName) Format(buf *TrackedBuffer) {
 	if !node.Qualifier.IsEmpty() {
-		buf.Myprintf("%v.", node.Qualifier)
+		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
-	buf.Myprintf("%v", node.Name)
+	buf.astPrintf(node, "%v", node.Name)
 }
 
 // Format formats the node.
 func (node ValTuple) Format(buf *TrackedBuffer) {
-	buf.Myprintf("(%v)", Exprs(node))
+	buf.astPrintf(node, "(%v)", Exprs(node))
 }
 
 // Format formats the node.
 func (node *Subquery) Format(buf *TrackedBuffer) {
-	buf.Myprintf("(%v)", node.Select)
+	buf.astPrintf(node, "(%v)", node.Select)
 }
 
 // Format formats the node.
@@ -1505,42 +1493,37 @@ func (node ListArg) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *BinaryExpr) Format(buf *TrackedBuffer) {
-	printWithParensIfNeeded(node, node.Left, buf)
-	buf.Myprintf(" %s ", node.Operator)
-	printWithParensIfNeeded(node, node.Right, buf)
+	buf.astPrintf(node, "%v %s %v", node.Left, node.Operator, node.Right)
 }
 
 // Format formats the node.
 func (node *UnaryExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s", node.Operator)
 	if _, unary := node.Expr.(*UnaryExpr); unary {
-		buf.Myprintf(" %v", node.Expr)
+		// They have same precedence so parenthesis is not required.
+		buf.astPrintf(node, "%s %v", node.Operator, node.Expr)
 		return
 	}
-
-	printWithParensIfNeeded(node, node.Expr, buf)
+	buf.astPrintf(node, "%s%v", node.Operator, node.Expr)
 }
 
 // Format formats the node.
 func (node *IntervalExpr) Format(buf *TrackedBuffer) {
-	buf.WriteString("interval ")
-	printWithParensIfNeeded(node, node.Expr, buf)
-	buf.Myprintf(" %s", node.Unit)
+	buf.astPrintf(node, "interval %v %s", node.Expr, node.Unit)
 }
 
 // Format formats the node.
 func (node *TimestampFuncExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s(%s, %v, %v)", node.Name, node.Unit, node.Expr1, node.Expr2)
+	buf.astPrintf(node, "%s(%s, %v, %v)", node.Name, node.Unit, node.Expr1, node.Expr2)
 }
 
 // Format formats the node.
 func (node *CurTimeFuncExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s(%v)", node.Name.String(), node.Fsp)
+	buf.astPrintf(node, "%s(%v)", node.Name.String(), node.Fsp)
 }
 
 // Format formats the node.
 func (node *CollateExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v collate %s", node.Expr, node.Charset)
+	buf.astPrintf(node, "%v collate %s", node.Expr, node.Charset)
 }
 
 // Format formats the node.
@@ -1550,7 +1533,7 @@ func (node *FuncExpr) Format(buf *TrackedBuffer) {
 		distinct = "distinct "
 	}
 	if !node.Qualifier.IsEmpty() {
-		buf.Myprintf("%v.", node.Qualifier)
+		buf.astPrintf(node, "%v.", node.Qualifier)
 	}
 	// Function names should not be back-quoted even
 	// if they match a reserved word, only if they contain illegal characters
@@ -1561,17 +1544,17 @@ func (node *FuncExpr) Format(buf *TrackedBuffer) {
 	} else {
 		buf.WriteString(funcName)
 	}
-	buf.Myprintf("(%s%v)", distinct, node.Exprs)
+	buf.astPrintf(node, "(%s%v)", distinct, node.Exprs)
 }
 
 // Format formats the node
 func (node *GroupConcatExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("group_concat(%s%v%v%s%v)", node.Distinct, node.Exprs, node.OrderBy, node.Separator, node.Limit)
+	buf.astPrintf(node, "group_concat(%s%v%v%s%v)", node.Distinct, node.Exprs, node.OrderBy, node.Separator, node.Limit)
 }
 
 // Format formats the node.
 func (node *ValuesFuncExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("values(%v)", node.Name)
+	buf.astPrintf(node, "values(%v)", node.Name)
 }
 
 // Format formats the node.
@@ -1584,75 +1567,75 @@ func (node *SubstrExpr) Format(buf *TrackedBuffer) {
 	}
 
 	if node.To == nil {
-		buf.Myprintf("substr(%v, %v)", val, node.From)
+		buf.astPrintf(node, "substr(%v, %v)", val, node.From)
 	} else {
-		buf.Myprintf("substr(%v, %v, %v)", val, node.From, node.To)
+		buf.astPrintf(node, "substr(%v, %v, %v)", val, node.From, node.To)
 	}
 }
 
 // Format formats the node.
 func (node *ConvertExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("convert(%v, %v)", node.Expr, node.Type)
+	buf.astPrintf(node, "convert(%v, %v)", node.Expr, node.Type)
 }
 
 // Format formats the node.
 func (node *ConvertUsingExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("convert(%v using %s)", node.Expr, node.Type)
+	buf.astPrintf(node, "convert(%v using %s)", node.Expr, node.Type)
 }
 
 // Format formats the node.
 func (node *ConvertType) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s", node.Type)
+	buf.astPrintf(node, "%s", node.Type)
 	if node.Length != nil {
-		buf.Myprintf("(%v", node.Length)
+		buf.astPrintf(node, "(%v", node.Length)
 		if node.Scale != nil {
-			buf.Myprintf(", %v", node.Scale)
+			buf.astPrintf(node, ", %v", node.Scale)
 		}
-		buf.Myprintf(")")
+		buf.astPrintf(node, ")")
 	}
 	if node.Charset != "" {
-		buf.Myprintf("%s %s", node.Operator, node.Charset)
+		buf.astPrintf(node, "%s %s", node.Operator, node.Charset)
 	}
 }
 
 // Format formats the node
 func (node *MatchExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("match(%v) against (%v%s)", node.Columns, node.Expr, node.Option)
+	buf.astPrintf(node, "match(%v) against (%v%s)", node.Columns, node.Expr, node.Option)
 }
 
 // Format formats the node.
 func (node *CaseExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("case ")
+	buf.astPrintf(node, "case ")
 	if node.Expr != nil {
-		buf.Myprintf("%v ", node.Expr)
+		buf.astPrintf(node, "%v ", node.Expr)
 	}
 	for _, when := range node.Whens {
-		buf.Myprintf("%v ", when)
+		buf.astPrintf(node, "%v ", when)
 	}
 	if node.Else != nil {
-		buf.Myprintf("else %v ", node.Else)
+		buf.astPrintf(node, "else %v ", node.Else)
 	}
-	buf.Myprintf("end")
+	buf.astPrintf(node, "end")
 }
 
 // Format formats the node.
 func (node *Default) Format(buf *TrackedBuffer) {
-	buf.Myprintf("default")
+	buf.astPrintf(node, "default")
 	if node.ColName != "" {
-		buf.Myprintf("(%s)", node.ColName)
+		buf.astPrintf(node, "(%s)", node.ColName)
 	}
 }
 
 // Format formats the node.
 func (node *When) Format(buf *TrackedBuffer) {
-	buf.Myprintf("when %v then %v", node.Cond, node.Val)
+	buf.astPrintf(node, "when %v then %v", node.Cond, node.Val)
 }
 
 // Format formats the node.
 func (node GroupBy) Format(buf *TrackedBuffer) {
 	prefix := " group by "
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1661,7 +1644,7 @@ func (node GroupBy) Format(buf *TrackedBuffer) {
 func (node OrderBy) Format(buf *TrackedBuffer) {
 	prefix := " order by "
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1669,17 +1652,17 @@ func (node OrderBy) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (node *Order) Format(buf *TrackedBuffer) {
 	if node, ok := node.Expr.(*NullVal); ok {
-		buf.Myprintf("%v", node)
+		buf.astPrintf(node, "%v", node)
 		return
 	}
 	if node, ok := node.Expr.(*FuncExpr); ok {
 		if node.Name.Lowered() == "rand" {
-			buf.Myprintf("%v", node)
+			buf.astPrintf(node, "%v", node)
 			return
 		}
 	}
 
-	buf.Myprintf("%v %s", node.Expr, node.Direction)
+	buf.astPrintf(node, "%v %s", node.Expr, node.Direction)
 }
 
 // Format formats the node.
@@ -1687,18 +1670,18 @@ func (node *Limit) Format(buf *TrackedBuffer) {
 	if node == nil {
 		return
 	}
-	buf.Myprintf(" limit ")
+	buf.astPrintf(node, " limit ")
 	if node.Offset != nil {
-		buf.Myprintf("%v, ", node.Offset)
+		buf.astPrintf(node, "%v, ", node.Offset)
 	}
-	buf.Myprintf("%v", node.Rowcount)
+	buf.astPrintf(node, "%v", node.Rowcount)
 }
 
 // Format formats the node.
 func (node Values) Format(buf *TrackedBuffer) {
 	prefix := "values "
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1707,21 +1690,21 @@ func (node Values) Format(buf *TrackedBuffer) {
 func (node UpdateExprs) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
 
 // Format formats the node.
 func (node *UpdateExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%v = %v", node.Name, node.Expr)
+	buf.astPrintf(node, "%v = %v", node.Name, node.Expr)
 }
 
 // Format formats the node.
 func (node SetExprs) Format(buf *TrackedBuffer) {
 	var prefix string
 	for _, n := range node {
-		buf.Myprintf("%s%v", prefix, n)
+		buf.astPrintf(node, "%s%v", prefix, n)
 		prefix = ", "
 	}
 }
@@ -1730,12 +1713,12 @@ func (node SetExprs) Format(buf *TrackedBuffer) {
 func (node *SetExpr) Format(buf *TrackedBuffer) {
 	// We don't have to backtick set variable names.
 	if node.Name.EqualString("charset") || node.Name.EqualString("names") {
-		buf.Myprintf("%s %v", node.Name.String(), node.Expr)
+		buf.astPrintf(node, "%s %v", node.Name.String(), node.Expr)
 	} else if node.Name.EqualString(TransactionStr) {
 		sqlVal := node.Expr.(*SQLVal)
-		buf.Myprintf("%s %s", node.Name.String(), strings.ToLower(string(sqlVal.Val)))
+		buf.astPrintf(node, "%s %s", node.Name.String(), strings.ToLower(string(sqlVal.Val)))
 	} else {
-		buf.Myprintf("%v = %v", node.Name, node.Expr)
+		buf.astPrintf(node, "%v = %v", node.Name, node.Expr)
 	}
 }
 
@@ -1744,7 +1727,7 @@ func (node OnDup) Format(buf *TrackedBuffer) {
 	if node == nil {
 		return
 	}
-	buf.Myprintf(" on duplicate key update %v", UpdateExprs(node))
+	buf.astPrintf(node, " on duplicate key update %v", UpdateExprs(node))
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -755,20 +755,6 @@ func (node *Union) SetLimit(limit *Limit) {
 	node.Limit = limit
 }
 
-func needParens(op, val Expr) bool {
-	opBinding := precedenceFor(op)
-	valBinding := precedenceFor(val)
-	return !(opBinding == Syntactic || valBinding == Syntactic) && valBinding > opBinding
-}
-
-func printWithParensIfNeeded(op, val Expr, buf *TrackedBuffer) {
-	if needParens(op, val) {
-		buf.WriteString("(")
-		defer buf.WriteString(")")
-	}
-	buf.Myprintf("%v", val)
-}
-
 type atCount int
 
 const (

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -83,7 +83,6 @@ func TestSelect(t *testing.T) {
 		t.Errorf("having: %q, want %s", buf.String(), want)
 	}
 
-	// OR clauses must be parenthesized.
 	tree, err = Parse("select * from t where a = 1 or b = 1")
 	require.NoError(t, err)
 	expr = tree.(*Select).Where.Expr
@@ -91,7 +90,7 @@ func TestSelect(t *testing.T) {
 	sel.AddWhere(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Where.Format(buf)
-	want = " where (a = 1 or b = 1)"
+	want = " where a = 1 or b = 1"
 	if buf.String() != want {
 		t.Errorf("where: %q, want %s", buf.String(), want)
 	}
@@ -99,7 +98,7 @@ func TestSelect(t *testing.T) {
 	sel.AddHaving(expr)
 	buf = NewTrackedBuffer(nil)
 	sel.Having.Format(buf)
-	want = " having (a = 1 or b = 1)"
+	want = " having a = 1 or b = 1"
 	if buf.String() != want {
 		t.Errorf("having: %q, want %s", buf.String(), want)
 	}
@@ -439,7 +438,7 @@ func TestReplaceExpr(t *testing.T) {
 		out: "not :a",
 	}, {
 		in:  "select * from t where ((select a from b))",
-		out: "(:a)",
+		out: ":a",
 	}, {
 		in:  "select * from t where (select a from b) = 1",
 		out: ":a = 1",

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -313,7 +314,8 @@ var (
 	}, {
 		input: "select /* exists */ 1 from t where exists (select 1 from t)",
 	}, {
-		input: "select /* (boolean) */ 1 from t where not (a = b)",
+		input:  "select /* (boolean) */ 1 from t where not (a = b)",
+		output: "select /* (boolean) */ 1 from t where not a = b",
 	}, {
 		input: "select /* in value list */ 1 from t where a in (b, c)",
 	}, {
@@ -376,11 +378,14 @@ var (
 	}, {
 		input: "select /* select as a value expression */ 1 from t where a = (select a from t)",
 	}, {
-		input: "select /* parenthesised value */ 1 from t where a = (b)",
+		input:  "select /* parenthesised value */ 1 from t where a = (b)",
+		output: "select /* parenthesised value */ 1 from t where a = b",
 	}, {
-		input: "select /* over-parenthesize */ ((1)) from t where ((a)) in (((1))) and ((a, b)) in ((((1, 1))), ((2, 2)))",
+		input:  "select /* over-parenthesize */ ((1)) from t where ((a)) in (((1))) and ((a, b)) in ((((1, 1))), ((2, 2)))",
+		output: "select /* over-parenthesize */ 1 from t where a in (1) and (a, b) in ((1, 1), (2, 2))",
 	}, {
-		input: "select /* dot-parenthesize */ (a.b) from t where (b.c) = 2",
+		input:  "select /* dot-parenthesize */ (a.b) from t where (b.c) = 2",
+		output: "select /* dot-parenthesize */ a.b from t where b.c = 2",
 	}, {
 		input: "select /* & */ 1 from t where a = b & c",
 	}, {
@@ -431,7 +436,7 @@ var (
 		input: "select /* function with distinct */ count(distinct a) from t",
 	}, {
 		input:  "select count(distinctrow(1)) from (select (1) from dual union all select 1 from dual) a",
-		output: "select count(distinct (1)) from (select (1) from dual union all select 1 from dual) as a",
+		output: "select count(distinct 1) from (select 1 from dual union all select 1 from dual) as a",
 	}, {
 		input: "select /* if as func */ 1 from t where a = if(b)",
 	}, {
@@ -604,7 +609,8 @@ var (
 	}, {
 		input: "select /* OR of mixed columns in where */ * from t where a = 5 or b and c is not null",
 	}, {
-		input: "select /* OR in select columns */ (a or b) from t where c = 5",
+		input:  "select /* OR in select columns */ (a or b) from t where c = 5",
+		output: "select /* OR in select columns */ a or b from t where c = 5",
 	}, {
 		input: "select /* bool as select value */ a, true from t",
 	}, {
@@ -1532,7 +1538,7 @@ var (
 		output: "delete a, b from tbl_a as a, tbl_b as b where a.id = b.id and b.name = 'test'",
 	}, {
 		input:  "select distinctrow a.* from (select (1) from dual union all select 1 from dual) a",
-		output: "select distinct a.* from (select (1) from dual union all select 1 from dual) as a",
+		output: "select distinct a.* from (select 1 from dual union all select 1 from dual) as a",
 	}, {
 		input: "select `weird function name`() from t",
 	}, {
@@ -1572,8 +1578,8 @@ func TestValid(t *testing.T) {
 			tree, err := Parse(tcase.input)
 			require.NoError(t, err)
 			out := String(tree)
-			if out != tcase.output {
-				t.Errorf("Parse(%q) = %q, want: %q", tcase.input, out, tcase.output)
+			if diff := cmp.Diff(tcase.output, out); diff != "" {
+				t.Errorf("Parse(%q):\n%s", tcase.input, diff)
 			}
 			// This test just exercises the tree walking functionality.
 			// There's no way automated way to verify that a node calls

--- a/go/vt/sqlparser/precedence.go
+++ b/go/vt/sqlparser/precedence.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlparser
+
+// Precendence is used to know the precedence between operators,
+// so we can introduce parens when needed in the String representation of the AST
+type Precendence int
+
+const (
+	Syntactic Precendence = iota
+	P1
+	P2
+	P3
+	P4
+	P5
+	P6
+	P7
+	P8
+	P9
+	P10
+	P11
+	P12
+	P13
+	P14
+	P15
+	P16
+	P17
+)
+
+func precedenceFor(in Expr) Precendence {
+	switch node := in.(type) {
+	case *OrExpr:
+		return P16
+	//case *XorExpr: TODO add parser support for XOR
+	//	return P15
+	case *AndExpr:
+		return P14
+	case *NotExpr:
+		return P13
+	case *RangeCond:
+		return P12
+	case *ComparisonExpr:
+		switch node.Operator {
+		case EqualStr, NotEqualStr, GreaterThanStr, GreaterEqualStr, LessThanStr, LessEqualStr, LikeStr, InStr, RegexpStr:
+			return P11
+		}
+	case *BinaryExpr:
+		switch node.Operator {
+		case BitOrStr:
+			return P10
+		case BitAndStr:
+			return P9
+		case ShiftLeftStr, ShiftRightStr:
+			return P8
+		case PlusStr, MinusStr:
+			return P7
+		case DivStr, MultStr, ModStr, IntDivStr:
+			return P6
+		case BitXorStr:
+			return P5
+		}
+	case *UnaryExpr:
+		switch node.Operator {
+		case UPlusStr, UMinusStr:
+			return P4
+		case BangStr:
+			return P3
+		case BinaryStr:
+			return P2
+		}
+	case *IntervalExpr:
+		return P1
+	}
+
+	return Syntactic
+}

--- a/go/vt/sqlparser/precedence.go
+++ b/go/vt/sqlparser/precedence.go
@@ -41,6 +41,10 @@ const (
 	P17
 )
 
+// precedenceFor returns the precedence of an expression.
+//
+// * NOTE: If you change anything here, update sql.y to keep them consistent.
+//   Also make sure to add the new constructs to random_expr.go so we have test coverage for the new expressions *
 func precedenceFor(in Expr) Precendence {
 	switch node := in.(type) {
 	case *OrExpr:

--- a/go/vt/sqlparser/precedence.go
+++ b/go/vt/sqlparser/precedence.go
@@ -62,6 +62,8 @@ func precedenceFor(in Expr) Precendence {
 		case EqualStr, NotEqualStr, GreaterThanStr, GreaterEqualStr, LessThanStr, LessEqualStr, LikeStr, InStr, RegexpStr:
 			return P11
 		}
+	case *IsExpr:
+		return P11
 	case *BinaryExpr:
 		switch node.Operator {
 		case BitOrStr:

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -18,7 +18,6 @@ package sqlparser
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -140,6 +139,7 @@ func TestParens(t *testing.T) {
 		{in: "(a) between (5) and (7)", expected: "a between 5 and 7"},
 		{in: "(a | b) between (5) and (7)", expected: "a | b between 5 and 7"},
 		{in: "(a and b) between (5) and (7)", expected: "(a and b) between 5 and 7"},
+		{in: "(true is true) is null", expected: "(true is true) is null"},
 	}
 
 	for _, tc := range tests {
@@ -157,11 +157,8 @@ func TestRandom(t *testing.T) {
 	// The idea is to generate random queries, and pass them through the parser and then the unparser, and one more time. The result of the first unparse should be the same as the second result.
 	seed := time.Now().UnixNano()
 	fmt.Println(fmt.Sprintf("seed is %d", seed))
-	g := generator{
-		seed: seed,
-		r:    rand.New(rand.NewSource(seed)),
-	}
-	endBy := time.Now().Add(5 * time.Second)
+	g := newGenerator(seed, 5)
+	endBy := time.Now().Add(1 * time.Second)
 
 	for {
 		if time.Now().After(endBy) {
@@ -173,7 +170,7 @@ func TestRandom(t *testing.T) {
 
 		// When it's parsed and unparsed
 		parsedInput, err := Parse(inputQ)
-		require.NoError(t, err)
+		require.NoError(t, err, inputQ)
 
 		// Then the unparsing should be the same as the input query
 		outputOfParseResult := String(parsedInput)

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlparser
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// This file is used to generate random expressions to be used for testing
+
+type generator struct {
+	seed  int64
+	r     *rand.Rand
+	depth int
+}
+
+// enter should be called whenever we are producing an intermediate node. it should be followed by a `defer g.exit()`
+func (g *generator) enter() {
+	g.depth++
+}
+
+// exit should be called when exiting an intermediate node
+func (g *generator) exit() {
+	g.depth--
+}
+
+// atMaxDepth returns true if we have reached the maximum allowed depth or the expression tree
+func (g *generator) atMaxDepth() bool {
+	return g.depth >= 3
+}
+
+func (g *generator) expression() Expr {
+	if g.randomBool() {
+		return g.booleanExpr()
+	}
+
+	return g.intExpr()
+}
+
+func (g *generator) booleanExpr() Expr {
+	if g.atMaxDepth() {
+		return g.booleanLiteral()
+	}
+
+	options := []exprF{
+		func() Expr { return g.andExpr() },
+		func() Expr { return g.orExpr() },
+		func() Expr { return g.booleanLiteral() },
+		func() Expr { return g.comparison() },
+		func() Expr { return g.inExpr() },
+		func() Expr { return g.between() },
+		func() Expr { return g.isExpr() },
+	}
+
+	return g.randomOf(options)
+}
+
+func (g *generator) intExpr() Expr {
+	if g.atMaxDepth() {
+		return g.intLiteral()
+	}
+
+	options := []exprF{
+		func() Expr { return g.arithmetic() },
+		func() Expr { return g.intLiteral() },
+		func() Expr { return g.caseExpr() },
+	}
+
+	return g.randomOf(options)
+}
+
+func (g *generator) booleanLiteral() Expr {
+	return BoolVal(g.randomBool())
+}
+
+func (g *generator) randomBool() bool {
+	return g.r.Float32() < 0.5
+}
+
+func (g *generator) intLiteral() Expr {
+	t := fmt.Sprintf("%d", g.r.Intn(1000)-g.r.Intn((1000)))
+
+	return NewIntVal([]byte(t))
+}
+
+var comparisonOps = []string{"=", ">", "<", ">=", "<=", "<=>", "!="}
+
+func (g *generator) comparison() Expr {
+	g.enter()
+	defer g.exit()
+
+	v := g.r.Intn(len(comparisonOps))
+
+	cmp := &ComparisonExpr{
+		Operator: comparisonOps[v],
+		Left:     g.intExpr(),
+		Right:    g.intExpr(),
+	}
+
+	return cmp
+}
+
+func (g *generator) caseExpr() Expr {
+	g.enter()
+	defer g.exit()
+
+	var exp Expr
+	var elseExpr Expr
+	if g.randomBool() {
+		exp = g.intExpr()
+	}
+	if g.randomBool() {
+		elseExpr = g.intExpr()
+	}
+
+	size := g.r.Intn(5) + 2
+	var whens []*When
+	for i := 0; i < size; i++ {
+		var cond Expr
+		if exp == nil {
+			cond = g.booleanExpr()
+		} else {
+			cond = g.expression()
+		}
+
+		whens = append(whens, &When{
+			Cond: cond,
+			Val:  g.expression(),
+		})
+	}
+
+	return &CaseExpr{
+		Expr:  exp,
+		Whens: whens,
+		Else:  elseExpr,
+	}
+}
+
+var arithmeticOps = []string{BitAndStr, BitOrStr, BitXorStr, PlusStr, MinusStr, MultStr, DivStr, IntDivStr, ModStr, ShiftRightStr, ShiftLeftStr}
+
+func (g *generator) arithmetic() Expr {
+	g.enter()
+	defer g.exit()
+
+	op := arithmeticOps[g.r.Intn(len(arithmeticOps))]
+
+	return &BinaryExpr{
+		Operator: op,
+		Left:     g.intExpr(),
+		Right:    g.intExpr(),
+	}
+}
+
+type exprF func() Expr
+
+func (g *generator) randomOf(options []exprF) Expr {
+	return options[g.r.Intn(len(options))]()
+}
+
+func (g *generator) randomOfS(options []string) string {
+	return options[g.r.Intn(len(options))]
+}
+
+func (g *generator) andExpr() Expr {
+	g.enter()
+	defer g.exit()
+	return &AndExpr{
+		Left:  g.booleanExpr(),
+		Right: g.booleanExpr(),
+	}
+}
+
+func (g *generator) orExpr() Expr {
+	g.enter()
+	defer g.exit()
+	return &OrExpr{
+		Left:  g.booleanExpr(),
+		Right: g.booleanExpr(),
+	}
+}
+
+func (g *generator) inExpr() Expr {
+	g.enter()
+	defer g.exit()
+
+	expr := g.intExpr()
+	size := g.r.Intn(5) + 2
+	tuples := ValTuple{}
+	for i := 0; i < size; i++ {
+		tuples = append(tuples, g.intExpr())
+	}
+	op := InStr
+	if g.randomBool() {
+		op = NotInStr
+	}
+
+	return &ComparisonExpr{
+		Operator: op,
+		Left:     expr,
+		Right:    tuples,
+	}
+}
+
+func (g *generator) between() Expr {
+	g.enter()
+	defer g.exit()
+
+	return &RangeCond{
+		Operator: BetweenStr,
+		Left:     g.intExpr(),
+		From:     g.intExpr(),
+		To:       g.intExpr(),
+	}
+}
+
+func (g *generator) isExpr() Expr {
+	g.enter()
+	defer g.exit()
+
+	ops := []string{IsNullStr, IsNotNullStr, IsTrueStr, IsNotTrueStr, IsFalseStr, IsNotFalseStr}
+
+	return &IsExpr{
+		Operator: g.randomOfS(ops),
+		Expr:     g.booleanExpr(),
+	}
+}

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -23,10 +23,20 @@ import (
 
 // This file is used to generate random expressions to be used for testing
 
+func newGenerator(seed int64, maxDepth int) *generator {
+	g := generator{
+		seed:     seed,
+		r:        rand.New(rand.NewSource(seed)),
+		maxDepth: maxDepth,
+	}
+	return &g
+}
+
 type generator struct {
-	seed  int64
-	r     *rand.Rand
-	depth int
+	seed     int64
+	r        *rand.Rand
+	depth    int
+	maxDepth int
 }
 
 // enter should be called whenever we are producing an intermediate node. it should be followed by a `defer g.exit()`
@@ -41,15 +51,32 @@ func (g *generator) exit() {
 
 // atMaxDepth returns true if we have reached the maximum allowed depth or the expression tree
 func (g *generator) atMaxDepth() bool {
-	return g.depth >= 3
+	return g.depth >= g.maxDepth
 }
 
+/* Creates a random expression. It builds an expression tree using the following constructs:
+    - true/false
+    - AND/OR/NOT
+    - string literalrs, numeric literals (-/+ 1000)
+    - =, >, <, >=, <=, <=>, !=
+	- &, |, ^, +, -, *, /, div, %, <<, >>
+    - IN, BETWEEN and CASE
+	- IS NULL, IS NOT NULL, IS TRUE, IS NOT TRUE, IS FALSE, IS NOT FALSE
+
+Note: It's important to update this method so that it produces all expressions that need precedence checking.
+It's currently missing function calls and string operators
+*/
 func (g *generator) expression() Expr {
 	if g.randomBool() {
 		return g.booleanExpr()
 	}
+	options := []exprF{
+		func() Expr { return g.intExpr() },
+		func() Expr { return g.stringExpr() },
+		func() Expr { return g.booleanExpr() },
+	}
 
-	return g.intExpr()
+	return g.randomOf(options)
 }
 
 func (g *generator) booleanExpr() Expr {
@@ -60,11 +87,14 @@ func (g *generator) booleanExpr() Expr {
 	options := []exprF{
 		func() Expr { return g.andExpr() },
 		func() Expr { return g.orExpr() },
-		func() Expr { return g.booleanLiteral() },
-		func() Expr { return g.comparison() },
+		func() Expr { return g.comparison(g.intExpr) },
+		func() Expr { return g.comparison(g.stringExpr) },
+		//func() Expr { return g.comparison(g.booleanExpr) }, // this is not accepted by the parser
 		func() Expr { return g.inExpr() },
 		func() Expr { return g.between() },
 		func() Expr { return g.isExpr() },
+		func() Expr { return g.notExpr() },
+		func() Expr { return g.likeExpr() },
 	}
 
 	return g.randomOf(options)
@@ -78,7 +108,7 @@ func (g *generator) intExpr() Expr {
 	options := []exprF{
 		func() Expr { return g.arithmetic() },
 		func() Expr { return g.intLiteral() },
-		func() Expr { return g.caseExpr() },
+		func() Expr { return g.caseExpr(g.intExpr) },
 	}
 
 	return g.randomOf(options)
@@ -98,34 +128,60 @@ func (g *generator) intLiteral() Expr {
 	return NewIntVal([]byte(t))
 }
 
-var comparisonOps = []string{"=", ">", "<", ">=", "<=", "<=>", "!="}
+var words = []string{"ox", "ant", "ape", "asp", "bat", "bee", "boa", "bug", "cat", "cod", "cow", "cub", "doe", "dog", "eel", "eft", "elf", "elk", "emu", "ewe", "fly", "fox", "gar", "gnu", "hen", "hog", "imp", "jay", "kid", "kit", "koi", "lab", "man", "owl", "pig", "pug", "pup", "ram", "rat", "ray", "yak", "bass", "bear", "bird", "boar", "buck", "bull", "calf", "chow", "clam", "colt", "crab", "crow", "dane", "deer", "dodo", "dory", "dove", "drum", "duck", "fawn", "fish", "flea", "foal", "fowl", "frog", "gnat", "goat", "grub", "gull", "hare", "hawk", "ibex", "joey", "kite", "kiwi", "lamb", "lark", "lion", "loon", "lynx", "mako", "mink", "mite", "mole", "moth", "mule", "mutt", "newt", "orca", "oryx", "pika", "pony", "puma", "seal", "shad", "slug", "sole", "stag", "stud", "swan", "tahr", "teal", "tick", "toad", "tuna", "wasp", "wolf", "worm", "wren", "yeti", "adder", "akita", "alien", "aphid", "bison", "boxer", "bream", "bunny", "burro", "camel", "chimp", "civet", "cobra", "coral", "corgi", "crane", "dingo", "drake", "eagle", "egret", "filly", "finch", "gator", "gecko", "ghost", "ghoul", "goose", "guppy", "heron", "hippo", "horse", "hound", "husky", "hyena", "koala", "krill", "leech", "lemur", "liger", "llama", "louse", "macaw", "midge", "molly", "moose", "moray", "mouse", "panda", "perch", "prawn", "quail", "racer", "raven", "rhino", "robin", "satyr", "shark", "sheep", "shrew", "skink", "skunk", "sloth", "snail", "snake", "snipe", "squid", "stork", "swift", "swine", "tapir", "tetra", "tiger", "troll", "trout", "viper", "wahoo", "whale", "zebra", "alpaca", "amoeba", "baboon", "badger", "beagle", "bedbug", "beetle", "bengal", "bobcat", "caiman", "cattle", "cicada", "collie", "condor", "cougar", "coyote", "dassie", "donkey", "dragon", "earwig", "falcon", "feline", "ferret", "gannet", "gibbon", "glider", "goblin", "gopher", "grouse", "guinea", "hermit", "hornet", "iguana", "impala", "insect", "jackal", "jaguar", "jennet", "kitten", "kodiak", "lizard", "locust", "maggot", "magpie", "mammal", "mantis", "marlin", "marmot", "marten", "martin", "mayfly", "minnow", "monkey", "mullet", "muskox", "ocelot", "oriole", "osprey", "oyster", "parrot", "pigeon", "piglet", "poodle", "possum", "python", "quagga", "rabbit", "raptor", "rodent", "roughy", "salmon", "sawfly", "serval", "shiner", "shrimp", "spider", "sponge", "tarpon", "thrush", "tomcat", "toucan", "turkey", "turtle", "urchin", "vervet", "walrus", "weasel", "weevil", "wombat", "anchovy", "anemone", "bluejay", "buffalo", "bulldog", "buzzard", "caribou", "catfish", "chamois", "cheetah", "chicken", "chigger", "cowbird", "crappie", "crawdad", "cricket", "dogfish", "dolphin", "firefly", "garfish", "gazelle", "gelding", "giraffe", "gobbler", "gorilla", "goshawk", "grackle", "griffon", "grizzly", "grouper", "haddock", "hagfish", "halibut", "hamster", "herring", "jackass", "javelin", "jawfish", "jaybird", "katydid", "ladybug", "lamprey", "lemming", "leopard", "lioness", "lobster", "macaque", "mallard", "mammoth", "manatee", "mastiff", "meerkat", "mollusk", "monarch", "mongrel", "monitor", "monster", "mudfish", "muskrat", "mustang", "narwhal", "oarfish", "octopus", "opossum", "ostrich", "panther", "peacock", "pegasus", "pelican", "penguin", "phoenix", "piranha", "polecat", "primate", "quetzal", "raccoon", "rattler", "redbird", "redfish", "reptile", "rooster", "sawfish", "sculpin", "seagull", "skylark", "snapper", "spaniel", "sparrow", "sunbeam", "sunbird", "sunfish", "tadpole", "termite", "terrier", "unicorn", "vulture", "wallaby", "walleye", "warthog", "whippet", "wildcat", "aardvark", "airedale", "albacore", "anteater", "antelope", "arachnid", "barnacle", "basilisk", "blowfish", "bluebird", "bluegill", "bonefish", "bullfrog", "cardinal", "chipmunk", "cockatoo", "crayfish", "dinosaur", "doberman", "duckling", "elephant", "escargot", "flamingo", "flounder", "foxhound", "glowworm", "goldfish", "grubworm", "hedgehog", "honeybee", "hookworm", "humpback", "kangaroo", "killdeer", "kingfish", "labrador", "lacewing", "ladybird", "lionfish", "longhorn", "mackerel", "malamute", "marmoset", "mastodon", "moccasin", "mongoose", "monkfish", "mosquito", "pangolin", "parakeet", "pheasant", "pipefish", "platypus", "polliwog", "porpoise", "reindeer", "ringtail", "sailfish", "scorpion", "seahorse", "seasnail", "sheepdog", "shepherd", "silkworm", "squirrel", "stallion", "starfish", "starling", "stingray", "stinkbug", "sturgeon", "terrapin", "titmouse", "tortoise", "treefrog", "werewolf", "woodcock"}
 
-func (g *generator) comparison() Expr {
+func (g *generator) stringLiteral() Expr {
+	return NewStrVal([]byte(g.randomOfS(words)))
+}
+
+func (g *generator) stringExpr() Expr {
+	if g.atMaxDepth() {
+		return g.stringLiteral()
+	}
+
+	options := []exprF{
+		func() Expr { return g.stringLiteral() },
+		func() Expr { return g.caseExpr(g.stringExpr) },
+	}
+
+	return g.randomOf(options)
+}
+
+func (g *generator) likeExpr() Expr {
+	g.enter()
+	defer g.exit()
+	return &ComparisonExpr{
+		Operator: LikeStr,
+		Left:     g.stringExpr(),
+		Right:    g.stringExpr(),
+	}
+}
+
+var comparisonOps = []string{EqualStr, LessThanStr, GreaterThanStr, LessEqualStr, GreaterEqualStr, NotEqualStr, NullSafeEqualStr}
+
+func (g *generator) comparison(f func() Expr) Expr {
 	g.enter()
 	defer g.exit()
 
-	v := g.r.Intn(len(comparisonOps))
-
 	cmp := &ComparisonExpr{
-		Operator: comparisonOps[v],
-		Left:     g.intExpr(),
-		Right:    g.intExpr(),
+		Operator: g.randomOfS(comparisonOps),
+		Left:     f(),
+		Right:    f(),
 	}
-
 	return cmp
 }
 
-func (g *generator) caseExpr() Expr {
+func (g *generator) caseExpr(valueF func() Expr) Expr {
 	g.enter()
 	defer g.exit()
 
 	var exp Expr
 	var elseExpr Expr
 	if g.randomBool() {
-		exp = g.intExpr()
+		exp = valueF()
 	}
 	if g.randomBool() {
-		elseExpr = g.intExpr()
+		elseExpr = valueF()
 	}
 
 	size := g.r.Intn(5) + 2
@@ -194,6 +250,12 @@ func (g *generator) orExpr() Expr {
 	}
 }
 
+func (g *generator) notExpr() Expr {
+	g.enter()
+	defer g.exit()
+	return &NotExpr{g.booleanExpr()}
+}
+
 func (g *generator) inExpr() Expr {
 	g.enter()
 	defer g.exit()
@@ -220,8 +282,15 @@ func (g *generator) between() Expr {
 	g.enter()
 	defer g.exit()
 
+	var op string
+	if g.randomBool() {
+		op = BetweenStr
+	} else {
+		op = NotBetweenStr
+	}
+
 	return &RangeCond{
-		Operator: BetweenStr,
+		Operator: op,
 		Left:     g.intExpr(),
 		From:     g.intExpr(),
 		To:       g.intExpr(),

--- a/go/vt/sqlparser/rewriter.go
+++ b/go/vt/sqlparser/rewriter.go
@@ -499,12 +499,12 @@ func (r *replacePartitionsItems) inc() {
 	*r++
 }
 
-func replaceRangeCondExpr(newNode, parent SQLNode) {
-	parent.(*RangeCond).Expr = newNode.(Expr)
-}
-
 func replaceRangeCondFrom(newNode, parent SQLNode) {
 	parent.(*RangeCond).From = newNode.(Expr)
+}
+
+func replaceRangeCondLeft(newNode, parent SQLNode) {
+	parent.(*RangeCond).Left = newNode.(Expr)
 }
 
 func replaceRangeCondTo(newNode, parent SQLNode) {
@@ -1114,8 +1114,8 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		}
 
 	case *RangeCond:
-		a.apply(node, n.Expr, replaceRangeCondExpr)
 		a.apply(node, n.From, replaceRangeCondFrom)
+		a.apply(node, n.Left, replaceRangeCondLeft)
 		a.apply(node, n.To, replaceRangeCondTo)
 
 	case ReferenceAction:

--- a/go/vt/sqlparser/rewriter.go
+++ b/go/vt/sqlparser/rewriter.go
@@ -459,10 +459,6 @@ func (r *replaceOrderByItems) inc() {
 	*r++
 }
 
-func replaceParenExprExpr(newNode, parent SQLNode) {
-	parent.(*ParenExpr).Expr = newNode.(Expr)
-}
-
 func replaceParenSelectSelect(newNode, parent SQLNode) {
 	parent.(*ParenSelect).Select = newNode.(SelectStatement)
 }
@@ -503,12 +499,12 @@ func (r *replacePartitionsItems) inc() {
 	*r++
 }
 
-func replaceRangeCondFrom(newNode, parent SQLNode) {
-	parent.(*RangeCond).From = newNode.(Expr)
+func replaceRangeCondExpr(newNode, parent SQLNode) {
+	parent.(*RangeCond).Expr = newNode.(Expr)
 }
 
-func replaceRangeCondLeft(newNode, parent SQLNode) {
-	parent.(*RangeCond).Left = newNode.(Expr)
+func replaceRangeCondFrom(newNode, parent SQLNode) {
+	parent.(*RangeCond).From = newNode.(Expr)
 }
 
 func replaceRangeCondTo(newNode, parent SQLNode) {
@@ -1090,9 +1086,6 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 
 	case *OtherRead:
 
-	case *ParenExpr:
-		a.apply(node, n.Expr, replaceParenExprExpr)
-
 	case *ParenSelect:
 		a.apply(node, n.Select, replaceParenSelectSelect)
 
@@ -1121,8 +1114,8 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		}
 
 	case *RangeCond:
+		a.apply(node, n.Expr, replaceRangeCondExpr)
 		a.apply(node, n.From, replaceRangeCondFrom)
-		a.apply(node, n.Left, replaceRangeCondLeft)
 		a.apply(node, n.To, replaceRangeCondTo)
 
 	case ReferenceAction:

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -6037,13 +6037,13 @@ yydefault:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:2258
 		{
-			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
+			yyVAL.expr = &RangeCond{Expr: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
 		}
 	case 426:
 		yyDollar = yyS[yypt-6 : yypt+1]
 //line sql.y:2262
 		{
-			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
+			yyVAL.expr = &RangeCond{Expr: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
 		}
 	case 427:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -7097,7 +7097,7 @@ yydefault:
 //line sql.y:3079
 		{
 			if len(yyDollar[1].valTuple) == 1 {
-				yyVAL.expr = &ParenExpr{yyDollar[1].valTuple[0]}
+				yyVAL.expr = yyDollar[1].valTuple[0]
 			} else {
 				yyVAL.expr = yyDollar[1].valTuple
 			}

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -6037,13 +6037,13 @@ yydefault:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:2258
 		{
-			yyVAL.expr = &RangeCond{Expr: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
+			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
 		}
 	case 426:
 		yyDollar = yyS[yypt-6 : yypt+1]
 //line sql.y:2262
 		{
-			yyVAL.expr = &RangeCond{Expr: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
+			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
 		}
 	case 427:
 		yyDollar = yyS[yypt-2 : yypt+1]

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -3603,53 +3603,53 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:324
+//line sql.y:325
 		{
 			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:329
+//line sql.y:330
 		{
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:330
+//line sql.y:331
 		{
 		}
 	case 4:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:334
+//line sql.y:335
 		{
 			yyVAL.statement = yyDollar[1].selStmt
 		}
 	case 23:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:356
+//line sql.y:357
 		{
 			setParseTree(yylex, nil)
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:362
+//line sql.y:363
 		{
 			yyVAL.colIdent = NewColIdentWithAt(string(yyDollar[1].bytes), NoAt)
 		}
 	case 25:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:366
+//line sql.y:367
 		{
 			yyVAL.colIdent = NewColIdentWithAt(string(yyDollar[1].bytes), SingleAt)
 		}
 	case 26:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:370
+//line sql.y:371
 		{
 			yyVAL.colIdent = NewColIdentWithAt(string(yyDollar[1].bytes), DoubleAt)
 		}
 	case 27:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:376
+//line sql.y:377
 		{
 			sel := yyDollar[1].selStmt.(*Select)
 			sel.OrderBy = yyDollar[2].orderBy
@@ -3659,55 +3659,55 @@ yydefault:
 		}
 	case 28:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:384
+//line sql.y:385
 		{
 			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt, OrderBy: yyDollar[4].orderBy, Limit: yyDollar[5].limit, Lock: yyDollar[6].str}
 		}
 	case 29:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:388
+//line sql.y:389
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, SelectExprs: SelectExprs{Nextval{Expr: yyDollar[5].expr}}, From: TableExprs{&AliasedTableExpr{Expr: yyDollar[7].tableName}}}
 		}
 	case 30:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:394
+//line sql.y:395
 		{
 			yyVAL.statement = &Stream{Comments: Comments(yyDollar[2].bytes2), SelectExpr: yyDollar[3].selectExpr, Table: yyDollar[5].tableName}
 		}
 	case 31:
 		yyDollar = yyS[yypt-10 : yypt+1]
-//line sql.y:401
+//line sql.y:402
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, Distinct: yyDollar[4].str, Hints: yyDollar[5].str, SelectExprs: yyDollar[6].selectExprs, From: yyDollar[7].tableExprs, Where: NewWhere(WhereStr, yyDollar[8].expr), GroupBy: GroupBy(yyDollar[9].exprs), Having: NewWhere(HavingStr, yyDollar[10].expr)}
 		}
 	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:407
+//line sql.y:408
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:411
+//line sql.y:412
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:417
+//line sql.y:418
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:421
+//line sql.y:422
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 36:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:428
+//line sql.y:429
 		{
 			// insert_data returns a *Insert pre-filled with Columns & Values
 			ins := yyDollar[6].ins
@@ -3721,7 +3721,7 @@ yydefault:
 		}
 	case 37:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:440
+//line sql.y:441
 		{
 			cols := make(Columns, 0, len(yyDollar[7].updateExprs))
 			vals := make(ValTuple, 0, len(yyDollar[8].updateExprs))
@@ -3733,192 +3733,192 @@ yydefault:
 		}
 	case 38:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:452
+//line sql.y:453
 		{
 			yyVAL.str = InsertStr
 		}
 	case 39:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:456
+//line sql.y:457
 		{
 			yyVAL.str = ReplaceStr
 		}
 	case 40:
 		yyDollar = yyS[yypt-9 : yypt+1]
-//line sql.y:462
+//line sql.y:463
 		{
 			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), Ignore: yyDollar[3].str, TableExprs: yyDollar[4].tableExprs, Exprs: yyDollar[6].updateExprs, Where: NewWhere(WhereStr, yyDollar[7].expr), OrderBy: yyDollar[8].orderBy, Limit: yyDollar[9].limit}
 		}
 	case 41:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:468
+//line sql.y:469
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), TableExprs: TableExprs{&AliasedTableExpr{Expr: yyDollar[4].tableName}}, Partitions: yyDollar[5].partitions, Where: NewWhere(WhereStr, yyDollar[6].expr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 42:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:472
+//line sql.y:473
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[4].tableNames, TableExprs: yyDollar[6].tableExprs, Where: NewWhere(WhereStr, yyDollar[7].expr)}
 		}
 	case 43:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:476
+//line sql.y:477
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[3].tableNames, TableExprs: yyDollar[5].tableExprs, Where: NewWhere(WhereStr, yyDollar[6].expr)}
 		}
 	case 44:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:480
+//line sql.y:481
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[3].tableNames, TableExprs: yyDollar[5].tableExprs, Where: NewWhere(WhereStr, yyDollar[6].expr)}
 		}
 	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:485
+//line sql.y:486
 		{
 		}
 	case 46:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:486
+//line sql.y:487
 		{
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:490
+//line sql.y:491
 		{
 			yyVAL.tableNames = TableNames{yyDollar[1].tableName}
 		}
 	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:494
+//line sql.y:495
 		{
 			yyVAL.tableNames = append(yyVAL.tableNames, yyDollar[3].tableName)
 		}
 	case 49:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:500
+//line sql.y:501
 		{
 			yyVAL.tableNames = TableNames{yyDollar[1].tableName}
 		}
 	case 50:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:504
+//line sql.y:505
 		{
 			yyVAL.tableNames = append(yyVAL.tableNames, yyDollar[3].tableName)
 		}
 	case 51:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:509
+//line sql.y:510
 		{
 			yyVAL.partitions = nil
 		}
 	case 52:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:513
+//line sql.y:514
 		{
 			yyVAL.partitions = yyDollar[3].partitions
 		}
 	case 53:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:519
+//line sql.y:520
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].setExprs}
 		}
 	case 54:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:523
+//line sql.y:524
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Scope: yyDollar[3].str, Exprs: yyDollar[4].setExprs}
 		}
 	case 55:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:527
+//line sql.y:528
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Scope: yyDollar[3].str, Exprs: yyDollar[5].setExprs}
 		}
 	case 56:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:531
+//line sql.y:532
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[4].setExprs}
 		}
 	case 57:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:537
+//line sql.y:538
 		{
 			yyVAL.setExprs = SetExprs{yyDollar[1].setExpr}
 		}
 	case 58:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:541
+//line sql.y:542
 		{
 			yyVAL.setExprs = append(yyVAL.setExprs, yyDollar[3].setExpr)
 		}
 	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:547
+//line sql.y:548
 		{
 			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(yyDollar[3].str))}
 		}
 	case 60:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:551
+//line sql.y:552
 		{
 			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadWrite))}
 		}
 	case 61:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:555
+//line sql.y:556
 		{
 			yyVAL.setExpr = &SetExpr{Name: NewColIdent(TransactionStr), Expr: NewStrVal([]byte(TxReadOnly))}
 		}
 	case 62:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:561
+//line sql.y:562
 		{
 			yyVAL.str = IsolationLevelRepeatableRead
 		}
 	case 63:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:565
+//line sql.y:566
 		{
 			yyVAL.str = IsolationLevelReadCommitted
 		}
 	case 64:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:569
+//line sql.y:570
 		{
 			yyVAL.str = IsolationLevelReadUncommitted
 		}
 	case 65:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:573
+//line sql.y:574
 		{
 			yyVAL.str = IsolationLevelSerializable
 		}
 	case 66:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:579
+//line sql.y:580
 		{
 			yyVAL.str = SessionStr
 		}
 	case 67:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:583
+//line sql.y:584
 		{
 			yyVAL.str = GlobalStr
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:589
+//line sql.y:590
 		{
 			yyDollar[1].ddl.TableSpec = yyDollar[2].TableSpec
 			yyVAL.statement = yyDollar[1].ddl
 		}
 	case 69:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:594
+//line sql.y:595
 		{
 			// Create table [name] like [name]
 			yyDollar[1].ddl.OptLike = yyDollar[2].optLike
@@ -3926,139 +3926,139 @@ yydefault:
 		}
 	case 70:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:600
+//line sql.y:601
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[7].tableName}
 		}
 	case 71:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:605
+//line sql.y:606
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, Table: yyDollar[3].tableName.ToViewName()}
 		}
 	case 72:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:609
+//line sql.y:610
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, Table: yyDollar[5].tableName.ToViewName()}
 		}
 	case 73:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:613
+//line sql.y:614
 		{
 			yyVAL.statement = &DBDDL{Action: CreateStr, DBName: string(yyDollar[4].colIdent.String())}
 		}
 	case 74:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:617
+//line sql.y:618
 		{
 			yyVAL.statement = &DBDDL{Action: CreateStr, DBName: string(yyDollar[4].colIdent.String())}
 		}
 	case 75:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:622
+//line sql.y:623
 		{
 			yyVAL.colIdent = NewColIdent("")
 		}
 	case 76:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:626
+//line sql.y:627
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 77:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:632
+//line sql.y:633
 		{
 			yyVAL.colIdent = yyDollar[1].colIdent
 		}
 	case 78:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:637
+//line sql.y:638
 		{
 			var v []VindexParam
 			yyVAL.vindexParams = v
 		}
 	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:642
+//line sql.y:643
 		{
 			yyVAL.vindexParams = yyDollar[2].vindexParams
 		}
 	case 80:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:648
+//line sql.y:649
 		{
 			yyVAL.vindexParams = make([]VindexParam, 0, 4)
 			yyVAL.vindexParams = append(yyVAL.vindexParams, yyDollar[1].vindexParam)
 		}
 	case 81:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:653
+//line sql.y:654
 		{
 			yyVAL.vindexParams = append(yyVAL.vindexParams, yyDollar[3].vindexParam)
 		}
 	case 82:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:659
+//line sql.y:660
 		{
 			yyVAL.vindexParam = VindexParam{Key: yyDollar[1].colIdent, Val: yyDollar[3].str}
 		}
 	case 83:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:665
+//line sql.y:666
 		{
 			yyVAL.ddl = &DDL{Action: CreateStr, Table: yyDollar[4].tableName}
 			setDDL(yylex, yyVAL.ddl)
 		}
 	case 84:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:672
+//line sql.y:673
 		{
 			yyVAL.TableSpec = yyDollar[2].TableSpec
 			yyVAL.TableSpec.Options = yyDollar[4].str
 		}
 	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:679
+//line sql.y:680
 		{
 			yyVAL.optLike = &OptLike{LikeTable: yyDollar[2].tableName}
 		}
 	case 86:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:683
+//line sql.y:684
 		{
 			yyVAL.optLike = &OptLike{LikeTable: yyDollar[3].tableName}
 		}
 	case 87:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:689
+//line sql.y:690
 		{
 			yyVAL.TableSpec = &TableSpec{}
 			yyVAL.TableSpec.AddColumn(yyDollar[1].columnDefinition)
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:694
+//line sql.y:695
 		{
 			yyVAL.TableSpec.AddColumn(yyDollar[3].columnDefinition)
 		}
 	case 89:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:698
+//line sql.y:699
 		{
 			yyVAL.TableSpec.AddIndex(yyDollar[3].indexDefinition)
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:702
+//line sql.y:703
 		{
 			yyVAL.TableSpec.AddConstraint(yyDollar[3].constraintDefinition)
 		}
 	case 91:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:708
+//line sql.y:709
 		{
 			yyDollar[2].columnType.NotNull = yyDollar[3].boolVal
 			yyDollar[2].columnType.Default = yyDollar[4].optVal
@@ -4070,7 +4070,7 @@ yydefault:
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:719
+//line sql.y:720
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 			yyVAL.columnType.Unsigned = yyDollar[2].boolVal
@@ -4078,74 +4078,74 @@ yydefault:
 		}
 	case 96:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:730
+//line sql.y:731
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 			yyVAL.columnType.Length = yyDollar[2].sqlVal
 		}
 	case 97:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:735
+//line sql.y:736
 		{
 			yyVAL.columnType = yyDollar[1].columnType
 		}
 	case 98:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:741
+//line sql.y:742
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 99:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:745
+//line sql.y:746
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 100:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:749
+//line sql.y:750
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 101:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:753
+//line sql.y:754
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 102:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:757
+//line sql.y:758
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 103:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:761
+//line sql.y:762
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 104:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:765
+//line sql.y:766
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 105:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:769
+//line sql.y:770
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 106:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:773
+//line sql.y:774
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 107:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:779
+//line sql.y:780
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -4153,7 +4153,7 @@ yydefault:
 		}
 	case 108:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:785
+//line sql.y:786
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -4161,7 +4161,7 @@ yydefault:
 		}
 	case 109:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:791
+//line sql.y:792
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -4169,7 +4169,7 @@ yydefault:
 		}
 	case 110:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:797
+//line sql.y:798
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -4177,7 +4177,7 @@ yydefault:
 		}
 	case 111:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:803
+//line sql.y:804
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 			yyVAL.columnType.Length = yyDollar[2].LengthScaleOption.Length
@@ -4185,206 +4185,206 @@ yydefault:
 		}
 	case 112:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:811
+//line sql.y:812
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 113:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:815
+//line sql.y:816
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 114:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:819
+//line sql.y:820
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 115:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:823
+//line sql.y:824
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 116:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:827
+//line sql.y:828
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 117:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:833
+//line sql.y:834
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal, Charset: yyDollar[3].str, Collate: yyDollar[4].str}
 		}
 	case 118:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:837
+//line sql.y:838
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal, Charset: yyDollar[3].str, Collate: yyDollar[4].str}
 		}
 	case 119:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:841
+//line sql.y:842
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 120:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:845
+//line sql.y:846
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 121:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:849
+//line sql.y:850
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 122:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:853
+//line sql.y:854
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 123:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:857
+//line sql.y:858
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 124:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:861
+//line sql.y:862
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), Charset: yyDollar[2].str, Collate: yyDollar[3].str}
 		}
 	case 125:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:865
+//line sql.y:866
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 126:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:869
+//line sql.y:870
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 127:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:873
+//line sql.y:874
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 128:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:877
+//line sql.y:878
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 129:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:881
+//line sql.y:882
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 130:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:885
+//line sql.y:886
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, Collate: yyDollar[6].str}
 		}
 	case 131:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:890
+//line sql.y:891
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes), EnumValues: yyDollar[3].strs, Charset: yyDollar[5].str, Collate: yyDollar[6].str}
 		}
 	case 132:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:896
+//line sql.y:897
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 133:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:900
+//line sql.y:901
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 134:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:904
+//line sql.y:905
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 135:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:908
+//line sql.y:909
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 136:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:912
+//line sql.y:913
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 137:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:916
+//line sql.y:917
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 138:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:920
+//line sql.y:921
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 139:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:924
+//line sql.y:925
 		{
 			yyVAL.columnType = ColumnType{Type: string(yyDollar[1].bytes)}
 		}
 	case 140:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:930
+//line sql.y:931
 		{
 			yyVAL.strs = make([]string, 0, 4)
 			yyVAL.strs = append(yyVAL.strs, "'"+string(yyDollar[1].bytes)+"'")
 		}
 	case 141:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:935
+//line sql.y:936
 		{
 			yyVAL.strs = append(yyDollar[1].strs, "'"+string(yyDollar[3].bytes)+"'")
 		}
 	case 142:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:940
+//line sql.y:941
 		{
 			yyVAL.sqlVal = nil
 		}
 	case 143:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:944
+//line sql.y:945
 		{
 			yyVAL.sqlVal = NewIntVal(yyDollar[2].bytes)
 		}
 	case 144:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:949
+//line sql.y:950
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{}
 		}
 	case 145:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:953
+//line sql.y:954
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -4393,13 +4393,13 @@ yydefault:
 		}
 	case 146:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:961
+//line sql.y:962
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{}
 		}
 	case 147:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:965
+//line sql.y:966
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -4407,7 +4407,7 @@ yydefault:
 		}
 	case 148:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:971
+//line sql.y:972
 		{
 			yyVAL.LengthScaleOption = LengthScaleOption{
 				Length: NewIntVal(yyDollar[2].bytes),
@@ -4416,478 +4416,478 @@ yydefault:
 		}
 	case 149:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:979
+//line sql.y:980
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 150:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:983
+//line sql.y:984
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 151:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:988
+//line sql.y:989
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 152:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:992
+//line sql.y:993
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 153:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:998
+//line sql.y:999
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 154:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1002
+//line sql.y:1003
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 155:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1006
+//line sql.y:1007
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 156:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1011
+//line sql.y:1012
 		{
 			yyVAL.optVal = nil
 		}
 	case 157:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1015
+//line sql.y:1016
 		{
 			yyVAL.optVal = yyDollar[2].expr
 		}
 	case 158:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1020
+//line sql.y:1021
 		{
 			yyVAL.optVal = nil
 		}
 	case 159:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1024
+//line sql.y:1025
 		{
 			yyVAL.optVal = yyDollar[3].expr
 		}
 	case 160:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1029
+//line sql.y:1030
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 161:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1033
+//line sql.y:1034
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 162:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1038
+//line sql.y:1039
 		{
 			yyVAL.str = ""
 		}
 	case 163:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1042
+//line sql.y:1043
 		{
 			yyVAL.str = string(yyDollar[3].colIdent.String())
 		}
 	case 164:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1046
+//line sql.y:1047
 		{
 			yyVAL.str = string(yyDollar[3].bytes)
 		}
 	case 165:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1051
+//line sql.y:1052
 		{
 			yyVAL.str = ""
 		}
 	case 166:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1055
+//line sql.y:1056
 		{
 			yyVAL.str = string(yyDollar[2].colIdent.String())
 		}
 	case 167:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1059
+//line sql.y:1060
 		{
 			yyVAL.str = string(yyDollar[2].bytes)
 		}
 	case 168:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1064
+//line sql.y:1065
 		{
 			yyVAL.colKeyOpt = colKeyNone
 		}
 	case 169:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1068
+//line sql.y:1069
 		{
 			yyVAL.colKeyOpt = colKeyPrimary
 		}
 	case 170:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1072
+//line sql.y:1073
 		{
 			yyVAL.colKeyOpt = colKey
 		}
 	case 171:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1076
+//line sql.y:1077
 		{
 			yyVAL.colKeyOpt = colKeyUniqueKey
 		}
 	case 172:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1080
+//line sql.y:1081
 		{
 			yyVAL.colKeyOpt = colKeyUnique
 		}
 	case 173:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1085
+//line sql.y:1086
 		{
 			yyVAL.sqlVal = nil
 		}
 	case 174:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1089
+//line sql.y:1090
 		{
 			yyVAL.sqlVal = NewStrVal(yyDollar[2].bytes)
 		}
 	case 175:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1095
+//line sql.y:1096
 		{
 			yyVAL.indexDefinition = &IndexDefinition{Info: yyDollar[1].indexInfo, Columns: yyDollar[3].indexColumns, Options: yyDollar[5].indexOptions}
 		}
 	case 176:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1099
+//line sql.y:1100
 		{
 			yyVAL.indexDefinition = &IndexDefinition{Info: yyDollar[1].indexInfo, Columns: yyDollar[3].indexColumns}
 		}
 	case 177:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1105
+//line sql.y:1106
 		{
 			yyVAL.indexOptions = []*IndexOption{yyDollar[1].indexOption}
 		}
 	case 178:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1109
+//line sql.y:1110
 		{
 			yyVAL.indexOptions = append(yyVAL.indexOptions, yyDollar[2].indexOption)
 		}
 	case 179:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1115
+//line sql.y:1116
 		{
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Using: string(yyDollar[2].colIdent.String())}
 		}
 	case 180:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1119
+//line sql.y:1120
 		{
 			// should not be string
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Value: NewIntVal(yyDollar[3].bytes)}
 		}
 	case 181:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1124
+//line sql.y:1125
 		{
 			yyVAL.indexOption = &IndexOption{Name: string(yyDollar[1].bytes), Value: NewStrVal(yyDollar[2].bytes)}
 		}
 	case 182:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1130
+//line sql.y:1131
 		{
 			yyVAL.str = ""
 		}
 	case 183:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1134
+//line sql.y:1135
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 184:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1140
+//line sql.y:1141
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].bytes), Name: NewColIdent("PRIMARY"), Primary: true, Unique: true}
 		}
 	case 185:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1144
+//line sql.y:1145
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].str), Name: NewColIdent(yyDollar[3].str), Spatial: true, Unique: false}
 		}
 	case 186:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1148
+//line sql.y:1149
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes) + " " + string(yyDollar[2].str), Name: NewColIdent(yyDollar[3].str), Unique: true}
 		}
 	case 187:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1152
+//line sql.y:1153
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].bytes), Name: NewColIdent(yyDollar[2].str), Unique: true}
 		}
 	case 188:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1156
+//line sql.y:1157
 		{
 			yyVAL.indexInfo = &IndexInfo{Type: string(yyDollar[1].str), Name: NewColIdent(yyDollar[2].str), Unique: false}
 		}
 	case 189:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1162
+//line sql.y:1163
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 190:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1166
+//line sql.y:1167
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 191:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1171
+//line sql.y:1172
 		{
 			yyVAL.str = ""
 		}
 	case 192:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1175
+//line sql.y:1176
 		{
 			yyVAL.str = string(yyDollar[1].colIdent.String())
 		}
 	case 193:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1181
+//line sql.y:1182
 		{
 			yyVAL.indexColumns = []*IndexColumn{yyDollar[1].indexColumn}
 		}
 	case 194:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1185
+//line sql.y:1186
 		{
 			yyVAL.indexColumns = append(yyVAL.indexColumns, yyDollar[3].indexColumn)
 		}
 	case 195:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1191
+//line sql.y:1192
 		{
 			yyVAL.indexColumn = &IndexColumn{Column: yyDollar[1].colIdent, Length: yyDollar[2].sqlVal}
 		}
 	case 196:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1197
+//line sql.y:1198
 		{
 			yyVAL.constraintDefinition = &ConstraintDefinition{Name: string(yyDollar[2].colIdent.String()), Details: yyDollar[3].constraintInfo}
 		}
 	case 197:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1201
+//line sql.y:1202
 		{
 			yyVAL.constraintDefinition = &ConstraintDefinition{Details: yyDollar[1].constraintInfo}
 		}
 	case 198:
 		yyDollar = yyS[yypt-10 : yypt+1]
-//line sql.y:1208
+//line sql.y:1209
 		{
 			yyVAL.constraintInfo = &ForeignKeyDefinition{Source: yyDollar[4].columns, ReferencedTable: yyDollar[7].tableName, ReferencedColumns: yyDollar[9].columns}
 		}
 	case 199:
 		yyDollar = yyS[yypt-11 : yypt+1]
-//line sql.y:1212
+//line sql.y:1213
 		{
 			yyVAL.constraintInfo = &ForeignKeyDefinition{Source: yyDollar[4].columns, ReferencedTable: yyDollar[7].tableName, ReferencedColumns: yyDollar[9].columns, OnDelete: yyDollar[11].ReferenceAction}
 		}
 	case 200:
 		yyDollar = yyS[yypt-11 : yypt+1]
-//line sql.y:1216
+//line sql.y:1217
 		{
 			yyVAL.constraintInfo = &ForeignKeyDefinition{Source: yyDollar[4].columns, ReferencedTable: yyDollar[7].tableName, ReferencedColumns: yyDollar[9].columns, OnUpdate: yyDollar[11].ReferenceAction}
 		}
 	case 201:
 		yyDollar = yyS[yypt-12 : yypt+1]
-//line sql.y:1220
+//line sql.y:1221
 		{
 			yyVAL.constraintInfo = &ForeignKeyDefinition{Source: yyDollar[4].columns, ReferencedTable: yyDollar[7].tableName, ReferencedColumns: yyDollar[9].columns, OnDelete: yyDollar[11].ReferenceAction, OnUpdate: yyDollar[12].ReferenceAction}
 		}
 	case 202:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1226
+//line sql.y:1227
 		{
 			yyVAL.ReferenceAction = yyDollar[3].ReferenceAction
 		}
 	case 203:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1232
+//line sql.y:1233
 		{
 			yyVAL.ReferenceAction = yyDollar[3].ReferenceAction
 		}
 	case 204:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1238
+//line sql.y:1239
 		{
 			yyVAL.ReferenceAction = Restrict
 		}
 	case 205:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1242
+//line sql.y:1243
 		{
 			yyVAL.ReferenceAction = Cascade
 		}
 	case 206:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1246
+//line sql.y:1247
 		{
 			yyVAL.ReferenceAction = NoAction
 		}
 	case 207:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1250
+//line sql.y:1251
 		{
 			yyVAL.ReferenceAction = SetDefault
 		}
 	case 208:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1254
+//line sql.y:1255
 		{
 			yyVAL.ReferenceAction = SetNull
 		}
 	case 209:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1259
+//line sql.y:1260
 		{
 			yyVAL.str = ""
 		}
 	case 210:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1263
+//line sql.y:1264
 		{
 			yyVAL.str = " " + string(yyDollar[1].str)
 		}
 	case 211:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1267
+//line sql.y:1268
 		{
 			yyVAL.str = string(yyDollar[1].str) + ", " + string(yyDollar[3].str)
 		}
 	case 212:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1275
+//line sql.y:1276
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 213:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1279
+//line sql.y:1280
 		{
 			yyVAL.str = yyDollar[1].str + " " + yyDollar[2].str
 		}
 	case 214:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1283
+//line sql.y:1284
 		{
 			yyVAL.str = yyDollar[1].str + "=" + yyDollar[3].str
 		}
 	case 215:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1289
+//line sql.y:1290
 		{
 			yyVAL.str = yyDollar[1].colIdent.String()
 		}
 	case 216:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1293
+//line sql.y:1294
 		{
 			yyVAL.str = "'" + string(yyDollar[1].bytes) + "'"
 		}
 	case 217:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1297
+//line sql.y:1298
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 218:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:1303
+//line sql.y:1304
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName}
 		}
 	case 219:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1307
+//line sql.y:1308
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName}
 		}
 	case 220:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1311
+//line sql.y:1312
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName}
 		}
 	case 221:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1315
+//line sql.y:1316
 		{
 			// Change this to a rename statement
 			yyVAL.statement = &DDL{Action: RenameStr, FromTables: TableNames{yyDollar[4].tableName}, ToTables: TableNames{yyDollar[7].tableName}}
 		}
 	case 222:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1320
+//line sql.y:1321
 		{
 			// Rename an index can just be an alter
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName}
 		}
 	case 223:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1325
+//line sql.y:1326
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[3].tableName.ToViewName()}
 		}
 	case 224:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1329
+//line sql.y:1330
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, PartitionSpec: yyDollar[5].partSpec}
 		}
 	case 225:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1333
+//line sql.y:1334
 		{
 			yyVAL.statement = &DBDDL{Action: AlterStr, DBName: string(yyDollar[3].colIdent.String())}
 		}
 	case 226:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1337
+//line sql.y:1338
 		{
 			yyVAL.statement = &DBDDL{Action: AlterStr, DBName: string(yyDollar[3].colIdent.String())}
 		}
 	case 227:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1341
+//line sql.y:1342
 		{
 			yyVAL.statement = &DDL{
 				Action: CreateVindexStr,
@@ -4901,7 +4901,7 @@ yydefault:
 		}
 	case 228:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1353
+//line sql.y:1354
 		{
 			yyVAL.statement = &DDL{
 				Action: DropVindexStr,
@@ -4913,19 +4913,19 @@ yydefault:
 		}
 	case 229:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1363
+//line sql.y:1364
 		{
 			yyVAL.statement = &DDL{Action: AddVschemaTableStr, Table: yyDollar[5].tableName}
 		}
 	case 230:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1367
+//line sql.y:1368
 		{
 			yyVAL.statement = &DDL{Action: DropVschemaTableStr, Table: yyDollar[5].tableName}
 		}
 	case 231:
 		yyDollar = yyS[yypt-12 : yypt+1]
-//line sql.y:1371
+//line sql.y:1372
 		{
 			yyVAL.statement = &DDL{
 				Action: AddColVindexStr,
@@ -4940,7 +4940,7 @@ yydefault:
 		}
 	case 232:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1384
+//line sql.y:1385
 		{
 			yyVAL.statement = &DDL{
 				Action: DropColVindexStr,
@@ -4952,13 +4952,13 @@ yydefault:
 		}
 	case 233:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1394
+//line sql.y:1395
 		{
 			yyVAL.statement = &DDL{Action: AddSequenceStr, Table: yyDollar[5].tableName}
 		}
 	case 234:
 		yyDollar = yyS[yypt-9 : yypt+1]
-//line sql.y:1398
+//line sql.y:1399
 		{
 			yyVAL.statement = &DDL{
 				Action: AddAutoIncStr,
@@ -4971,49 +4971,49 @@ yydefault:
 		}
 	case 249:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1427
+//line sql.y:1428
 		{
 			yyVAL.partSpec = &PartitionSpec{Action: ReorganizeStr, Name: yyDollar[3].colIdent, Definitions: yyDollar[6].partDefs}
 		}
 	case 250:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1433
+//line sql.y:1434
 		{
 			yyVAL.partDefs = []*PartitionDefinition{yyDollar[1].partDef}
 		}
 	case 251:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1437
+//line sql.y:1438
 		{
 			yyVAL.partDefs = append(yyDollar[1].partDefs, yyDollar[3].partDef)
 		}
 	case 252:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:1443
+//line sql.y:1444
 		{
 			yyVAL.partDef = &PartitionDefinition{Name: yyDollar[2].colIdent, Limit: yyDollar[7].expr}
 		}
 	case 253:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:1447
+//line sql.y:1448
 		{
 			yyVAL.partDef = &PartitionDefinition{Name: yyDollar[2].colIdent, Maxvalue: true}
 		}
 	case 254:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1453
+//line sql.y:1454
 		{
 			yyVAL.statement = yyDollar[3].ddl
 		}
 	case 255:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1459
+//line sql.y:1460
 		{
 			yyVAL.ddl = &DDL{Action: RenameStr, FromTables: TableNames{yyDollar[1].tableName}, ToTables: TableNames{yyDollar[3].tableName}}
 		}
 	case 256:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1463
+//line sql.y:1464
 		{
 			yyVAL.ddl = yyDollar[1].ddl
 			yyVAL.ddl.FromTables = append(yyVAL.ddl.FromTables, yyDollar[3].tableName)
@@ -5021,7 +5021,7 @@ yydefault:
 		}
 	case 257:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1471
+//line sql.y:1472
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -5031,14 +5031,14 @@ yydefault:
 		}
 	case 258:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:1479
+//line sql.y:1480
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[5].tableName}
 		}
 	case 259:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1484
+//line sql.y:1485
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -5048,150 +5048,150 @@ yydefault:
 		}
 	case 260:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1492
+//line sql.y:1493
 		{
 			yyVAL.statement = &DBDDL{Action: DropStr, DBName: string(yyDollar[4].colIdent.String())}
 		}
 	case 261:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1496
+//line sql.y:1497
 		{
 			yyVAL.statement = &DBDDL{Action: DropStr, DBName: string(yyDollar[4].colIdent.String())}
 		}
 	case 262:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1502
+//line sql.y:1503
 		{
 			yyVAL.statement = &DDL{Action: TruncateStr, Table: yyDollar[3].tableName}
 		}
 	case 263:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1506
+//line sql.y:1507
 		{
 			yyVAL.statement = &DDL{Action: TruncateStr, Table: yyDollar[2].tableName}
 		}
 	case 264:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1511
+//line sql.y:1512
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 265:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1517
+//line sql.y:1518
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].colIdent.String())}
 		}
 	case 266:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1522
+//line sql.y:1523
 		{
 			showTablesOpt := &ShowTablesOpt{Filter: yyDollar[4].showFilter}
 			yyVAL.statement = &Show{Type: CharsetStr, ShowTablesOpt: showTablesOpt}
 		}
 	case 267:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1527
+//line sql.y:1528
 		{
 			showTablesOpt := &ShowTablesOpt{Filter: yyDollar[3].showFilter}
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes), ShowTablesOpt: showTablesOpt}
 		}
 	case 268:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1532
+//line sql.y:1533
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 269:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1537
+//line sql.y:1538
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].colIdent.String())}
 		}
 	case 270:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1541
+//line sql.y:1542
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 271:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1545
+//line sql.y:1546
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes), Table: yyDollar[4].tableName}
 		}
 	case 272:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1549
+//line sql.y:1550
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 273:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1553
+//line sql.y:1554
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 274:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1557
+//line sql.y:1558
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 275:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1561
+//line sql.y:1562
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 276:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:1565
+//line sql.y:1566
 		{
 			showTablesOpt := &ShowTablesOpt{DbName: yyDollar[5].str, Filter: yyDollar[6].showFilter}
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes), ShowTablesOpt: showTablesOpt, OnTable: yyDollar[4].tableName}
 		}
 	case 277:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:1570
+//line sql.y:1571
 		{
 			showTablesOpt := &ShowTablesOpt{DbName: yyDollar[5].str, Filter: yyDollar[6].showFilter}
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes), ShowTablesOpt: showTablesOpt, OnTable: yyDollar[4].tableName}
 		}
 	case 278:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1575
+//line sql.y:1576
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 279:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1579
+//line sql.y:1580
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 280:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1583
+//line sql.y:1584
 		{
 			yyVAL.statement = &Show{Scope: yyDollar[2].str, Type: string(yyDollar[3].bytes)}
 		}
 	case 281:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1587
+//line sql.y:1588
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 282:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1591
+//line sql.y:1592
 		{
 			showTablesOpt := &ShowTablesOpt{Full: yyDollar[2].str, DbName: yyDollar[6].str, Filter: yyDollar[7].showFilter}
 			yyVAL.statement = &Show{Type: string(yyDollar[3].str), ShowTablesOpt: showTablesOpt, OnTable: yyDollar[5].tableName}
 		}
 	case 283:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1596
+//line sql.y:1597
 		{
 			// this is ugly, but I couldn't find a better way for now
 			if yyDollar[3].str == "processlist" {
@@ -5203,19 +5203,19 @@ yydefault:
 		}
 	case 284:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1606
+//line sql.y:1607
 		{
 			yyVAL.statement = &Show{Scope: yyDollar[2].str, Type: string(yyDollar[3].bytes)}
 		}
 	case 285:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1610
+//line sql.y:1611
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 286:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1614
+//line sql.y:1615
 		{
 			// Cannot dereference $4 directly, or else the parser stackcannot be pooled. See yyParsePooled
 			showCollationFilterOpt := yyDollar[4].expr
@@ -5223,429 +5223,429 @@ yydefault:
 		}
 	case 287:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:1620
+//line sql.y:1621
 		{
 			showTablesOpt := &ShowTablesOpt{Filter: yyDollar[4].showFilter}
 			yyVAL.statement = &Show{Scope: string(yyDollar[2].bytes), Type: string(yyDollar[3].bytes), ShowTablesOpt: showTablesOpt}
 		}
 	case 288:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1625
+//line sql.y:1626
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 289:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1629
+//line sql.y:1630
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes)}
 		}
 	case 290:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1633
+//line sql.y:1634
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes) + " " + string(yyDollar[3].bytes), OnTable: yyDollar[5].tableName}
 		}
 	case 291:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1637
+//line sql.y:1638
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].bytes)}
 		}
 	case 292:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1651
+//line sql.y:1652
 		{
 			yyVAL.statement = &Show{Type: string(yyDollar[2].colIdent.String())}
 		}
 	case 293:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1657
+//line sql.y:1658
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 294:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1661
+//line sql.y:1662
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 295:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1667
+//line sql.y:1668
 		{
 			yyVAL.str = ""
 		}
 	case 296:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1671
+//line sql.y:1672
 		{
 			yyVAL.str = "full "
 		}
 	case 297:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1677
+//line sql.y:1678
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 298:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1681
+//line sql.y:1682
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 299:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1687
+//line sql.y:1688
 		{
 			yyVAL.str = ""
 		}
 	case 300:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1691
+//line sql.y:1692
 		{
 			yyVAL.str = yyDollar[2].tableIdent.v
 		}
 	case 301:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1695
+//line sql.y:1696
 		{
 			yyVAL.str = yyDollar[2].tableIdent.v
 		}
 	case 302:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1701
+//line sql.y:1702
 		{
 			yyVAL.showFilter = nil
 		}
 	case 303:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1705
+//line sql.y:1706
 		{
 			yyVAL.showFilter = &ShowFilter{Like: string(yyDollar[2].bytes)}
 		}
 	case 304:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1709
+//line sql.y:1710
 		{
 			yyVAL.showFilter = &ShowFilter{Filter: yyDollar[2].expr}
 		}
 	case 305:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1715
+//line sql.y:1716
 		{
 			yyVAL.showFilter = nil
 		}
 	case 306:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1719
+//line sql.y:1720
 		{
 			yyVAL.showFilter = &ShowFilter{Like: string(yyDollar[2].bytes)}
 		}
 	case 307:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1725
+//line sql.y:1726
 		{
 			yyVAL.str = ""
 		}
 	case 308:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1729
+//line sql.y:1730
 		{
 			yyVAL.str = SessionStr
 		}
 	case 309:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1733
+//line sql.y:1734
 		{
 			yyVAL.str = GlobalStr
 		}
 	case 310:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1739
+//line sql.y:1740
 		{
 			yyVAL.statement = &Use{DBName: yyDollar[2].tableIdent}
 		}
 	case 311:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1743
+//line sql.y:1744
 		{
 			yyVAL.statement = &Use{DBName: TableIdent{v: ""}}
 		}
 	case 312:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1749
+//line sql.y:1750
 		{
 			yyVAL.statement = &Begin{}
 		}
 	case 313:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1753
+//line sql.y:1754
 		{
 			yyVAL.statement = &Begin{}
 		}
 	case 314:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1759
+//line sql.y:1760
 		{
 			yyVAL.statement = &Commit{}
 		}
 	case 315:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1765
+//line sql.y:1766
 		{
 			yyVAL.statement = &Rollback{}
 		}
 	case 316:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1771
+//line sql.y:1772
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 317:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1775
+//line sql.y:1776
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 318:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1779
+//line sql.y:1780
 		{
 			yyVAL.statement = &OtherRead{}
 		}
 	case 319:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1783
+//line sql.y:1784
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 320:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1787
+//line sql.y:1788
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 321:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1791
+//line sql.y:1792
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 322:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1795
+//line sql.y:1796
 		{
 			yyVAL.statement = &OtherAdmin{}
 		}
 	case 323:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1801
+//line sql.y:1802
 		{
 			yyVAL.statement = &DDL{Action: FlushStr}
 		}
 	case 324:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1805
+//line sql.y:1806
 		{
 			setAllowComments(yylex, true)
 		}
 	case 325:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1809
+//line sql.y:1810
 		{
 			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 326:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1815
+//line sql.y:1816
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 327:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1819
+//line sql.y:1820
 		{
 			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 328:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1825
+//line sql.y:1826
 		{
 			yyVAL.str = UnionStr
 		}
 	case 329:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1829
+//line sql.y:1830
 		{
 			yyVAL.str = UnionAllStr
 		}
 	case 330:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1833
+//line sql.y:1834
 		{
 			yyVAL.str = UnionDistinctStr
 		}
 	case 331:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1838
+//line sql.y:1839
 		{
 			yyVAL.str = ""
 		}
 	case 332:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1842
+//line sql.y:1843
 		{
 			yyVAL.str = SQLNoCacheStr
 		}
 	case 333:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1846
+//line sql.y:1847
 		{
 			yyVAL.str = SQLCacheStr
 		}
 	case 334:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1851
+//line sql.y:1852
 		{
 			yyVAL.str = ""
 		}
 	case 335:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1855
+//line sql.y:1856
 		{
 			yyVAL.str = DistinctStr
 		}
 	case 336:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1859
+//line sql.y:1860
 		{
 			yyVAL.str = DistinctStr
 		}
 	case 337:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1864
+//line sql.y:1865
 		{
 			yyVAL.str = ""
 		}
 	case 338:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1868
+//line sql.y:1869
 		{
 			yyVAL.str = StraightJoinHint
 		}
 	case 339:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1873
+//line sql.y:1874
 		{
 			yyVAL.selectExprs = nil
 		}
 	case 340:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1877
+//line sql.y:1878
 		{
 			yyVAL.selectExprs = yyDollar[1].selectExprs
 		}
 	case 341:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1883
+//line sql.y:1884
 		{
 			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 342:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1887
+//line sql.y:1888
 		{
 			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 343:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1893
+//line sql.y:1894
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 344:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1897
+//line sql.y:1898
 		{
 			yyVAL.selectExpr = &AliasedExpr{Expr: yyDollar[1].expr, As: yyDollar[2].colIdent}
 		}
 	case 345:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1901
+//line sql.y:1902
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Name: yyDollar[1].tableIdent}}
 		}
 	case 346:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:1905
+//line sql.y:1906
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}}
 		}
 	case 347:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1910
+//line sql.y:1911
 		{
 			yyVAL.colIdent = ColIdent{}
 		}
 	case 348:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1914
+//line sql.y:1915
 		{
 			yyVAL.colIdent = yyDollar[1].colIdent
 		}
 	case 349:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1918
+//line sql.y:1919
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 351:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1925
+//line sql.y:1926
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 352:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:1930
+//line sql.y:1931
 		{
 			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
 		}
 	case 353:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:1934
+//line sql.y:1935
 		{
 			yyVAL.tableExprs = yyDollar[2].tableExprs
 		}
 	case 354:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1940
+//line sql.y:1941
 		{
 			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 355:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1944
+//line sql.y:1945
 		{
 			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 358:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1954
+//line sql.y:1955
 		{
 			yyVAL.tableExpr = yyDollar[1].aliasedTableName
 		}
 	case 359:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1958
+//line sql.y:1959
 		{
 			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].subquery, As: yyDollar[3].tableIdent}
 		}
 	case 360:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1962
+//line sql.y:1963
 		{
 			// missed alias for subquery
 			yylex.Error("Every derived table must have its own alias")
@@ -5653,199 +5653,199 @@ yydefault:
 		}
 	case 361:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1968
+//line sql.y:1969
 		{
 			yyVAL.tableExpr = &ParenTableExpr{Exprs: yyDollar[2].tableExprs}
 		}
 	case 362:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1974
+//line sql.y:1975
 		{
 			yyVAL.aliasedTableName = &AliasedTableExpr{Expr: yyDollar[1].tableName, As: yyDollar[2].tableIdent, Hints: yyDollar[3].indexHints}
 		}
 	case 363:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:1978
+//line sql.y:1979
 		{
 			yyVAL.aliasedTableName = &AliasedTableExpr{Expr: yyDollar[1].tableName, Partitions: yyDollar[4].partitions, As: yyDollar[6].tableIdent, Hints: yyDollar[7].indexHints}
 		}
 	case 364:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1984
+//line sql.y:1985
 		{
 			yyVAL.columns = Columns{yyDollar[1].colIdent}
 		}
 	case 365:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1988
+//line sql.y:1989
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[3].colIdent)
 		}
 	case 366:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:1994
+//line sql.y:1995
 		{
 			yyVAL.partitions = Partitions{yyDollar[1].colIdent}
 		}
 	case 367:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:1998
+//line sql.y:1999
 		{
 			yyVAL.partitions = append(yyVAL.partitions, yyDollar[3].colIdent)
 		}
 	case 368:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2011
+//line sql.y:2012
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 369:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2015
+//line sql.y:2016
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 370:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2019
+//line sql.y:2020
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, Condition: yyDollar[4].joinCondition}
 		}
 	case 371:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2023
+//line sql.y:2024
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 372:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2029
+//line sql.y:2030
 		{
 			yyVAL.joinCondition = JoinCondition{On: yyDollar[2].expr}
 		}
 	case 373:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2031
+//line sql.y:2032
 		{
 			yyVAL.joinCondition = JoinCondition{Using: yyDollar[3].columns}
 		}
 	case 374:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2035
+//line sql.y:2036
 		{
 			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 375:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2037
+//line sql.y:2038
 		{
 			yyVAL.joinCondition = yyDollar[1].joinCondition
 		}
 	case 376:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2041
+//line sql.y:2042
 		{
 			yyVAL.joinCondition = JoinCondition{}
 		}
 	case 377:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2043
+//line sql.y:2044
 		{
 			yyVAL.joinCondition = JoinCondition{On: yyDollar[2].expr}
 		}
 	case 378:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2046
+//line sql.y:2047
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 379:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2048
+//line sql.y:2049
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 380:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2051
+//line sql.y:2052
 		{
 			yyVAL.tableIdent = NewTableIdent("")
 		}
 	case 381:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2055
+//line sql.y:2056
 		{
 			yyVAL.tableIdent = yyDollar[1].tableIdent
 		}
 	case 382:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2059
+//line sql.y:2060
 		{
 			yyVAL.tableIdent = yyDollar[2].tableIdent
 		}
 	case 384:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2066
+//line sql.y:2067
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 385:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2072
+//line sql.y:2073
 		{
 			yyVAL.str = JoinStr
 		}
 	case 386:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2076
+//line sql.y:2077
 		{
 			yyVAL.str = JoinStr
 		}
 	case 387:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2080
+//line sql.y:2081
 		{
 			yyVAL.str = JoinStr
 		}
 	case 388:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2086
+//line sql.y:2087
 		{
 			yyVAL.str = StraightJoinStr
 		}
 	case 389:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2092
+//line sql.y:2093
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 390:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2096
+//line sql.y:2097
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 391:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2100
+//line sql.y:2101
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 392:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2104
+//line sql.y:2105
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 393:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2110
+//line sql.y:2111
 		{
 			yyVAL.str = NaturalJoinStr
 		}
 	case 394:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2114
+//line sql.y:2115
 		{
 			if yyDollar[2].str == LeftJoinStr {
 				yyVAL.str = NaturalLeftJoinStr
@@ -5855,469 +5855,469 @@ yydefault:
 		}
 	case 395:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2124
+//line sql.y:2125
 		{
 			yyVAL.tableName = yyDollar[2].tableName
 		}
 	case 396:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2128
+//line sql.y:2129
 		{
 			yyVAL.tableName = yyDollar[1].tableName
 		}
 	case 397:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2134
+//line sql.y:2135
 		{
 			yyVAL.tableName = TableName{Name: yyDollar[1].tableIdent}
 		}
 	case 398:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2138
+//line sql.y:2139
 		{
 			yyVAL.tableName = TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}
 		}
 	case 399:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2144
+//line sql.y:2145
 		{
 			yyVAL.tableName = TableName{Name: yyDollar[1].tableIdent}
 		}
 	case 400:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2149
+//line sql.y:2150
 		{
 			yyVAL.indexHints = nil
 		}
 	case 401:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2153
+//line sql.y:2154
 		{
 			yyVAL.indexHints = &IndexHints{Type: UseStr, Indexes: yyDollar[4].columns}
 		}
 	case 402:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2157
+//line sql.y:2158
 		{
 			yyVAL.indexHints = &IndexHints{Type: UseStr}
 		}
 	case 403:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2161
+//line sql.y:2162
 		{
 			yyVAL.indexHints = &IndexHints{Type: IgnoreStr, Indexes: yyDollar[4].columns}
 		}
 	case 404:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2165
+//line sql.y:2166
 		{
 			yyVAL.indexHints = &IndexHints{Type: ForceStr, Indexes: yyDollar[4].columns}
 		}
 	case 405:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2170
+//line sql.y:2171
 		{
 			yyVAL.expr = nil
 		}
 	case 406:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2174
+//line sql.y:2175
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 407:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2180
+//line sql.y:2181
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 408:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2184
+//line sql.y:2185
 		{
 			yyVAL.expr = &AndExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 409:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2188
+//line sql.y:2189
 		{
 			yyVAL.expr = &OrExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 410:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2192
+//line sql.y:2193
 		{
 			yyVAL.expr = &NotExpr{Expr: yyDollar[2].expr}
 		}
 	case 411:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2196
+//line sql.y:2197
 		{
 			yyVAL.expr = &IsExpr{Operator: yyDollar[3].str, Expr: yyDollar[1].expr}
 		}
 	case 412:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2200
+//line sql.y:2201
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 413:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2204
+//line sql.y:2205
 		{
 			yyVAL.expr = &Default{ColName: yyDollar[2].str}
 		}
 	case 414:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2210
+//line sql.y:2211
 		{
 			yyVAL.str = ""
 		}
 	case 415:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2214
+//line sql.y:2215
 		{
 			yyVAL.str = string(yyDollar[2].colIdent.String())
 		}
 	case 416:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2220
+//line sql.y:2221
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 417:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2224
+//line sql.y:2225
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 418:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2230
+//line sql.y:2231
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: yyDollar[2].str, Right: yyDollar[3].expr}
 		}
 	case 419:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2234
+//line sql.y:2235
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: InStr, Right: yyDollar[3].colTuple}
 		}
 	case 420:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2238
+//line sql.y:2239
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotInStr, Right: yyDollar[4].colTuple}
 		}
 	case 421:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2242
+//line sql.y:2243
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: LikeStr, Right: yyDollar[3].expr, Escape: yyDollar[4].expr}
 		}
 	case 422:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2246
+//line sql.y:2247
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotLikeStr, Right: yyDollar[4].expr, Escape: yyDollar[5].expr}
 		}
 	case 423:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2250
+//line sql.y:2251
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: RegexpStr, Right: yyDollar[3].expr}
 		}
 	case 424:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2254
+//line sql.y:2255
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotRegexpStr, Right: yyDollar[4].expr}
 		}
 	case 425:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2258
+//line sql.y:2259
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
 		}
 	case 426:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:2262
+//line sql.y:2263
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
 		}
 	case 427:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2266
+//line sql.y:2267
 		{
 			yyVAL.expr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 428:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2272
+//line sql.y:2273
 		{
 			yyVAL.str = IsNullStr
 		}
 	case 429:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2276
+//line sql.y:2277
 		{
 			yyVAL.str = IsNotNullStr
 		}
 	case 430:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2280
+//line sql.y:2281
 		{
 			yyVAL.str = IsTrueStr
 		}
 	case 431:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2284
+//line sql.y:2285
 		{
 			yyVAL.str = IsNotTrueStr
 		}
 	case 432:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2288
+//line sql.y:2289
 		{
 			yyVAL.str = IsFalseStr
 		}
 	case 433:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2292
+//line sql.y:2293
 		{
 			yyVAL.str = IsNotFalseStr
 		}
 	case 434:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2298
+//line sql.y:2299
 		{
 			yyVAL.str = EqualStr
 		}
 	case 435:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2302
+//line sql.y:2303
 		{
 			yyVAL.str = LessThanStr
 		}
 	case 436:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2306
+//line sql.y:2307
 		{
 			yyVAL.str = GreaterThanStr
 		}
 	case 437:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2310
+//line sql.y:2311
 		{
 			yyVAL.str = LessEqualStr
 		}
 	case 438:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2314
+//line sql.y:2315
 		{
 			yyVAL.str = GreaterEqualStr
 		}
 	case 439:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2318
+//line sql.y:2319
 		{
 			yyVAL.str = NotEqualStr
 		}
 	case 440:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2322
+//line sql.y:2323
 		{
 			yyVAL.str = NullSafeEqualStr
 		}
 	case 441:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2327
+//line sql.y:2328
 		{
 			yyVAL.expr = nil
 		}
 	case 442:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2331
+//line sql.y:2332
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 443:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2337
+//line sql.y:2338
 		{
 			yyVAL.colTuple = yyDollar[1].valTuple
 		}
 	case 444:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2341
+//line sql.y:2342
 		{
 			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 445:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2345
+//line sql.y:2346
 		{
 			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 446:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2351
+//line sql.y:2352
 		{
 			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 447:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2357
+//line sql.y:2358
 		{
 			yyVAL.exprs = Exprs{yyDollar[1].expr}
 		}
 	case 448:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2361
+//line sql.y:2362
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 449:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2367
+//line sql.y:2368
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 450:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2371
+//line sql.y:2372
 		{
 			yyVAL.expr = yyDollar[1].boolVal
 		}
 	case 451:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2375
+//line sql.y:2376
 		{
 			yyVAL.expr = yyDollar[1].colName
 		}
 	case 452:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2379
+//line sql.y:2380
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 453:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2383
+//line sql.y:2384
 		{
 			yyVAL.expr = yyDollar[1].subquery
 		}
 	case 454:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2387
+//line sql.y:2388
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitAndStr, Right: yyDollar[3].expr}
 		}
 	case 455:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2391
+//line sql.y:2392
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitOrStr, Right: yyDollar[3].expr}
 		}
 	case 456:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2395
+//line sql.y:2396
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitXorStr, Right: yyDollar[3].expr}
 		}
 	case 457:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2399
+//line sql.y:2400
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: PlusStr, Right: yyDollar[3].expr}
 		}
 	case 458:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2403
+//line sql.y:2404
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MinusStr, Right: yyDollar[3].expr}
 		}
 	case 459:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2407
+//line sql.y:2408
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MultStr, Right: yyDollar[3].expr}
 		}
 	case 460:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2411
+//line sql.y:2412
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: DivStr, Right: yyDollar[3].expr}
 		}
 	case 461:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2415
+//line sql.y:2416
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: IntDivStr, Right: yyDollar[3].expr}
 		}
 	case 462:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2419
+//line sql.y:2420
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 463:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2423
+//line sql.y:2424
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 464:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2427
+//line sql.y:2428
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftLeftStr, Right: yyDollar[3].expr}
 		}
 	case 465:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2431
+//line sql.y:2432
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftRightStr, Right: yyDollar[3].expr}
 		}
 	case 466:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2435
+//line sql.y:2436
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONExtractOp, Right: yyDollar[3].expr}
 		}
 	case 467:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2439
+//line sql.y:2440
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONUnquoteExtractOp, Right: yyDollar[3].expr}
 		}
 	case 468:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2443
+//line sql.y:2444
 		{
 			yyVAL.expr = &CollateExpr{Expr: yyDollar[1].expr, Charset: yyDollar[3].str}
 		}
 	case 469:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2447
+//line sql.y:2448
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BinaryStr, Expr: yyDollar[2].expr}
 		}
 	case 470:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2451
+//line sql.y:2452
 		{
 			yyVAL.expr = &UnaryExpr{Operator: UBinaryStr, Expr: yyDollar[2].expr}
 		}
 	case 471:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2455
+//line sql.y:2456
 		{
 			yyVAL.expr = &UnaryExpr{Operator: Utf8mb4Str, Expr: yyDollar[2].expr}
 		}
 	case 472:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2459
+//line sql.y:2460
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				yyVAL.expr = num
@@ -6327,7 +6327,7 @@ yydefault:
 		}
 	case 473:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2467
+//line sql.y:2468
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				// Handle double negative
@@ -6343,19 +6343,19 @@ yydefault:
 		}
 	case 474:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2481
+//line sql.y:2482
 		{
 			yyVAL.expr = &UnaryExpr{Operator: TildaStr, Expr: yyDollar[2].expr}
 		}
 	case 475:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2485
+//line sql.y:2486
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BangStr, Expr: yyDollar[2].expr}
 		}
 	case 476:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2489
+//line sql.y:2490
 		{
 			// This rule prevents the usage of INTERVAL
 			// as a function. If support is needed for that,
@@ -6365,325 +6365,325 @@ yydefault:
 		}
 	case 481:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2507
+//line sql.y:2508
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Exprs: yyDollar[3].selectExprs}
 		}
 	case 482:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2511
+//line sql.y:2512
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 483:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2515
+//line sql.y:2516
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 484:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:2519
+//line sql.y:2520
 		{
 			yyVAL.expr = &FuncExpr{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].colIdent, Exprs: yyDollar[5].selectExprs}
 		}
 	case 485:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2529
+//line sql.y:2530
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("left"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 486:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2533
+//line sql.y:2534
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("right"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 487:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:2537
+//line sql.y:2538
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 488:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:2541
+//line sql.y:2542
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 489:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:2545
+//line sql.y:2546
 		{
 			yyVAL.expr = &ConvertUsingExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].str}
 		}
 	case 490:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2549
+//line sql.y:2550
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 491:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2553
+//line sql.y:2554
 		{
 			yyVAL.expr = &SubstrExpr{Name: yyDollar[3].colName, From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 492:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2557
+//line sql.y:2558
 		{
 			yyVAL.expr = &SubstrExpr{StrVal: NewStrVal(yyDollar[3].bytes), From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 493:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2561
+//line sql.y:2562
 		{
 			yyVAL.expr = &SubstrExpr{StrVal: NewStrVal(yyDollar[3].bytes), From: yyDollar[5].expr, To: yyDollar[7].expr}
 		}
 	case 494:
 		yyDollar = yyS[yypt-9 : yypt+1]
-//line sql.y:2565
+//line sql.y:2566
 		{
 			yyVAL.expr = &MatchExpr{Columns: yyDollar[3].selectExprs, Expr: yyDollar[7].expr, Option: yyDollar[8].str}
 		}
 	case 495:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2569
+//line sql.y:2570
 		{
 			yyVAL.expr = &GroupConcatExpr{Distinct: yyDollar[3].str, Exprs: yyDollar[4].selectExprs, OrderBy: yyDollar[5].orderBy, Separator: yyDollar[6].str, Limit: yyDollar[7].limit}
 		}
 	case 496:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2573
+//line sql.y:2574
 		{
 			yyVAL.expr = &CaseExpr{Expr: yyDollar[2].expr, Whens: yyDollar[3].whens, Else: yyDollar[4].expr}
 		}
 	case 497:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2577
+//line sql.y:2578
 		{
 			yyVAL.expr = &ValuesFuncExpr{Name: yyDollar[3].colName}
 		}
 	case 498:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2587
+//line sql.y:2588
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_timestamp")}
 		}
 	case 499:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2591
+//line sql.y:2592
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_timestamp")}
 		}
 	case 500:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2595
+//line sql.y:2596
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_time")}
 		}
 	case 501:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2600
+//line sql.y:2601
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_date")}
 		}
 	case 502:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2605
+//line sql.y:2606
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtime")}
 		}
 	case 503:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2610
+//line sql.y:2611
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtimestamp")}
 		}
 	case 504:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2616
+//line sql.y:2617
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_date")}
 		}
 	case 505:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2621
+//line sql.y:2622
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_time")}
 		}
 	case 506:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2626
+//line sql.y:2627
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("current_timestamp"), Fsp: yyDollar[2].expr}
 		}
 	case 507:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2630
+//line sql.y:2631
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("utc_timestamp"), Fsp: yyDollar[2].expr}
 		}
 	case 508:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2634
+//line sql.y:2635
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("utc_time"), Fsp: yyDollar[2].expr}
 		}
 	case 509:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2639
+//line sql.y:2640
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("localtime"), Fsp: yyDollar[2].expr}
 		}
 	case 510:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2644
+//line sql.y:2645
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("localtimestamp"), Fsp: yyDollar[2].expr}
 		}
 	case 511:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2649
+//line sql.y:2650
 		{
 			yyVAL.expr = &CurTimeFuncExpr{Name: NewColIdent("current_time"), Fsp: yyDollar[2].expr}
 		}
 	case 512:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2653
+//line sql.y:2654
 		{
 			yyVAL.expr = &TimestampFuncExpr{Name: string("timestampadd"), Unit: yyDollar[3].colIdent.String(), Expr1: yyDollar[5].expr, Expr2: yyDollar[7].expr}
 		}
 	case 513:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line sql.y:2657
+//line sql.y:2658
 		{
 			yyVAL.expr = &TimestampFuncExpr{Name: string("timestampdiff"), Unit: yyDollar[3].colIdent.String(), Expr1: yyDollar[5].expr, Expr2: yyDollar[7].expr}
 		}
 	case 516:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2667
+//line sql.y:2668
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 517:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2677
+//line sql.y:2678
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("if"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 518:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2681
+//line sql.y:2682
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("database"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 519:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2685
+//line sql.y:2686
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("schema"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 520:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2689
+//line sql.y:2690
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("mod"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 521:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2693
+//line sql.y:2694
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("replace"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 522:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2697
+//line sql.y:2698
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("substr"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 523:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2701
+//line sql.y:2702
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("substr"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 524:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2707
+//line sql.y:2708
 		{
 			yyVAL.str = ""
 		}
 	case 525:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2711
+//line sql.y:2712
 		{
 			yyVAL.str = BooleanModeStr
 		}
 	case 526:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2715
+//line sql.y:2716
 		{
 			yyVAL.str = NaturalLanguageModeStr
 		}
 	case 527:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line sql.y:2719
+//line sql.y:2720
 		{
 			yyVAL.str = NaturalLanguageModeWithQueryExpansionStr
 		}
 	case 528:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2723
+//line sql.y:2724
 		{
 			yyVAL.str = QueryExpansionStr
 		}
 	case 529:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2729
+//line sql.y:2730
 		{
 			yyVAL.str = string(yyDollar[1].colIdent.String())
 		}
 	case 530:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2733
+//line sql.y:2734
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 531:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2739
+//line sql.y:2740
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 532:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2743
+//line sql.y:2744
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal, Charset: yyDollar[3].str, Operator: CharacterSetStr}
 		}
 	case 533:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2747
+//line sql.y:2748
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal, Charset: string(yyDollar[3].colIdent.String())}
 		}
 	case 534:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2751
+//line sql.y:2752
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 535:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2755
+//line sql.y:2756
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 536:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2759
+//line sql.y:2760
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 			yyVAL.convertType.Length = yyDollar[2].LengthScaleOption.Length
@@ -6691,169 +6691,169 @@ yydefault:
 		}
 	case 537:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2765
+//line sql.y:2766
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 538:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2769
+//line sql.y:2770
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 539:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2773
+//line sql.y:2774
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 540:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2777
+//line sql.y:2778
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 541:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2781
+//line sql.y:2782
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes), Length: yyDollar[2].sqlVal}
 		}
 	case 542:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2785
+//line sql.y:2786
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 543:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2789
+//line sql.y:2790
 		{
 			yyVAL.convertType = &ConvertType{Type: string(yyDollar[1].bytes)}
 		}
 	case 544:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2794
+//line sql.y:2795
 		{
 			yyVAL.expr = nil
 		}
 	case 545:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2798
+//line sql.y:2799
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 546:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2803
+//line sql.y:2804
 		{
 			yyVAL.str = string("")
 		}
 	case 547:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2807
+//line sql.y:2808
 		{
 			yyVAL.str = " separator '" + string(yyDollar[2].bytes) + "'"
 		}
 	case 548:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2813
+//line sql.y:2814
 		{
 			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 549:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2817
+//line sql.y:2818
 		{
 			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 550:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2823
+//line sql.y:2824
 		{
 			yyVAL.when = &When{Cond: yyDollar[2].expr, Val: yyDollar[4].expr}
 		}
 	case 551:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2828
+//line sql.y:2829
 		{
 			yyVAL.expr = nil
 		}
 	case 552:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2832
+//line sql.y:2833
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 553:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2838
+//line sql.y:2839
 		{
 			yyVAL.colName = &ColName{Name: yyDollar[1].colIdent}
 		}
 	case 554:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2842
+//line sql.y:2843
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Name: yyDollar[1].tableIdent}, Name: yyDollar[3].colIdent}
 		}
 	case 555:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:2846
+//line sql.y:2847
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}, Name: yyDollar[5].colIdent}
 		}
 	case 556:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2852
+//line sql.y:2853
 		{
 			yyVAL.expr = NewStrVal(yyDollar[1].bytes)
 		}
 	case 557:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2856
+//line sql.y:2857
 		{
 			yyVAL.expr = NewHexVal(yyDollar[1].bytes)
 		}
 	case 558:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2860
+//line sql.y:2861
 		{
 			yyVAL.expr = NewBitVal(yyDollar[1].bytes)
 		}
 	case 559:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2864
+//line sql.y:2865
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 560:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2868
+//line sql.y:2869
 		{
 			yyVAL.expr = NewFloatVal(yyDollar[1].bytes)
 		}
 	case 561:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2872
+//line sql.y:2873
 		{
 			yyVAL.expr = NewHexNum(yyDollar[1].bytes)
 		}
 	case 562:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2876
+//line sql.y:2877
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 563:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2880
+//line sql.y:2881
 		{
 			yyVAL.expr = &NullVal{}
 		}
 	case 564:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2886
+//line sql.y:2887
 		{
 			// TODO(sougou): Deprecate this construct.
 			if yyDollar[1].colIdent.Lowered() != "value" {
@@ -6864,237 +6864,237 @@ yydefault:
 		}
 	case 565:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2895
+//line sql.y:2896
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 566:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2899
+//line sql.y:2900
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 567:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2904
+//line sql.y:2905
 		{
 			yyVAL.exprs = nil
 		}
 	case 568:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2908
+//line sql.y:2909
 		{
 			yyVAL.exprs = yyDollar[3].exprs
 		}
 	case 569:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2913
+//line sql.y:2914
 		{
 			yyVAL.expr = nil
 		}
 	case 570:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2917
+//line sql.y:2918
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 571:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2922
+//line sql.y:2923
 		{
 			yyVAL.orderBy = nil
 		}
 	case 572:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2926
+//line sql.y:2927
 		{
 			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 573:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2932
+//line sql.y:2933
 		{
 			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 574:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:2936
+//line sql.y:2937
 		{
 			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 575:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2942
+//line sql.y:2943
 		{
 			yyVAL.order = &Order{Expr: yyDollar[1].expr, Direction: yyDollar[2].str}
 		}
 	case 576:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2947
+//line sql.y:2948
 		{
 			yyVAL.str = AscScr
 		}
 	case 577:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2951
+//line sql.y:2952
 		{
 			yyVAL.str = AscScr
 		}
 	case 578:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:2955
+//line sql.y:2956
 		{
 			yyVAL.str = DescScr
 		}
 	case 579:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2960
+//line sql.y:2961
 		{
 			yyVAL.limit = nil
 		}
 	case 580:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2964
+//line sql.y:2965
 		{
 			yyVAL.limit = &Limit{Rowcount: yyDollar[2].expr}
 		}
 	case 581:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2968
+//line sql.y:2969
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[2].expr, Rowcount: yyDollar[4].expr}
 		}
 	case 582:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2972
+//line sql.y:2973
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[4].expr, Rowcount: yyDollar[2].expr}
 		}
 	case 583:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:2977
+//line sql.y:2978
 		{
 			yyVAL.str = ""
 		}
 	case 584:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2981
+//line sql.y:2982
 		{
 			yyVAL.str = ForUpdateStr
 		}
 	case 585:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:2985
+//line sql.y:2986
 		{
 			yyVAL.str = ShareModeStr
 		}
 	case 586:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:2998
+//line sql.y:2999
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[2].values}
 		}
 	case 587:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3002
+//line sql.y:3003
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[1].selStmt}
 		}
 	case 588:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3006
+//line sql.y:3007
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Rows: yyDollar[2].selStmt}
 		}
 	case 589:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:3011
+//line sql.y:3012
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].values}
 		}
 	case 590:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line sql.y:3015
+//line sql.y:3016
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[4].selStmt}
 		}
 	case 591:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line sql.y:3019
+//line sql.y:3020
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].selStmt}
 		}
 	case 592:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3026
+//line sql.y:3027
 		{
 			yyVAL.columns = Columns{yyDollar[1].colIdent}
 		}
 	case 593:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3030
+//line sql.y:3031
 		{
 			yyVAL.columns = Columns{yyDollar[3].colIdent}
 		}
 	case 594:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3034
+//line sql.y:3035
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[3].colIdent)
 		}
 	case 595:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:3038
+//line sql.y:3039
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[5].colIdent)
 		}
 	case 596:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3043
+//line sql.y:3044
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 597:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line sql.y:3047
+//line sql.y:3048
 		{
 			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 598:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3053
+//line sql.y:3054
 		{
 			yyVAL.values = Values{yyDollar[1].valTuple}
 		}
 	case 599:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3057
+//line sql.y:3058
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].valTuple)
 		}
 	case 600:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3063
+//line sql.y:3064
 		{
 			yyVAL.valTuple = yyDollar[1].valTuple
 		}
 	case 601:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:3067
+//line sql.y:3068
 		{
 			yyVAL.valTuple = ValTuple{}
 		}
 	case 602:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3073
+//line sql.y:3074
 		{
 			yyVAL.valTuple = ValTuple(yyDollar[2].exprs)
 		}
 	case 603:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3079
+//line sql.y:3080
 		{
 			if len(yyDollar[1].valTuple) == 1 {
 				yyVAL.expr = yyDollar[1].valTuple[0]
@@ -7104,277 +7104,277 @@ yydefault:
 		}
 	case 604:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3089
+//line sql.y:3090
 		{
 			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 605:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3093
+//line sql.y:3094
 		{
 			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 606:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3099
+//line sql.y:3100
 		{
 			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].expr}
 		}
 	case 607:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3105
+//line sql.y:3106
 		{
 			yyVAL.setExprs = SetExprs{yyDollar[1].setExpr}
 		}
 	case 608:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3109
+//line sql.y:3110
 		{
 			yyVAL.setExprs = append(yyDollar[1].setExprs, yyDollar[3].setExpr)
 		}
 	case 609:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3115
+//line sql.y:3116
 		{
 			yyVAL.setExpr = &SetExpr{Name: yyDollar[1].colIdent, Expr: NewStrVal([]byte("on"))}
 		}
 	case 610:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3119
+//line sql.y:3120
 		{
 			yyVAL.setExpr = &SetExpr{Name: yyDollar[1].colIdent, Expr: NewStrVal([]byte("off"))}
 		}
 	case 611:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3123
+//line sql.y:3124
 		{
 			yyVAL.setExpr = &SetExpr{Name: yyDollar[1].colIdent, Expr: yyDollar[3].expr}
 		}
 	case 612:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3127
+//line sql.y:3128
 		{
 			yyVAL.setExpr = &SetExpr{Name: NewColIdent(string(yyDollar[1].bytes)), Expr: yyDollar[2].expr}
 		}
 	case 614:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:3134
+//line sql.y:3135
 		{
 			yyVAL.bytes = []byte("charset")
 		}
 	case 616:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3141
+//line sql.y:3142
 		{
 			yyVAL.expr = NewStrVal([]byte(yyDollar[1].colIdent.String()))
 		}
 	case 617:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3145
+//line sql.y:3146
 		{
 			yyVAL.expr = NewStrVal(yyDollar[1].bytes)
 		}
 	case 618:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3149
+//line sql.y:3150
 		{
 			yyVAL.expr = &Default{}
 		}
 	case 621:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3158
+//line sql.y:3159
 		{
 			yyVAL.byt = 0
 		}
 	case 622:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:3160
+//line sql.y:3161
 		{
 			yyVAL.byt = 1
 		}
 	case 623:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3163
+//line sql.y:3164
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 624:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line sql.y:3165
+//line sql.y:3166
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 625:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3168
+//line sql.y:3169
 		{
 			yyVAL.str = ""
 		}
 	case 626:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3170
+//line sql.y:3171
 		{
 			yyVAL.str = IgnoreStr
 		}
 	case 627:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3174
+//line sql.y:3175
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 628:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3176
+//line sql.y:3177
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 629:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3178
+//line sql.y:3179
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 630:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3180
+//line sql.y:3181
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 631:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3182
+//line sql.y:3183
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 632:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3184
+//line sql.y:3185
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 633:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3186
+//line sql.y:3187
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 634:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3188
+//line sql.y:3189
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 635:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3190
+//line sql.y:3191
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 636:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3192
+//line sql.y:3193
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 637:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3195
+//line sql.y:3196
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 638:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3197
+//line sql.y:3198
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 639:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3199
+//line sql.y:3200
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 640:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3203
+//line sql.y:3204
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 641:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3205
+//line sql.y:3206
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 642:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3208
+//line sql.y:3209
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 643:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3210
+//line sql.y:3211
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 644:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3212
+//line sql.y:3213
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 645:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3215
+//line sql.y:3216
 		{
 			yyVAL.colIdent = ColIdent{}
 		}
 	case 646:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line sql.y:3217
+//line sql.y:3218
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 647:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3221
+//line sql.y:3222
 		{
 			yyVAL.colIdent = yyDollar[1].colIdent
 		}
 	case 648:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3225
+//line sql.y:3226
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 650:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3232
+//line sql.y:3233
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 651:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3238
+//line sql.y:3239
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].colIdent.String()))
 		}
 	case 652:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3242
+//line sql.y:3243
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 654:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3249
+//line sql.y:3250
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 942:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3562
+//line sql.y:3563
 		{
 			if incNesting(yylex) {
 				yylex.Error("max nesting level reached")
@@ -7383,31 +7383,31 @@ yydefault:
 		}
 	case 943:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3571
+//line sql.y:3572
 		{
 			decNesting(yylex)
 		}
 	case 944:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3576
+//line sql.y:3577
 		{
 			skipToEnd(yylex)
 		}
 	case 945:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line sql.y:3581
+//line sql.y:3582
 		{
 			skipToEnd(yylex)
 		}
 	case 946:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3585
+//line sql.y:3586
 		{
 			skipToEnd(yylex)
 		}
 	case 947:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line sql.y:3589
+//line sql.y:3590
 		{
 			skipToEnd(yylex)
 		}

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -135,6 +135,7 @@ func skipToEnd(yylex interface{}) {
 // Some of these operators don't conflict in our situation. Nevertheless,
 // it's better to have these listed in the correct order. Also, we don't
 // support all operators yet.
+// * NOTE: If you change anything here, update precedence.go as well *
 %left <bytes> OR
 %left <bytes> AND
 %right <bytes> NOT '!'
@@ -2256,11 +2257,11 @@ condition:
   }
 | value_expression BETWEEN value_expression AND value_expression
   {
-    $$ = &RangeCond{Expr: $1, Operator: BetweenStr, From: $3, To: $5}
+    $$ = &RangeCond{Left: $1, Operator: BetweenStr, From: $3, To: $5}
   }
 | value_expression NOT BETWEEN value_expression AND value_expression
   {
-    $$ = &RangeCond{Expr: $1, Operator: NotBetweenStr, From: $4, To: $6}
+    $$ = &RangeCond{Left: $1, Operator: NotBetweenStr, From: $4, To: $6}
   }
 | EXISTS subquery
   {

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -2256,11 +2256,11 @@ condition:
   }
 | value_expression BETWEEN value_expression AND value_expression
   {
-    $$ = &RangeCond{Left: $1, Operator: BetweenStr, From: $3, To: $5}
+    $$ = &RangeCond{Expr: $1, Operator: BetweenStr, From: $3, To: $5}
   }
 | value_expression NOT BETWEEN value_expression AND value_expression
   {
-    $$ = &RangeCond{Left: $1, Operator: NotBetweenStr, From: $4, To: $6}
+    $$ = &RangeCond{Expr: $1, Operator: NotBetweenStr, From: $4, To: $6}
   }
 | EXISTS subquery
   {
@@ -3078,7 +3078,7 @@ tuple_expression:
   row_tuple
   {
     if len($1) == 1 {
-      $$ = &ParenExpr{$1[0]}
+      $$ = $1[0]
     } else {
       $$ = $1
     }

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -56,10 +56,23 @@ func (buf *TrackedBuffer) WriteNode(node SQLNode) *TrackedBuffer {
 // Myprintf mimics fmt.Fprintf(buf, ...), but limited to Node(%v),
 // Node.Value(%s) and string(%s). It also allows a %a for a value argument, in
 // which case it adds tracking info for future substitutions.
+// It adds parens as needed to follow precedence rules when printing expressions
 //
 // The name must be something other than the usual Printf() to avoid "go vet"
 // warnings due to our custom format specifiers.
+// *** THIS METHOD SHOULD NOT BE USED FROM ast.go. USE astPrintf INSTEAD ***
 func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
+	buf.astPrintf(nil, format, values...)
+}
+
+// astPrintf is for internal use by the ast structs
+func (buf *TrackedBuffer) astPrintf(currentNode SQLNode, format string, values ...interface{}) {
+	currentExpr, checkParens := currentNode.(Expr)
+	if checkParens {
+		// expressions that have Precedence Syntactic will never need parens
+		checkParens = precedenceFor(currentExpr) != Syntactic
+	}
+
 	end := len(format)
 	fieldnum := 0
 	for i := 0; i < end; {
@@ -94,12 +107,18 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 				panic(fmt.Sprintf("unexpected TrackedBuffer type %T", v))
 			}
 		case 'v':
-			node := values[fieldnum].(SQLNode)
-			if buf.nodeFormatter == nil {
-				node.Format(buf)
+			value := values[fieldnum]
+			expr := getExpressionForParensEval(checkParens, value)
+
+			if expr != nil { //
+				needParens := needParens(currentExpr, expr)
+				buf.printIf(needParens, "(")
+				buf.formatter(expr)
+				buf.printIf(needParens, ")")
 			} else {
-				buf.nodeFormatter(buf, node)
+				buf.formatter(value.(SQLNode))
 			}
+
 		case 'a':
 			buf.WriteArg(values[fieldnum].(string))
 		default:
@@ -110,10 +129,34 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 	}
 }
 
-// WriteString appends the contents of s to b's buffer.
-// It returns the length of s and a nil error.
-func (buf *TrackedBuffer) WriteString(s string) (int, error) {
-	return buf.Builder.WriteString(s)
+func getExpressionForParensEval(checkParens bool, value interface{}) Expr {
+	if checkParens {
+		expr, isExpr := value.(Expr)
+		if isExpr {
+			return expr
+		}
+	}
+	return nil
+}
+
+func (buf *TrackedBuffer) printIf(condition bool, text string) {
+	if condition {
+		buf.WriteString(text)
+	}
+}
+
+func (buf *TrackedBuffer) formatter(node SQLNode) {
+	if buf.nodeFormatter == nil {
+		node.Format(buf)
+	} else {
+		buf.nodeFormatter(buf, node)
+	}
+}
+
+func needParens(op, val Expr) bool {
+	opBinding := precedenceFor(op)
+	valBinding := precedenceFor(val)
+	return !(opBinding == Syntactic || valBinding == Syntactic) && valBinding > opBinding
 }
 
 // WriteArg writes a value argument into the buffer along with

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -154,9 +154,26 @@ func (buf *TrackedBuffer) formatter(node SQLNode) {
 }
 
 func needParens(op, val Expr) bool {
+	if areBothISExpr(op, val) {
+		return true
+	}
+
 	opBinding := precedenceFor(op)
 	valBinding := precedenceFor(val)
+
 	return !(opBinding == Syntactic || valBinding == Syntactic) && valBinding > opBinding
+}
+
+func areBothISExpr(op Expr, val Expr) bool {
+	_, isOpIS := op.(*IsExpr)
+	if isOpIS {
+		_, isValIS := val.(*IsExpr)
+		if isValIS {
+			// when using IS on an IS op, we need special handling
+			return true
+		}
+	}
+	return false
 }
 
 // WriteArg writes a value argument into the buffer along with

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -110,6 +110,12 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 	}
 }
 
+// WriteString appends the contents of s to b's buffer.
+// It returns the length of s and a nil error.
+func (buf *TrackedBuffer) WriteString(s string) (int, error) {
+	return buf.Builder.WriteString(s)
+}
+
 // WriteArg writes a value argument into the buffer along with
 // tracking information for future substitutions. arg must contain
 // the ":" or "::" prefix.

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -28,10 +28,10 @@ select * from user where name = 'bob' /* vindex lookup */
 ----------------------------------------------------------------------
 select * from user where name = 'bob' or nickname = 'bob' /* vindex lookup */
 
-1 ks_sharded/-40: select * from user where (name = 'bob' or nickname = 'bob') limit 10001 /* vindex lookup */
-1 ks_sharded/40-80: select * from user where (name = 'bob' or nickname = 'bob') limit 10001 /* vindex lookup */
-1 ks_sharded/80-c0: select * from user where (name = 'bob' or nickname = 'bob') limit 10001 /* vindex lookup */
-1 ks_sharded/c0-: select * from user where (name = 'bob' or nickname = 'bob') limit 10001 /* vindex lookup */
+1 ks_sharded/-40: select * from user where name = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/40-80: select * from user where name = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/80-c0: select * from user where name = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/c0-: select * from user where name = 'bob' or nickname = 'bob' limit 10001 /* vindex lookup */
 
 ----------------------------------------------------------------------
 select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */
@@ -97,16 +97,16 @@ select name from user where id = (select id from t1) /* non-correlated subquery 
 select name from user where id in (select id from t1) /* non-correlated subquery in IN clause */
 
 1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in IN clause */
-2 ks_sharded/-40: select name from user where 1 = 1 and (id in (1)) limit 10001 /* non-correlated subquery in IN clause */
+2 ks_sharded/-40: select name from user where 1 = 1 and id in (1) limit 10001 /* non-correlated subquery in IN clause */
 
 ----------------------------------------------------------------------
 select name from user where id not in (select id from t1) /* non-correlated subquery in NOT IN clause */
 
 1 ks_unsharded/-: select id from t1 limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/-40: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/40-80: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/80-c0: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
-2 ks_sharded/c0-: select name from user where (1 = 0 or (id not in (1))) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/-40: select name from user where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/40-80: select name from user where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/80-c0: select name from user where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
+2 ks_sharded/c0-: select name from user where 1 = 0 or id not in (1) limit 10001 /* non-correlated subquery in NOT IN clause */
 
 ----------------------------------------------------------------------
 select name from user where exists (select id from t1) /* non-correlated subquery as EXISTS */
@@ -128,7 +128,7 @@ select * from name_info order by info /* select * and order by varchar column */
 ----------------------------------------------------------------------
 select distinct(name) from user where id = 1 /* select distinct */
 
-1 ks_sharded/-40: select distinct (name) from user where id = 1 limit 10001 /* select distinct */
+1 ks_sharded/-40: select distinct name from user where id = 1 limit 10001 /* select distinct */
 
 ----------------------------------------------------------------------
 select distinct name from user where id = 1 /* select distinct */

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -569,8 +569,6 @@ func inferColTypeFromExpr(node sqlparser.Expr, colTypeMap map[string]querypb.Typ
 		default:
 			log.Errorf("vtexplain: unsupported sql value %s", sqlparser.String(node))
 		}
-	case *sqlparser.ParenExpr:
-		colNames, colTypes = inferColTypeFromExpr(node.Expr, colTypeMap, colNames, colTypes)
 	case *sqlparser.CaseExpr:
 		colNames, colTypes = inferColTypeFromExpr(node.Whens[0].Val, colTypeMap, colNames, colTypes)
 	case *sqlparser.NullVal:

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -63,13 +63,6 @@ func getDMLRouting(where *sqlparser.Where, table *vindexes.Table) (engine.DMLOpc
 func getMatch(node sqlparser.Expr, col sqlparser.ColIdent) (pv sqltypes.PlanValue, ok bool) {
 	filters := splitAndExpression(nil, node)
 	for _, filter := range filters {
-		filter = skipParenthesis(filter)
-		if parenthesis, ok := node.(*sqlparser.ParenExpr); ok {
-			if pv, ok := getMatch(parenthesis.Expr, col); ok {
-				return pv, ok
-			}
-			continue
-		}
 		comparison, ok := filter.(*sqlparser.ComparisonExpr)
 		if !ok {
 			continue

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -36,23 +36,8 @@ func splitAndExpression(filters []sqlparser.Expr, node sqlparser.Expr) []sqlpars
 	case *sqlparser.AndExpr:
 		filters = splitAndExpression(filters, node.Left)
 		return splitAndExpression(filters, node.Right)
-	case *sqlparser.ParenExpr:
-		// If the inner expression is AndExpr, then we can remove
-		// the parenthesis because they are unnecessary.
-		if node, ok := node.Expr.(*sqlparser.AndExpr); ok {
-			return splitAndExpression(filters, node)
-		}
 	}
 	return append(filters, node)
-}
-
-// skipParenthesis skips the parenthesis (if any) of an expression and
-// returns the innermost unparenthesized expression.
-func skipParenthesis(node sqlparser.Expr) sqlparser.Expr {
-	if node, ok := node.(*sqlparser.ParenExpr); ok {
-		return skipParenthesis(node.Expr)
-	}
-	return node
 }
 
 type subqueryInfo struct {
@@ -179,33 +164,25 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr) (pullouts []*pullout
 		case *sqlparser.ComparisonExpr:
 			if construct.Operator == sqlparser.InStr {
 				// a in (subquery) -> (:__sq_has_values = 1 and (a in ::__sq))
-				newExpr := &sqlparser.ParenExpr{
-					Expr: &sqlparser.AndExpr{
-						Left: &sqlparser.ComparisonExpr{
-							Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
-							Operator: sqlparser.EqualStr,
-							Right:    sqlparser.NewIntVal([]byte("1")),
-						},
-						Right: &sqlparser.ParenExpr{
-							Expr: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
-						},
+				newExpr := &sqlparser.AndExpr{
+					Left: &sqlparser.ComparisonExpr{
+						Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
+						Operator: sqlparser.EqualStr,
+						Right:    sqlparser.NewIntVal([]byte("1")),
 					},
+					Right: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
 				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutIn, sqName, hasValues, sqi.bldr))
 			} else {
 				// a not in (subquery) -> (:__sq_has_values = 0 or (a not in ::__sq))
-				newExpr := &sqlparser.ParenExpr{
-					Expr: &sqlparser.OrExpr{
-						Left: &sqlparser.ComparisonExpr{
-							Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
-							Operator: sqlparser.EqualStr,
-							Right:    sqlparser.NewIntVal([]byte("0")),
-						},
-						Right: &sqlparser.ParenExpr{
-							Expr: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
-						},
+				newExpr := &sqlparser.OrExpr{
+					Left: &sqlparser.ComparisonExpr{
+						Left:     sqlparser.NewValArg([]byte(":" + hasValues)),
+						Operator: sqlparser.EqualStr,
+						Right:    sqlparser.NewIntVal([]byte("0")),
 					},
+					Right: sqlparser.ReplaceExpr(construct, sqi.ast, sqlparser.ListArg([]byte("::"+sqName))),
 				}
 				expr = sqlparser.ReplaceExpr(expr, construct, newExpr)
 				pullouts = append(pullouts, newPulloutSubquery(engine.PulloutNotIn, sqName, hasValues, sqi.bldr))

--- a/go/vt/vtgate/planbuilder/expr_test.go
+++ b/go/vt/vtgate/planbuilder/expr_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package planbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -100,17 +99,6 @@ func TestValEqual(t *testing.T) {
 		out := valEqual(tc.in1, tc.in2)
 		if out != tc.out {
 			t.Errorf("valEqual(%#v, %#v): %v, want %v", tc.in1, tc.in2, out, tc.out)
-		}
-	}
-}
-
-func TestSkipParenthesis(t *testing.T) {
-	baseNode := newIntVal("1")
-	paren1 := &sqlparser.ParenExpr{Expr: baseNode}
-	paren2 := &sqlparser.ParenExpr{Expr: paren1}
-	for _, tcase := range []sqlparser.Expr{baseNode, paren1, paren2} {
-		if got, want := skipParenthesis(tcase), baseNode; !reflect.DeepEqual(got, want) {
-			t.Errorf("skipParenthesis(%v): %v, want %v", sqlparser.String(tcase), sqlparser.String(got), sqlparser.String(want))
 		}
 	}
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -243,7 +243,7 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vindexes.VSchema)
 
 				if out != tcase.output {
 					fail = true
-					t.Errorf("File: %s, Line: %v\n %s", filename, tcase.lineno, cmp.Diff(out, tcase.output))
+					t.Errorf("File: %s, Line: %v\n %s", filename, tcase.lineno, cmp.Diff(tcase.output, out))
 				}
 
 				if err != nil {

--- a/go/vt/vtgate/planbuilder/route_option.go
+++ b/go/vt/vtgate/planbuilder/route_option.go
@@ -169,7 +169,6 @@ func (ro *routeOption) canMerge(rro *routeOption, customCheck func() bool) bool 
 // mergeable by unique vindex. The constraint has to be an equality
 // like a.id = b.id where both columns have the same unique vindex.
 func (ro *routeOption) canMergeOnFilter(pb *primitiveBuilder, rro *routeOption, filter sqlparser.Expr) bool {
-	filter = skipParenthesis(filter)
 	comparison, ok := filter.(*sqlparser.ComparisonExpr)
 	if !ok {
 		return false
@@ -254,8 +253,6 @@ func (ro *routeOption) computePlan(pb *primitiveBuilder, filter sqlparser.Expr) 
 		case sqlparser.InStr:
 			return ro.computeINPlan(pb, node)
 		}
-	case *sqlparser.ParenExpr:
-		return ro.computePlan(pb, node.Expr)
 	}
 	return engine.SelectScatter, nil, nil
 }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -185,7 +185,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "update user set val = 1 where (id = 1)",
+    "Query": "update user set val = 1 where id = 1",
     "Vindex": "user_index",
     "Values": [
       1
@@ -204,7 +204,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "update user set val = 1 where (name = 'foo' and id = 1)",
+    "Query": "update user set val = 1 where name = 'foo' and id = 1",
     "Vindex": "user_index",
     "Values": [
       1
@@ -1950,7 +1950,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "update user_extra set val = 1 where (name = 'foo' or id = 1)",
+    "Query": "update user_extra set val = 1 where name = 'foo' or id = 1",
     "Table": "user_extra"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -481,8 +481,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select (id or col) as val from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa'",
-    "FieldQuery": "select (id or col) as val from user where 1 != 1",
+    "Query": "select id or col as val from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa'",
+    "FieldQuery": "select id or col as val from user where 1 != 1",
     "Vindex": "name_user_map",
     "Values": [
       "aa"
@@ -561,7 +561,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select id from user where (user.id = 1 or user.name = 'aa' and user.id in (1, 2))",
+    "Query": "select id from user where user.id = 1 or user.name = 'aa' and user.id in (1, 2)",
     "FieldQuery": "select id from user where 1 != 1",
     "Table": "user"
   }
@@ -898,7 +898,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where :__sq_has_values1 = 1 and (id in ::__vals)",
+      "Query": "select id from user where :__sq_has_values1 = 1 and id in ::__vals",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -933,7 +933,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user where (:__sq_has_values1 = 0 or (id not in ::__sq1))",
+      "Query": "select id from user where :__sq_has_values1 = 0 or id not in ::__sq1",
       "FieldQuery": "select id from user where 1 != 1",
       "Table": "user"
     }
@@ -1034,7 +1034,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select id2 from user where :__sq_has_values1 = 1 and (id2 in ::__sq1)",
+        "Query": "select id2 from user where :__sq_has_values1 = 1 and id2 in ::__sq1",
         "FieldQuery": "select id2 from user where 1 != 1",
         "Table": "user"
       }

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -664,8 +664,8 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select user.col from user join user_extra on (user.id = user_extra.user_id)",
-    "FieldQuery": "select user.col from user join user_extra on (user.id = user_extra.user_id) where 1 != 1",
+    "Query": "select user.col from user join user_extra on user.id = user_extra.user_id",
+    "FieldQuery": "select user.col from user join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Table": "user"
   }
 }
@@ -1530,8 +1530,8 @@
         "Name": "main",
         "Sharded": false
       },
-      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on (:__sq_has_values1 = 1 and (unsharded_a.col in ::__sq1))",
-      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on (:__sq_has_values1 = 1 and (unsharded_a.col in ::__sq1)) where 1 != 1",
+      "Query": "select unsharded_a.col from unsharded_a join unsharded_b on :__sq_has_values1 = 1 and unsharded_a.col in ::__sq1",
+      "FieldQuery": "select unsharded_a.col from unsharded_a join unsharded_b on :__sq_has_values1 = 1 and unsharded_a.col in ::__sq1 where 1 != 1",
       "Table": "unsharded_a"
     }
   }
@@ -1573,7 +1573,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__sq_has_values1 = 1 and user.col in ::__sq1",
         "FieldQuery": "select 1 from user where 1 != 1",
         "Table": "user"
       },
@@ -1621,7 +1621,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
+        "Query": "select 1 from user where :__sq_has_values1 = 1 and user.col in ::__sq1",
         "FieldQuery": "select 1 from user where 1 != 1",
         "Table": "user"
       }
@@ -1671,7 +1671,7 @@
             "Name": "user",
             "Sharded": true
           },
-          "Query": "select 1 from user where :__sq_has_values1 = 1 and (user.col in ::__sq1)",
+          "Query": "select 1 from user where :__sq_has_values1 = 1 and user.col in ::__sq1",
           "FieldQuery": "select 1 from user where 1 != 1",
           "Table": "user"
         },

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -109,7 +109,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select id from user having :__sq_has_values1 = 1 and (id in ::__vals)",
+      "Query": "select id from user having :__sq_has_values1 = 1 and id in ::__vals",
       "FieldQuery": "select id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [
@@ -368,7 +368,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by col asc",
+      "Query": "select col from user where :__sq_has_values1 = 1 and col in ::__sq1 order by col asc",
       "FieldQuery": "select col from user where 1 != 1",
       "OrderBy": [
         {
@@ -540,7 +540,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by null",
+      "Query": "select col from user where :__sq_has_values1 = 1 and col in ::__sq1 order by null",
       "FieldQuery": "select col from user where 1 != 1",
       "Table": "user"
     }
@@ -632,7 +632,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) order by rand()",
+      "Query": "select col from user where :__sq_has_values1 = 1 and col in ::__sq1 order by rand()",
       "FieldQuery": "select col from user where 1 != 1",
       "Table": "user"
     }
@@ -1040,7 +1040,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "select col from user where :__sq_has_values1 = 1 and (col in ::__sq1) limit :__upper_limit",
+        "Query": "select col from user where :__sq_has_values1 = 1 and col in ::__sq1 limit :__upper_limit",
         "FieldQuery": "select col from user where 1 != 1",
         "Table": "user"
       }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -781,7 +781,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select * from user where name = 'abc' and (id = 4) limit 5",
+    "Query": "select * from user where name = 'abc' and id = 4 limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
@@ -801,7 +801,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select * from user where (id = 4) and (name = 'abc') limit 5",
+    "Query": "select * from user where id = 4 and name = 'abc' limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
@@ -881,7 +881,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select * from user where (id = 1) and name = true limit 5",
+    "Query": "select * from user where id = 1 and name = true limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
@@ -901,7 +901,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select * from user where (id = 1) and name limit 5",
+    "Query": "select * from user where id = 1 and name limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
@@ -921,7 +921,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select * from user where (id = 5) and name = true limit 5",
+    "Query": "select * from user where id = 5 and name = true limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
@@ -527,7 +527,7 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select 1 from user where :__sq_has_values1 = 1 and (id in ::__vals)",
+      "Query": "select 1 from user where :__sq_has_values1 = 1 and id in ::__vals",
       "FieldQuery": "select 1 from user where 1 != 1",
       "Vindex": "user_index",
       "Values": [

--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -281,8 +281,8 @@ func TestQueries(t *testing.T) {
 				{"1"},
 			},
 			Rewritten: []string{
-				"select (eid) from vitess_a where 1 != 1",
-				"select /* parenthesised col */ (eid) from vitess_a where eid = 1 and id = 1 limit 10001",
+				"select eid from vitess_a where 1 != 1",
+				"select /* parenthesised col */ eid from vitess_a where eid = 1 and id = 1 limit 10001",
 			},
 			RowsAffected: 1,
 		},
@@ -355,7 +355,7 @@ func TestQueries(t *testing.T) {
 			},
 			Rewritten: []string{
 				"select * from vitess_a where 1 != 1",
-				"select /* (condition) */ * from vitess_a where (eid = 1) limit 10001",
+				"select /* (condition) */ * from vitess_a where eid = 1 limit 10001",
 			},
 			RowsAffected: 2,
 		},

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -413,12 +413,6 @@ func splitAndExpression(filters []sqlparser.Expr, node sqlparser.Expr) []sqlpars
 	case *sqlparser.AndExpr:
 		filters = splitAndExpression(filters, node.Left)
 		return splitAndExpression(filters, node.Right)
-	case *sqlparser.ParenExpr:
-		// If the inner expression is AndExpr, then we can remove
-		// the parenthesis because they are unnecessary.
-		if node, ok := node.Expr.(*sqlparser.AndExpr); ok {
-			return splitAndExpression(filters, node)
-		}
 	}
 	return append(filters, node)
 }

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -882,10 +882,6 @@ func removeExprKeyrange(node sqlparser.Expr) sqlparser.Expr {
 			Left:  removeExprKeyrange(node.Left),
 			Right: removeExprKeyrange(node.Right),
 		}
-	case *sqlparser.ParenExpr:
-		return &sqlparser.ParenExpr{
-			Expr: removeExprKeyrange(node.Expr),
-		}
 	}
 	return node
 }

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -308,7 +308,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		table: "t1",
 		td: &tableDiffer{
 			targetTable:      "t1",
-			sourceExpression: "select c1, c2 from t1 where (c2 = 2) order by c1 asc",
+			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
 			compareCols:      []int{-1, 1},
 			comparePKs:       []int{0},
@@ -359,12 +359,14 @@ func TestVDiffPlanSuccess(t *testing.T) {
 		},
 	}}
 	for _, tcase := range testcases {
-		filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
-		df := &vdiff{}
-		err := df.buildVDiffPlan(context.Background(), filter, schm)
-		require.NoError(t, err, tcase.input)
-		require.Equal(t, 1, len(df.differs), tcase.input)
-		assert.Equal(t, tcase.td, df.differs[tcase.table], tcase.input)
+		t.Run(tcase.input.Filter, func(t *testing.T) {
+			filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
+			df := &vdiff{}
+			err := df.buildVDiffPlan(context.Background(), filter, schm)
+			require.NoError(t, err, tcase.input)
+			require.Equal(t, 1, len(df.differs), tcase.input)
+			assert.Equal(t, tcase.td, df.differs[tcase.table], tcase.input)
+		})
 	}
 }
 


### PR DESCRIPTION
To make sure that the meaning of queries didn't change by mistake, Vitess used to keep parens around in the AST even though they are nog strictly speaking needed there.

This change set solves the parens problem by taking precedence into consideration, and adding parens to the output string when needed instead of keeping them in the AST structure.

The benefit is that other parts of the code can just ignore parenthesis and trust that the AST will handle it for them.

**NOTE:** This introduces a behaviour change that can be noticable for end-users. Unaliased SELECT expressions can get the column name used changed (by parens being removed).

Example:
```
mysql> select (1)+1;

+-------+
| 1 + 1 |
+-------+
|     2 |
+-------+
1 row in set (0.00 sec)
```

Vitess already did some changing of column names (white spaces were not kept around). Now it does it a little differently. If you need a specific name, it's advisable to use the `AS columnAlias` construct.