### PR TITLE
Harmonize local examples with helm improvements

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,11 +21,11 @@ source ./env.sh
 
 # start topo server
 if [ "${TOPO}" = "zk2" ]; then
- CELL=zone1 ./scripts/zk-up.sh
+	CELL=zone1 ./scripts/zk-up.sh
 elif [ "${TOPO}" = "k8s" ]; then
- CELL=zone1 ./scripts/k3s-up.sh
+	CELL=zone1 ./scripts/k3s-up.sh
 else
- CELL=zone1 ./scripts/etcd-up.sh
+	CELL=zone1 ./scripts/etcd-up.sh
 fi
 
 # start vtctld
@@ -33,18 +33,18 @@ CELL=zone1 ./scripts/vtctld-up.sh
 
 # start vttablets for keyspace commerce
 for i in 100 101 102; do
- CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
- CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ./scripts/vttablet-up.sh
+	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
+	CELL=zone1 KEYSPACE=commerce TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
 # set one of the replicas to master
-vtctlclient -server localhost:15999 InitShardMaster -force commerce/0 zone1-100
+vtctlclient InitShardMaster -force commerce/0 zone1-100
 
 # create the schema
-vtctlclient -server localhost:15999 ApplySchema -sql-file create_commerce_schema.sql commerce
+vtctlclient ApplySchema -sql-file create_commerce_schema.sql commerce
 
 # create the vschema
-vtctlclient -server localhost:15999 ApplyVSchema -vschema_file vschema_commerce_initial.json commerce
+vtctlclient ApplyVSchema -vschema_file vschema_commerce_initial.json commerce
 
 # start vtgate
 CELL=zone1 ./scripts/vtgate-up.sh

--- a/examples/local/201_customer_tablets.sh
+++ b/examples/local/201_customer_tablets.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,11 +21,8 @@
 source ./env.sh
 
 for i in 200 201 202; do
- CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
+	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
+	CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctlclient -server localhost:15999 InitShardMaster -force customer/0 zone1-200
-vtctlclient -server localhost:15999 ApplyVSchema -vschema '{ "tables": { "product": {} } }' commerce
-vtctlclient -server localhost:15999 ApplyVSchema -vschema '{ "tables": { "customer": {}, "corder": {} } }' customer
-
+vtctlclient InitShardMaster -force customer/0 zone1-200

--- a/examples/local/202_move_tables.sh
+++ b/examples/local/202_move_tables.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,12 +19,4 @@
 
 source ./env.sh
 
-vtctlclient \
-    -server localhost:15999 \
-    -log_dir "$VTDATAROOT"/tmp \
-    -alsologtostderr \
-    MoveTables \
-    -workflow=commerce2customer \
-    commerce customer customer,corder
-
-sleep 2
+vtctlclient MoveTables -workflow=commerce2customer commerce customer '{"customer":{}, "corder":{}}'

--- a/examples/local/203_switch_reads.sh
+++ b/examples/local/203_switch_reads.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,20 +17,7 @@
 # this script migrates traffic for the new customer keyspace to the new
 # tablets of types rdonly and replica
 
+source ./env.sh
 
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchReads \
- -tablet_type=rdonly \
- customer.commerce2customer
-
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchReads \
- -tablet_type=replica \
- customer.commerce2customer
-
+vtctlclient SwitchReads -tablet_type=rdonly customer.commerce2customer
+vtctlclient SwitchReads -tablet_type=replica customer.commerce2customer

--- a/examples/local/204_switch_writes.sh
+++ b/examples/local/204_switch_writes.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,6 @@
 # this script migrates master traffic for the customer keyspace to the
 # new master tablet
 
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchWrites \
- customer.commerce2customer
+source ./env.sh
+
+vtctlclient SwitchWrites customer.commerce2customer

--- a/examples/local/205_clean_commerce.sh
+++ b/examples/local/205_clean_commerce.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,9 @@
 # this script removes the customer and corder tables from the commerce
 # keyspace
 
-vtctlclient -server localhost:15999 ApplySchema -sql-file drop_commerce_tables.sql commerce
-vtctlclient -server localhost:15999 SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 rdonly
-vtctlclient -server localhost:15999 SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 replica
-vtctlclient -server localhost:15999 SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 master
+source ./env.sh
+
+vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 rdonly
+vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 replica
+vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 master
+vtctlclient ApplyRoutingRules -rules='{}'

--- a/examples/local/301_customer_sharded.sh
+++ b/examples/local/301_customer_sharded.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,9 @@
 # it also changes the customer vschema from unsharded to sharded and
 # sets up the necessary vindexes
 
-vtctlclient -server localhost:15999 ApplySchema -sql-file create_commerce_seq.sql commerce
-vtctlclient -server localhost:15999 ApplyVSchema -vschema_file vschema_commerce_seq.json commerce
-vtctlclient -server localhost:15999 ApplySchema -sql-file create_customer_sharded.sql customer
-vtctlclient -server localhost:15999 ApplyVSchema -vschema_file vschema_customer_sharded.json customer
+source ./env.sh
+
+vtctlclient ApplySchema -sql-file create_commerce_seq.sql commerce
+vtctlclient ApplyVSchema -vschema_file vschema_commerce_seq.json commerce
+vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer
+vtctlclient ApplyVSchema -vschema_file vschema_customer_sharded.json customer

--- a/examples/local/302_new_shards.sh
+++ b/examples/local/302_new_shards.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,19 +15,19 @@
 # limitations under the License.
 
 # this script brings up new tablets for the two new shards that we will
-# be creating in the customer keyspace and copies the schema 
+# be creating in the customer keyspace and copies the schema
 
 source ./env.sh
 
 for i in 300 301 302; do
- CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
- SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
+	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
+	SHARD=-80 CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
 for i in 400 401 402; do
- CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
- SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
+	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-up.sh
+	SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctlclient -server localhost:15999 InitShardMaster -force customer/-80 zone1-300
-vtctlclient -server localhost:15999 InitShardMaster -force customer/80- zone1-400
+vtctlclient InitShardMaster -force customer/-80 zone1-300
+vtctlclient InitShardMaster -force customer/80- zone1-400

--- a/examples/local/303_reshard.sh
+++ b/examples/local/303_reshard.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,11 +19,4 @@
 
 source ./env.sh
 
-vtctlclient \
-    -server localhost:15999 \
-    -log_dir "$VTDATAROOT"/tmp \
-    -alsologtostderr \
-    Reshard \
-    customer.cust2cust "0" "-80,80-"
-
-sleep 2
+vtctlclient Reshard customer.cust2cust '0' '-80,80-'

--- a/examples/local/304_switch_reads.sh
+++ b/examples/local/304_switch_reads.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,18 +16,7 @@
 
 # this script migrates traffic for the rdonly and replica tablets
 
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchReads \
- -tablet_type=rdonly \
- customer.cust2cust
+source ./env.sh
 
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchReads \
- -tablet_type=replica \
- customer.cust2cust
+vtctlclient SwitchReads -tablet_type=rdonly customer.cust2cust
+vtctlclient SwitchReads -tablet_type=replica customer.cust2cust

--- a/examples/local/305_switch_writes.sh
+++ b/examples/local/305_switch_writes.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2020 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +16,6 @@
 
 # this script migrates traffic for the master tablet
 
-vtctlclient \
- -server localhost:15999 \
- -log_dir "$VTDATAROOT"/tmp \
- -alsologtostderr \
- SwitchWrites \
- customer.cust2cust
+source ./env.sh
 
-# data has been copied over to shards, and databases for the new shards are now available
-
+vtctlclient SwitchWrites customer.cust2cust

--- a/examples/local/306_down_shard_0.sh
+++ b/examples/local/306_down_shard_0.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,8 +15,9 @@
 # limitations under the License.
 # this script brings down the tablets for customer/0 keyspace
 
-for i in 200 201 202; do
- CELL=zone1 TABLET_UID=$i ./scripts/vttablet-down.sh
- CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-down.sh
-done
+source ./env.sh
 
+for i in 200 201 202; do
+	CELL=zone1 TABLET_UID=$i ./scripts/vttablet-down.sh
+	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-down.sh
+done

--- a/examples/local/307_delete_shard_0.sh
+++ b/examples/local/307_delete_shard_0.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,4 +16,6 @@
 
 # this script deletes the old shard 0 which has been replaced by 2 shards
 
-vtctlclient -server localhost:15999 DeleteShard -recursive customer/0
+source ./env.sh
+
+vtctlclient DeleteShard -recursive customer/0

--- a/examples/local/401_teardown.sh
+++ b/examples/local/401_teardown.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,41 +22,41 @@ source ./env.sh
 ./scripts/vtgate-down.sh
 
 for tablet in 100 200 300 400; do
- if vtctlclient -server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1 ; then
-  # The zero tablet is up. Try to shutdown 0-2 tablet + mysqlctl
-  for i in 0 1 2; do
-   uid=$[$tablet + $i]
-   echo "Shutting down tablet zone1-$uid"
-   CELL=zone1 TABLET_UID=$uid ./scripts/vttablet-down.sh
-   echo "Shutting down mysql zone1-$uid"
-   CELL=zone1 TABLET_UID=$uid ./scripts/mysqlctl-down.sh
-  done
- fi
+	if vtctlclient -server localhost:15999 GetTablet zone1-$tablet >/dev/null 2>&1; then
+		# The zero tablet is up. Try to shutdown 0-2 tablet + mysqlctl
+		for i in 0 1 2; do
+			uid=$(($tablet + $i))
+			echo "Shutting down tablet zone1-$uid"
+			CELL=zone1 TABLET_UID=$uid ./scripts/vttablet-down.sh
+			echo "Shutting down mysql zone1-$uid"
+			CELL=zone1 TABLET_UID=$uid ./scripts/mysqlctl-down.sh
+		done
+	fi
 done
 
 ./scripts/vtctld-down.sh
 
 if [ "${TOPO}" = "zk2" ]; then
-    CELL=zone1 ./scripts/zk-down.sh
+	CELL=zone1 ./scripts/zk-down.sh
 elif [ "${TOPO}" = "k8s" ]; then
-    CELL=zone1 ./scripts/k3s-down.sh
+	CELL=zone1 ./scripts/k3s-down.sh
 else
-    CELL=zone1 ./scripts/etcd-down.sh
+	CELL=zone1 ./scripts/etcd-down.sh
 fi
 
 # pedantic check: grep for any remaining processes
 
 if [ ! -z "$VTDATAROOT" ]; then
 
- if pgrep -f -l "$VTDATAROOT" > /dev/null; then
-  echo "ERROR: Stale processes detected! It is recommended to manuallly kill them:"
-  pgrep -f -l "$VTDATAROOT"
- else
-  echo "All good! It looks like every process has shut down"
- fi
+	if pgrep -f -l "$VTDATAROOT" >/dev/null; then
+		echo "ERROR: Stale processes detected! It is recommended to manuallly kill them:"
+		pgrep -f -l "$VTDATAROOT"
+	else
+		echo "All good! It looks like every process has shut down"
+	fi
 
- # shellcheck disable=SC2086
- rm -r ${VTDATAROOT:?}/*
+	# shellcheck disable=SC2086
+	rm -r ${VTDATAROOT:?}/*
 
 fi
 

--- a/examples/local/alias.source
+++ b/examples/local/alias.source
@@ -1,4 +1,0 @@
-echo "Setting alias mysql to mysql -h 127.0.0.1 -P 15306"
-alias mysql="mysql -h 127.0.0.1 -P 15306"
-echo "Setting alias vtctlclient to vtctlclient -server localhost:15999 -log_dir $VTDATAROOT/tmp -alsologtostderr"
-alias vtctlclient="vtctlclient -server localhost:15999 -log_dir $VTDATAROOT/tmp -alsologtostderr"

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
-hostname=`hostname -f`
+hostname=$(hostname -f)
 vtctld_web_port=15000
 export VTDATAROOT="${VTDATAROOT:-${PWD}/vtdataroot}"
 
@@ -55,7 +53,7 @@ if [ "${TOPO}" = "zk2" ]; then
     # shellcheck disable=SC2034
     TOPOLOGY_FLAGS="-topo_implementation zk2 -topo_global_server_address ${ZK_SERVER} -topo_global_root /vitess/global"
 
-    mkdir -p $VTDATAROOT/tmp
+    mkdir -p "${VTDATAROOT}/tmp"
 elif [ "${TOPO}" = "k8s" ]; then
     # Set topology environment parameters.
     K8S_ADDR="localhost"
@@ -71,3 +69,14 @@ else
 fi
 
 mkdir -p "${VTDATAROOT}/tmp"
+
+# Set aliases to simplify instructions.
+# In your own environment you may prefer to use config files,
+# such as ~/.my.cnf
+
+alias mysql="command mysql -h 127.0.0.1 -P 15306"
+alias vtctlclient="command vtctlclient -server localhost:15999 -log_dir ${VTDATAROOT}/tmp -alsologtostderr"
+
+# Make sure aliases are expanded in non-interactive shell
+shopt -s expand_aliases
+

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -29,6 +29,8 @@ source ./env.sh # Required so that "mysql" works from alias
 
 ./101_initial_cluster.sh
 
+sleep 1 # Give vtgate a second to really start.
+
 mysql < ../common/insert_commerce_data.sql
 mysql --table < ../common/select_commerce_data.sql
 


### PR DESCRIPTION
This harmonizes the local examples with the improvements made to helm in https://github.com/vitessio/vitess/pull/6052

<strike>There will need to be a docs update to say `source ./env.sh` instead of `source alias.source` ([here](https://vitess.io/docs/get-started/local-vitess6/#setup-aliases)).</strike> See https://github.com/vitessio/website/pull/431 for docs updates.

As the examples were changes a bit, I also ran `shfmt`.

Signed-off-by: Morgan Tocker <tocker@gmail.com>