### PR TITLE
Reduce race in legacy_local_example

### DIFF
--- a/test/legacy_local_example.sh
+++ b/test/legacy_local_example.sh
@@ -28,6 +28,8 @@ unset VTROOT # ensure that the examples can run without VTROOT now.
 
 ./101_initial_cluster.sh
 
+sleep 1 # Give vtgate a second to really start.
+
 mysql -h 127.0.0.1 -P 15306 < ../common/insert_commerce_data.sql
 mysql -h 127.0.0.1 -P 15306 --table < ../common/select_commerce_data.sql
 ./201_customer_keyspace.sh


### PR DESCRIPTION
There is a race in the local example, where starting vtgate actually waits for the status port to be up, but it seems the MySQL port may come up just a fraction later.

I added a sleep in the local_example, which has actually improved the stability. This adds a sleep in the legacy example, which should similarly improve it.

I know sleeps is not a good solution, and long term it probably makes sense to bring up the status port when the MySQL port is healthy. But that's a solution I've not looked into yet.

Signed-off-by: Morgan Tocker <tocker@gmail.com>