### PR TITLE
go/mysql: Fix TLS test for Go 1.13+.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ MAKEFLAGS = -s
 
 export GOBIN=$(PWD)/bin
 export GO111MODULE=on
-export GODEBUG=tls13=0
 export REWRITER=go/vt/sqlparser/rewriter.go
 
 # Disabled parallel processing of target prerequisites to avoid that integration tests are racing each other (e.g. for ports) and may fail.

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -47,6 +47,7 @@ const (
 	versionTLS10      = "TLS10"
 	versionTLS11      = "TLS11"
 	versionTLS12      = "TLS12"
+	versionTLS13      = "TLS13"
 	versionTLSUnknown = "UnknownTLSVersion"
 	versionNoTLS      = "None"
 )
@@ -798,6 +799,8 @@ func tlsVersionToString(version uint16) string {
 		return versionTLS11
 	case tls.VersionTLS12:
 		return versionTLS12
+	case tls.VersionTLS13:
+		return versionTLS13
 	default:
 		return versionTLSUnknown
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1006,7 +1007,11 @@ func TestTLSServer(t *testing.T) {
 		t.Errorf("Unexpected output for 'ssl echo': %v", results)
 	}
 
-	checkCountForTLSVer(t, versionTLS12, 1)
+	// Find out which TLS version the connection actually used,
+	// so we can check that the corresponding counter was incremented.
+	tlsVersion := conn.conn.(*tls.Conn).ConnectionState().Version
+
+	checkCountForTLSVer(t, tlsVersionToString(tlsVersion), 1)
 	checkCountForTLSVer(t, versionNoTLS, 0)
 	conn.Close()
 
@@ -1101,7 +1106,7 @@ func checkCountForTLSVer(t *testing.T, version string, expected int64) {
 			t.Errorf("Expected connection count for version %s to be %d, got %d", version, expected, count)
 		}
 	} else {
-		t.Errorf("No count found for version %s", version)
+		t.Errorf("No count for version %s found in %v", version, connCounts)
 	}
 }
 


### PR DESCRIPTION
The default TLS version changed, so we need to check the appropriate counter.

Fixes #5533.