### PR TITLE
Rebuild SrvVSchema during InitTablet.

### DIFF
--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -342,7 +342,7 @@ func (ts *Server) GetOrCreateShard(ctx context.Context, keyspace, shard, cell st
 
 	// make sure a valid vschema has been loaded
 	log.Info("EnsureVSchema %s/%s", keyspace, shard)
-	if err = ts.EnsureVSchema(ctx, keyspace, []string{cell}); err != nil {
+	if err = ts.EnsureVSchema(ctx, keyspace); err != nil {
 		return nil, vterrors.Wrapf(err, "EnsureVSchema(%v) failed", keyspace)
 	}
 

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -72,7 +72,7 @@ func (ts *Server) GetVSchema(ctx context.Context, keyspace string) (*vschemapb.K
 }
 
 // EnsureVSchema makes sure that a vschema is present for this keyspace or creates a blank one if it is missing
-func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string, cells []string) error {
+func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string) error {
 	vschema, err := ts.GetVSchema(ctx, keyspace)
 	if err != nil && !IsErrType(err, NoNode) {
 		log.Info("error in getting vschema for keyspace %s: %v", keyspace, err)
@@ -87,12 +87,6 @@ func (ts *Server) EnsureVSchema(ctx context.Context, keyspace string, cells []st
 			log.Errorf("could not create blank vschema: %v", err)
 			return err
 		}
-	}
-
-	err = ts.RebuildSrvVSchema(ctx, cells)
-	if err != nil {
-		log.Errorf("could not rebuild SrvVschema after creating keyspace: %v", err)
-		return err
 	}
 	return nil
 }

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1666,18 +1666,14 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		wr.Logger().Infof("keyspace %v already exists (ignoring error with -force)", keyspace)
 		err = nil
 	}
-
-	if !*allowEmptyVSchema {
-		cells, err := wr.TopoServer().GetKnownCells(ctx)
-		if err != nil {
-			return fmt.Errorf("GetKnownCells failed: %v", err)
-		}
-
-		err = wr.TopoServer().EnsureVSchema(ctx, keyspace, cells)
-	}
-
 	if err != nil {
 		return err
+	}
+
+	if !*allowEmptyVSchema {
+		if err := wr.TopoServer().EnsureVSchema(ctx, keyspace); err != nil {
+			return err
+		}
 	}
 
 	if ktype == topodatapb.KeyspaceType_SNAPSHOT {
@@ -1703,9 +1699,9 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 			wr.Logger().Infof("error from SaveVSchema %v:%v", vs, err)
 			return err
 		}
-		return wr.TopoServer().RebuildSrvVSchema(ctx, []string{} /* cells */)
 	}
-	return nil
+
+	return wr.TopoServer().RebuildSrvVSchema(ctx, []string{} /* cells */)
 }
 
 func commandDeleteKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {


### PR DESCRIPTION
We used to rebuild SrvVSchema in all cells as part of running GetOrCreateShard from any cell. That caused VSchema problems to spread instantly to all cells at once, so we changed EnsureVSchema to only rebuild SrvVSchema in the local cell (#5930).

We believed that at least one tablet in a given cell would still end up rebuilding SrvVschema in the cell since they all call GetOrCreateShard at startup. However, I didn't realize that GetOrCreateShard
short-circuits if the shard already exists, so it was skipping EnsureVSchema entirely. As a result, only one cell (corresponding to the one tablet that won the race) actually had its SrvVSchema rebuilt.

This moves the rebuild of SrvVSchema to be an explicit step in InitTablet alongside the rebuild of the keyspace graph. This keeps GetOrCreateShard as a task that only needs to be done by one tablet globally because it affects global topo. The rebuilding of per-cell records should be done by a tablet in that cell.