### PR TITLE
[K8s Topo] Move CRD to v1beta1

### DIFF
--- a/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
+++ b/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: vitesstoponodes.topo.vitess.io

--- a/helm/vitess/CHANGELOG.md
+++ b/helm/vitess/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1-0 - 2020-04-16
+
+The charts now officially support Kubernetes 1.11 and newer.
+
+### Changes
+* The VitessTopoNode CRD is now created using the `apiextensions.k8s.io/v1beta1` API.
+
 ## 2.0.0-0 - 2020-04-03
 
 Vitess now supports using the Kubernetes API as a topology provider. This means that it is now easier than ever to run Vitess on Kubernetes! 

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vitess
-version: 2.0.0-0
+version: 2.0.1-0
 description: Single-Chart Vitess Cluster
 keywords:
   - vitess

--- a/helm/vitess/crds/VitessTopoNodes-crd.yaml
+++ b/helm/vitess/crds/VitessTopoNodes-crd.yaml
@@ -1,6 +1,6 @@
 # This is a copy of the crd def from: vitess/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
 # It is not symlinked so that the helm charts do not have references to outside files
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: vitesstoponodes.topo.vitess.io


### PR DESCRIPTION
This will allow the CRD to be used in K8s clusters 1.7 or newer.
But some of the features, like the additionalPrinterColumns, will
only be available in 1.11 or newer, which is the minimum recommend
version

Signed-off-by: Carson Anderson <ca@carsonoid.net>

This is a backwards-compatible change for anyone that has already installed the charts.