### PR TITLE
tabletserver: refactor parameters

### DIFF
--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -69,7 +69,8 @@ type Reader struct {
 }
 
 // NewReader returns a new heartbeat reader.
-func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Reader {
+func NewReader(env tabletenv.Env) *Reader {
+	config := env.Config()
 	if !config.HeartbeatEnable {
 		return &Reader{}
 	}
@@ -80,7 +81,7 @@ func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Re
 		interval: config.HeartbeatInterval,
 		ticks:    timer.NewTimer(config.HeartbeatInterval),
 		errorLog: logutil.NewThrottledLogger("HeartbeatReporter", 60*time.Second),
-		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9), env),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -81,7 +81,7 @@ func NewReader(env tabletenv.Env) *Reader {
 		interval: config.HeartbeatInterval,
 		ticks:    timer.NewTimer(config.HeartbeatInterval),
 		errorLog: logutil.NewThrottledLogger("HeartbeatReporter", 60*time.Second),
-		pool:     connpool.New(config.PoolNamePrefix+"HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9), env),
+		pool:     connpool.New(env, config.PoolNamePrefix+"HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9)),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/reader_test.go
+++ b/go/vt/vttablet/heartbeat/reader_test.go
@@ -110,7 +110,7 @@ func newReader(db *fakesqldb.DB, nowFunc func() time.Time) *Reader {
 	cp := *params
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "")
 
-	tr := NewReader(&fakeMysqlChecker{}, config)
+	tr := NewReader(tabletenv.NewTestEnv(&config, nil))
 	tr.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
 	tr.keyspaceShard = "test:0"
 	tr.now = nowFunc

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -86,7 +86,7 @@ func NewWriter(env tabletenv.Env, alias topodatapb.TabletAlias) *Writer {
 		interval:    config.HeartbeatInterval,
 		ticks:       timer.NewTimer(config.HeartbeatInterval),
 		errorLog:    logutil.NewThrottledLogger("HeartbeatWriter", 60*time.Second),
-		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9), env),
+		pool:        connpool.New(env, config.PoolNamePrefix+"HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9)),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -73,7 +73,8 @@ type Writer struct {
 }
 
 // NewWriter creates a new Writer.
-func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, config tabletenv.TabletConfig) *Writer {
+func NewWriter(env tabletenv.Env, alias topodatapb.TabletAlias) *Writer {
+	config := env.Config()
 	if !config.HeartbeatEnable {
 		return &Writer{}
 	}
@@ -84,7 +85,7 @@ func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, conf
 		interval:    config.HeartbeatInterval,
 		ticks:       timer.NewTimer(config.HeartbeatInterval),
 		errorLog:    logutil.NewThrottledLogger("HeartbeatWriter", 60*time.Second),
-		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9), checker),
+		pool:        connpool.New(config.PoolNamePrefix+"HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9), env),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/writer_test.go
+++ b/go/vt/vttablet/heartbeat/writer_test.go
@@ -115,9 +115,7 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 	cp := *params
 	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "")
 
-	tw := NewWriter(&fakeMysqlChecker{},
-		topodatapb.TabletAlias{Cell: "test", Uid: 1111},
-		config)
+	tw := NewWriter(tabletenv.NewTestEnv(&config, nil), topodatapb.TabletAlias{Cell: "test", Uid: 1111})
 	tw.dbName = sqlescape.EscapeID(dbc.SidecarDBName.Get())
 	tw.keyspaceShard = "test:0"
 	tw.now = nowFunc
@@ -125,7 +123,3 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 
 	return tw
 }
-
-type fakeMysqlChecker struct{}
-
-func (f fakeMysqlChecker) CheckMySQL() {}

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -87,8 +87,7 @@ func TestMain(m *testing.M) {
 
 		// engines cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		streamerEngine = vstreamer.NewEngine(env.SrvTopo, env.SchemaEngine)
-		streamerEngine.InitDBConfig(env.Dbcfgs.DbaWithDB())
+		streamerEngine = vstreamer.NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine)
 		streamerEngine.Open(env.KeyspaceName, env.Cells[0])
 		defer streamerEngine.Close()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
@@ -159,7 +159,7 @@ func (vsClient *MySQLVStreamerClient) Open(ctx context.Context) (err error) {
 	// Let's create all the required components by vstreamer
 
 	config := tabletenv.DefaultQsConfig
-	vsClient.sourceSe = schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
+	vsClient.sourceSe = schema.NewEngine(tabletenv.NewTestEnv(&config, nil))
 	vsClient.sourceSe.InitDBConfig(vsClient.sourceConnParams)
 	err = vsClient.sourceSe.Open()
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
@@ -158,7 +158,8 @@ func (vsClient *MySQLVStreamerClient) Open(ctx context.Context) (err error) {
 
 	// Let's create all the required components by vstreamer
 
-	vsClient.sourceSe = schema.NewEngine(checker{}, tabletenv.DefaultQsConfig)
+	config := tabletenv.DefaultQsConfig
+	vsClient.sourceSe = schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
 	vsClient.sourceSe.InitDBConfig(vsClient.sourceConnParams)
 	err = vsClient.sourceSe.Open()
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vstreamer_client.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
@@ -211,9 +210,3 @@ func (vsClient *MySQLVStreamerClient) VStreamRows(ctx context.Context, query str
 func InitVStreamerClient(cfg *dbconfigs.DBConfigs) {
 	dbcfgs = cfg
 }
-
-type checker struct{}
-
-var _ = connpool.MySQLChecker(checker{})
-
-func (checker) CheckMySQL() {}

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -67,7 +67,7 @@ func NewDBConn(
 	appParams dbconfigs.Connector) (*DBConn, error) {
 	c, err := dbconnpool.NewDBConnection(appParams, tabletenv.MySQLStats)
 	if err != nil {
-		cp.checker.CheckMySQL()
+		cp.env.CheckMySQL()
 		return nil, err
 	}
 	return &DBConn{
@@ -120,7 +120,7 @@ func (dbc *DBConn) Exec(ctx context.Context, query string, maxrows int, wantfiel
 		}
 
 		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
-			dbc.pool.checker.CheckMySQL()
+			dbc.pool.env.CheckMySQL()
 			// Return the error of the reconnect and not the original connection error.
 			return nil, reconnectErr
 		}
@@ -201,7 +201,7 @@ func (dbc *DBConn) Stream(ctx context.Context, query string, callback func(*sqlt
 		default:
 		}
 		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
-			dbc.pool.checker.CheckMySQL()
+			dbc.pool.env.CheckMySQL()
 			// Return the error of the reconnect and not the original connection error.
 			return reconnectErr
 		}

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	"golang.org/x/net/context"
 )
@@ -220,19 +221,12 @@ func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 	}
 }
 
-type dummyChecker struct {
-}
-
-func (dummyChecker) CheckMySQL() {}
-
-var checker = dummyChecker{}
-
 func newPool() *Pool {
 	return New(
+		tabletenv.NewTestEnv(nil, nil),
 		fmt.Sprintf("TestPool%d", rand.Int63()),
 		100,
 		0,
 		10*time.Second,
-		checker,
 	)
 }

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -36,6 +36,7 @@ import (
 // TabletService defines the functions of TabletServer
 // that the messager needs for callback.
 type TabletService interface {
+	tabletenv.Env
 	PostponeMessages(ctx context.Context, target *querypb.Target, name string, ids []string) (count int64, err error)
 	PurgeMessages(ctx context.Context, target *querypb.Target, name string, timeCutoff int64) (count int64, err error)
 }
@@ -60,12 +61,12 @@ type Engine struct {
 }
 
 // NewEngine creates a new Engine.
-func NewEngine(tsv TabletService, se *schema.Engine, vs VStreamer, config tabletenv.TabletConfig) *Engine {
+func NewEngine(tsv TabletService, se *schema.Engine, vs VStreamer) *Engine {
 	return &Engine{
 		tsv:          tsv,
 		se:           se,
 		vs:           vs,
-		postponeSema: sync2.NewSemaphore(config.MessagePostponeCap, 0),
+		postponeSema: sync2.NewSemaphore(tsv.Config().MessagePostponeCap, 0),
 		managers:     make(map[string]*messageManager),
 	}
 }

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -175,9 +175,11 @@ func newTestEngine(db *fakesqldb.DB) *Engine {
 	randID := rand.Int63()
 	config := tabletenv.DefaultQsConfig
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
-	tsv := newFakeTabletServer()
+	tsv := &fakeTabletServer{
+		Env: tabletenv.NewTestEnv(&config, nil),
+	}
 	se := schema.NewEngine(tsv)
-	te := NewEngine(tsv, se, newFakeVStreamer(), config)
+	te := NewEngine(tsv, se, newFakeVStreamer())
 	te.Open()
 	return te
 }

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -176,7 +176,7 @@ func newTestEngine(db *fakesqldb.DB) *Engine {
 	config := tabletenv.DefaultQsConfig
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
 	tsv := newFakeTabletServer()
-	se := schema.NewEngine(tsv, config)
+	se := schema.NewEngine(tsv)
 	te := NewEngine(tsv, se, newFakeVStreamer(), config)
 	te.Open()
 	return te

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -33,6 +33,7 @@ import (
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -810,6 +811,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 }
 
 type fakeTabletServer struct {
+	tabletenv.Env
 	postponeCount sync2.AtomicInt64
 	purgeCount    sync2.AtomicInt64
 
@@ -817,7 +819,12 @@ type fakeTabletServer struct {
 	ch chan string
 }
 
-func newFakeTabletServer() *fakeTabletServer { return &fakeTabletServer{} }
+func newFakeTabletServer() *fakeTabletServer {
+	config := tabletenv.DefaultQsConfig
+	return &fakeTabletServer{
+		Env: tabletenv.NewTestEnv(&config, nil, nil),
+	}
+}
 
 func (fts *fakeTabletServer) CheckMySQL() {}
 

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -822,7 +822,7 @@ type fakeTabletServer struct {
 func newFakeTabletServer() *fakeTabletServer {
 	config := tabletenv.DefaultQsConfig
 	return &fakeTabletServer{
-		Env: tabletenv.NewTestEnv(&config, nil, nil),
+		Env: tabletenv.NewTestEnv(&config, nil),
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -188,22 +188,10 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 		queryPoolWaiterCap: sync2.NewAtomicInt64(int64(config.QueryPoolWaiterCap)),
 	}
 
-	qe.conns = connpool.New(
-		config.PoolNamePrefix+"ConnPool",
-		config.PoolSize,
-		config.PoolPrefillParallelism,
-		time.Duration(config.IdleTimeout*1e9),
-		env,
-	)
+	qe.conns = connpool.New(env, config.PoolNamePrefix+"ConnPool", config.PoolSize, config.PoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9))
 	qe.connTimeout.Set(time.Duration(config.QueryPoolTimeout * 1e9))
 
-	qe.streamConns = connpool.New(
-		config.PoolNamePrefix+"StreamConnPool",
-		config.StreamPoolSize,
-		config.StreamPoolPrefillParallelism,
-		time.Duration(config.IdleTimeout*1e9),
-		env,
-	)
+	qe.streamConns = connpool.New(env, config.PoolNamePrefix+"StreamConnPool", config.StreamPoolSize, config.StreamPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9))
 	qe.enableConsolidator = config.EnableConsolidator
 	qe.enableConsolidatorReplicas = config.EnableConsolidatorReplicas
 	qe.enableQueryPlanFieldCaching = config.EnableQueryPlanFieldCaching

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -33,7 +33,6 @@ import (
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/trace"
-	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -122,8 +121,8 @@ var (
 // Close: There should be no more pending queries when this
 // function is called.
 type QueryEngine struct {
-	se        *schema.Engine
-	dbconfigs *dbconfigs.DBConfigs
+	env tabletenv.Env
+	se  *schema.Engine
 
 	// mu protects the following fields.
 	mu               sync.RWMutex
@@ -178,8 +177,10 @@ var (
 // NewQueryEngine creates a new QueryEngine.
 // This is a singleton class.
 // You must call this only once.
-func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tabletenv.TabletConfig) *QueryEngine {
+func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
+	config := env.Config()
 	qe := &QueryEngine{
+		env:                env,
 		se:                 se,
 		tables:             make(map[string]*schema.Table),
 		plans:              cache.NewLRUCache(int64(config.QueryPlanCacheSize)),
@@ -192,7 +193,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		config.PoolSize,
 		config.PoolPrefillParallelism,
 		time.Duration(config.IdleTimeout*1e9),
-		checker,
+		env,
 	)
 	qe.connTimeout.Set(time.Duration(config.QueryPoolTimeout * 1e9))
 
@@ -201,7 +202,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		config.StreamPoolSize,
 		config.StreamPoolPrefillParallelism,
 		time.Duration(config.IdleTimeout*1e9),
-		checker,
+		env,
 	)
 	qe.enableConsolidator = config.EnableConsolidator
 	qe.enableConsolidatorReplicas = config.EnableConsolidatorReplicas
@@ -277,14 +278,9 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	return qe
 }
 
-// InitDBConfig must be called before Open.
-func (qe *QueryEngine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
-	qe.dbconfigs = dbcfgs
-}
-
 // Open must be called before sending requests to QueryEngine.
 func (qe *QueryEngine) Open() error {
-	qe.conns.Open(qe.dbconfigs.AppWithDB(), qe.dbconfigs.DbaWithDB(), qe.dbconfigs.AppDebugWithDB())
+	qe.conns.Open(qe.env.DBConfigs().AppWithDB(), qe.env.DBConfigs().DbaWithDB(), qe.env.DBConfigs().AppDebugWithDB())
 
 	conn, err := qe.conns.Get(tabletenv.LocalContext())
 	if err != nil {
@@ -301,7 +297,7 @@ func (qe *QueryEngine) Open() error {
 		return err
 	}
 
-	qe.streamConns.Open(qe.dbconfigs.AppWithDB(), qe.dbconfigs.DbaWithDB(), qe.dbconfigs.AppDebugWithDB())
+	qe.streamConns.Open(qe.env.DBConfigs().AppWithDB(), qe.env.DBConfigs().DbaWithDB(), qe.env.DBConfigs().AppDebugWithDB())
 	qe.se.RegisterNotifier("qe", qe.schemaChanged)
 	return nil
 }
@@ -431,7 +427,7 @@ func (qe *QueryEngine) ClearQueryPlanCache() {
 
 // IsMySQLReachable returns true if we can connect to MySQL.
 func (qe *QueryEngine) IsMySQLReachable() bool {
-	conn, err := dbconnpool.NewDBConnection(qe.dbconfigs.DbaWithDB(), tabletenv.MySQLStats)
+	conn, err := dbconnpool.NewDBConnection(qe.env.DBConfigs().DbaWithDB(), tabletenv.MySQLStats)
 	if err != nil {
 		if mysql.IsConnErr(err) {
 			return false

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -51,7 +51,7 @@ func TestStrictMode(t *testing.T) {
 
 	// Test default behavior.
 	config := tabletenv.DefaultQsConfig
-	env := tabletenv.NewTestEnv(&config, dbcfgs, nil)
+	env := tabletenv.NewTestEnv(&config, dbcfgs)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 	qe.se.InitDBConfig(dbcfgs.DbaWithDB())
@@ -294,7 +294,7 @@ func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, stric
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	env := tabletenv.NewTestEnv(&config, dbcfgs, nil)
+	env := tabletenv.NewTestEnv(&config, dbcfgs)
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
 	se.InitDBConfig(dbcfgs.DbaWithDB())

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -51,10 +51,9 @@ func TestStrictMode(t *testing.T) {
 
 	// Test default behavior.
 	config := tabletenv.DefaultQsConfig
-	// config.EnforceStrictTransTable is true by default.
-	se := schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
-	qe := NewQueryEngine(DummyChecker, se, config)
-	qe.InitDBConfig(dbcfgs)
+	env := tabletenv.NewTestEnv(&config, dbcfgs, nil)
+	se := schema.NewEngine(env)
+	qe := NewQueryEngine(env, se)
 	qe.se.InitDBConfig(dbcfgs.DbaWithDB())
 	qe.se.Open()
 	if err := qe.Open(); err != nil {
@@ -70,8 +69,7 @@ func TestStrictMode(t *testing.T) {
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("")}},
 		},
 	)
-	qe = NewQueryEngine(DummyChecker, se, config)
-	qe.InitDBConfig(dbcfgs)
+	qe = NewQueryEngine(env, se)
 	err := qe.Open()
 	wantErr := "require sql_mode to be STRICT_TRANS_TABLES or STRICT_ALL_TABLES: got ''"
 	if err == nil || err.Error() != wantErr {
@@ -81,8 +79,7 @@ func TestStrictMode(t *testing.T) {
 
 	// Test that we succeed if the enforcement flag is off.
 	config.EnforceStrictTransTables = false
-	qe = NewQueryEngine(DummyChecker, se, config)
-	qe.InitDBConfig(dbcfgs)
+	qe = NewQueryEngine(env, se)
 	if err := qe.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -297,10 +294,10 @@ func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, stric
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	se := schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
-	qe := NewQueryEngine(DummyChecker, se, config)
+	env := tabletenv.NewTestEnv(&config, dbcfgs, nil)
+	se := schema.NewEngine(env)
+	qe := NewQueryEngine(env, se)
 	se.InitDBConfig(dbcfgs.DbaWithDB())
-	qe.InitDBConfig(dbcfgs)
 	return qe
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -52,7 +52,8 @@ func TestStrictMode(t *testing.T) {
 	// Test default behavior.
 	config := tabletenv.DefaultQsConfig
 	// config.EnforceStrictTransTable is true by default.
-	qe := NewQueryEngine(DummyChecker, schema.NewEngine(DummyChecker, config), config)
+	se := schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
+	qe := NewQueryEngine(DummyChecker, se, config)
 	qe.InitDBConfig(dbcfgs)
 	qe.se.InitDBConfig(dbcfgs.DbaWithDB())
 	qe.se.Open()
@@ -69,7 +70,7 @@ func TestStrictMode(t *testing.T) {
 			Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("")}},
 		},
 	)
-	qe = NewQueryEngine(DummyChecker, schema.NewEngine(DummyChecker, config), config)
+	qe = NewQueryEngine(DummyChecker, se, config)
 	qe.InitDBConfig(dbcfgs)
 	err := qe.Open()
 	wantErr := "require sql_mode to be STRICT_TRANS_TABLES or STRICT_ALL_TABLES: got ''"
@@ -80,7 +81,7 @@ func TestStrictMode(t *testing.T) {
 
 	// Test that we succeed if the enforcement flag is off.
 	config.EnforceStrictTransTables = false
-	qe = NewQueryEngine(DummyChecker, schema.NewEngine(DummyChecker, config), config)
+	qe = NewQueryEngine(DummyChecker, se, config)
 	qe.InitDBConfig(dbcfgs)
 	if err := qe.Open(); err != nil {
 		t.Fatal(err)
@@ -296,7 +297,7 @@ func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, stric
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	se := schema.NewEngine(DummyChecker, config)
+	se := schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
 	qe := NewQueryEngine(DummyChecker, se, config)
 	se.InitDBConfig(dbcfgs.DbaWithDB())
 	qe.InitDBConfig(dbcfgs)

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -75,7 +75,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 		env: env,
 		// We need only one connection because the reloader is
 		// the only one that needs this.
-		conns:      connpool.New("", 1, 0, idleTimeout, env),
+		conns:      connpool.New(env, "", 1, 0, idleTimeout),
 		ticks:      timer.NewTimer(reloadTime),
 		reloadTime: reloadTime,
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -48,7 +48,8 @@ type notifier func(full map[string]*Table, created, altered, dropped []string)
 // Engine stores the schema info and performs operations that
 // keep itself up-to-date.
 type Engine struct {
-	cp dbconfigs.Connector
+	env tabletenv.Env
+	cp  dbconfigs.Connector
 
 	// mu protects the following fields.
 	mu         sync.Mutex
@@ -67,13 +68,14 @@ type Engine struct {
 var schemaOnce sync.Once
 
 // NewEngine creates a new Engine.
-func NewEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Engine {
-	reloadTime := time.Duration(config.SchemaReloadTime * 1e9)
-	idleTimeout := time.Duration(config.IdleTimeout * 1e9)
+func NewEngine(env tabletenv.Env) *Engine {
+	reloadTime := time.Duration(env.Config().SchemaReloadTime * 1e9)
+	idleTimeout := time.Duration(env.Config().IdleTimeout * 1e9)
 	se := &Engine{
+		env: env,
 		// We need only one connection because the reloader is
 		// the only one that needs this.
-		conns:      connpool.New("", 1, 0, idleTimeout, checker),
+		conns:      connpool.New("", 1, 0, idleTimeout, env),
 		ticks:      timer.NewTimer(reloadTime),
 		reloadTime: reloadTime,
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -310,7 +310,7 @@ func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout tim
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.SchemaReloadTime = float64(reloadTime) / 1e9
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	se := NewEngine(DummyChecker, config)
+	se := NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
 	se.InitDBConfig(newDBConfigs(db).DbaWithDB())
 	return se
 }

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -298,13 +298,6 @@ func TestStatsURL(t *testing.T) {
 	se.ServeHTTP(response, request)
 }
 
-type dummyChecker struct {
-}
-
-func (dummyChecker) CheckMySQL() {}
-
-var DummyChecker = dummyChecker{}
-
 func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout time.Duration, strict bool, db *fakesqldb.DB) *Engine {
 	config := tabletenv.DefaultQsConfig
 	config.QueryPlanCacheSize = queryPlanCacheSize

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -310,7 +310,7 @@ func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout tim
 	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.SchemaReloadTime = float64(reloadTime) / 1e9
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	se := NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
+	se := NewEngine(tabletenv.NewTestEnv(&config, nil))
 	se.InitDBConfig(newDBConfigs(db).DbaWithDB())
 	return se
 }

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -161,7 +162,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	appParams := db.ConnParams()
 	dbaParams := db.ConnParams()
 	connPoolIdleTimeout := 10 * time.Second
-	connPool := connpool.New("", 2, 0, connPoolIdleTimeout, DummyChecker)
+	connPool := connpool.New(tabletenv.NewTestEnv(nil, nil), "", 2, 0, connPoolIdleTimeout)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
@@ -133,6 +134,7 @@ func TestLoadTableMessage(t *testing.T) {
 
 	// Test loading min/max backoff
 	table, err = newTestLoadTable("USER_TABLE", "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30,vt_min_backoff=10,vt_max_backoff=100", db)
+	require.NoError(t, err)
 	want.MessageInfo.MinBackoff = 10 * time.Second
 	want.MessageInfo.MaxBackoff = 100 * time.Second
 	assert.Equal(t, want, table)

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -26,7 +26,9 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -118,6 +120,36 @@ var (
 	// Errorf can be overridden during tests
 	Errorf = log.Errorf
 )
+
+// Env defines the functions supported by TabletServer
+// that the sub-componennts need to access.
+type Env interface {
+	CheckMySQL()
+	Config() *TabletConfig
+	DBConfigs() *dbconfigs.DBConfigs
+	Exporter() *servenv.Exporter
+}
+
+type testEnv struct {
+	config    *TabletConfig
+	dbconfigs *dbconfigs.DBConfigs
+	exporter  *servenv.Exporter
+}
+
+// NewTestEnv creates an Env that can be used for tests.
+// CheckMySQL is a no-op.
+func NewTestEnv(config *TabletConfig, dbconfigs *dbconfigs.DBConfigs, exporter *servenv.Exporter) Env {
+	return &testEnv{
+		config:    config,
+		dbconfigs: dbconfigs,
+		exporter:  exporter,
+	}
+}
+
+func (*testEnv) CheckMySQL()                        {}
+func (te *testEnv) Config() *TabletConfig           { return te.config }
+func (te *testEnv) DBConfigs() *dbconfigs.DBConfigs { return te.dbconfigs }
+func (te *testEnv) Exporter() *servenv.Exporter     { return te.exporter }
 
 // RecordUserQuery records the query data against the user.
 func RecordUserQuery(ctx context.Context, tableName sqlparser.TableIdent, queryType string, duration int64) {

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sqlparser"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -127,29 +126,25 @@ type Env interface {
 	CheckMySQL()
 	Config() *TabletConfig
 	DBConfigs() *dbconfigs.DBConfigs
-	Exporter() *servenv.Exporter
 }
 
 type testEnv struct {
 	config    *TabletConfig
 	dbconfigs *dbconfigs.DBConfigs
-	exporter  *servenv.Exporter
 }
 
 // NewTestEnv creates an Env that can be used for tests.
 // CheckMySQL is a no-op.
-func NewTestEnv(config *TabletConfig, dbconfigs *dbconfigs.DBConfigs, exporter *servenv.Exporter) Env {
+func NewTestEnv(config *TabletConfig, dbconfigs *dbconfigs.DBConfigs) Env {
 	return &testEnv{
 		config:    config,
 		dbconfigs: dbconfigs,
-		exporter:  exporter,
 	}
 }
 
 func (*testEnv) CheckMySQL()                        {}
 func (te *testEnv) Config() *TabletConfig           { return te.config }
 func (te *testEnv) DBConfigs() *dbconfigs.DBConfigs { return te.dbconfigs }
-func (te *testEnv) Exporter() *servenv.Exporter     { return te.exporter }
 
 // RecordUserQuery records the query data against the user.
 func RecordUserQuery(ctx context.Context, tableName sqlparser.TableIdent, queryType string, duration int64) {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -224,8 +224,8 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	tsv.se = schema.NewEngine(tsv)
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
 	tsv.te = NewTxEngine(tsv)
-	tsv.hw = heartbeat.NewWriter(tsv, alias, config)
-	tsv.hr = heartbeat.NewReader(tsv, config)
+	tsv.hw = heartbeat.NewWriter(tsv, alias)
+	tsv.hr = heartbeat.NewReader(tsv)
 	tsv.txThrottler = txthrottler.CreateTxThrottlerFromTabletConfig(topoServer)
 	// FIXME(alainjobart) could we move this to the Register method below?
 	// So that vtcombo doesn't even call it once, on the first tablet.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -223,7 +223,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	}
 	tsv.se = schema.NewEngine(tsv)
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
-	tsv.te = NewTxEngine(tsv, config)
+	tsv.te = NewTxEngine(tsv)
 	tsv.hw = heartbeat.NewWriter(tsv, alias, config)
 	tsv.hr = heartbeat.NewReader(tsv, config)
 	tsv.txThrottler = txthrottler.CreateTxThrottlerFromTabletConfig(topoServer)
@@ -349,7 +349,6 @@ func (tsv *TabletServer) InitDBConfig(target querypb.Target, dbcfgs *dbconfigs.D
 	tsv.dbconfigs = dbcfgs
 
 	tsv.se.InitDBConfig(tsv.dbconfigs.DbaWithDB())
-	tsv.te.InitDBConfig(tsv.dbconfigs)
 	tsv.hw.InitDBConfig(tsv.dbconfigs)
 	tsv.hr.InitDBConfig(tsv.dbconfigs)
 	tsv.vstreamer.InitDBConfig(tsv.dbconfigs.DbaWithDB())

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -222,7 +222,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 		alias:                  alias,
 	}
 	tsv.se = schema.NewEngine(tsv)
-	tsv.qe = NewQueryEngine(tsv, tsv.se, config)
+	tsv.qe = NewQueryEngine(tsv, tsv.se)
 	tsv.te = NewTxEngine(tsv, config)
 	tsv.hw = heartbeat.NewWriter(tsv, alias, config)
 	tsv.hr = heartbeat.NewReader(tsv, config)
@@ -349,7 +349,6 @@ func (tsv *TabletServer) InitDBConfig(target querypb.Target, dbcfgs *dbconfigs.D
 	tsv.dbconfigs = dbcfgs
 
 	tsv.se.InitDBConfig(tsv.dbconfigs.DbaWithDB())
-	tsv.qe.InitDBConfig(tsv.dbconfigs)
 	tsv.te.InitDBConfig(tsv.dbconfigs)
 	tsv.hw.InitDBConfig(tsv.dbconfigs)
 	tsv.hr.InitDBConfig(tsv.dbconfigs)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -247,7 +247,7 @@ func NewTabletServer(config tabletenv.TabletConfig, topoServer *topo.Server, ali
 	})
 	tsv.vstreamer = vstreamer.NewEngine(tsv, srvTopoServer, tsv.se)
 	tsv.watcher = NewReplicationWatcher(tsv.vstreamer, config)
-	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer, config)
+	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer)
 	return tsv
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1439,7 +1439,10 @@ func TestDMLQueryWithoutWhereClause(t *testing.T) {
 
 	db.AddQuery(q+" limit 10001", &sqltypes.Result{})
 
-	_, _, err = tsv.BeginExecute(context.Background(), &target, q, nil, nil)
+	ctx := context.Background()
+	_, txid, err := tsv.BeginExecute(ctx, &target, q, nil, nil)
+	require.NoError(t, err)
+	err = tsv.Commit(ctx, &target, txid)
 	require.NoError(t, err)
 }
 

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -28,13 +28,6 @@ import (
 
 var errRejected = errors.New("rejected")
 
-type dummyChecker struct {
-}
-
-func (dummyChecker) CheckMySQL() {}
-
-var DummyChecker = dummyChecker{}
-
 type testUtils struct{}
 
 func newTestUtils() *testUtils {

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -26,7 +26,6 @@ import (
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
-	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/dtids"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
@@ -67,6 +66,7 @@ func (state txEngineState) String() string {
 // states. It will start and shut down the underlying tx-pool as required.
 // It does this in a concurrently safe way.
 type TxEngine struct {
+	env tabletenv.Env
 	// the following four fields are interconnected. `state` and `nextState` should be protected by the
 	// `stateLock`
 	//
@@ -84,8 +84,6 @@ type TxEngine struct {
 	// transition while creating new transactions
 	beginRequests sync.WaitGroup
 
-	dbconfigs *dbconfigs.DBConfigs
-
 	twopcEnabled        bool
 	shutdownGracePeriod time.Duration
 	coordinatorAddress  string
@@ -98,32 +96,14 @@ type TxEngine struct {
 }
 
 // NewTxEngine creates a new TxEngine.
-func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *TxEngine {
+func NewTxEngine(env tabletenv.Env) *TxEngine {
+	config := env.Config()
 	te := &TxEngine{
+		env:                 env,
 		shutdownGracePeriod: time.Duration(config.TxShutDownGracePeriod * 1e9),
 	}
-	limiter := txlimiter.New(
-		config.TransactionCap,
-		config.TransactionLimitPerUser,
-		config.EnableTransactionLimit,
-		config.EnableTransactionLimitDryRun,
-		config.TransactionLimitByUsername,
-		config.TransactionLimitByPrincipal,
-		config.TransactionLimitByComponent,
-		config.TransactionLimitBySubcomponent,
-	)
-	te.txPool = NewTxPool(
-		config.PoolNamePrefix,
-		config.TransactionCap,
-		config.FoundRowsPoolSize,
-		config.TxPoolPrefillParallelism,
-		time.Duration(config.TransactionTimeout*1e9),
-		time.Duration(config.TxPoolTimeout*1e9),
-		time.Duration(config.IdleTimeout*1e9),
-		config.TxPoolWaiterCap,
-		checker,
-		limiter,
-	)
+	limiter := txlimiter.New(env)
+	te.txPool = NewTxPool(env, limiter)
 	te.twopcEnabled = config.TwoPCEnable
 	if te.twopcEnabled {
 		if config.TwoPCCoordinatorAddress == "" {
@@ -150,7 +130,7 @@ func NewTxEngine(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *
 		3,
 		0,
 		time.Duration(config.IdleTimeout*1e9),
-		checker,
+		env,
 	)
 	te.twoPC = NewTwoPC(readPool)
 	te.transitionSignal = make(chan struct{})
@@ -359,16 +339,11 @@ func (te *TxEngine) transitionTo(nextState txEngineState) error {
 	return nil
 }
 
-// InitDBConfig must be called before Init.
-func (te *TxEngine) InitDBConfig(dbcfgs *dbconfigs.DBConfigs) {
-	te.dbconfigs = dbcfgs
-}
-
 // Init must be called once when vttablet starts for setting
 // up the metadata tables.
 func (te *TxEngine) Init() error {
 	if te.twopcEnabled {
-		return te.twoPC.Init(te.dbconfigs.SidecarDBName.Get(), te.dbconfigs.DbaWithDB())
+		return te.twoPC.Init(te.env.DBConfigs().SidecarDBName.Get(), te.env.DBConfigs().DbaWithDB())
 	}
 	return nil
 }
@@ -377,10 +352,10 @@ func (te *TxEngine) Init() error {
 // all previously prepared transactions from the redo log.
 // this should only be called when the state is already locked
 func (te *TxEngine) open() {
-	te.txPool.Open(te.dbconfigs.AppWithDB(), te.dbconfigs.DbaWithDB(), te.dbconfigs.AppDebugWithDB())
+	te.txPool.Open(te.env.DBConfigs().AppWithDB(), te.env.DBConfigs().DbaWithDB(), te.env.DBConfigs().AppDebugWithDB())
 
 	if te.twopcEnabled && te.state == AcceptingReadAndWrite {
-		te.twoPC.Open(te.dbconfigs)
+		te.twoPC.Open(te.env.DBConfigs())
 		if err := te.prepareFromRedo(); err != nil {
 			// If this operation fails, we choose to raise an alert and
 			// continue anyway. Serving traffic is considered more important

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -125,13 +125,7 @@ func NewTxEngine(env tabletenv.Env) *TxEngine {
 	// the system can deadlock if all connections get moved to
 	// the TxPreparedPool.
 	te.preparedPool = NewTxPreparedPool(config.TransactionCap - 2)
-	readPool := connpool.New(
-		config.PoolNamePrefix+"TxReadPool",
-		3,
-		0,
-		time.Duration(config.IdleTimeout*1e9),
-		env,
-	)
+	readPool := connpool.New(env, config.PoolNamePrefix+"TxReadPool", 3, 0, time.Duration(config.IdleTimeout*1e9))
 	te.twoPC = NewTwoPC(readPool)
 	te.transitionSignal = make(chan struct{})
 	// By immediately closing this channel, all state changes can simply be made blocking by issuing the

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -42,8 +42,7 @@ func TestTxEngineClose(t *testing.T) {
 	config.TransactionCap = 10
 	config.TransactionTimeout = 0.5
 	config.TxShutDownGracePeriod = 0
-	te := NewTxEngine(nil, config)
-	te.InitDBConfig(dbcfgs)
+	te := NewTxEngine(tabletenv.NewTestEnv(&config, dbcfgs))
 
 	// Normal close.
 	te.open()
@@ -467,8 +466,7 @@ func setupTxEngine(db *fakesqldb.DB) *TxEngine {
 	config.TransactionCap = 10
 	config.TransactionTimeout = 0.5
 	config.TxShutDownGracePeriod = 0
-	te := NewTxEngine(nil, config)
-	te.InitDBConfig(dbcfgs)
+	te := NewTxEngine(tabletenv.NewTestEnv(&config, dbcfgs))
 	return te
 }
 

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -105,8 +105,8 @@ func NewTxPool(env tabletenv.Env, limiter txlimiter.TxLimiter) *TxPool {
 	transactionTimeout := time.Duration(config.TransactionTimeout * 1e9)
 	axp := &TxPool{
 		env:                    env,
-		conns:                  connpool.New(prefix+"TransactionPool", config.TransactionCap, config.TxPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9), env),
-		foundRowsPool:          connpool.New(prefix+"FoundRowsPool", config.FoundRowsPoolSize, config.TxPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9), env),
+		conns:                  connpool.New(env, prefix+"TransactionPool", config.TransactionCap, config.TxPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9)),
+		foundRowsPool:          connpool.New(env, prefix+"FoundRowsPool", config.FoundRowsPoolSize, config.TxPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9)),
 		activePool:             pools.NewNumbered(),
 		lastID:                 sync2.NewAtomicInt64(time.Now().UnixNano()),
 		transactionTimeout:     sync2.NewAtomicDuration(transactionTimeout),

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -697,24 +697,14 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 }
 
 func newTxPool() *TxPool {
+	config := tabletenv.DefaultQsConfig
 	randID := rand.Int63()
-	poolName := fmt.Sprintf("TestTransactionPool-%d", randID)
-	transactionCap := 300
-	transactionTimeout := time.Duration(30 * time.Second)
-	transactionPoolTimeout := time.Duration(40 * time.Second)
-	waiterCap := 500000
-	idleTimeout := time.Duration(30 * time.Second)
+	config.PoolNamePrefix = fmt.Sprintf("TestTransactionPool-%d", randID)
+	config.TransactionCap = 300
+	config.TransactionTimeout = 30
+	config.TxPoolTimeout = 40
+	config.TxPoolWaiterCap = 500000
+	config.IdleTimeout = 30
 	limiter := &txlimiter.TxAllowAll{}
-	return NewTxPool(
-		poolName,
-		transactionCap,
-		transactionCap,
-		0,
-		transactionTimeout,
-		transactionPoolTimeout,
-		idleTimeout,
-		waiterCap,
-		DummyChecker,
-		limiter,
-	)
+	return NewTxPool(tabletenv.NewTestEnv(&config, nil), limiter)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/main_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_test.go
@@ -22,6 +22,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 )
 
@@ -48,12 +52,21 @@ func TestMain(m *testing.M) {
 
 		// engine cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		engine = NewEngine(env.SrvTopo, env.SchemaEngine)
-		engine.InitDBConfig(env.Dbcfgs.DbaWithDB())
+		engine = NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine)
 		engine.Open(env.KeyspaceName, env.Cells[0])
 		defer engine.Close()
 
 		return m.Run()
 	}()
 	os.Exit(exitCode)
+}
+
+func customEngine(t *testing.T, modifier func(mysql.ConnParams) mysql.ConnParams) *Engine {
+	original, err := env.Dbcfgs.AppWithDB().MysqlParams()
+	require.NoError(t, err)
+	modified := modifier(*original)
+	dbcfgs := dbconfigs.NewTestDBConfigs(modified, modified, modified.DbName)
+	engine := NewEngine(tabletenv.NewTestEnv(env.TabletEnv.Config(), dbcfgs), env.SrvTopo, env.SchemaEngine)
+	engine.Open(env.KeyspaceName, env.Cells[0])
+	return engine
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
@@ -39,7 +39,7 @@ func TestStartSnapshot(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	conn, err := snapshotConnect(ctx, engine.cp)
+	conn, err := snapshotConnect(ctx, env.TabletEnv.DBConfigs().AppWithDB())
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -46,6 +46,7 @@ type Env struct {
 	ShardName    string
 	Cells        []string
 
+	TabletEnv    tabletenv.Env
 	TopoServ     *topo.Server
 	SrvTopo      srvtopo.Server
 	Dbcfgs       *dbconfigs.DBConfigs
@@ -102,9 +103,10 @@ func Init() (*Env, error) {
 	}
 
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
-	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
 	config := tabletenv.DefaultQsConfig
-	te.SchemaEngine = schema.NewEngine(tabletenv.NewTestEnv(&config, nil))
+	te.TabletEnv = tabletenv.NewTestEnv(&config, te.Dbcfgs)
+	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
+	te.SchemaEngine = schema.NewEngine(te.TabletEnv)
 	te.SchemaEngine.InitDBConfig(te.Dbcfgs.DbaWithDB())
 
 	// The first vschema should not be empty. Leads to Node not found error.

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -103,7 +103,8 @@ func Init() (*Env, error) {
 
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
-	te.SchemaEngine = schema.NewEngine(checker{}, tabletenv.DefaultQsConfig)
+	config := tabletenv.DefaultQsConfig
+	te.SchemaEngine = schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
 	te.SchemaEngine.InitDBConfig(te.Dbcfgs.DbaWithDB())
 
 	// The first vschema should not be empty. Leads to Node not found error.

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -104,7 +104,7 @@ func Init() (*Env, error) {
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
 	config := tabletenv.DefaultQsConfig
-	te.SchemaEngine = schema.NewEngine(tabletenv.NewTestEnv(&config, nil, nil))
+	te.SchemaEngine = schema.NewEngine(tabletenv.NewTestEnv(&config, nil))
 	te.SchemaEngine.InitDBConfig(te.Dbcfgs.DbaWithDB())
 
 	// The first vschema should not be empty. Leads to Node not found error.

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -28,7 +28,6 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/vttest"
@@ -53,12 +52,6 @@ type Env struct {
 	Mysqld       *mysqlctl.Mysqld
 	SchemaEngine *schema.Engine
 }
-
-type checker struct{}
-
-var _ = connpool.MySQLChecker(checker{})
-
-func (checker) CheckMySQL() {}
 
 // Init initializes an Env.
 func Init() (*Env, error) {


### PR DESCRIPTION
This cleanup improves readability where all the common parameters of tabletserver are unified under an interface tabletenv.Env. This will further facilitate componentization.