### PR TITLE
Cluster test logging changes

### DIFF
--- a/go/test/endtoend/backup/transform/backup_transform_utils.go
+++ b/go/test/endtoend/backup/transform/backup_transform_utils.go
@@ -266,7 +266,7 @@ func TestBackupTransformImpl(t *testing.T) {
 
 }
 
-// TestBackupTransformError validate backup with test_backup_error
+// TestBackupTransformErrorImpl validate backup with test_backup_error
 // backup_storage_hook, which should fail.
 func TestBackupTransformErrorImpl(t *testing.T) {
 	// restart the replica with transform hook parameter
@@ -309,13 +309,13 @@ func validateManifestFile(t *testing.T, backupLocation string) {
 	require.Nilf(t, err, "error while parsing MANIFEST %v", err)
 
 	// validate manifest
-	transformHook, _ := manifest["TransformHook"]
+	transformHook := manifest["TransformHook"]
 	require.Equalf(t, "test_backup_transform", transformHook, "invalid transformHook in MANIFEST")
-	skipCompress, _ := manifest["SkipCompress"]
+	skipCompress := manifest["SkipCompress"]
 	assert.Equalf(t, skipCompress, true, "invalid value of skipCompress")
 
 	// validate backup files
-	fielEntries, _ := manifest["FileEntries"]
+	fielEntries := manifest["FileEntries"]
 	fileArr, ok := fielEntries.([]interface{})
 	require.True(t, ok)
 	for i := range fileArr {

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -344,7 +344,7 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 // the required services (ex topo, vtgate, mysql and vttablet)
 func (cluster *LocalProcessCluster) LaunchCluster(keyspace *Keyspace, shards []Shard) (err error) {
 
-	log.Infof("Starting keyspace : %v", keyspace.Name)
+	log.Infof("Starting keyspace: %v", keyspace.Name)
 
 	// Create Keyspace
 	err = cluster.VtctlProcess.CreateKeyspace(keyspace.Name)
@@ -577,6 +577,7 @@ func (cluster *LocalProcessCluster) GetAndReservePort() int {
 	}
 	for {
 		cluster.nextPortForProcess = cluster.nextPortForProcess + 1
+		log.Infof("Attempting to reserve port: %v", cluster.nextPortForProcess)
 		ln, err := net.Listen("tcp", fmt.Sprintf(":%v", cluster.nextPortForProcess))
 
 		if err != nil {
@@ -584,6 +585,7 @@ func (cluster *LocalProcessCluster) GetAndReservePort() int {
 			continue
 		}
 
+		log.Infof("Port %v is available, reserving..", cluster.nextPortForProcess)
 		ln.Close()
 		break
 	}

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -86,7 +86,7 @@ func (mysqlctl *MysqlctlProcess) StartProcess() (*exec.Cmd, error) {
 			"-init_db_sql_file", mysqlctl.InitDBFile)
 	}
 	tmpProcess.Args = append(tmpProcess.Args, "start")
-
+	log.Infof("Starting mysqlctl with command: %v", tmpProcess.Args)
 	return tmpProcess, tmpProcess.Start()
 }
 

--- a/go/test/endtoend/cluster/vtbackup_process.go
+++ b/go/test/endtoend/cluster/vtbackup_process.go
@@ -47,8 +47,6 @@ type VtbackupProcess struct {
 	ExtraArgs     []string
 	initialBackup bool
 	initDBfile    string
-	dbPassword    string
-	dbName        string
 
 	proc *exec.Cmd
 	exit chan error

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -26,11 +26,11 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/log"
+
 	"vitess.io/vitess/go/sqltypes"
 
 	"vitess.io/vitess/go/mysql"
-
-	"github.com/prometheus/common/log"
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/sharding"
@@ -255,7 +255,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {
 		for _, tablet := range shard.Vttablets {
-			log.Infof("Starting MySql for tablet %v", tablet.Alias)
+			log.Infof("Starting mysql for tablet %v", tablet.Alias)
 			if proc, err := tablet.MysqlctlProcess.StartProcess(); err != nil {
 				t.Fatal(err)
 			} else {
@@ -548,9 +548,9 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 
 	// testing filtered replication: insert a bunch of data on shard 1, check we get most of it after a few seconds,
 	// wait for binlog server timeout, check we get all of it.
-	log.Debug("Inserting lots of data on source shard")
+	log.Info("Inserting lots of data on source shard")
 	insertLots(100, 0, *shard1Master, tableName, fixedParentID, keyspaceName)
-	log.Debug("Executing MultiValue Insert Queries")
+	log.Info("Executing MultiValue Insert Queries")
 	execMultiShardDmls(t, keyspaceName)
 
 	// Checking 100 percent of data is sent quickly
@@ -574,7 +574,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	clusterInstance.VtworkerProcess.Cell = cell1
 
 	// Compare using SplitDiff
-	log.Debug("Running vtworker SplitDiff")
+	log.Info("Running vtworker SplitDiff")
 	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
 		clusterInstance.GetAndReservePort(),
 		"--use_v3_resharding_mode=true",
@@ -585,7 +585,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.Nil(t, err)
 
 	// Compare using MultiSplitDiff
-	log.Debug("Running vtworker MultiSplitDiff")
+	log.Info("Running vtworker MultiSplitDiff")
 	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
 		clusterInstance.GetAndReservePort(),
 		"--use_v3_resharding_mode=true",
@@ -618,9 +618,9 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.Nil(t, err)
 
 	// test data goes through again
-	log.Debug("Inserting lots of data on source shard")
+	log.Info("Inserting lots of data on source shard")
 	insertLots(100, 100, *shard1Master, tableName, fixedParentID, keyspaceName)
-	log.Debug("Checking 100 percent of data was sent quickly")
+	log.Info("Checking 100 percent of data was sent quickly")
 	assert.True(t, checkLotsTimeout(t, 100, 100, tableName, keyspaceName, shardingKeyType))
 
 	sharding.CheckBinlogServerVars(t, *shard1Replica2, 80, 80, false)
@@ -640,7 +640,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 			"VtTabletStreamHealth",
 			"-count", "1", master.Alias)
 		require.Nil(t, err)
-		log.Debug("Got health: ", streamHealth)
+		log.Info("Got health: ", streamHealth)
 
 		var streamHealthResponse querypb.StreamHealthResponse
 		err = json.Unmarshal([]byte(streamHealth), &streamHealthResponse)
@@ -788,7 +788,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	assert.True(t, checkLotsTimeout(t, 100, 200, tableName, keyspaceName, shardingKeyType))
 
 	// Compare using SplitDiff
-	log.Debug("Running vtworker SplitDiff")
+	log.Info("Running vtworker SplitDiff")
 	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
 		clusterInstance.GetAndReservePort(),
 		"--use_v3_resharding_mode=true",
@@ -799,7 +799,7 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	require.Nil(t, err)
 
 	// Compare using MultiSplitDiff
-	log.Debug("Running vtworker MultiSplitDiff")
+	log.Info("Running vtworker MultiSplitDiff")
 	err = clusterInstance.VtworkerProcess.ExecuteVtworkerCommand(clusterInstance.GetAndReservePort(),
 		clusterInstance.GetAndReservePort(),
 		"--use_v3_resharding_mode=true",


### PR DESCRIPTION
* Add back logging of reserve port because it sometimes hangs in CI. 
* Use vt/log instead of prometheus/common/log
* add logging for mysqlctl startup
* staticcheck fixes

Signed-off-by: deepthi <deepthi@planetscale.com>