### PR TITLE
Helm charts use the K8s topology by default

### DIFF
--- a/examples/helm/101_initial_cluster.yaml
+++ b/examples/helm/101_initial_cluster.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -50,10 +48,6 @@ topology:
                   "corder": {}
                 }
               }
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/201_customer_keyspace.yaml
+++ b/examples/helm/201_customer_keyspace.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -26,10 +24,6 @@ jobs:
   - name: "create-customer-ks"
     kind: "vtctlclient"
     command: "CreateKeyspace -served_from='master:commerce,replica:commerce,rdonly:commerce' customer"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/202_customer_tablets.yaml
+++ b/examples/helm/202_customer_tablets.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -51,10 +49,6 @@ topology:
                   "corder": {}
                 }
               }
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/203_vertical_split.yaml
+++ b/examples/helm/203_vertical_split.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -37,10 +35,6 @@ jobs:
     kind: "vtworker"
     cell: "zone1"
     command: "VerticalSplitClone -min_healthy_tablets=1 -tables=customer,corder customer/0"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/204_vertical_migrate_replicas.yaml
+++ b/examples/helm/204_vertical_migrate_replicas.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -39,10 +37,6 @@ jobs:
   - name: "msf2"
     kind: "vtctlclient"
     command: "MigrateServedFrom customer/0 replica"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/205_vertical_migrate_master.yaml
+++ b/examples/helm/205_vertical_migrate_master.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -36,10 +34,6 @@ jobs:
   - name: "msf3"
     kind: "vtctlclient"
     command: "MigrateServedFrom customer/0 master"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/206_clean_commerce.yaml
+++ b/examples/helm/206_clean_commerce.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -46,10 +44,6 @@ jobs:
   - name: "vclean3"
     kind: "vtctlclient"
     command: "SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 master"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/301_customer_sharded.yaml
+++ b/examples/helm/301_customer_sharded.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -90,10 +88,6 @@ topology:
                   }
                 }
               }
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/302_new_shards.yaml
+++ b/examples/helm/302_new_shards.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -51,10 +49,6 @@ topology:
                     replicas: 1
               copySchema:
                 source: "customer/0"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/303_horizontal_split.yaml
+++ b/examples/helm/303_horizontal_split.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -53,10 +51,6 @@ jobs:
     kind: "vtworker"
     cell: "zone1"
     command: "SplitClone -min_healthy_rdonly_tablets=1 customer/0"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/304_migrate_replicas.yaml
+++ b/examples/helm/304_migrate_replicas.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -55,10 +53,6 @@ jobs:
   - name: "mst2"
     kind: "vtctlclient"
     command: "MigrateServedTypes customer/0 replica"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/305_migrate_master.yaml
+++ b/examples/helm/305_migrate_master.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -52,10 +50,6 @@ jobs:
   - name: "mst3"
     kind: "vtctlclient"
     command: "MigrateServedTypes customer/0 master"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/306_down_shard_0.yaml
+++ b/examples/helm/306_down_shard_0.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -39,10 +37,6 @@ topology:
                 - type: "rdonly"
                   vttablet:
                     replicas: 1
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/307_delete_shard_0.yaml
+++ b/examples/helm/307_delete_shard_0.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -44,10 +42,6 @@ jobs:
   - name: "delete-shard0"
     kind: "vtctlclient"
     command: "DeleteShard -recursive customer/0"
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/examples/helm/308_final.yaml
+++ b/examples/helm/308_final.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -45,9 +43,6 @@ jobs:
     kind: "vtctlclient"
     command: "DeleteShard -recursive customer/0"
 
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.0.0-0 - 2020-04-03
+
+Vitess now supports using the Kubernetes API as a topology provider. This means that it is now easier than ever to run Vitess on Kubernetes! 
+
+Properly supporting this new provider requires a major, breaking change of the helm charts. The `etcd-operator` has been deprecated as well so the Vitess team has decided to make the Kubernetes topology the default going forward.
+
+### Upgrade and Migration Information
+
+* This version introduces a `topologyProvider` configuration in `topology.globalCell` and in the configuration for each cell individually. The default from v2 on is to use the `k8s` topology provider. Explicitly set these values to `etcd2` in order to continue to use the etcd topology provider.
+* The `root` is now being set properly for all topology cells. Prior to this version, all cells were using `""` as the root which worked, but was invalid. The root path for all cells  will now be set to `/vitess/{{ $cell.name }}`. In order to upgrade a helm deployment from v1 to v2 you will need to stop all vitess components, migrate all etcd keys except `/global`, from `/` to `/vitess/{{ $cell.name }}`. There is no automation for this procedure at this time.
+
+### Changes
+* Update images of Vitess components to **TODO: we need new images based on a released tag, not just master at a point in time**
+* Set the topology `root` in all new and existing cells to `/vitess/{{ $cell.name }}`
+* Add `topology.globalCell.topologyProvider` - default to `k8s`
+* Add `topolgy.cells[*].topologyProvider` - default to `k8s`
+
 ## 1.0.7-5 - 2019-12-02
 
 ### Changes

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 1.0.7-5
+version: 2.0.0-0
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/README.md
+++ b/helm/vitess/README.md
@@ -8,13 +8,14 @@ and has been used there since 2011.
 
 This chart creates a Vitess cluster on Kubernetes in a single
 [release](https://github.com/kubernetes/helm/blob/master/docs/glossary.md#release).
-It currently includes all dependencies (e.g. etcd) and Vitess components
+It currently includes all Vitess components
 (vtctld, vtgate, vttablet) inline (in `templates/`) rather than as sub-charts.
 
-## Prerequisites
+## Using Etcd For Topology Data
 
-* Install [etcd-operator](https://github.com/coreos/etcd-operator) in the
-  namespace where you plan to install this chart.
+The chart will use Kubernetes as the topology store for Vitess. This is the preferred configuration when running Vitess in Kubernetes as it has no external dependencesi.
+
+If you do wish to use `etcd` as the toplogy service, then you will need to create an etcd cluster and provide the configuration in your `values.yaml`. Etcd can be managed manually or via the [etcd-operator](https://github.com/coreos/etcd-operator).
 
 ## Installing the Chart
 
@@ -49,8 +50,6 @@ look at the default `values.yaml` file, which is well commented.
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 3
       vtctld:
         replicas: 1
       vtgate:

--- a/helm/vitess/crds/VitessTopoNodes-crd.yaml
+++ b/helm/vitess/crds/VitessTopoNodes-crd.yaml
@@ -1,0 +1,45 @@
+# This is a copy of the crd def from: vitess/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
+# It is not symlinked so that the helm charts do not have references to outside files
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vitesstoponodes.topo.vitess.io
+spec:
+  group: topo.vitess.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Key
+          type: string
+          description: The full key path
+          jsonPath: .data.key
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - data
+          properties:
+            data:
+              type: object
+              required:
+                - key
+                - value
+              properties:
+                key:
+                  description: A file-path like key. Must be an absolute path. Must not end with a /.
+                  type: string
+                  pattern: '^\/.+[^\/]$'
+                value:
+                  description: A base64 encoded value. Must be a base64 encoded string or empty string.
+                  type: string
+                  pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+                ephemeral:
+                  description: Whether or not the node is considered ephemeral. True for lock and election nodes.
+                  type: boolean
+  scope: Namespaced
+  names:
+    plural: vitesstoponodes
+    singular: vitesstoponode
+    kind: VitessTopoNode

--- a/helm/vitess/examples/minikube.yaml
+++ b/helm/vitess/examples/minikube.yaml
@@ -1,8 +1,6 @@
 topology:
   cells:
     - name: "zone1"
-      etcd:
-        replicas: 1
       vtctld:
         replicas: 1
       vtgate:
@@ -47,10 +45,6 @@ topology:
                   "corder": {}
                 }
               }
-
-etcd:
-  replicas: 1
-  resources:
 
 vtctld:
   serviceType: "NodePort"

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -123,7 +123,7 @@ spec:
               value: "15999"
 
         - name: recovery-log
-          image: vitess/logtail:helm-1.0.7-5
+          image: vitess/logtail:helm-2.0.0-0
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH
@@ -133,7 +133,7 @@ spec:
               mountPath: /tmp
 
         - name: audit-log
-          image: vitess/logtail:helm-1.0.7-5
+          image: vitess/logtail:helm-2.0.0-0
           imagePullPolicy: IfNotPresent
           env:
           - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -219,7 +219,7 @@ spec:
       trap : TERM INT; sleep infinity & wait
 
 - name: pmm-client-metrics-log
-  image: vitess/logtail:helm-1.0.7-5
+  image: vitess/logtail:helm-2.0.0-0
   imagePullPolicy: IfNotPresent
   env:
   - name: TAIL_FILEPATH

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -36,10 +36,39 @@ spec:
     app: vitess
   type: {{.serviceType | default $defaultVtctld.serviceType}}
 ---
+
+###################################
+# vtctld ServiceAccount
+###################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vtctld
+  labels:
+    app: vitess
+---
+
+###################################
+# vtctld RoleBinding
+###################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vtctld-topo-member
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vt-topo-member
+subjects:
+- kind: ServiceAccount
+  name: vtctld
+  namespace: {{ $namespace }}
+---
+
 ###################################
 # vtctld Service + Deployment
 ###################################
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vtctld
@@ -55,6 +84,7 @@ spec:
         app: vitess
         component: vtctld
     spec:
+      serviceAccountName: vtctld
 {{ include "pod-security" . | indent 6 }}
 {{ include "vtctld-affinity" (tuple $cellClean $cell.region) | indent 6 }}
       containers:
@@ -99,9 +129,14 @@ spec:
                 -port=15000
                 -grpc_port=15999
                 -service_map="grpc-vtctl"
+                -topo_global_root=/vitess/global
+                {{- if eq ($cell.topologyProvider | default "") "etcd2" }}
                 -topo_implementation="etcd2"
                 -topo_global_server_address="etcd-global-client.{{ $namespace }}:2379"
-                -topo_global_root=/vitess/global
+                {{- else }}
+                -topo_implementation="k8s"
+                -topo_global_server_address="k8s"
+                {{- end }}
 {{ include "backup-flags" (tuple $config.backup "vtctld") | indent 16 }}
 {{ include "format-flags-all" (tuple $defaultVtctld.extraFlags .extraFlags) | indent 16 }}
               END_OF_COMMAND

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -29,8 +29,41 @@ spec:
   selector:
     app: vitess
     component: vttablet
-
+---
 {{- end -}}
+
+###################################
+# vttablet ServiceAccount
+###################################
+{{ define "vttablet-serviceaccount" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vttablet
+  labels:
+    app: vitess
+---
+{{ end }}
+
+###################################
+# vttablet RoleBinding
+###################################
+{{ define "vttablet-topo-role-binding" -}}
+{{- $namespace := index . 0 -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vttablet-topo-member
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vt-topo-member
+subjects:
+- kind: ServiceAccount
+  name: vttablet
+  namespace: {{ $namespace }}
+---
+{{ end }}
 
 ###################################
 # vttablet
@@ -68,7 +101,7 @@ spec:
 ###################################
 # vttablet StatefulSet
 ###################################
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $setName | quote }}
@@ -96,6 +129,7 @@ spec:
         shard: {{ $shardClean | quote }}
         type: {{ $tablet.type | quote }}
     spec:
+      serviceAccountName: vttablet
       terminationGracePeriodSeconds: 60000000
 {{ include "pod-security" . | indent 6 }}
 {{ include "vttablet-affinity" (tuple $cellClean $keyspaceClean $shardClean $cell.region) | indent 6 }}
@@ -241,13 +275,23 @@ spec:
 
       # make sure that etcd is initialized
       eval exec /vt/bin/vtctl $(cat <<END_OF_COMMAND
-        -topo_implementation="etcd2"
         -topo_global_root=/vitess/global
+        {{- if eq ($cell.topologyProvider | default "") "etcd2" }}
+        -topo_implementation="etcd2"
         -topo_global_server_address="etcd-global-client.{{ $namespace }}:2379"
+        {{- else }}
+        -topo_implementation=k8s
+        -topo_global_server_address=k8s
+        {{- end }}
         -logtostderr=true
         -stderrthreshold=0
         UpdateCellInfo
+        -root /vitess/{{ $cell.name }}
+        {{- if eq ($cell.topologyProvider | default "") "etcd2" }}
         -server_address="etcd-global-client.{{ $namespace }}:2379"
+        {{- else }}
+        -server_address=k8s
+        {{- end }}
         {{ $cellClean | quote}}
       END_OF_COMMAND
       )
@@ -403,9 +447,14 @@ spec:
 {{ include "backup-exec" $config.backup | indent 6 }}
 
       eval exec /vt/bin/vttablet $(cat <<END_OF_COMMAND
+        -topo_global_root /vitess/global
+        {{- if eq ($cell.topologyProvider | default "") "etcd2" }}
         -topo_implementation="etcd2"
         -topo_global_server_address="etcd-global-client.{{ $namespace }}:2379"
-        -topo_global_root=/vitess/global
+        {{- else }}
+        -topo_implementation k8s
+        -topo_global_server_address k8s
+        {{- end }}
         -logtostderr
         -port 15002
         -grpc_port 16002
@@ -534,7 +583,7 @@ spec:
 {{ define "cont-logrotate" }}
 
 - name: logrotate
-  image: vitess/logrotate:helm-1.0.7-5
+  image: vitess/logrotate:helm-2.0.0-0
   imagePullPolicy: IfNotPresent
   volumeMounts:
     - name: vtdataroot
@@ -548,7 +597,7 @@ spec:
 {{ define "cont-mysql-errorlog" }}
 
 - name: error-log
-  image: vitess/logtail:helm-1.0.7-5
+  image: vitess/logtail:helm-2.0.0-0
   imagePullPolicy: IfNotPresent
 
   env:
@@ -566,7 +615,7 @@ spec:
 {{ define "cont-mysql-slowlog" }}
 
 - name: slow-log
-  image: vitess/logtail:helm-1.0.7-5
+  image: vitess/logtail:helm-2.0.0-0
   imagePullPolicy: IfNotPresent
 
   env:
@@ -584,7 +633,7 @@ spec:
 {{ define "cont-mysql-generallog" }}
 
 - name: general-log
-  image: vitess/logtail:helm-1.0.7-5
+  image: vitess/logtail:helm-2.0.0-0
   imagePullPolicy: IfNotPresent
 
   env:

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -1,7 +1,30 @@
 # Create global resources.
 ---
+# Create role for topology crd
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vt-topo-member
+rules:
+- apiGroups:
+  - topo.vitess.io
+  resources:
+  - vitesstoponodes
+  verbs:
+  - '*'
+
+---
+
 # create a single vttablet service
 {{ include "vttablet-service" (tuple $.Values.pmm) }}
+
+# create a single vttablet serviceaccount
+{{ include "vttablet-serviceaccount" (tuple $.Release.Namespace) }}
+
+# create a single vttablet rolebinding
+{{ if eq $.Values.topology.globalCell.topologyProvider "k8s" }}
+{{ include "vttablet-topo-role-binding" (tuple $.Release.Namespace) }}
+{{ end }}
 ---
 {{ if $.Values.pmm.enabled }}
 # create the pmm service and stateful set
@@ -25,6 +48,7 @@
 
 {{ end }}
 
+{{ if eq $.Values.topology.globalCell.topologyProvider "etcd2" }}
 # create an etcd cluster for the global topology
 {{- $replicas := $.Values.topology.globalCell.replicas | default $.Values.etcd.replicas -}}
 {{- $version := $.Values.topology.globalCell.version | default $.Values.etcd.version -}}
@@ -32,10 +56,12 @@
 {{- $clusterWide := $.Values.topology.globalCell.resources | default $.Values.etcd.clusterWide -}}
 
 {{ include "etcd" (tuple "global" $replicas $version $resources $clusterWide) }}
+{{ end }}
 
 # Create requested resources in each cell.
 {{ range $cell := $.Values.topology.cells }}
 
+{{ if eq ($cell.topologyProvider | default "") "etcd2" }}
 ---
 # create an etcd cluster per cell
 {{- $cellClean := include "clean-label" $cell.name -}}
@@ -45,6 +71,8 @@
 {{- $clusterWide := $cell.etcd.clusterWide | default $.Values.etcd.clusterWide -}}
 
 {{ include "etcd" (tuple $cellClean $replicas $version $resources $clusterWide) }}
+{{ end }}
+
 ---
 # create one controller per cell
 {{ include "vtctld" (tuple $.Values.topology $cell $.Values.vtctld $.Release.Namespace $.Values.config) }}
@@ -77,7 +105,11 @@
   {{ if eq $job.kind "vtctlclient" }}
     {{ include "vtctlclient-job" (tuple $job $.Values.vtctlclient $.Release.Namespace) }}
   {{ else }}
-    {{ include "vtworker-job" (tuple $job $.Values.vtworker $.Release.Namespace) }}
+    {{ range $cell := $.Values.topology.cells }}
+      {{ if eq $cell.name $job.cell }}
+        {{ include "vtworker-job" (tuple $job $.Values.vtworker $.Release.Namespace $cell) }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 ---

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -73,10 +73,12 @@ config:
 
 topology:
   globalCell:
+    topologyProvider: k8s
     etcd:
       replicas: 3
   cells:
     - name: zone1
+      topologyProvider: k8s
 
       # set failure-domain.beta.kubernetes.io/region
       # region: eastus
@@ -180,7 +182,7 @@ etcd:
 # Default values for vtctld resources defined in 'topology'
 vtctld:
   serviceType: ClusterIP
-  vitessTag: helm-1.0.7-5
+  vitessTag: helm-2.0.0-0
   resources:
     # requests:
     #   cpu: 100m
@@ -191,7 +193,7 @@ vtctld:
 # Default values for vtgate resources defined in 'topology'
 vtgate:
   serviceType: ClusterIP
-  vitessTag: helm-1.0.7-5
+  vitessTag: helm-2.0.0-0
   resources:
     # requests:
     #   cpu: 500m
@@ -210,13 +212,13 @@ vtgate:
 
 # Default values for vtctlclient resources defined in 'topology'
 vtctlclient:
-  vitessTag: helm-1.0.7-5
+  vitessTag: helm-2.0.0-0
   extraFlags: {}
   secrets: [] # secrets are mounted under /vt/usersecrets/{secretname}
 
 # Default values for vtworker resources defined in 'jobs'
 vtworker:
-  vitessTag: helm-1.0.7-5
+  vitessTag: helm-2.0.0-0
   extraFlags: {}
   resources:
     # requests:
@@ -227,7 +229,7 @@ vtworker:
 
 # Default values for vttablet resources defined in 'topology'
 vttablet:
-  vitessTag: helm-1.0.7-5
+  vitessTag: helm-2.0.0-0
 
   # valid values are
   # - mysql56 (for MySQL 8.0)


### PR DESCRIPTION
Now that Vitess has a `k8s` topology. The helm charts should use it by default.  This PR will not only enable the use of Helm 3, but will make now require it for automatic CRD installation.

This also means that the helm installation no longer depends on the etcd-operator! :tada: 

The PR is currently a draft since the charts will not work until a new series of docker images based on the latest version of vitess are pushed to docker hub.