### PR TITLE
GTIDSet Union

### DIFF
--- a/go/mysql/filepos_gtid.go
+++ b/go/mysql/filepos_gtid.go
@@ -136,14 +136,11 @@ func (gtid filePosGTID) AddGTID(other GTID) GTIDSet {
 // Union implements GTIDSet.Union().
 func (gtid filePosGTID) Union(other GTIDSet) GTIDSet {
 	filePosOther, ok := other.(filePosGTID)
-	if !ok {
+	if !ok || gtid.Contains(other) {
 		return gtid
 	}
-	if filePosOther.pos > gtid.pos {
-		return filePosOther
-	}
 
-	return gtid
+	return filePosOther
 }
 
 func init() {

--- a/go/mysql/filepos_gtid.go
+++ b/go/mysql/filepos_gtid.go
@@ -133,6 +133,19 @@ func (gtid filePosGTID) AddGTID(other GTID) GTIDSet {
 	return filePosOther
 }
 
+// Union implements GTIDSet.Union().
+func (gtid filePosGTID) Union(other GTIDSet) GTIDSet {
+	filePosOther, ok := other.(filePosGTID)
+	if !ok {
+		return gtid
+	}
+	if filePosOther.pos > gtid.pos {
+		return filePosOther
+	}
+
+	return gtid
+}
+
 func init() {
 	gtidParsers[filePosFlavorID] = parseFilePosGTID
 	gtidSetParsers[filePosFlavorID] = parseFilePosGTIDSet

--- a/go/mysql/gtid_set.go
+++ b/go/mysql/gtid_set.go
@@ -46,7 +46,7 @@ type GTIDSet interface {
 	// AddGTID returns a new GTIDSet that is expanded to contain the given GTID.
 	AddGTID(GTID) GTIDSet
 
-	// Union return a union of the caller GTIDSet and the supplied GTIDSet.
+	// Union returns a union of the receiver GTIDSet and the supplied GTIDSet.
 	Union(GTIDSet) GTIDSet
 }
 

--- a/go/mysql/gtid_set.go
+++ b/go/mysql/gtid_set.go
@@ -45,6 +45,9 @@ type GTIDSet interface {
 
 	// AddGTID returns a new GTIDSet that is expanded to contain the given GTID.
 	AddGTID(GTID) GTIDSet
+
+	// Union return a union of the caller GTIDSet and the supplied GTIDSet.
+	Union(GTIDSet) GTIDSet
 }
 
 // gtidSetParsers maps flavor names to parser functions. It is used by

--- a/go/mysql/gtid_test.go
+++ b/go/mysql/gtid_test.go
@@ -199,9 +199,9 @@ func (fakeGTID) SequenceNumber() interface{} { return int(1) }
 func (fakeGTID) SequenceDomain() interface{} { return int(1) }
 func (f fakeGTID) GTIDSet() GTIDSet          { return nil }
 
-func (fakeGTID) ContainsGTID(GTID) bool { return false }
-func (fakeGTID) Contains(GTIDSet) bool  { return false }
-func (f fakeGTID) Union(GTIDSet) GTIDSet  { return f }
+func (fakeGTID) ContainsGTID(GTID) bool  { return false }
+func (fakeGTID) Contains(GTIDSet) bool   { return false }
+func (f fakeGTID) Union(GTIDSet) GTIDSet { return f }
 func (f fakeGTID) Equal(other GTIDSet) bool {
 	otherFake, ok := other.(fakeGTID)
 	if !ok {

--- a/go/mysql/gtid_test.go
+++ b/go/mysql/gtid_test.go
@@ -201,6 +201,7 @@ func (f fakeGTID) GTIDSet() GTIDSet          { return nil }
 
 func (fakeGTID) ContainsGTID(GTID) bool { return false }
 func (fakeGTID) Contains(GTIDSet) bool  { return false }
+func (f fakeGTID) Union(GTIDSet) GTIDSet  { return f }
 func (f fakeGTID) Equal(other GTIDSet) bool {
 	otherFake, ok := other.(fakeGTID)
 	if !ok {

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -211,20 +211,24 @@ func (gtidSet MariadbGTIDSet) Union(other GTIDSet)  GTIDSet {
 	}
 
 	// Create a map of Domain to GTID for efficient lookup when adding.
-	mySet := make(map[uint32]*MariadbGTID, len(gtidSet) + len(mdbOther))
-	for _, gtid := range gtidSet {
-		mySet[gtid.Domain] = &gtid
+	mySet := make(map[uint32]*MariadbGTID)
+	for i, _ := range gtidSet {
+		gtid := &gtidSet[i]
+		mySet[gtid.Domain] = gtid
 	}
 
-	for _, otherGtid := range mdbOther {
+	for i,_ := range mdbOther {
+		otherGtid := &mdbOther[i]
 		if myGtid, ok := mySet[otherGtid.Domain]; ok {
 			if otherGtid.Sequence > myGtid.Sequence {
-				mySet[otherGtid.Domain] = &otherGtid
+				mySet[otherGtid.Domain] = otherGtid
 			}
+		} else {
+			mySet[otherGtid.Domain] = otherGtid
 		}
 	}
 
-	gtidList := make(MariadbGTIDSet, len(mySet))
+	gtidList := make(MariadbGTIDSet, 0, len(mySet))
 	for _, gtid := range mySet {
 		if gtid == nil {
 			continue

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -212,9 +212,13 @@ func (gtidSet MariadbGTIDSet) AddGTID(other GTID) GTIDSet {
 
 // Union implements GTIDSet.Union(). This is a pure method, and does not mutate the receiver.
 func (gtidSet MariadbGTIDSet) Union(other GTIDSet) GTIDSet {
+	if gtidSet == nil && other != nil {
+		return other
+	}
 	if gtidSet == nil || other == nil {
 		return gtidSet
 	}
+
 	mdbOther, ok := other.(MariadbGTIDSet)
 	if !ok {
 		return gtidSet

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -230,9 +230,6 @@ func (gtidSet MariadbGTIDSet) Union(other GTIDSet)  GTIDSet {
 
 	gtidList := make(MariadbGTIDSet, 0, len(mySet))
 	for _, gtid := range mySet {
-		if gtid == nil {
-			continue
-		}
 		gtidList = append(gtidList, *gtid)
 	}
 

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -210,7 +210,7 @@ func (gtidSet MariadbGTIDSet) AddGTID(other GTID) GTIDSet {
 	return append(gtidSet, mdbOther)
 }
 
-// Union implements GTIDSet.Union(). This is a pure method, and does not mutate the caller.
+// Union implements GTIDSet.Union(). This is a pure method, and does not mutate the receiver.
 func (gtidSet MariadbGTIDSet) Union(other GTIDSet) GTIDSet {
 	if gtidSet == nil || other == nil {
 		return gtidSet

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -222,12 +222,12 @@ func (gtidSet MariadbGTIDSet) Union(other GTIDSet) GTIDSet {
 
 	// Create a map of Domain to GTID for efficient lookup when adding.
 	mySet := make(map[uint32]*MariadbGTID)
-	for i, _ := range gtidSet {
+	for i := range gtidSet {
 		gtid := &gtidSet[i]
 		mySet[gtid.Domain] = gtid
 	}
 
-	for i, _ := range mdbOther {
+	for i := range mdbOther {
 		otherGtid := &mdbOther[i]
 		if myGtid, ok := mySet[otherGtid.Domain]; ok {
 			if otherGtid.Sequence > myGtid.Sequence {

--- a/go/mysql/mariadb_gtid.go
+++ b/go/mysql/mariadb_gtid.go
@@ -18,6 +18,7 @@ package mysql
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -86,6 +87,15 @@ type MariadbGTID struct {
 
 // MariadbGTIDSet implements GTIDSet
 type MariadbGTIDSet []MariadbGTID
+
+// Len implements sort.Interface.
+func (s MariadbGTIDSet) Len() int { return len(s) }
+
+// Less implements sort.Interface.
+func (s MariadbGTIDSet) Less(i, j int) bool { return s[i].Domain < s[j].Domain }
+
+// Swap implements sort.Interface.
+func (s MariadbGTIDSet) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // String implements GTID.String().
 func (gtid MariadbGTID) String() string {
@@ -201,7 +211,7 @@ func (gtidSet MariadbGTIDSet) AddGTID(other GTID) GTIDSet {
 }
 
 // Union implements GTIDSet.Union(). This is a pure method, and does not mutate the caller.
-func (gtidSet MariadbGTIDSet) Union(other GTIDSet)  GTIDSet {
+func (gtidSet MariadbGTIDSet) Union(other GTIDSet) GTIDSet {
 	if gtidSet == nil || other == nil {
 		return gtidSet
 	}
@@ -217,7 +227,7 @@ func (gtidSet MariadbGTIDSet) Union(other GTIDSet)  GTIDSet {
 		mySet[gtid.Domain] = gtid
 	}
 
-	for i,_ := range mdbOther {
+	for i, _ := range mdbOther {
 		otherGtid := &mdbOther[i]
 		if myGtid, ok := mySet[otherGtid.Domain]; ok {
 			if otherGtid.Sequence > myGtid.Sequence {
@@ -232,6 +242,8 @@ func (gtidSet MariadbGTIDSet) Union(other GTIDSet)  GTIDSet {
 	for _, gtid := range mySet {
 		gtidList = append(gtidList, *gtid)
 	}
+
+	sort.Sort(gtidList)
 
 	return gtidList
 }

--- a/go/mysql/mariadb_gtid_test.go
+++ b/go/mysql/mariadb_gtid_test.go
@@ -472,3 +472,55 @@ func TestMariaGTIDSetAddGTIDDifferentDomain(t *testing.T) {
 		t.Errorf("%#v.AddGTID(%#v) = %v, want %v", input1, input2, got, want)
 	}
 }
+
+func TestMariaGTIDSetUnion(t *testing.T) {
+	set1 := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
+	}
+	set2 := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+	}
+
+	got := set1.Union(set2)
+
+	want := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+	}
+
+	if !got.Equal(want) {
+		t.Errorf("set1: %#v, set1.Union(%#v) = %#v, want %#v", set1, set2, got, want)
+	}
+}
+
+func TestMariaGTIDSetUnionNewDomain(t *testing.T) {
+	set1 := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
+	}
+	set2 := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
+	}
+
+	got := set1.Union(set2)
+
+	want := MariadbGTIDSet{
+		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
+	}
+
+	if !got.Equal(want) {
+		t.Errorf("set1: %#v, set1.Union(%#v) = %#v, want %#v", set1, set2, got, want)
+	}
+}

--- a/go/mysql/mariadb_gtid_test.go
+++ b/go/mysql/mariadb_gtid_test.go
@@ -523,4 +523,14 @@ func TestMariaGTIDSetUnionNewDomain(t *testing.T) {
 	if !got.Equal(want) {
 		t.Errorf("set1: %#v, set1.Union(%#v) = %#v, want %#v", set1, set2, got, want)
 	}
+
+	switch g := got.(type) {
+	case MariadbGTIDSet:
+		// Enforce order of want. Results should be sorted by domain.
+		if g[0] != want[0] || g[1] != want[1] || g[2] != want[2] || g[3] != want[3] {
+			t.Error("Set was not sorted by domain when returned.")
+		}
+	default:
+		t.Error("Union result was not of type MariadbGTIDSet.")
+	}
 }

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -348,18 +348,17 @@ func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
 	// This function is not supposed to modify the original set.
 	newSet := make(Mysql56GTIDSet)
 
-	for OtherSID, otherIntervals := range mydbOther {
-		intervals, ok := set[OtherSID]
-
+	for otherSID, otherIntervals := range mydbOther {
+		intervals, ok := set[otherSID]
 		if !ok {
 			// No matching server id, so we must add it from other set.
-			newSet[OtherSID] = otherIntervals
+			newSet[otherSID] = otherIntervals
 			continue
 		}
 
 		// Found server id match between sets, so now we need to add each interval.
-		s1 := intervals[:]
-		s2 := otherIntervals[:]
+		s1 := intervals
+		s2 := otherIntervals
 		var nextInterval interval
 		var newIntervals []interval
 
@@ -398,7 +397,7 @@ func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
 			activeInterval.end = nextInterval.end
 		}
 
-		newSet[OtherSID] = newIntervals
+		newSet[otherSID] = newIntervals
 	}
 
 	// Add any intervals from SIDs that exist in caller set, but don't exist in other set.

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -336,6 +336,9 @@ func (set Mysql56GTIDSet) AddGTID(gtid GTID) GTIDSet {
 
 // Union implements GTIDSet.Union().
 func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
+	if set == nil && other != nil {
+		return other
+	}
 	if set == nil || other == nil {
 		return set
 	}

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -366,18 +366,14 @@ func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
 		// While our stacks have intervals to process, do work.
 		for len(s1) != 0 || len(s2) != 0 {
 			// Find which intervals list has earliest start.
-			if intervals[0].start <= otherIntervals[0].start {
-				nextInterval = intervals[0]
-				if len(s1) != 0 {
-					// Progress pointer since this stack has earliest.
-					s1 = s1[1:]
-				}
+			if len(s2) == 0 || (len(s1) != 0 && s1[0].start <= s2[0].start) {
+				nextInterval = s1[0]
+				// Progress pointer since this stack has earliest.
+				s1 = s1[1:]
 			} else {
-				nextInterval = otherIntervals[0]
-				if len(s2) != 0 {
-					// Progress pointer since this stack has earliest.
-					s2 = s2[1:]
-				}
+				nextInterval = s2[0]
+				// Progress pointer since this stack has earliest.
+				s2 = s2[1:]
 			}
 
 			if len(newIntervals) == 0 {

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -334,6 +334,87 @@ func (set Mysql56GTIDSet) AddGTID(gtid GTID) GTIDSet {
 	return newSet
 }
 
+// Union implements GTIDSet.Union().
+func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
+	if set == nil || other == nil {
+		return set
+	}
+	mydbOther, ok := other.(Mysql56GTIDSet)
+	if !ok {
+		return set
+	}
+
+	// Make a copy and add the new GTID in the proper place.
+	// This function is not supposed to modify the original set.
+	newSet := make(Mysql56GTIDSet)
+
+	for OtherSID, otherIntervals := range mydbOther {
+		intervals, ok := set[OtherSID]
+
+		if !ok {
+			// No matching server id, so we must add it from other set.
+			newSet[OtherSID] = otherIntervals
+			continue
+		}
+
+		// Found server id match between sets, so now we need to add each interval.
+		s1 := intervals[:]
+		s2 := otherIntervals[:]
+		var nextInterval interval
+		var newIntervals []interval
+
+		// While our stacks have intervals to process, do work.
+		for len(s1) != 0 || len(s2) != 0 {
+			// Find which intervals list has earliest start.
+			if intervals[0].start <= otherIntervals[0].start {
+				nextInterval = intervals[0]
+				if len(s1) != 0 {
+					// Progress pointer since this stack has earliest.
+					s1 = s1[1:]
+				}
+			} else {
+				nextInterval = otherIntervals[0]
+				if len(s2) != 0 {
+					// Progress pointer since this stack has earliest.
+					s2 = s2[1:]
+				}
+			}
+
+			if len(newIntervals) == 0 {
+				newIntervals = append(newIntervals, nextInterval)
+			}
+
+			activeInterval := &newIntervals[len(newIntervals)-1]
+
+			if nextInterval.end < activeInterval.end {
+				// We hit an interval whose start was after the previous intervals start, but whose
+				// end is prior to the active intervals end. Skip to next interval.
+				continue
+			}
+
+			if nextInterval.start > activeInterval.end {
+				// We found a gap, so we need to start a new interval.
+				newIntervals = append(newIntervals, nextInterval)
+				continue
+			}
+
+			// Extend our active interval.
+			activeInterval.end = nextInterval.end
+		}
+
+		newSet[OtherSID] = newIntervals
+	}
+
+	// Add any intervals from SIDs that exist in caller set, but don't exist in other set.
+	for sid, intervals := range set {
+		if _, ok := newSet[sid]; !ok {
+			newSet[sid] = intervals
+		}
+	}
+
+	return newSet
+}
+
 // SIDBlock returns the binary encoding of a MySQL 5.6 GTID set as expected
 // by internal commands that refer to an "SID block".
 //

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -371,13 +371,13 @@ func (set Mysql56GTIDSet) Union(other GTIDSet) GTIDSet {
 
 			activeInterval := &newIntervals[len(newIntervals)-1]
 
-			if nextInterval.end < activeInterval.end {
-				// We hit an interval whose start was after the previous intervals start, but whose
+			if nextInterval.end <= activeInterval.end {
+				// We hit an interval whose start was after or equal to the previous interval's start, but whose
 				// end is prior to the active intervals end. Skip to next interval.
 				continue
 			}
 
-			if nextInterval.start > activeInterval.end {
+			if nextInterval.start > activeInterval.end+1 {
 				// We found a gap, so we need to start a new interval.
 				newIntervals = append(newIntervals, nextInterval)
 				continue

--- a/go/mysql/mysql56_gtid_set.go
+++ b/go/mysql/mysql56_gtid_set.go
@@ -477,10 +477,6 @@ func NewMysql56GTIDSetFromSIDBlock(data []byte) (Mysql56GTIDSet, error) {
 // will mutate the destination interval with the next earliest interval based on start sequence.
 // popInterval will return true if we were able to pop, or false if both stacks are now empty.
 func popInterval(dst *interval, s1, s2 *[]interval) bool {
-	if s1 == nil || s2 == nil {
-		return false
-	}
-
 	if len(*s1) == 0 && len(*s2) == 0 {
 		return false
 	}

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -417,6 +417,35 @@ func TestMysql56GTIDSetAddGTID(t *testing.T) {
 	}
 }
 
+func TestMysql56GTIDSetUnion(t *testing.T) {
+	sid1 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	sid2 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16}
+	sid3 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17}
+
+	set1 := Mysql56GTIDSet{
+		sid1: []interval{{20, 30}, {35, 40}, {42, 45}},
+		sid2: []interval{{1, 5}, {20, 50}, {60, 70}},
+	}
+
+	set2 := Mysql56GTIDSet{
+		sid1: []interval{{20, 31}, {35, 37}, {43, 46}},
+		sid2: []interval{{3, 6}, {22, 49}, {67, 72}},
+		sid3: []interval{{1, 45}},
+	}
+
+	got := set1.Union(set2)
+
+	want := Mysql56GTIDSet{
+		sid1: []interval{{20, 31}, {35, 40}, {42, 46}},
+		sid2: []interval{{1, 6}, {20, 50}, {60, 72}},
+		sid3: []interval{{1, 45}},
+	}
+
+	if !got.Equal(want) {
+		t.Errorf("set1: %#v, set1.Union(%#v) = %#v, want %#v", set1, set2, got, want)
+	}
+}
+
 func TestMysql56GTIDSetSIDBlock(t *testing.T) {
 	sid1 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	sid2 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16}

--- a/go/mysql/mysql56_gtid_set_test.go
+++ b/go/mysql/mysql56_gtid_set_test.go
@@ -428,7 +428,7 @@ func TestMysql56GTIDSetUnion(t *testing.T) {
 	}
 
 	set2 := Mysql56GTIDSet{
-		sid1: []interval{{20, 31}, {35, 37}, {43, 46}},
+		sid1: []interval{{20, 31}, {35, 37}, {41, 46}},
 		sid2: []interval{{3, 6}, {22, 49}, {67, 72}},
 		sid3: []interval{{1, 45}},
 	}
@@ -436,7 +436,7 @@ func TestMysql56GTIDSetUnion(t *testing.T) {
 	got := set1.Union(set2)
 
 	want := Mysql56GTIDSet{
-		sid1: []interval{{20, 31}, {35, 40}, {42, 46}},
+		sid1: []interval{{20, 31}, {35, 46}},
 		sid2: []interval{{1, 6}, {20, 50}, {60, 72}},
 		sid3: []interval{{1, 45}},
 	}

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -942,7 +942,7 @@ func (wr *Wrangler) emergencyReparentShardLocked(ctx context.Context, ev *events
 	}
 	wg.Wait()
 
-	// Check we stil have the topology lock.
+	// Check we still have the topology lock.
 	if err := topo.CheckShardLocked(ctx, keyspace, shard); err != nil {
 		return fmt.Errorf("lost topology lock, aborting: %v", err)
 	}


### PR DESCRIPTION
## Problem:

We need a way to get the union of two GTIDSets, so we can get the union of both the applied GTIDs, and relay log GTIDs for appropriately considering the most caught up replica when issuing an emergency reparent.

## Solution

This PR adds a `Union` method to the `GTIDSet` interface, and implements it across the board for all existing implementors of the `GTIDSet` interface.