### PR TITLE
Support uppercase user defined variables

### DIFF
--- a/go/test/endtoend/vtgate/setstatement/udv_test.go
+++ b/go/test/endtoend/vtgate/setstatement/udv_test.go
@@ -49,9 +49,15 @@ func TestSetUDV(t *testing.T) {
 	}, {
 		query:        "/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE */",
 		expectedRows: "", rowsAffected: 0,
-	}, {
-		query:        "select @foo, @bar, @baz, @tablet, @OLD_SQL_MODE",
-		expectedRows: `[[VARBINARY("abc") INT64(42) FLOAT64(30.5) VARBINARY("foobar") VARBINARY("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION")]]`, rowsAffected: 1,
+	}, { // This is handled at vtgate.
+		query:        "select @foo, @bar, @baz, @tablet",
+		expectedRows: `[[VARBINARY("abc") INT64(42) FLOAT64(30.5) VARBINARY("foobar")]]`, rowsAffected: 1,
+	}, { // Cannot really check a specific value for sql_mode as it will differ based on database selected to run these tests.
+		query:        "select @OLD_SQL_MODE = @@SQL_MODE",
+		expectedRows: `[[INT64(1)]]`, rowsAffected: 1,
+	}, { // This one is sent to tablet.
+		query:        "select @foo, @bar, @baz, @tablet, @OLD_SQL_MODE = @@SQL_MODE",
+		expectedRows: `[[VARCHAR("abc") INT64(42) DECIMAL(30.5) VARCHAR("foobar") INT64(1)]]`, rowsAffected: 1,
 	}, {
 		query:        "insert into test(id, val1, val2, val3) values(1, @foo, null, null), (2, null, @bar, null), (3, null, null, @baz)",
 		expectedRows: ``, rowsAffected: 3,

--- a/go/test/endtoend/vtgate/setstatement/udv_test.go
+++ b/go/test/endtoend/vtgate/setstatement/udv_test.go
@@ -47,8 +47,11 @@ func TestSetUDV(t *testing.T) {
 		query:        "set @foo = 'abc', @bar = 42, @baz = 30.5, @tablet = concat('foo','bar')",
 		expectedRows: "", rowsAffected: 0,
 	}, {
-		query:        "select @foo, @bar, @baz, @tablet",
-		expectedRows: `[[VARBINARY("abc") INT64(42) FLOAT64(30.5) VARBINARY("foobar")]]`, rowsAffected: 1,
+		query:        "/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE */",
+		expectedRows: "", rowsAffected: 0,
+	}, {
+		query:        "select @foo, @bar, @baz, @tablet, @OLD_SQL_MODE",
+		expectedRows: `[[VARBINARY("abc") INT64(42) FLOAT64(30.5) VARBINARY("foobar") VARBINARY("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION")]]`, rowsAffected: 1,
 	}, {
 		query:        "insert into test(id, val1, val2, val3) values(1, @foo, null, null), (2, null, @bar, null), (3, null, null, @baz)",
 		expectedRows: ``, rowsAffected: 3,

--- a/go/vt/sqlparser/expression_rewriting.go
+++ b/go/vt/sqlparser/expression_rewriting.go
@@ -17,6 +17,8 @@ limitations under the License.
 package sqlparser
 
 import (
+	"strings"
+
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
@@ -155,7 +157,7 @@ func (er *expressionRewriter) goingDown(cursor *Cursor) bool {
 		er.funcRewrite(cursor, node)
 	case *ColName:
 		if node.Name.at == SingleAt {
-			cursor.Replace(bindVarExpression(UserDefinedVariableName + node.Name.CompliantName()))
+			cursor.Replace(bindVarExpression(UserDefinedVariableName + strings.ToLower(node.Name.CompliantName())))
 			er.needBindVarFor(UserDefinedVariableName)
 		}
 	}

--- a/go/vt/vtgate/plan_executor_set_test.go
+++ b/go/vt/vtgate/plan_executor_set_test.go
@@ -56,7 +56,7 @@ func TestPlanExecutorSetUDV(t *testing.T) {
 		out *vtgatepb.Session
 		err string
 	}{{
-		in:  "set @foo = 'bar'",
+		in:  "set @FOO = 'bar'",
 		out: &vtgatepb.Session{UserDefinedVariables: createMap([]string{"foo"}, []interface{}{"bar"}), Autocommit: true},
 	}, {
 		in:  "set @foo = 2",


### PR DESCRIPTION
This handled uppercase UDV which causing issues of missing bindvars from the vttablet
#6218

Similar to mysql behaviour.
```
mysql > select @myvalue;
+----------+
| @myvalue |
+----------+
| NULL     |
+----------+
1 row in set (0.00 sec)

mysql > set @MYVALUE = 42;
Query OK, 0 rows affected (0.00 sec)

mysql > select @myvalue;
+----------+
| @myvalue |
+----------+
|       42 |
+----------+
1 row in set (0.00 sec)

```

Signed-off-by: Harshit Gangal <harshit@planetscale.com>