### PR TITLE
Fix regression in release script

### DIFF
--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -41,16 +41,21 @@ done;
 
 # Copy remaining files, preserving date/permissions
 # But resolving symlinks
-mkdir -p "${RELEASE_DIR}"/share/vitess/
-cp -rpfL examples "${RELEASE_DIR}"/share/vitess/
+cp -rpfL examples "${RELEASE_DIR}"
 
-echo "Follow the binary installation instructions at: https://vitess.io/docs/get-started/local/" > "${RELEASE_DIR}"/share/vitess/examples/README.md
+echo "Follow the installation instructions at: https://vitess.io/docs/get-started/local/" > "${RELEASE_DIR}"/examples/README.md
 
 cd "${RELEASE_DIR}/.."
 tar -czf "${TAR_FILE}" "${RELEASE_ID}"
 
 cd "${RELEASE_DIR}"
 PREFIX=${PREFIX:-/usr}
+
+# For RPMs and DEBs, binaries will be in /usr/bin
+# Examples will be in /usr/share/vitess/examples
+
+mkdir -p share/vitess/
+mv examples share/vitess/
 
 fpm \
    --force \


### PR DESCRIPTION
There is a regression in Vitess 6, where examples in the tar.gz moved to share/vitess/examples. This was intended for (and makes a lot of sense) in RPMs and DEBs.

I've tweaked it slightly so that tar archives move back to examples, and RPMs and DEBs still have this behavior.

This makes sense as a backport to 6 as well, as we intend to have a point release to fix a `use db` issue with the MySQL client.

Signed-off-by: Morgan Tocker <tocker@gmail.com>