### PR TITLE
Fix go-lint warning: package comment should be of the form 'Package trace'

### DIFF
--- a/go/trace/opentracing.go
+++ b/go/trace/opentracing.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package trace
 
 import (

--- a/go/trace/plugin_jaeger.go
+++ b/go/trace/plugin_jaeger.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package trace
 
 import (


### PR DESCRIPTION
Signed-off-by: ZouYu <zouy.fnst@cn.fujitsu.com>