### PR TITLE
Vtctl Materialize optimizations

### DIFF
--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1970,7 +1970,7 @@ func TestMaterializerTableMismatch(t *testing.T) {
 	delete(env.tmc.schema, "targetks.t1")
 
 	err := env.wr.Materialize(context.Background(), ms)
-	assert.EqualError(t, err, "source and target table names must match for copying schema: t2 vs t1")
+	assert.EqualError(t, err, "copy: source tables do not exist: [t1].")
 }
 
 func TestMaterializerNoSourceTable(t *testing.T) {
@@ -1991,7 +1991,7 @@ func TestMaterializerNoSourceTable(t *testing.T) {
 	delete(env.tmc.schema, "sourceks.t1")
 
 	err := env.wr.Materialize(context.Background(), ms)
-	assert.EqualError(t, err, "source table t1 does not exist")
+	assert.EqualError(t, err, "copy: source tables do not exist: [t1].")
 }
 
 func TestMaterializerSyntaxError(t *testing.T) {

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1990,7 +1990,7 @@ func TestMaterializerTableMismatchCopy(t *testing.T) {
 	delete(env.tmc.schema, "targetks.t1")
 
 	err := env.wr.Materialize(context.Background(), ms)
-	assert.EqualError(t, err, "copy: source tables do not exist: [t1].")
+	assert.EqualError(t, err, "source and target table names must match for copying schema: t2 vs t1")
 }
 
 func TestMaterializerNoSourceTable(t *testing.T) {
@@ -2011,7 +2011,7 @@ func TestMaterializerNoSourceTable(t *testing.T) {
 	delete(env.tmc.schema, "sourceks.t1")
 
 	err := env.wr.Materialize(context.Background(), ms)
-	assert.EqualError(t, err, "copy: source tables do not exist: [t1].")
+	assert.EqualError(t, err, "source table t1 does not exist")
 }
 
 func TestMaterializerSyntaxError(t *testing.T) {


### PR DESCRIPTION
- Only get source and target schemas once, saving network roundtrips and O(n) -> O(1) performance
- Allow empty `source` entries to be equivalent to `select * from table`, as used by VReplication
- Change variables for better readability