### PR TITLE
vtctld: make cell optional

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -286,18 +286,15 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		keyspace := parts[1]
 
 		if cell == "local" {
-			aliases, err := ts.GetCellsAliases(ctx, false)
-			if err != nil {
-				return nil, fmt.Errorf("could not fetch cell info: %v", err)
-			}
-			if len(aliases) == 0 {
-				return nil, fmt.Errorf("no local cells have been created yet")
-			}
 			if *localCell == "" {
-				// Choose a random cell.
-				for cell = range aliases {
-					break
+				cells, err := ts.GetCellInfoNames(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("could not fetch cell info: %v", err)
 				}
+				if len(cells) == 0 {
+					return nil, fmt.Errorf("no local cells have been created yet")
+				}
+				cell = cells[0]
 			} else {
 				cell = *localCell
 			}

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -286,10 +286,21 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 		keyspace := parts[1]
 
 		if cell == "local" {
-			if *localCell == "" {
-				return nil, fmt.Errorf("local cell requested, but not specified. Please set with -cell flag")
+			aliases, err := ts.GetCellsAliases(ctx, false)
+			if err != nil {
+				return nil, fmt.Errorf("could not fetch cell info: %v", err)
 			}
-			cell = *localCell
+			if len(aliases) == 0 {
+				return nil, fmt.Errorf("no local cells have been created yet")
+			}
+			if *localCell == "" {
+				// Choose a random cell.
+				for cell = range aliases {
+					break
+				}
+			} else {
+				cell = *localCell
+			}
 		}
 
 		// If a keyspace is provided then return the specified srvkeyspace.


### PR DESCRIPTION
This change makes the cell flag optional for vtctld. This removes
the catch-22 that you have to create a cell before launching vtctld.
But then, how do you create a cell without a vtctld?

This required a one-time use of vtctl tool to create this initial
cell.

If you don't specify a cell, vtctld will choose one for you.
I believe the main use case for this is for identifying which shards
are serving vs. non-serving. This info is now available in global
topo itself as the "IsMasterServing" flag. But, we'll need to
go into the UI to make this change, which is non-trivial right now.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>