### PR TITLE
Use apps/v1 for all statefulsets

### DIFF
--- a/helm/vitess/templates/NOTES.txt
+++ b/helm/vitess/templates/NOTES.txt
@@ -10,5 +10,5 @@ Then use the following URLs:
 
       vtctld: {{$proxyURL}}/services/vtctld:web/proxy/app/
       vtgate: {{$proxyURL}}/services/vtgate-{{$cell}}:web/proxy/
-{{ if $.Values.orchestrator.enabled }}orchestrator: {{$proxyURL}}/services/orchestrator:web/{{ end }}
-{{ if $.Values.pmm.enabled }}         pmm: {{$proxyURL}}/services/pmm:web/{{ end }}
+{{ if $.Values.orchestrator.enabled }}orchestrator: {{$proxyURL}}/services/orchestrator:web/proxy/{{ end }}
+{{ if $.Values.pmm.enabled }}         pmm: {{$proxyURL}}/services/pmm:web/proxy/{{ end }}

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -51,7 +51,7 @@ spec:
 ###################################
 # Orchestrator StatefulSet
 ###################################
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: orchestrator

--- a/helm/vitess/templates/_pmm.tpl
+++ b/helm/vitess/templates/_pmm.tpl
@@ -29,7 +29,7 @@ spec:
 ###################################
 # pmm StatefulSet
 ###################################
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pmm


### PR DESCRIPTION
This fixes orchestrator and pmm on k8s 1.16+. All of the other
statefulsets were already on apps/v1 so this just brings those two
components in line with the rest of the chart.

I have also fixed the printed proxy urls to actually work

Signed-off-by: Carson Anderson <ca@carsonoid.net>