### PR TITLE
Make sure to handle types no matter casing

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -199,7 +199,7 @@ func (ct *ColumnType) DescribeType() string {
 
 // SQLType returns the sqltypes type code for the given column
 func (ct *ColumnType) SQLType() querypb.Type {
-	switch ct.Type {
+	switch strings.ToLower(ct.Type) {
 	case keywordStrings[TINYINT]:
 		if ct.Unsigned {
 			return sqltypes.Uint8

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -783,4 +785,10 @@ func TestSplitStatementToPieces(t *testing.T) {
 			t.Errorf("out: %s, want %s", out, tcase.output)
 		}
 	}
+}
+
+func TestTypeConversion(t *testing.T) {
+	ct1 := &ColumnType{Type: "BIGINT"}
+	ct2 := &ColumnType{Type: "bigint"}
+	assert.Equal(t, ct1.SQLType(), ct2.SQLType())
 }

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/sqltypes"
@@ -418,7 +419,7 @@ func init() {
 		if id == UNUSED {
 			continue
 		}
-		keywordStrings[id] = str
+		keywordStrings[id] = strings.ToLower(str)
 	}
 }
 


### PR DESCRIPTION
This query:
```
create table t1 (
 id BIGINT,
 public_key varchar(255)
) ENGINE=innodb;
```

was failing with:

```
panic: unimplemented type BIGINT
/usr/local/go/src/runtime/panic.go:969 (0x4360f5)
	gopanic: done = runOpenDeferFrame(gp, d)
go/src/vitess.io/vitess/go/vt/sqlparser/ast_funcs.go:295 (0x987aa3)
	go/vt/sqlparser.(*ColumnType).SQLType: panic("unimplemented type " + ct.Type)
go/src/vitess.io/vitess/go/vt/vtexplain/vtexplain_vttablet.go:407 (0xd0dc82)
	go/vt/vtexplain.initTabletEnvironment: Type: col.Type.SQLType(),
go/src/vitess.io/vitess/go/vt/vtexplain/vtexplain.go:158 (0xd06662)
	go/vt/vtexplain.Init: err = initTabletEnvironment(parsedDDLs, opts)
go/src/vitess.io/vitess/go/cmd/vtexplain/vtexplain.go:167 (0xd1327f)
	parseAndRun: err = vtexplain.Init(vschema, schema, opts)
go/src/vitess.io/vitess/go/cmd/vtexplain/vtexplain.go:132 (0xd12db1)
	main: err := parseAndRun()
```