### PR TITLE
Tracing query comments

### DIFF
--- a/go/trace/opentracing.go
+++ b/go/trace/opentracing.go
@@ -88,9 +88,6 @@ func (jf openTracingService) New(parent Span, label string) Span {
 func extractMapFromString(in string) (opentracing.TextMapCarrier, error) {
 	m := make(opentracing.TextMapCarrier)
 	items := strings.Split(in, ",")
-	if len(items) < 2 {
-		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "expected transmitted context to contain at least span id and trace id")
-	}
 	for _, v := range items {
 		idx := strings.Index(v, "=")
 		if idx < 1 {

--- a/go/trace/opentracing.go
+++ b/go/trace/opentracing.go
@@ -87,7 +87,7 @@ func (jf openTracingService) New(parent Span, label string) Span {
 
 func extractMapFromString(in string) (opentracing.TextMapCarrier, error) {
 	m := make(opentracing.TextMapCarrier)
-	items := strings.Split(in, ":")
+	items := strings.Split(in, ",")
 	if len(items) < 2 {
 		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "expected transmitted context to contain at least span id and trace id")
 	}

--- a/go/trace/opentracing_test.go
+++ b/go/trace/opentracing_test.go
@@ -27,7 +27,8 @@ func TestExtractMapFromString(t *testing.T) {
 	expected := make(opentracing.TextMapCarrier)
 	expected["apa"] = "12"
 	expected["banan"] = "x-tracing-backend-12"
-	result, err := extractMapFromString("apa=12,banan=x-tracing-backend-12")
+	expected["uber-trace-id"] = "123:456:789:1"
+	result, err := extractMapFromString("apa=12,banan=x-tracing-backend-12,uber-trace-id=123:456:789:1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }

--- a/go/trace/opentracing_test.go
+++ b/go/trace/opentracing_test.go
@@ -27,7 +27,7 @@ func TestExtractMapFromString(t *testing.T) {
 	expected := make(opentracing.TextMapCarrier)
 	expected["apa"] = "12"
 	expected["banan"] = "x-tracing-backend-12"
-	result, err := extractMapFromString("apa=12:banan=x-tracing-backend-12")
+	result, err := extractMapFromString("apa=12,banan=x-tracing-backend-12")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
@@ -36,6 +36,6 @@ func TestErrorConditions(t *testing.T) {
 	_, err := extractMapFromString("")
 	assert.Error(t, err)
 
-	_, err = extractMapFromString("key=value:keywithnovalue")
+	_, err = extractMapFromString("key=value,keywithnovalue")
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## Setup
While trying to enable the `opentracing-jaeger` tracer for vitess, I ran into an issue with how the span information is parsed in vitess. We connect to vtgates using the mysql protocol, and the trace information is passed to vitess using leading query comments. 

## Problem
In `extractMapFromString` ([code](https://github.com/tinyspeck/vitess/blob/master/go/trace/opentracing.go#L88-L92)), the string is split on the `:` delimeter and then each of those as key/value pairs are passed to the opentracing library.

In the opentracing library, there is similar validation done where it expects key value pairs ([code](https://github.com/jaegertracing/jaeger-client-go/blob/b8ed773b3a349fee3ce01318374e7173b0ed4fba/propagation.go#L138)) and then depending on the key, the value is further split on `:`. The code for that is [here](https://github.com/jaegertracing/jaeger-client-go/blob/b8ed773b3a349fee3ce01318374e7173b0ed4fba/span_context.go#L222-L247).

So, we are splitting on a delimeter that is expected to be passed along as values in the key/value pairs containing trace information. The docs for the jaeger client also say this is the expected format of values ([ref](https://www.jaegertracing.io/docs/1.18/client-libraries/#value))