### PR TITLE
Log warning when vttablet StreamHealth RPC fails

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -621,6 +621,7 @@ func (hcc *healthCheckConn) stream(ctx context.Context, hc *HealthCheckImpl, cal
 	}
 
 	if err := hcc.conn.StreamHealth(ctx, callback); err != nil {
+		log.Warningf("tablet %v healthcheck stream error: %v", hcc.tabletStats.Tablet.Alias, err)
 		hcc.setServingState(false, err.Error())
 		hcc.tabletStats.LastError = err
 		// Send nil because we intend to close the connection.


### PR DESCRIPTION
We store the lastError on healthcheck stats, but this will allow us to see if the error occurs many times in succession.

Signed-off-by: deepthi <deepthi@planetscale.com>