### PR TITLE
Only check for k3s binary on Linux

### DIFF
--- a/tools/dependency_check.sh
+++ b/tools/dependency_check.sh
@@ -21,9 +21,14 @@ function fail() {
   exit 1
 }
 
+PLATFORM_BINARIES=""
+case "$(uname -s)" in
+    Linux*) PLATFORM_BINARIES="k3s";;
+esac
+
 # These binaries are required to 'make test'
 # mysqld might be in /usr/sbin which will not be in the default PATH
 PATH="/usr/sbin:$PATH"
-for binary in k3s mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip; do
+for binary in mysqld consul etcd etcdctl zksrv.sh javadoc mvn ant curl wget zip unzip $PLATFORM_BINARIES; do
   command -v "$binary" > /dev/null || fail "${binary} is not installed in PATH. See https://vitess.io/contributing/build-from-source for install instructions."
 done;


### PR DESCRIPTION
The tests that require k3s are already skipped when not running on Linux. We should skip the dep check as well.

Signed-off-by: Carson Anderson <ca@carsonoid.net>