### PR TITLE
pools: add timeouts for all conn pools

### DIFF
--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -45,6 +45,11 @@ type connectResult struct {
 // FIXME(alainjobart) once we have more of a server side, add test cases
 // to cover all failure scenarios.
 func Connect(ctx context.Context, params *ConnParams) (*Conn, error) {
+	if params.ConnectTimeoutMs != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(params.ConnectTimeoutMs)*time.Millisecond)
+		defer cancel()
+	}
 	netProto := "tcp"
 	addr := ""
 	if params.UnixSocket != "" {

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -92,6 +92,16 @@ func TestConnectTimeout(t *testing.T) {
 		t.Errorf("Was expecting context.DeadlineExceeded but got: %v", err)
 	}
 
+	// Tests a connection timeout through params
+	ctx = context.Background()
+	paramsWithTimeout := params
+	paramsWithTimeout.ConnectTimeoutMs = 1
+	_, err = Connect(ctx, paramsWithTimeout)
+	cancel()
+	if err != context.DeadlineExceeded {
+		t.Errorf("Was expecting context.DeadlineExceeded but got: %v", err)
+	}
+
 	// Now the server will listen, but close all connections on accept.
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -45,7 +45,7 @@ var (
 )
 
 // Factory is a function that can be used to create a resource.
-type Factory func() (Resource, error)
+type Factory func(context.Context) (Resource, error)
 
 // Resource defines the interface that every resource must provide.
 // Thread synchronization between Close() and IsClosed()
@@ -228,7 +228,7 @@ func (rp *ResourcePool) get(ctx context.Context) (resource Resource, err error) 
 	// Unwrap
 	if wrapper.resource == nil {
 		span, _ := trace.NewSpan(ctx, "ResourcePool.factory")
-		wrapper.resource, err = rp.factory()
+		wrapper.resource, err = rp.factory(ctx)
 		span.Finish()
 		if err != nil {
 			rp.resources <- resourceWrapper{}
@@ -267,7 +267,7 @@ func (rp *ResourcePool) Put(resource Resource) {
 }
 
 func (rp *ResourcePool) reopenResource(wrapper *resourceWrapper) {
-	if r, err := rp.factory(); err == nil {
+	if r, err := rp.factory(context.TODO()); err == nil {
 		wrapper.resource = r
 		wrapper.timeUsed = time.Now()
 	} else {

--- a/go/pools/resource_pool_flaky_test.go
+++ b/go/pools/resource_pool_flaky_test.go
@@ -44,16 +44,16 @@ func logWait(start time.Time) {
 	waitStarts = append(waitStarts, start)
 }
 
-func PoolFactory() (Resource, error) {
+func PoolFactory(ctx context.Context) (Resource, error) {
 	count.Add(1)
 	return &TestResource{lastID.Add(1), false}, nil
 }
 
-func FailFactory() (Resource, error) {
+func FailFactory(ctx context.Context) (Resource, error) {
 	return nil, errors.New("Failed")
 }
 
-func SlowFailFactory() (Resource, error) {
+func SlowFailFactory(ctx context.Context) (Resource, error) {
 	time.Sleep(10 * time.Millisecond)
 	return nil, errors.New("Failed")
 }

--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -19,7 +19,6 @@ package dbconnpool
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -36,16 +35,7 @@ type DBConnection struct {
 // NewDBConnection returns a new DBConnection based on the ConnParams
 // and will use the provided stats to collect timing.
 func NewDBConnection(info dbconfigs.Connector) (*DBConnection, error) {
-	ctx := context.Background()
-	params, err := info.MysqlParams()
-	if err != nil {
-		return nil, err
-	}
-	if params.ConnectTimeoutMs != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(params.ConnectTimeoutMs)*time.Millisecond)
-		defer cancel()
-	}
+	ctx := context.TODO()
 	c, err := info.Connect(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -34,8 +34,7 @@ type DBConnection struct {
 
 // NewDBConnection returns a new DBConnection based on the ConnParams
 // and will use the provided stats to collect timing.
-func NewDBConnection(info dbconfigs.Connector) (*DBConnection, error) {
-	ctx := context.TODO()
+func NewDBConnection(ctx context.Context, info dbconfigs.Connector) (*DBConnection, error) {
 	c, err := info.Connect(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -167,8 +167,8 @@ func (cp *ConnectionPool) Open(info dbconfigs.Connector) {
 }
 
 // connect is used by the resource pool to create a new Resource.
-func (cp *ConnectionPool) connect() (pools.Resource, error) {
-	c, err := NewDBConnection(cp.info)
+func (cp *ConnectionPool) connect(ctx context.Context) (pools.Resource, error) {
+	c, err := NewDBConnection(ctx, cp.info)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (cp *ConnectionPool) Get(ctx context.Context) (*PooledDBConnection, error) 
 	if cp.resolutionFrequency > 0 &&
 		cp.hostIsNotIP &&
 		!cp.validAddress(net.ParseIP(r.(*PooledDBConnection).RemoteAddr().String())) {
-		err := r.(*PooledDBConnection).Reconnect()
+		err := r.(*PooledDBConnection).Reconnect(ctx)
 		if err != nil {
 			p.Put(r)
 			return nil, err

--- a/go/vt/dbconnpool/pooled_connection.go
+++ b/go/vt/dbconnpool/pooled_connection.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package dbconnpool
 
+import "context"
+
 // PooledDBConnection re-exposes DBConnection to be used by ConnectionPool.
 type PooledDBConnection struct {
 	*DBConnection
@@ -33,9 +35,9 @@ func (pc *PooledDBConnection) Recycle() {
 
 // Reconnect replaces the existing underlying connection with a new one,
 // if possible. Recycle should still be called afterwards.
-func (pc *PooledDBConnection) Reconnect() error {
+func (pc *PooledDBConnection) Reconnect(ctx context.Context) error {
 	pc.DBConnection.Close()
-	newConn, err := NewDBConnection(pc.pool.info)
+	newConn, err := NewDBConnection(ctx, pc.pool.info)
 	if err != nil {
 		return err
 	}

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -472,12 +472,12 @@ func (fmd *FakeMysqlDaemon) GetAppConnection(ctx context.Context) (*dbconnpool.P
 
 // GetDbaConnection is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) GetDbaConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(fmd.db.ConnParams())
+	return dbconnpool.NewDBConnection(context.Background(), fmd.db.ConnParams())
 }
 
 // GetAllPrivsConnection is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) GetAllPrivsConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(fmd.db.ConnParams())
+	return dbconnpool.NewDBConnection(context.Background(), fmd.db.ConnParams())
 }
 
 // SetSemiSyncEnabled is part of the MysqlDaemon interface.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1097,12 +1097,12 @@ func (mysqld *Mysqld) GetAppConnection(ctx context.Context) (*dbconnpool.PooledD
 
 // GetDbaConnection creates a new DBConnection.
 func (mysqld *Mysqld) GetDbaConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(mysqld.dbcfgs.Dba())
+	return dbconnpool.NewDBConnection(context.TODO(), mysqld.dbcfgs.Dba())
 }
 
 // GetAllPrivsConnection creates a new DBConnection.
 func (mysqld *Mysqld) GetAllPrivsConnection() (*dbconnpool.DBConnection, error) {
-	return dbconnpool.NewDBConnection(mysqld.dbcfgs.AllPrivsWithDB())
+	return dbconnpool.NewDBConnection(context.TODO(), mysqld.dbcfgs.AllPrivsWithDB())
 }
 
 // Close will close this instance of Mysqld. It will wait for all dba

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -40,7 +40,7 @@ func getPoolReconnect(ctx context.Context, pool *dbconnpool.ConnectionPool) (*db
 	if _, err := conn.ExecuteFetch("SELECT 1", 1, false); err != nil {
 		// If we get a connection error, try to reconnect.
 		if sqlErr, ok := err.(*mysql.SQLError); ok && (sqlErr.Number() == mysql.CRServerGone || sqlErr.Number() == mysql.CRServerLost) {
-			if err := conn.Reconnect(); err != nil {
+			if err := conn.Reconnect(ctx); err != nil {
 				conn.Recycle()
 				return nil, err
 			}

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -81,7 +81,7 @@ func NewReader(env tabletenv.Env) *Reader {
 		interval: config.HeartbeatInterval,
 		ticks:    timer.NewTimer(config.HeartbeatInterval),
 		errorLog: logutil.NewThrottledLogger("HeartbeatReporter", 60*time.Second),
-		pool:     connpool.New(env, "HeartbeatReadPool", 1, 0, time.Duration(config.IdleTimeout*1e9)),
+		pool:     connpool.New(env, "HeartbeatReadPool", 1, 0, 0, time.Duration(config.IdleTimeout*1e9)),
 	}
 }
 

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -152,7 +152,7 @@ func (w *Writer) Close() {
 // and we also execute them with an isolated connection that turns off the binlog and
 // is closed at the end.
 func (w *Writer) initializeTables(cp dbconfigs.Connector) error {
-	conn, err := dbconnpool.NewDBConnection(cp)
+	conn, err := dbconnpool.NewDBConnection(context.TODO(), cp)
 	if err != nil {
 		return vterrors.Wrap(err, "Failed to create connection for heartbeat")
 	}

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -84,7 +84,7 @@ func NewWriter(env tabletenv.Env, alias topodatapb.TabletAlias) *Writer {
 		interval:    config.HeartbeatInterval,
 		ticks:       timer.NewTimer(config.HeartbeatInterval),
 		errorLog:    logutil.NewThrottledLogger("HeartbeatWriter", 60*time.Second),
-		pool:        connpool.New(env, "HeartbeatWritePool", 1, 0, time.Duration(config.IdleTimeout*1e9)),
+		pool:        connpool.New(env, "HeartbeatWritePool", 1, 0, 0, time.Duration(config.IdleTimeout*1e9)),
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -64,7 +64,7 @@ func TestDBConnExec(t *testing.T) {
 	defer connPool.Close()
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 	defer cancel()
-	dbConn, err := NewDBConn(connPool, db.ConnParams())
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
 	if dbConn != nil {
 		defer dbConn.Close()
 	}
@@ -140,7 +140,7 @@ func TestDBConnDeadline(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(50*time.Millisecond))
 	defer cancel()
 
-	dbConn, err := NewDBConn(connPool, db.ConnParams())
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
 	if dbConn != nil {
 		defer dbConn.Close()
 	}
@@ -174,7 +174,7 @@ func TestDBConnDeadline(t *testing.T) {
 
 	startCounts = mysqlTimings.Counts()
 
-	// Test with just the background context (with no deadline)
+	// Test with just the Background context (with no deadline)
 	result, err = dbConn.Exec(context.Background(), sql, 1, false)
 	if err != nil {
 		t.Fatalf("should not get an error, err: %v", err)
@@ -193,7 +193,7 @@ func TestDBConnKill(t *testing.T) {
 	connPool := newPool()
 	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer connPool.Close()
-	dbConn, err := NewDBConn(connPool, db.ConnParams())
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
 	if dbConn != nil {
 		defer dbConn.Close()
 	}
@@ -217,7 +217,7 @@ func TestDBConnKill(t *testing.T) {
 		t.Fatalf("kill should succeed, but got error: %v", err)
 	}
 
-	err = dbConn.reconnect()
+	err = dbConn.reconnect(context.Background())
 	if err != nil {
 		t.Fatalf("reconnect should succeed, but got error: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestDBNoPoolConnKill(t *testing.T) {
 	connPool := newPool()
 	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer connPool.Close()
-	dbConn, err := NewDBConnNoPool(db.ConnParams(), connPool.dbaPool)
+	dbConn, err := NewDBConnNoPool(context.Background(), db.ConnParams(), connPool.dbaPool)
 	if dbConn != nil {
 		defer dbConn.Close()
 	}
@@ -260,7 +260,7 @@ func TestDBNoPoolConnKill(t *testing.T) {
 		t.Fatalf("kill should succeed, but got error: %v", err)
 	}
 
-	err = dbConn.reconnect()
+	err = dbConn.reconnect(context.Background())
 	if err != nil {
 		t.Fatalf("reconnect should succeed, but got error: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestDBConnStream(t *testing.T) {
 	defer connPool.Close()
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 	defer cancel()
-	dbConn, err := NewDBConn(connPool, db.ConnParams())
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
 	if dbConn != nil {
 		defer dbConn.Close()
 	}

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -50,6 +50,7 @@ type Pool struct {
 	connections        *pools.ResourcePool
 	capacity           int
 	prefillParallelism int
+	timeout            time.Duration
 	idleTimeout        time.Duration
 	dbaPool            *dbconnpool.ConnectionPool
 	appDebugParams     dbconfigs.Connector
@@ -57,12 +58,13 @@ type Pool struct {
 
 // New creates a new Pool. The name is used
 // to publish stats only.
-func New(env tabletenv.Env, name string, capacity int, prefillParallelism int, idleTimeout time.Duration) *Pool {
+func New(env tabletenv.Env, name string, capacity int, prefillParallelism int, timeout, idleTimeout time.Duration) *Pool {
 	cp := &Pool{
 		env:                env,
 		name:               name,
 		capacity:           capacity,
 		prefillParallelism: prefillParallelism,
+		timeout:            timeout,
 		idleTimeout:        idleTimeout,
 		dbaPool:            dbconnpool.NewConnectionPool("", 1, idleTimeout, 0),
 	}
@@ -151,6 +153,11 @@ func (cp *Pool) Get(ctx context.Context) (*DBConn, error) {
 	span.Annotate("available", p.Available())
 	span.Annotate("active", p.Active())
 
+	if cp.timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cp.timeout)
+		defer cancel()
+	}
 	r, err := p.Get(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -99,8 +99,8 @@ func (cp *Pool) Open(appParams, dbaParams, appDebugParams dbconfigs.Connector) {
 		defer log.Infof("Done opening pool: '%s'", cp.name)
 	}
 
-	f := func() (pools.Resource, error) {
-		return NewDBConn(cp, appParams)
+	f := func(ctx context.Context) (pools.Resource, error) {
+		return NewDBConn(ctx, cp, appParams)
 	}
 	cp.connections = pools.NewResourcePool(f, cp.capacity, cp.capacity, cp.idleTimeout, cp.prefillParallelism, cp.getLogWaitCallback())
 	cp.appDebugParams = appDebugParams
@@ -140,7 +140,7 @@ func (cp *Pool) Get(ctx context.Context) (*DBConn, error) {
 	defer span.Finish()
 
 	if cp.isCallerIDAppDebug(ctx) {
-		return NewDBConnNoPool(cp.appDebugParams, cp.dbaPool)
+		return NewDBConnNoPool(ctx, cp.appDebugParams, cp.dbaPool)
 	}
 	p := cp.pool()
 	if p == nil {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -139,7 +139,6 @@ type QueryEngine struct {
 	streamQList  *QueryList
 
 	// Vars
-	connTimeout        sync2.AtomicDuration
 	queryPoolWaiters   sync2.AtomicInt64
 	queryPoolWaiterCap sync2.AtomicInt64
 	maxResultSize      sync2.AtomicInt64
@@ -181,10 +180,9 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 		queryPoolWaiterCap: sync2.NewAtomicInt64(int64(config.QueryPoolWaiterCap)),
 	}
 
-	qe.conns = connpool.New(env, "ConnPool", config.PoolSize, config.PoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9))
-	qe.connTimeout.Set(time.Duration(config.QueryPoolTimeout * 1e9))
+	qe.conns = connpool.New(env, "ConnPool", config.PoolSize, config.PoolPrefillParallelism, time.Duration(config.QueryPoolTimeout*1e9), time.Duration(config.IdleTimeout*1e9))
 
-	qe.streamConns = connpool.New(env, "StreamConnPool", config.StreamPoolSize, config.StreamPoolPrefillParallelism, time.Duration(config.IdleTimeout*1e9))
+	qe.streamConns = connpool.New(env, "StreamConnPool", config.StreamPoolSize, config.StreamPoolPrefillParallelism, time.Duration(config.QueryPoolTimeout*1e9), time.Duration(config.IdleTimeout*1e9))
 	qe.enableConsolidator = config.EnableConsolidator
 	qe.enableConsolidatorReplicas = config.EnableConsolidatorReplicas
 	qe.enableQueryPlanFieldCaching = config.EnableQueryPlanFieldCaching
@@ -348,16 +346,6 @@ func (qe *QueryEngine) getQueryConn(ctx context.Context) (*connpool.DBConn, erro
 		return nil, vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, "query pool waiter count exceeded")
 	}
 
-	timeout := qe.connTimeout.Get()
-	if timeout != 0 {
-		ctxTimeout, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-		conn, err := qe.conns.Get(ctxTimeout)
-		if err != nil {
-			return nil, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "query pool wait time exceeded")
-		}
-		return conn, err
-	}
 	return qe.conns.Get(ctx)
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -397,7 +397,7 @@ func (qe *QueryEngine) ClearQueryPlanCache() {
 
 // IsMySQLReachable returns true if we can connect to MySQL.
 func (qe *QueryEngine) IsMySQLReachable() bool {
-	conn, err := dbconnpool.NewDBConnection(qe.env.DBConfigs().DbaWithDB())
+	conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.DBConfigs().DbaWithDB())
 	if err != nil {
 		if mysql.IsConnErr(err) {
 			return false

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -72,7 +72,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 		env: env,
 		// We need only one connection because the reloader is
 		// the only one that needs this.
-		conns:      connpool.New(env, "", 1, 0, idleTimeout),
+		conns:      connpool.New(env, "", 1, 0, 0, idleTimeout),
 		ticks:      timer.NewTimer(reloadTime),
 		reloadTime: reloadTime,
 	}

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -162,7 +162,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	appParams := db.ConnParams()
 	dbaParams := db.ConnParams()
 	connPoolIdleTimeout := 10 * time.Second
-	connPool := connpool.New(tabletenv.NewTestEnv(nil, nil, "SchemaTest"), "", 2, 0, connPoolIdleTimeout)
+	connPool := connpool.New(tabletenv.NewTestEnv(nil, nil, "SchemaTest"), "", 2, 0, 0, connPoolIdleTimeout)
 	connPool.Open(appParams, dbaParams, appParams)
 	conn, err := connPool.Get(ctx)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -515,7 +515,7 @@ func (tsv *TabletServer) decideAction(tabletType topodatapb.TabletType, serving 
 }
 
 func (tsv *TabletServer) fullStart() (err error) {
-	c, err := dbconnpool.NewDBConnection(tsv.dbconfigs.AppWithDB())
+	c, err := dbconnpool.NewDBConnection(context.TODO(), tsv.dbconfigs.AppWithDB())
 	if err != nil {
 		log.Errorf("error creating db app connection: %v", err)
 		return err

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -251,7 +251,6 @@ func NewTabletServer(name string, config tabletenv.TabletConfig, topoServer *top
 		return map[string]int64{tsv.GetState(): 1}
 	})
 	tsv.exporter.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", tsv.QueryTimeout.Get)
-	tsv.exporter.NewGaugeDurationFunc("QueryPoolTimeout", "Tablet server timeout to get a connection from the query pool", tsv.qe.connTimeout.Get)
 
 	tsv.registerDebugHealthHandler()
 	tsv.registerQueryzHandler()
@@ -1874,17 +1873,6 @@ func (tsv *TabletServer) TxTimeout() time.Duration {
 	return tsv.te.txPool.Timeout()
 }
 
-// SetTxPoolTimeout changes the transaction pool timeout to the specified value.
-// This function should only be used for testing.
-func (tsv *TabletServer) SetTxPoolTimeout(val time.Duration) {
-	tsv.te.txPool.SetPoolTimeout(val)
-}
-
-// TxPoolTimeout returns the transaction pool timeout.
-func (tsv *TabletServer) TxPoolTimeout() time.Duration {
-	return tsv.te.txPool.PoolTimeout()
-}
-
 // SetQueryPlanCacheCap changes the pool size to the specified value.
 // This function should only be used for testing.
 func (tsv *TabletServer) SetQueryPlanCacheCap(val int) {
@@ -1933,20 +1921,6 @@ func (tsv *TabletServer) MaxDMLRows() int {
 // It should only be used for testing
 func (tsv *TabletServer) SetPassthroughDMLs(val bool) {
 	planbuilder.PassthroughDMLs = val
-}
-
-// SetQueryPoolTimeout changes the timeout to get a connection from the
-// query pool
-// This function should only be used for testing.
-func (tsv *TabletServer) SetQueryPoolTimeout(val time.Duration) {
-	tsv.qe.connTimeout.Set(val)
-}
-
-// GetQueryPoolTimeout returns the timeout to get a connection from the
-// query pool
-// This function should only be used for testing.
-func (tsv *TabletServer) GetQueryPoolTimeout() time.Duration {
-	return tsv.qe.connTimeout.Get()
 }
 
 // SetQueryPoolWaiterCap changes the limit on the number of queries that can be

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -127,7 +127,7 @@ func NewTwoPC(readPool *connpool.Pool) *TwoPC {
 // are not present, they are created.
 func (tpc *TwoPC) Init(sidecarDBName string, dbaparams dbconfigs.Connector) error {
 	dbname := sqlescape.EscapeID(sidecarDBName)
-	conn, err := dbconnpool.NewDBConnection(dbaparams)
+	conn, err := dbconnpool.NewDBConnection(context.TODO(), dbaparams)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -125,7 +125,7 @@ func NewTxEngine(env tabletenv.Env) *TxEngine {
 	// the system can deadlock if all connections get moved to
 	// the TxPreparedPool.
 	te.preparedPool = NewTxPreparedPool(config.TransactionCap - 2)
-	readPool := connpool.New(env, "TxReadPool", 3, 0, time.Duration(config.IdleTimeout*1e9))
+	readPool := connpool.New(env, "TxReadPool", 3, 0, 0, time.Duration(config.IdleTimeout*1e9))
 	te.twoPC = NewTwoPC(readPool)
 	te.transitionSignal = make(chan struct{})
 	// By immediately closing this channel, all state changes can simply be made blocking by issuing the


### PR DESCRIPTION
This is required to make all pools uniform. Currently, there are two different variables, one for conn pool and one for tx pool. But other pools don't have a timeout.

Additional cleanup:
* Plumb context through calls to open connections through resource pool.
* Push down the connection timeout in the mysql params into mysql.Connect.