### PR TITLE
Refactor CRD to support K8s 1.15 specific requirements

### DIFF
--- a/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
+++ b/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
@@ -4,38 +4,35 @@ metadata:
   name: vitesstoponodes.topo.vitess.io
 spec:
   group: topo.vitess.io
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Key
-          type: string
-          description: The full key path
-          jsonPath: .data.key
-      schema:
-        openAPIV3Schema:
+  additionalPrinterColumns:
+    - name: Key
+      type: string
+      description: The full key path
+      JSONPath: .data.key
+  validation:
+    openAPIV3Schema:
+      type: object
+      required:
+        - data
+      properties:
+        data:
           type: object
           required:
-            - data
+            - key
+            - value
           properties:
-            data:
-              type: object
-              required:
-                - key
-                - value
-              properties:
-                key:
-                  description: A file-path like key. Must be an absolute path. Must not end with a /.
-                  type: string
-                  pattern: '^\/.+[^\/]$'
-                value:
-                  description: A base64 encoded value. Must be a base64 encoded string or empty string.
-                  type: string
-                  pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
-                ephemeral:
-                  description: Whether or not the node is considered ephemeral. True for lock and election nodes.
-                  type: boolean
+            key:
+              description: A file-path like key. Must be an absolute path. Must not end with a /.
+              type: string
+              pattern: '^\/.+[^\/]$'
+            value:
+              description: A base64 encoded value. Must be a base64 encoded string or empty string.
+              type: string
+              pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+            ephemeral:
+              description: Whether or not the node is considered ephemeral. True for lock and election nodes.
+              type: boolean
+  version: v1beta1
   scope: Namespaced
   names:
     plural: vitesstoponodes

--- a/go/vt/topo/k8stopo/server_test.go
+++ b/go/vt/topo/k8stopo/server_test.go
@@ -29,7 +29,7 @@ import (
 
 	"testing"
 
-	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/clientcmd"
@@ -102,16 +102,16 @@ func TestKubernetesTopo(t *testing.T) {
 		}
 
 		crdFile, err := os.Open("./VitessTopoNodes-crd.yaml")
-		defer crdFile.Close()
 		if err != nil {
 			t.Fatal(err)
+			defer crdFile.Close()
 		}
 
-		crd := &extensionsv1.CustomResourceDefinition{}
+		crd := &extensionsv1beta1.CustomResourceDefinition{}
 
 		kubeyaml.NewYAMLOrJSONDecoder(crdFile, 2048).Decode(crd)
 
-		_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
+		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/helm/vitess/crds/VitessTopoNodes-crd.yaml
+++ b/helm/vitess/crds/VitessTopoNodes-crd.yaml
@@ -6,38 +6,35 @@ metadata:
   name: vitesstoponodes.topo.vitess.io
 spec:
   group: topo.vitess.io
-  versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Key
-          type: string
-          description: The full key path
-          jsonPath: .data.key
-      schema:
-        openAPIV3Schema:
+  additionalPrinterColumns:
+    - name: Key
+      type: string
+      description: The full key path
+      JSONPath: .data.key
+  validation:
+    openAPIV3Schema:
+      type: object
+      required:
+        - data
+      properties:
+        data:
           type: object
           required:
-            - data
+            - key
+            - value
           properties:
-            data:
-              type: object
-              required:
-                - key
-                - value
-              properties:
-                key:
-                  description: A file-path like key. Must be an absolute path. Must not end with a /.
-                  type: string
-                  pattern: '^\/.+[^\/]$'
-                value:
-                  description: A base64 encoded value. Must be a base64 encoded string or empty string.
-                  type: string
-                  pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
-                ephemeral:
-                  description: Whether or not the node is considered ephemeral. True for lock and election nodes.
-                  type: boolean
+            key:
+              description: A file-path like key. Must be an absolute path. Must not end with a /.
+              type: string
+              pattern: '^\/.+[^\/]$'
+            value:
+              description: A base64 encoded value. Must be a base64 encoded string or empty string.
+              type: string
+              pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+            ephemeral:
+              description: Whether or not the node is considered ephemeral. True for lock and election nodes.
+              type: boolean
+  version: v1beta1
   scope: Namespaced
   names:
     plural: vitesstoponodes


### PR DESCRIPTION
K8s 1.15 added extra validation to CRD structure when using
the v1beta1 api. The CRD has been restructured to conform
to the new rules.

I also moved the test to the v1beta1 api client.

Signed-off-by: Carson Anderson <ca@carsonoid.net>

---

I have manually validated that the crd below works for  K8s 1.13, 1.14, 1.15 and 1.16:

This was the validation script:
```
k3d create --name=113 --port=6113 --version=v0.3.0
k3d create --name=114 --port=6114 --version=v0.8.1
k3d create --name=115 --port=6115 --version=v0.9.0-rc1
k3d create --name=116 --port=6116

for v in 113 114 115 116; do
    echo
    echo testing $v
    export KUBECONFIG="$(k3d get-kubeconfig --name=$v)"
    kubectl version
    kubectl apply -f helm/vitess/crds/VitessTopoNodes-crd.yaml
done

k3d delete --name=113
k3d delete --name=114
k3d delete --name=115
k3d delete --name=116
```

Results:

```
testing 113
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.5-k3s.1", GitCommit:"256ea73aeb2627eb9b510f6c22881af8f967dd0c", GitTreeState:"clean", BuildDate:"2019-03-27T18:49+00:00Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"linux/amd64"}
customresourcedefinition.apiextensions.k8s.io/vitesstoponodes.topo.vitess.io created

testing 114
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.6-k3s.1", GitCommit:"4cd85f14854d942e9016cc15f399785c103242e9", GitTreeState:"clean", BuildDate:"2019-08-19T16:12+00:00Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
customresourcedefinition.apiextensions.k8s.io/vitesstoponodes.topo.vitess.io created

testing 115
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3-k3s.1", GitCommit:"2258cf7b7c767ecca887c5fc17784b3f8472b271", GitTreeState:"clean", BuildDate:"2019-08-29T05:27+00:00Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
customresourcedefinition.apiextensions.k8s.io/vitesstoponodes.topo.vitess.io created

testing 116
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:16:51Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2-k3s.1", GitCommit:"b8b17ba55f20e590df507fce333dfee13ab438c6", GitTreeState:"clean", BuildDate:"2019-10-16T05:17Z", GoVersion:"go1.13.3", Compiler:"gc", Platform:"linux/amd64"}
customresourcedefinition.apiextensions.k8s.io/vitesstoponodes.topo.vitess.io created
```