### PR TITLE
Allow empty shards when validating schemas

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -391,10 +391,10 @@ var commands = []commandGroup{
 				"[-concurrency=10] [-include_master=false] <keyspace>",
 				"Reloads the schema on all the tablets in a keyspace."},
 			{"ValidateSchemaShard", commandValidateSchemaShard,
-				"[-exclude_tables=''] [-include-views] [-allow-empty] <keyspace/shard>",
+				"[-exclude_tables=''] [-include-views] <keyspace/shard>",
 				"Validates that the master schema matches all of the slaves."},
 			{"ValidateSchemaKeyspace", commandValidateSchemaKeyspace,
-				"[-exclude_tables=''] [-include-views] <keyspace name>",
+				"[-exclude_tables=''] [-include-views] [-skip-no-master] <keyspace name>",
 				"Validates that the master schema from shard 0 matches the schema on all of the other tablets in the keyspace."},
 			{"ApplySchema", commandApplySchema,
 				"[-allow_long_unavailability] [-wait_slave_timeout=10s] {-sql=<sql> || -sql-file=<filename>} <keyspace>",
@@ -2257,7 +2257,7 @@ func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subF
 func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the validation")
-	allowEmpty := subFlags.Bool("allow-empty", false, "Allow empty shards when validating")
+	skipNoMaster := subFlags.Bool("skip-no-master", false, "Skip shards that don't have master when performing validation")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2270,7 +2270,7 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 	if *excludeTables != "" {
 		excludeTableArray = strings.Split(*excludeTables, ",")
 	}
-	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews, *allowEmpty)
+	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews, *skipNoMaster)
 }
 
 func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -391,7 +391,7 @@ var commands = []commandGroup{
 				"[-concurrency=10] [-include_master=false] <keyspace>",
 				"Reloads the schema on all the tablets in a keyspace."},
 			{"ValidateSchemaShard", commandValidateSchemaShard,
-				"[-exclude_tables=''] [-include-views] <keyspace/shard>",
+				"[-exclude_tables=''] [-include-views] [-allow-empty] <keyspace/shard>",
 				"Validates that the master schema matches all of the slaves."},
 			{"ValidateSchemaKeyspace", commandValidateSchemaKeyspace,
 				"[-exclude_tables=''] [-include-views] <keyspace name>",
@@ -2257,6 +2257,7 @@ func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subF
 func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the validation")
+	allowEmpty := subFlags.Bool("allow-empty", false, "Allow empty shards when validating")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2269,7 +2270,7 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 	if *excludeTables != "" {
 		excludeTableArray = strings.Split(*excludeTables, ",")
 	}
-	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews)
+	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews, *allowEmpty)
 }
 
 func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -59,7 +59,7 @@ func InitVtctld(ts *topo.Server) {
 
 	actionRepo.RegisterKeyspaceAction("ValidateSchemaKeyspace",
 		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
-			return "", wr.ValidateSchemaKeyspace(ctx, keyspace, nil, false)
+			return "", wr.ValidateSchemaKeyspace(ctx, keyspace, nil, false, false)
 		})
 
 	actionRepo.RegisterKeyspaceAction("ValidateVersionKeyspace",

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -240,6 +240,10 @@ func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string,
 		}
 
 		for _, alias := range aliases {
+			// Don't diff schemas for self
+			if referenceAlias == alias {
+				continue
+			}
 			wg.Add(1)
 			go wr.diffSchema(ctx, referenceSchema, referenceAlias, alias, excludeTables, includeViews, &wg, &er)
 		}

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -186,7 +186,7 @@ func (wr *Wrangler) ValidateSchemaShard(ctx context.Context, keyspace, shard str
 
 // ValidateSchemaKeyspace will diff the schema from all the tablets in
 // the keyspace.
-func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews, allowEmpty bool) error {
+func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews, skipNoMaster bool) error {
 	// find all the shards
 	shards, err := wr.ts.GetShardNames(ctx, keyspace)
 	if err != nil {
@@ -218,7 +218,7 @@ func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string,
 		}
 
 		if !si.HasMaster() {
-			if !allowEmpty {
+			if !skipNoMaster {
 				er.RecordError(fmt.Errorf("no master in shard %v/%v", keyspace, shard))
 			}
 			continue

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -186,7 +186,7 @@ func (wr *Wrangler) ValidateSchemaShard(ctx context.Context, keyspace, shard str
 
 // ValidateSchemaKeyspace will diff the schema from all the tablets in
 // the keyspace.
-func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews bool) error {
+func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews, allowEmpty bool) error {
 	// find all the shards
 	shards, err := wr.ts.GetShardNames(ctx, keyspace)
 	if err != nil {
@@ -202,42 +202,15 @@ func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string,
 		return wr.ValidateSchemaShard(ctx, keyspace, shards[0], excludeTables, includeViews)
 	}
 
-	// find the reference schema using the first shard's master
-	si, err := wr.ts.GetShard(ctx, keyspace, shards[0])
-	if err != nil {
-		return fmt.Errorf("GetShard(%v, %v) failed: %v", keyspace, shards[0], err)
-	}
-	if !si.HasMaster() {
-		return fmt.Errorf("no master in shard %v/%v", keyspace, shards[0])
-	}
-	referenceAlias := si.MasterAlias
-	log.Infof("Gathering schema for reference master %v", topoproto.TabletAliasString(referenceAlias))
-	referenceSchema, err := wr.GetSchema(ctx, referenceAlias, nil, excludeTables, includeViews)
-	if err != nil {
-		return fmt.Errorf("GetSchema(%v, nil, %v, %v) failed: %v", referenceAlias, excludeTables, includeViews, err)
-	}
+	var referenceSchema *tabletmanagerdatapb.SchemaDefinition
+	var referenceAlias *topodatapb.TabletAlias
 
 	// then diff with all other tablets everywhere
 	er := concurrency.AllErrorRecorder{}
 	wg := sync.WaitGroup{}
 
-	// first diff the slaves in the reference shard 0
-	aliases, err := wr.ts.FindAllTabletAliasesInShard(ctx, keyspace, shards[0])
-	if err != nil {
-		return fmt.Errorf("FindAllTabletAliasesInShard(%v, %v) failed: %v", keyspace, shards[0], err)
-	}
-
-	for _, alias := range aliases {
-		if topoproto.TabletAliasEqual(alias, si.MasterAlias) {
-			continue
-		}
-
-		wg.Add(1)
-		go wr.diffSchema(ctx, referenceSchema, referenceAlias, alias, excludeTables, includeViews, &wg, &er)
-	}
-
 	// then diffs all tablets in the other shards
-	for _, shard := range shards[1:] {
+	for _, shard := range shards[0:] {
 		si, err := wr.ts.GetShard(ctx, keyspace, shard)
 		if err != nil {
 			er.RecordError(fmt.Errorf("GetShard(%v, %v) failed: %v", keyspace, shard, err))
@@ -245,8 +218,19 @@ func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string,
 		}
 
 		if !si.HasMaster() {
-			er.RecordError(fmt.Errorf("no master in shard %v/%v", keyspace, shard))
+			if !allowEmpty {
+				er.RecordError(fmt.Errorf("no master in shard %v/%v", keyspace, shard))
+			}
 			continue
+		}
+
+		if referenceSchema == nil {
+			referenceAlias = si.MasterAlias
+			log.Infof("Gathering schema for reference master %v", topoproto.TabletAliasString(referenceAlias))
+			referenceSchema, err = wr.GetSchema(ctx, referenceAlias, nil, excludeTables, includeViews)
+			if err != nil {
+				return fmt.Errorf("GetSchema(%v, nil, %v, %v) failed: %v", referenceAlias, excludeTables, includeViews, err)
+			}
 		}
 
 		aliases, err := wr.ts.FindAllTabletAliasesInShard(ctx, keyspace, shard)


### PR DESCRIPTION
# Description

* We have some cases where we have a valid keyspace that has empty shards. In those cases, we can't use this command because it fails in the empty shards. 
* This is a behavior that is probably very specific to Slack, but seems like is harmless as is behind flag of the command. 