### PR TITLE
Improve error codes returned by tabletserver

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -327,6 +327,7 @@ const (
 	ERNoDefault                     = 1230
 	EROperandColumns                = 1241
 	ERSubqueryNo1Row                = 1242
+	ERWarnDataOutOfRange            = 1264
 	ERNonUpdateableTable            = 1288
 	ERFeatureDisabled               = 1289
 	EROptionPreventsStatement       = 1290

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -372,8 +372,8 @@ func TestQueryTimeout(t *testing.T) {
 		return
 	}
 	_, err = client.Execute("select sleep(1) from vitess_test", nil)
-	if code := vterrors.Code(err); code != vtrpcpb.Code_DEADLINE_EXCEEDED {
-		t.Errorf("Error code: %v, want %v", code, vtrpcpb.Code_DEADLINE_EXCEEDED)
+	if code := vterrors.Code(err); code != vtrpcpb.Code_CANCELED {
+		t.Errorf("Error code: %v, want %v", code, vtrpcpb.Code_CANCELED)
 	}
 	_, err = client.Execute("select 1 from dual", nil)
 	if code := vterrors.Code(err); code != vtrpcpb.Code_ABORTED {
@@ -435,8 +435,8 @@ func TestQueryPoolTimeout(t *testing.T) {
 	framework.Server.QueryTimeout.Set(100 * time.Millisecond)
 
 	_, err = client.Execute("select sleep(1) from vitess_test", nil)
-	if code := vterrors.Code(err); code != vtrpcpb.Code_DEADLINE_EXCEEDED {
-		t.Errorf("Error code: %v, want %v", code, vtrpcpb.Code_DEADLINE_EXCEEDED)
+	if code := vterrors.Code(err); code != vtrpcpb.Code_CANCELED {
+		t.Errorf("Error code: %v, want %v", code, vtrpcpb.Code_CANCELED)
 	}
 
 	vend := framework.DebugVars()

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -116,8 +116,8 @@ func TestStreamTerminate(t *testing.T) {
 			return nil
 		},
 	)
-	if code := vterrors.Code(err); code != vtrpcpb.Code_DEADLINE_EXCEEDED {
-		t.Errorf("Errorcode: %v, want %v", code, vtrpcpb.Code_DEADLINE_EXCEEDED)
+	if code := vterrors.Code(err); code != vtrpcpb.Code_CANCELED {
+		t.Errorf("Errorcode: %v, want %v", code, vtrpcpb.Code_CANCELED)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1556,7 +1556,7 @@ func convertErrorCode(err error) vtrpcpb.Code {
 		mysql.ERTooLongString, mysql.ERDelayedInsertTableLocked, mysql.ERDupUnique, mysql.ERRequiresPrimaryKey, mysql.ERCantDoThisDuringAnTransaction, mysql.ERReadOnlyTransaction,
 		mysql.ERCannotAddForeign, mysql.ERNoReferencedRow, mysql.ERRowIsReferenced, mysql.ERCantUpdateWithReadLock, mysql.ERNoDefault, mysql.EROperandColumns,
 		mysql.ERSubqueryNo1Row, mysql.ERNonUpdateableTable, mysql.ERFeatureDisabled, mysql.ERDuplicatedValueInType, mysql.ERRowIsReferenced2,
-		mysql.ErNoReferencedRow2:
+		mysql.ErNoReferencedRow2, mysql.ERWarnDataOutOfRange:
 		errCode = vtrpcpb.Code_FAILED_PRECONDITION
 	case mysql.EROptionPreventsStatement:
 		// Special-case this error code. It's probably because
@@ -1596,7 +1596,7 @@ func convertErrorCode(err error) vtrpcpb.Code {
 		}
 	case mysql.CRServerLost:
 		// Query was killed.
-		errCode = vtrpcpb.Code_DEADLINE_EXCEEDED
+		errCode = vtrpcpb.Code_CANCELED
 	}
 
 	return errCode


### PR DESCRIPTION
# Desc
* Small PR to improve some error codes returned by tabletserver. Per discussion with @sougou, it is clearer to return CANCELED when a query is killed. DeadlineExceeded, could be missleading.
* Also noticed that we are not capturing correctly errors with code 1264. I added it to the list. 