### PR TITLE
messaging: add new priority field

### DIFF
--- a/go/test/endtoend/messaging/cluster_ops_test.go
+++ b/go/test/endtoend/messaging/cluster_ops_test.go
@@ -45,8 +45,8 @@ func TestUnsharded(t *testing.T) {
 	testMessaging(t, "unsharded_message", lookupKeyspace)
 }
 
-// TestRepareting checks the client connection count after reparenting.
-func TestRepareting(t *testing.T) {
+// TestReparenting checks the client connection count after reparenting.
+func TestReparenting(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	name := "sharded_message"
 

--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -42,22 +42,24 @@ var (
 	lookupKeyspace       = "lookup"
 	createShardedMessage = `create table sharded_message(
 		id bigint,
+		priority bigint default 0,
 		time_next bigint default 0,
 		epoch bigint,
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(time_next, epoch),
+		index next_idx(priority, time_next),
 		index ack_idx(time_acked)
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	createUnshardedMessage = `create table unsharded_message(
 		id bigint,
+		priority bigint default 0,
 		time_next bigint default 0,
 		epoch bigint,
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(time_next, epoch),
+		index next_idx(priority, time_next),
 		index ack_idx(time_acked)
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	userVschema = `{

--- a/go/test/endtoend/messaging/main_test.go
+++ b/go/test/endtoend/messaging/main_test.go
@@ -48,7 +48,7 @@ var (
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(priority, time_next),
+		index next_idx(priority, time_next desc),
 		index ack_idx(time_acked)
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	createUnshardedMessage = `create table unsharded_message(
@@ -59,7 +59,7 @@ var (
 		time_acked bigint,
 		message varchar(128),
 		primary key(id),
-		index next_idx(priority, time_next),
+		index next_idx(priority, time_next desc),
 		index ack_idx(time_acked)
 		) comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 	userVschema = `{

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -31,12 +31,13 @@ import (
 
 var createMessage = `create table vitess_message(
 	id bigint,
+	priority bigint default 0,
 	time_next bigint default 0,
 	epoch bigint,
 	time_acked bigint,
 	message varchar(128),
 	primary key(id),
-	index next_idx(time_next, epoch),
+	index next_idx(priority, time_next),
 	index ack_idx(time_acked))
 comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 
@@ -141,13 +142,14 @@ func TestMessage(t *testing.T) {
 
 var createThreeColMessage = `create table vitess_message3(
 	id bigint,
+	priority bigint default 0,
 	time_next bigint default 0,
 	epoch bigint,
 	time_acked bigint,
 	msg1 varchar(128),
 	msg2 bigint,
 	primary key(id),
-	index next_idx(time_next, epoch),
+	index next_idx(priority, time_next),
 	index ack_idx(time_acked))
 comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -37,7 +37,7 @@ var createMessage = `create table vitess_message(
 	time_acked bigint,
 	message varchar(128),
 	primary key(id),
-	index next_idx(priority, time_next),
+	index next_idx(priority, time_next desc),
 	index ack_idx(time_acked))
 comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 
@@ -149,7 +149,7 @@ var createThreeColMessage = `create table vitess_message3(
 	msg1 varchar(128),
 	msg2 bigint,
 	primary key(id),
-	index next_idx(priority, time_next),
+	index next_idx(priority, time_next desc),
 	index ack_idx(time_acked))
 comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
 

--- a/go/vt/vttablet/tabletserver/messager/cache.go
+++ b/go/vt/vttablet/tabletserver/messager/cache.go
@@ -28,6 +28,7 @@ import (
 // MessageRow represents a message row.
 // The first column in Row is always the "id".
 type MessageRow struct {
+	Priority  int64
 	TimeNext  int64
 	Epoch     int64
 	TimeAcked int64
@@ -47,8 +48,8 @@ func (mh messageHeap) Len() int {
 func (mh messageHeap) Less(i, j int) bool {
 	// Lower epoch is more important.
 	// If epochs match, newer messages are more important.
-	return mh[i].Epoch < mh[j].Epoch ||
-		(mh[i].Epoch == mh[j].Epoch && mh[i].TimeNext > mh[j].TimeNext)
+	return mh[i].Priority < mh[j].Priority ||
+		(mh[i].Priority == mh[j].Priority && mh[i].TimeNext > mh[j].TimeNext)
 }
 
 func (mh messageHeap) Swap(i, j int) {

--- a/go/vt/vttablet/tabletserver/messager/cache_test.go
+++ b/go/vt/vttablet/tabletserver/messager/cache_test.go
@@ -26,6 +26,7 @@ import (
 func TestMessagerCacheOrder(t *testing.T) {
 	mc := newCache(10)
 	if !mc.Add(&MessageRow{
+		Priority: 1,
 		TimeNext: 1,
 		Epoch:    0,
 		Row:      []sqltypes.Value{sqltypes.NewVarBinary("row01")},
@@ -33,6 +34,7 @@ func TestMessagerCacheOrder(t *testing.T) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
+		Priority: 1,
 		TimeNext: 2,
 		Epoch:    0,
 		Row:      []sqltypes.Value{sqltypes.NewVarBinary("row02")},
@@ -40,6 +42,7 @@ func TestMessagerCacheOrder(t *testing.T) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
+		Priority: 2,
 		TimeNext: 2,
 		Epoch:    1,
 		Row:      []sqltypes.Value{sqltypes.NewVarBinary("row12")},
@@ -47,6 +50,7 @@ func TestMessagerCacheOrder(t *testing.T) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
+		Priority: 2,
 		TimeNext: 1,
 		Epoch:    1,
 		Row:      []sqltypes.Value{sqltypes.NewVarBinary("row11")},
@@ -54,6 +58,7 @@ func TestMessagerCacheOrder(t *testing.T) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
+		Priority: 1,
 		TimeNext: 3,
 		Epoch:    0,
 		Row:      []sqltypes.Value{sqltypes.NewVarBinary("row03")},

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -52,6 +52,7 @@ var (
 		{Type: sqltypes.Int64},
 		{Type: sqltypes.Int64},
 		{Type: sqltypes.Int64},
+		{Type: sqltypes.Int64},
 		{Type: sqltypes.VarBinary},
 	}
 )

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -74,6 +74,7 @@ func newMMTable() *schema.Table {
 func newMMRow(id int64) *querypb.Row {
 	return sqltypes.RowToProto3([]sqltypes.Value{
 		sqltypes.NewInt64(1),
+		sqltypes.NewInt64(1),
 		sqltypes.NewInt64(0),
 		sqltypes.NULL,
 		sqltypes.NewInt64(id),

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/schema_test.json
@@ -313,19 +313,16 @@
     "Name": "msg",
     "Columns": [
       {
-        "Name": "time_scheduled"
+        "Name": "id"
       },
       {
-        "Name": "id"
+        "Name": "priority"
       },
       {
         "Name": "time_next"
       },
       {
         "Name": "epoch"
-      },
-      {
-        "Name": "time_created"
       },
       {
         "Name": "time_acked"

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1235,6 +1235,9 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 				Name: "id",
 				Type: sqltypes.Int64,
 			}, {
+				Name: "priority",
+				Type: sqltypes.Int64,
+			}, {
 				Name: "time_next",
 				Type: sqltypes.Int64,
 			}, {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -376,6 +376,9 @@ func initialSchema() map[string]*Table {
 				Name: "id",
 				Type: sqltypes.Int64,
 			}, {
+				Name: "priority",
+				Type: sqltypes.Int64,
+			}, {
 				Name: "time_next",
 				Type: sqltypes.Int64,
 			}, {

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -58,6 +58,7 @@ func fetchColumns(ta *Table, conn *connpool.DBConn, sqlTableName string) error {
 
 func loadMessageInfo(ta *Table, comment string) error {
 	hiddenCols := map[string]struct{}{
+		"priority":   {},
 		"time_next":  {},
 		"epoch":      {},
 		"time_acked": {},
@@ -65,6 +66,7 @@ func loadMessageInfo(ta *Table, comment string) error {
 
 	requiredCols := []string{
 		"id",
+		"priority",
 		"time_next",
 		"epoch",
 		"time_acked",

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -98,6 +98,9 @@ func TestLoadTableMessage(t *testing.T) {
 			Name: "id",
 			Type: sqltypes.Int64,
 		}, {
+			Name: "priority",
+			Type: sqltypes.Int64,
+		}, {
 			Name: "time_next",
 			Type: sqltypes.Int64,
 		}, {
@@ -178,12 +181,13 @@ func getTestLoadTableQueries() map[string]*sqltypes.Result {
 }
 
 func getMessageTableQueries() map[string]*sqltypes.Result {
-	// id is intentionally after the message column to ensure that the
-	// loader still makes it the first one.
 	return map[string]*sqltypes.Result{
 		"select * from test_table where 1 != 1": {
 			Fields: []*querypb.Field{{
 				Name: "id",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "priority",
 				Type: sqltypes.Int64,
 			}, {
 				Name: "time_next",

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -119,6 +119,9 @@ func Queries() map[string]*sqltypes.Result {
 				Name: "id",
 				Type: sqltypes.Int64,
 			}, {
+				Name: "priority",
+				Type: sqltypes.Int64,
+			}, {
 				Name: "time_next",
 				Type: sqltypes.Int64,
 			}, {

--- a/go/vt/vttablet/tabletserver/tabletserver_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_flaky_test.go
@@ -2592,6 +2592,9 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				Name: "id",
 				Type: sqltypes.Int64,
 			}, {
+				Name: "priority",
+				Type: sqltypes.Int64,
+			}, {
 				Name: "time_next",
 				Type: sqltypes.Int64,
 			}, {


### PR DESCRIPTION
As discussed on Slack with @sougou, we decided to add a new required priority field. This PR adds the field to the tests and modifies the load query + index to order by priority and then time_next.

> epoch remains as is, it just won't be used to prioritize. instead you can introduce a new priority column, and that will be used instead of epoch (both for the select query and in the cache)
https://vitess.slack.com/archives/C9EDPDJT1/p1584943246101100