### PR TITLE
vttablet: fix deadlock in schema engine

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -85,10 +85,10 @@ func NewEngine(env tabletenv.Env) *Engine {
 	reloadTime := time.Duration(env.Config().SchemaReloadIntervalSeconds * 1e9)
 	se := &Engine{
 		env: env,
-		// We need only one connection because the reloader is
-		// the only one that needs this.
+		// We need two connections: one for the reloader, and one for
+		// the historian.
 		conns: connpool.NewPool(env, "", tabletenv.ConnPoolConfig{
-			Size:               1,
+			Size:               2,
 			IdleTimeoutSeconds: env.Config().OltpReadPool.IdleTimeoutSeconds,
 		}),
 		ticks:      timer.NewTimer(reloadTime),


### PR DESCRIPTION
The new historian reuses the pool from schema engine. But that pool
has only one connection. I found a deadlock where se calls the
historian with that conn open, and the historian in turn requests
a connection for its own reload. This causes a deadlock. This is
fixed by increasing pool size to 2.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>