### PR TITLE
exporter: framework for componentizing TabletServer

### DIFF
--- a/go/stats/counter.go
+++ b/go/stats/counter.go
@@ -99,6 +99,11 @@ func (cf CounterFunc) Help() string {
 	return cf.help
 }
 
+// Get returns the value.
+func (cf CounterFunc) Get() int64 {
+	return cf.F()
+}
+
 // String implements expvar.Var.
 func (cf CounterFunc) String() string {
 	return strconv.FormatInt(cf.F(), 10)

--- a/go/stats/duration.go
+++ b/go/stats/duration.go
@@ -106,6 +106,11 @@ func (cf CounterDurationFunc) Help() string {
 	return cf.help
 }
 
+// Get returns the value.
+func (cf CounterDurationFunc) Get() int64 {
+	return int64(cf.F())
+}
+
 // String is the implementation of expvar.var.
 func (cf CounterDurationFunc) String() string {
 	return strconv.FormatInt(int64(cf.F()), 10)

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -100,7 +100,7 @@ type Exporter struct {
 }
 
 // NewExporter creates a new Exporter with name as namespace.
-// label is the name of the additonial dimension for the stats vars.
+// label is the name of the additional dimension for the stats vars.
 func NewExporter(name, label string) *Exporter {
 	if name == "" {
 		return &Exporter{}

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -14,25 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package servenv allows you to remap http and stats end-points
-// to distinct names thereby allowing you to create multiple instances
-// of the same object within a single process.
-//
-// Unnamed instances are treated as unscoped, and requests are passed
-// through to the underlying functions.
-//
-// For named instances, http handle requests of the form /path will
-// be remapped to /name/path. In the case of stats variables, a new
-// dimension will be added. For example, a Counter of value 1
-// will be changed to a map {"name": 1}. A multi-counter like
-// { "a.b": 1, "c.d": 2} will be mapped to {"name.a.b": 1, "name.c.d": 2}.
-// Stats vars of the same name are merged onto a single map. For example,
-// if instances name1 and name2 independently create a stats Counter
-// named foo and export values 1 and 2, the result is a merged stats var
-// named foo with the following content: {"name1": 1, "name2": 2}.
-// This approach works for counters and gauges, but does not work for
-// the more complex vars like Timings. In those cases, no remapping is
-// done. The embedder returns unexported variables instead.
 package servenv
 
 import (
@@ -45,81 +26,41 @@ import (
 )
 
 var (
-	// embedmu protects embeds, members of Instance and globalStatVars.
-	// However, varMap and handlFunc have their own mutexes. This is
-	// because their handler functions directly access them.
-	embedmu sync.Mutex
+	// exporterMu protects exporters and globalStatVars, timingsVars and otherStatsVars.
+	// varMap and handleFunc have their own mutexes.
+	exporterMu sync.Mutex
 
-	// embeds contains the full list of instances. Entries can only be
-	// added. The creation of a new instance with a previously existing
-	// name causes that instance to be reused.
-	embeds = make(map[string]*Exporter)
+	// exporters contains the full list of exporters. Entries can only be
+	// added. The creation of a new Exporter with a previously existing
+	// name causes that Exporter to be reused.
+	exporters = make(map[string]*Exporter)
 
-	// globalStatVars contains the merged stats vars created for the instances.
+	// globalStatVars contains the merged stats vars created for the exporters.
 	globalStatVars = make(map[string]*varMap)
+
+	// timingsVars contains all the timings vars.
+	timingsVars = make(map[string]*stats.MultiTimings)
+
+	// otherStatsVars contains Rates, Histograms and Publish vars.
+	otherStatsVars = make(map[string]*expvar.Map)
 )
 
 //-----------------------------------------------------------------
 
-// varMap contains the metadata for a merged stats var. It supports
-// only gauges and counters. For every Instance, it stores a function
-// that yields the counter or gauge values for that Instance.
-type varMap struct {
-	mu   sync.Mutex
-	vars map[string]func() map[string]int64
-}
-
-// Set adds or updates the func for an Instance.
-func (vmap *varMap) Set(name string, f func() map[string]int64) {
-	vmap.mu.Lock()
-	defer vmap.mu.Unlock()
-	vmap.vars[name] = f
-}
-
-// Fetch returns the consolidated stats value for all Instances.
-func (vmap *varMap) Fetch() map[string]int64 {
-	result := make(map[string]int64)
-	vmap.mu.Lock()
-	defer vmap.mu.Unlock()
-	for k, f := range vmap.vars {
-		for innerk, innerv := range f() {
-			if innerk == "" {
-				result[k] = innerv
-			} else {
-				result[k+"."+innerk] = innerv
-			}
-		}
-	}
-	return result
-}
-
-//-----------------------------------------------------------------
-
-// handleFunc stores the http Handler for an Instance. This function can
-// be replaced as needed.
-type handleFunc struct {
-	mu sync.Mutex
-	f  func(w http.ResponseWriter, r *http.Request)
-}
-
-// Set replaces the existing handler with a new one.
-func (hf *handleFunc) Set(f func(w http.ResponseWriter, r *http.Request)) {
-	hf.mu.Lock()
-	defer hf.mu.Unlock()
-	hf.f = f
-}
-
-// Get returns the current handler.
-func (hf *handleFunc) Get() func(w http.ResponseWriter, r *http.Request) {
-	hf.mu.Lock()
-	defer hf.mu.Unlock()
-	return hf.f
-}
-
-//-----------------------------------------------------------------
-
-// Exporter provides the functions needed to embed an object
-// by remapping global endpoints into different namespaces.
+// Exporter remaps http and stats end-points to distinct namespaces.
+//
+// Unnamed exporters are treated as unscoped, and requests are passed
+// through to the underlying functions.
+//
+// For named exporters, http handle requests of the form /path will
+// be remapped to /name/path. In the case of stats variables, a new
+// dimension will be added. For example, a Counter of value 1
+// will be changed to a map {"name": 1}. A multi-counter like
+// { "a.b": 1, "c.d": 2} will be mapped to {"name.a.b": 1, "name.c.d": 2}.
+// Stats vars of the same name are merged onto a single map. For example,
+// if exporters name1 and name2 independently create a stats Counter
+// named foo and export values 1 and 2, the result is a merged stats var
+// named foo with the following content: {"name1": 1, "name2": 2}.
 type Exporter struct {
 	name, label string
 	handleFuncs map[string]*handleFunc
@@ -127,26 +68,26 @@ type Exporter struct {
 }
 
 // NewExporter creates a new Exporter with name as namespace.
-// The label specifies the prefix for the variables, and is also
-// used to label the additonial dimension for the stats vars.
+// label is the name of the additonial dimension for the stats vars.
 func NewExporter(name, label string) *Exporter {
-	embedmu.Lock()
-	defer embedmu.Unlock()
+	if name == "" {
+		return &Exporter{}
+	}
 
-	e, ok := embeds[name]
-	if ok {
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	if e, ok := exporters[name]; ok {
 		e.resetLocked()
 		return e
 	}
-	e = &Exporter{
+	e := &Exporter{
 		name:        name,
 		label:       label,
 		handleFuncs: make(map[string]*handleFunc),
+		sp:          newStatusPage(name),
 	}
-	if name != "" {
-		e.sp = newStatusPage(name)
-	}
-	embeds[name] = e
+	exporters[name] = e
 	return e
 }
 
@@ -155,16 +96,12 @@ func (e *Exporter) resetLocked() {
 		hf.Set(nil)
 	}
 	for _, vmap := range globalStatVars {
-		vmap.mu.Lock()
-		delete(vmap.vars, e.name)
-		vmap.mu.Unlock()
+		vmap.Unset(e.name)
 	}
-	if e.sp != nil {
-		e.sp.reset()
-	}
+	e.sp.reset()
 }
 
-// URLPrefix returns the URL prefix for all the embedder.
+// URLPrefix returns the URL prefix for the exporter.
 func (e *Exporter) URLPrefix() string {
 	// There are two other places where this logic is duplicated:
 	// status.go and go/vt/vtgate/discovery/healthcheck.go.
@@ -174,7 +111,7 @@ func (e *Exporter) URLPrefix() string {
 	return "/" + e.name
 }
 
-// HandleFunc sets or overwrites the handler for url. If Instance has a name,
+// HandleFunc sets or overwrites the handler for url. If Exporter has a name,
 // url remapped from /path to /name/path. If name is empty, the request
 // is passed through to http.HandleFunc.
 func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
@@ -183,15 +120,11 @@ func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.
 		return
 	}
 
-	embedmu.Lock()
-	defer embedmu.Unlock()
-
-	hf, ok := e.handleFuncs[url]
-	if ok {
+	if hf, ok := e.handleFuncs[url]; ok {
 		hf.Set(f)
 		return
 	}
-	hf = &handleFunc{f: f}
+	hf := &handleFunc{f: f}
 	e.handleFuncs[url] = hf
 
 	http.HandleFunc(e.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
@@ -201,16 +134,13 @@ func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.
 	})
 }
 
-// AddStatusPart adds a status part to the status page. If instance has a name,
+// AddStatusPart adds a status part to the status page. If Exporter has a name,
 // the part is added to a url named /name/debug/status. Otherwise, it's /debug/status.
 func (e *Exporter) AddStatusPart(banner, frag string, f func() interface{}) {
-	if e.sp == nil {
+	if e.name == "" {
 		AddStatusPart(banner, frag, f)
 		return
 	}
-
-	embedmu.Lock()
-	defer embedmu.Unlock()
 	e.sp.addStatusPart(banner, frag, f)
 }
 
@@ -222,8 +152,8 @@ func (e *Exporter) NewCountersFuncWithMultiLabels(name, help string, labels []st
 		return stats.NewCountersFuncWithMultiLabels(name, help, labels, f)
 	}
 
-	embedmu.Lock()
-	defer embedmu.Unlock()
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
 
 	if vmap, ok := globalStatVars[name]; ok {
 		vmap.Set(e.name, f)
@@ -232,10 +162,8 @@ func (e *Exporter) NewCountersFuncWithMultiLabels(name, help string, labels []st
 	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
 	globalStatVars[name] = vmap
 
-	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
-	_ = stats.NewCountersFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
-		return vmap.Fetch()
-	})
+	newlabels := combineLabels(e.label, labels)
+	_ = stats.NewCountersFuncWithMultiLabels(name, help, newlabels, vmap.Fetch)
 	return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
 }
 
@@ -246,8 +174,8 @@ func (e *Exporter) NewGaugesFuncWithMultiLabels(name, help string, labels []stri
 		return stats.NewGaugesFuncWithMultiLabels(name, help, labels, f)
 	}
 
-	embedmu.Lock()
-	defer embedmu.Unlock()
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
 
 	if vmap, ok := globalStatVars[name]; ok {
 		vmap.Set(e.name, f)
@@ -256,10 +184,8 @@ func (e *Exporter) NewGaugesFuncWithMultiLabels(name, help string, labels []stri
 	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
 	globalStatVars[name] = vmap
 
-	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
-	_ = stats.NewGaugesFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
-		return vmap.Fetch()
-	})
+	newlabels := combineLabels(e.label, labels)
+	_ = stats.NewGaugesFuncWithMultiLabels(name, help, newlabels, vmap.Fetch)
 	return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
 }
 
@@ -324,7 +250,7 @@ func (e *Exporter) NewGaugeDurationFunc(name string, help string, f func() time.
 }
 
 // NewCountersWithSingleLabel creates a name-spaced equivalent for stats.NewCountersWithSingleLabel.
-// Tags are ignored if embedded.
+// Tags are ignored if the exporter is named.
 func (e *Exporter) NewCountersWithSingleLabel(name, help string, label string, tags ...string) *stats.CountersWithSingleLabel {
 	if e.name == "" || name == "" {
 		return stats.NewCountersWithSingleLabel(name, help, label, tags...)
@@ -336,7 +262,7 @@ func (e *Exporter) NewCountersWithSingleLabel(name, help string, label string, t
 }
 
 // NewGaugesWithSingleLabel creates a name-spaced equivalent for stats.NewGaugesWithSingleLabel.
-// Tags are ignored if embedded.
+// Tags are ignored if the exporter is named.
 func (e *Exporter) NewGaugesWithSingleLabel(name, help string, label string, tags ...string) *stats.GaugesWithSingleLabel {
 	if e.name == "" || name == "" {
 		return stats.NewGaugesWithSingleLabel(name, help, label, tags...)
@@ -371,49 +297,245 @@ func (e *Exporter) NewGaugesWithMultiLabels(name, help string, labels []string) 
 
 // NewTimings creates a name-spaced equivalent for stats.NewTimings.
 // The function currently just returns an unexported variable.
-// TODO(sougou): implement.
-func (e *Exporter) NewTimings(name string, help string, label string) *stats.Timings {
+func (e *Exporter) NewTimings(name string, help string, label string) *TimingsWrapper {
 	if e.name == "" || name == "" {
-		return stats.NewTimings(name, help, label)
+		return &TimingsWrapper{
+			timings: stats.NewMultiTimings(name, help, []string{label}),
+		}
 	}
-	return stats.NewTimings("", help, label)
+
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	if tv, ok := timingsVars[name]; ok {
+		return &TimingsWrapper{
+			name:    e.name,
+			timings: tv,
+		}
+	}
+	mt := stats.NewMultiTimings(name, help, []string{e.label, label})
+	timingsVars[name] = mt
+	return &TimingsWrapper{
+		name:    e.name,
+		timings: mt,
+	}
 }
 
 // NewMultiTimings creates a name-spaced equivalent for stats.NewMultiTimings.
 // The function currently just returns an unexported variable.
-// TODO(sougou): implement.
-func (e *Exporter) NewMultiTimings(name string, help string, labels []string) *stats.MultiTimings {
+func (e *Exporter) NewMultiTimings(name string, help string, labels []string) *MultiTimingsWrapper {
 	if e.name == "" || name == "" {
-		return stats.NewMultiTimings(name, help, labels)
+		return &MultiTimingsWrapper{
+			timings: stats.NewMultiTimings(name, help, labels),
+		}
 	}
-	return stats.NewMultiTimings("", help, labels)
+
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	if tv, ok := timingsVars[name]; ok {
+		return &MultiTimingsWrapper{
+			name:    e.name,
+			timings: tv,
+		}
+	}
+	mt := stats.NewMultiTimings(name, help, combineLabels(e.label, labels))
+	timingsVars[name] = mt
+	return &MultiTimingsWrapper{
+		name:    e.name,
+		timings: mt,
+	}
 }
 
 // NewRates creates a name-spaced equivalent for stats.NewRates.
 // The function currently just returns an unexported variable.
-// TODO(sougou): implement.
 func (e *Exporter) NewRates(name string, countTracker stats.CountTracker, samples int, interval time.Duration) *stats.Rates {
 	if e.name == "" || name == "" {
 		return stats.NewRates(name, countTracker, samples, interval)
 	}
-	return stats.NewRates("", countTracker, samples, interval)
+
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	ov, ok := otherStatsVars[name]
+	if !ok {
+		ov = expvar.NewMap(name)
+		otherStatsVars[name] = ov
+	}
+	rates := stats.NewRates("", countTracker, samples, interval)
+	ov.Set(e.name, rates)
+	return rates
 }
 
 // NewHistogram creates a name-spaced equivalent for stats.NewHistogram.
 // The function currently just returns an unexported variable.
-// TODO(sougou): implement.
 func (e *Exporter) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
 	if e.name == "" || name == "" {
 		return stats.NewHistogram(name, help, cutoffs)
 	}
-	return stats.NewHistogram("", help, cutoffs)
+
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	ov, ok := otherStatsVars[name]
+	if !ok {
+		ov = expvar.NewMap(name)
+		otherStatsVars[name] = ov
+	}
+	hist := stats.NewHistogram("", help, cutoffs)
+	ov.Set(e.name, hist)
+	return hist
 }
 
 // Publish creates a name-spaced equivalent for stats.Publish.
-// The function just passes through if the Instance name is empty.
-// TODO(sougou): implement.
+// The function just passes through if the Exporter name is empty.
 func (e *Exporter) Publish(name string, v expvar.Var) {
-	if e.name == "" {
+	if e.name == "" || name == "" {
 		stats.Publish(name, v)
+		return
 	}
+
+	exporterMu.Lock()
+	defer exporterMu.Unlock()
+
+	ov, ok := otherStatsVars[name]
+	if !ok {
+		ov = expvar.NewMap(name)
+		otherStatsVars[name] = ov
+	}
+	ov.Set(e.name, v)
+}
+
+//-----------------------------------------------------------------
+
+// varMap contains the metadata for a merged stats var. It supports
+// gauges and counters. For every Exporter, it stores a function
+// that yields the counter or gauge values for that Exporter.
+type varMap struct {
+	mu   sync.Mutex
+	vars map[string]func() map[string]int64
+}
+
+// Set adds or updates the func for an Exporter.
+func (vmap *varMap) Set(name string, f func() map[string]int64) {
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	vmap.vars[name] = f
+}
+
+// Unset removes the Exporter's entry from varMap.
+func (vmap *varMap) Unset(name string) {
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	delete(vmap.vars, name)
+}
+
+// Fetch returns the consolidated stats value for all exporters.
+func (vmap *varMap) Fetch() map[string]int64 {
+	result := make(map[string]int64)
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	for k, f := range vmap.vars {
+		for innerk, innerv := range f() {
+			if innerk == "" {
+				result[k] = innerv
+			} else {
+				result[k+"."+innerk] = innerv
+			}
+		}
+	}
+	return result
+}
+
+//-----------------------------------------------------------------
+
+// TimingsWrapper provides a namespaced version of stats.Timings.
+type TimingsWrapper struct {
+	name    string
+	timings *stats.MultiTimings
+}
+
+// Add behaves like Timings.Add.
+func (tw *TimingsWrapper) Add(name string, elapsed time.Duration) {
+	if tw.name == "" {
+		tw.timings.Add([]string{name}, elapsed)
+		return
+	}
+	tw.timings.Add([]string{tw.name, name}, elapsed)
+}
+
+// Record behaves like Timings.Record.
+func (tw *TimingsWrapper) Record(name string, startTime time.Time) {
+	if tw.name == "" {
+		tw.timings.Record([]string{name}, startTime)
+		return
+	}
+	tw.timings.Record([]string{tw.name, name}, startTime)
+}
+
+// Counts behaves lie Timings.Counts.
+func (tw *TimingsWrapper) Counts() map[string]int64 {
+	return tw.timings.Counts()
+}
+
+//-----------------------------------------------------------------
+
+// MultiTimingsWrapper provides a namespaced version of stats.MultiTimings.
+type MultiTimingsWrapper struct {
+	name    string
+	timings *stats.MultiTimings
+}
+
+// Add behaves like MultiTimings.Add.
+func (tw *MultiTimingsWrapper) Add(names []string, elapsed time.Duration) {
+	if tw.name == "" {
+		tw.timings.Add(names, elapsed)
+		return
+	}
+	newlabels := combineLabels(tw.name, names)
+	tw.timings.Add(newlabels, elapsed)
+}
+
+// Record behaves like MultiTimings.Record.
+func (tw *MultiTimingsWrapper) Record(names []string, startTime time.Time) {
+	if tw.name == "" {
+		tw.timings.Record(names, startTime)
+		return
+	}
+	newlabels := combineLabels(tw.name, names)
+	tw.timings.Record(newlabels, startTime)
+}
+
+// Counts behaves lie MultiTimings.Counts.
+func (tw *MultiTimingsWrapper) Counts() map[string]int64 {
+	return tw.timings.Counts()
+}
+
+//-----------------------------------------------------------------
+
+// handleFunc stores the http Handler for an Exporter. This function can
+// be replaced as needed.
+type handleFunc struct {
+	mu sync.Mutex
+	f  func(w http.ResponseWriter, r *http.Request)
+}
+
+// Set replaces the existing handler with a new one.
+func (hf *handleFunc) Set(f func(w http.ResponseWriter, r *http.Request)) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	hf.f = f
+}
+
+// Get returns the current handler.
+func (hf *handleFunc) Get() func(w http.ResponseWriter, r *http.Request) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	return hf.f
+}
+
+//-----------------------------------------------------------------
+
+func combineLabels(label string, labels []string) []string {
+	return append(append(make([]string, 0, len(labels)+1), label), labels...)
 }

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -353,17 +353,8 @@ func (e *Exporter) NewRates(name string, countTracker stats.CountTracker, sample
 	if e.name == "" || name == "" {
 		return stats.NewRates(name, countTracker, samples, interval)
 	}
-
-	exporterMu.Lock()
-	defer exporterMu.Unlock()
-
-	ov, ok := otherStatsVars[name]
-	if !ok {
-		ov = expvar.NewMap(name)
-		otherStatsVars[name] = ov
-	}
 	rates := stats.NewRates("", countTracker, samples, interval)
-	ov.Set(e.name, rates)
+	e.addToOtherVars(name, rates)
 	return rates
 }
 
@@ -373,17 +364,8 @@ func (e *Exporter) NewHistogram(name, help string, cutoffs []int64) *stats.Histo
 	if e.name == "" || name == "" {
 		return stats.NewHistogram(name, help, cutoffs)
 	}
-
-	exporterMu.Lock()
-	defer exporterMu.Unlock()
-
-	ov, ok := otherStatsVars[name]
-	if !ok {
-		ov = expvar.NewMap(name)
-		otherStatsVars[name] = ov
-	}
 	hist := stats.NewHistogram("", help, cutoffs)
-	ov.Set(e.name, hist)
+	e.addToOtherVars(name, hist)
 	return hist
 }
 
@@ -394,7 +376,10 @@ func (e *Exporter) Publish(name string, v expvar.Var) {
 		stats.Publish(name, v)
 		return
 	}
+	e.addToOtherVars(name, v)
+}
 
+func (e *Exporter) addToOtherVars(name string, v expvar.Var) {
 	exporterMu.Lock()
 	defer exporterMu.Unlock()
 

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package servenv allows you to remap http and stats end-points
+// to distinct names thereby allowing you to create multiple instances
+// of the same object within a single process.
+//
+// Unnamed instances are treated as unscoped, and requests are passed
+// through to the underlying functions.
+//
+// For named instances, http handle requests of the form /path will
+// be remapped to /name/path. In the case of stats variables, a new
+// dimension will be added. For example, a Counter of value 1
+// will be changed to a map {"name": 1}. A multi-counter like
+// { "a.b": 1, "c.d": 2} will be mapped to {"name.a.b": 1, "name.c.d": 2}.
+// Stats vars of the same name are merged onto a single map. For example,
+// if instances name1 and name2 independently create a stats Counter
+// named foo and export values 1 and 2, the result is a merged stats var
+// named foo with the following content: {"name1": 1, "name2": 2}.
+// This approach works for counters and gauges, but does not work for
+// the more complex vars like Timings. In those cases, no remapping is
+// done. The embedder returns unexported variables instead.
+package servenv
+
+import (
+	"expvar"
+	"net/http"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+)
+
+var (
+	// embedmu protects embeds, members of Instance and globalStatVars.
+	// However, varMap and handlFunc have their own mutexes. This is
+	// because their handler functions directly access them.
+	embedmu sync.Mutex
+
+	// embeds contains the full list of instances. Entries can only be
+	// added. The creation of a new instance with a previously existing
+	// name causes that instance to be reused.
+	embeds = make(map[string]*Exporter)
+
+	// globalStatVars contains the merged stats vars created for the instances.
+	globalStatVars = make(map[string]*varMap)
+)
+
+//-----------------------------------------------------------------
+
+// varMap contains the metadata for a merged stats var. It supports
+// only gauges and counters. For every Instance, it stores a function
+// that yields the counter or gauge values for that Instance.
+type varMap struct {
+	mu   sync.Mutex
+	vars map[string]func() map[string]int64
+}
+
+// Set adds or updates the func for an Instance.
+func (vmap *varMap) Set(name string, f func() map[string]int64) {
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	vmap.vars[name] = f
+}
+
+// Fetch returns the consolidated stats value for all Instances.
+func (vmap *varMap) Fetch() map[string]int64 {
+	result := make(map[string]int64)
+	vmap.mu.Lock()
+	defer vmap.mu.Unlock()
+	for k, f := range vmap.vars {
+		for innerk, innerv := range f() {
+			if innerk == "" {
+				result[k] = innerv
+			} else {
+				result[k+"."+innerk] = innerv
+			}
+		}
+	}
+	return result
+}
+
+//-----------------------------------------------------------------
+
+// handleFunc stores the http Handler for an Instance. This function can
+// be replaced as needed.
+type handleFunc struct {
+	mu sync.Mutex
+	f  func(w http.ResponseWriter, r *http.Request)
+}
+
+// Set replaces the existing handler with a new one.
+func (hf *handleFunc) Set(f func(w http.ResponseWriter, r *http.Request)) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	hf.f = f
+}
+
+// Get returns the current handler.
+func (hf *handleFunc) Get() func(w http.ResponseWriter, r *http.Request) {
+	hf.mu.Lock()
+	defer hf.mu.Unlock()
+	return hf.f
+}
+
+//-----------------------------------------------------------------
+
+// Exporter provides the functions needed to embed an object
+// by remapping global endpoints into different namespaces.
+type Exporter struct {
+	name, label string
+	handleFuncs map[string]*handleFunc
+	sp          *statusPage
+}
+
+// NewExporter creates a new Exporter with name as namespace.
+// The label specifies the prefix for the variables, and is also
+// used to label the additonial dimension for the stats vars.
+func NewExporter(name, label string) *Exporter {
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	e, ok := embeds[name]
+	if ok {
+		e.resetLocked()
+		return e
+	}
+	e = &Exporter{
+		name:        name,
+		label:       label,
+		handleFuncs: make(map[string]*handleFunc),
+	}
+	if name != "" {
+		e.sp = newStatusPage(name)
+	}
+	embeds[name] = e
+	return e
+}
+
+func (e *Exporter) resetLocked() {
+	for _, hf := range e.handleFuncs {
+		hf.Set(nil)
+	}
+	for _, vmap := range globalStatVars {
+		vmap.mu.Lock()
+		delete(vmap.vars, e.name)
+		vmap.mu.Unlock()
+	}
+	if e.sp != nil {
+		e.sp.reset()
+	}
+}
+
+// URLPrefix returns the URL prefix for all the embedder.
+func (e *Exporter) URLPrefix() string {
+	// There are two other places where this logic is duplicated:
+	// status.go and go/vt/vtgate/discovery/healthcheck.go.
+	if e.name == "" {
+		return e.name
+	}
+	return "/" + e.name
+}
+
+// HandleFunc sets or overwrites the handler for url. If Instance has a name,
+// url remapped from /path to /name/path. If name is empty, the request
+// is passed through to http.HandleFunc.
+func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
+	if e.name == "" {
+		http.HandleFunc(url, f)
+		return
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	hf, ok := e.handleFuncs[url]
+	if ok {
+		hf.Set(f)
+		return
+	}
+	hf = &handleFunc{f: f}
+	e.handleFuncs[url] = hf
+
+	http.HandleFunc(e.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
+		if f := hf.Get(); f != nil {
+			f(w, r)
+		}
+	})
+}
+
+// AddStatusPart adds a status part to the status page. If instance has a name,
+// the part is added to a url named /name/debug/status. Otherwise, it's /debug/status.
+func (e *Exporter) AddStatusPart(banner, frag string, f func() interface{}) {
+	if e.sp == nil {
+		AddStatusPart(banner, frag, f)
+		return
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+	e.sp.addStatusPart(banner, frag, f)
+}
+
+// NewCountersFuncWithMultiLabels creates a name-spaced equivalent for stats.NewCountersFuncWithMultiLabels.
+func (e *Exporter) NewCountersFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.CountersFuncWithMultiLabels {
+	// If e.name is empty, it's a pass-through.
+	// If name is empty, it's an unexported var.
+	if e.name == "" || name == "" {
+		return stats.NewCountersFuncWithMultiLabels(name, help, labels, f)
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	if vmap, ok := globalStatVars[name]; ok {
+		vmap.Set(e.name, f)
+		return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
+	}
+	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
+	globalStatVars[name] = vmap
+
+	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
+	_ = stats.NewCountersFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
+		return vmap.Fetch()
+	})
+	return stats.NewCountersFuncWithMultiLabels("", help, labels, f)
+}
+
+// NewGaugesFuncWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesFuncWithMultiLabels.
+func (e *Exporter) NewGaugesFuncWithMultiLabels(name, help string, labels []string, f func() map[string]int64) *stats.GaugesFuncWithMultiLabels {
+	// This implementation is identical to NewCountersFuncWithMultiLabels, except it's for Gauges.
+	if e.name == "" || name == "" {
+		return stats.NewGaugesFuncWithMultiLabels(name, help, labels, f)
+	}
+
+	embedmu.Lock()
+	defer embedmu.Unlock()
+
+	if vmap, ok := globalStatVars[name]; ok {
+		vmap.Set(e.name, f)
+		return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
+	}
+	vmap := &varMap{vars: map[string]func() map[string]int64{e.name: f}}
+	globalStatVars[name] = vmap
+
+	newlabels := append(append(make([]string, 0, len(labels)+1), e.label), labels...)
+	_ = stats.NewGaugesFuncWithMultiLabels(e.label+name, help, newlabels, func() map[string]int64 {
+		return vmap.Fetch()
+	})
+	return stats.NewGaugesFuncWithMultiLabels("", help, labels, f)
+}
+
+// NewCounter creates a name-spaced equivalent for stats.NewCounter.
+func (e *Exporter) NewCounter(name string, help string) *stats.Counter {
+	if e.name == "" || name == "" {
+		return stats.NewCounter(name, help)
+	}
+	v := stats.NewCounter("", help)
+	_ = e.NewCounterFunc(name, help, v.Get)
+	return v
+}
+
+// NewGauge creates a name-spaced equivalent for stats.NewGauge.
+func (e *Exporter) NewGauge(name string, help string) *stats.Gauge {
+	if e.name == "" || name == "" {
+		return stats.NewGauge(name, help)
+	}
+	v := stats.NewGauge("", help)
+	_ = e.NewGaugeFunc(name, help, v.Get)
+	return v
+}
+
+// NewCounterFunc creates a name-spaced equivalent for stats.NewCounterFunc.
+func (e *Exporter) NewCounterFunc(name string, help string, f func() int64) *stats.CounterFunc {
+	if e.name == "" || name == "" {
+		return stats.NewCounterFunc(name, help, f)
+	}
+	_ = e.NewCountersFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+		return map[string]int64{"": f()}
+	})
+	return stats.NewCounterFunc("", help, f)
+}
+
+// NewGaugeFunc creates a name-spaced equivalent for stats.NewGaugeFunc.
+func (e *Exporter) NewGaugeFunc(name string, help string, f func() int64) *stats.GaugeFunc {
+	if e.name == "" || name == "" {
+		return stats.NewGaugeFunc(name, help, f)
+	}
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, nil, func() map[string]int64 {
+		return map[string]int64{"": f()}
+	})
+	return stats.NewGaugeFunc("", help, f)
+}
+
+// NewCounterDurationFunc creates a name-spaced equivalent for stats.NewCounterDurationFunc.
+func (e *Exporter) NewCounterDurationFunc(name string, help string, f func() time.Duration) *stats.CounterDurationFunc {
+	if e.name == "" || name == "" {
+		return stats.NewCounterDurationFunc(name, help, f)
+	}
+	_ = e.NewCounterFunc(name, help, func() int64 { return int64(f()) })
+	return stats.NewCounterDurationFunc("", help, f)
+}
+
+// NewGaugeDurationFunc creates a name-spaced equivalent for stats.NewGaugeDurationFunc.
+func (e *Exporter) NewGaugeDurationFunc(name string, help string, f func() time.Duration) *stats.GaugeDurationFunc {
+	if e.name == "" || name == "" {
+		return stats.NewGaugeDurationFunc(name, help, f)
+	}
+	_ = e.NewGaugeFunc(name, help, func() int64 { return int64(f()) })
+	return stats.NewGaugeDurationFunc("", help, f)
+}
+
+// NewCountersWithSingleLabel creates a name-spaced equivalent for stats.NewCountersWithSingleLabel.
+// Tags are ignored if embedded.
+func (e *Exporter) NewCountersWithSingleLabel(name, help string, label string, tags ...string) *stats.CountersWithSingleLabel {
+	if e.name == "" || name == "" {
+		return stats.NewCountersWithSingleLabel(name, help, label, tags...)
+	}
+
+	v := stats.NewCountersWithSingleLabel("", help, label)
+	_ = e.NewCountersFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	return v
+}
+
+// NewGaugesWithSingleLabel creates a name-spaced equivalent for stats.NewGaugesWithSingleLabel.
+// Tags are ignored if embedded.
+func (e *Exporter) NewGaugesWithSingleLabel(name, help string, label string, tags ...string) *stats.GaugesWithSingleLabel {
+	if e.name == "" || name == "" {
+		return stats.NewGaugesWithSingleLabel(name, help, label, tags...)
+	}
+
+	v := stats.NewGaugesWithSingleLabel("", help, label)
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, []string{label}, v.Counts)
+	return v
+}
+
+// NewCountersWithMultiLabels creates a name-spaced equivalent for stats.NewCountersWithMultiLabels.
+func (e *Exporter) NewCountersWithMultiLabels(name, help string, labels []string) *stats.CountersWithMultiLabels {
+	if e.name == "" || name == "" {
+		return stats.NewCountersWithMultiLabels(name, help, labels)
+	}
+
+	v := stats.NewCountersWithMultiLabels("", help, labels)
+	_ = e.NewCountersFuncWithMultiLabels(name, help, labels, v.Counts)
+	return v
+}
+
+// NewGaugesWithMultiLabels creates a name-spaced equivalent for stats.NewGaugesWithMultiLabels.
+func (e *Exporter) NewGaugesWithMultiLabels(name, help string, labels []string) *stats.GaugesWithMultiLabels {
+	if e.name == "" || name == "" {
+		return stats.NewGaugesWithMultiLabels(name, help, labels)
+	}
+
+	v := stats.NewGaugesWithMultiLabels("", help, labels)
+	_ = e.NewGaugesFuncWithMultiLabels(name, help, labels, v.Counts)
+	return v
+}
+
+// NewTimings creates a name-spaced equivalent for stats.NewTimings.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (e *Exporter) NewTimings(name string, help string, label string) *stats.Timings {
+	if e.name == "" || name == "" {
+		return stats.NewTimings(name, help, label)
+	}
+	return stats.NewTimings("", help, label)
+}
+
+// NewMultiTimings creates a name-spaced equivalent for stats.NewMultiTimings.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (e *Exporter) NewMultiTimings(name string, help string, labels []string) *stats.MultiTimings {
+	if e.name == "" || name == "" {
+		return stats.NewMultiTimings(name, help, labels)
+	}
+	return stats.NewMultiTimings("", help, labels)
+}
+
+// NewRates creates a name-spaced equivalent for stats.NewRates.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (e *Exporter) NewRates(name string, countTracker stats.CountTracker, samples int, interval time.Duration) *stats.Rates {
+	if e.name == "" || name == "" {
+		return stats.NewRates(name, countTracker, samples, interval)
+	}
+	return stats.NewRates("", countTracker, samples, interval)
+}
+
+// NewHistogram creates a name-spaced equivalent for stats.NewHistogram.
+// The function currently just returns an unexported variable.
+// TODO(sougou): implement.
+func (e *Exporter) NewHistogram(name, help string, cutoffs []int64) *stats.Histogram {
+	if e.name == "" || name == "" {
+		return stats.NewHistogram(name, help, cutoffs)
+	}
+	return stats.NewHistogram("", help, cutoffs)
+}
+
+// Publish creates a name-spaced equivalent for stats.Publish.
+// The function just passes through if the Instance name is empty.
+// TODO(sougou): implement.
+func (e *Exporter) Publish(name string, v expvar.Var) {
+	if e.name == "" {
+		stats.Publish(name, v)
+	}
+}

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -137,24 +137,24 @@ func TestCountersFuncWithMultiLabels(t *testing.T) {
 	ebd.NewCountersFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
 
 	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
-	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lcfwml").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
-	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lcfwml").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcfwml").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcfwml").String(), "{}"; got != want {
 		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
-	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lcfwml").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
@@ -162,7 +162,7 @@ func TestCountersFuncWithMultiLabels(t *testing.T) {
 	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellcfwml").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcfwml").String(); got != want1 && got != want2 {
 		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -181,24 +181,24 @@ func TestGaugesFuncWithMultiLabels(t *testing.T) {
 	ebd.NewGaugesFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
 
 	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
-	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lgfwml").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
-	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lgfwml").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgfwml").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgfwml").String(), "{}"; got != want {
 		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
-	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lgfwml").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
 	}
 
@@ -206,7 +206,7 @@ func TestGaugesFuncWithMultiLabels(t *testing.T) {
 	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellgfwml").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgfwml").String(); got != want1 && got != want2 {
 		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -227,26 +227,26 @@ func TestCounter(t *testing.T) {
 
 	c = ebd.NewCounter("lcounter", "")
 	c.Add(4)
-	if got, want := expvar.Get("labellcounter").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lcounter").String(), `{"i1": 4}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	c = ebd.NewCounter("lcounter", "")
 	c.Add(5)
-	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcounter").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcounter").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcounter").String(), "{}"; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	c = ebd.NewCounter("lcounter", "")
 	c.Add(5)
-	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcounter").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
@@ -255,7 +255,7 @@ func TestCounter(t *testing.T) {
 	c.Add(6)
 	want1 := `{"i1": 5, "i2": 6}`
 	want2 := `{"i2": 6, "i1": 5}`
-	if got := expvar.Get("labellcounter").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcounter").String(); got != want1 && got != want2 {
 		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -276,26 +276,26 @@ func TestGauge(t *testing.T) {
 
 	c = ebd.NewGauge("lgauge", "")
 	c.Set(4)
-	if got, want := expvar.Get("labellgauge").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lgauge").String(), `{"i1": 4}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	c = ebd.NewGauge("lgauge", "")
 	c.Set(5)
-	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lgauge").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgauge").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgauge").String(), "{}"; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	c = ebd.NewGauge("lgauge", "")
 	c.Set(5)
-	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lgauge").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
@@ -304,7 +304,7 @@ func TestGauge(t *testing.T) {
 	c.Set(6)
 	want1 := `{"i1": 5, "i2": 6}`
 	want2 := `{"i2": 6, "i1": 5}`
-	if got := expvar.Get("labellgauge").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgauge").String(); got != want1 && got != want2 {
 		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -323,24 +323,24 @@ func TestCounterFunc(t *testing.T) {
 	ebd.NewCounterFunc("", "", func() int64 { return 3 })
 
 	ebd.NewCounterFunc("lcf", "", func() int64 { return 4 })
-	if got, want := expvar.Get("labellcf").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lcf").String(), `{"i1": 4}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
-	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcf").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcf").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcf").String(), "{}"; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
-	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcf").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Counter get: %s, want %s", got, want)
 	}
 
@@ -348,7 +348,7 @@ func TestCounterFunc(t *testing.T) {
 	ebd.NewCounterFunc("lcf", "", func() int64 { return 6 })
 	want1 := `{"i1": 5, "i2": 6}`
 	want2 := `{"i2": 6, "i1": 5}`
-	if got := expvar.Get("labellcf").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcf").String(); got != want1 && got != want2 {
 		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -367,24 +367,24 @@ func TestGaugeFunc(t *testing.T) {
 	ebd.NewGaugeFunc("", "", func() int64 { return 3 })
 
 	ebd.NewGaugeFunc("lgf", "", func() int64 { return 4 })
-	if got, want := expvar.Get("labellgf").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lgf").String(), `{"i1": 4}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
-	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lgf").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgf").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgf").String(), "{}"; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
-	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lgf").String(), `{"i1": 5}`; got != want {
 		t.Errorf("Gauge get: %s, want %s", got, want)
 	}
 
@@ -392,7 +392,7 @@ func TestGaugeFunc(t *testing.T) {
 	ebd.NewGaugeFunc("lgf", "", func() int64 { return 6 })
 	want1 := `{"i1": 5, "i2": 6}`
 	want2 := `{"i2": 6, "i1": 5}`
-	if got := expvar.Get("labellgf").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgf").String(); got != want1 && got != want2 {
 		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -411,24 +411,24 @@ func TestCounterDurationFunc(t *testing.T) {
 	ebd.NewCounterDurationFunc("", "", func() time.Duration { return 3 })
 
 	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 4 })
-	if got, want := expvar.Get("labellcduration").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lcduration").String(), `{"i1": 4}`; got != want {
 		t.Errorf("CounterDuration get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
-	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcduration").String(), `{"i1": 5}`; got != want {
 		t.Errorf("CounterDuration get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcduration").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcduration").String(), "{}"; got != want {
 		t.Errorf("CounterDuration get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
-	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lcduration").String(), `{"i1": 5}`; got != want {
 		t.Errorf("CounterDuration get: %s, want %s", got, want)
 	}
 
@@ -436,7 +436,7 @@ func TestCounterDurationFunc(t *testing.T) {
 	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 6 })
 	want1 := `{"i1": 5, "i2": 6}`
 	want2 := `{"i2": 6, "i1": 5}`
-	if got := expvar.Get("labellcduration").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcduration").String(); got != want1 && got != want2 {
 		t.Errorf("CounterDuration get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -455,24 +455,24 @@ func TestGaugeDurationFunc(t *testing.T) {
 	ebd.NewGaugeDurationFunc("", "", func() time.Duration { return 3 })
 
 	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 4 })
-	if got, want := expvar.Get("labellgduration").String(), `{"i1": 4}`; got != want {
+	if got, want := expvar.Get("lgduration").String(), `{"i1": 4}`; got != want {
 		t.Errorf("GaugeDuration get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 5 })
-	if got, want := expvar.Get("labellgduration").String(), `{"i1": 5}`; got != want {
+	if got, want := expvar.Get("lgduration").String(), `{"i1": 5}`; got != want {
 		t.Errorf("GaugeDuration get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgduration").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgduration").String(), "{}"; got != want {
 		t.Errorf("GaugeDuration get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 6 })
-	if got, want := expvar.Get("labellgduration").String(), `{"i1": 6}`; got != want {
+	if got, want := expvar.Get("lgduration").String(), `{"i1": 6}`; got != want {
 		t.Errorf("GaugeDuration get: %s, want %s", got, want)
 	}
 
@@ -480,7 +480,7 @@ func TestGaugeDurationFunc(t *testing.T) {
 	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 7 })
 	want1 := `{"i1": 6, "i2": 7}`
 	want2 := `{"i2": 7, "i1": 6}`
-	if got := expvar.Get("labellgduration").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgduration").String(); got != want1 && got != want2 {
 		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -501,26 +501,26 @@ func TestCountersWithSingleLabel(t *testing.T) {
 
 	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
 	g.Add("a", 4)
-	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lcwsl").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
 	g.Add("a", 5)
-	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lcwsl").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcwsl").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcwsl").String(), "{}"; got != want {
 		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
 	g.Add("a", 6)
-	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lcwsl").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
 	}
 
@@ -529,7 +529,7 @@ func TestCountersWithSingleLabel(t *testing.T) {
 	g.Add("a", 7)
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellcwsl").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcwsl").String(); got != want1 && got != want2 {
 		t.Errorf("CountersWithSingleLabel get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -550,26 +550,26 @@ func TestGaugesWithSingleLabel(t *testing.T) {
 
 	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
 	g.Set("a", 4)
-	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lgwsl").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
 	g.Set("a", 5)
-	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lgwsl").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgwsl").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgwsl").String(), "{}"; got != want {
 		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
 	g.Set("a", 6)
-	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lgwsl").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
 	}
 
@@ -578,7 +578,7 @@ func TestGaugesWithSingleLabel(t *testing.T) {
 	g.Set("a", 7)
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellgwsl").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgwsl").String(); got != want1 && got != want2 {
 		t.Errorf("GaugesWithSingleLabel get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -599,26 +599,26 @@ func TestCountersWithMultiLabels(t *testing.T) {
 
 	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
 	g.Add([]string{"a"}, 4)
-	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lcwml").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
 	g.Add([]string{"a"}, 5)
-	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lcwml").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellcwml").String(), "{}"; got != want {
+	if got, want := expvar.Get("lcwml").String(), "{}"; got != want {
 		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
 	g.Add([]string{"a"}, 6)
-	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lcwml").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
 	}
 
@@ -627,7 +627,7 @@ func TestCountersWithMultiLabels(t *testing.T) {
 	g.Add([]string{"a"}, 7)
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellcwml").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lcwml").String(); got != want1 && got != want2 {
 		t.Errorf("CountersWithMultiLabels get: %s, want %s or %s", got, want1, want2)
 	}
 }
@@ -648,26 +648,26 @@ func TestGaugesWithMultiLabels(t *testing.T) {
 
 	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
 	g.Set([]string{"a"}, 4)
-	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 4}`; got != want {
+	if got, want := expvar.Get("lgwml").String(), `{"i1.a": 4}`; got != want {
 		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	// Ensure var gets replaced.
 	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
 	g.Set([]string{"a"}, 5)
-	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 5}`; got != want {
+	if got, want := expvar.Get("lgwml").String(), `{"i1.a": 5}`; got != want {
 		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
 	}
 
 	ebd = NewExporter("i1", "label")
 	// Ensure gauge gets reset on re-instantiation.
-	if got, want := expvar.Get("labellgwml").String(), "{}"; got != want {
+	if got, want := expvar.Get("lgwml").String(), "{}"; got != want {
 		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
 	}
 	// Ensure new value is returned after var gets added.
 	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
 	g.Set([]string{"a"}, 6)
-	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 6}`; got != want {
+	if got, want := expvar.Get("lgwml").String(), `{"i1.a": 6}`; got != want {
 		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
 	}
 
@@ -676,7 +676,7 @@ func TestGaugesWithMultiLabels(t *testing.T) {
 	g.Set([]string{"a"}, 7)
 	want1 := `{"i1.a": 6, "i2.a": 7}`
 	want2 := `{"i2.a": 7, "i1.a": 6}`
-	if got := expvar.Get("labellgwml").String(); got != want1 && got != want2 {
+	if got := expvar.Get("lgwml").String(); got != want1 && got != want2 {
 		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
 	}
 }

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -513,11 +513,11 @@ func TestRates(t *testing.T) {
 	// Ensure var gets reused.
 	rates1 := ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
 	rates2 := ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
-	assert.Equal(t, rates2, rates1)
+	assert.True(t, rates2 == rates1)
 
 	ebd = NewExporter("i2", "label")
 	rates3 := ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
-	assert.NotEqual(t, rates3, rates1)
+	assert.True(t, rates3 != rates1)
 }
 
 func TestHistogram(t *testing.T) {

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -1,0 +1,773 @@
+/*
+Copyright 2018 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"expvar"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+)
+
+func TestURLPrefix(t *testing.T) {
+	if got, want := NewExporter("", "").URLPrefix(), ""; got != want {
+		t.Errorf("URLPrefix(''): %v, want %v", got, want)
+	}
+	if got, want := NewExporter("a", "").URLPrefix(), "/a"; got != want {
+		t.Errorf("URLPrefix('a'): %v, want %v", got, want)
+	}
+}
+
+func TestHandleFunc(t *testing.T) {
+	// Listen on a random port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Cannot listen: %v", err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	go http.Serve(listener, nil)
+
+	ebd := NewExporter("", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("1"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/path", port)), "1"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
+
+	ebd = NewExporter("a", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("2"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "2"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
+
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("3"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "3"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
+
+	ebd = NewExporter("a", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("4"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "4"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("b", "")
+	ebd.HandleFunc("/path", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("5"))
+	})
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/b/path", port)), "5"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/b/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
+	// Ensure "a" is still the same.
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/path", port)), "4"; got != want {
+		t.Errorf("httpGet: %s, want %s", got, want)
+	}
+	if got, want := httpGet(t, fmt.Sprintf("http://localhost:%d/a/debug/status", port)), "Status for"; !strings.Contains(got, want) {
+		t.Errorf("httpGet: %s, must contain %s", got, want)
+	}
+}
+
+func httpGet(t *testing.T, url string) string {
+	t.Helper()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func TestCountersFuncWithMultiLabels(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewCountersFuncWithMultiLabels("gcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 1} })
+	if got, want := expvar.Get("gcfwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 2} })
+	ebd.NewCountersFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
+
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcfwml").String(), "{}"; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
+	if got, want := expvar.Get("labellcfwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewCountersFuncWithMultiLabels("lcfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcfwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesFuncWithMultiLabels(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewGaugesFuncWithMultiLabels("ggfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 1} })
+	if got, want := expvar.Get("ggfwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 2} })
+	ebd.NewGaugesFuncWithMultiLabels("", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 3} })
+
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 4} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 5} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgfwml").String(), "{}"; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 6} })
+	if got, want := expvar.Get("labellgfwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewGaugesFuncWithMultiLabels("lgfwml", "", []string{"l"}, func() map[string]int64 { return map[string]int64{"a": 7} })
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgfwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounter(t *testing.T) {
+	ebd := NewExporter("", "")
+	c := ebd.NewCounter("gcounter", "")
+	c.Add(1)
+	if got, want := expvar.Get("gcounter").String(), "1"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounter("", "")
+	ebd.NewCounter("", "")
+
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(4)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(5)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcounter").String(), "{}"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(5)
+	if got, want := expvar.Get("labellcounter").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	c = ebd.NewCounter("lcounter", "")
+	c.Add(6)
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcounter").String(); got != want1 && got != want2 {
+		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGauge(t *testing.T) {
+	ebd := NewExporter("", "")
+	c := ebd.NewGauge("ggauge", "")
+	c.Set(1)
+	if got, want := expvar.Get("ggauge").String(), "1"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGauge("", "")
+	ebd.NewGauge("", "")
+
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(4)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(5)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgauge").String(), "{}"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(5)
+	if got, want := expvar.Get("labellgauge").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	c = ebd.NewGauge("lgauge", "")
+	c.Set(6)
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellgauge").String(); got != want1 && got != want2 {
+		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounterFunc(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewCounterFunc("gcf", "", func() int64 { return 1 })
+	if got, want := expvar.Get("gcf").String(), "1"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounterFunc("", "", func() int64 { return 2 })
+	ebd.NewCounterFunc("", "", func() int64 { return 3 })
+
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 4 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcf").String(), "{}"; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellcf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Counter get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewCounterFunc("lcf", "", func() int64 { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcf").String(); got != want1 && got != want2 {
+		t.Errorf("Counter get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugeFunc(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewGaugeFunc("ggf", "", func() int64 { return 1 })
+	if got, want := expvar.Get("ggf").String(), "1"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugeFunc("", "", func() int64 { return 2 })
+	ebd.NewGaugeFunc("", "", func() int64 { return 3 })
+
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 4 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 4}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgf").String(), "{}"; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 5 })
+	if got, want := expvar.Get("labellgf").String(), `{"i1": 5}`; got != want {
+		t.Errorf("Gauge get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewGaugeFunc("lgf", "", func() int64 { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellgf").String(); got != want1 && got != want2 {
+		t.Errorf("Gauge get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCounterDurationFunc(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewCounterDurationFunc("gcduration", "", func() time.Duration { return 1 })
+	if got, want := expvar.Get("gcduration").String(), "1"; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCounterDurationFunc("", "", func() time.Duration { return 2 })
+	ebd.NewCounterDurationFunc("", "", func() time.Duration { return 3 })
+
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 4 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 4}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcduration").String(), "{}"; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellcduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("CounterDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewCounterDurationFunc("lcduration", "", func() time.Duration { return 6 })
+	want1 := `{"i1": 5, "i2": 6}`
+	want2 := `{"i2": 6, "i1": 5}`
+	if got := expvar.Get("labellcduration").String(); got != want1 && got != want2 {
+		t.Errorf("CounterDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugeDurationFunc(t *testing.T) {
+	ebd := NewExporter("", "")
+	ebd.NewGaugeDurationFunc("ggduration", "", func() time.Duration { return 1 })
+	if got, want := expvar.Get("ggduration").String(), "1"; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugeDurationFunc("", "", func() time.Duration { return 2 })
+	ebd.NewGaugeDurationFunc("", "", func() time.Duration { return 3 })
+
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 4 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 4}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 5 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 5}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgduration").String(), "{}"; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 6 })
+	if got, want := expvar.Get("labellgduration").String(), `{"i1": 6}`; got != want {
+		t.Errorf("GaugeDuration get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	ebd.NewGaugeDurationFunc("lgduration", "", func() time.Duration { return 7 })
+	want1 := `{"i1": 6, "i2": 7}`
+	want2 := `{"i2": 7, "i1": 6}`
+	if got := expvar.Get("labellgduration").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCountersWithSingleLabel(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewCountersWithSingleLabel("gcwsl", "", "l")
+	g.Add("a", 1)
+	if got, want := expvar.Get("gcwsl").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersWithSingleLabel("", "", "l")
+	ebd.NewCountersWithSingleLabel("", "", "l")
+
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 4)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 5)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcwsl").String(), "{}"; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 6)
+	if got, want := expvar.Get("labellcwsl").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	g = ebd.NewCountersWithSingleLabel("lcwsl", "", "l")
+	g.Add("a", 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcwsl").String(); got != want1 && got != want2 {
+		t.Errorf("CountersWithSingleLabel get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesWithSingleLabel(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewGaugesWithSingleLabel("ggwsl", "", "l")
+	g.Set("a", 1)
+	if got, want := expvar.Get("ggwsl").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesWithSingleLabel("", "", "l")
+	ebd.NewGaugesWithSingleLabel("", "", "l")
+
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 4)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 5)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgwsl").String(), "{}"; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 6)
+	if got, want := expvar.Get("labellgwsl").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	g = ebd.NewGaugesWithSingleLabel("lgwsl", "", "l")
+	g.Set("a", 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgwsl").String(); got != want1 && got != want2 {
+		t.Errorf("GaugesWithSingleLabel get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestCountersWithMultiLabels(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewCountersWithMultiLabels("gcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 1)
+	if got, want := expvar.Get("gcwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewCountersWithMultiLabels("", "", []string{"l"})
+	ebd.NewCountersWithMultiLabels("", "", []string{"l"})
+
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 4)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 5)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellcwml").String(), "{}"; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 6)
+	if got, want := expvar.Get("labellcwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	g = ebd.NewCountersWithMultiLabels("lcwml", "", []string{"l"})
+	g.Add([]string{"a"}, 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellcwml").String(); got != want1 && got != want2 {
+		t.Errorf("CountersWithMultiLabels get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestGaugesWithMultiLabels(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewGaugesWithMultiLabels("ggwml", "", []string{"l"})
+	g.Set([]string{"a"}, 1)
+	if got, want := expvar.Get("ggwml").String(), `{"a": 1}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewGaugesWithMultiLabels("", "", []string{"l"})
+	ebd.NewGaugesWithMultiLabels("", "", []string{"l"})
+
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 4)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 4}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	// Ensure var gets replaced.
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 5)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 5}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+	// Ensure gauge gets reset on re-instantiation.
+	if got, want := expvar.Get("labellgwml").String(), "{}"; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+	// Ensure new value is returned after var gets added.
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 6)
+	if got, want := expvar.Get("labellgwml").String(), `{"i1.a": 6}`; got != want {
+		t.Errorf("GaugesWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i2", "label")
+	g = ebd.NewGaugesWithMultiLabels("lgwml", "", []string{"l"})
+	g.Set([]string{"a"}, 7)
+	want1 := `{"i1.a": 6, "i2.a": 7}`
+	want2 := `{"i2.a": 7, "i1.a": 6}`
+	if got := expvar.Get("labellgwml").String(); got != want1 && got != want2 {
+		t.Errorf("GaugeDuration get: %s, want %s or %s", got, want1, want2)
+	}
+}
+
+func TestTimings(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewTimings("gtimings", "", "l")
+	g.Add("a", 1)
+	if got, want := expvar.Get("gtimings").String(), "TotalCount"; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewTimings("", "", "l")
+	ebd.NewTimings("", "", "l")
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewTimings("ltimings", "", "l")
+	ebd.NewTimings("ltimings", "", "l")
+}
+
+func TestMultiTimings(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewMultiTimings("gmtimings", "", []string{"l"})
+	g.Add([]string{"a"}, 1)
+	if got, want := expvar.Get("gmtimings").String(), "TotalCount"; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewMultiTimings("", "", []string{"l"})
+	ebd.NewMultiTimings("", "", []string{"l"})
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewMultiTimings("lmtimings", "", []string{"l"})
+	ebd.NewMultiTimings("lmtimings", "", []string{"l"})
+}
+
+func TestRates(t *testing.T) {
+	ebd := NewExporter("", "")
+	tm := ebd.NewMultiTimings("gratetimings", "", []string{"l"})
+	ebd.NewRates("grates", tm, 15*60/5, 5*time.Second)
+	if got, want := expvar.Get("grates").String(), "{}"; got != want {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, want %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewRates("", tm, 15*60/5, 5*time.Second)
+	ebd.NewRates("", tm, 15*60/5, 5*time.Second)
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
+	ebd.NewRates("lrates", tm, 15*60/5, 5*time.Second)
+}
+
+func TestHistogram(t *testing.T) {
+	ebd := NewExporter("", "")
+	g := ebd.NewHistogram("ghebdogram", "", []int64{10})
+	g.Add(1)
+	if got, want := expvar.Get("ghebdogram").String(), `{"10": 1, "inf": 1, "Count": 1, "Total": 1}`; !strings.Contains(got, want) {
+		t.Errorf("CountersFuncWithMultiLabels get: %s, must contain %s", got, want)
+	}
+
+	ebd = NewExporter("i1", "label")
+
+	// Ensure anonymous vars don't cause panics.
+	ebd.NewHistogram("", "", []int64{10})
+	ebd.NewHistogram("", "", []int64{10})
+
+	// Ensure non-anonymous vars also don't cause panics
+	ebd.NewHistogram("lhebdogram", "", []int64{10})
+	ebd.NewHistogram("lhebdogram", "", []int64{10})
+}
+
+func TestPublish(t *testing.T) {
+	ebd := NewExporter("", "")
+	s := stats.NewString("")
+	ebd.Publish("gpub", s)
+	s.Set("1")
+	if got, want := expvar.Get("gpub").String(), `"1"`; got != want {
+		t.Errorf("Publish get: %s, want %s", got, want)
+	}
+
+	// This should not crash.
+	ebd = NewExporter("i1", "label")
+	ebd.Publish("lpub", s)
+	ebd.Publish("lpub", s)
+}

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2017 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -34,40 +34,45 @@ import (
 	"vitess.io/vitess/go/vt/log"
 )
 
-var (
-	binaryName  = filepath.Base(os.Args[0])
-	hostname    string
-	serverStart = time.Now()
-
-	statusMu       sync.RWMutex
-	statusSections []section
-	statusTmpl     = template.Must(reparse(nil))
-	statusFuncMap  = make(template.FuncMap)
-)
-
-type section struct {
-	Banner   string
-	Fragment string
-	F        func() interface{}
+// AddStatusPart adds a new section to status. fragment is used as a
+// subtemplate of the template used to render /debug/status, and will
+// be executed using the value of invoking f at the time of the
+// /debug/status request. fragment is parsed and executed with the
+// html/template package. Functions registered with AddStatusFuncs
+// may be used in the template.
+func AddStatusPart(banner, fragment string, f func() interface{}) {
+	globalStatus.addStatusPart(banner, fragment, f)
 }
 
 // AddStatusFuncs merges the provided functions into the set of
 // functions used to render /debug/status. Call this before AddStatusPart
 // if your template requires custom functions.
 func AddStatusFuncs(fmap template.FuncMap) {
-	statusMu.Lock()
-	defer statusMu.Unlock()
-
-	for name, fun := range fmap {
-		if !strings.HasPrefix(name, "github_com_vitessio_vitess_") {
-			panic("status func registered without proper prefix, need github_com_vitessio_vitess_:" + name)
-		}
-		if _, ok := statusFuncMap[name]; ok {
-			panic("duplicate status func registered: " + name)
-		}
-		statusFuncMap[name] = fun
-	}
+	globalStatus.addStatusFuncs(fmap)
 }
+
+// AddStatusSection registers a function that generates extra
+// information for the global status page, it will be
+// used as a header before the information. If more complex output
+// than a simple string is required use AddStatusPart instead.
+func AddStatusSection(banner string, f func() string) {
+	globalStatus.addStatusSection(banner, f)
+}
+
+// StatusURLPath returns the path to the status page.
+func StatusURLPath() string {
+	return "/debug/status"
+}
+
+//-----------------------------------------------------------------
+
+var (
+	binaryName  = filepath.Base(os.Args[0])
+	hostname    string
+	serverStart = time.Now()
+
+	globalStatus = newStatusPage("")
+)
 
 var statusHTML = `<!DOCTYPE html>
 <html>
@@ -104,11 +109,114 @@ Started: {{.StartTime}}<br>
 Running on {{.Hostname}}<br>
 View <a href=/debug/vars>variables</a>,
      <a href=/debug/pprof>debugging profiles</a>,
-     <a href=/debug/scatter_stats>scatter query statistics</a>,
 </div>
 </div>`
 
-func reparse(sections []section) (*template.Template, error) {
+type statusPage struct {
+	mu       sync.RWMutex
+	sections []section
+	tmpl     *template.Template
+	funcMap  template.FuncMap
+}
+
+type section struct {
+	Banner   string
+	Fragment string
+	F        func() interface{}
+}
+
+func newStatusPage(name string) *statusPage {
+	sp := &statusPage{
+		funcMap: make(template.FuncMap),
+	}
+	sp.tmpl = template.Must(sp.reparse(nil))
+	if name == "" {
+		http.HandleFunc(StatusURLPath(), sp.statusHandler)
+	} else {
+		http.HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
+	}
+	return sp
+}
+
+func (sp *statusPage) reset() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	sp.sections = nil
+	sp.tmpl = template.Must(sp.reparse(nil))
+	sp.funcMap = make(template.FuncMap)
+}
+
+func (sp *statusPage) addStatusFuncs(fmap template.FuncMap) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	for name, fun := range fmap {
+		if !strings.HasPrefix(name, "github_com_vitessio_vitess_") {
+			panic("status func registered without proper prefix, need github_com_vitessio_vitess_:" + name)
+		}
+		if _, ok := sp.funcMap[name]; ok {
+			panic("duplicate status func registered: " + name)
+		}
+		sp.funcMap[name] = fun
+	}
+}
+
+func (sp *statusPage) addStatusPart(banner, fragment string, f func() interface{}) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	secs := append(sp.sections, section{
+		Banner:   banner,
+		Fragment: fragment,
+		F:        f,
+	})
+
+	var err error
+	sp.tmpl, err = sp.reparse(secs)
+	if err != nil {
+		secs[len(secs)-1] = section{
+			Banner:   banner,
+			Fragment: "<code>bad status template: {{.}}</code>",
+			F:        func() interface{} { return err },
+		}
+	}
+	sp.tmpl, _ = sp.reparse(secs)
+	sp.sections = secs
+}
+
+func (sp *statusPage) addStatusSection(banner string, f func() string) {
+	sp.addStatusPart(banner, `{{.}}`, func() interface{} { return f() })
+}
+
+func (sp *statusPage) statusHandler(w http.ResponseWriter, r *http.Request) {
+	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		acl.SendError(w, err)
+		return
+	}
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	data := struct {
+		Sections   []section
+		BinaryName string
+		Hostname   string
+		StartTime  string
+	}{
+		Sections:   sp.sections,
+		BinaryName: binaryName,
+		Hostname:   hostname,
+		StartTime:  serverStart.Format(time.RFC1123),
+	}
+
+	if err := sp.tmpl.ExecuteTemplate(w, "status", data); err != nil {
+		if _, ok := err.(net.Error); !ok {
+			log.Errorf("servenv: couldn't execute template: %v", err)
+		}
+	}
+}
+
+func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 	var buf bytes.Buffer
 
 	io.WriteString(&buf, `{{define "status"}}`)
@@ -125,76 +233,7 @@ func reparse(sections []section) (*template.Template, error) {
 	for i, sec := range sections {
 		fmt.Fprintf(&buf, `{{define "sec-%d"}}%s{{end}}\n`, i, sec.Fragment)
 	}
-	return template.New("").Funcs(statusFuncMap).Parse(buf.String())
-}
-
-// AddStatusPart adds a new section to status. frag is used as a
-// subtemplate of the template used to render /debug/status, and will
-// be executed using the value of invoking f at the time of the
-// /debug/status request. frag is parsed and executed with the
-// html/template package. Functions registered with AddStatusFuncs
-// may be used in the template.
-func AddStatusPart(banner, frag string, f func() interface{}) {
-	statusMu.Lock()
-	defer statusMu.Unlock()
-
-	secs := append(statusSections, section{
-		Banner:   banner,
-		Fragment: frag,
-		F:        f,
-	})
-
-	var err error
-	statusTmpl, err = reparse(secs)
-	if err != nil {
-		secs[len(secs)-1] = section{
-			Banner:   banner,
-			Fragment: "<code>bad status template: {{.}}</code>",
-			F:        func() interface{} { return err },
-		}
-	}
-	statusTmpl, _ = reparse(secs)
-	statusSections = secs
-}
-
-// AddStatusSection registers a function that generates extra
-// information for /debug/status. If banner is not empty, it will be
-// used as a header before the information. If more complex output
-// than a simple string is required use AddStatusPart instead.
-func AddStatusSection(banner string, f func() string) {
-	AddStatusPart(banner, `{{.}}`, func() interface{} { return f() })
-}
-
-func statusHandler(w http.ResponseWriter, r *http.Request) {
-	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
-		acl.SendError(w, err)
-		return
-	}
-	statusMu.Lock()
-	defer statusMu.Unlock()
-
-	data := struct {
-		Sections   []section
-		BinaryName string
-		Hostname   string
-		StartTime  string
-	}{
-		Sections:   statusSections,
-		BinaryName: binaryName,
-		Hostname:   hostname,
-		StartTime:  serverStart.Format(time.RFC1123),
-	}
-
-	if err := statusTmpl.ExecuteTemplate(w, "status", data); err != nil {
-		if _, ok := err.(net.Error); !ok {
-			log.Errorf("servenv: couldn't execute template: %v", err)
-		}
-	}
-}
-
-// StatusURLPath returns the path to the status page.
-func StatusURLPath() string {
-	return "/debug/status"
+	return template.New("").Funcs(sp.funcMap).Parse(buf.String())
 }
 
 func init() {
@@ -203,5 +242,4 @@ func init() {
 	if err != nil {
 		log.Exitf("os.Hostname: %v", err)
 	}
-	http.HandleFunc("/debug/status", statusHandler)
 }

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Google Inc.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/go/vt/servenv/status_test.go
+++ b/go/vt/servenv/status_test.go
@@ -24,6 +24,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -45,16 +47,12 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + StatusURLPath())
-	if err != nil {
-		t.Fatalf("http.Get: %v", err)
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("ioutil.ReadAll: %v", err)
-	}
+	require.NoError(t, err)
 
 	cases := []string{
 		`h1.*test_part.*/h1`,
@@ -88,16 +86,12 @@ func TestNamedStatus(t *testing.T) {
 	})
 
 	resp, err := http.Get(server.URL + "/" + name + StatusURLPath())
-	if err != nil {
-		t.Fatalf("http.Get: %v", err)
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("ioutil.ReadAll: %v", err)
-	}
+	require.NoError(t, err)
 
 	cases := []string{
 		`h1.*test_part.*/h1`,

--- a/go/vt/servenv/status_test.go
+++ b/go/vt/servenv/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Google Inc.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/go/vt/servenv/status_test.go
+++ b/go/vt/servenv/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2017 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreedto in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -45,6 +45,49 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + StatusURLPath())
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll: %v", err)
+	}
+
+	cases := []string{
+		`h1.*test_part.*/h1`,
+		`THIS SHOULD BE UPPERCASE`,
+		`h1.*test_section.*/h1`,
+	}
+	for _, cas := range cases {
+		if !regexp.MustCompile(cas).Match(body) {
+			t.Errorf("failed matching: %q", cas)
+		}
+	}
+	t.Logf("body: \n%s", body)
+}
+
+func TestNamedStatus(t *testing.T) {
+	server := httptest.NewServer(nil)
+	defer server.Close()
+
+	name := "test"
+	sp := newStatusPage(name)
+	sp.addStatusFuncs(
+		template.FuncMap{
+			"github_com_vitessio_vitess_to_upper": strings.ToUpper,
+		})
+
+	sp.addStatusPart("test_part", `{{github_com_vitessio_vitess_to_upper . }}`, func() interface{} {
+		return "this should be uppercase"
+	})
+	sp.addStatusSection("test_section", func() string {
+		return "this is a section"
+	})
+
+	resp, err := http.Get(server.URL + "/" + name + StatusURLPath())
 	if err != nil {
 		t.Fatalf("http.Get: %v", err)
 	}


### PR DESCRIPTION
The new framework allows you to create a named environment under which all stats variables and http endpoints get remapped to distinct URLs or var dimensions.

Details are in #5791