### PR TITLE
test: faster unit tests

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -210,7 +210,6 @@ func (db *DB) Close() {
 	db.listener.Close()
 	db.acceptWG.Wait()
 
-	db.WaitForClose(250 * time.Millisecond)
 	db.CloseAllConnections()
 
 	tmpDir := path.Dir(db.socketFile)


### PR DESCRIPTION
The fakesqldb was waiting .25 seconds on every call to Close.
This speeds up the tabletserver test considerably.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>