### PR TITLE
topo: exit if topo info is bad

### DIFF
--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -45,7 +45,6 @@ package topo
 import (
 	"flag"
 	"fmt"
-	"strings"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -219,8 +218,8 @@ func Open() *Server {
 	if *topoGlobalServerAddress == "" && *topoImplementation != "k8s" {
 		log.Exitf("topo_global_server_address must be configured")
 	}
-	if !strings.HasPrefix(*topoGlobalRoot, "/") {
-		log.Exitf("topo_global_root must be non-empty and must begin with a '/': %v", *topoGlobalRoot)
+	if *topoGlobalRoot == "" {
+		log.Exit("topo_global_root must be non-empty")
 	}
 	ts, err := OpenServer(*topoImplementation, *topoGlobalServerAddress, *topoGlobalRoot)
 	if err != nil {

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -45,6 +45,7 @@ package topo
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -217,6 +218,9 @@ func OpenServer(implementation, serverAddress, root string) (*Server, error) {
 func Open() *Server {
 	if *topoGlobalServerAddress == "" && *topoImplementation != "k8s" {
 		log.Exitf("topo_global_server_address must be configured")
+	}
+	if !strings.HasPrefix(*topoGlobalRoot, "/") {
+		log.Exitf("topo_global_root must be non-empty and must begin with a '/': %v", *topoGlobalRoot)
 	}
 	ts, err := OpenServer(*topoImplementation, *topoGlobalServerAddress, *topoGlobalRoot)
 	if err != nil {

--- a/go/vt/vtctl/cell_info.go
+++ b/go/vt/vtctl/cell_info.go
@@ -73,8 +73,8 @@ func commandAddCellInfo(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
-	if !strings.HasPrefix(*root, "/") {
-		return fmt.Errorf("root must be non-empty and must begin with a '/': %v", *root)
+	if *root == "" {
+		return fmt.Errorf("root must be non-empty")
 	}
 	if subFlags.NArg() != 1 {
 		return fmt.Errorf("the <cell> argument is required for the AddCellInfo command")

--- a/go/vt/vtctl/cell_info.go
+++ b/go/vt/vtctl/cell_info.go
@@ -73,6 +73,9 @@ func commandAddCellInfo(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
+	if !strings.HasPrefix(*root, "/") {
+		return fmt.Errorf("root must be non-empty and must begin with a '/': %v", *root)
+	}
 	if subFlags.NArg() != 1 {
 		return fmt.Errorf("the <cell> argument is required for the AddCellInfo command")
 	}


### PR DESCRIPTION
If the global topo root is not specified, or if a local cell is not
found, it's better to exit early.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>