### PR TITLE
Make sure to protect insert lookup queries from bind var name clashes (6.0)

### DIFF
--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -97,11 +97,11 @@ func TestAutocommitUpdateVindexChange(t *testing.T) {
 			"keyspace_id": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
 		},
 	}, {
-		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0)",
+		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":        sqltypes.BytesBindVariable([]byte("myname")),
-			"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
-			"keyspace_id0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
+			"name_0":        sqltypes.BytesBindVariable([]byte("myname")),
+			"lastname_0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+			"keyspace_id_0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
 		},
 	}})
 	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
@@ -269,10 +269,10 @@ func TestAutocommitInsertLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}})
 	testAsTransactionCount(t, "sbclookup", sbclookup, 0)

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -538,13 +538,13 @@ func TestInsertShardedOwned(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1), (:from12, :from22, :toc2) ` +
-			`from10: type:INT64 value:"4" from11: type:INT64 value:"5" from12: type:INT64 value:"6" ` +
-			`from20: type:INT64 value:"7" from21: type:INT64 value:"8" from22: type:INT64 value:"9" ` +
-			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0), (:from1, :toc1), (:from2, :toc2) ` +
-			`from0: type:INT64 value:"10" from1: type:INT64 value:"11" from2: type:INT64 value:"12" ` +
-			`toc0: type:VARBINARY value:"\026k@\264J\272K\326" toc1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0), (:from1_1, :from2_1, :toc_1), (:from1_2, :from2_2, :toc_2) ` +
+			`from1_0: type:INT64 value:"4" from1_1: type:INT64 value:"5" from1_2: type:INT64 value:"6" ` +
+			`from2_0: type:INT64 value:"7" from2_1: type:INT64 value:"8" from2_2: type:INT64 value:"9" ` +
+			`toc_0: type:VARBINARY value:"\026k@\264J\272K\326" toc_1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc_2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0), (:from_1, :toc_1), (:from_2, :toc_2) ` +
+			`from_0: type:INT64 value:"10" from_1: type:INT64 value:"11" from_2: type:INT64 value:"12" ` +
+			`toc_0: type:VARBINARY value:"\026k@\264J\272K\326" toc_1: type:VARBINARY value:"\006\347\352\"\316\222p\217" toc_2: type:VARBINARY value:"N\261\220\311\242\372\026\234"  true`,
 		// Based on shardForKsid, values returned will be 20-, -20, 20-.
 		`ResolveDestinations sharded [value:"0"  value:"1"  value:"2" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(4eb190c9a2fa169c)`,
 		`ExecuteMultiShard ` +
@@ -636,7 +636,7 @@ func TestInsertShardedOwnedWithNull(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: toc0: type:VARBINARY ` +
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: toc_0: type:VARBINARY ` +
 			`value:"\026k@\264J\272K\326"  true`,
 		`ResolveDestinations sharded [value:"0" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
 		`ExecuteMultiShard sharded.20-: prefix mid1 suffix ` +
@@ -732,9 +732,9 @@ func TestInsertShardedGeo(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute insert into id_idx(id, keyspace_id) values(:id0, :keyspace_id0), (:id1, :keyspace_id1) ` +
-			`id0: type:INT64 value:"1" id1: type:INT64 value:"1" ` +
-			`keyspace_id0: type:VARBINARY value:"\001\026k@\264J\272K\326" keyspace_id1: type:VARBINARY value:"\377\026k@\264J\272K\326"  true`,
+		`Execute insert into id_idx(id, keyspace_id) values(:id_0, :keyspace_id_0), (:id_1, :keyspace_id_1) ` +
+			`id_0: type:INT64 value:"1" id_1: type:INT64 value:"1" ` +
+			`keyspace_id_0: type:VARBINARY value:"\001\026k@\264J\272K\326" keyspace_id_1: type:VARBINARY value:"\377\026k@\264J\272K\326"  true`,
 		`ResolveDestinations sharded [value:"0"  value:"1" ] Destinations:DestinationKeyspaceID(01166b40b44aba4bd6),DestinationKeyspaceID(ff166b40b44aba4bd6)`,
 		`ExecuteMultiShard sharded.20-: prefix mid1 suffix ` +
 			`{_id0: type:INT64 value:"1" _id1: type:INT64 value:"1" ` +
@@ -904,18 +904,18 @@ func TestInsertShardedIgnoreOwned(t *testing.T) {
 		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"2"  false`,
 		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"3"  false`,
 		`Execute select toc from prim where from1 = :from1 from1: type:INT64 value:"4"  false`,
-		`Execute insert ignore into lkp2(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1), (:from12, :from22, :toc2) ` +
-			`from10: type:INT64 value:"5" from11: type:INT64 value:"7" from12: type:INT64 value:"8" ` +
-			`from20: type:INT64 value:"9" from21: type:INT64 value:"11" from22: type:INT64 value:"12" ` +
-			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000" toc2: type:VARBINARY value:"\000"  ` +
+		`Execute insert ignore into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0), (:from1_1, :from2_1, :toc_1), (:from1_2, :from2_2, :toc_2) ` +
+			`from1_0: type:INT64 value:"5" from1_1: type:INT64 value:"7" from1_2: type:INT64 value:"8" ` +
+			`from2_0: type:INT64 value:"9" from2_1: type:INT64 value:"11" from2_2: type:INT64 value:"12" ` +
+			`toc_0: type:VARBINARY value:"\000" toc_1: type:VARBINARY value:"\000" toc_2: type:VARBINARY value:"\000"  ` +
 			`true`,
 		// row 2 is out because it didn't map to a ksid.
 		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"5" toc: type:VARBINARY value:"\000"  false`,
 		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"7" toc: type:VARBINARY value:"\000"  false`,
 		`Execute select from1 from lkp2 where from1 = :from1 and toc = :toc from1: type:INT64 value:"8" toc: type:VARBINARY value:"\000"  false`,
-		`Execute insert ignore into lkp1(from, toc) values(:from0, :toc0), (:from1, :toc1) ` +
-			`from0: type:INT64 value:"13" from1: type:INT64 value:"16" ` +
-			`toc0: type:VARBINARY value:"\000" toc1: type:VARBINARY value:"\000"  ` +
+		`Execute insert ignore into lkp1(from, toc) values(:from_0, :toc_0), (:from_1, :toc_1) ` +
+			`from_0: type:INT64 value:"13" from_1: type:INT64 value:"16" ` +
+			`toc_0: type:VARBINARY value:"\000" toc_1: type:VARBINARY value:"\000"  ` +
 			`true`,
 		// row 3 is out because it failed Verify. Only two verifications from lkp1.
 		`Execute select from from lkp1 where from = :from and toc = :toc from: type:INT64 value:"13" toc: type:VARBINARY value:"\000"  false`,
@@ -1023,7 +1023,7 @@ func TestInsertShardedIgnoreOwnedWithNull(t *testing.T) {
 		t.Fatal(err)
 	}
 	vc.ExpectLog(t, []string{
-		`Execute insert ignore into lkp1(from, toc) values(:from0, :toc0) from0: toc0: type:VARBINARY ` +
+		`Execute insert ignore into lkp1(from, toc) values(:from_0, :toc_0) from_0: toc_0: type:VARBINARY ` +
 			`value:"\026k@\264J\272K\326"  true`,
 		`Execute select from from lkp1 where from = :from and toc = :toc from: toc: type:VARBINARY value:"\026k@\264J\272K\326"  false`,
 		`ResolveDestinations sharded [value:"0" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -236,10 +236,10 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -282,14 +282,14 @@ func TestUpdateEqualChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"7" from2: type:INT64 value:"8" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"9" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -339,10 +339,10 @@ func TestUpdateScatterChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} sharded.20-: dummy_update {} true false`,
 	})
@@ -387,17 +387,17 @@ func TestUpdateScatterChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// Those values are returned as 7,8 for twocol and 9 for onecol.
 		// 7,8 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"7" from2: type:INT64 value:"8" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 9 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"9" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} sharded.20-: dummy_update {} true false`,
 	})
@@ -481,16 +481,16 @@ func TestUpdateInChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 21,22 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"21" from2: type:INT64 value:"22" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
 		// 23 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"23" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -534,26 +534,25 @@ func TestUpdateInChangedVindex(t *testing.T) {
 		// Those values are returned as 4,5 for twocol and 6 for onecol.
 		// 4,5 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"4" from2: type:INT64 value:"5" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 6 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 7,8 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"7" from2: type:INT64 value:"8" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 9 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"9" toc: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\026k@\264J\272K\326"  true`,
 		// 21,22 have to be replaced by 1,2 (the new values).
 		`Execute delete from lkp2 where from1 = :from1 and from2 = :from2 and toc = :toc from1: type:INT64 value:"21" from2: type:INT64 value:"22" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute insert into lkp2(from1, from2, toc) values(:from10, :from20, :toc0) from10: type:INT64 value:"1" from20: type:INT64 value:"2" toc0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
+		`Execute insert into lkp2(from1, from2, toc) values(:from1_0, :from2_0, :toc_0) from1_0: type:INT64 value:"1" from2_0: type:INT64 value:"2" toc_0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
 		// 23 has to be replaced by 3.
 		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"23" toc: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
-		`Execute insert into lkp1(from, toc) values(:from0, :toc0) from0: type:INT64 value:"3" toc0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"3" toc_0: type:VARBINARY value:"\006\347\352\"\316\222p\217"  true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
-
 }
 
 func TestUpdateNoStream(t *testing.T) {

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -133,11 +133,11 @@ func TestUpdateEqual(t *testing.T) {
 			},
 		},
 		{
-			Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0)",
+			Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0)",
 			BindVariables: map[string]*querypb.BindVariable{
-				"name0":        sqltypes.BytesBindVariable([]byte("myname")),
-				"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
-				"keyspace_id0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
+				"name_0":        sqltypes.BytesBindVariable([]byte("myname")),
+				"lastname_0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+				"keyspace_id_0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
 			},
 		},
 	}
@@ -241,11 +241,11 @@ func TestUpdateMultiOwned(t *testing.T) {
 			"user_id": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
-		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from1_0, :from2_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10":   sqltypes.Int64BindVariable(1),
-			"from20":   sqltypes.Int64BindVariable(2),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"from1_0":   sqltypes.Int64BindVariable(1),
+			"from2_0":   sqltypes.Int64BindVariable(2),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
 		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
@@ -255,17 +255,15 @@ func TestUpdateMultiOwned(t *testing.T) {
 			"user_id": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
-		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from1_0, :from2_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10":   sqltypes.Int64BindVariable(3),
-			"from20":   sqltypes.Int64BindVariable(4),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"from1_0":   sqltypes.Int64BindVariable(3),
+			"from2_0":   sqltypes.Int64BindVariable(4),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 }
 
 func TestUpdateComments(t *testing.T) {
@@ -569,17 +567,17 @@ func TestInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
 	}
 
-	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name0, :user_id0)", 1)
+	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)", 1)
 	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (1, 2, 'myname')", 1)
 
 	sbc1.Queries = nil
@@ -601,10 +599,10 @@ func TestInsertSharded(t *testing.T) {
 		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname2")),
-			"user_id0": sqltypes.Uint64BindVariable(3),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname2")),
+			"user_id_0": sqltypes.Uint64BindVariable(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -703,10 +701,10 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0) on duplicate key update name = values(name), user_id = values(user_id)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0) on duplicate key update name = values(name), user_id = values(user_id)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	// autocommit should go as ExecuteBatch
@@ -821,18 +819,18 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"music_id": sqltypes.Int64BindVariable(6),
 		},
 	}, {
-		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol0, :tocol0), (:fromcol1, :tocol1), (:fromcol2, :tocol2), (:fromcol3, :tocol3), (:fromcol4, :tocol4)",
+		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0), (:fromcol_1, :tocol_1), (:fromcol_2, :tocol_2), (:fromcol_3, :tocol_3), (:fromcol_4, :tocol_4)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol0": sqltypes.Int64BindVariable(1),
-			"tocol0":   sqltypes.Uint64BindVariable(1),
-			"fromcol1": sqltypes.Int64BindVariable(3),
-			"tocol1":   sqltypes.Uint64BindVariable(1),
-			"fromcol2": sqltypes.Int64BindVariable(4),
-			"tocol2":   sqltypes.Uint64BindVariable(1),
-			"fromcol3": sqltypes.Int64BindVariable(5),
-			"tocol3":   sqltypes.Uint64BindVariable(1),
-			"fromcol4": sqltypes.Int64BindVariable(6),
-			"tocol4":   sqltypes.Uint64BindVariable(3),
+			"fromcol_0": sqltypes.Int64BindVariable(1),
+			"tocol_0":   sqltypes.Uint64BindVariable(1),
+			"fromcol_1": sqltypes.Int64BindVariable(3),
+			"tocol_1":   sqltypes.Uint64BindVariable(1),
+			"fromcol_2": sqltypes.Int64BindVariable(4),
+			"tocol_2":   sqltypes.Uint64BindVariable(1),
+			"fromcol_3": sqltypes.Int64BindVariable(5),
+			"tocol_3":   sqltypes.Uint64BindVariable(1),
+			"fromcol_4": sqltypes.Int64BindVariable(6),
+			"tocol_4":   sqltypes.Uint64BindVariable(3),
 		},
 	}, {
 		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
@@ -926,10 +924,10 @@ func TestInsertOnDupKey(t *testing.T) {
 			"music_id": sqltypes.Int64BindVariable(1),
 		},
 	}, {
-		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol0, :tocol0)",
+		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol0": sqltypes.Int64BindVariable(1),
-			"tocol0":   sqltypes.Uint64BindVariable(1),
+			"fromcol_0": sqltypes.Int64BindVariable(1),
+			"tocol_0":   sqltypes.Uint64BindVariable(1),
 		},
 	}, {
 		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
@@ -963,10 +961,10 @@ func TestInsertComments(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0) /* trailing */",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1001,15 +999,13 @@ func TestInsertGeneratorSharded(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 	wantResult := *sandboxconn.SingleRowResult
 	wantResult.InsertID = 1
 	if !result.Equal(&wantResult) {
@@ -1114,15 +1110,13 @@ func TestInsertLookupOwned(t *testing.T) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"music_id0": sqltypes.Int64BindVariable(3),
-			"user_id0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(3),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 }
 
 func TestInsertLookupOwnedGenerator(t *testing.T) {
@@ -1152,10 +1146,10 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"music_id0": sqltypes.Int64BindVariable(4),
-			"user_id0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(4),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1301,12 +1295,12 @@ func TestMultiInsertSharded(t *testing.T) {
 	}
 
 	wantQueries1 = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
-			"name1":    sqltypes.BytesBindVariable([]byte("myname3")),
-			"user_id1": sqltypes.Uint64BindVariable(3),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname1")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
+			"name_1":    sqltypes.BytesBindVariable([]byte("myname3")),
+			"user_id_1": sqltypes.Uint64BindVariable(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries1) {
@@ -1337,12 +1331,12 @@ func TestMultiInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
-			"name1":    sqltypes.BytesBindVariable([]byte("myname2")),
-			"user_id1": sqltypes.Uint64BindVariable(2),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname1")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
+			"name_1":    sqltypes.BytesBindVariable([]byte("myname2")),
+			"user_id_1": sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1370,14 +1364,14 @@ func TestMultiInsertSharded(t *testing.T) {
 		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0), (:name1, :lastname1, :keyspace_id1)",
+		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0), (:name_1, :lastname_1, :keyspace_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":        sqltypes.BytesBindVariable([]byte("myname")),
-			"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
-			"keyspace_id0": sqltypes.BytesBindVariable([]byte("\006\347\352\"\316\222p\217")),
-			"name1":        sqltypes.BytesBindVariable([]byte("myname2")),
-			"lastname1":    sqltypes.BytesBindVariable([]byte("mylastname2")),
-			"keyspace_id1": sqltypes.BytesBindVariable([]byte("N\261\220\311\242\372\026\234")),
+			"name_0":        sqltypes.BytesBindVariable([]byte("myname")),
+			"lastname_0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+			"keyspace_id_0": sqltypes.BytesBindVariable([]byte("\006\347\352\"\316\222p\217")),
+			"name_1":        sqltypes.BytesBindVariable([]byte("myname2")),
+			"lastname_1":    sqltypes.BytesBindVariable([]byte("mylastname2")),
+			"keyspace_id_1": sqltypes.BytesBindVariable([]byte("N\261\220\311\242\372\026\234")),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1416,17 +1410,15 @@ func TestMultiInsertGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0), (:music_id_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"user_id0":  sqltypes.Uint64BindVariable(2),
-			"music_id0": sqltypes.Int64BindVariable(1),
-			"user_id1":  sqltypes.Uint64BindVariable(2),
-			"music_id1": sqltypes.Int64BindVariable(2),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(1),
+			"user_id_1":  sqltypes.Uint64BindVariable(2),
+			"music_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 	wantResult := *sandboxconn.SingleRowResult
 	wantResult.InsertID = 1
 	if !result.Equal(&wantResult) {
@@ -1468,19 +1460,17 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1), (:music_id2, :user_id2)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0), (:music_id_1, :user_id_1), (:music_id_2, :user_id_2)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"user_id0":  sqltypes.Uint64BindVariable(2),
-			"music_id0": sqltypes.Int64BindVariable(1),
-			"user_id1":  sqltypes.Uint64BindVariable(2),
-			"music_id1": sqltypes.Int64BindVariable(2),
-			"user_id2":  sqltypes.Uint64BindVariable(2),
-			"music_id2": sqltypes.Int64BindVariable(2),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(1),
+			"user_id_1":  sqltypes.Uint64BindVariable(2),
+			"music_id_1": sqltypes.Int64BindVariable(2),
+			"user_id_2":  sqltypes.Uint64BindVariable(2),
+			"music_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 	wantResult := *sandboxconn.SingleRowResult
 	wantResult.InsertID = 1
 	if !result.Equal(&wantResult) {
@@ -1644,10 +1634,10 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name0')", map[string]*querypb.BindVariable{
-		"_Id0":   sqltypes.Int64BindVariable(1),
-		"_name0": sqltypes.BytesBindVariable([]byte("myname")),
-		"__seq0": sqltypes.Int64BindVariable(1),
+	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')", map[string]*querypb.BindVariable{
+		"_Id0":    sqltypes.Int64BindVariable(1),
+		"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
+		"__seq0":  sqltypes.Int64BindVariable(1),
 	})
 	require.NoError(t, err)
 

--- a/go/vt/vtgate/plan_executor_dml_test.go
+++ b/go/vt/vtgate/plan_executor_dml_test.go
@@ -133,18 +133,16 @@ func TestPlanUpdateEqual(t *testing.T) {
 			},
 		},
 		{
-			Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0)",
+			Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0)",
 			BindVariables: map[string]*querypb.BindVariable{
-				"name0":        sqltypes.BytesBindVariable([]byte("myname")),
-				"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
-				"keyspace_id0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
+				"name_0":        sqltypes.BytesBindVariable([]byte("myname")),
+				"lastname_0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+				"keyspace_id_0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
 			},
 		},
 	}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 }
 
 func TestPlanUpdateMultiOwned(t *testing.T) {
@@ -241,11 +239,11 @@ func TestPlanUpdateMultiOwned(t *testing.T) {
 			"user_id": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
-		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from1_0, :from2_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10":   sqltypes.Int64BindVariable(1),
-			"from20":   sqltypes.Int64BindVariable(2),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"from1_0":   sqltypes.Int64BindVariable(1),
+			"from2_0":   sqltypes.Int64BindVariable(2),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
 		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
@@ -255,17 +253,15 @@ func TestPlanUpdateMultiOwned(t *testing.T) {
 			"user_id": sqltypes.Uint64BindVariable(1),
 		},
 	}, {
-		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from1_0, :from2_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10":   sqltypes.Int64BindVariable(3),
-			"from20":   sqltypes.Int64BindVariable(4),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"from1_0":   sqltypes.Int64BindVariable(3),
+			"from2_0":   sqltypes.Int64BindVariable(4),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 }
 
 func TestPlanUpdateComments(t *testing.T) {
@@ -569,17 +565,17 @@ func TestPlanInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
 	}
 
-	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name0, :user_id0)", 1)
+	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)", 1)
 	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (1, 2, 'myname')", 1)
 
 	sbc1.Queries = nil
@@ -601,10 +597,10 @@ func TestPlanInsertSharded(t *testing.T) {
 		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname2")),
-			"user_id0": sqltypes.Uint64BindVariable(3),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname2")),
+			"user_id_0": sqltypes.Uint64BindVariable(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -703,10 +699,10 @@ func TestPlanInsertShardedAutocommitLookup(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0) on duplicate key update name = values(name), user_id = values(user_id)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0) on duplicate key update name = values(name), user_id = values(user_id)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	// autocommit should go as ExecuteBatch
@@ -821,18 +817,18 @@ func TestPlanInsertShardedIgnore(t *testing.T) {
 			"music_id": sqltypes.Int64BindVariable(6),
 		},
 	}, {
-		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol0, :tocol0), (:fromcol1, :tocol1), (:fromcol2, :tocol2), (:fromcol3, :tocol3), (:fromcol4, :tocol4)",
+		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0), (:fromcol_1, :tocol_1), (:fromcol_2, :tocol_2), (:fromcol_3, :tocol_3), (:fromcol_4, :tocol_4)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol0": sqltypes.Int64BindVariable(1),
-			"tocol0":   sqltypes.Uint64BindVariable(1),
-			"fromcol1": sqltypes.Int64BindVariable(3),
-			"tocol1":   sqltypes.Uint64BindVariable(1),
-			"fromcol2": sqltypes.Int64BindVariable(4),
-			"tocol2":   sqltypes.Uint64BindVariable(1),
-			"fromcol3": sqltypes.Int64BindVariable(5),
-			"tocol3":   sqltypes.Uint64BindVariable(1),
-			"fromcol4": sqltypes.Int64BindVariable(6),
-			"tocol4":   sqltypes.Uint64BindVariable(3),
+			"fromcol_0": sqltypes.Int64BindVariable(1),
+			"tocol_0":   sqltypes.Uint64BindVariable(1),
+			"fromcol_1": sqltypes.Int64BindVariable(3),
+			"tocol_1":   sqltypes.Uint64BindVariable(1),
+			"fromcol_2": sqltypes.Int64BindVariable(4),
+			"tocol_2":   sqltypes.Uint64BindVariable(1),
+			"fromcol_3": sqltypes.Int64BindVariable(5),
+			"tocol_3":   sqltypes.Uint64BindVariable(1),
+			"fromcol_4": sqltypes.Int64BindVariable(6),
+			"tocol_4":   sqltypes.Uint64BindVariable(3),
 		},
 	}, {
 		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
@@ -926,10 +922,10 @@ func TestPlanInsertOnDupKey(t *testing.T) {
 			"music_id": sqltypes.Int64BindVariable(1),
 		},
 	}, {
-		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol0, :tocol0)",
+		Sql: "insert ignore into ins_lookup(fromcol, tocol) values (:fromcol_0, :tocol_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromcol0": sqltypes.Int64BindVariable(1),
-			"tocol0":   sqltypes.Uint64BindVariable(1),
+			"fromcol_0": sqltypes.Int64BindVariable(1),
+			"tocol_0":   sqltypes.Uint64BindVariable(1),
 		},
 	}, {
 		Sql: "select fromcol from ins_lookup where fromcol = :fromcol and tocol = :tocol",
@@ -963,10 +959,10 @@ func TestPlanInsertComments(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0) /* trailing */",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1001,10 +997,10 @@ func TestPlanInsertGeneratorSharded(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1114,10 +1110,10 @@ func TestPlanInsertLookupOwned(t *testing.T) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"music_id0": sqltypes.Int64BindVariable(3),
-			"user_id0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(3),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1152,10 +1148,10 @@ func TestPlanInsertLookupOwnedGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"music_id0": sqltypes.Int64BindVariable(4),
-			"user_id0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(4),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1301,12 +1297,12 @@ func TestPlanMultiInsertSharded(t *testing.T) {
 	}
 
 	wantQueries1 = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
-			"name1":    sqltypes.BytesBindVariable([]byte("myname3")),
-			"user_id1": sqltypes.Uint64BindVariable(3),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname1")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
+			"name_1":    sqltypes.BytesBindVariable([]byte("myname3")),
+			"user_id_1": sqltypes.Uint64BindVariable(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries1) {
@@ -1337,12 +1333,12 @@ func TestPlanMultiInsertSharded(t *testing.T) {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		Sql: "insert into name_user_map(name, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":    sqltypes.BytesBindVariable([]byte("myname1")),
-			"user_id0": sqltypes.Uint64BindVariable(1),
-			"name1":    sqltypes.BytesBindVariable([]byte("myname2")),
-			"user_id1": sqltypes.Uint64BindVariable(2),
+			"name_0":    sqltypes.BytesBindVariable([]byte("myname1")),
+			"user_id_0": sqltypes.Uint64BindVariable(1),
+			"name_1":    sqltypes.BytesBindVariable([]byte("myname2")),
+			"user_id_1": sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
@@ -1370,19 +1366,17 @@ func TestPlanMultiInsertSharded(t *testing.T) {
 		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
 	}
 	wantQueries = []*querypb.BoundQuery{{
-		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0), (:name1, :lastname1, :keyspace_id1)",
+		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0), (:name_1, :lastname_1, :keyspace_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"name0":        sqltypes.BytesBindVariable([]byte("myname")),
-			"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
-			"keyspace_id0": sqltypes.BytesBindVariable([]byte("\006\347\352\"\316\222p\217")),
-			"name1":        sqltypes.BytesBindVariable([]byte("myname2")),
-			"lastname1":    sqltypes.BytesBindVariable([]byte("mylastname2")),
-			"keyspace_id1": sqltypes.BytesBindVariable([]byte("N\261\220\311\242\372\026\234")),
+			"name_0":        sqltypes.BytesBindVariable([]byte("myname")),
+			"lastname_0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+			"keyspace_id_0": sqltypes.BytesBindVariable([]byte("\006\347\352\"\316\222p\217")),
+			"name_1":        sqltypes.BytesBindVariable([]byte("myname2")),
+			"lastname_1":    sqltypes.BytesBindVariable([]byte("mylastname2")),
+			"keyspace_id_1": sqltypes.BytesBindVariable([]byte("N\261\220\311\242\372\026\234")),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 }
 
 func TestPlanMultiInsertGenerator(t *testing.T) {
@@ -1416,17 +1410,15 @@ func TestPlanMultiInsertGenerator(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0), (:music_id_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"user_id0":  sqltypes.Uint64BindVariable(2),
-			"music_id0": sqltypes.Int64BindVariable(1),
-			"user_id1":  sqltypes.Uint64BindVariable(2),
-			"music_id1": sqltypes.Int64BindVariable(2),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(1),
+			"user_id_1":  sqltypes.Uint64BindVariable(2),
+			"music_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 	wantResult := *sandboxconn.SingleRowResult
 	wantResult.InsertID = 1
 	if !result.Equal(&wantResult) {
@@ -1468,19 +1460,17 @@ func TestPlanMultiInsertGeneratorSparse(t *testing.T) {
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}, {
-		Sql: "insert into music_user_map(music_id, user_id) values (:music_id0, :user_id0), (:music_id1, :user_id1), (:music_id2, :user_id2)",
+		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0), (:music_id_1, :user_id_1), (:music_id_2, :user_id_2)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"user_id0":  sqltypes.Uint64BindVariable(2),
-			"music_id0": sqltypes.Int64BindVariable(1),
-			"user_id1":  sqltypes.Uint64BindVariable(2),
-			"music_id1": sqltypes.Int64BindVariable(2),
-			"user_id2":  sqltypes.Uint64BindVariable(2),
-			"music_id2": sqltypes.Int64BindVariable(2),
+			"user_id_0":  sqltypes.Uint64BindVariable(2),
+			"music_id_0": sqltypes.Int64BindVariable(1),
+			"user_id_1":  sqltypes.Uint64BindVariable(2),
+			"music_id_1": sqltypes.Int64BindVariable(2),
+			"user_id_2":  sqltypes.Uint64BindVariable(2),
+			"music_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
 	wantResult := *sandboxconn.SingleRowResult
 	wantResult.InsertID = 1
 	if !result.Equal(&wantResult) {
@@ -1653,10 +1643,10 @@ func TestPlanInsertShardedWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name0')", map[string]*querypb.BindVariable{
-		"_Id0":   sqltypes.Int64BindVariable(1),
-		"_name0": sqltypes.BytesBindVariable([]byte("myname")),
-		"__seq0": sqltypes.Int64BindVariable(1),
+	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')", map[string]*querypb.BindVariable{
+		"_Id0":    sqltypes.Int64BindVariable(1),
+		"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
+		"__seq0":  sqltypes.Int64BindVariable(1),
 	})
 	require.NoError(t, err)
 

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -73,10 +73,9 @@ func TestQueryzHandler(t *testing.T) {
 	plan3 := result.(*engine.Plan)
 
 	// vindex insert from above execution
-	result, ok = executor.plans.Get("@master:" + "insert into name_user_map(name, user_id) values(:name0, :user_id0)")
-	if !ok {
-		t.Fatalf("couldn't get plan from cache")
-	}
+	result, ok = executor.plans.Get("@master:" + "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)")
+	require.True(t, ok, "couldn't get plan from cache")
+
 	plan4 := result.(*engine.Plan)
 
 	// same query again should add query counts to existing plans

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -236,7 +236,7 @@ func TestConsistentLookupCreateSimple(t *testing.T) {
 		t.Error(err)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0), (:fromc11, :fromc21, :toc1) [{fromc10 1} {fromc11 3} {fromc20 2} {fromc21 4} {toc0 test1} {toc1 test2}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0), (:fromc1_1, :fromc2_1, :toc_1) [{fromc1_0 1} {fromc1_1 3} {fromc2_0 2} {fromc2_1 4} {toc_0 test1} {toc_1 test2}] true",
 	})
 }
 
@@ -257,7 +257,7 @@ func TestConsistentLookupCreateThenRecreate(t *testing.T) {
 		t.Error(err)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 test1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
 		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1, :fromc2, :toc) [{fromc1 1} {fromc2 2} {toc test1}] true",
 	})
@@ -281,7 +281,7 @@ func TestConsistentLookupCreateThenUpdate(t *testing.T) {
 		t.Error(err)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 test1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
 		"ExecuteKeyspaceID select fc1 from t1 where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc test1}] false",
 		"ExecutePre update t set toc=:toc where fromc1 = :fromc1 and fromc2 = :fromc2 [{fromc1 1} {fromc2 2} {toc test1}] true",
@@ -306,7 +306,7 @@ func TestConsistentLookupCreateThenSkipUpdate(t *testing.T) {
 		t.Error(err)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc 1}] false",
 		"ExecuteKeyspaceID select fc1 from t1 where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc 1}] false",
 	})
@@ -332,7 +332,7 @@ func TestConsistentLookupCreateThenDupkey(t *testing.T) {
 		t.Errorf("lookup(query fail) err: %v, must contain %s", err, want)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 test1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
 		"ExecuteKeyspaceID select fc1 from t1 where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc test1}] false",
 	})
@@ -355,7 +355,7 @@ func TestConsistentLookupCreateNonDupError(t *testing.T) {
 		t.Errorf("lookup(query fail) err: %v, must contain %s", err, want)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 test1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 	})
 }
 
@@ -377,7 +377,7 @@ func TestConsistentLookupCreateThenBadRows(t *testing.T) {
 		t.Errorf("lookup(query fail) err: %v, must contain %s", err, want)
 	}
 	vc.verifyLog(t, []string{
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 1} {fromc20 2} {toc0 test1}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
 	})
 }
@@ -420,7 +420,7 @@ func TestConsistentLookupUpdate(t *testing.T) {
 	}
 	vc.verifyLog(t, []string{
 		"ExecutePost delete from t where fromc1 = :fromc1 and fromc2 = :fromc2 and toc = :toc [{fromc1 1} {fromc2 2} {toc test}] true",
-		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc10, :fromc20, :toc0) [{fromc10 3} {fromc20 4} {toc0 test}] true",
+		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 3} {fromc2_0 4} {toc_0 test}] true",
 	})
 }
 

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -189,11 +189,11 @@ func (lkp *lookupInternal) createCustom(vcursor VCursor, rowsColValues [][]sqlty
 			buf.WriteString(", (")
 		}
 		for colIdx, colID := range colIds {
-			fromStr := lkp.FromColumns[colIdx] + strconv.Itoa(rowIdx)
+			fromStr := lkp.FromColumns[colIdx] + "_" + strconv.Itoa(rowIdx)
 			bindVars[fromStr] = sqltypes.ValueBindVariable(colID)
 			buf.WriteString(":" + fromStr + ", ")
 		}
-		toStr := lkp.To + strconv.Itoa(rowIdx)
+		toStr := lkp.To + "_" + strconv.Itoa(rowIdx)
 		buf.WriteString(":" + toStr + ")")
 		bindVars[toStr] = sqltypes.ValueBindVariable(toValues[rowIdx])
 	}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -355,12 +355,12 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
-		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)",
+		Sql: "insert into t(fromc, toc) values(:fromc_0, :toc_0), (:fromc_1, :toc_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromc0": sqltypes.Int64BindVariable(1),
-			"toc0":   sqltypes.BytesBindVariable([]byte("test1")),
-			"fromc1": sqltypes.Int64BindVariable(2),
-			"toc1":   sqltypes.BytesBindVariable([]byte("test2")),
+			"fromc_0": sqltypes.Int64BindVariable(1),
+			"toc_0":   sqltypes.BytesBindVariable([]byte("test1")),
+			"fromc_1": sqltypes.Int64BindVariable(2),
+			"toc_1":   sqltypes.BytesBindVariable([]byte("test2")),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -372,7 +372,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(2)}, {sqltypes.NewInt64(1)}}, [][]byte{[]byte("test2"), []byte("test1")}, true /* ignoreMode */)
 	require.NoError(t, err)
 
-	wantqueries[0].Sql = "insert ignore into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)"
+	wantqueries[0].Sql = "insert ignore into t(fromc, toc) values(:fromc_0, :toc_0), (:fromc_1, :toc_1)"
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
 		t.Errorf("lookup.Create queries:\n%v, want\n%v", vc.queries, wantqueries)
 	}
@@ -418,14 +418,14 @@ func TestLookupNonUniqueCreateAutocommit(t *testing.T) {
 	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
-		Sql: "insert into t(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
+		Sql: "insert into t(from1, from2, toc) values(:from1_0, :from2_0, :toc_0), (:from1_1, :from2_1, :toc_1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10": sqltypes.Int64BindVariable(1),
-			"from20": sqltypes.Int64BindVariable(2),
-			"toc0":   sqltypes.BytesBindVariable([]byte("test1")),
-			"from11": sqltypes.Int64BindVariable(3),
-			"from21": sqltypes.Int64BindVariable(4),
-			"toc1":   sqltypes.BytesBindVariable([]byte("test2")),
+			"from1_0": sqltypes.Int64BindVariable(1),
+			"from2_0": sqltypes.Int64BindVariable(2),
+			"toc_0":   sqltypes.BytesBindVariable([]byte("test1")),
+			"from1_1": sqltypes.Int64BindVariable(3),
+			"from2_1": sqltypes.Int64BindVariable(4),
+			"toc_1":   sqltypes.BytesBindVariable([]byte("test2")),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -510,10 +510,10 @@ func TestLookupNonUniqueUpdate(t *testing.T) {
 			"toc":   sqltypes.BytesBindVariable([]byte("test")),
 		},
 	}, {
-		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0)",
+		Sql: "insert into t(fromc, toc) values(:fromc_0, :toc_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromc0": sqltypes.Int64BindVariable(2),
-			"toc0":   sqltypes.BytesBindVariable([]byte("test")),
+			"fromc_0": sqltypes.Int64BindVariable(2),
+			"toc_0":   sqltypes.BytesBindVariable([]byte("test")),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {

--- a/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unicodeloosemd5_hash_test.go
@@ -266,12 +266,12 @@ func TestLookupUnicodeLooseMD5HashCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
-		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)",
+		Sql: "insert into t(fromc, toc) values(:fromc_0, :toc_0), (:fromc_1, :toc_1)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromc0": sqltypes.Uint64BindVariable(hashed10),
-			"toc0":   sqltypes.Uint64BindVariable(1),
-			"fromc1": sqltypes.Uint64BindVariable(hashed20),
-			"toc1":   sqltypes.Uint64BindVariable(2),
+			"fromc_0": sqltypes.Uint64BindVariable(hashed10),
+			"toc_0":   sqltypes.Uint64BindVariable(1),
+			"fromc_1": sqltypes.Uint64BindVariable(hashed20),
+			"toc_1":   sqltypes.Uint64BindVariable(2),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -284,7 +284,7 @@ func TestLookupUnicodeLooseMD5HashCreate(t *testing.T) {
 		[][]byte{[]byte("\x16k@\xb4J\xbaK\xd6"), []byte("\x06\xe7\xea\"Βp\x8f")}, true /* ignoreMode */)
 	require.NoError(t, err)
 
-	wantqueries[0].Sql = "insert ignore into t(fromc, toc) values(:fromc0, :toc0), (:fromc1, :toc1)"
+	wantqueries[0].Sql = "insert ignore into t(fromc, toc) values(:fromc_0, :toc_0), (:fromc_1, :toc_1)"
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
 		t.Errorf("lookup.Create queries:\n%v, want\n%v", vc.queries, wantqueries)
 	}
@@ -330,14 +330,14 @@ func TestLookupUnicodeLooseMD5HashCreateAutocommit(t *testing.T) {
 	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
-		Sql: "insert into t(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
+		Sql: "insert into t(from1, from2, toc) values(:from1_0, :from2_0, :toc_0), (:from1_1, :from2_1, :toc_1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from10": sqltypes.Uint64BindVariable(hashed30),
-			"from20": sqltypes.Uint64BindVariable(hashed40),
-			"toc0":   sqltypes.Uint64BindVariable(2),
-			"from11": sqltypes.Uint64BindVariable(hashed10),
-			"from21": sqltypes.Uint64BindVariable(hashed20),
-			"toc1":   sqltypes.Uint64BindVariable(1),
+			"from1_0": sqltypes.Uint64BindVariable(hashed30),
+			"from2_0": sqltypes.Uint64BindVariable(hashed40),
+			"toc_0":   sqltypes.Uint64BindVariable(2),
+			"from1_1": sqltypes.Uint64BindVariable(hashed10),
+			"from2_1": sqltypes.Uint64BindVariable(hashed20),
+			"toc_1":   sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {
@@ -422,10 +422,10 @@ func TestLookupUnicodeLooseMD5HashUpdate(t *testing.T) {
 			"toc":   sqltypes.Uint64BindVariable(1),
 		},
 	}, {
-		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0)",
+		Sql: "insert into t(fromc, toc) values(:fromc_0, :toc_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"fromc0": sqltypes.Uint64BindVariable(hashed20),
-			"toc0":   sqltypes.Uint64BindVariable(1),
+			"fromc_0": sqltypes.Uint64BindVariable(hashed20),
+			"toc_0":   sqltypes.Uint64BindVariable(1),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -167,10 +167,10 @@ func TestLookupUniqueCreate(t *testing.T) {
 	require.NoError(t, err)
 
 	wantqueries := []*querypb.BoundQuery{{
-		Sql: "insert into t(from, toc) values(:from0, :toc0)",
+		Sql: "insert into t(from, toc) values(:from_0, :toc_0)",
 		BindVariables: map[string]*querypb.BindVariable{
-			"from0": sqltypes.Int64BindVariable(1),
-			"toc0":  sqltypes.BytesBindVariable([]byte("test")),
+			"from_0": sqltypes.Int64BindVariable(1),
+			"toc_0":  sqltypes.BytesBindVariable([]byte("test")),
 		},
 	}}
 	if !reflect.DeepEqual(vc.queries, wantqueries) {


### PR DESCRIPTION
This is a bug fix for the 6.0 branch.