### PR TITLE
Add `-rename_tables` to DropSources

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -209,9 +209,15 @@ func shardCustomer(t *testing.T, testReverse bool) {
 		if output, err := vc.VtctlClient.ExecuteCommandWithOutput("SwitchWrites", "customer.p2c"); err != nil {
 			t.Fatalf("SwitchWrites error: %s\n", output)
 		}
-		want = dryRunResultsDropSourcesCustomerShard
+		want = dryRunResultsDropSourcesDropCustomerShard
 		if output, err = vc.VtctlClient.ExecuteCommandWithOutput("DropSources", "-dry_run", "customer.p2c"); err != nil {
 			t.Fatalf("DropSources dry run error: %s\n", output)
+		}
+		validateDryRunResults(t, output, want)
+
+		want = dryRunResultsDropSourcesRenameCustomerShard
+		if output, err = vc.VtctlClient.ExecuteCommandWithOutput("DropSources", "-dry_run", "-rename_tables", "customer.p2c"); err != nil {
+			t.Fatalf("DropSources dry run with rename error: %s\n", output)
 		}
 		validateDryRunResults(t, output, want)
 

--- a/go/test/endtoend/vreplication/vreplication_test_env.go
+++ b/go/test/endtoend/vreplication/vreplication_test_env.go
@@ -94,11 +94,27 @@ var dryrunresultsswitchwritesM2m3 = []string{
 	"Unlock keyspace merchant",
 }
 
-var dryRunResultsDropSourcesCustomerShard = []string{
+var dryRunResultsDropSourcesDropCustomerShard = []string{
 	"Lock keyspace product",
 	"Lock keyspace customer",
 	"Dropping following tables:",
-	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer",
+	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer RemovalType DROP TABLE",
+	"Blacklisted tables customer will be removed from:",
+	"	Keyspace product Shard 0 Tablet 100",
+	"Delete reverse vreplication streams on source:",
+	"	Keyspace product Shard 0 Workflow p2c_reverse DbName vt_product Tablet 100",
+	"Delete vreplication streams on target:",
+	"	Keyspace customer Shard -80 Workflow p2c DbName vt_customer Tablet 200",
+	"	Keyspace customer Shard 80- Workflow p2c DbName vt_customer Tablet 300",
+	"Unlock keyspace customer",
+	"Unlock keyspace product",
+}
+
+var dryRunResultsDropSourcesRenameCustomerShard = []string{
+	"Lock keyspace product",
+	"Lock keyspace customer",
+	"Dropping following tables:",
+	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer RemovalType RENAME TABLE",
 	"Blacklisted tables customer will be removed from:",
 	"	Keyspace product Shard 0 Tablet 100",
 	"Delete reverse vreplication streams on source:",

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -315,7 +315,7 @@ var commands = []commandGroup{
 				"[-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>",
 				`Move table(s) to another keyspace, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{"column_vindexes": [{""column": "id1", "name": "hash"}]}, "t2":{"column_vindexes": [{""column": "id2", "name": "hash"}]}}`},
 			{"DropSources", commandDropSources,
-				"[-dry_run] <keyspace.workflow>",
+				"[-dry_run] [-rename_tables] <keyspace.workflow>",
 				"After a MoveTables or Resharding workflow cleanup unused artifacts like source tables, source shards and blacklists"},
 			{"CreateLookupVindex", commandCreateLookupVindex,
 				"[-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>",
@@ -2042,6 +2042,7 @@ func commandMigrateServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFla
 
 func commandDropSources(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of commandDropSources and only reports the actions to be taken")
+	renameTables := subFlags.Bool("rename_tables", false, "Rename tables instead of dropping them")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2052,8 +2053,14 @@ func commandDropSources(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	if err != nil {
 		return err
 	}
+
+	removalType := wrangler.DropTable
+	if *renameTables {
+		removalType = wrangler.RenameTable
+	}
+
 	_, _, _ = dryRun, keyspace, workflow
-	dryRunResults, err := wr.DropSources(ctx, keyspace, workflow, *dryRun)
+	dryRunResults, err := wr.DropSources(ctx, keyspace, workflow, removalType, *dryRun)
 	if err != nil {
 		return err
 	}

--- a/go/vt/wrangler/stream_migrater_test.go
+++ b/go/vt/wrangler/stream_migrater_test.go
@@ -178,7 +178,7 @@ func TestStreamMigrateMainflow(t *testing.T) {
 
 	tme.expectDeleteReverseVReplication()
 	tme.expectDeleteTargetVReplication()
-	if _, err := tme.wr.DropSources(ctx, tme.targetKeyspace, "test", false); err != nil {
+	if _, err := tme.wr.DropSources(ctx, tme.targetKeyspace, "test", DropTable, false); err != nil {
 		t.Fatal(err)
 	}
 	verifyQueries(t, tme.allDBClients)

--- a/go/vt/wrangler/switcher.go
+++ b/go/vt/wrangler/switcher.go
@@ -41,8 +41,8 @@ func (r *switcher) validateWorkflowHasCompleted(ctx context.Context) error {
 
 //TODO: do we need to disable ForeignKey before dropping tables?
 //TODO: delete multiple tables in single statement?
-func (r *switcher) dropSourceTables(ctx context.Context) error {
-	return r.ts.dropSourceTables(ctx)
+func (r *switcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
+	return r.ts.removeSourceTables(ctx, removalType)
 }
 
 func (r *switcher) dropSourceShards(ctx context.Context) error {

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -225,12 +225,12 @@ func (dr *switcherDryRun) lockKeyspace(ctx context.Context, keyspace, _ string) 
 	}, nil
 }
 
-func (dr *switcherDryRun) dropSourceTables(ctx context.Context) error {
+func (dr *switcherDryRun) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
 	logs := make([]string, 0)
 	for _, source := range dr.ts.sources {
 		for _, tableName := range dr.ts.tables {
-			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s",
-				source.master.Keyspace, source.master.Shard, source.master.DbName(), source.master.Alias.Uid, tableName))
+			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s RemovalType %s",
+				source.master.Keyspace, source.master.Shard, source.master.DbName(), source.master.Alias.Uid, tableName, TableRemovalType(removalType)))
 		}
 	}
 	if len(logs) > 0 {

--- a/go/vt/wrangler/switcher_interface.go
+++ b/go/vt/wrangler/switcher_interface.go
@@ -40,7 +40,7 @@ type iswitcher interface {
 	switchTableReads(ctx context.Context, cells []string, servedType topodatapb.TabletType, direction TrafficSwitchDirection) error
 	switchShardReads(ctx context.Context, cells []string, servedType topodatapb.TabletType, direction TrafficSwitchDirection) error
 	validateWorkflowHasCompleted(ctx context.Context) error
-	dropSourceTables(ctx context.Context) error
+	removeSourceTables(ctx context.Context, removalType TableRemovalType) error
 	dropSourceShards(ctx context.Context) error
 	dropSourceBlacklistedTables(ctx context.Context) error
 	freezeTargetVReplication(ctx context.Context) error

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -802,7 +802,7 @@ func TestTableMigrateOneToMany(t *testing.T) {
 		tme.dbTargetClients[1].addQuery("select 1 from _vt.vreplication where db_name='vt_ks2' and workflow='test' and message!='FROZEN'", &sqltypes.Result{}, nil)
 	}
 	dropSourcesInvalid()
-	_, err = tme.wr.DropSources(ctx, tme.targetKeyspace, "test", false)
+	_, err = tme.wr.DropSources(ctx, tme.targetKeyspace, "test", DropTable, false)
 	require.Error(t, err, "Workflow has not completed, cannot DropSources")
 
 	_, _, err = tme.wr.SwitchWrites(ctx, tme.targetKeyspace, "test", 1*time.Second, false, false, false)
@@ -815,13 +815,12 @@ func TestTableMigrateOneToMany(t *testing.T) {
 		tme.dbTargetClients[1].addQuery("select 1 from _vt.vreplication where db_name='vt_ks2' and workflow='test' and message!='FROZEN'", &sqltypes.Result{}, nil)
 	}
 	dropSourcesDryRun()
-
 	wantdryRunDropSources := []string{
 		"Lock keyspace ks1",
 		"Lock keyspace ks2",
 		"Dropping following tables:",
-		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t1",
-		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t2",
+		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t1 RemovalType DROP TABLE",
+		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t2 RemovalType DROP TABLE",
 		"Blacklisted tables t1,t2 will be removed from:",
 		"	Keyspace ks1 Shard 0 Tablet 10",
 		"Delete reverse vreplication streams on source:",
@@ -832,9 +831,35 @@ func TestTableMigrateOneToMany(t *testing.T) {
 		"Unlock keyspace ks2",
 		"Unlock keyspace ks1",
 	}
-	results, err := tme.wr.DropSources(ctx, tme.targetKeyspace, "test", true)
+	results, err := tme.wr.DropSources(ctx, tme.targetKeyspace, "test", DropTable, true)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(wantdryRunDropSources, *results))
+	checkBlacklist(t, tme.ts, fmt.Sprintf("%s:%s", "ks1", "0"), []string{"t1", "t2"})
+
+	dropSourcesDryRunRename := func() {
+		tme.dbTargetClients[0].addQuery("select 1 from _vt.vreplication where db_name='vt_ks2' and workflow='test' and message!='FROZEN'", &sqltypes.Result{}, nil)
+		tme.dbTargetClients[1].addQuery("select 1 from _vt.vreplication where db_name='vt_ks2' and workflow='test' and message!='FROZEN'", &sqltypes.Result{}, nil)
+	}
+	dropSourcesDryRunRename()
+	wantdryRunRenameSources := []string{
+		"Lock keyspace ks1",
+		"Lock keyspace ks2",
+		"Dropping following tables:",
+		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t1 RemovalType RENAME TABLE",
+		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t2 RemovalType RENAME TABLE",
+		"Blacklisted tables t1,t2 will be removed from:",
+		"	Keyspace ks1 Shard 0 Tablet 10",
+		"Delete reverse vreplication streams on source:",
+		"	Keyspace ks1 Shard 0 Workflow test_reverse DbName vt_ks1 Tablet 10",
+		"Delete vreplication streams on target:",
+		"	Keyspace ks2 Shard -80 Workflow test DbName vt_ks2 Tablet 20",
+		"	Keyspace ks2 Shard 80- Workflow test DbName vt_ks2 Tablet 30",
+		"Unlock keyspace ks2",
+		"Unlock keyspace ks1",
+	}
+	results, err = tme.wr.DropSources(ctx, tme.targetKeyspace, "test", RenameTable, true)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(wantdryRunRenameSources, *results))
 	checkBlacklist(t, tme.ts, fmt.Sprintf("%s:%s", "ks1", "0"), []string{"t1", "t2"})
 
 	dropSources := func() {
@@ -852,7 +877,7 @@ func TestTableMigrateOneToMany(t *testing.T) {
 	}
 	dropSources()
 
-	_, err = tme.wr.DropSources(ctx, tme.targetKeyspace, "test", false)
+	_, err = tme.wr.DropSources(ctx, tme.targetKeyspace, "test", DropTable, false)
 	require.NoError(t, err)
 	checkBlacklist(t, tme.ts, fmt.Sprintf("%s:%s", "ks1", "0"), nil)
 


### PR DESCRIPTION
This addition allows the optional bool -rename_tables for DropSources.
This can be useful when dropping sources for larger tables. Instead of a
`drop table`, a `rename table` is run. This will be faster in most cases
but will require the user to clean up the tables at a later date.

Signed-off-by: Tom Krouper <tomkrouper@github.com>