### PR TITLE
messager: add 33% jitter to postpone backoff

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -269,7 +269,7 @@ func buildPostponeQuery(name sqlparser.TableIdent, minBackoff, maxBackoff time.D
 
 	// have backoff be +/- 33%, seeded with :time_now to be consistent in multiple usages
 	// whenever this is injected, append (:time_now, :min_backoff, :time_now)
-	baseTimeNext := "%a+FLOOR((%a<<ifnull(epoch, 0))*(-.333333 + (RAND(%a) * .666666))"
+	baseTimeNext := "(%a+FLOOR((%a<<ifnull(epoch, 0))*(-.333333 + (RAND(%a) * .666666))))"
 
 	//
 	// add sanity checks for the jittered time_next

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -282,8 +282,8 @@ func buildPostponeQuery(name sqlparser.TableIdent, minBackoff, maxBackoff time.D
 
 	// now we are setting the false case on the above IF statement
 	if maxBackoff == 0 {
-	// if there is no max_backoff, just use :time_now + jitteredBackoff
-		buf.WriteString(fmt.Sprintf("%%a + %s",jitteredBackoff))
+		// if there is no max_backoff, just use :time_now + jitteredBackoff
+		buf.WriteString(fmt.Sprintf("%%a + %s", jitteredBackoff))
 		args = append(args, ":time_now", ":min_backoff", ":time_now")
 	} else {
 		// make sure that it doesn't exceed max_backoff

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -753,7 +753,7 @@ func TestMMGenerate(t *testing.T) {
 	utils.MustMatch(t, wantids, gotids, "did not match")
 
 	query, bv = mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery = "update foo set time_next = :time_now+(:min_backoff<<ifnull(epoch, 0)), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery = "update foo set time_next = IF(:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now < :min_backoff, :time_now + :min_backoff, :time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -790,7 +790,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	wantids := sqltypes.TestBindVariable([]interface{}{"1", "2"})
 
 	query, bv := mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery := "update foo set time_next = :time_now+if(:min_backoff<<ifnull(epoch, 0) > :max_backoff, :max_backoff, :min_backoff<<ifnull(epoch, 0)), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery := "update foo set time_next = IF(:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now < :min_backoff, :time_now + :min_backoff, IF(:time_now+FLOOR((:max_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now > :max_backoff, :time_now + :max_backoff, :time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -753,7 +753,7 @@ func TestMMGenerate(t *testing.T) {
 	utils.MustMatch(t, wantids, gotids, "did not match")
 
 	query, bv = mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery = "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery = "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, :time_now + FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -790,7 +790,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	wantids := sqltypes.TestBindVariable([]interface{}{"1", "2"})
 
 	query, bv := mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery := "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) > :max_backoff, :time_now + :max_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery := "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) > :max_backoff, :time_now + :max_backoff, :time_now + FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -753,7 +753,7 @@ func TestMMGenerate(t *testing.T) {
 	utils.MustMatch(t, wantids, gotids, "did not match")
 
 	query, bv = mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery = "update foo set time_next = IF(:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now < :min_backoff, :time_now + :min_backoff, :time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery = "update foo set time_next = IF((:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now < :min_backoff, :time_now + :min_backoff, (:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -790,7 +790,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	wantids := sqltypes.TestBindVariable([]interface{}{"1", "2"})
 
 	query, bv := mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery := "update foo set time_next = IF(:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now < :min_backoff, :time_now + :min_backoff, IF(:time_now+FLOOR((:max_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)) - :time_now > :max_backoff, :time_now + :max_backoff, :time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery := "update foo set time_next = IF((:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now < :min_backoff, :time_now + :min_backoff, IF((:time_now+FLOOR((:max_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now > :max_backoff, :time_now + :max_backoff, (:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -753,7 +753,7 @@ func TestMMGenerate(t *testing.T) {
 	utils.MustMatch(t, wantids, gotids, "did not match")
 
 	query, bv = mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery = "update foo set time_next = IF((:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now < :min_backoff, :time_now + :min_backoff, (:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery = "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -790,7 +790,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	wantids := sqltypes.TestBindVariable([]interface{}{"1", "2"})
 
 	query, bv := mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery := "update foo set time_next = IF((:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now < :min_backoff, :time_now + :min_backoff, IF((:time_now+FLOOR((:max_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))) - :time_now > :max_backoff, :time_now + :max_backoff, (:time_now+FLOOR((:min_backoff<<ifnull(epoch, 0))*(-.333333 + (RAND(:time_now) * .666666)))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery := "update foo set time_next = IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :time_now + :min_backoff, IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) > :max_backoff, :time_now + :max_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}


### PR DESCRIPTION
As mentioned in #5882, it's preferable to add jitter to any exponential backoff. This adds it to the postpone query. The query itself looks more complex than it actually is since it potentially has to repeat the backoff calculation many times.