### PR TITLE
Adds supports to target DestinationKeyspaceID to handle other

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1161,6 +1161,15 @@ func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sq
 	}
 
 	switch dest.(type) {
+	case key.DestinationKeyspaceID:
+		rss, err := e.resolver.resolver.ResolveDestination(ctx, destKeyspace, destTabletType, dest)
+		if err != nil {
+			return nil, err
+		}
+		if len(rss) != 1 {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Unexpected error, DestinationKeyspaceID mapping to multiple shards: %s, got: %v", sql, dest)
+		}
+		destKeyspace, dest = rss[0].Target.Keyspace, key.DestinationShard(rss[0].Target.Shard)
 	case key.DestinationShard:
 	// noop
 	default:

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1102,6 +1102,22 @@ func TestExecutorOther(t *testing.T) {
 				SbcLookupCnt: 0,
 			},
 		},
+		{
+			targetStr: "TestExecutor/-20",
+			wantCnts: cnts{
+				Sbc1Cnt:      1,
+				Sbc2Cnt:      0,
+				SbcLookupCnt: 0,
+			},
+		},
+		{
+			targetStr: "TestExecutor[00]",
+			wantCnts: cnts{
+				Sbc1Cnt:      1,
+				Sbc2Cnt:      0,
+				SbcLookupCnt: 0,
+			},
+		},
 	}
 
 	stmts := []string{


### PR DESCRIPTION
# Description

* minor change: for handle other if the target is a keyspaceID, it should be safe to execute it because is by definition a single shard. 
* Use case for this is to be able to do queries like this:
   ```
    # Let's say we have a shard with two shards -40 ,  40-
    # Before this change, this works:
    use ks/-40
    show tables; 
    # But this does not work:
    use ks[00];
    show tables;
   ```
* Given that a targeting to a keyspaceID is also a single shard, it seems like this should be supported. 