### PR TITLE
vitessdriver: allow overriding the driver name

### DIFF
--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -85,7 +85,7 @@ func OpenWithConfiguration(c Configuration) (*sql.DB, error) {
 		vtgateconn.RegisterDialer(c.Protocol, grpcvtgateconn.DialWithOpts(context.TODO(), c.GRPCDialOptions...))
 	}
 
-	return sql.Open("vitess", json)
+	return sql.Open(c.DriverName, json)
 }
 
 type drv struct {
@@ -160,6 +160,12 @@ type Configuration struct {
 	//
 	// Default: none
 	GRPCDialOptions []grpc.DialOption `json:"-"`
+
+	// Driver is the name registered with the database/sql package. This override
+	// is here in case you have wrapped the driver for stats or other interceptors.
+	//
+	// Default: "vitess"
+	DriverName string `json:"-"`
 }
 
 // toJSON converts Configuration to the JSON string which is required by the
@@ -178,6 +184,10 @@ func (c *Configuration) setDefaults() {
 	// of the connection protocol and not the flag vtgateconn.VtgateProtocol
 	if c.Protocol == "" {
 		c.Protocol = "grpc"
+	}
+
+	if c.DriverName == "" {
+		c.DriverName = "vitess"
 	}
 }
 

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -81,8 +81,9 @@ func TestOpen(t *testing.T) {
 			connStr: fmt.Sprintf(`{"address": "%s", "target": "@replica", "timeout": %d}`, testAddress, int64(30*time.Second)),
 			conn: &conn{
 				Configuration: Configuration{
-					Protocol: "grpc",
-					Target:   "@replica",
+					Protocol:   "grpc",
+					DriverName: "vitess",
+					Target:     "@replica",
 				},
 				convert: &converter{
 					location: time.UTC,
@@ -94,7 +95,8 @@ func TestOpen(t *testing.T) {
 			connStr: fmt.Sprintf(`{"address": "%s", "timeout": %d}`, testAddress, int64(30*time.Second)),
 			conn: &conn{
 				Configuration: Configuration{
-					Protocol: "grpc",
+					Protocol:   "grpc",
+					DriverName: "vitess",
 				},
 				convert: &converter{
 					location: time.UTC,
@@ -106,8 +108,9 @@ func TestOpen(t *testing.T) {
 			connStr: fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "target": "ks:0@replica", "timeout": %d}`, testAddress, int64(30*time.Second)),
 			conn: &conn{
 				Configuration: Configuration{
-					Protocol: "grpc",
-					Target:   "ks:0@replica",
+					Protocol:   "grpc",
+					DriverName: "vitess",
+					Target:     "ks:0@replica",
 				},
 				convert: &converter{
 					location: time.UTC,
@@ -122,6 +125,7 @@ func TestOpen(t *testing.T) {
 			conn: &conn{
 				Configuration: Configuration{
 					Protocol:        "grpc",
+					DriverName:      "vitess",
 					DefaultLocation: "America/Los_Angeles",
 				},
 				convert: &converter{


### PR DESCRIPTION
We are using https://github.com/opencensus-integrations/ocsql to wrap this driver for stats. It is necessary to use a custom driver name for that to work. Defaults haven't changed, so this should have no impact on any other users.