### PR TITLE
Retry "use of closed network connection" in s3 backup handle

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/retryer.go
+++ b/go/vt/mysqlctl/s3backupstorage/retryer.go
@@ -8,14 +8,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+// ClosedConnectionRetryer implements the aws request.Retryer interface
+// and is used to retry closed connection errors during MultipartUpload
+// operations.
 type ClosedConnectionRetryer struct {
 	awsRetryer request.Retryer
 }
 
+// RetryRules is part of the Retryer interface. It defers to the underlying
+// aws Retryer to compute backoff rules.
 func (retryer *ClosedConnectionRetryer) RetryRules(r *request.Request) time.Duration {
 	return retryer.awsRetryer.RetryRules(r)
 }
 
+// ShouldRetry is part of the Retryer interface. It retries on errors that occur
+// due to a closed network connection, and then falls back to the underlying aws
+// Retryer for checking additional retry conditions.
 func (retryer *ClosedConnectionRetryer) ShouldRetry(r *request.Request) bool {
 	if retryer.MaxRetries() == 0 {
 		return false
@@ -34,6 +42,8 @@ func (retryer *ClosedConnectionRetryer) ShouldRetry(r *request.Request) bool {
 	return retryer.awsRetryer.ShouldRetry(r)
 }
 
+// MaxRetries is part of the Retryer interface. It defers to the
+// underlying aws Retryer for the max number of retries.
 func (retryer *ClosedConnectionRetryer) MaxRetries() int {
 	return retryer.awsRetryer.MaxRetries()
 }

--- a/go/vt/mysqlctl/s3backupstorage/retryer.go
+++ b/go/vt/mysqlctl/s3backupstorage/retryer.go
@@ -1,0 +1,32 @@
+package s3backupstorage
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+type ClosedConnectionRetryer struct {
+	awsRetryer request.Retryer
+}
+
+func (retryer *ClosedConnectionRetryer) RetryRules(r *request.Request) time.Duration {
+	return retryer.awsRetryer.RetryRules(r)
+}
+
+func (retryer *ClosedConnectionRetryer) ShouldRetry(r *request.Request) bool {
+	if retryer.MaxRetries() == 0 {
+		return false
+	}
+
+	if r.Error != nil && strings.Contains(r.Error.Error(), "use of closed network connection") {
+		return true
+	}
+
+	return retryer.awsRetryer.ShouldRetry(r)
+}
+
+func (retryer *ClosedConnectionRetryer) MaxRetries() int {
+	return retryer.awsRetryer.MaxRetries()
+}

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -37,6 +37,8 @@ import (
 	"vitess.io/vitess/go/vt/log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -354,6 +356,11 @@ func (bs *S3BackupStorage) client() (*s3.S3, error) {
 
 		if *retryCount >= 0 {
 			awsConfig.WithMaxRetries(*retryCount)
+			awsConfig = *request.WithRetryer(&awsConfig, &ClosedConnectionRetryer{
+				awsRetryer: &client.DefaultRetryer{
+					NumMaxRetries: *retryCount,
+				},
+			})
 		}
 
 		bs._client = s3.New(session, &awsConfig)

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -355,7 +355,6 @@ func (bs *S3BackupStorage) client() (*s3.S3, error) {
 		}
 
 		if *retryCount >= 0 {
-			awsConfig.WithMaxRetries(*retryCount)
 			awsConfig = *request.WithRetryer(&awsConfig, &ClosedConnectionRetryer{
 				awsRetryer: &client.DefaultRetryer{
 					NumMaxRetries: *retryCount,


### PR DESCRIPTION
This address some of the issues with taking backups with s3backupstorage after upgrade to aws-sdk-go version 1.28.x.

The approach is to create a [custom retryer](https://docs.aws.amazon.com/sdk-for-go/api/aws/request/#Retryer) to check for errors that match the "closed network connection" error string.

When creating the retryer, embed aws's `DefaultRetryer` (which is the logic that gets used if you don't specify anything), and use this to determine the rest of the retryable errors, as well as the backoff logic.