### PR TITLE
tm revamp: remove most topo.ChangeType

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -160,10 +160,6 @@ type ActionAgent struct {
 	// instead of asking mysqld what port it's serving on.
 	mysqlAdvertisePort int32
 
-	// initReplication remembers whether an action has initialized
-	// replication.  It is protected by actionMutex.
-	initReplication bool
-
 	// initialTablet remembers the state of the tablet record at startup.
 	// It can be used to notice, for example, if another tablet has taken
 	// over the record.

--- a/go/vt/vttablet/tabletmanager/healthcheck_test.go
+++ b/go/vt/vttablet/tabletmanager/healthcheck_test.go
@@ -930,10 +930,7 @@ func TestBackupStateChange(t *testing.T) {
 	agent.HealthReporter.(*fakeHealthCheck).reportReplicationDelay = 16 * time.Second
 
 	// change to BACKUP, query service will turn off
-	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_BACKUP, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := agent.RefreshState(ctx); err != nil {
+	if err := agent.ChangeType(ctx, topodatapb.TabletType_BACKUP); err != nil {
 		t.Fatal(err)
 	}
 	if agent.QueryServiceControl.IsServing() {
@@ -944,10 +941,7 @@ func TestBackupStateChange(t *testing.T) {
 	}
 	// change back to REPLICA, query service should not start
 	// because replication delay > unhealthyThreshold
-	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_REPLICA, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := agent.RefreshState(ctx); err != nil {
+	if err := agent.ChangeType(ctx, topodatapb.TabletType_REPLICA); err != nil {
 		t.Fatal(err)
 	}
 	if agent.QueryServiceControl.IsServing() {
@@ -984,10 +978,7 @@ func TestRestoreStateChange(t *testing.T) {
 	agent.HealthReporter.(*fakeHealthCheck).reportReplicationDelay = 16 * time.Second
 
 	// change to RESTORE, query service will turn off
-	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_RESTORE, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := agent.RefreshState(ctx); err != nil {
+	if err := agent.ChangeType(ctx, topodatapb.TabletType_RESTORE); err != nil {
 		t.Fatal(err)
 	}
 	if agent.QueryServiceControl.IsServing() {
@@ -998,10 +989,7 @@ func TestRestoreStateChange(t *testing.T) {
 	}
 	// change back to REPLICA, query service should not start
 	// because replication delay > unhealthyThreshold
-	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_REPLICA, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := agent.RefreshState(ctx); err != nil {
+	if err := agent.ChangeType(ctx, topodatapb.TabletType_REPLICA); err != nil {
 		t.Fatal(err)
 	}
 	if agent.QueryServiceControl.IsServing() {

--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -64,7 +64,11 @@ func (agent *ActionAgent) ChangeType(ctx context.Context, tabletType topodatapb.
 		return err
 	}
 	defer agent.unlock()
+	return agent.changeTypeLocked(ctx, tabletType)
+}
 
+// ChangeType changes the tablet type
+func (agent *ActionAgent) changeTypeLocked(ctx context.Context, tabletType topodatapb.TabletType) error {
 	// We don't want to allow multiple callers to claim a tablet as drained. There is a race that could happen during
 	// horizontal resharding where two vtworkers will try to DRAIN the same tablet. This check prevents that race from
 	// causing errors.

--- a/go/vt/wrangler/testlib/rpc_reparent_external_test.go
+++ b/go/vt/wrangler/testlib/rpc_reparent_external_test.go
@@ -292,6 +292,10 @@ func TestRPCTabletExternallyReparentedFailedOldMaster(t *testing.T) {
 		"START SLAVE",
 	}
 
+	// On the oldMaster, we expect a ChangeType to REPLICA.
+	oldMaster.StartActionLoop(t, wr)
+	defer oldMaster.StopActionLoop(t)
+
 	// On the good slave, we will respond to
 	// TabletActionSlaveWasRestarted.
 	goodSlave.StartActionLoop(t, wr)
@@ -472,6 +476,10 @@ func TestRPCTabletExternallyReparentedFailedImpostorMaster(t *testing.T) {
 	// TabletActionSlaveWasRestarted.
 	oldMaster.StartActionLoop(t, wr)
 	defer oldMaster.StopActionLoop(t)
+
+	// On the bad slave, we expect a ChangeType to REPLICA.
+	badSlave.StartActionLoop(t, wr)
+	defer badSlave.StopActionLoop(t)
 
 	// The reparent should work as expected here
 	tmc := tmclient.NewTabletManagerClient()


### PR DESCRIPTION
All those calls have been replaced with agent.ChangeType.
agent.ChangeType is the only one that should call topo.ChangeType.
One exception is agent.finalizeTabletExternallyReparented. It
actually changes the tablet's internal state before updating
topo, which seems to break the main rule. So, I've left it alone
for now.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>