### PR TITLE
Remove code disallowing transaction_mode upgrade from the version vtgate

### DIFF
--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -53,17 +53,6 @@ func (txc *TxConn) Begin(ctx context.Context, session *SafeSession) error {
 			return err
 		}
 	}
-	// UNSPECIFIED & SINGLE mode are always allowed.
-	switch session.TransactionMode {
-	case vtgatepb.TransactionMode_MULTI:
-		if txc.mode == vtgatepb.TransactionMode_SINGLE {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "requested transaction mode %v disallowed: vtgate must be started with --transaction_mode=MULTI (or TWOPC). Current transaction mode: %v", session.TransactionMode, txc.mode)
-		}
-	case vtgatepb.TransactionMode_TWOPC:
-		if txc.mode != vtgatepb.TransactionMode_TWOPC {
-			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "requested transaction mode %v disallowed: vtgate must be started with --transaction_mode=TWOPC. Current transaction mode: %v", session.TransactionMode, txc.mode)
-		}
-	}
 	session.Session.InTransaction = true
 	return nil
 }
@@ -79,10 +68,6 @@ func (txc *TxConn) Commit(ctx context.Context, session *SafeSession) error {
 	twopc := false
 	switch session.TransactionMode {
 	case vtgatepb.TransactionMode_TWOPC:
-		if txc.mode != vtgatepb.TransactionMode_TWOPC {
-			_ = txc.Rollback(ctx, session)
-			return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "2pc transaction disallowed")
-		}
 		twopc = true
 	case vtgatepb.TransactionMode_UNSPECIFIED:
 		twopc = (txc.mode == vtgatepb.TransactionMode_TWOPC)

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -64,26 +64,6 @@ func TestTxConnBegin(t *testing.T) {
 	}
 }
 
-func TestTxConnBeginDisallowed(t *testing.T) {
-	sc, _, _, _, _, _ := newTestTxConnEnv(t, "TestTxConn")
-
-	sc.txConn.mode = vtgatepb.TransactionMode_SINGLE
-	session := &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_MULTI}
-	err := sc.txConn.Begin(context.Background(), NewSafeSession(session))
-	wantErr := "requested transaction mode MULTI disallowed: vtgate must be started with --transaction_mode=MULTI (or TWOPC). Current transaction mode: SINGLE"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("txConn.Begin: %v, want %s", err, wantErr)
-	}
-
-	sc.txConn.mode = vtgatepb.TransactionMode_MULTI
-	session = &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_TWOPC}
-	err = sc.txConn.Begin(context.Background(), NewSafeSession(session))
-	wantErr = "requested transaction mode TWOPC disallowed: vtgate must be started with --transaction_mode=TWOPC. Current transaction mode: MULTI"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("txConn.Begin: %v, want %s", err, wantErr)
-	}
-}
-
 func TestTxConnCommitSuccess(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, "TestTxConn")
 	sc.txConn.mode = vtgatepb.TransactionMode_MULTI


### PR DESCRIPTION
was started with.  This is a potential breaking change if you depended
on an upgrade being impossible.
The use-case we are enabling is when you want to default to a lower
transaction mode, and then allow upgrade to a higher mode for advanced
users, or apps that need the higher-level transaction guarantees.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>