### PR TITLE
Remove synchronizing VTGateConnection on itself

### DIFF
--- a/java/client/src/main/java/io/vitess/client/VTGateConnection.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateConnection.java
@@ -92,29 +92,27 @@ public class VTGateConnection implements Closeable {
    */
   public SQLFuture<Cursor> execute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
       final VTSession vtSession) throws SQLException {
-    synchronized (this) {
-      vtSession.checkCallIsAllowed("execute");
-      ExecuteRequest.Builder requestBuilder = ExecuteRequest.newBuilder()
-          .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-          .setSession(vtSession.getSession());
+    vtSession.checkCallIsAllowed("execute");
+    ExecuteRequest.Builder requestBuilder = ExecuteRequest.newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setSession(vtSession.getSession());
 
-      if (ctx.getCallerId() != null) {
-        requestBuilder.setCallerId(ctx.getCallerId());
-      }
-
-      SQLFuture<Cursor> call = new SQLFuture<>(
-          transformAsync(client.execute(ctx, requestBuilder.build()),
-              new AsyncFunction<ExecuteResponse, Cursor>() {
-                @Override
-                public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
-                  vtSession.setSession(response.getSession());
-                  Proto.checkError(response.getError());
-                  return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                }
-              }, directExecutor()));
-      vtSession.setLastCall(call);
-      return call;
+    if (ctx.getCallerId() != null) {
+      requestBuilder.setCallerId(ctx.getCallerId());
     }
+
+    SQLFuture<Cursor> call = new SQLFuture<>(
+        transformAsync(client.execute(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
+                vtSession.setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }, directExecutor()));
+    vtSession.setLastCall(call);
+    return call;
   }
 
   /**
@@ -151,45 +149,43 @@ public class VTGateConnection implements Closeable {
   public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
       @Nullable List<Map<String, ?>> bindVarsList, boolean asTransaction, final VTSession vtSession)
       throws SQLException {
-    synchronized (this) {
-      vtSession.checkCallIsAllowed("executeBatch");
-      List<Query.BoundQuery> queries = new ArrayList<>();
+    vtSession.checkCallIsAllowed("executeBatch");
+    List<Query.BoundQuery> queries = new ArrayList<>();
 
-      if (null != bindVarsList && bindVarsList.size() != queryList.size()) {
-        throw new SQLDataException(
-            "Size of SQL Query list does not match the bind variables list");
-      }
-
-      for (int i = 0; i < queryList.size(); ++i) {
-        queries.add(i, Proto.bindQuery(checkNotNull(queryList.get(i)),
-            bindVarsList == null ? null : bindVarsList.get(i)));
-      }
-
-      Vtgate.ExecuteBatchRequest.Builder requestBuilder =
-          Vtgate.ExecuteBatchRequest.newBuilder()
-              .addAllQueries(checkNotNull(queries))
-              .setSession(vtSession.getSession())
-              .setAsTransaction(asTransaction);
-
-      if (ctx.getCallerId() != null) {
-        requestBuilder.setCallerId(ctx.getCallerId());
-      }
-
-      SQLFuture<List<CursorWithError>> call = new SQLFuture<>(
-          transformAsync(client.executeBatch(ctx, requestBuilder.build()),
-              new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
-                @Override
-                public ListenableFuture<List<CursorWithError>> apply(
-                    Vtgate.ExecuteBatchResponse response) throws Exception {
-                  vtSession.setSession(response.getSession());
-                  Proto.checkError(response.getError());
-                  return Futures.immediateFuture(
-                      Proto.fromQueryResponsesToCursorList(response.getResultsList()));
-                }
-              }, directExecutor()));
-      vtSession.setLastCall(call);
-      return call;
+    if (null != bindVarsList && bindVarsList.size() != queryList.size()) {
+      throw new SQLDataException(
+          "Size of SQL Query list does not match the bind variables list");
     }
+
+    for (int i = 0; i < queryList.size(); ++i) {
+      queries.add(i, Proto.bindQuery(checkNotNull(queryList.get(i)),
+          bindVarsList == null ? null : bindVarsList.get(i)));
+    }
+
+    Vtgate.ExecuteBatchRequest.Builder requestBuilder =
+        Vtgate.ExecuteBatchRequest.newBuilder()
+            .addAllQueries(checkNotNull(queries))
+            .setSession(vtSession.getSession())
+            .setAsTransaction(asTransaction);
+
+    if (ctx.getCallerId() != null) {
+      requestBuilder.setCallerId(ctx.getCallerId());
+    }
+
+    SQLFuture<List<CursorWithError>> call = new SQLFuture<>(
+        transformAsync(client.executeBatch(ctx, requestBuilder.build()),
+            new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
+              @Override
+              public ListenableFuture<List<CursorWithError>> apply(
+                  Vtgate.ExecuteBatchResponse response) throws Exception {
+                vtSession.setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.immediateFuture(
+                    Proto.fromQueryResponsesToCursorList(response.getResultsList()));
+              }
+            }, directExecutor()));
+    vtSession.setLastCall(call);
+    return call;
   }
 
   /**


### PR DESCRIPTION
We're doing some feature work on a fork of Vitess where this
synchronized instance lock is creating extra pausing in our client
application. The only state the connection maintains is the RpcClient,
where I believe GRPC should not have a need to be synchronized.

We've removed these blocks in our fork and run some overall query load
testing (nothing explicitly targeting this code block, just throwing a
bunch of transaction reads and inserts through the client). We didn't
encounter any noticeable issues with the change.

Reading the code, the only thing that seems stateful to me is the
VtSession maybe racing between the check to allow a call and then
setting the `lastCall` after constructing the new `SQLFuture`. However,
I don't think an instance lock on the `VTGateConnection` would prevent
anyone else from racing against the `VTSession` instance? I do not have
complete understanding, this is just my surface level observation.