### PR TITLE
tabletserver: improved state transitions with new stateManager

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -761,13 +761,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 	data, err := c.readEphemeralPacket()
 	if err != nil {
 		// Don't log EOF errors. They cause too much spam.
-		// Note the EOF detection is not 100%
-		// guaranteed, in the case where the client
-		// connection is already closed before we call
-		// 'readEphemeralPacket'.  This is a corner
-		// case though, and very unlikely to happen,
-		// and the only downside is we log a bit more then.
-		if err != io.EOF {
+		if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
 			log.Errorf("Error reading packet from %s: %v", c, err)
 		}
 		return err

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -24,10 +24,11 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/yaml2"
 )
 
@@ -193,7 +194,7 @@ func (c Connector) Connect(ctx context.Context) (*mysql.Conn, error) {
 func (c Connector) MysqlParams() (*mysql.ConnParams, error) {
 	if c.connParams == nil {
 		// This is only possible during tests.
-		return nil, fmt.Errorf("parameters are empty")
+		return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "parameters are empty")
 	}
 	params, err := withCredentials(c.connParams)
 	if err != nil {

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
@@ -190,6 +191,10 @@ func (c Connector) Connect(ctx context.Context) (*mysql.Conn, error) {
 
 // MysqlParams returns the connections params
 func (c Connector) MysqlParams() (*mysql.ConnParams, error) {
+	if c.connParams == nil {
+		// This is only possible during tests.
+		return nil, fmt.Errorf("parameters are empty")
+	}
 	params, err := withCredentials(c.connParams)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/endtoend/vstreamer_test.go
+++ b/go/vt/vttablet/endtoend/vstreamer_test.go
@@ -409,6 +409,7 @@ func TestSchemaVersioningLongDDL(t *testing.T) {
 }
 
 func runCases(ctx context.Context, t *testing.T, tests []test, eventCh chan []*binlogdatapb.VEvent) {
+	t.Helper()
 	client := framework.NewClient()
 
 	for _, test := range tests {

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -89,11 +89,8 @@ func NewReader(env tabletenv.Env) *Reader {
 	}
 }
 
-// Init does last minute initialization of db settings, such as keyspaceShard.
-func (r *Reader) Init(target querypb.Target) {
-	if !r.enabled {
-		return
-	}
+// InitDBConfig initializes the target name for the Reader.
+func (r *Reader) InitDBConfig(target querypb.Target) {
 	r.keyspaceShard = fmt.Sprintf("%s:%s", target.Keyspace, target.Shard)
 }
 

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -45,7 +45,6 @@ const (
   ts BIGINT UNSIGNED NOT NULL
         ) engine=InnoDB`
 	sqlUpsertHeartbeat = "INSERT INTO %s.heartbeat (ts, tabletUid, keyspaceShard) VALUES (%a, %a, %a) ON DUPLICATE KEY UPDATE ts=VALUES(ts), tabletUid=VALUES(tabletUid)"
-	sqlUpdateHeartbeat = "UPDATE %s.heartbeat SET ts=%a, tabletUid=%a WHERE keyspaceShard=%a"
 )
 
 var withDDL = withddl.New([]string{

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -21,14 +21,12 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/withddl"
 
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/timer"
-	"vitess.io/vitess/go/vt/dbconfigs"
-	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -46,9 +44,14 @@ const (
   tabletUid INT UNSIGNED NOT NULL,
   ts BIGINT UNSIGNED NOT NULL
         ) engine=InnoDB`
-	sqlInsertInitialRow = "INSERT INTO %s.heartbeat (ts, tabletUid, keyspaceShard) VALUES (%a, %a, %a) ON DUPLICATE KEY UPDATE ts=VALUES(ts)"
-	sqlUpdateHeartbeat  = "UPDATE %s.heartbeat SET ts=%a, tabletUid=%a WHERE keyspaceShard=%a"
+	sqlUpsertHeartbeat = "INSERT INTO %s.heartbeat (ts, tabletUid, keyspaceShard) VALUES (%a, %a, %a) ON DUPLICATE KEY UPDATE ts=VALUES(ts), tabletUid=VALUES(tabletUid)"
+	sqlUpdateHeartbeat = "UPDATE %s.heartbeat SET ts=%a, tabletUid=%a WHERE keyspaceShard=%a"
 )
+
+var withDDL = withddl.New([]string{
+	fmt.Sprintf(sqlCreateSidecarDB, "_vt"),
+	fmt.Sprintf(sqlCreateHeartbeatTable, "_vt"),
+})
 
 // Writer runs on master tablets and writes heartbeats to the _vt.heartbeat
 // table at a regular interval, defined by heartbeat_interval.
@@ -99,26 +102,20 @@ func (w *Writer) InitDBConfig(target querypb.Target) {
 // responsible for periodically writing to the heartbeat table.
 // Open may be called multiple times, as long as it was closed since
 // last invocation.
-func (w *Writer) Open() error {
+func (w *Writer) Open() {
 	if !w.enabled {
-		return nil
+		return
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.isOpen {
-		return nil
-	}
-
-	if err := w.initializeTables(w.env.Config().DB.AppWithDB()); err != nil {
-		w.recordError(err)
-		return err
+		return
 	}
 
 	log.Info("Beginning heartbeat writes")
 	w.pool.Open(w.env.Config().DB.AppWithDB(), w.env.Config().DB.DbaWithDB(), w.env.Config().DB.AppDebugWithDB())
-	w.ticks.Start(func() { w.writeHeartbeat() })
+	w.ticks.Start(w.writeHeartbeat)
 	w.isOpen = true
-	return nil
 }
 
 // Close closes the Writer's db connection and stops the periodic ticker. A writer
@@ -136,36 +133,6 @@ func (w *Writer) Close() {
 	w.pool.Close()
 	log.Info("Stopped heartbeat writes.")
 	w.isOpen = false
-}
-
-// initializeTables attempts to create the heartbeat tables and record an
-// initial row. The row is created only on master and is replicated to all
-// other servers.
-func (w *Writer) initializeTables(cp dbconfigs.Connector) error {
-	conn, err := dbconnpool.NewDBConnection(context.TODO(), cp)
-	if err != nil {
-		return vterrors.Wrap(err, "Failed to create connection for heartbeat")
-	}
-	defer conn.Close()
-	statements := []string{
-		fmt.Sprintf(sqlCreateSidecarDB, "_vt"),
-		fmt.Sprintf(sqlCreateHeartbeatTable, "_vt"),
-	}
-	for _, s := range statements {
-		if _, err := conn.ExecuteFetch(s, 0, false); err != nil {
-			return vterrors.Wrap(err, "Failed to execute heartbeat init query")
-		}
-	}
-	insert, err := w.bindHeartbeatVars(sqlInsertInitialRow)
-	if err != nil {
-		return vterrors.Wrap(err, "Failed to bindHeartbeatVars initial heartbeat insert")
-	}
-	_, err = conn.ExecuteFetch(insert, 0, false)
-	if err != nil {
-		return vterrors.Wrap(err, "Failed to execute initial heartbeat insert")
-	}
-	writes.Add(1)
-	return nil
 }
 
 // bindHeartbeatVars takes a heartbeat write (insert or update) and
@@ -187,29 +154,27 @@ func (w *Writer) bindHeartbeatVars(query string) (string, error) {
 
 // writeHeartbeat updates the heartbeat row for this tablet with the current time in nanoseconds.
 func (w *Writer) writeHeartbeat() {
-	defer w.env.LogError()
-	ctx, cancel := context.WithDeadline(context.Background(), w.now().Add(w.interval))
-	defer cancel()
-	update, err := w.bindHeartbeatVars(sqlUpdateHeartbeat)
-	if err != nil {
-		w.recordError(err)
-		return
-	}
-	err = w.exec(ctx, update)
-	if err != nil {
+	if err := w.write(); err != nil {
 		w.recordError(err)
 		return
 	}
 	writes.Add(1)
 }
 
-func (w *Writer) exec(ctx context.Context, query string) error {
+func (w *Writer) write() error {
+	defer w.env.LogError()
+	ctx, cancel := context.WithDeadline(context.Background(), w.now().Add(w.interval))
+	defer cancel()
+	upsert, err := w.bindHeartbeatVars(sqlUpsertHeartbeat)
+	if err != nil {
+		return err
+	}
 	conn, err := w.pool.Get(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Recycle()
-	_, err = conn.Exec(ctx, query, 0, false)
+	_, err = withDDL.Exec(ctx, upsert, conn.Exec)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
@@ -88,14 +88,15 @@ func (ec *externalConnector) Get(name string) (*mysqlConnector, error) {
 	c := &mysqlConnector{}
 	c.env = tabletenv.NewEnv(config, name)
 	c.se = schema.NewEngine(c.env)
-	c.vstreamer = vstreamer.NewEngine(c.env, nil, c.se)
+	c.vstreamer = vstreamer.NewEngine(c.env, nil, c.se, "")
+	c.vstreamer.InitDBConfig("")
 	c.se.InitDBConfig(c.env.Config().DB.DbaWithDB())
 
 	// Open
 	if err := c.se.Open(); err != nil {
 		return nil, vterrors.Wrapf(err, "external mysqlConnector: %v", name)
 	}
-	c.vstreamer.Open("", "")
+	c.vstreamer.Open()
 
 	// Register
 	ec.connectors[name] = c

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -89,8 +89,9 @@ func TestMain(m *testing.M) {
 
 		// engines cannot be initialized in testenv because it introduces
 		// circular dependencies.
-		streamerEngine = vstreamer.NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine)
-		streamerEngine.Open(env.KeyspaceName, env.Cells[0])
+		streamerEngine = vstreamer.NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine, env.Cells[0])
+		streamerEngine.InitDBConfig(env.KeyspaceName)
+		streamerEngine.Open()
 		defer streamerEngine.Close()
 
 		if err := env.Mysqld.ExecuteSuperQuery(context.Background(), fmt.Sprintf("create database %s", vrepldb)); err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1901,7 +1901,7 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set message='vstream ended'",
 	})
-	if err := streamerEngine.Open(env.KeyspaceName, env.ShardName); err != nil {
+	if err := streamerEngine.Open(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1901,9 +1901,7 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set message='vstream ended'",
 	})
-	if err := streamerEngine.Open(); err != nil {
-		t.Fatal(err)
-	}
+	streamerEngine.Open()
 
 	execStatements(t, []string{
 		"insert into t1 values(2, 'aaa')",

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -27,8 +27,6 @@ import (
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/topo/memorytopo"
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 // Benchmark run on 6/27/17, with optimized byte-level operations
@@ -57,8 +55,10 @@ func init() {
 }
 
 func BenchmarkExecuteVarBinary(b *testing.B) {
-	db := setUpTabletServerTest(nil)
+	db, tsv := setupTabletServerTest(nil)
 	defer db.Close()
+	defer tsv.StopService()
+
 	// sql that will be executed in this test
 	bv := map[string]*querypb.BindVariable{
 		"vtg1": sqltypes.Int64BindVariable(1),
@@ -67,14 +67,7 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 		bv[fmt.Sprintf("vtg%d", i)] = sqltypes.BytesBindVariable(benchVarValue)
 	}
 
-	config := tabletenv.NewDefaultConfig()
-	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, newDBConfigs(db)); err != nil {
-		panic(err)
-	}
-	defer tsv.StopService()
-
 	db.AllowAll = true
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {
@@ -84,8 +77,10 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 }
 
 func BenchmarkExecuteExpression(b *testing.B) {
-	db := setUpTabletServerTest(nil)
+	db, tsv := setupTabletServerTest(nil)
 	defer db.Close()
+	defer tsv.StopService()
+
 	// sql that will be executed in this test
 	bv := map[string]*querypb.BindVariable{
 		"vtg1": sqltypes.Int64BindVariable(1),
@@ -97,14 +92,7 @@ func BenchmarkExecuteExpression(b *testing.B) {
 		}
 	}
 
-	config := tabletenv.NewDefaultConfig()
-	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, newDBConfigs(db)); err != nil {
-		panic(err)
-	}
-	defer tsv.StopService()
-
 	db.AllowAll = true
 	for i := 0; i < b.N; i++ {
 		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, 0, nil); err != nil {

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -72,14 +72,17 @@ func NewEngine(tsv TabletService, se *schema.Engine, vs VStreamer) *Engine {
 }
 
 // Open starts the Engine service.
-func (me *Engine) Open() error {
+func (me *Engine) Open() {
+	me.mu.Lock()
 	if me.isOpen {
-		return nil
+		me.mu.Unlock()
+		return
 	}
-
+	me.mu.Unlock()
+	// Unlock before invoking RegisterNotifier because it
+	// obtains the same lock.
 	me.se.RegisterNotifier("messages", me.schemaChanged)
 	me.isOpen = true
-	return nil
 }
 
 // Close closes the Engine service.

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -258,6 +258,12 @@ func (qe *QueryEngine) Open() error {
 	return nil
 }
 
+// StopServing kills all streaming queries.
+// Other queries are handled by the tsv.requests Waitgroup.
+func (qe *QueryEngine) StopServing() {
+	qe.streamQList.TerminateAll()
+}
+
 // Close must be called to shut down QueryEngine.
 // You must ensure that no more queries will be sent
 // before calling Close.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -262,11 +262,12 @@ func TestQueryExecutorPlans(t *testing.T) {
 			assert.Equal(t, tcase.logWant, qre.logStats.RewrittenSQL(), tcase.input)
 
 			// Test inside a transaction.
-			txid, alias, err := tsv.Begin(ctx, &tsv.target, nil)
+			target := tsv.sm.Target()
+			txid, alias, err := tsv.Begin(ctx, &target, nil)
 			require.NoError(t, err)
 			require.NotNil(t, alias, "alias should not be nil")
 			assert.Equal(t, tsv.alias, *alias, "Wrong alias returned by Begin")
-			defer tsv.Commit(ctx, &tsv.target, txid)
+			defer tsv.Commit(ctx, &target, txid)
 
 			qre = newTestQueryExecutor(ctx, tsv, tcase.input, txid)
 			got, err = qre.Execute()
@@ -328,11 +329,12 @@ func TestQueryExecutorSelectImpossible(t *testing.T) {
 			assert.Equal(t, tcase.resultWant, got, tcase.input)
 			assert.Equal(t, tcase.planWant, qre.logStats.PlanType, tcase.input)
 			assert.Equal(t, tcase.logWant, qre.logStats.RewrittenSQL(), tcase.input)
-			txid, alias, err := tsv.Begin(ctx, &tsv.target, nil)
+			target := tsv.sm.Target()
+			txid, alias, err := tsv.Begin(ctx, &target, nil)
 			require.NoError(t, err)
 			require.NotNil(t, alias, "alias should not be nil")
 			assert.Equal(t, tsv.alias, *alias, "Wrong tablet alias from Begin")
-			defer tsv.Commit(ctx, &tsv.target, txid)
+			defer tsv.Commit(ctx, &target, txid)
 
 			qre = newTestQueryExecutor(ctx, tsv, tcase.input, txid)
 			got, err = qre.Execute()
@@ -435,11 +437,12 @@ func TestQueryExecutorLimitFailure(t *testing.T) {
 			assert.Equal(t, tcase.logWant, qre.logStats.RewrittenSQL(), tcase.input)
 
 			// Test inside a transaction.
-			txid, alias, err := tsv.Begin(ctx, &tsv.target, nil)
+			target := tsv.sm.Target()
+			txid, alias, err := tsv.Begin(ctx, &target, nil)
 			require.NoError(t, err)
 			require.NotNil(t, alias, "alias should not be nil")
 			assert.Equal(t, tsv.alias, *alias, "Wrong tablet alias from Begin")
-			defer tsv.Commit(ctx, &tsv.target, txid)
+			defer tsv.Commit(ctx, &target, txid)
 
 			qre = newTestQueryExecutor(ctx, tsv, tcase.input, txid)
 			_, err = qre.Execute()
@@ -1111,7 +1114,8 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 }
 
 func newTransaction(tsv *TabletServer, options *querypb.ExecuteOptions) int64 {
-	transactionID, _, err := tsv.Begin(context.Background(), &tsv.target, options)
+	target := tsv.sm.Target()
+	transactionID, _, err := tsv.Begin(context.Background(), &target, options)
 	if err != nil {
 		panic(vterrors.Wrap(err, "failed to start a transaction"))
 	}

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1109,7 +1109,10 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
 	dbconfigs := newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	tsv.StartService(target, dbconfigs)
+	err := tsv.StartService(target, dbconfigs)
+	if err != nil {
+		panic(err)
+	}
 	return tsv
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1158,7 +1158,6 @@ func getTestTableFields() []*querypb.Field {
 func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[string]*sqltypes.Result {
 	return map[string]*sqltypes.Result{
 		// queries for twopc
-		sqlTurnoffBinlog:                                {},
 		fmt.Sprintf(sqlCreateSidecarDB, "_vt"):          {},
 		fmt.Sprintf(sqlDropLegacy1, "_vt"):              {},
 		fmt.Sprintf(sqlDropLegacy2, "_vt"):              {},

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -261,6 +261,8 @@ func (se *Engine) reload(ctx context.Context) error {
 		tableName := row[0].ToString()
 		curTables[tableName] = true
 		createTime, _ := evalengine.ToInt64(row[2])
+		// TODO(sougou); find a better way detect changed tables. This method
+		// seems unreliable. The endtoend test flags all tables as changed.
 		if _, ok := se.tables[tableName]; ok && createTime < se.lastChange {
 			continue
 		}

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -151,6 +151,11 @@ type txThrottler interface {
 func (sm *stateManager) SetServingType(tabletType topodatapb.TabletType, state int64, alsoAllow []topodatapb.TabletType) (stateChanged bool, err error) {
 	defer sm.ExitLameduck()
 
+	if tabletType == topodatapb.TabletType_RESTORE {
+		// TODO(sougou): remove this code once tm can give us more accurate state requests.
+		state = StateNotConnected
+	}
+
 	log.Infof("Starting transition to %v %v", tabletType, stateName[state])
 	stateChanged, errch := sm.setDesiredState(tabletType, state, alsoAllow)
 	err = <-errch

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -123,6 +123,8 @@ type txThrottler interface {
 }
 
 func (sm *stateManager) SetServingType(tabletType topodatapb.TabletType, state int64, alsoAllow []topodatapb.TabletType) (stateChanged bool, err error) {
+	defer sm.ExitLameduck()
+
 	log.Infof("Starting transition to %v %v", tabletType, stateName[state])
 	stateChanged, errch := sm.setDesiredState(tabletType, state, alsoAllow)
 	err = <-errch
@@ -508,10 +510,7 @@ func (sm *stateManager) StateByName() string {
 	if sm.lameduck.Get() != 0 {
 		return "NOT_SERVING"
 	}
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	name := stateName[sm.state]
-	return name
+	return stateName[sm.State()]
 }
 
 // stateInfo returns a string representation of the state and optional detail

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -1,0 +1,466 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/net/context"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+const (
+	// StateNotConnected is the state where tabletserver is not
+	// connected to an underlying mysql instance.
+	StateNotConnected = iota
+	// StateNotServing is the state where tabletserver is connected
+	// to an underlying mysql instance, but is not serving queries.
+	StateNotServing
+	// StateServing is where queries are allowed.
+	StateServing
+	// StateTransitioning is a transient state indicating that
+	// the tabletserver is tranisitioning to a new state.
+	// In order to achieve clean transitions, no requests are
+	// allowed during this state.
+	StateTransitioning
+	// StateShuttingDown indicates that the tabletserver
+	// is shutting down. In this state, we wait for outstanding
+	// requests and transactions to conclude.
+	StateShuttingDown
+)
+
+// stateName names every state. The number of elements must
+// match the number of states. Names can overlap.
+var stateName = []string{
+	"NOT_SERVING",
+	"NOT_SERVING",
+	"SERVING",
+	"NOT_SERVING",
+	"SHUTTING_DOWN",
+}
+
+// stateDetail matches every state and optionally more information about the reason
+// why the state is serving / not serving.
+var stateDetail = []string{
+	"Not Connected",
+	"Not Serving",
+	"",
+	"Transitioning",
+	"Shutting Down",
+}
+
+// stateInfo returns a string representation of the state and optional detail
+// about the reason for the state transition
+func stateInfo(state int64) string {
+	if state == StateServing {
+		return "SERVING"
+	}
+	return fmt.Sprintf("%s (%s)", stateName[state], stateDetail[state])
+}
+
+// EnterLameduck causes tabletserver to enter the lameduck state. This
+// state causes health checks to fail, but the behavior of tabletserver
+// otherwise remains the same. Any subsequent calls to SetServingType will
+// cause the tabletserver to exit this mode.
+func (tsv *TabletServer) EnterLameduck() {
+	tsv.lameduck.Set(1)
+}
+
+// ExitLameduck causes the tabletserver to exit the lameduck mode.
+func (tsv *TabletServer) ExitLameduck() {
+	tsv.lameduck.Set(0)
+}
+
+// GetState returns the name of the current TabletServer state.
+func (tsv *TabletServer) GetState() string {
+	if tsv.lameduck.Get() != 0 {
+		return "NOT_SERVING"
+	}
+	tsv.mu.Lock()
+	name := stateName[tsv.state]
+	tsv.mu.Unlock()
+	return name
+}
+
+// setState changes the state and logs the event.
+// It requires the caller to hold a lock on mu.
+func (tsv *TabletServer) setState(state int64) {
+	log.Infof("TabletServer state: %s -> %s", stateInfo(tsv.state), stateInfo(state))
+	tsv.state = state
+	tsv.history.Add(&historyRecord{
+		Time:         time.Now(),
+		ServingState: stateInfo(state),
+		TabletType:   tsv.target.TabletType.String(),
+	})
+}
+
+// transition obtains a lock and changes the state.
+func (tsv *TabletServer) transition(newState int64) {
+	tsv.mu.Lock()
+	tsv.setState(newState)
+	tsv.mu.Unlock()
+}
+
+// IsServing returns true if TabletServer is in SERVING state.
+func (tsv *TabletServer) IsServing() bool {
+	return tsv.GetState() == "SERVING"
+}
+
+// StartService is a convenience function for InitDBConfig->SetServingType
+// with serving=true.
+func (tsv *TabletServer) StartService(target querypb.Target, dbcfgs *dbconfigs.DBConfigs) (err error) {
+	err = tsv.InitDBConfig(target, dbcfgs)
+	if err != nil {
+		return err
+	}
+	_ /* state changed */, err = tsv.SetServingType(target.TabletType, true, nil)
+	return err
+}
+
+const (
+	actionNone = iota
+	actionFullStart
+	actionServeNewType
+	actionGracefulStop
+)
+
+// SetServingType changes the serving type of the tabletserver. It starts or
+// stops internal services as deemed necessary. The tabletType determines the
+// primary serving type, while alsoAllow specifies other tablet types that
+// should also be honored for serving.
+// Returns true if the state of QueryService or the tablet type changed.
+func (tsv *TabletServer) SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (stateChanged bool, err error) {
+	defer tsv.ExitLameduck()
+
+	action, err := tsv.decideAction(tabletType, serving, alsoAllow)
+	if err != nil {
+		return false, err
+	}
+	switch action {
+	case actionNone:
+		return false, nil
+	case actionFullStart:
+		if err := tsv.fullStart(); err != nil {
+			tsv.closeAll()
+			return true, err
+		}
+		return true, nil
+	case actionServeNewType:
+		if err := tsv.serveNewType(); err != nil {
+			tsv.closeAll()
+			return true, err
+		}
+		return true, nil
+	case actionGracefulStop:
+		tsv.gracefulStop()
+		return true, nil
+	}
+	panic("unreachable")
+}
+
+func (tsv *TabletServer) decideAction(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (action int, err error) {
+	tsv.mu.Lock()
+	defer tsv.mu.Unlock()
+
+	tsv.alsoAllow = alsoAllow
+
+	// Handle the case where the requested TabletType and serving state
+	// match our current state. This avoids an unnecessary transition.
+	// There's no similar shortcut if serving is false, because there
+	// are different 'not serving' states that require different actions.
+	if tsv.target.TabletType == tabletType {
+		if serving && tsv.state == StateServing {
+			// We're already in the desired state.
+			return actionNone, nil
+		}
+	}
+	tsv.target.TabletType = tabletType
+	switch tsv.state {
+	case StateNotConnected:
+		if serving {
+			tsv.setState(StateTransitioning)
+			return actionFullStart, nil
+		}
+	case StateNotServing:
+		if serving {
+			tsv.setState(StateTransitioning)
+			return actionServeNewType, nil
+		}
+	case StateServing:
+		if !serving {
+			tsv.setState(StateShuttingDown)
+			return actionGracefulStop, nil
+		}
+		tsv.setState(StateTransitioning)
+		return actionServeNewType, nil
+	case StateTransitioning, StateShuttingDown:
+		return actionNone, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "cannot SetServingType, current state: %s", stateName[tsv.state])
+	default:
+		panic("unreachable")
+	}
+	return actionNone, nil
+}
+
+func (tsv *TabletServer) fullStart() error {
+	if err := tsv.qe.IsMySQLReachable(); err != nil {
+		return err
+	}
+	if err := tsv.se.Open(); err != nil {
+		return err
+	}
+	tsv.vstreamer.Open()
+	if err := tsv.qe.Open(); err != nil {
+		return err
+	}
+	if err := tsv.txThrottler.Open(); err != nil {
+		return err
+	}
+	return tsv.serveNewType()
+}
+
+func (tsv *TabletServer) serveNewType() (err error) {
+	if tsv.target.TabletType == topodatapb.TabletType_MASTER {
+		tsv.watcher.Close()
+		tsv.hr.Close()
+
+		tsv.hw.Open()
+		tsv.tracker.Open()
+		tsv.te.AcceptReadWrite()
+		tsv.messager.Open()
+	} else {
+		tsv.messager.Close()
+		tsv.te.AcceptReadOnly()
+		tsv.tracker.Close()
+		tsv.hw.Close()
+		tsv.se.MakeNonMaster()
+
+		tsv.hr.Open()
+		tsv.watcher.Open()
+	}
+	tsv.transition(StateServing)
+	return nil
+}
+
+func (tsv *TabletServer) gracefulStop() {
+	defer close(tsv.setTimeBomb())
+	tsv.waitForShutdown()
+	tsv.transition(StateNotServing)
+}
+
+// StopService shuts down the tabletserver to the uninitialized state.
+// It first transitions to StateShuttingDown, then waits for active
+// services to shut down. Then it shuts down the rest. This function
+// should be called before process termination, or if MySQL is unreachable.
+// Under normal circumstances, SetServingType should be called.
+func (tsv *TabletServer) StopService() {
+	defer close(tsv.setTimeBomb())
+	defer tsv.LogError()
+
+	tsv.mu.Lock()
+	if tsv.state != StateServing && tsv.state != StateNotServing {
+		tsv.mu.Unlock()
+		return
+	}
+	tsv.setState(StateShuttingDown)
+	tsv.mu.Unlock()
+
+	log.Info("Executing complete shutdown.")
+	tsv.waitForShutdown()
+	tsv.qe.Close()
+	tsv.watcher.Close()
+	tsv.vstreamer.Close()
+	tsv.hr.Close()
+	tsv.hw.Close()
+	tsv.se.Close()
+	log.Info("Shutdown complete.")
+	tsv.transition(StateNotConnected)
+}
+
+func (tsv *TabletServer) waitForShutdown() {
+	tsv.messager.Close()
+	tsv.te.Close()
+	tsv.txThrottler.Close()
+	tsv.tracker.Close()
+	tsv.qe.StopServing()
+	tsv.requests.Wait()
+}
+
+// closeAll is called if TabletServer fails to start.
+// It forcibly shuts down everything.
+func (tsv *TabletServer) closeAll() {
+	tsv.messager.Close()
+	tsv.te.Close()
+	tsv.txThrottler.Close()
+	tsv.qe.StopServing()
+	tsv.qe.Close()
+	tsv.watcher.Close()
+	tsv.tracker.Close()
+	tsv.vstreamer.Close()
+	tsv.hr.Close()
+	tsv.hw.Close()
+	tsv.se.Close()
+	tsv.transition(StateNotConnected)
+}
+
+func (tsv *TabletServer) setTimeBomb() chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		qt := tsv.QueryTimeout.Get()
+		if qt == 0 {
+			return
+		}
+		tmr := time.NewTimer(10 * qt)
+		defer tmr.Stop()
+		select {
+		case <-tmr.C:
+			log.Fatal("Shutdown took too long. Crashing")
+		case <-done:
+		}
+	}()
+	return done
+}
+
+// CheckMySQL initiates a check to see if MySQL is reachable.
+// If not, it shuts down the query service. The check is rate-limited
+// to no more than once per second.
+// The function satisfies tabletenv.Env.
+func (tsv *TabletServer) CheckMySQL() {
+	if !tsv.checkMySQLThrottler.TryAcquire() {
+		return
+	}
+	go func() {
+		defer func() {
+			tsv.LogError()
+			time.Sleep(1 * time.Second)
+			tsv.checkMySQLThrottler.Release()
+		}()
+		if tsv.isMySQLReachable() {
+			return
+		}
+		log.Info("Check MySQL failed. Shutting down query service")
+		tsv.StopService()
+	}()
+}
+
+// isMySQLReachable returns true if we can connect to MySQL.
+// The function returns false only if the query service is
+// in StateServing or StateNotServing.
+func (tsv *TabletServer) isMySQLReachable() bool {
+	tsv.mu.Lock()
+	switch tsv.state {
+	case StateServing:
+		// Prevent transition out of this state by
+		// reserving a request.
+		tsv.requests.Add(1)
+		defer tsv.requests.Done()
+	case StateNotServing:
+		// Prevent transition out of this state by
+		// temporarily switching to StateTransitioning.
+		tsv.setState(StateTransitioning)
+		defer func() {
+			tsv.transition(StateNotServing)
+		}()
+	default:
+		tsv.mu.Unlock()
+		return true
+	}
+	tsv.mu.Unlock()
+	if err := tsv.qe.IsMySQLReachable(); err != nil {
+		log.Errorf("Cannot connect to MySQL: %v", err)
+		return false
+	}
+	return true
+}
+
+// startRequest validates the current state and target and registers
+// the request (a waitgroup) as started. Every startRequest requires
+// one and only one corresponding endRequest. When the service shuts
+// down, StopService will wait on this waitgroup to ensure that there
+// are no requests in flight.
+func (tsv *TabletServer) startRequest(ctx context.Context, target *querypb.Target, allowOnShutdown bool) (err error) {
+	tsv.mu.Lock()
+	defer tsv.mu.Unlock()
+	if tsv.state == StateServing {
+		goto verifyTarget
+	}
+	if allowOnShutdown && tsv.state == StateShuttingDown {
+		goto verifyTarget
+	}
+	return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "operation not allowed in state %s", stateName[tsv.state])
+
+verifyTarget:
+	if target != nil {
+		// a valid target needs to be used
+		switch {
+		case target.Keyspace != tsv.target.Keyspace:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v", target.Keyspace)
+		case target.Shard != tsv.target.Shard:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v", target.Shard)
+		case target.TabletType != tsv.target.TabletType:
+			for _, otherType := range tsv.alsoAllow {
+				if target.TabletType == otherType {
+					goto ok
+				}
+			}
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "invalid tablet type: %v, want: %v or %v", target.TabletType, tsv.target.TabletType, tsv.alsoAllow)
+		}
+	} else if !tabletenv.IsLocalContext(ctx) {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "No target")
+	}
+
+ok:
+	tsv.requests.Add(1)
+	return nil
+}
+
+// endRequest unregisters the current request (a waitgroup) as done.
+func (tsv *TabletServer) endRequest() {
+	tsv.requests.Done()
+}
+
+// verifyTarget allows requests to be executed even in non-serving state.
+func (tsv *TabletServer) verifyTarget(ctx context.Context, target *querypb.Target) error {
+	tsv.mu.Lock()
+	defer tsv.mu.Unlock()
+
+	if target != nil {
+		// a valid target needs to be used
+		switch {
+		case target.Keyspace != tsv.target.Keyspace:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v", target.Keyspace)
+		case target.Shard != tsv.target.Shard:
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v", target.Shard)
+		case target.TabletType != tsv.target.TabletType:
+			for _, otherType := range tsv.alsoAllow {
+				if target.TabletType == otherType {
+					return nil
+				}
+			}
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "invalid tablet type: %v, want: %v or %v", target.TabletType, tsv.target.TabletType, tsv.alsoAllow)
+		}
+	} else if !tabletenv.IsLocalContext(ctx) {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "No target")
+	}
+	return nil
+}

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package tabletserver
 
 import (
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/history"
+	"vitess.io/vitess/go/sync2"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
-func TestTabletServerGetState(t *testing.T) {
+func TestStateManagerStateByName(t *testing.T) {
 	states := []int64{
 		StateNotConnected,
 		StateNotServing,
@@ -39,4 +47,543 @@ func TestTabletServerGetState(t *testing.T) {
 		sm.state = state
 		require.Equal(t, names[i], sm.StateByName(), "StateByName")
 	}
+	sm.EnterLameduck()
+	require.Equal(t, "NOT_SERVING", sm.StateByName(), "StateByName")
+}
+
+func TestStateManagerServeMaster(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	verifySubcomponent(t, sm.watcher, 1, testStateClosed)
+	verifySubcomponent(t, sm.hr, 2, testStateClosed)
+
+	verifySubcomponent(t, sm.se, 3, testStateOpen)
+	verifySubcomponent(t, sm.vstreamer, 4, testStateOpen)
+	verifySubcomponent(t, sm.qe, 5, testStateOpen)
+	verifySubcomponent(t, sm.txThrottler, 6, testStateOpen)
+	verifySubcomponent(t, sm.hw, 7, testStateOpen)
+	verifySubcomponent(t, sm.tracker, 8, testStateOpen)
+	verifySubcomponent(t, sm.te, 9, testStateAcceptReadWrite)
+	verifySubcomponent(t, sm.messager, 10, testStateOpen)
+
+	assert.False(t, sm.se.(*testSchemaEngine).nonMaster)
+	assert.True(t, sm.qe.(*testQueryEngine).isReachable)
+	assert.False(t, sm.qe.(*testQueryEngine).stopServing)
+
+	assert.Equal(t, topodatapb.TabletType_MASTER, sm.target.TabletType)
+	assert.Equal(t, int64(StateServing), sm.state)
+}
+
+func TestStateManagerServeNonMaster(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_REPLICA, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	verifySubcomponent(t, sm.messager, 1, testStateClosed)
+	verifySubcomponent(t, sm.tracker, 2, testStateClosed)
+	verifySubcomponent(t, sm.hw, 3, testStateClosed)
+	assert.True(t, sm.se.(*testSchemaEngine).nonMaster)
+
+	verifySubcomponent(t, sm.se, 4, testStateOpen)
+	verifySubcomponent(t, sm.vstreamer, 5, testStateOpen)
+	verifySubcomponent(t, sm.qe, 6, testStateOpen)
+	verifySubcomponent(t, sm.txThrottler, 7, testStateOpen)
+	verifySubcomponent(t, sm.te, 8, testStateAcceptReadOnly)
+	verifySubcomponent(t, sm.hr, 9, testStateOpen)
+	verifySubcomponent(t, sm.watcher, 10, testStateOpen)
+
+	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
+	assert.Equal(t, int64(StateServing), sm.state)
+}
+
+func TestStateManagerUnserveMaster(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateNotServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	verifySubcomponent(t, sm.messager, 1, testStateClosed)
+	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
+
+	verifySubcomponent(t, sm.watcher, 3, testStateClosed)
+	verifySubcomponent(t, sm.hr, 4, testStateClosed)
+
+	verifySubcomponent(t, sm.se, 5, testStateOpen)
+	verifySubcomponent(t, sm.vstreamer, 6, testStateOpen)
+	verifySubcomponent(t, sm.qe, 7, testStateOpen)
+	verifySubcomponent(t, sm.txThrottler, 8, testStateOpen)
+
+	verifySubcomponent(t, sm.hw, 9, testStateOpen)
+	verifySubcomponent(t, sm.tracker, 10, testStateOpen)
+
+	assert.Equal(t, topodatapb.TabletType_MASTER, sm.target.TabletType)
+	assert.Equal(t, int64(StateNotServing), sm.state)
+}
+
+func TestStateManagerUnserveNonmaster(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_RDONLY, StateNotServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	verifySubcomponent(t, sm.messager, 1, testStateClosed)
+	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
+
+	verifySubcomponent(t, sm.tracker, 3, testStateClosed)
+	verifySubcomponent(t, sm.hw, 4, testStateClosed)
+	assert.True(t, sm.se.(*testSchemaEngine).nonMaster)
+
+	verifySubcomponent(t, sm.se, 5, testStateOpen)
+	verifySubcomponent(t, sm.vstreamer, 6, testStateOpen)
+	verifySubcomponent(t, sm.qe, 7, testStateOpen)
+	verifySubcomponent(t, sm.txThrottler, 8, testStateOpen)
+
+	verifySubcomponent(t, sm.hr, 9, testStateOpen)
+	verifySubcomponent(t, sm.watcher, 10, testStateOpen)
+
+	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
+	assert.Equal(t, int64(StateNotServing), sm.state)
+}
+
+func TestStateManagerClose(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_RDONLY, StateNotConnected, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	verifySubcomponent(t, sm.messager, 1, testStateClosed)
+	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
+
+	verifySubcomponent(t, sm.txThrottler, 3, testStateClosed)
+	verifySubcomponent(t, sm.qe, 4, testStateClosed)
+	verifySubcomponent(t, sm.watcher, 5, testStateClosed)
+	verifySubcomponent(t, sm.tracker, 6, testStateClosed)
+	verifySubcomponent(t, sm.vstreamer, 7, testStateClosed)
+	verifySubcomponent(t, sm.hr, 8, testStateClosed)
+	verifySubcomponent(t, sm.hw, 9, testStateClosed)
+	verifySubcomponent(t, sm.se, 10, testStateClosed)
+
+	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
+	assert.Equal(t, int64(StateNotConnected), sm.state)
+}
+
+func TestStateManagerStopService(t *testing.T) {
+	sm := newTestStateManager(t)
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_REPLICA, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
+	assert.Equal(t, int64(StateServing), sm.state)
+
+	sm.StopService()
+	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
+	assert.Equal(t, int64(StateNotConnected), sm.state)
+}
+
+// testWatcher1 is used as a hook to invoke another transition
+type testWatcher1 struct {
+	t  *testing.T
+	sm *stateManager
+}
+
+func (te *testWatcher1) Open() {
+}
+
+func (te *testWatcher1) Close() {
+	stateChanged, err := te.sm.SetServingType(topodatapb.TabletType_RDONLY, StateNotServing, nil)
+	// We are transitioning.
+	// This should return immediately with no error.
+	require.NoError(te.t, err)
+	assert.True(te.t, stateChanged)
+}
+
+func TestStateManagerSetServingTypeRace(t *testing.T) {
+	sm := newTestStateManager(t)
+	sm.watcher = &testWatcher1{
+		t:  t,
+		sm: sm,
+	}
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	// The watcher, being special, is not counted in the ordering.
+	verifySubcomponent(t, sm.messager, 10, testStateClosed)
+	verifySubcomponent(t, sm.te, 11, testStateClosed)
+
+	verifySubcomponent(t, sm.tracker, 12, testStateClosed)
+	verifySubcomponent(t, sm.hw, 13, testStateClosed)
+
+	verifySubcomponent(t, sm.se, 14, testStateOpen)
+	verifySubcomponent(t, sm.vstreamer, 15, testStateOpen)
+	verifySubcomponent(t, sm.qe, 16, testStateOpen)
+	verifySubcomponent(t, sm.txThrottler, 17, testStateOpen)
+
+	verifySubcomponent(t, sm.hr, 18, testStateOpen)
+
+	// End state should be the final desired state.
+	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
+	assert.Equal(t, int64(StateNotServing), sm.state)
+}
+
+// testWatcher2 is used as a hook to invoke another transition
+type testWatcher2 struct {
+	t  *testing.T
+	sm *stateManager
+}
+
+func (te *testWatcher2) Open() {
+}
+
+func (te *testWatcher2) Close() {
+	stateChanged, err := te.sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	// We are transitioning.
+	// This should return immediately with no error.
+	require.NoError(te.t, err)
+	assert.False(te.t, stateChanged)
+}
+
+func TestStateManagerSetServingTypeNoChange(t *testing.T) {
+	sm := newTestStateManager(t)
+	sm.watcher = &testWatcher2{
+		t:  t,
+		sm: sm,
+	}
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	// End state should be the final desired state.
+	assert.Equal(t, topodatapb.TabletType_MASTER, sm.target.TabletType)
+	assert.Equal(t, int64(StateServing), sm.state)
+}
+
+func TestStateManagerTransitionFailRetry(t *testing.T) {
+	defer func(saved time.Duration) { transitionRetryInterval = saved }(transitionRetryInterval)
+	transitionRetryInterval = 10 * time.Millisecond
+
+	sm := newTestStateManager(t)
+	sm.qe.(*testQueryEngine).failMySQL = true
+
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.Error(t, err)
+	assert.True(t, stateChanged)
+
+	for {
+		sm.mu.Lock()
+		transitioning := sm.transitioning
+		sm.mu.Unlock()
+		if !transitioning {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.Equal(t, topodatapb.TabletType_MASTER, sm.Target().TabletType)
+	assert.Equal(t, int64(StateServing), sm.State())
+}
+
+func TestStateManagerCheckMySQL(t *testing.T) {
+	defer func(saved time.Duration) { transitionRetryInterval = saved }(transitionRetryInterval)
+	transitionRetryInterval = 10 * time.Millisecond
+
+	sm := newTestStateManager(t)
+
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	sm.qe.(*testQueryEngine).failMySQL = true
+	order.Set(0)
+	sm.CheckMySQL()
+
+	// Wait for closeAll to get under way.
+	for {
+		if order.Get() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait to get out of transitioning state.
+	for {
+		sm.mu.Lock()
+		transitioning := sm.transitioning
+		sm.mu.Unlock()
+		if !transitioning {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.Equal(t, topodatapb.TabletType_MASTER, sm.Target().TabletType)
+	assert.Equal(t, int64(StateServing), sm.State())
+}
+
+func TestStateManagerValidations(t *testing.T) {
+	sm := newTestStateManager(t)
+	target := &querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	sm.target = *target
+
+	err := sm.StartRequest(ctx, target, false)
+	assert.Contains(t, err.Error(), "operation not allowed")
+
+	sm.state = StateServing
+	sm.transitioning = true
+	err = sm.StartRequest(ctx, target, false)
+	assert.Contains(t, err.Error(), "operation not allowed")
+
+	err = sm.StartRequest(ctx, target, true)
+	assert.NoError(t, err)
+
+	sm.transitioning = false
+	target.Keyspace = "a"
+	err = sm.StartRequest(ctx, target, false)
+	assert.Contains(t, err.Error(), "invalid keyspace")
+	err = sm.VerifyTarget(ctx, target)
+	assert.Contains(t, err.Error(), "invalid keyspace")
+
+	target.Keyspace = ""
+	target.Shard = "a"
+	err = sm.StartRequest(ctx, target, false)
+	assert.Contains(t, err.Error(), "invalid shard")
+	err = sm.VerifyTarget(ctx, target)
+	assert.Contains(t, err.Error(), "invalid shard")
+
+	target.Shard = ""
+	target.TabletType = topodatapb.TabletType_REPLICA
+	err = sm.StartRequest(ctx, target, false)
+	assert.Contains(t, err.Error(), "invalid tablet type")
+	err = sm.VerifyTarget(ctx, target)
+	assert.Contains(t, err.Error(), "invalid tablet type")
+
+	sm.alsoAllow = []topodatapb.TabletType{topodatapb.TabletType_REPLICA}
+	err = sm.StartRequest(ctx, target, false)
+	assert.NoError(t, err)
+	err = sm.VerifyTarget(ctx, target)
+	assert.NoError(t, err)
+
+	err = sm.StartRequest(ctx, nil, false)
+	assert.Contains(t, err.Error(), "No target")
+	err = sm.VerifyTarget(ctx, nil)
+	assert.Contains(t, err.Error(), "No target")
+
+	localctx := tabletenv.LocalContext()
+	err = sm.StartRequest(localctx, nil, false)
+	assert.NoError(t, err)
+	err = sm.VerifyTarget(localctx, nil)
+	assert.NoError(t, err)
+}
+
+func TestStateManagerWaitForRequests(t *testing.T) {
+	sm := newTestStateManager(t)
+	target := &querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	sm.target = *target
+	sm.timebombDuration = 10 * time.Second
+
+	_, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
+	require.NoError(t, err)
+
+	err = sm.StartRequest(ctx, target, false)
+	require.NoError(t, err)
+
+	// This will go into transition and wait.
+	// Wait for that state.
+	go sm.StopService()
+	for {
+		sm.mu.Lock()
+		transitioning := sm.transitioning
+		sm.mu.Unlock()
+		if !transitioning {
+			continue
+		}
+		time.Sleep(10 * time.Millisecond)
+		break
+	}
+
+	// Verify that we're still transitioning.
+	sm.mu.Lock()
+	assert.True(t, sm.transitioning)
+	sm.mu.Unlock()
+
+	sm.EndRequest()
+
+	for {
+		sm.mu.Lock()
+		transitioning := sm.transitioning
+		sm.mu.Unlock()
+		if transitioning {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	assert.Equal(t, int64(StateNotConnected), sm.State())
+}
+
+func verifySubcomponent(t *testing.T, component interface{}, order int64, state testState) {
+	tos := component.(orderState)
+	assert.Equal(t, order, tos.Order())
+	assert.Equal(t, state, tos.State())
+}
+
+func newTestStateManager(t *testing.T) *stateManager {
+	order.Set(0)
+	return &stateManager{
+		se:          &testSchemaEngine{},
+		hw:          &testSubcomponent{},
+		hr:          &testSubcomponent{},
+		vstreamer:   &testSubcomponent{},
+		tracker:     &testSubcomponent{},
+		watcher:     &testSubcomponent{},
+		qe:          &testQueryEngine{},
+		txThrottler: &testTxThrottler{},
+		te:          &testTxEngine{},
+		messager:    &testSubcomponent{},
+
+		checkMySQLThrottler: sync2.NewSemaphore(1, 0),
+		history:             history.New(10),
+		timebombDuration:    time.Duration(10 * time.Millisecond),
+	}
+}
+
+var order sync2.AtomicInt64
+
+type testState int
+
+const (
+	testStateUnknown = testState(iota)
+	testStateOpen
+	testStateClosed
+	testStateMakeNonMaster
+	testStateAcceptReadOnly
+	testStateAcceptReadWrite
+)
+
+type orderState interface {
+	Order() int64
+	State() testState
+}
+
+type testOrderState struct {
+	order int64
+	state testState
+}
+
+func (tos testOrderState) Order() int64 {
+	return tos.order
+}
+
+func (tos testOrderState) State() testState {
+	return tos.state
+}
+
+type testSchemaEngine struct {
+	testOrderState
+	nonMaster bool
+}
+
+func (te *testSchemaEngine) Open() error {
+	te.order = order.Add(1)
+	te.state = testStateOpen
+	return nil
+}
+
+func (te *testSchemaEngine) MakeNonMaster() {
+	te.nonMaster = true
+}
+
+func (te *testSchemaEngine) Close() {
+	te.order = order.Add(1)
+	te.state = testStateClosed
+}
+
+type testQueryEngine struct {
+	testOrderState
+	isReachable bool
+	stopServing bool
+
+	failMySQL bool
+}
+
+func (te *testQueryEngine) Open() error {
+	te.order = order.Add(1)
+	te.state = testStateOpen
+	return nil
+}
+
+func (te *testQueryEngine) IsMySQLReachable() error {
+	if te.failMySQL {
+		te.failMySQL = false
+		return errors.New("intentional error")
+	}
+	te.isReachable = true
+	return nil
+}
+
+func (te *testQueryEngine) StopServing() {
+	te.stopServing = true
+}
+
+func (te *testQueryEngine) Close() {
+	te.order = order.Add(1)
+	te.state = testStateClosed
+}
+
+type testTxEngine struct {
+	testOrderState
+}
+
+func (te *testTxEngine) AcceptReadWrite() error {
+	te.order = order.Add(1)
+	te.state = testStateAcceptReadWrite
+	return nil
+}
+
+func (te *testTxEngine) AcceptReadOnly() error {
+	te.order = order.Add(1)
+	te.state = testStateAcceptReadOnly
+	return nil
+}
+
+func (te *testTxEngine) Close() {
+	te.order = order.Add(1)
+	te.state = testStateClosed
+}
+
+type testSubcomponent struct {
+	testOrderState
+}
+
+func (te *testSubcomponent) Open() {
+	te.order = order.Add(1)
+	te.state = testStateOpen
+}
+
+func (te *testSubcomponent) Close() {
+	te.order = order.Add(1)
+	te.state = testStateClosed
+}
+
+type testTxThrottler struct {
+	testOrderState
+}
+
+func (te *testTxThrottler) Open() error {
+	te.order = order.Add(1)
+	te.state = testStateOpen
+	return nil
+}
+
+func (te *testTxThrottler) Close() {
+	te.order = order.Add(1)
+	te.state = testStateClosed
 }

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTabletServerGetState(t *testing.T) {
+	states := []int64{
+		StateNotConnected,
+		StateNotServing,
+		StateServing,
+	}
+	// Don't reuse stateName.
+	names := []string{
+		"NOT_SERVING",
+		"NOT_SERVING",
+		"SERVING",
+	}
+	sm := &stateManager{}
+	for i, state := range states {
+		sm.state = state
+		require.Equal(t, names[i], sm.StateByName(), "StateByName")
+	}
+}

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -294,6 +294,18 @@ func TestStateManagerTransitionFailRetry(t *testing.T) {
 	assert.Equal(t, int64(StateServing), sm.State())
 }
 
+func TestStateManagerRestoreType(t *testing.T) {
+	sm := newTestStateManager(t)
+	sm.EnterLameduck()
+	stateChanged, err := sm.SetServingType(topodatapb.TabletType_RESTORE, StateNotServing, nil)
+	require.NoError(t, err)
+	assert.True(t, stateChanged)
+
+	assert.Equal(t, topodatapb.TabletType_RESTORE, sm.target.TabletType)
+	// RESTORE can only be in StateNotConnected.
+	assert.Equal(t, int64(StateNotConnected), sm.state)
+}
+
 func TestStateManagerCheckMySQL(t *testing.T) {
 	defer func(saved time.Duration) { transitionRetryInterval = saved }(transitionRetryInterval)
 	transitionRetryInterval = 10 * time.Millisecond

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestStateManagerStateByName(t *testing.T) {
-	states := []int64{
+	states := []servingState{
 		StateNotConnected,
 		StateNotServing,
 		StateServing,
@@ -61,24 +61,24 @@ func TestStateManagerServeMaster(t *testing.T) {
 
 	assert.Equal(t, int32(0), sm.lameduck.Get())
 
-	verifySubcomponent(t, sm.watcher, 1, testStateClosed)
-	verifySubcomponent(t, sm.hr, 2, testStateClosed)
+	verifySubcomponent(t, 1, sm.watcher, testStateClosed)
+	verifySubcomponent(t, 2, sm.hr, testStateClosed)
 
-	verifySubcomponent(t, sm.se, 3, testStateOpen)
-	verifySubcomponent(t, sm.vstreamer, 4, testStateOpen)
-	verifySubcomponent(t, sm.qe, 5, testStateOpen)
-	verifySubcomponent(t, sm.txThrottler, 6, testStateOpen)
-	verifySubcomponent(t, sm.hw, 7, testStateOpen)
-	verifySubcomponent(t, sm.tracker, 8, testStateOpen)
-	verifySubcomponent(t, sm.te, 9, testStateAcceptReadWrite)
-	verifySubcomponent(t, sm.messager, 10, testStateOpen)
+	verifySubcomponent(t, 3, sm.se, testStateOpen)
+	verifySubcomponent(t, 4, sm.vstreamer, testStateOpen)
+	verifySubcomponent(t, 5, sm.qe, testStateOpen)
+	verifySubcomponent(t, 6, sm.txThrottler, testStateOpen)
+	verifySubcomponent(t, 7, sm.hw, testStateOpen)
+	verifySubcomponent(t, 8, sm.tracker, testStateOpen)
+	verifySubcomponent(t, 9, sm.te, testStateAcceptReadWrite)
+	verifySubcomponent(t, 10, sm.messager, testStateOpen)
 
 	assert.False(t, sm.se.(*testSchemaEngine).nonMaster)
 	assert.True(t, sm.qe.(*testQueryEngine).isReachable)
 	assert.False(t, sm.qe.(*testQueryEngine).stopServing)
 
 	assert.Equal(t, topodatapb.TabletType_MASTER, sm.target.TabletType)
-	assert.Equal(t, int64(StateServing), sm.state)
+	assert.Equal(t, StateServing, sm.state)
 }
 
 func TestStateManagerServeNonMaster(t *testing.T) {
@@ -87,21 +87,21 @@ func TestStateManagerServeNonMaster(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, stateChanged)
 
-	verifySubcomponent(t, sm.messager, 1, testStateClosed)
-	verifySubcomponent(t, sm.tracker, 2, testStateClosed)
-	verifySubcomponent(t, sm.hw, 3, testStateClosed)
+	verifySubcomponent(t, 1, sm.messager, testStateClosed)
+	verifySubcomponent(t, 2, sm.tracker, testStateClosed)
+	verifySubcomponent(t, 3, sm.hw, testStateClosed)
 	assert.True(t, sm.se.(*testSchemaEngine).nonMaster)
 
-	verifySubcomponent(t, sm.se, 4, testStateOpen)
-	verifySubcomponent(t, sm.vstreamer, 5, testStateOpen)
-	verifySubcomponent(t, sm.qe, 6, testStateOpen)
-	verifySubcomponent(t, sm.txThrottler, 7, testStateOpen)
-	verifySubcomponent(t, sm.te, 8, testStateAcceptReadOnly)
-	verifySubcomponent(t, sm.hr, 9, testStateOpen)
-	verifySubcomponent(t, sm.watcher, 10, testStateOpen)
+	verifySubcomponent(t, 4, sm.se, testStateOpen)
+	verifySubcomponent(t, 5, sm.vstreamer, testStateOpen)
+	verifySubcomponent(t, 6, sm.qe, testStateOpen)
+	verifySubcomponent(t, 7, sm.txThrottler, testStateOpen)
+	verifySubcomponent(t, 8, sm.te, testStateAcceptReadOnly)
+	verifySubcomponent(t, 9, sm.hr, testStateOpen)
+	verifySubcomponent(t, 10, sm.watcher, testStateOpen)
 
 	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
-	assert.Equal(t, int64(StateServing), sm.state)
+	assert.Equal(t, StateServing, sm.state)
 }
 
 func TestStateManagerUnserveMaster(t *testing.T) {
@@ -110,23 +110,23 @@ func TestStateManagerUnserveMaster(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, stateChanged)
 
-	verifySubcomponent(t, sm.messager, 1, testStateClosed)
-	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	verifySubcomponent(t, 1, sm.messager, testStateClosed)
+	verifySubcomponent(t, 2, sm.te, testStateClosed)
 	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
 
-	verifySubcomponent(t, sm.watcher, 3, testStateClosed)
-	verifySubcomponent(t, sm.hr, 4, testStateClosed)
+	verifySubcomponent(t, 3, sm.watcher, testStateClosed)
+	verifySubcomponent(t, 4, sm.hr, testStateClosed)
 
-	verifySubcomponent(t, sm.se, 5, testStateOpen)
-	verifySubcomponent(t, sm.vstreamer, 6, testStateOpen)
-	verifySubcomponent(t, sm.qe, 7, testStateOpen)
-	verifySubcomponent(t, sm.txThrottler, 8, testStateOpen)
+	verifySubcomponent(t, 5, sm.se, testStateOpen)
+	verifySubcomponent(t, 6, sm.vstreamer, testStateOpen)
+	verifySubcomponent(t, 7, sm.qe, testStateOpen)
+	verifySubcomponent(t, 8, sm.txThrottler, testStateOpen)
 
-	verifySubcomponent(t, sm.hw, 9, testStateOpen)
-	verifySubcomponent(t, sm.tracker, 10, testStateOpen)
+	verifySubcomponent(t, 9, sm.hw, testStateOpen)
+	verifySubcomponent(t, 10, sm.tracker, testStateOpen)
 
 	assert.Equal(t, topodatapb.TabletType_MASTER, sm.target.TabletType)
-	assert.Equal(t, int64(StateNotServing), sm.state)
+	assert.Equal(t, StateNotServing, sm.state)
 }
 
 func TestStateManagerUnserveNonmaster(t *testing.T) {
@@ -135,24 +135,24 @@ func TestStateManagerUnserveNonmaster(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, stateChanged)
 
-	verifySubcomponent(t, sm.messager, 1, testStateClosed)
-	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	verifySubcomponent(t, 1, sm.messager, testStateClosed)
+	verifySubcomponent(t, 2, sm.te, testStateClosed)
 	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
 
-	verifySubcomponent(t, sm.tracker, 3, testStateClosed)
-	verifySubcomponent(t, sm.hw, 4, testStateClosed)
+	verifySubcomponent(t, 3, sm.tracker, testStateClosed)
+	verifySubcomponent(t, 4, sm.hw, testStateClosed)
 	assert.True(t, sm.se.(*testSchemaEngine).nonMaster)
 
-	verifySubcomponent(t, sm.se, 5, testStateOpen)
-	verifySubcomponent(t, sm.vstreamer, 6, testStateOpen)
-	verifySubcomponent(t, sm.qe, 7, testStateOpen)
-	verifySubcomponent(t, sm.txThrottler, 8, testStateOpen)
+	verifySubcomponent(t, 5, sm.se, testStateOpen)
+	verifySubcomponent(t, 6, sm.vstreamer, testStateOpen)
+	verifySubcomponent(t, 7, sm.qe, testStateOpen)
+	verifySubcomponent(t, 8, sm.txThrottler, testStateOpen)
 
-	verifySubcomponent(t, sm.hr, 9, testStateOpen)
-	verifySubcomponent(t, sm.watcher, 10, testStateOpen)
+	verifySubcomponent(t, 9, sm.hr, testStateOpen)
+	verifySubcomponent(t, 10, sm.watcher, testStateOpen)
 
 	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
-	assert.Equal(t, int64(StateNotServing), sm.state)
+	assert.Equal(t, StateNotServing, sm.state)
 }
 
 func TestStateManagerClose(t *testing.T) {
@@ -161,21 +161,21 @@ func TestStateManagerClose(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, stateChanged)
 
-	verifySubcomponent(t, sm.messager, 1, testStateClosed)
-	verifySubcomponent(t, sm.te, 2, testStateClosed)
+	verifySubcomponent(t, 1, sm.messager, testStateClosed)
+	verifySubcomponent(t, 2, sm.te, testStateClosed)
 	assert.True(t, sm.qe.(*testQueryEngine).stopServing)
 
-	verifySubcomponent(t, sm.txThrottler, 3, testStateClosed)
-	verifySubcomponent(t, sm.qe, 4, testStateClosed)
-	verifySubcomponent(t, sm.watcher, 5, testStateClosed)
-	verifySubcomponent(t, sm.tracker, 6, testStateClosed)
-	verifySubcomponent(t, sm.vstreamer, 7, testStateClosed)
-	verifySubcomponent(t, sm.hr, 8, testStateClosed)
-	verifySubcomponent(t, sm.hw, 9, testStateClosed)
-	verifySubcomponent(t, sm.se, 10, testStateClosed)
+	verifySubcomponent(t, 3, sm.txThrottler, testStateClosed)
+	verifySubcomponent(t, 4, sm.qe, testStateClosed)
+	verifySubcomponent(t, 5, sm.watcher, testStateClosed)
+	verifySubcomponent(t, 6, sm.tracker, testStateClosed)
+	verifySubcomponent(t, 7, sm.vstreamer, testStateClosed)
+	verifySubcomponent(t, 8, sm.hr, testStateClosed)
+	verifySubcomponent(t, 9, sm.hw, testStateClosed)
+	verifySubcomponent(t, 10, sm.se, testStateClosed)
 
 	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
-	assert.Equal(t, int64(StateNotConnected), sm.state)
+	assert.Equal(t, StateNotConnected, sm.state)
 }
 
 func TestStateManagerStopService(t *testing.T) {
@@ -185,11 +185,11 @@ func TestStateManagerStopService(t *testing.T) {
 	assert.True(t, stateChanged)
 
 	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
-	assert.Equal(t, int64(StateServing), sm.state)
+	assert.Equal(t, StateServing, sm.state)
 
 	sm.StopService()
 	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
-	assert.Equal(t, int64(StateNotConnected), sm.state)
+	assert.Equal(t, StateNotConnected, sm.state)
 }
 
 // testWatcher is used as a hook to invoke another transition
@@ -229,7 +229,7 @@ func TestStateManagerSetServingTypeRace(t *testing.T) {
 
 	// End state should be the final desired state.
 	assert.Equal(t, topodatapb.TabletType_RDONLY, sm.target.TabletType)
-	assert.Equal(t, int64(StateNotServing), sm.state)
+	assert.Equal(t, StateNotServing, sm.state)
 }
 
 func TestStateManagerSetServingTypeNoChange(t *testing.T) {
@@ -242,21 +242,21 @@ func TestStateManagerSetServingTypeNoChange(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, stateChanged)
 
-	verifySubcomponent(t, sm.messager, 1, testStateClosed)
-	verifySubcomponent(t, sm.tracker, 2, testStateClosed)
-	verifySubcomponent(t, sm.hw, 3, testStateClosed)
+	verifySubcomponent(t, 1, sm.messager, testStateClosed)
+	verifySubcomponent(t, 2, sm.tracker, testStateClosed)
+	verifySubcomponent(t, 3, sm.hw, testStateClosed)
 	assert.True(t, sm.se.(*testSchemaEngine).nonMaster)
 
-	verifySubcomponent(t, sm.se, 4, testStateOpen)
-	verifySubcomponent(t, sm.vstreamer, 5, testStateOpen)
-	verifySubcomponent(t, sm.qe, 6, testStateOpen)
-	verifySubcomponent(t, sm.txThrottler, 7, testStateOpen)
-	verifySubcomponent(t, sm.te, 8, testStateAcceptReadOnly)
-	verifySubcomponent(t, sm.hr, 9, testStateOpen)
-	verifySubcomponent(t, sm.watcher, 10, testStateOpen)
+	verifySubcomponent(t, 4, sm.se, testStateOpen)
+	verifySubcomponent(t, 5, sm.vstreamer, testStateOpen)
+	verifySubcomponent(t, 6, sm.qe, testStateOpen)
+	verifySubcomponent(t, 7, sm.txThrottler, testStateOpen)
+	verifySubcomponent(t, 8, sm.te, testStateAcceptReadOnly)
+	verifySubcomponent(t, 9, sm.hr, testStateOpen)
+	verifySubcomponent(t, 10, sm.watcher, testStateOpen)
 
 	assert.Equal(t, topodatapb.TabletType_REPLICA, sm.target.TabletType)
-	assert.Equal(t, int64(StateServing), sm.state)
+	assert.Equal(t, StateServing, sm.state)
 }
 
 func TestStateManagerTransitionFailRetry(t *testing.T) {
@@ -281,7 +281,7 @@ func TestStateManagerTransitionFailRetry(t *testing.T) {
 	}
 
 	assert.Equal(t, topodatapb.TabletType_MASTER, sm.Target().TabletType)
-	assert.Equal(t, int64(StateServing), sm.State())
+	assert.Equal(t, StateServing, sm.State())
 }
 
 func TestStateManagerRestoreType(t *testing.T) {
@@ -293,7 +293,7 @@ func TestStateManagerRestoreType(t *testing.T) {
 
 	assert.Equal(t, topodatapb.TabletType_RESTORE, sm.target.TabletType)
 	// RESTORE can only be in StateNotConnected.
-	assert.Equal(t, int64(StateNotConnected), sm.state)
+	assert.Equal(t, StateNotConnected, sm.state)
 }
 
 func TestStateManagerCheckMySQL(t *testing.T) {
@@ -338,7 +338,7 @@ func TestStateManagerCheckMySQL(t *testing.T) {
 	}
 
 	assert.Equal(t, topodatapb.TabletType_MASTER, sm.Target().TabletType)
-	assert.Equal(t, int64(StateServing), sm.State())
+	assert.Equal(t, StateServing, sm.State())
 }
 
 func TestStateManagerValidations(t *testing.T) {
@@ -431,10 +431,10 @@ func TestStateManagerWaitForRequests(t *testing.T) {
 		}
 		break
 	}
-	assert.Equal(t, int64(StateNotConnected), sm.State())
+	assert.Equal(t, StateNotConnected, sm.State())
 }
 
-func verifySubcomponent(t *testing.T, component interface{}, order int64, state testState) {
+func verifySubcomponent(t *testing.T, order int64, component interface{}, state testState) {
 	tos := component.(orderState)
 	assert.Equal(t, order, tos.Order())
 	assert.Equal(t, state, tos.State())

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -474,10 +474,9 @@ var order sync2.AtomicInt64
 type testState int
 
 const (
-	testStateUnknown = testState(iota)
+	_ = testState(iota)
 	testStateOpen
 	testStateClosed
-	testStateMakeNonMaster
 	testStateAcceptReadOnly
 	testStateAcceptReadWrite
 )

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -53,9 +53,12 @@ func TestStateManagerStateByName(t *testing.T) {
 
 func TestStateManagerServeMaster(t *testing.T) {
 	sm := newTestStateManager(t)
+	sm.EnterLameduck()
 	stateChanged, err := sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
 	require.NoError(t, err)
 	assert.True(t, stateChanged)
+
+	assert.Equal(t, int32(0), sm.lameduck.Get())
 
 	verifySubcomponent(t, sm.watcher, 1, testStateClosed)
 	verifySubcomponent(t, sm.hr, 2, testStateClosed)

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -204,7 +204,7 @@ func (te *testWatcher1) Close() {
 	stateChanged, err := te.sm.SetServingType(topodatapb.TabletType_RDONLY, StateNotServing, nil)
 	// We are transitioning.
 	// This should return immediately with no error.
-	require.NoError(te.t, err)
+	assert.Contains(te.t, err.Error(), "a transition is already in progress")
 	assert.True(te.t, stateChanged)
 }
 
@@ -250,7 +250,7 @@ func (te *testWatcher2) Close() {
 	stateChanged, err := te.sm.SetServingType(topodatapb.TabletType_MASTER, StateServing, nil)
 	// We are transitioning.
 	// This should return immediately with no error.
-	require.NoError(te.t, err)
+	assert.Contains(te.t, err.Error(), "a transition is already in progress")
 	assert.False(te.t, stateChanged)
 }
 

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -182,12 +182,10 @@ type queryserviceStatus struct {
 // AddStatusHeader registers a standlone header for the status page.
 func (tsv *TabletServer) AddStatusHeader() {
 	tsv.exporter.AddStatusPart("Tablet Server", headerTemplate, func() interface{} {
-		tsv.mu.Lock()
-		defer tsv.mu.Unlock()
 		return map[string]interface{}{
 			"Alias":  tsv.exporter.Name(),
 			"Prefix": tsv.exporter.URLPrefix(),
-			"Target": tsv.target,
+			"Target": tsv.sm.Target(),
 		}
 	})
 }
@@ -196,8 +194,8 @@ func (tsv *TabletServer) AddStatusHeader() {
 func (tsv *TabletServer) AddStatusPart() {
 	tsv.exporter.AddStatusPart("Queryservice", queryserviceStatusTemplate, func() interface{} {
 		status := queryserviceStatus{
-			State:   tsv.GetState(),
-			History: tsv.history.Records(),
+			State:   tsv.sm.StateByName(),
+			History: tsv.sm.history.Records(),
 		}
 		rates := tsv.stats.QPSRates.Get()
 		if qps, ok := rates["All"]; ok && len(qps) > 0 {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -182,7 +182,7 @@ func NewTabletServer(name string, config *tabletenv.TabletConfig, topoServer *to
 		timebombDuration:    time.Duration(config.OltpReadPool.TimeoutSeconds * 10),
 	}
 
-	tsv.exporter.NewGaugeFunc("TabletState", "Tablet server state", tsv.sm.State)
+	tsv.exporter.NewGaugeFunc("TabletState", "Tablet server state", func() int64 { return int64(tsv.sm.State()) })
 	tsv.exporter.Publish("TabletStateName", stats.StringFunc(tsv.sm.StateByName))
 
 	// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
@@ -311,7 +311,7 @@ func (tsv *TabletServer) InitACL(tableACLConfigFile string, enforceTableACLConfi
 // should also be honored for serving.
 // Returns true if the state of QueryService or the tablet type changed.
 func (tsv *TabletServer) SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (stateChanged bool, err error) {
-	state := int64(StateNotServing)
+	state := StateNotServing
 	if serving {
 		state = StateServing
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -539,9 +539,6 @@ func (tsv *TabletServer) fullStart() (err error) {
 	if err := tsv.txThrottler.Open(); err != nil {
 		return err
 	}
-	if err := tsv.te.Init(); err != nil {
-		return err
-	}
 	return tsv.serveNewType()
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -548,9 +548,7 @@ func (tsv *TabletServer) serveNewType() (err error) {
 		tsv.watcher.Close()
 		tsv.hr.Close()
 
-		if err := tsv.hw.Open(); err != nil {
-			return err
-		}
+		tsv.hw.Open()
 		tsv.tracker.Open()
 		tsv.te.AcceptReadWrite()
 		tsv.messager.Open()

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -529,7 +529,7 @@ func (tsv *TabletServer) fullStart() (err error) {
 	c.Close()
 
 	if err := tsv.se.Open(); err != nil {
-		log.Errorf("Could not load historian, but starting the query service anyways: %v", err)
+		return err
 	}
 	if err := tsv.qe.Open(); err != nil {
 		return err

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -609,7 +609,7 @@ func (tsv *TabletServer) waitForShutdown() {
 	tsv.txThrottler.Close()
 	tsv.watcher.Close()
 	tsv.te.Close()
-	tsv.qe.streamQList.TerminateAll()
+	tsv.qe.StopServing()
 	tsv.requests.Wait()
 }
 
@@ -624,7 +624,7 @@ func (tsv *TabletServer) closeAll() {
 	tsv.hr.Close()
 	tsv.hw.Close()
 	tsv.te.Close()
-	tsv.qe.streamQList.TerminateAll()
+	tsv.qe.StopServing()
 	tsv.qe.Close()
 	tsv.se.Close()
 	tsv.transition(StateNotConnected)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -230,7 +230,7 @@ func NewTabletServer(name string, config *tabletenv.TabletConfig, topoServer *to
 	tsv.se = schema.NewEngine(tsv)
 	tsv.hw = heartbeat.NewWriter(tsv, alias)
 	tsv.hr = heartbeat.NewReader(tsv)
-	tsv.vstreamer = vstreamer.NewEngine(tsv, srvTopoServer, tsv.se)
+	tsv.vstreamer = vstreamer.NewEngine(tsv, srvTopoServer, tsv.se, alias.Cell)
 	tsv.tracker = schema.NewTracker(tsv, tsv.vstreamer, tsv.se)
 	tsv.watcher = NewReplicationWatcher(tsv, tsv.vstreamer, tsv.config)
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
@@ -372,6 +372,7 @@ func (tsv *TabletServer) InitDBConfig(target querypb.Target, dbcfgs *dbconfigs.D
 	tsv.hw.InitDBConfig(target)
 	tsv.hr.InitDBConfig(target)
 	tsv.txThrottler.InitDBConfig(target)
+	tsv.vstreamer.InitDBConfig(target.Keyspace)
 	return nil
 }
 
@@ -532,7 +533,7 @@ func (tsv *TabletServer) fullStart() (err error) {
 	if err := tsv.se.Open(); err != nil {
 		return err
 	}
-	tsv.vstreamer.Open(tsv.target.Keyspace, tsv.alias.Cell)
+	tsv.vstreamer.Open()
 	if err := tsv.qe.Open(); err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -297,10 +297,7 @@ func TestTabletServerSingleSchemaFailure(t *testing.T) {
 	dbcfgs := newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	err := tsv.StartService(target, dbcfgs)
-	defer tsv.StopService()
-	if err != nil {
-		t.Fatalf("TabletServer should successfully start even if a table's schema is unloadable, but got error: %v", err)
-	}
+	assert.Error(t, err)
 }
 
 func TestTabletServerCheckMysql(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2756,7 +2756,6 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 			RowsAffected: 1,
 		},
 		// queries for twopc
-		sqlTurnoffBinlog:                                {},
 		fmt.Sprintf(sqlCreateSidecarDB, "_vt"):          {},
 		fmt.Sprintf(sqlDropLegacy1, "_vt"):              {},
 		fmt.Sprintf(sqlDropLegacy2, "_vt"):              {},

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -61,16 +61,12 @@ func TestTabletServerGetState(t *testing.T) {
 		StateNotConnected,
 		StateNotServing,
 		StateServing,
-		StateTransitioning,
-		StateShuttingDown,
 	}
 	// Don't reuse stateName.
 	names := []string{
 		"NOT_SERVING",
 		"NOT_SERVING",
 		"SERVING",
-		"NOT_SERVING",
-		"SHUTTING_DOWN",
 	}
 	config := tabletenv.NewDefaultConfig()
 	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2162,7 +2162,7 @@ func setupTabletServerTest(t *testing.T) (*fakesqldb.DB, *TabletServer) {
 func setupTabletServerTestCustom(t *testing.T, config *tabletenv.TabletConfig) (*fakesqldb.DB, *TabletServer) {
 	db := setupFakeDB(t)
 	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
-	require.Equal(t, int64(StateNotConnected), tsv.sm.State())
+	require.Equal(t, StateNotConnected, tsv.sm.State())
 	dbcfgs := newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	err := tsv.StartService(target, dbcfgs)

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -223,7 +223,7 @@ func (t *TxThrottler) Open() error {
 		return nil
 	}
 	if t.state != nil {
-		return fmt.Errorf("transaction throttler already opened")
+		return nil
 	}
 	var err error
 	t.state, err = newTxThrottlerState(t.config, t.target.Keyspace, t.target.Shard)

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -39,7 +39,11 @@ func TestDisabledThrottler(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	config.EnableTxThrottler = false
 	throttler := NewTxThrottler(config, nil)
-	if err := throttler.Open("keyspace", "shard"); err != nil {
+	throttler.InitDBConfig(querypb.Target{
+		Keyspace: "keyspace",
+		Shard:    "shard",
+	})
+	if err := throttler.Open(); err != nil {
 		t.Fatalf("want: nil, got: %v", err)
 	}
 	if result := throttler.Throttle(); result != false {
@@ -117,7 +121,11 @@ func TestEnabledThrottler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("want: nil, got: %v", err)
 	}
-	if err := throttler.Open("keyspace", "shard"); err != nil {
+	throttler.InitDBConfig(querypb.Target{
+		Keyspace: "keyspace",
+		Shard:    "shard",
+	})
+	if err := throttler.Open(); err != nil {
 		t.Fatalf("want: nil, got: %v", err)
 	}
 	if result := throttler.Throttle(); result != false {

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -100,15 +100,14 @@ func (vse *Engine) InitDBConfig(keyspace string) {
 }
 
 // Open starts the Engine service.
-func (vse *Engine) Open() error {
+func (vse *Engine) Open() {
 	vse.mu.Lock()
 	defer vse.mu.Unlock()
 	if vse.isOpen {
-		return nil
+		return
 	}
 	log.Info("VStreamer is open.")
 	vse.isOpen = true
-	return nil
 }
 
 // IsOpen checks if the engine is opened

--- a/go/vt/vttablet/tabletserver/vstreamer/main_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/main_test.go
@@ -52,8 +52,9 @@ func TestMain(m *testing.M) {
 
 		// engine cannot be initialized in testenv because it introduces
 		// circular dependencies
-		engine = NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine)
-		engine.Open(env.KeyspaceName, env.Cells[0])
+		engine = NewEngine(env.TabletEnv, env.SrvTopo, env.SchemaEngine, env.Cells[0])
+		engine.InitDBConfig(env.KeyspaceName)
+		engine.Open()
 		defer engine.Close()
 
 		return m.Run()
@@ -68,7 +69,8 @@ func customEngine(t *testing.T, modifier func(mysql.ConnParams) mysql.ConnParams
 	config := env.TabletEnv.Config().Clone()
 	config.DB = dbconfigs.NewTestDBConfigs(modified, modified, modified.DbName)
 
-	engine := NewEngine(tabletenv.NewEnv(config, "VStreamerTest"), env.SrvTopo, env.SchemaEngine)
-	engine.Open(env.KeyspaceName, env.Cells[0])
+	engine := NewEngine(tabletenv.NewEnv(config, "VStreamerTest"), env.SrvTopo, env.SchemaEngine, env.Cells[0])
+	engine.InitDBConfig(env.KeyspaceName)
+	engine.Open()
 	return engine
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -424,6 +424,10 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 					Type: binlogdatapb.VEventType_DDL,
 					Ddl:  q.SQL,
 				})
+				// Reload schema only if the DDL change is relevant.
+				// TODO(sougou): move this back to always load after
+				// the schema reload bug is fixed.
+				vs.se.ReloadAt(context.Background(), vs.pos)
 			} else {
 				// If the DDL need not be sent, send a dummy OTHER event.
 				vevents = append(vevents, &binlogdatapb.VEvent{
@@ -433,7 +437,6 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 					Type: binlogdatapb.VEventType_OTHER,
 				})
 			}
-			vs.se.ReloadAt(context.Background(), vs.pos)
 		case sqlparser.StmtOther, sqlparser.StmtPriv:
 			// These are either:
 			// 1) DBA statements like REPAIR that can be ignored.

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -57,8 +57,9 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 	defer env.SchemaEngine.EnableHistorian(false)
 
-	engine = NewEngine(engine.env, env.SrvTopo, env.SchemaEngine)
-	engine.Open(env.KeyspaceName, env.Cells[0])
+	engine = NewEngine(engine.env, env.SrvTopo, env.SchemaEngine, env.Cells[0])
+	engine.InitDBConfig(env.KeyspaceName)
+	engine.Open()
 	defer engine.Close()
 
 	execStatements(t, []string{

--- a/go/vt/withddl/withddl.go
+++ b/go/vt/withddl/withddl.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 // WithDDL allows you to execute statements against
@@ -64,7 +65,7 @@ func (wd *WithDDL) Exec(ctx context.Context, query string, f interface{}) (*sqlt
 		return nil, err
 	}
 
-	log.Infof("Updating schema for %v and retrying: %v", query, err)
+	log.Infof("Updating schema for %v and retrying: %v", sqlparser.TruncateForUI(err.Error()), err)
 	for _, query := range wd.ddls {
 		_, merr := exec(query)
 		if merr == nil {


### PR DESCRIPTION
The tabletserver can now remember its desired state and continuously retry if the first attempt fails. This responsibility was previously with tabletmanager. This change allows us to delete the corresponding code from tabletmanager.

Most sub-component function calls have been normalized to simplify state management. All such functions are now idempotent.

The new stateManager invokes the necessary functions to reach any required state knowing that the functions are idempotent. This allows it to act in a manner that is agnostic of what the current state is.

Strict ordering rules have been defined for how to open and close various services.