### PR TITLE
Stream query counts

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1258,6 +1258,7 @@ func (e *Executor) StreamExecute(ctx context.Context, method string, safeSession
 	}
 
 	logStats.ExecuteTime = time.Since(execStart)
+	e.updateQueryCounts("StreamExecute", plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
 
 	return err
 }

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -223,7 +223,7 @@ func (e *planExecute) executePlan(ctx context.Context, plan *engine.Plan, vcurso
 func (e *planExecute) logExecutionEnd(logStats *LogStats, execStart time.Time, plan *engine.Plan, err error, qr *sqltypes.Result) uint64 {
 	logStats.ExecuteTime = time.Since(execStart)
 
-	e.e.updateQueryCounts(plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
+	e.e.updateQueryCounts("Execute", plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
 
 	var errCount uint64
 	if err != nil {


### PR DESCRIPTION
## Description
We use the QueriesProcessedByTable metric to get visibility into the QPS per table. Currently, this metric has two limitations.
1. it does not include stream queries. This PR handles that by incrementing query counts in the StreamExecute API.
2. it does not include what type of operation it was (`Execute` vs. `StreamExecute`). This PR handles that by explicitly passing the operation before incrementing counts.

