### PR TITLE
make docker_local, docker/local/run.sh utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,10 @@ docker_lite_testing:
 	chmod -R o=g *
 	docker build -f docker/lite/Dockerfile.testing -t vitess/lite:testing .
 
+docker_local:
+	chmod -R o=g *
+	docker build -f docker/local/Dockerfile -t vitess/local .
+
 # This rule loads the working copy of the code into a bootstrap image,
 # and then runs the tests inside Docker.
 # Example: $ make docker_test flavor=mariadb

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,0 +1,30 @@
+FROM vitess/bootstrap:common
+
+RUN apt-get update
+RUN apt-get install -y sudo curl vim jq mysql-server
+
+COPY docker/local/install_local_dependencies.sh /vt/dist/install_local_dependencies.sh
+RUN /vt/dist/install_local_dependencies.sh
+RUN echo "source /vt/local/env.sh" >> /etc/bash.bashrc
+
+# Allows some docker builds to disable CGO
+ARG CGO_ENABLED=0
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+# Build and install Vitess in a temporary output directory.
+USER vitess
+
+WORKDIR /vt/src/vitess.io/vitess
+RUN make install PREFIX=/vt/install
+
+ENV VTROOT /vt/src/vitess.io/vitess
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+ENV PATH="/var/opt/etcd:${PATH}"
+
+RUN mkdir /vt/local
+COPY examples/local /vt/local
+
+CMD cd /vt/local && ./101_initial_cluster.sh && /bin/bash

--- a/docker/local/install_local_dependencies.sh
+++ b/docker/local/install_local_dependencies.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a script that gets run as part of the Dockerfile build
+# to install dependencies for the vitess/mini image.
+#
+# Usage: install_mini_dependencies.sh
+
+set -euo pipefail
+
+# Install etcd
+ETCD_VER=v3.4.9
+DOWNLOAD_URL=https://storage.googleapis.com/etcd
+
+curl -k -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+mkdir -p /var/opt/etcd
+sudo tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /var/opt/etcd --strip-components=1
+rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+
+mkdir -p /var/run/etcd && chown -R vitess:vitess /var/run/etcd
+
+# Clean up files we won't need in the final image.
+rm -rf /var/lib/apt/lists/*

--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -p 15000:15000 -p 15001:15001 --rm -it vitess/local


### PR DESCRIPTION
This PR adds:

- a `make docker_local` target
- `docker/local/run.sh` script

together (`make docker_local && ./docker/local/run.sh`) these spin up a docker image with a local vitess setup + MySQL topology, using `examples/local/` and using `101_initial_cluster.sh` as depicted in https://vitess.io/docs/get-started/local/

This allows a user to experiment with a self-contained local vitess environment without the need to install and configure MySQL, etcd, golang, etc. on a host.