### PR TITLE
Misc cleanups: Remove deadcode in tests, makefile

### DIFF
--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -2,7 +2,7 @@ name: sonar_analysis
 on:
   push:
     branches:
-      - 'master'
+      - 'sonartest'
 jobs:
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,6 @@ install: build
 	# binaries
 	mkdir -p "$${PREFIX}/bin"
 	cp "$${VTROOT}/bin/"{mysqlctld,vtctld,vtctlclient,vtgate,vttablet,vtworker,vtbackup} "$${PREFIX}/bin/"
-	# config files
-	mkdir -p "$${PREFIX}/src/vitess.io/vitess"
-	cp -R config "$${PREFIX}/src/vitess.io/vitess/"
-	# also symlink config files in the old location
-	ln -sf src/vitess.io/vitess/config "$${PREFIX}/config"
-	# vtctld web UI files
-	mkdir -p "$${PREFIX}/src/vitess.io/vitess/web/vtctld2"
-	cp -R web/vtctld2/app "$${PREFIX}/src/vitess.io/vitess/web/vtctld2/"
 
 parser:
 	make -C go/vt/sqlparser
@@ -288,12 +280,6 @@ docker_test:
 
 docker_unit_test:
 	go run test.go -flavor $(flavor) unit
-
-# This can be used to rebalance the total average runtime of each group of
-# tests in Travis. The results are saved in test/config.json, which you can
-# then commit and push.
-rebalance_tests:
-	go run test.go -rebalance 5
 
 # Release a version.
 # This will generate a tar.gz file into the releases folder with the current source

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.13 || fail "Go version reported: ${go version}. Version 1.13+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.13 || fail "Go version reported: `go version`. Version 1.13+ required. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/tools/dependency_check.sh
+++ b/tools/dependency_check.sh
@@ -24,6 +24,6 @@ function fail() {
 # These binaries are required to 'make test'
 # mysqld might be in /usr/sbin which will not be in the default PATH
 PATH="/usr/sbin:$PATH"
-for binary in mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
+for binary in k3s mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
   command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/contributing/build-from-source for install instructions."
 done;


### PR DESCRIPTION
Hopefully not too controversial:

This removes the shard rebalancing make target, and the feature from test.go. It is not doing any harm, but we don't need this with GitHub actions - we can run unlimited shards.

I have also removed the `make install` feature which copies vtctl2 web files and config files. These are now embedded in rice boxes.

Fixes a bug in echo'ing current go version when it is out of date.

Add k3s to dependency check for running tests.

Move failing sonar action to a special branch instead of master. When we get it working, we can enable on master again.

Signed-off-by: Morgan Tocker <tocker@gmail.com>