### PR TITLE
Update binlog_event_rbr.go

### DIFF
--- a/go/mysql/binlog_event_rbr.go
+++ b/go/mysql/binlog_event_rbr.go
@@ -700,7 +700,7 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, styp querypb.Typ
 		// now the full digits, 32 bits each, 9 digits
 		for i := 0; i < intg0; i++ {
 			val = binary.BigEndian.Uint32(d[pos : pos+4])
-			fmt.Fprintf(txt, "%9d", val)
+			fmt.Fprintf(txt, "%09d", val)
 			pos += 4
 		}
 


### PR DESCRIPTION
decimal type data(20,2) should be write as 
`000000000000000001.10` or `1.10`
now it formatted as 
`        0        1.10`