### PR TITLE
mysql rollback transactions should not bump query counts

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -160,8 +160,8 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 		t.Errorf("logstats: expected non-zero CommitTime")
 	}
 
-	// rollback doesn't emit a logstats record when it doesn't do anything
-	_, err = executor.Execute(context.Background(), "TestExecute", session, "rollback", nil)
+	// CloseSession doesn't log anything
+	err = executor.CloseSession(context.Background(), session)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/plan_executor_test.go
+++ b/go/vt/vtgate/plan_executor_test.go
@@ -156,8 +156,8 @@ func TestPlanExecutorTransactionsNoAutoCommit(t *testing.T) {
 		t.Errorf("logstats: expected non-zero CommitTime")
 	}
 
-	// rollback doesn't emit a logstats record when it doesn't do anything
-	_, err = executor.Execute(context.Background(), "TestExecute", session, "rollback", nil)
+	// CloseSession doesn't log anything
+	err = executor.CloseSession(context.Background(), session)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -108,7 +108,7 @@ func (vh *vtgateHandler) ComResetConnection(c *mysql.Conn) {
 	if session.InTransaction {
 		defer atomic.AddInt32(&busyConnections, -1)
 	}
-	_, _, err := vh.vtg.Execute(ctx, session, "rollback", make(map[string]*querypb.BindVariable))
+	err := vh.vtg.CloseSession(ctx, session)
 	if err != nil {
 		log.Errorf("Error happened in transaction rollback: %v", err)
 	}
@@ -134,7 +134,7 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 	if session.InTransaction {
 		defer atomic.AddInt32(&busyConnections, -1)
 	}
-	_, _, _ = vh.vtg.Execute(ctx, session, "rollback", make(map[string]*querypb.BindVariable))
+	_ = vh.vtg.CloseSession(ctx, session)
 }
 
 // Regexp to extract parent span id over the sql query

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -346,6 +346,13 @@ handleError:
 	return nil
 }
 
+// CloseSession closes the session, rolling back any implicit transactions. This has the
+// same effect as if a "rollback" statement was executed, but does not affect the query
+// statistics.
+func (vtg *VTGate) CloseSession(ctx context.Context, session *vtgatepb.Session) error {
+	return vtg.executor.CloseSession(ctx, NewSafeSession(session))
+}
+
 // ResolveTransaction resolves the specified 2PC transaction.
 func (vtg *VTGate) ResolveTransaction(ctx context.Context, dtid string) error {
 	return formatError(vtg.txConn.Resolve(ctx, dtid))


### PR DESCRIPTION
## Description
Stop mysql protocol connection closing from artificially counting "rollback" queries.

## Details
When executing implicit rollbacks upon mysql connection close, use an explicit CloseSession function in vtgate rather than executing a "rollback" statement, so as to not artificially inflate the query counts.
