### PR TITLE
Resharding Workflow Gen: Modified logic to find serving shards. 

### DIFF
--- a/go/vt/workflow/reshardingworkflowgen/workflow.go
+++ b/go/vt/workflow/reshardingworkflowgen/workflow.go
@@ -182,12 +182,12 @@ func findSourceAndDestinationShards(ts *topo.Server, keyspace string) ([][][]str
 		var sourceShards, destinationShards []string
 		var sourceShardInfo *topo.ShardInfo
 		var destinationShardInfos []*topo.ShardInfo
-		// Judge which side is source shard by checking the number of servedTypes.
-		leftServingTypes, err := ts.GetShardServingTypes(context.Background(), os.Left[0])
+
+		isLeftServing := os.Left[0].IsMasterServing
 		if err != nil {
 			return nil, err
 		}
-		if len(leftServingTypes) > 0 {
+		if isLeftServing {
 			sourceShardInfo = os.Left[0]
 			destinationShardInfos = os.Right
 		} else {

--- a/go/vt/workflow/reshardingworkflowgen/workflow_test.go
+++ b/go/vt/workflow/reshardingworkflowgen/workflow_test.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 // TestWorkflowGenerator runs the happy path of HorizontalReshardingWorkflow.
-func TestWorfklowGenerator(t *testing.T) {
+func TestWorkflowGenerator(t *testing.T) {
 	ctx := context.Background()
 
 	// Initialize the topology.


### PR DESCRIPTION
Earlier one was broken resulting in a flaky test which depended on the sequence of shards returned by the topo. Test was breaking 20% of the time earlier and now it worked fine for 100s of runs.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>