### PR TITLE
fix: golangci-lint precheck

### DIFF
--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -19,6 +19,9 @@
 
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 
+# xargs -n1 because dirname on MacOS does not support multiple arguments.
+gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
+
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then
   echo "Downloading golangci-lint..."
@@ -26,8 +29,8 @@ if [ $? -eq 1 ]; then
 fi
 
 #golangci-lint run --disable=ineffassign,unused,gosimple,staticcheck,errcheck,structcheck,varcheck,deadcode
-for gofile in $gofiles
+for gopackage in $gopackages
 do
- golangci-lint run --disable=errcheck --timeout=10m $gofile
- echo $gofile
+ echo "Linting $gopackage"
+ golangci-lint run --disable=errcheck --timeout=10m $gopackage
 done


### PR DESCRIPTION
Running ci on just a changed file raises warnings because the tool
doesn't seem to include other files in the package. So, changing
it to check the whole package instead.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>