### PR TITLE
go/mysql: Fix flaky TestConnectTimeout.

### DIFF
--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -94,9 +94,9 @@ func TestConnectTimeout(t *testing.T) {
 
 	// Tests a connection timeout through params
 	ctx = context.Background()
-	paramsWithTimeout := params
+	paramsWithTimeout := *params
 	paramsWithTimeout.ConnectTimeoutMs = 1
-	_, err = Connect(ctx, paramsWithTimeout)
+	_, err = Connect(ctx, &paramsWithTimeout)
 	cancel()
 	if err != context.DeadlineExceeded {
 		t.Errorf("Was expecting context.DeadlineExceeded but got: %v", err)


### PR DESCRIPTION
The 1ms timeout was mistakenly being applied to all subsequent connection attempts.