### PR TITLE
Update Docker to Debian buster

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,34 +1,20 @@
-FROM golang:1.13-stretch
+FROM golang:1.13-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    # TODO(mberlin): Group these to make it easier to understand which library actually requires them.
-    automake \
-    bison \
-    bzip2 \
-    chromium=70.0.3538.110-1~deb9u1 \
+    chromium \
     curl \
     g++ \
     git \
-    libgconf-2-4 \
-    libtool \
     make \
-    openjdk-8-jdk \
-    software-properties-common \
-    virtualenv \
     unzip \
-    xvfb \
-    zip \
-    libz-dev \
     ant \
+    maven \
+    default-jdk \
+    zip \
+    etcd \
+    software-properties-common \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Maven 3.1+
-RUN mkdir -p /vt/src/vitess.io/vitess/dist && \
-    cd /vt/src/vitess.io/vitess/dist && \
-    curl -sL --connect-timeout 10 --retry 3 \
-        http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar -xz && \
-    mv apache-maven-3.3.9 maven
 
 # Set up Vitess environment (equivalent to '. dev.env')
 ENV VTROOT /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
@@ -22,6 +22,5 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
 
-ENV MYSQL_FLAVOR MariaDB
 USER vitess
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mariadb103
+++ b/docker/bootstrap/Dockerfile.mariadb103
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10.3
 RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8 \
-    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian stretch main' \
+    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian buster main' \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        mariadb-server-10.3 \
        libmariadb-dev \
@@ -11,6 +11,5 @@ RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
 
-ENV MYSQL_FLAVOR MariaDB103
 USER vitess
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -2,9 +2,9 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 5.6
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.6' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -3,9 +3,9 @@ FROM vitess/bootstrap:common
 # Install MySQL 5.7
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
     for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.7' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql57-arm64v8
+++ b/docker/bootstrap/Dockerfile.mysql57-arm64v8
@@ -57,6 +57,6 @@ WORKDIR /vt/src/vitess.io/vitess
 COPY --from=builder /usr/local/xtrabackup/bin /usr/local/xtrabackup/bin
 COPY --from=builder /usr/local/xtrabackup/lib /usr/local/xtrabackup/lib
 ENV PATH="/usr/local/xtrabackup/bin:${PATH}"
-ENV MYSQL_FLAVOR MySQL56
+
 USER vitess
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -2,9 +2,9 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-8.0' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
@@ -17,6 +17,5 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.poo
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
 
-ENV MYSQL_FLAVOR MySQL80
 USER vitess
 RUN ./bootstrap.sh

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 5.6
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 5.7
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done \
-    && echo 'deb http://repo.percona.com/ps-80/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    && echo 'deb http://repo.percona.com/ps-80/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
@@ -19,7 +19,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 	rsync \
 	libev4 \
 #    && rm -f /etc/apt/sources.list.d/percona.list \
-    && echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list \
+    && echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list \
 #    { \
 #        echo debconf debconf/frontend select Noninteractive; \
 #        echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
@@ -32,6 +32,5 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 # Bootstrap Vitess
 WORKDIR /vt/src/vitess.io/vitess
 
-ENV MYSQL_FLAVOR MySQL80
 USER vitess
 RUN ./bootstrap.sh


### PR DESCRIPTION
This updates the base docker image from Debian 9 (stretch) to Debian 10 (Buster). Buster was released in July 2019.

I have also made the following changes:
- Unpin chromium version (the version pinned is no longer available in buster)
- Install maven and etcd from repos
- Change jdk to default jdk
- Remove MYSQL_FLAVOR (should no longer be required since python tests are removed).

I am awaiting the results of a full docker bootstrap test and will paste them here.

Signed-off-by: Morgan Tocker <tocker@gmail.com>