### PR TITLE
go/mysql: Fix MariadbGTIDSet multi-domain support.

### DIFF
--- a/go/mysql/mariadb_gtid_test.go
+++ b/go/mysql/mariadb_gtid_test.go
@@ -88,7 +88,10 @@ func TestParseMariaGTIDInvalidSequence(t *testing.T) {
 
 func TestParseMariaGTIDSet(t *testing.T) {
 	input := "12-34-5678,11-22-3333"
-	want := MariadbGTIDSet{MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}, MariadbGTID{Domain: 11, Server: 22, Sequence: 3333}}
+	want := MariadbGTIDSet{
+		12: MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
+		11: MariadbGTID{Domain: 11, Server: 22, Sequence: 3333},
+	}
 
 	got, err := parseMariadbGTIDSet(input)
 	if err != nil {
@@ -165,7 +168,7 @@ func TestMariaGTIDSequenceNumber(t *testing.T) {
 
 func TestMariaGTIDGTIDSet(t *testing.T) {
 	input := MariadbGTID{Domain: 12, Server: 345, Sequence: 6789}
-	want := MariadbGTIDSet{input}
+	want := MariadbGTIDSet{12: input}
 
 	got := input.GTIDSet()
 	if !got.Equal(want) {
@@ -173,9 +176,23 @@ func TestMariaGTIDGTIDSet(t *testing.T) {
 	}
 }
 
+func TestMariaGTIDSetString(t *testing.T) {
+	input := MariadbGTIDSet{
+		5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1737373},
+		3: MariadbGTID{Domain: 3, Server: 4321, Sequence: 9876},
+		1: MariadbGTID{Domain: 1, Server: 1234, Sequence: 5678},
+	}
+	want := "1-1234-5678,3-4321-9876,5-4727-1737373"
+
+	got := input.String()
+	if got != want {
+		t.Errorf("%#v.String() = '%v', want '%v'", input, got, want)
+	}
+}
+
 func TestMariaGTIDSetContainsLess(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 300}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 700}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 300}}
+	input2 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 700}}
 	want := false
 
 	if got := input1.Contains(input2); got != want {
@@ -184,8 +201,8 @@ func TestMariaGTIDSetContainsLess(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGreater(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 9000}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 100}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 9000}}
+	input2 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 5555, Sequence: 100}}
 	want := true
 
 	if got := input1.Contains(input2); got != want {
@@ -194,8 +211,14 @@ func TestMariaGTIDSetContainsGreater(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsEqual(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
+	input1 := MariadbGTIDSet{
+		1: MariadbGTID{Domain: 1, Server: 4321, Sequence: 100},
+		5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234},
+	}
+	input2 := MariadbGTIDSet{
+		1: MariadbGTID{Domain: 1, Server: 4321, Sequence: 100},
+		5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234},
+	}
 	want := true
 
 	if got := input1.Contains(input2); got != want {
@@ -204,8 +227,13 @@ func TestMariaGTIDSetContainsEqual(t *testing.T) {
 }
 
 func TestMariaGTIDSetMultipleContainsLess(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 123}, MariadbGTID{Domain: 5, Server: 5, Sequence: 24601}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 124}}
+	input1 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 123},
+		5: MariadbGTID{Domain: 5, Server: 5, Sequence: 24601},
+	}
+	input2 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 124},
+	}
 	want := false
 
 	if got := input1.Contains(input2); got != want {
@@ -214,8 +242,13 @@ func TestMariaGTIDSetMultipleContainsLess(t *testing.T) {
 }
 
 func TestMariaGTIDSetMultipleContainsGreater(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 123}, MariadbGTID{Domain: 5, Server: 5, Sequence: 24601}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 122}}
+	input1 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 123},
+		5: MariadbGTID{Domain: 5, Server: 5, Sequence: 24601},
+	}
+	input2 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 2, Sequence: 122},
+	}
 	want := true
 
 	if got := input1.Contains(input2); got != want {
@@ -224,8 +257,14 @@ func TestMariaGTIDSetMultipleContainsGreater(t *testing.T) {
 }
 
 func TestMariaGTIDSetMultipleContainsMultipleGreater(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 123}, MariadbGTID{Domain: 5, Server: 5, Sequence: 24601}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 122}, MariadbGTID{Domain: 5, Server: 4, Sequence: 1999}}
+	input1 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 123},
+		5: MariadbGTID{Domain: 5, Server: 5, Sequence: 24601},
+	}
+	input2 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 122},
+		5: MariadbGTID{Domain: 5, Server: 4, Sequence: 1999},
+	}
 	want := true
 
 	if got := input1.Contains(input2); got != want {
@@ -234,8 +273,14 @@ func TestMariaGTIDSetMultipleContainsMultipleGreater(t *testing.T) {
 }
 
 func TestMariaGTIDSetMultipleContainsOneLess(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 123}, MariadbGTID{Domain: 5, Server: 5, Sequence: 24601}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 122}, MariadbGTID{Domain: 5, Server: 4, Sequence: 24602}}
+	input1 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 123},
+		5: MariadbGTID{Domain: 5, Server: 5, Sequence: 24601},
+	}
+	input2 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 122},
+		5: MariadbGTID{Domain: 5, Server: 4, Sequence: 24602},
+	}
 	want := false
 
 	if got := input1.Contains(input2); got != want {
@@ -244,8 +289,13 @@ func TestMariaGTIDSetMultipleContainsOneLess(t *testing.T) {
 }
 
 func TestMariaGTIDSetSingleContainsMultiple(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 123}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 1, Sequence: 122}, MariadbGTID{Domain: 5, Server: 4, Sequence: 24602}}
+	input1 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 123},
+	}
+	input2 := MariadbGTIDSet{
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 122},
+		5: MariadbGTID{Domain: 5, Server: 4, Sequence: 24602},
+	}
 	want := false
 
 	if got := input1.Contains(input2); got != want {
@@ -254,7 +304,7 @@ func TestMariaGTIDSetSingleContainsMultiple(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsNil(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 1, Server: 2, Sequence: 123}}
+	input1 := MariadbGTIDSet{1: MariadbGTID{Domain: 1, Server: 2, Sequence: 123}}
 	input2 := GTIDSet(nil)
 	want := true
 
@@ -264,7 +314,7 @@ func TestMariaGTIDSetContainsNil(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsWrongType(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
 	input2 := fakeGTID{}
 	want := false
 
@@ -274,8 +324,8 @@ func TestMariaGTIDSetContainsWrongType(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsDifferentDomain(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
+	input2 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
 	want := false
 
 	if got := input1.Contains(input2); got != want {
@@ -284,8 +334,8 @@ func TestMariaGTIDSetContainsDifferentDomain(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsDifferentServer(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
+	input2 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	want := true
 
 	if got := input1.Contains(input2); got != want {
@@ -294,7 +344,7 @@ func TestMariaGTIDSetContainsDifferentServer(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDLess(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 300}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 300}}
 	input2 := MariadbGTID{Domain: 5, Server: 4727, Sequence: 700}
 	want := false
 
@@ -304,7 +354,7 @@ func TestMariaGTIDSetContainsGTIDLess(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDGreater(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 9000}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 9000}}
 	input2 := MariadbGTID{Domain: 5, Server: 4727, Sequence: 100}
 	want := true
 
@@ -314,7 +364,7 @@ func TestMariaGTIDSetContainsGTIDGreater(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDEqual(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
 	input2 := MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}
 	want := true
 
@@ -324,7 +374,7 @@ func TestMariaGTIDSetContainsGTIDEqual(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDNil(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 1, Server: 2, Sequence: 123}}
+	input1 := MariadbGTIDSet{1: MariadbGTID{Domain: 1, Server: 2, Sequence: 123}}
 	input2 := GTID(nil)
 	want := true
 
@@ -334,7 +384,7 @@ func TestMariaGTIDSetContainsGTIDNil(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDWrongType(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
+	input1 := MariadbGTIDSet{5: MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}}
 	input2 := fakeGTID{}
 	want := false
 
@@ -344,7 +394,7 @@ func TestMariaGTIDSetContainsGTIDWrongType(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDDifferentDomain(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
 	input2 := MariadbGTID{Domain: 5, Server: 4727, Sequence: 1234}
 	want := false
 
@@ -354,7 +404,7 @@ func TestMariaGTIDSetContainsGTIDDifferentDomain(t *testing.T) {
 }
 
 func TestMariaGTIDSetContainsGTIDDifferentServer(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4727, Sequence: 1235}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}
 	want := true
 
@@ -364,8 +414,14 @@ func TestMariaGTIDSetContainsGTIDDifferentServer(t *testing.T) {
 }
 
 func TestMariaGTIDSetEqual(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{
+		1: MariadbGTID{Domain: 1, Server: 1234, Sequence: 5678},
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+	}
+	input2 := MariadbGTIDSet{
+		1: MariadbGTID{Domain: 1, Server: 1234, Sequence: 5678},
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+	}
 	want := true
 
 	if got := input1.Equal(input2); got != want {
@@ -374,8 +430,45 @@ func TestMariaGTIDSetEqual(t *testing.T) {
 }
 
 func TestMariaGTIDSetNotEqual(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
-	input2 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+		4: MariadbGTID{Domain: 4, Server: 4555, Sequence: 1234},
+	}
+	input2 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 4555, Sequence: 1234},
+		4: MariadbGTID{Domain: 4, Server: 4555, Sequence: 1234},
+	}
+	want := false
+
+	if got := input1.Equal(input2); got != want {
+		t.Errorf("%#v.Equal(%#v) = %v, want %v", input1, input2, got, want)
+	}
+}
+
+func TestMariaGTIDSetNotEqualDifferentDomain(t *testing.T) {
+	input1 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+		4: MariadbGTID{Domain: 4, Server: 4555, Sequence: 1234},
+	}
+	input2 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+		5: MariadbGTID{Domain: 5, Server: 4555, Sequence: 1234},
+	}
+	want := false
+
+	if got := input1.Equal(input2); got != want {
+		t.Errorf("%#v.Equal(%#v) = %v, want %v", input1, input2, got, want)
+	}
+}
+
+func TestMariaGTIDSetNotEqualExtraDomain(t *testing.T) {
+	input1 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+	}
+	input2 := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+		4: MariadbGTID{Domain: 4, Server: 4555, Sequence: 1234},
+	}
 	want := false
 
 	if got := input1.Equal(input2); got != want {
@@ -384,7 +477,7 @@ func TestMariaGTIDSetNotEqual(t *testing.T) {
 }
 
 func TestMariaGTIDSetEqualWrongType(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := fakeGTID{}
 	want := false
 
@@ -394,7 +487,7 @@ func TestMariaGTIDSetEqualWrongType(t *testing.T) {
 }
 
 func TestMariaGTIDSetEqualNil(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := GTIDSet(nil)
 	want := false
 
@@ -404,7 +497,7 @@ func TestMariaGTIDSetEqualNil(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDEqual(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}
 	want := input1
 
@@ -414,7 +507,7 @@ func TestMariaGTIDSetAddGTIDEqual(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDGreater(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 5234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 5234}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}
 	want := input1
 
@@ -424,9 +517,9 @@ func TestMariaGTIDSetAddGTIDGreater(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDLess(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 5234}
-	want := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 5234}}
+	want := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 5234}}
 
 	if got := input1.AddGTID(input2); !got.Equal(want) {
 		t.Errorf("%#v.AddGTID(%#v) = %v, want %v", input1, input2, got, want)
@@ -434,7 +527,7 @@ func TestMariaGTIDSetAddGTIDLess(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDWrongType(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := fakeGTID{}
 	want := input1
 
@@ -444,7 +537,7 @@ func TestMariaGTIDSetAddGTIDWrongType(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDNil(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := GTID(nil)
 	want := input1
 
@@ -454,9 +547,9 @@ func TestMariaGTIDSetAddGTIDNil(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDDifferentServer(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := MariadbGTID{Domain: 3, Server: 4444, Sequence: 5234}
-	want := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4444, Sequence: 5234}}
+	want := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4444, Sequence: 5234}}
 
 	if got := input1.AddGTID(input2); !got.Equal(want) {
 		t.Errorf("%#v.AddGTID(%#v) = %v, want %v", input1, input2, got, want)
@@ -464,9 +557,12 @@ func TestMariaGTIDSetAddGTIDDifferentServer(t *testing.T) {
 }
 
 func TestMariaGTIDSetAddGTIDDifferentDomain(t *testing.T) {
-	input1 := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
+	input1 := MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}
 	input2 := MariadbGTID{Domain: 5, Server: 5555, Sequence: 5234}
-	want := MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}, MariadbGTID{Domain: 5, Server: 5555, Sequence: 5234}}
+	want := MariadbGTIDSet{
+		3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234},
+		5: MariadbGTID{Domain: 5, Server: 5555, Sequence: 5234},
+	}
 
 	if got := input1.AddGTID(input2); !got.Equal(want) {
 		t.Errorf("%#v.AddGTID(%#v) = %v, want %v", input1, input2, got, want)
@@ -475,22 +571,22 @@ func TestMariaGTIDSetAddGTIDDifferentDomain(t *testing.T) {
 
 func TestMariaGTIDSetUnion(t *testing.T) {
 	set1 := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
 	}
 	set2 := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
 	}
 
 	got := set1.Union(set2)
 
 	want := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
 	}
 
 	if !got.Equal(want) {
@@ -500,24 +596,24 @@ func TestMariaGTIDSetUnion(t *testing.T) {
 
 func TestMariaGTIDSetUnionNewDomain(t *testing.T) {
 	set1 := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 1},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 3},
 	}
 	set2 := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
-		MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 1},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		6: MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
 	}
 
 	got := set1.Union(set2)
 
 	want := MariadbGTIDSet{
-		MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
-		MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
-		MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
+		3: MariadbGTID{Domain: 3, Server: 1, Sequence: 2},
+		4: MariadbGTID{Domain: 4, Server: 1, Sequence: 2},
+		5: MariadbGTID{Domain: 5, Server: 1, Sequence: 4},
+		6: MariadbGTID{Domain: 6, Server: 1, Sequence: 7},
 	}
 
 	if !got.Equal(want) {

--- a/go/mysql/replication_position_test.go
+++ b/go/mysql/replication_position_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestPositionEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.Equal(input2); got != want {
@@ -33,8 +33,8 @@ func TestPositionEqual(t *testing.T) {
 }
 
 func TestPositionNotEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 12345}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 12345}}}
 	want := false
 
 	if got := input1.Equal(input2); got != want {
@@ -43,7 +43,7 @@ func TestPositionNotEqual(t *testing.T) {
 }
 
 func TestPositionEqualZero(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := Position{}
 	want := false
 
@@ -63,8 +63,8 @@ func TestPositionZeroEqualZero(t *testing.T) {
 }
 
 func TestPositionAtLeastLess(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1233}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1233}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -73,8 +73,8 @@ func TestPositionAtLeastLess(t *testing.T) {
 }
 
 func TestPositionAtLeastEqual(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -83,8 +83,8 @@ func TestPositionAtLeastEqual(t *testing.T) {
 }
 
 func TestPositionAtLeastGreater(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -93,8 +93,8 @@ func TestPositionAtLeastGreater(t *testing.T) {
 }
 
 func TestPositionAtLeastDifferentServer(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 4444, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 4444, Sequence: 1234}}}
 	want := true
 
 	if got := input1.AtLeast(input2); got != want {
@@ -103,8 +103,8 @@ func TestPositionAtLeastDifferentServer(t *testing.T) {
 }
 
 func TestPositionAtLeastDifferentDomain(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 4, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{4: MariadbGTID{Domain: 4, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -114,7 +114,7 @@ func TestPositionAtLeastDifferentDomain(t *testing.T) {
 
 func TestPositionZeroAtLeast(t *testing.T) {
 	input1 := Position{}
-	input2 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input2 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input1.AtLeast(input2); got != want {
@@ -123,7 +123,7 @@ func TestPositionZeroAtLeast(t *testing.T) {
 }
 
 func TestPositionAtLeastZero(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := Position{}
 	want := true
 
@@ -143,7 +143,7 @@ func TestPositionZeroAtLeastZero(t *testing.T) {
 }
 
 func TestPositionString(t *testing.T) {
-	input := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := "3-5555-1234"
 
 	if got := input.String(); got != want {
@@ -170,7 +170,7 @@ func TestPositionIsZero(t *testing.T) {
 }
 
 func TestPositionIsNotZero(t *testing.T) {
-	input := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	want := false
 
 	if got := input.IsZero(); got != want {
@@ -179,9 +179,9 @@ func TestPositionIsNotZero(t *testing.T) {
 }
 
 func TestPositionAppend(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}
-	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
+	want := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1235}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)
@@ -189,9 +189,9 @@ func TestPositionAppend(t *testing.T) {
 }
 
 func TestPositionAppendNil(t *testing.T) {
-	input1 := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	input1 := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 	input2 := GTID(nil)
-	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	want := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)
@@ -201,7 +201,7 @@ func TestPositionAppendNil(t *testing.T) {
 func TestPositionAppendToZero(t *testing.T) {
 	input1 := Position{}
 	input2 := MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}
-	want := Position{GTIDSet: MariadbGTIDSet{MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
+	want := Position{GTIDSet: MariadbGTIDSet{3: MariadbGTID{Domain: 3, Server: 5555, Sequence: 1234}}}
 
 	if got := AppendGTID(input1, input2); !got.Equal(want) {
 		t.Errorf("AppendGTID(%#v, %#v) = %#v, want %#v", input1, input2, got, want)

--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -236,7 +236,7 @@ func TestStreamerParseRBREvents(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -481,7 +481,7 @@ func TestStreamerParseRBRNameEscapes(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -105,7 +105,7 @@ func TestStreamerParseEventsXID(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -168,7 +168,7 @@ func TestStreamerParseEventsCommit(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -584,7 +584,7 @@ func TestStreamerParseEventsRollback(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -602,7 +602,7 @@ func TestStreamerParseEventsRollback(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -658,7 +658,7 @@ func TestStreamerParseEventsDMLWithoutBegin(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -673,7 +673,7 @@ func TestStreamerParseEventsDMLWithoutBegin(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -733,7 +733,7 @@ func TestStreamerParseEventsBeginWithoutCommit(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -748,7 +748,7 @@ func TestStreamerParseEventsBeginWithoutCommit(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -810,7 +810,7 @@ func TestStreamerParseEventsSetInsertID(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -914,7 +914,7 @@ func TestStreamerParseEventsOtherDB(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -976,7 +976,7 @@ func TestStreamerParseEventsOtherDBBegin(t *testing.T) {
 				Timestamp: 1407805592,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 0x0d,
@@ -1086,7 +1086,7 @@ func TestStreamerParseEventsMariadbBeginGTID(t *testing.T) {
 				Timestamp: 1409892744,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 10,
@@ -1145,7 +1145,7 @@ func TestStreamerParseEventsMariadbStandaloneGTID(t *testing.T) {
 				Timestamp: 1409892744,
 				Position: mysql.EncodePosition(mysql.Position{
 					GTIDSet: mysql.MariadbGTIDSet{
-						mysql.MariadbGTID{
+						0: mysql.MariadbGTID{
 							Domain:   0,
 							Server:   62344,
 							Sequence: 9,

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -171,7 +171,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 			},
 		}
 		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-			GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
+			GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 			"STOP SLAVE",

--- a/go/vt/worker/split_clone_flaky_test.go
+++ b/go/vt/worker/split_clone_flaky_test.go
@@ -214,7 +214,7 @@ func (tc *splitCloneTestCase) setUpWithConcurrency(v3 bool, concurrency, writeQu
 			},
 		}
 		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-			GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
+			GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 			"STOP SLAVE",

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -132,7 +132,7 @@ func TestVerticalSplitClone(t *testing.T) {
 		},
 	}
 	sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
-		GTIDSet: mysql.MariadbGTIDSet{mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
+		GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 	}
 	sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -102,7 +102,7 @@ func TestBackupRestore(t *testing.T) {
 	master.FakeMysqlDaemon.Replicating = false
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,
@@ -121,7 +121,7 @@ func TestBackupRestore(t *testing.T) {
 	sourceTablet.FakeMysqlDaemon.Replicating = true
 	sourceTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,
@@ -163,7 +163,7 @@ func TestBackupRestore(t *testing.T) {
 	destTablet.FakeMysqlDaemon.Replicating = true
 	destTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,
@@ -274,7 +274,7 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 	master.FakeMysqlDaemon.Replicating = false
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,
@@ -292,7 +292,7 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 	sourceTablet.FakeMysqlDaemon.Replicating = true
 	sourceTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,
@@ -323,7 +323,7 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 	destTablet.FakeMysqlDaemon.Replicating = true
 	destTablet.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -51,7 +51,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 456,
@@ -66,7 +66,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 456,
@@ -86,7 +86,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	goodReplica1.FakeMysqlDaemon.Replicating = true
 	goodReplica1.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 455,
@@ -107,7 +107,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 	goodReplica2.FakeMysqlDaemon.Replicating = false
 	goodReplica2.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 454,
@@ -162,7 +162,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// this server has executed upto 455, which is the highest among replicas
 	newMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 455,
@@ -173,7 +173,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// moreAdvancedReplica
 	newMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 456,
@@ -195,7 +195,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// position up to which this replica has executed is behind desired new master
 	moreAdvancedReplica.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 454,
@@ -205,7 +205,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	// relay log position is more advanced than desired new master
 	moreAdvancedReplica.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			2: mysql.MariadbGTID{
 				Domain:   2,
 				Server:   123,
 				Sequence: 457,

--- a/go/vt/wrangler/testlib/init_shard_master_test.go
+++ b/go/vt/wrangler/testlib/init_shard_master_test.go
@@ -59,7 +59,7 @@ func TestInitMasterShard(t *testing.T) {
 	// and expect to add entry in _vt.reparent_journal
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 890,
@@ -213,7 +213,7 @@ func TestInitMasterShardOneSlaveFails(t *testing.T) {
 	// and expect to add entry in _vt.reparent_journal
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 890,

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -82,7 +82,7 @@ func TestMigrateServedFrom(t *testing.T) {
 	// also will be asked about its replication position.
 	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 892,

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -129,7 +129,7 @@ func TestMigrateServedTypes(t *testing.T) {
 	// also will be asked about its replication position.
 	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 892,
@@ -336,7 +336,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	// also will be asked about its replication position.
 	source1Master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 892,
@@ -382,7 +382,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	// also will be asked about its replication position.
 	source2Master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 892,

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -51,7 +51,7 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -60,7 +60,7 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   456,
 				Sequence: 991,
@@ -154,7 +154,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -163,7 +163,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   456,
 				Sequence: 991,
@@ -290,7 +290,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -299,7 +299,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   456,
 				Sequence: 991,
@@ -385,7 +385,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	newMaster.FakeMysqlDaemon.Replicating = true
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -394,7 +394,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   456,
 				Sequence: 991,
@@ -475,7 +475,7 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 	master.FakeMysqlDaemon.SlaveStatusError = mysql.ErrNotSlave
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -540,7 +540,7 @@ func TestPlannedReparentShardRelayLogErrorStartSlave(t *testing.T) {
 	master.FakeMysqlDaemon.SlaveStatusError = mysql.ErrNotSlave
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -613,7 +613,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	newMaster.FakeMysqlDaemon.PromoteError = errors.New("some error")
 	newMaster.FakeMysqlDaemon.WaitMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,
@@ -622,7 +622,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	}
 	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   456,
 				Sequence: 991,
@@ -739,7 +739,7 @@ func TestPlannedReparentShardSameMaster(t *testing.T) {
 	oldMaster.FakeMysqlDaemon.SlaveStatusError = mysql.ErrNotSlave
 	oldMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			7: mysql.MariadbGTID{
 				Domain:   7,
 				Server:   123,
 				Sequence: 990,

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -55,7 +55,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	// master action loop (to initialize host and port)
 	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 892,
@@ -68,7 +68,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	// slave loop
 	slave.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
-			mysql.MariadbGTID{
+			5: mysql.MariadbGTID{
 				Domain:   5,
 				Server:   456,
 				Sequence: 890,

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -359,7 +359,7 @@ func (tme *testMigraterEnv) setMasterPositions() {
 	for _, master := range tme.sourceMasters {
 		master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{
-				mysql.MariadbGTID{
+				5: mysql.MariadbGTID{
 					Domain:   5,
 					Server:   456,
 					Sequence: 892,
@@ -370,7 +370,7 @@ func (tme *testMigraterEnv) setMasterPositions() {
 	for _, master := range tme.targetMasters {
 		master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{
-				mysql.MariadbGTID{
+				5: mysql.MariadbGTID{
 					Domain:   5,
 					Server:   456,
 					Sequence: 893,


### PR DESCRIPTION
This fixes two bugs:

1. AddGTID was mutating the original set. GTIDSet implementations are
supposed to be immutable.

2. AddGTID and parseMariadbGTIDSet did not enforce any order among
domains, yet Equal and other functions expected order to be enforced.

This switches from a list to a map to better represent the fact that the order of domains doesn't matter, which also simplifies some code. We always enforce order when serializing back to a string.