### PR TITLE
Pass in cell to EnsureVSchema and GetOrCreateShard

### DIFF
--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -54,7 +54,6 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
 		"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
 		"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
-	require.Nil(t, err)
 
 	replicaTabletArgs := commonTabletArg
 	if UseXb {

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -51,13 +51,10 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	tablet.ValidateTabletRestart(t)
 	tm := time.Now().UTC()
 	tm.Format(time.RFC3339)
-	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("GetKeyspace", keyspaceName)
-	if err != nil {
-		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
-			"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
-			"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
-		require.Nil(t, err)
-	}
+	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
+		"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
+		"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
+	require.Nil(t, err)
 
 	replicaTabletArgs := commonTabletArg
 	if UseXb {

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -54,6 +54,7 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
 		"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
 		"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
+	require.Nil(t, err)
 
 	replicaTabletArgs := commonTabletArg
 	if UseXb {

--- a/go/test/endtoend/recovery/recovery_util.go
+++ b/go/test/endtoend/recovery/recovery_util.go
@@ -51,10 +51,13 @@ func RestoreTablet(t *testing.T, localCluster *cluster.LocalProcessCluster, tabl
 	tablet.ValidateTabletRestart(t)
 	tm := time.Now().UTC()
 	tm.Format(time.RFC3339)
-	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
-		"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
-		"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
-	require.Nil(t, err)
+	_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("GetKeyspace", keyspaceName)
+	if err != nil {
+		_, err := localCluster.VtctlProcess.ExecuteCommandWithOutput("CreateKeyspace",
+			"-keyspace_type=SNAPSHOT", "-base_keyspace="+keyspaceName,
+			"-snapshot_time", tm.Format(time.RFC3339), restoreKSName)
+		require.Nil(t, err)
+	}
 
 	replicaTabletArgs := commonTabletArg
 	if UseXb {

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -325,7 +325,7 @@ func (ts *Server) CreateShard(ctx context.Context, keyspace, shard string) (err 
 
 // GetOrCreateShard will return the shard object, or create one if it doesn't
 // already exist. Note the shard creation is protected by a keyspace Lock.
-func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard string) (si *ShardInfo, err error) {
+func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard, cell string) (si *ShardInfo, err error) {
 	log.Info("GetShard %s/%s", keyspace, shard)
 	si, err = ts.GetShard(ctx, keyspace, shard)
 	if !IsErrType(err, NoNode) {
@@ -340,7 +340,7 @@ func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard string) 
 
 	// make sure a valid vschema has been loaded
 	log.Info("EnsureVSchema %s/%s", keyspace, shard)
-	if err = ts.EnsureVSchema(ctx, keyspace); err != nil {
+	if err = ts.EnsureVSchema(ctx, keyspace, []string{cell}); err != nil {
 		return nil, vterrors.Wrapf(err, "EnsureVSchema(%v) failed", keyspace)
 	}
 

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -94,7 +94,6 @@ func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string, cells []st
 		log.Errorf("could not rebuild SrvVschema after creating keyspace: %v", err)
 		return err
 	}
-
 	return nil
 }
 

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -72,7 +72,7 @@ func (ts *Server) GetVSchema(ctx context.Context, keyspace string) (*vschemapb.K
 }
 
 // EnsureVSchema makes sure that a vschema is present for this keyspace or creates a blank one if it is missing
-func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string) error {
+func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string, cells []string) error {
 	vschema, err := ts.GetVSchema(ctx, keyspace)
 	if err != nil && !IsErrType(err, NoNode) {
 		log.Info("error in getting vschema for keyspace %s: %v", keyspace, err)
@@ -89,11 +89,12 @@ func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string) error {
 		}
 	}
 
-	err = ts.RebuildSrvVSchema(ctx, []string{} /* cells */)
+	err = ts.RebuildSrvVSchema(ctx, cells)
 	if err != nil {
 		log.Errorf("could not rebuild SrvVschema after creating keyspace: %v", err)
 		return err
 	}
+
 	return nil
 }
 

--- a/go/vt/topotools/shard_test.go
+++ b/go/vt/topotools/shard_test.go
@@ -105,7 +105,8 @@ func TestGetOrCreateShard(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up topology.
-	ts := memorytopo.NewServer("test_cell")
+	cell := "test_cell"
+	ts := memorytopo.NewServer(cell)
 
 	// and do massive parallel GetOrCreateShard
 	keyspace := "test_keyspace"
@@ -119,7 +120,7 @@ func TestGetOrCreateShard(t *testing.T) {
 			for j := 0; j < 100; j++ {
 				index := rand.Intn(10)
 				shard := fmt.Sprintf("%v", index)
-				si, err := ts.GetOrCreateShard(ctx, keyspace, shard)
+				si, err := ts.GetOrCreateShard(ctx, keyspace, shard, cell)
 				if err != nil {
 					t.Errorf("GetOrCreateShard(%v, %v) failed: %v", i, shard, err)
 				}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1620,7 +1620,12 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 	}
 
 	if !*allowEmptyVSchema {
-		err = wr.TopoServer().EnsureVSchema(ctx, keyspace)
+		cells, err := wr.TopoServer().GetKnownCells(ctx)
+		if err != nil {
+			return fmt.Errorf("GetKnownCells failed: %v", err)
+		}
+
+		err = wr.TopoServer().EnsureVSchema(ctx, keyspace, cells)
 	}
 
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/init_tablet.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet.go
@@ -90,7 +90,8 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 	var si *topo.ShardInfo
 	if err := agent.withRetry(ctx, "creating keyspace and shard", func() error {
 		var err error
-		si, err = agent.TopoServer.GetOrCreateShard(ctx, *initKeyspace, shard)
+		cell := agent.TabletAlias.GetCell()
+		si, err = agent.TopoServer.GetOrCreateShard(ctx, *initKeyspace, shard, cell)
 		return err
 	}); err != nil {
 		return vterrors.Wrap(err, "InitTablet cannot GetOrCreateShard shard")

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -53,7 +53,7 @@ func (wr *Wrangler) InitTablet(ctx context.Context, tablet *topodatapb.Tablet, a
 
 	if createShardAndKeyspace {
 		// create the parent keyspace and shard if needed
-		si, err = wr.ts.GetOrCreateShard(ctx, tablet.Keyspace, tablet.Shard)
+		si, err = wr.ts.GetOrCreateShard(ctx, tablet.Keyspace, tablet.Shard, tablet.Alias.GetCell())
 	} else {
 		si, err = wr.ts.GetShard(ctx, tablet.Keyspace, tablet.Shard)
 		if topo.IsErrType(err, topo.NoNode) {

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -38,7 +38,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// create shard and tablets
-	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
+	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0", "cell1"); err != nil {
 		t.Fatalf("GetOrCreateShard failed: %v", err)
 	}
 	master := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)
@@ -108,7 +108,7 @@ func TestReparentTablet(t *testing.T) {
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// create shard and tablets
-	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
+	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0", "cell1"); err != nil {
 		t.Fatalf("CreateShard failed: %v", err)
 	}
 	master := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)


### PR DESCRIPTION

### Description
Modifies `EnsureVSchema` so that we always pass in a cell and it rebuilds SrvVSchema only in the provided cell. This removes its auto-rebuild of all cells automatically when you're creating a new shard or keyspace.

### Background
During a setup of a new region, we had a misconfigured topology and spinning up a new shard caused us to corrupt **all cells in the topology**, just as part of booting up a new tablet. For safety reasons, it seems better to decouple spinning up a new shard from rebuilding SrvVSchema on all cells. As talked about in person a few weeks ago--we'll keep the rebuild for the simple case where there's only one cell.

Signed-off-by: Maggie Zhou <mzhou@slack-corp.com>