### PR TITLE
Changed logrotate tag on values.yaml

### DIFF
--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -401,5 +401,5 @@ orchestrator:
       memory: 350Mi
 
 logrotate:
-  vitessTag: 3.1.1
+  tag: 3.1.1
   image: vitess/orchestrator


### PR DESCRIPTION
When runnning this command: helm install ../../helm/vitess -f 101_initial_cluster.yaml  
Error: YAML parse error on vitess/templates/vitess.yaml: error converting YAML to JSON: yaml: line 444: mapping values are not allowed in this context