### PR TITLE
exclude `DestinationKeyspaceID,DestinationKeyspaceIDs` from the plan cache key prefix

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2013,6 +2013,22 @@ func TestGetPlanCacheUnnormalized(t *testing.T) {
 	if len(r.plans.Keys()) != 1 {
 		t.Errorf("Plan keys should be 1, got: %v", len(r.plans.Keys()))
 	}
+
+	// the target string will be resolved and become part of the plan cache key, which adds a new entry
+	ksIDVc1, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded + "[deadbeef]"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver)
+	_, err = r.getPlan(ksIDVc1, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
+	require.NoError(t, err)
+	if len(r.plans.Keys()) != 2 {
+		t.Errorf("Plan keys should be 2, got: %v", len(r.plans.Keys()))
+	}
+
+	// the target string will be resolved and become part of the plan cache key, as it's an unsharded ks, it will be the same entry as above
+	ksIDVc2, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded + "[beefdead]"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver)
+	_, err = r.getPlan(ksIDVc2, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
+	require.NoError(t, err)
+	if len(r.plans.Keys()) != 2 {
+		t.Errorf("Plan keys should be 2, got: %v", len(r.plans.Keys()))
+	}
 }
 
 func TestGetPlanCacheNormalized(t *testing.T) {
@@ -2058,6 +2074,22 @@ func TestGetPlanCacheNormalized(t *testing.T) {
 	require.NoError(t, err)
 	if len(r.plans.Keys()) != 1 {
 		t.Errorf("Plan keys should be 1, got: %v", len(r.plans.Keys()))
+	}
+
+	// the target string will be resolved and become part of the plan cache key, which adds a new entry
+	ksIDVc1, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded + "[deadbeef]"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver)
+	_, err = r.getPlan(ksIDVc1, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
+	require.NoError(t, err)
+	if len(r.plans.Keys()) != 2 {
+		t.Errorf("Plan keys should be 2, got: %v", len(r.plans.Keys()))
+	}
+
+	// the target string will be resolved and become part of the plan cache key, as it's an unsharded ks, it will be the same entry as above
+	ksIDVc2, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded + "[beefdead]"}), makeComments(""), r, nil, r.vm, r.VSchema(), r.resolver.resolver)
+	_, err = r.getPlan(ksIDVc2, query1, makeComments(" /* comment */"), map[string]*querypb.BindVariable{}, false, logStats1)
+	require.NoError(t, err)
+	if len(r.plans.Keys()) != 2 {
+		t.Errorf("Plan keys should be 2, got: %v", len(r.plans.Keys()))
 	}
 }
 

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -18,6 +18,8 @@ package vtgate
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -420,6 +422,20 @@ func parseDestinationTarget(targetString string, vschema *vindexes.VSchema) (str
 
 func (vc *vcursorImpl) planPrefixKey() string {
 	if vc.destination != nil {
+		switch vc.destination.(type) {
+		case key.DestinationKeyspaceID, key.DestinationKeyspaceIDs:
+			resolved, _, err := vc.ResolveDestinations(vc.keyspace, nil, []key.Destination{vc.destination})
+			if err == nil && len(resolved) > 0 {
+				shards := make([]string, len(resolved))
+				for i := 0; i < len(shards); i++ {
+					shards[i] = resolved[i].Target.GetShard()
+				}
+				sort.Strings(shards)
+				return fmt.Sprintf("%s%sDestinationKeyspaceIDsResolved(%s)", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], strings.Join(shards, ","))
+			}
+		default:
+			// use destination string (out of the switch)
+		}
 		return fmt.Sprintf("%s%s%s", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], vc.destination.String())
 	}
 	return fmt.Sprintf("%s%s", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType])

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -431,7 +431,7 @@ func (vc *vcursorImpl) planPrefixKey() string {
 					shards[i] = resolved[i].Target.GetShard()
 				}
 				sort.Strings(shards)
-				return fmt.Sprintf("%s%sDestinationKeyspaceIDsResolved(%s)", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], strings.Join(shards, ","))
+				return fmt.Sprintf("%s%sKsIDsResolved(%s)", vc.keyspace, vindexes.TabletTypeSuffix[vc.tabletType], strings.Join(shards, ","))
 			}
 		default:
 			// use destination string (out of the switch)

--- a/go/vt/vtgate/vcursor_impl_test.go
+++ b/go/vt/vtgate/vcursor_impl_test.go
@@ -300,7 +300,7 @@ func TestPlanPrefixKey(t *testing.T) {
 	}, {
 		vschema:               vschemaWith1KS,
 		targetString:          "ks1[deadbeef]",
-		expectedPlanPrefixKey: "ks1@masterDestinationKeyspaceIDsResolved(80-)",
+		expectedPlanPrefixKey: "ks1@masterKsIDsResolved(80-)",
 	}}
 
 	for i, tc := range tests {

--- a/go/vt/vtgate/vcursor_impl_test.go
+++ b/go/vt/vtgate/vcursor_impl_test.go
@@ -2,9 +2,13 @@ package vtgate
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 
 	"vitess.io/vitess/go/vt/proto/vschema"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/topo"
 
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -31,6 +35,45 @@ func (f fakeVSchemaOperator) GetCurrentVschema() (*vindexes.VSchema, error) {
 
 func (f fakeVSchemaOperator) UpdateVSchema(ctx context.Context, ksName string, vschema *vschema.SrvVSchema) error {
 	panic("implement me")
+}
+
+type fakeTopoServer struct {
+}
+
+// GetTopoServer returns the full topo.Server instance.
+func (f *fakeTopoServer) GetTopoServer() (*topo.Server, error) {
+	return nil, nil
+}
+
+// GetSrvKeyspaceNames returns the list of keyspaces served in
+// the provided cell.
+func (f *fakeTopoServer) GetSrvKeyspaceNames(ctx context.Context, cell string, staleOK bool) ([]string, error) {
+	return []string{"ks1"}, nil
+}
+
+// GetSrvKeyspace returns the SrvKeyspace for a cell/keyspace.
+func (f *fakeTopoServer) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*topodatapb.SrvKeyspace, error) {
+	zeroHexBytes, _ := hex.DecodeString("")
+	eightyHexBytes, _ := hex.DecodeString("80")
+	ks := &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_MASTER,
+				ShardReferences: []*topodatapb.ShardReference{
+					{Name: "-80", KeyRange: &topodatapb.KeyRange{Start: zeroHexBytes, End: eightyHexBytes}},
+					{Name: "80-", KeyRange: &topodatapb.KeyRange{Start: eightyHexBytes, End: zeroHexBytes}},
+				},
+			},
+		},
+	}
+	return ks, nil
+}
+
+// WatchSrvVSchema starts watching the SrvVSchema object for
+// the provided cell.  It will call the callback when
+// a new value or an error occurs.
+func (f *fakeTopoServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+
 }
 
 func TestDestinationKeyspace(t *testing.T) {
@@ -215,6 +258,59 @@ func TestSetTarget(t *testing.T) {
 			} else {
 				require.EqualError(t, err, tc.expectedError)
 			}
+		})
+	}
+}
+
+func TestPlanPrefixKey(t *testing.T) {
+	ks1 := &vindexes.Keyspace{
+		Name:    "ks1",
+		Sharded: false,
+	}
+	ks1Schema := &vindexes.KeyspaceSchema{
+		Keyspace: ks1,
+		Tables:   nil,
+		Vindexes: nil,
+		Error:    nil,
+	}
+	vschemaWith1KS := &vindexes.VSchema{
+		Keyspaces: map[string]*vindexes.KeyspaceSchema{
+			ks1.Name: ks1Schema,
+		},
+	}
+
+	type testCase struct {
+		vschema               *vindexes.VSchema
+		targetString          string
+		expectedPlanPrefixKey string
+	}
+
+	tests := []testCase{{
+		vschema:               vschemaWith1KS,
+		targetString:          "",
+		expectedPlanPrefixKey: "ks1@master",
+	}, {
+		vschema:               vschemaWith1KS,
+		targetString:          "ks1@replica",
+		expectedPlanPrefixKey: "ks1@replica",
+	}, {
+		vschema:               vschemaWith1KS,
+		targetString:          "ks1:-80",
+		expectedPlanPrefixKey: "ks1@masterDestinationShard(-80)",
+	}, {
+		vschema:               vschemaWith1KS,
+		targetString:          "ks1[deadbeef]",
+		expectedPlanPrefixKey: "ks1@masterDestinationKeyspaceIDsResolved(80-)",
+	}}
+
+	for i, tc := range tests {
+		t.Run(string(i)+"#"+tc.targetString, func(t *testing.T) {
+			ss := NewSafeSession(&vtgatepb.Session{InTransaction: false})
+			ss.SetTargetString(tc.targetString)
+			vc, err := newVCursorImpl(context.Background(), ss, sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, srvtopo.NewResolver(&fakeTopoServer{}, nil, ""))
+			require.NoError(t, err)
+			vc.vschema = tc.vschema
+			require.Equal(t, tc.expectedPlanPrefixKey, vc.planPrefixKey())
 		})
 	}
 }


### PR DESCRIPTION
as this is causing our plan cache to quickly reach capacity at pinterest.
we does use `DestinationKeyspaceID` heavily, and the `keyspaceID` has a really large cardinality, causing frequent evictions.

[update] simply excluding `destination.String()` doesn't work, it could cause wrong destination cached in the plan. as a result, added resolved shard as part of the cache key.