### PR TITLE
Check for nil before using struct

### DIFF
--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -120,22 +120,26 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 				log.Error(err)
 				continue
 			}
-			duration := txc.txProps.EndTime.Sub(txc.txProps.StartTime).Seconds()
-			var level string
-			if duration < 0.1 {
-				level = "low"
-			} else if duration < 1.0 {
-				level = "medium"
-			} else {
-				level = "high"
-			}
-			tmplData := struct {
-				*StatefulConnection
-				Duration   float64
-				ColorLevel string
-			}{txc, duration, level}
-			if err := txlogzTmpl.Execute(w, tmplData); err != nil {
-				log.Errorf("txlogz: couldn't execute template: %v", err)
+			props := txc.txProps
+			// not all StatefulConnections contain transactions
+			if props != nil {
+				var level string
+				duration := props.EndTime.Sub(props.StartTime).Seconds()
+				if duration < 0.1 {
+					level = "low"
+				} else if duration < 1.0 {
+					level = "medium"
+				} else {
+					level = "high"
+				}
+				tmplData := struct {
+					*StatefulConnection
+					Duration   float64
+					ColorLevel string
+				}{txc, duration, level}
+				if err := txlogzTmpl.Execute(w, tmplData); err != nil {
+					log.Errorf("txlogz: couldn't execute template: %v", err)
+				}
 			}
 		case <-tmr.C:
 			return


### PR DESCRIPTION
Fix for this problem:

```
I0529 01:54:58.175001    1272 logutil.go:31] log: http: panic serving 172.17.0.1:48142: runtime error: invalid memory address or nil pointer dereference
goroutine 26452 [running]:
net/http.(*conn).serve.func1(0xc0008aec80)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0x1e35d80, 0x3827060)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
vitess.io/vitess/go/vt/vttablet/tabletserver.txlogzHandler(0x25c8400, 0xc0005082a0, 0xc00010f800)
	/vt/src/vitess.io/vitess/go/vt/vttablet/tabletserver/txlogz.go:123 +0x368
net/http.HandlerFunc.ServeHTTP(0x22536f8, 0x25c8400, 0xc0005082a0, 0xc00010f800)
	/usr/local/go/src/net/http/server.go:2007 +0x44
net/http.(*ServeMux).ServeHTTP(0x3855320, 0x25c8400, 0xc0005082a0, 0xc00010f800)
	/usr/local/go/src/net/http/server.go:2387 +0x1bd
net/http.serverHandler.ServeHTTP(0xc0002321c0, 0x25c8400, 0xc0005082a0, 0xc00010f800)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0008aec80, 0x25d4fc0, 0xc0009db980)
	/usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2928 +0x384
```