### PR TITLE
Simplified code

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -39,16 +39,6 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-// BinlogFormat is used for specifying the binlog format.
-type BinlogFormat int
-
-// The following constants specify the possible binlog format values.
-const (
-	BinlogFormatStatement BinlogFormat = iota
-	BinlogFormatRow
-	BinlogFormatMixed
-)
-
 // DBConn is a db connection for tabletserver.
 // It performs automatic reconnects as needed.
 // Its Execute function has a timeout that can kill
@@ -84,7 +74,7 @@ func NewDBConn(ctx context.Context, cp *Pool, appParams dbconfigs.Connector) (*D
 }
 
 // NewDBConnNoPool creates a new DBConn without a pool.
-func NewDBConnNoPool(ctx context.Context, params dbconfigs.Connector, dbaPool *dbconnpool.ConnectionPool, stats *tabletenv.Stats) (*DBConn, error) {
+func NewDBConnNoPool(ctx context.Context, params dbconfigs.Connector, dbaPool *dbconnpool.ConnectionPool) (*DBConn, error) {
 	c, err := dbconnpool.NewDBConnection(ctx, params)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -31,8 +31,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 func compareTimingCounts(t *testing.T, op string, delta int64, before, after map[string]int64) {
@@ -238,7 +236,7 @@ func TestDBNoPoolConnKill(t *testing.T) {
 	connPool := newPool()
 	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer connPool.Close()
-	dbConn, err := NewDBConnNoPool(context.Background(), db.ConnParams(), connPool.dbaPool, tabletenv.NewStats(servenv.NewExporter("Test", "Tablet")))
+	dbConn, err := NewDBConnNoPool(context.Background(), db.ConnParams(), connPool.dbaPool)
 	if dbConn != nil {
 		defer dbConn.Close()
 	}

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -155,7 +155,7 @@ func (cp *Pool) Get(ctx context.Context) (*DBConn, error) {
 	}
 
 	if cp.isCallerIDAppDebug(ctx) {
-		return NewDBConnNoPool(ctx, cp.appDebugParams, cp.dbaPool, cp.env.Stats())
+		return NewDBConnNoPool(ctx, cp.appDebugParams, cp.dbaPool)
 	}
 	p := cp.pool()
 	if p == nil {


### PR DESCRIPTION
 - Removed unused types and parameters
 - Renamed TxPool receiver from `axp` to `tp`