### PR TITLE
Reverting breaking change relating to filter regular expressions in #6242

### DIFF
--- a/go/vt/mysqlctl/tmutils/schema.go
+++ b/go/vt/mysqlctl/tmutils/schema.go
@@ -91,7 +91,7 @@ func NewTableFilter(tables, excludeTables []string, includeViews bool) (*TableFi
 	if len(tables) > 0 {
 		f.filterTables = true
 		for _, table := range tables {
-			if strings.HasPrefix(table, "/") && strings.HasSuffix(table, "/") {
+			if strings.HasPrefix(table, "/") {
 				table = strings.Trim(table, "/")
 				re, err := regexp.Compile(table)
 				if err != nil {
@@ -108,7 +108,7 @@ func NewTableFilter(tables, excludeTables []string, includeViews bool) (*TableFi
 	if len(excludeTables) > 0 {
 		f.filterExcludeTables = true
 		for _, table := range excludeTables {
-			if strings.HasPrefix(table, "/") && strings.HasSuffix(table, "/") {
+			if strings.HasPrefix(table, "/") {
 				table = strings.Trim(table, "/")
 				re, err := regexp.Compile(table)
 				if err != nil {


### PR DESCRIPTION
#6242 requires regular expression filter matches to end with a trailing /. There are code paths that use /.* (without the trailing slash) and hence the change would break these. In particular local example failed in CI.

For now reverting only this specific change in #6242 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>