### PR TITLE
Fix issue #6240.  PR #6130 did not take the header length offset into

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -1087,7 +1087,7 @@ func (c *Conn) writeBinaryRow(fields []*querypb.Field, row []sqltypes.Value) err
 
 	for i, val := range row {
 		if val.IsNull() {
-			bytePos := (i+2)/8 + 1
+			bytePos := (i+2)/8 + 1 + packetHeaderSize
 			bitPos := (i + 2) % 8
 			data[bytePos] |= 1 << uint(bitPos)
 		} else {


### PR DESCRIPTION
account in writeBinaryRow().  Not an ideal fix, but something cleaner
will involve invasive cleanup.

I have not added a test (this was tested manually).  I will defer to someone who knows this module tests better to suggest an effective test with the mocks in place.