### PR TITLE
Update query counts for stream queries from vtgate

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1267,6 +1267,7 @@ func (e *Executor) StreamExecute(ctx context.Context, method string, safeSession
 	}
 
 	logStats.ExecuteTime = time.Since(execStart)
+	e.updateQueryCounts(plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
 
 	return err
 }


### PR DESCRIPTION
## Description
We use the QueriesProcessedByTable metric to get visibility into the QPS per table. Currently, this metric does not get incremented in the stream query path. This PR handles that by incrementing query counts in the `StreamExecute` API.

## Testing
Manually tested by uploading the build to a vtgate and sent some olap mode queries via
`set workload='olap';`

Signed-off-by: Arka Ganguli <arkaganguli1@gmail.com>