### PR TITLE
Stream execute query logging

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -216,7 +216,6 @@ func (qre *QueryExecutor) txConnExec(conn *TxConnection) (*sqltypes.Result, erro
 
 // Stream performs a streaming query execution.
 func (qre *QueryExecutor) Stream(callback func(*sqltypes.Result) error) error {
-	qre.logStats.OriginalSQL = qre.query
 	qre.logStats.PlanType = qre.plan.PlanID.String()
 
 	defer func(start time.Time) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1085,6 +1085,7 @@ func TestTabletServerStreamExecuteComments(t *testing.T) {
 			t.Errorf("logstats: SQL want %s got %s", wantSQL, stats.OriginalSQL)
 		}
 	default:
+		t.Fatal("stats are empty")
 	}
 }
 func TestTabletServerExecuteBatch(t *testing.T) {


### PR DESCRIPTION
## Description
At Slack, we noticed that we're dropping logs for all queries of type `STREAM_EXECUTE` at the vttablet level. We run with the `querylog-filter-tag` option to determine what queries should be logged. The reason we were dropping all the logs for stream queries is because the `Stream()` codepath overwrites the `OriginalSQL` in logstats, which we rely on for checking if we should log this query [here](https://github.com/tinyspeck/vitess/blob/master/go/vt/vttablet/tabletserver/tabletenv/logstats.go#L183-L185). This PR fixes that by not overwriting that field.

## More details
The bug seems to be in the Stream vttablet method, we [overwrite](https://github.com/tinyspeck/vitess/blob/master/go/vt/vttablet/tabletserver/query_executor.go#L205) `OriginalSQL` to the version without the comments. In the [callback](https://github.com/tinyspeck/vitess/blob/master/go/vt/vttablet/tabletserver/tabletserver.go#L1074-L1090) that we pass to `execRequest`, we end up calling `SplitMarginComments` which strips comments before invoking `Stream()`. So, in the stream context, we don’t have the comments attached to the sql. This is fine because execRequest wraps the entire thing, and it has the full query with the comment.

I thought about two possible fixes:
1. append the leading and trailing comments when overwriting OriginalSQL inside Stream()
2. don’t overwrite OriginalSQL inside Stream(). this assignment seems unnecessary because execRequest initializes this properly and wraps the call. This PR implements this approach.

## Testing
Added a unit test to ensure we preserve comments in the stream path.


