### PR TITLE
messager: fix bug in build row

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -838,21 +838,21 @@ func BuildMessageRow(row []sqltypes.Value) (*MessageRow, error) {
 		mr.Priority = v
 	}
 	if !row[1].IsNull() {
-		v, err := evalengine.ToInt64(row[0])
+		v, err := evalengine.ToInt64(row[1])
 		if err != nil {
 			return nil, err
 		}
 		mr.TimeNext = v
 	}
 	if !row[2].IsNull() {
-		v, err := evalengine.ToInt64(row[1])
+		v, err := evalengine.ToInt64(row[2])
 		if err != nil {
 			return nil, err
 		}
 		mr.Epoch = v
 	}
 	if !row[3].IsNull() {
-		v, err := evalengine.ToInt64(row[2])
+		v, err := evalengine.ToInt64(row[3])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The row builder had an off-by-one bug causing time next
to be interpreted as 0, which caused messages to get spammed.
This also fixes a flaky test.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>