### PR TITLE
Allow 'binary' for character_set_results; it's equivalent to null, which

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -558,7 +558,7 @@ func handleSessionSetting(ctx context.Context, name string, session *SafeSession
 	case "character_set_results":
 		// This is a statement that mysql-connector-j sends at the beginning. We return a canned response for it.
 		switch value {
-		case nil, "utf8", "utf8mb4", "latin1":
+		case nil, "binary", "utf8", "utf8mb4", "latin1":
 		default:
 			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "disallowed value for character_set_results: %v", value)
 		}

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -184,6 +184,18 @@ func TestExecutorSet(t *testing.T) {
 		in:  "set character_set_results=null",
 		out: &vtgatepb.Session{Autocommit: true},
 	}, {
+		in:  "set character_set_results='binary'",
+		out: &vtgatepb.Session{Autocommit: true},
+	}, {
+		in:  "set character_set_results='utf8'",
+		out: &vtgatepb.Session{Autocommit: true},
+	}, {
+		in:  "set character_set_results='utf8mb4'",
+		out: &vtgatepb.Session{Autocommit: true},
+	}, {
+		in:  "set character_set_results='latin1'",
+		out: &vtgatepb.Session{Autocommit: true},
+	}, {
 		in:  "set character_set_results='abcd'",
 		err: "disallowed value for character_set_results: abcd",
 	}, {


### PR DESCRIPTION
we already allow.
Add some more tests to cover all the positive character_set_results cases.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>