### PR TITLE
Print version/build tag to every INFO logfile at startup

### DIFF
--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -55,11 +55,15 @@ type versionInfo struct {
 }
 
 func (v *versionInfo) Print() {
+	fmt.Println(v)
+}
+
+func (v *versionInfo) String() string {
 	version := fmt.Sprintf("Version: %s", v.buildGitRev)
 	if v.jenkinsBuildNumber != 0 {
 		version = fmt.Sprintf("Version: %s (Jenkins build %d)", v.buildGitRev, v.jenkinsBuildNumber)
 	}
-	fmt.Printf("%s (Git branch '%s') built on %s by %s@%s using %s %s/%s\n", version, v.buildGitBranch, v.buildTimePretty, v.buildUser, v.buildHost, v.goVersion, v.goOS, v.goArch)
+	return fmt.Sprintf("%s (Git branch '%s') built on %s by %s@%s using %s %s/%s\n", version, v.buildGitBranch, v.buildTimePretty, v.buildUser, v.buildHost, v.goVersion, v.goOS, v.goArch)
 }
 
 func init() {

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -77,6 +77,9 @@ var (
 func Init() {
 	mu.Lock()
 	defer mu.Unlock()
+
+	// Add version tag to every info log
+	log.Infof(AppVersion.String())
 	if inited {
 		log.Fatal("servenv.Init called second time")
 	}

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -206,8 +206,8 @@ func RunDefault() {
 func ParseFlags(cmd string) {
 	flag.Parse()
 
-	AppVersion.Print()
 	if *Version {
+		AppVersion.Print()
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Revert previous committed change; which would print the build/version info on every program invocation to STDOUT, which could potentially break scripts, and also appeared on non-server component output, like vtexplain.

Implement code for serverenv to print it explicitly to the INFO log at startup instead.