### PR TITLE
messager: use ackWaitTimeout in postpone query

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -264,36 +264,38 @@ func newMessageManager(tsv TabletService, vs VStreamer, table *schema.Table, pos
 func buildPostponeQuery(name sqlparser.TableIdent, minBackoff, maxBackoff time.Duration) *sqlparser.ParsedQuery {
 	var args []interface{}
 
-	buf := bytes.NewBufferString("update %v set time_next = ")
-	args = append(args, name)
+	// since messages are immediately postponed upon sending, we need to add exponential backoff on top
+	// of the ackWaitTime, otherwise messages will be resent too quickly.
+	buf := bytes.NewBufferString("update %v set time_next = %a + %a + ")
+	args = append(args, name, ":time_now", ":wait_time")
 
 	// have backoff be +/- 33%, seeded with :time_now to be consistent in multiple usages
 	// whenever this is injected, append (:min_backoff, :time_now)
 	jitteredBackoff := "FLOOR((%a<<ifnull(epoch, 0))*(.666666 + (RAND(%a) * .666666)))"
 
 	//
-	// if the jittered backoff is less than min_backoff, just set it to time_now + min_backoff
+	// if the jittered backoff is less than min_backoff, just set it to :min_backoff
 	//
-	buf.WriteString(fmt.Sprintf("IF(%s < %%a, %%a + %%a, ", jitteredBackoff))
+	buf.WriteString(fmt.Sprintf("IF(%s < %%a, %%a, ", jitteredBackoff))
 	// jitteredBackoff < :min_backoff
 	args = append(args, ":min_backoff", ":time_now", ":min_backoff")
-	// if it is less, then use :time_now + :min_backoff
-	args = append(args, ":time_now", ":min_backoff")
+	// if it is less, then use :min_backoff
+	args = append(args, ":min_backoff")
 
 	// now we are setting the false case on the above IF statement
 	if maxBackoff == 0 {
-		// if there is no max_backoff, just use :time_now + jitteredBackoff
-		buf.WriteString(fmt.Sprintf("%%a + %s", jitteredBackoff))
-		args = append(args, ":time_now", ":min_backoff", ":time_now")
+		// if there is no max_backoff, just use jitteredBackoff
+		buf.WriteString(jitteredBackoff)
+		args = append(args, ":min_backoff", ":time_now")
 	} else {
 		// make sure that it doesn't exceed max_backoff
-		buf.WriteString(fmt.Sprintf("IF(%s > %%a, %%a + %%a, %%a + %s)", jitteredBackoff, jitteredBackoff))
+		buf.WriteString(fmt.Sprintf("IF(%s > %%a, %%a, %s)", jitteredBackoff, jitteredBackoff))
 		// jitteredBackoff > :max_backoff
 		args = append(args, ":min_backoff", ":time_now", ":max_backoff")
-		// if it is greater, then use :time_now + :max_backoff
-		args = append(args, ":time_now", ":max_backoff")
-		// otherwise just use :time_now + jitteredBackoff
-		args = append(args, ":time_now", ":min_backoff", ":time_now")
+		// if it is greater, then use :max_backoff
+		args = append(args, ":max_backoff")
+		// otherwise just use jitteredBackoff
+		args = append(args, ":min_backoff", ":time_now")
 	}
 
 	// close the if statement
@@ -847,6 +849,7 @@ func (mm *messageManager) GeneratePostponeQuery(ids []string) (string, map[strin
 
 	bvs := map[string]*querypb.BindVariable{
 		"time_now":    sqltypes.Int64BindVariable(time.Now().UnixNano()),
+		"wait_time":   sqltypes.Int64BindVariable(int64(mm.ackWaitTime)),
 		"min_backoff": sqltypes.Int64BindVariable(int64(mm.minBackoff)),
 		"ids":         idbvs,
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -753,7 +753,7 @@ func TestMMGenerate(t *testing.T) {
 	utils.MustMatch(t, wantids, gotids, "did not match")
 
 	query, bv = mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery = "update foo set time_next = :time_now + :wait_time + IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :min_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666)))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery = "update foo set time_next = :time_now + :wait_time + IF(FLOOR((:min_backoff<<ifnull(epoch, 0)) * :jitter) < :min_backoff, :min_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0)) * :jitter)), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -762,6 +762,12 @@ func TestMMGenerate(t *testing.T) {
 	} else {
 		// time_now cannot be compared.
 		delete(bv, "time_now")
+	}
+	if _, ok := bv["jitter"]; !ok {
+		t.Errorf("jitter is absent in %v", bv)
+	} else {
+		// jitter cannot be compared.
+		delete(bv, "jitter")
 	}
 	wantbv := map[string]*querypb.BindVariable{
 		"wait_time":   sqltypes.Int64BindVariable(1e9),
@@ -791,7 +797,7 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	wantids := sqltypes.TestBindVariable([]interface{}{"1", "2"})
 
 	query, bv := mm.GeneratePostponeQuery([]string{"1", "2"})
-	wantQuery := "update foo set time_next = :time_now + :wait_time + IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) < :min_backoff, :min_backoff, IF(FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))) > :max_backoff, :max_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0))*(.666666 + (RAND(:time_now) * .666666))))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
+	wantQuery := "update foo set time_next = :time_now + :wait_time + IF(FLOOR((:min_backoff<<ifnull(epoch, 0)) * :jitter) < :min_backoff, :min_backoff, IF(FLOOR((:min_backoff<<ifnull(epoch, 0)) * :jitter) > :max_backoff, :max_backoff, FLOOR((:min_backoff<<ifnull(epoch, 0)) * :jitter))), epoch = ifnull(epoch, 0)+1 where id in ::ids and time_acked is null"
 	if query != wantQuery {
 		t.Errorf("GeneratePostponeQuery query: %s, want %s", query, wantQuery)
 	}
@@ -800,6 +806,12 @@ func TestMMGenerateWithBackoff(t *testing.T) {
 	} else {
 		// time_now cannot be compared.
 		delete(bv, "time_now")
+	}
+	if _, ok := bv["jitter"]; !ok {
+		t.Errorf("jitter is absent in %v", bv)
+	} else {
+		// jitter cannot be compared.
+		delete(bv, "jitter")
 	}
 	wantbv := map[string]*querypb.BindVariable{
 		"wait_time":   sqltypes.Int64BindVariable(1e10),


### PR DESCRIPTION
Since messages are immediately postponed upon sending, we need to add exponential backoff on top of the ackWaitTime, otherwise messages will be resent too quickly.

This also simplifies the query by pulling out the `time_now` addition to the front of the query and leaving the IF statement to only calculate backoff.

In the second commit, I move the jitter calculation from SQL into Go. This makes the postpone sql easier to follow, and it will make it easier to allow for user provided jitter % in the future