### PR TITLE
Randomize slave connection server_id;  or RDS can get upset.

### DIFF
--- a/go/pools/id_pool.go
+++ b/go/pools/id_pool.go
@@ -36,9 +36,10 @@ type IDPool struct {
 }
 
 // NewIDPool creates and initializes an IDPool.
-func NewIDPool() *IDPool {
+func NewIDPool(initialValue uint32) *IDPool {
 	return &IDPool{
-		used: make(map[uint32]bool),
+		used:    make(map[uint32]bool),
+		maxUsed: initialValue,
 	}
 }
 
@@ -54,7 +55,7 @@ func (pool *IDPool) Get() (id uint32) {
 	}
 
 	// No recycled IDs are available, so increase the pool size.
-	pool.maxUsed += 1
+	pool.maxUsed++
 	return pool.maxUsed
 }
 

--- a/go/pools/id_pool_test.go
+++ b/go/pools/id_pool_test.go
@@ -33,7 +33,7 @@ func (pool *IDPool) want(want *IDPool, t *testing.T) {
 }
 
 func TestIDPoolFirstGet(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 
 	if got := pool.Get(); got != 1 {
 		t.Errorf("pool.Get() = %v, want 1", got)
@@ -43,7 +43,7 @@ func TestIDPoolFirstGet(t *testing.T) {
 }
 
 func TestIDPoolSecondGet(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	pool.Get()
 
 	if got := pool.Get(); got != 2 {
@@ -54,7 +54,7 @@ func TestIDPoolSecondGet(t *testing.T) {
 }
 
 func TestIDPoolPutToUsedSet(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	id1 := pool.Get()
 	pool.Get()
 	pool.Put(id1)
@@ -63,7 +63,7 @@ func TestIDPoolPutToUsedSet(t *testing.T) {
 }
 
 func TestIDPoolPutMaxUsed1(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	id1 := pool.Get()
 	pool.Put(id1)
 
@@ -71,7 +71,7 @@ func TestIDPoolPutMaxUsed1(t *testing.T) {
 }
 
 func TestIDPoolPutMaxUsed2(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	pool.Get()
 	id2 := pool.Get()
 	pool.Put(id2)
@@ -80,7 +80,7 @@ func TestIDPoolPutMaxUsed2(t *testing.T) {
 }
 
 func TestIDPoolGetFromUsedSet(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	id1 := pool.Get()
 	pool.Get()
 	pool.Put(id1)
@@ -104,7 +104,7 @@ func wantError(want string, t *testing.T) {
 }
 
 func TestIDPoolPut0(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	pool.Get()
 
 	defer wantError("invalid value", t)
@@ -112,7 +112,7 @@ func TestIDPoolPut0(t *testing.T) {
 }
 
 func TestIDPoolPutInvalid(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	pool.Get()
 
 	defer wantError("invalid value", t)
@@ -120,7 +120,7 @@ func TestIDPoolPutInvalid(t *testing.T) {
 }
 
 func TestIDPoolPutDuplicate(t *testing.T) {
-	pool := NewIDPool()
+	pool := NewIDPool(0)
 	pool.Get()
 	pool.Get()
 	pool.Put(1)

--- a/go/vt/binlog/slave_connection.go
+++ b/go/vt/binlog/slave_connection.go
@@ -18,6 +18,7 @@ package binlog
 
 import (
 	"fmt"
+	"math/rand"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -85,7 +86,9 @@ func connectForReplication(cp dbconfigs.Connector) (*mysql.Conn, error) {
 }
 
 // slaveIDPool is the IDPool for server IDs used to connect as a slave.
-var slaveIDPool = pools.NewIDPool()
+//   We use a randomized value, because RDS doesn't like clients re-using
+//   values among themselves.
+var slaveIDPool = pools.NewIDPool(uint32(rand.Intn(100000000)))
 
 // StartBinlogDumpFromCurrent requests a replication binlog dump from
 // the current position.


### PR DESCRIPTION
Apparently RDS' binlog server keeps track of which server_ids have been connecting to it, and can get upset when multiple clients try to use the same ID, e.g. https://forums.aws.amazon.com/thread.jspa?threadID=243996

Signed-off-by: Jacques Grove <aquarapid@gmail.com>