### PR TITLE
Add flag to catch and ignore SIGPIPE

### DIFF
--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -32,6 +32,7 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
 	"sync"
@@ -59,6 +60,7 @@ var (
 	onTermTimeout        = flag.Duration("onterm_timeout", 10*time.Second, "wait no more than this for OnTermSync handlers before stopping")
 	memProfileRate       = flag.Int("mem-profile-rate", 512*1024, "profile every n bytes allocated")
 	mutexProfileFraction = flag.Int("mutex-profile-fraction", 0, "profile every n mutex contention events (see runtime.SetMutexProfileFraction)")
+	catchSigpipe         = flag.Bool("catch-sigpipe", false, "catch and ignore SIGPIPE on stdout and stderr if specified")
 
 	// mutex used to protect the Init function
 	mu sync.Mutex
@@ -77,6 +79,19 @@ var (
 func Init() {
 	mu.Lock()
 	defer mu.Unlock()
+
+	// Ignore SIGPIPE if specified
+	// The Go runtime catches SIGPIPE for us on all fds except stdout/stderr
+	// See https://golang.org/pkg/os/signal/#hdr-SIGPIPE
+	if *catchSigpipe {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGPIPE)
+		go func() {
+			<-sigChan
+			log.Warning("Caught SIGPIPE (ignoring all future SIGPIPEs)")
+			signal.Ignore(syscall.SIGPIPE)
+		}()
+	}
 
 	// Add version tag to every info log
 	log.Infof(AppVersion.String())


### PR DESCRIPTION
The Go runtime catches SIGPIPE for us on all fds except stdout and stderr. (See https://golang.org/pkg/os/signal/#hdr-SIGPIPE.) This patch adds a flag that catches SIGPIPE not handled by the runtime, prints a warning, and then ignores all future SIGPIPEs.

In our case, we run Vitess components via systemd. journald was restarted at an unlucky time, causing vttablet to receive a SIGPIPE when trying to write to stderr. As explained above, the Go runtime does not catch SIGPIPE on stdout or stderr, so vttablet was killed.

As an additional note to anyone running systemd services, systemd bizarrely counts death by SIGPIPE (and a few other signals) to be a successful exit. That means you need to set `Restart=always` if you want your service to restart on SIGPIPE. (We had ours set to `Restart=on-failure` so the service did not restart.)

Signed-off-by: Adam Saponara <as@php.net>