### PR TITLE
Remove references to slave where possible

### DIFF
--- a/go/cmd/vtctld/schema.go
+++ b/go/cmd/vtctld/schema.go
@@ -36,7 +36,7 @@ var (
 	schemaChangeController    = flag.String("schema_change_controller", "", "schema change controller is responsible for finding schema changes and responding to schema change events")
 	schemaChangeCheckInterval = flag.Int("schema_change_check_interval", 60, "this value decides how often we check schema change dir, in seconds")
 	schemaChangeUser          = flag.String("schema_change_user", "", "The user who submits this schema change.")
-	schemaChangeSlaveTimeout  = flag.Duration("schema_change_slave_timeout", 10*time.Second, "how long to wait for slaves to receive the schema change")
+	schemaChangeSlaveTimeout  = flag.Duration("schema_change_slave_timeout", 10*time.Second, "how long to wait for replicas to receive the schema change")
 )
 
 func initSchema() {

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -44,7 +44,6 @@ var (
 	flagMasterInfoFile        *string
 	flagPidFile               *string
 	flagTmpDir                *string
-	flagSlaveLoadTmpDir       *string
 
 	// the file to use to specify them all
 	flagMycnfFile *string
@@ -70,7 +69,6 @@ func RegisterFlags() {
 	flagMasterInfoFile = flag.String("mycnf_master_info_file", "", "mysql master.info file")
 	flagPidFile = flag.String("mycnf_pid_file", "", "mysql pid file")
 	flagTmpDir = flag.String("mycnf_tmp_dir", "", "mysql tmp directory")
-	flagSlaveLoadTmpDir = flag.String("mycnf_slave_load_tmp_dir", "", "slave load tmp directory")
 
 	flagMycnfFile = flag.String("mycnf-file", "", "path to my.cnf, if reading all config params from there")
 }
@@ -109,7 +107,6 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 			MasterInfoFile:        *flagMasterInfoFile,
 			PidFile:               *flagPidFile,
 			TmpDir:                *flagTmpDir,
-			SlaveLoadTmpDir:       *flagSlaveLoadTmpDir,
 
 			// This is probably not going to be used by anybody,
 			// but fill in a default value. (Note it's used by

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -75,7 +75,7 @@ var (
 	socketFile        = flag.String("mysqlctl_socket", "", "socket file to use for remote mysqlctl actions (empty for local actions)")
 
 	// masterConnectRetry is used in 'SET MASTER' commands
-	masterConnectRetry = flag.Duration("master_connect_retry", 10*time.Second, "how long to wait in between slave -> connection attempts. Only precise to the second.")
+	masterConnectRetry = flag.Duration("master_connect_retry", 10*time.Second, "how long to wait in between replica reconnect attempts. Only precise to the second.")
 
 	versionRegex = regexp.MustCompile(`Ver ([0-9]+)\.([0-9]+)\.([0-9]+)`)
 )

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -35,13 +35,13 @@ func init() {
 		"ReparentTablet",
 		commandReparentTablet,
 		"<tablet alias>",
-		"Reparent a tablet to the current master in the shard. This only works if the current slave position matches the last known reparent action."})
+		"Reparent a tablet to the current master in the shard. This only works if the current replica position matches the last known reparent action."})
 
 	addCommand("Shards", command{
 		"InitShardMaster",
 		commandInitShardMaster,
 		"[-force] [-wait_slave_timeout=<duration>] <keyspace/shard> <tablet alias>",
-		"Sets the initial master for a shard. Will make all other tablets in the shard slaves of the provided master. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead."})
+		"Sets the initial master for a shard. Will make all other tablets in the shard replicas of the provided master. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead."})
 	addCommand("Shards", command{
 		"PlannedReparentShard",
 		commandPlannedReparentShard,
@@ -84,7 +84,7 @@ func commandInitShardMaster(ctx context.Context, wr *wrangler.Wrangler, subFlags
 	}
 
 	force := subFlags.Bool("force", false, "will force the reparent even if the provided tablet is not a master or the shard master")
-	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for slaves to catch up in reparenting")
+	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for replicas to catch up in reparenting")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
-	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for slaves to catch up in reparenting")
+	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for replicas to catch up in reparenting")
 	keyspaceShard := subFlags.String("keyspace_shard", "", "keyspace/shard of the shard that needs to be reparented")
 	newMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
 	if err := subFlags.Parse(args); err != nil {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -60,33 +60,33 @@ COMMAND ARGUMENT DEFINITIONS
             should be a positively signed value.
 
 - db type, tablet type: The vttablet's role. Valid values are:
-  -- backup: A slaved copy of data that is offline to queries other than
+  -- backup: A replica copy of data that is offline to queries other than
              for backup purposes
   -- batch: A slaved copy of data for OLAP load patterns (typically for
             MapReduce jobs)
   -- drained: A tablet that is reserved for a background process. For example,
               a tablet used by a vtworker process, where the tablet is likely
               lagging in replication.
-  -- experimental: A slaved copy of data that is ready but not serving query
+  -- experimental: A replica copy of data that is ready but not serving query
                    traffic. The value indicates a special characteristic of
                    the tablet that indicates the tablet should not be
                    considered a potential master. Vitess also does not
                    worry about lag for experimental tablets when reparenting.
   -- master: A primary copy of data
-  -- rdonly: A slaved copy of data for OLAP load patterns
-  -- replica: A slaved copy of data ready to be promoted to master
+  -- rdonly: A replica copy of data for OLAP load patterns
+  -- replica: A replica copy of data ready to be promoted to master
   -- restore: A tablet that is restoring from a snapshot. Typically, this
               happens at tablet startup, then it goes to its right state.
-  -- schema_apply: A slaved copy of data that had been serving query traffic
+  -- schema_apply: A replica copy of data that had been serving query traffic
                    but that is now applying a schema change. Following the
                    change, the tablet will revert to its serving type.
-  -- snapshot_source: A slaved copy of data where mysqld is <b>not</b>
+  -- snapshot_source: A replica copy of data where mysqld is <b>not</b>
                       running and where Vitess is serving data files to
                       clone slaves. Use this command to enter this mode:
                       <pre>vtctl Snapshot -server-mode ...</pre>
                       Use this command to exit this mode:
                       <pre>vtctl SnapshotSourceEnd ...</pre>
-  -- spare: A slaved copy of data that is ready but not serving query traffic.
+  -- spare: A replica copy of data that is ready but not serving query traffic.
             The data could be a potential master tablet.
 */
 


### PR DESCRIPTION
There was one mysql setting called `slave_load_tmp_dir` which I removed. This appears to no longer be in MySQL; I forget the context, but Vitess requires RBR anyway, which means `LOAD DATA` events do not need a tmpdir.

Signed-off-by: Morgan Tocker <tocker@gmail.com>