### PR TITLE
SIGHUP support for tls config update

### DIFF
--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -65,7 +65,7 @@ func TestValidCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	l.TLSConfig = serverConfig
+	l.TLSConfig.Store(serverConfig)
 	go func() {
 		l.Accept()
 	}()
@@ -147,7 +147,7 @@ func TestNoCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	l.TLSConfig = serverConfig
+	l.TLSConfig.Store(serverConfig)
 	go func() {
 		l.Accept()
 	}()

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -129,7 +129,7 @@ func TestSSLConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	l.TLSConfig = serverConfig
+	l.TLSConfig.Store(serverConfig)
 	go func() {
 		l.Accept()
 	}()

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -957,7 +957,7 @@ func TestTLSServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	l.TLSConfig = serverConfig
+	l.TLSConfig.Store(serverConfig)
 	go l.Accept()
 
 	// Setup the right parameters.
@@ -1063,7 +1063,7 @@ func TestTLSRequired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	l.TLSConfig = serverConfig
+	l.TLSConfig.Store(serverConfig)
 	l.RequireSecureTransport = true
 	go l.Accept()
 

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -19,8 +19,11 @@ package vtgate
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"vitess.io/vitess/go/trace"
@@ -30,6 +33,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/tlstest"
 )
 
 type testHandler struct {
@@ -221,5 +225,33 @@ func TestDefaultWorkloadOLAP(t *testing.T) {
 	sess := vh.session(&mysql.Conn{})
 	if sess.Options.Workload != querypb.ExecuteOptions_OLAP {
 		t.Fatalf("Expected default workload OLAP")
+	}
+}
+
+func TestInitTLSConfig(t *testing.T) {
+	// Create the certs.
+	root, err := ioutil.TempDir("", "TestInitTLSConfig")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+
+	listener := &mysql.Listener{}
+	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), true); err != nil {
+		t.Fatalf("init tls config failure due to: +%v", err)
+	}
+
+	serverConfig := listener.TLSConfig.Load()
+	if serverConfig == nil {
+		t.Fatalf("init tls config shouldn't create nil server config")
+	}
+
+	sigChan <- syscall.SIGHUP
+	time.Sleep(100 * time.Millisecond) // wait for signal handler
+
+	if listener.TLSConfig.Load() == serverConfig {
+		t.Fatalf("init tls config should have been recreated after SIGHUP")
 	}
 }


### PR DESCRIPTION
similar to tablet config and mysql auth config, at pinterest, we need some mechanism to update the `tls config` and would like to use the same `SIGHUP` approach.

