### PR TITLE
Change all external links in vitess to use https

### DIFF
--- a/go/vt/logz/logz_utils.go
+++ b/go/vt/logz/logz_utils.go
@@ -79,7 +79,7 @@ func StartHTMLTable(w http.ResponseWriter) {
                 }
 </style>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
 
 <script type="text/javascript">
 $.fn.sortableByColumn = function() {

--- a/go/vt/servenv/jquery.go
+++ b/go/vt/servenv/jquery.go
@@ -18,7 +18,7 @@ package servenv
 
 // JQueryIncludes is the include to use to be able to use jquery and jquery-ui
 const JQueryIncludes = `
-<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 `

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -55,7 +55,7 @@ COMMAND ARGUMENT DEFINITIONS
             of decimal numbers, each with optional fraction and a unit
             suffix, such as "300ms" or "1h45m". See the definition of the
             Go language's <a
-            href="http://golang.org/pkg/time/#ParseDuration">ParseDuration</a>
+            href="https://golang.org/pkg/time/#ParseDuration">ParseDuration</a>
             function for more details. Note that, in practice, the value
             should be a positively signed value.
 

--- a/java/client/src/main/java/io/vitess/mysql/DateTime.java
+++ b/java/client/src/main/java/io/vitess/mysql/DateTime.java
@@ -92,7 +92,7 @@ public class DateTime {
    * Parse a MySQL TIME format into a {@link Time} with the given {@link Calendar}.
    *
    * <p>The range for TIME values is '-838:59:59.000000' to '838:59:59.000000'
-   * <a href="http://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
+   * <a href="https://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
    *
    * <p>Note that this is meant to parse only valid values, assumed to be
    * returned by MySQL. Results are undefined for invalid input.
@@ -178,7 +178,7 @@ public class DateTime {
    * Format a {@link Time} as a MySQL TIME with the given {@link Calendar}.
    *
    * <p>The range for TIME values is '-838:59:59.000000' to '838:59:59.000000'
-   * <a href="http://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
+   * <a href="https://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
    * We don't enforce that range, but we do print >24 hours rather than wrapping around to the next
    * day.
    */
@@ -223,7 +223,7 @@ public class DateTime {
    *
    * <p>The format is 'YYYY-MM-DD HH:MM:SS[.fraction]' where the fraction
    * can be up to 6 digits.
-   * <a href="http://dev.mysql.com/doc/refman/5.6/en/datetime.html">[1]</a>.
+   * <a href="https://dev.mysql.com/doc/refman/5.6/en/datetime.html">[1]</a>.
    *
    * <p>Note that this is meant to parse only valid values, assumed to be
    * returned by MySQL. Results are undefined for invalid input.


### PR DESCRIPTION
Changing all external links in vitess to https, for security.
- Includes web page UIs that may be served over HTTPS (but using non-HTTPS resources), and fail when loading under HTTPS urls.
- Documentation links have been individually verified to work, like `https://dev.mysql.com`

Fixes #6170

Signed-off-by: Toliver Jue <toliver@planetscale.com>