### PR TITLE
Change select commerce

### DIFF
--- a/examples/common/select_commerce_data.sql
+++ b/examples/common/select_commerce_data.sql
@@ -1,5 +1,5 @@
-\! echo 'Using commerce/0'
-use commerce/0;
+\! echo 'Using commerce'
+use commerce;
 \! echo 'Customer'
 select * from customer;
 \! echo 'Product'


### PR DESCRIPTION
@sougou in the operator example, I noticed that you use a local copy of this file in the instructions:

```
mysql --table < select_commerce_data.sql
```

This will cause some problems for using shared instructions since the other install methods use:

```
mysql --table < ../common/select_commerce_data.sql
```

This PR copies your changes into the common directory, so that the instructions can be harmonized. If there is a specific reason you didn't make the change in common, please let me know :-) In which case I will need to rework the guide so they don't share common steps here.

Signed-off-by: Morgan Tocker <tocker@gmail.com>