### PR TITLE
show vitess_tablets should show new master's timestamp after reparenting

### DIFF
--- a/examples/local/scripts/vtgate-up.sh
+++ b/examples/local/scripts/vtgate-up.sh
@@ -37,7 +37,6 @@ vtgate \
   -cell $cell \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \
-  -gateway_implementation discoverygateway \
   -service_map 'grpc-vtgateservice' \
   -pid_file $VTDATAROOT/tmp/vtgate.pid \
   -mysql_auth_server_impl none \

--- a/examples/region_sharding/scripts/vtgate-up.sh
+++ b/examples/region_sharding/scripts/vtgate-up.sh
@@ -37,7 +37,6 @@ vtgate \
   -cell $cell \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \
-  -gateway_implementation discoverygateway \
   -service_map 'grpc-vtgateservice' \
   -pid_file $VTDATAROOT/tmp/vtgate.pid \
   -mysql_auth_server_impl none \

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1008,7 +1008,6 @@ func (e *Executor) showTablets() (*sqltypes.Result, error) {
 			}
 		}
 	} else {
-		log.Info("DEBUG: in showTablets")
 		status := e.scatterConn.GetHealthCheckCacheStatus()
 		for _, s := range status {
 			for _, ts := range s.TabletsStats {
@@ -1021,7 +1020,6 @@ func (e *Executor) showTablets() (*sqltypes.Result, error) {
 				if mtst > 0 {
 					// this code depends on the fact that MasterTermStartTime is the seconds since epoch start
 					mtstStr = time.Unix(mtst, 0).UTC().Format(time.RFC3339)
-					log.Infof("DEBUG: MasterTermStartTime: %v", mtstStr)
 				}
 				rows = append(rows, buildVarCharRow(
 					s.Cell,

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -29,8 +29,6 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/logutil"
-
 	"vitess.io/vitess/go/vt/log"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 
@@ -991,10 +989,11 @@ func (e *Executor) showTablets() (*sqltypes.Result, error) {
 				if !ts.Serving {
 					state = "NOT_SERVING"
 				}
-				mtst := ts.Tablet.MasterTermStartTime
+				mtst := ts.TabletExternallyReparentedTimestamp
 				mtstStr := ""
-				if mtst != nil && mtst.Seconds > 0 {
-					mtstStr = logutil.ProtoToTime(ts.Tablet.MasterTermStartTime).Format(time.RFC3339)
+				if mtst > 0 {
+					// this code depends on the fact that TabletExternallyReparentedTimestamp is the seconds since epoch start
+					mtstStr = time.Unix(mtst, 0).UTC().Format(time.RFC3339)
 				}
 				rows = append(rows, buildVarCharRow(
 					s.Cell,
@@ -1009,6 +1008,7 @@ func (e *Executor) showTablets() (*sqltypes.Result, error) {
 			}
 		}
 	} else {
+		log.Info("DEBUG: in showTablets")
 		status := e.scatterConn.GetHealthCheckCacheStatus()
 		for _, s := range status {
 			for _, ts := range s.TabletsStats {
@@ -1016,10 +1016,12 @@ func (e *Executor) showTablets() (*sqltypes.Result, error) {
 				if !ts.Serving {
 					state = "NOT_SERVING"
 				}
-				mtst := ts.Tablet.MasterTermStartTime
+				mtst := ts.MasterTermStartTime
 				mtstStr := ""
-				if mtst != nil && mtst.Seconds > 0 {
-					mtstStr = logutil.ProtoToTime(ts.Tablet.MasterTermStartTime).Format(time.RFC3339)
+				if mtst > 0 {
+					// this code depends on the fact that MasterTermStartTime is the seconds since epoch start
+					mtstStr = time.Unix(mtst, 0).UTC().Format(time.RFC3339)
+					log.Infof("DEBUG: MasterTermStartTime: %v", mtstStr)
 				}
 				rows = append(rows, buildVarCharRow(
 					s.Cell,

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -532,6 +532,7 @@ func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topo
 	tablet := agent.Tablet()
 	if tablet.Type == topodatapb.TabletType_MASTER {
 		tablet.Type = topodatapb.TabletType_REPLICA
+		tablet.MasterTermStartTime = nil
 		agent.setMasterTermStartTime(time.Time{})
 		agent.updateState(ctx, tablet, "setMasterLocked")
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -532,7 +532,7 @@ func (agent *ActionAgent) setMasterLocked(ctx context.Context, parentAlias *topo
 	tablet := agent.Tablet()
 	if tablet.Type == topodatapb.TabletType_MASTER {
 		tablet.Type = topodatapb.TabletType_REPLICA
-		tablet.MasterTermStartTime = nil
+		agent.setMasterTermStartTime(time.Time{})
 		agent.updateState(ctx, tablet, "setMasterLocked")
 	}
 


### PR DESCRIPTION
Fixes #6292 

* vtgate was using the wrong time fields from health cache.
* agentMasterTermTime should be reset to 0 when a tablet is demoted from MASTER.
* change examples to use new gateway.

Signed-off-by: deepthi <deepthi@planetscale.com>