### PR TITLE
helm: use proxy_tablets

### DIFF
--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -130,6 +130,7 @@ spec:
                 -grpc_port=15999
                 -service_map="grpc-vtctl"
                 -topo_global_root=/vitess/global
+                -proxy_tablets=true
                 {{- if eq ($cell.topologyProvider | default "") "etcd2" }}
                 -topo_implementation="etcd2"
                 -topo_global_server_address="etcd-global-client.{{ $namespace }}:2379"

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -182,7 +182,7 @@ etcd:
 # Default values for vtctld resources defined in 'topology'
 vtctld:
   serviceType: ClusterIP
-  vitessTag: helm-2.0.0-0
+  vitessTag: helm-2.0.1-0
   resources:
     # requests:
     #   cpu: 100m
@@ -193,7 +193,7 @@ vtctld:
 # Default values for vtgate resources defined in 'topology'
 vtgate:
   serviceType: ClusterIP
-  vitessTag: helm-2.0.0-0
+  vitessTag: helm-2.0.1-0
   resources:
     # requests:
     #   cpu: 500m
@@ -212,13 +212,13 @@ vtgate:
 
 # Default values for vtctlclient resources defined in 'topology'
 vtctlclient:
-  vitessTag: helm-2.0.0-0
+  vitessTag: helm-2.0.1-0
   extraFlags: {}
   secrets: [] # secrets are mounted under /vt/usersecrets/{secretname}
 
 # Default values for vtworker resources defined in 'jobs'
 vtworker:
-  vitessTag: helm-2.0.0-0
+  vitessTag: helm-2.0.1-0
   extraFlags: {}
   resources:
     # requests:
@@ -229,7 +229,7 @@ vtworker:
 
 # Default values for vttablet resources defined in 'topology'
 vttablet:
-  vitessTag: helm-2.0.0-0
+  vitessTag: helm-2.0.1-0
 
   # valid values are
   # - mysql56 (for MySQL 8.0)


### PR DESCRIPTION
The redirect leads to a 404. However, adding a /debug/status to
the redirect URL does work. So, this is still an improvement.

I'll make a separate PR to append the /debug/status to the redirect
URL, which will fix this good. Then we'll have to build another helm
image.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>