### PR TITLE
Fix automated release script

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y make ruby ruby-dev
         go mod download
-        sudo gem install --no-ri --no-rdoc fpm
+        sudo gem install fpm
 
     - name: Make Packages
       run: |


### PR DESCRIPTION
The option `--no-ri` has been removed from Ruby gems.

This has been tested as an automated release in my personal branch:  https://github.com/morgo/vitess/actions/runs/89376099

Signed-off-by: Morgan Tocker <tocker@gmail.com>