### PR TITLE
increment query counts for stream queries from vtgate

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1258,6 +1258,7 @@ func (e *Executor) StreamExecute(ctx context.Context, method string, safeSession
 	}
 
 	logStats.ExecuteTime = time.Since(execStart)
+	e.updateQueryCounts(plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
 
 	return err
 }


### PR DESCRIPTION
## Description
We use the QueriesProcessedByTable metric to get visibility into the QPS per table. Currently, this metric does not include stream queries. This PR handles that by incrementing query counts in the `StreamExecute` API.