### PR TITLE
For default() - make sure to escape columns when necessary

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1705,7 +1705,9 @@ func (node *CaseExpr) Format(buf *TrackedBuffer) {
 func (node *Default) Format(buf *TrackedBuffer) {
 	buf.astPrintf(node, "default")
 	if node.ColName != "" {
-		buf.astPrintf(node, "(%s)", node.ColName)
+		buf.WriteString("(")
+		formatID(buf, node.ColName, strings.ToLower(node.ColName), NoAt)
+		buf.WriteString(")")
 	}
 }
 

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -792,3 +792,9 @@ func TestTypeConversion(t *testing.T) {
 	ct2 := &ColumnType{Type: "bigint"}
 	assert.Equal(t, ct1.SQLType(), ct2.SQLType())
 }
+
+func TestDefaultStatus(t *testing.T) {
+	assert.Equal(t,
+		String(&Default{ColName: "status"}),
+		"default(`status`)")
+}

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -698,6 +698,8 @@ var (
 	}, {
 		input: "insert /* bool expression on duplicate */ into a values (1, 2) on duplicate key update b = func(a), c = a > d",
 	}, {
+		input: "insert into user(username, `status`) values ('Chuck', default(`status`))",
+	}, {
 		input: "update /* simple */ a set b = 3",
 	}, {
 		input: "update /* a.b */ a.b set b = 3",


### PR DESCRIPTION
Fixes #6221
