### PR TITLE
vtctld: add /debug/status to tablet URLs

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -409,7 +409,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			MasterTermStartTime: t.MasterTermStartTime,
 		}
 		if *proxyTablets {
-			tab.URL = fmt.Sprintf("/vttablet/%s-%d", t.Alias.Cell, t.Alias.Uid)
+			tab.URL = fmt.Sprintf("/vttablet/%s-%d/debug/status", t.Alias.Cell, t.Alias.Uid)
 		} else {
 			tab.URL = "http://" + netutil.JoinHostPort(t.Hostname, t.PortMap["vt"])
 		}


### PR DESCRIPTION
Without that explicit path, the redirect leads to a 404 in the
case of helm charts eventhough it works fine in the local
example case.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>