### PR TITLE
batch the lookup query when the column type is integral or binary

### DIFF
--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -214,6 +214,22 @@ func BuildBindVariable(v interface{}) (*querypb.BindVariable, error) {
 			bv.Values[i] = &values[i]
 		}
 		return bv, nil
+	case []Value:
+		bv := &querypb.BindVariable{
+			Type:   querypb.Type_TUPLE,
+			Values: make([]*querypb.Value, len(v)),
+		}
+		values := make([]querypb.Value, len(v))
+		for i, lv := range v {
+			lbv, err := BuildBindVariable(lv)
+			if err != nil {
+				return nil, err
+			}
+			values[i].Type = lbv.Type
+			values[i].Value = lbv.Value
+			bv.Values[i] = &values[i]
+		}
+		return bv, nil
 	}
 	return nil, fmt.Errorf("type %T not supported as bind var: %v", v, v)
 }

--- a/go/vt/vtexplain/testdata/multi-output/deletesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/deletesharded-output.txt
@@ -27,7 +27,7 @@ delete from user where id=1
 delete from user where name='billy'
 
 1 ks_sharded/c0-: begin
-1 ks_sharded/c0-: select user_id from name_user_map where name = 'billy' limit 10001
+1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('billy') limit 10001
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: select id, name from user where name = 'billy' limit 10001 for update
 3 ks_sharded/40-80: begin

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -22,7 +22,7 @@ select * from user where id > 100 /* scatter range */
 ----------------------------------------------------------------------
 select * from user where name = 'bob' /* vindex lookup */
 
-1 ks_sharded/c0-: select user_id from name_user_map where name = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('bob') limit 10001 /* vindex lookup */
 2 ks_sharded/-40: select * from user where name = 'bob' limit 10001 /* vindex lookup */
 
 ----------------------------------------------------------------------
@@ -59,9 +59,9 @@ select count(*) from user where id = 1 /* point aggregate */
 ----------------------------------------------------------------------
 select count(*) from user where name in ('alice','bob') /* scatter aggregate */
 
-1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001 /* scatter aggregate */
-2 ks_sharded/c0-: select user_id from name_user_map where name = 'bob' limit 10001 /* scatter aggregate */
-3 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
+1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice') limit 10001 /* scatter aggregate */
+1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('bob') limit 10001 /* scatter aggregate */
+2 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */

--- a/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
@@ -9,7 +9,7 @@ update user set nickname='alice' where id=1
 update user set nickname='alice' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001
+1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice') limit 10001
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: update user set nickname = 'alice' where name = 'alice' limit 10001
 3 ks_sharded/40-80: commit
@@ -40,7 +40,7 @@ update user set name='alicia' where id=1
 update user set name='alicia' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001
+1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice') limit 10001
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: select id, name from user where name = 'alice' limit 10001 for update
 3 ks_sharded/40-80: delete from name_user_map where name = 'name_val_2' and user_id = 1 limit 10001
@@ -71,7 +71,7 @@ update /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ name_info set has_nickname=1 where nick
 update user set pet='rover' where name='alice'
 
 1 ks_sharded/40-80: begin
-1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001
+1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice') limit 10001
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: update user set pet = 'rover' where name = 'alice' limit 10001
 3 ks_sharded/40-80: commit

--- a/go/vt/vtexplain/testdata/twopc-output/deletesharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/deletesharded-output.txt
@@ -42,7 +42,7 @@ delete from user where id=1
 delete from user where name='billy'
 
 1 ks_sharded/c0-: begin
-1 ks_sharded/c0-: select user_id from name_user_map where name = 'billy' limit 10001
+1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('billy') limit 10001
 2 ks_sharded/-40: begin
 2 ks_sharded/-40: select name from user where name = 'billy' limit 10001 for update
 3 ks_sharded/80-c0: begin

--- a/go/vt/vtexplain/testdata/twopc-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/selectsharded-output.txt
@@ -22,7 +22,7 @@ select * from user where id > 100 /* scatter range */
 ----------------------------------------------------------------------
 select * from user where name = 'bob' /* vindex lookup */
 
-1 ks_sharded/c0-: select user_id from name_user_map where name = 'bob' limit 10001 /* vindex lookup */
+1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('bob') limit 10001 /* vindex lookup */
 2 ks_sharded/-40: select * from user where name = 'bob' limit 10001 /* vindex lookup */
 
 ----------------------------------------------------------------------
@@ -59,9 +59,8 @@ select count(*) from user where id = 1 /* point aggregate */
 ----------------------------------------------------------------------
 select count(*) from user where name in ('alice','bob') /* scatter aggregate */
 
-1 ks_sharded/40-80: select user_id from name_user_map where name = 'alice' limit 10001 /* scatter aggregate */
-2 ks_sharded/c0-: select user_id from name_user_map where name = 'bob' limit 10001 /* scatter aggregate */
-3 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
+1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
+2 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -499,30 +499,66 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 			}
 		}
 
+		// the query against lookup table is in-query, handle it specifically
+		var inColName string
+		inVal := make([][]byte, 0, 10)
+		rowCount := 1
+		if selStmt.Where != nil {
+			switch v := selStmt.Where.Expr.(type) {
+			case *sqlparser.ComparisonExpr:
+				if v.Operator == sqlparser.InStr {
+					switch c := v.Left.(type) {
+					case *sqlparser.ColName:
+						switch values := v.Right.(type) {
+						case sqlparser.ValTuple:
+							for _, val := range values {
+								switch v := val.(type) {
+								case *sqlparser.SQLVal:
+									inVal = append(inVal, v.Val)
+								}
+							}
+							rowCount = len(inVal)
+						}
+						inColName = strings.ToLower(c.Name.String())
+					}
+				}
+			}
+		}
+
 		fields := make([]*querypb.Field, len(colNames))
-		values := make([]sqltypes.Value, len(colNames))
+		rows := make([][]sqltypes.Value, 0, rowCount)
 		for i, col := range colNames {
 			colType := colTypes[i]
 			fields[i] = &querypb.Field{
 				Name: col,
 				Type: colType,
 			}
+		}
 
-			// Generate a fake value for the given column. For numeric types,
-			// use the column index. For all other types, just shortcut to using
-			// a string type that encodes the column name + index.
-			if sqltypes.IsIntegral(colType) {
-				values[i] = sqltypes.NewInt32(int32(i + 1))
-			} else if sqltypes.IsFloat(colType) {
-				values[i] = sqltypes.NewFloat64(1.0 + float64(i))
-			} else {
-				values[i] = sqltypes.NewVarChar(fmt.Sprintf("%s_val_%d", col, i+1))
+		for j := 0; j < rowCount; j++ {
+			values := make([]sqltypes.Value, len(colNames))
+			for i, col := range colNames {
+				// Generate a fake value for the given column. For the column in the IN clause,
+				// use the provided values in the query, For numeric types,
+				// use the column index. For all other types, just shortcut to using
+				// a string type that encodes the column name + index.
+				colType := colTypes[i]
+				if len(inVal) > j && col == inColName {
+					values[i], _ = sqltypes.NewValue(querypb.Type_VARBINARY, inVal[j])
+				} else if sqltypes.IsIntegral(colType) {
+					values[i] = sqltypes.NewInt32(int32(i + 1))
+				} else if sqltypes.IsFloat(colType) {
+					values[i] = sqltypes.NewFloat64(1.0 + float64(i))
+				} else {
+					values[i] = sqltypes.NewVarChar(fmt.Sprintf("%s_val_%d", col, i+1))
+				}
 			}
+			rows = append(rows, values)
 		}
 		result = &sqltypes.Result{
 			Fields:   fields,
 			InsertID: 0,
-			Rows:     [][]sqltypes.Value{values},
+			Rows:     rows,
 		}
 
 		resultJSON, _ := json.MarshalIndent(result, "", "    ")

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -111,7 +111,7 @@ func TestDeleteEqualNoRoute(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		// This lookup query will return no rows. So, the DML will not be sent anywhere.
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:<type:INT64 value:"1" >  false`,
 	})
 }
 

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -163,7 +163,7 @@ func TestUpdateEqualNoRoute(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		// This lookup query will return no rows. So, the DML will not be sent anywhere.
-		`Execute select toc from lkp where from = :from from: type:INT64 value:"1"  false`,
+		`Execute select from, toc from lkp where from in ::from from: type:TUPLE values:<type:INT64 value:"1" >  false`,
 	})
 }
 

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -69,8 +69,7 @@ func TestConsistentLookupUniqueInfo(t *testing.T) {
 func TestConsistentLookupMap(t *testing.T) {
 	lookup := createConsistentLookup(t, "consistent_lookup", false)
 	vc := &loggingVCursor{}
-	vc.AddResult(makeTestResult(2), nil)
-	vc.AddResult(makeTestResult(2), nil)
+	vc.AddResult(makeTestResultLookup([]int{2, 2}), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	require.NoError(t, err)
@@ -88,8 +87,7 @@ func TestConsistentLookupMap(t *testing.T) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 	vc.verifyLog(t, []string{
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 1}] false",
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 2}] false",
+		"Execute select fromc1, toc from t where fromc1 in ::fromc1 [{fromc1 }] false",
 	})
 
 	// Test query fail.
@@ -122,8 +120,7 @@ func TestConsistentLookupMapWriteOnly(t *testing.T) {
 func TestConsistentLookupUniqueMap(t *testing.T) {
 	lookup := createConsistentLookup(t, "consistent_lookup_unique", false)
 	vc := &loggingVCursor{}
-	vc.AddResult(makeTestResult(0), nil)
-	vc.AddResult(makeTestResult(1), nil)
+	vc.AddResult(makeTestResultLookup([]int{0, 1}), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	require.NoError(t, err)
@@ -135,12 +132,11 @@ func TestConsistentLookupUniqueMap(t *testing.T) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 	vc.verifyLog(t, []string{
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 1}] false",
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 2}] false",
+		"Execute select fromc1, toc from t where fromc1 in ::fromc1 [{fromc1 }] false",
 	})
 
 	// More than one result is invalid
-	vc.AddResult(makeTestResult(2), nil)
+	vc.AddResult(makeTestResultLookup([]int{2}), nil)
 	_, err = lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
 	wanterr := "Lookup.Map: unexpected multiple results from vindex t: INT64(1)"
 	if err == nil || err.Error() != wanterr {
@@ -169,8 +165,7 @@ func TestConsistentLookupUniqueMapWriteOnly(t *testing.T) {
 func TestConsistentLookupMapAbsent(t *testing.T) {
 	lookup := createConsistentLookup(t, "consistent_lookup", false)
 	vc := &loggingVCursor{}
-	vc.AddResult(makeTestResult(0), nil)
-	vc.AddResult(makeTestResult(0), nil)
+	vc.AddResult(makeTestResultLookup([]int{0, 0}), nil)
 
 	got, err := lookup.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	require.NoError(t, err)
@@ -182,8 +177,7 @@ func TestConsistentLookupMapAbsent(t *testing.T) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 	vc.verifyLog(t, []string{
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 1}] false",
-		"Execute select toc from t where fromc1 = :fromc1 [{fromc1 2}] false",
+		"Execute select fromc1, toc from t where fromc1 in ::fromc1 [{fromc1 }] false",
 	})
 }
 
@@ -572,15 +566,38 @@ func (vc *loggingVCursor) verifyLog(t *testing.T, want []string) {
 	}
 }
 
+// create lookup result with one to one mapping
 func makeTestResult(numRows int) *sqltypes.Result {
 	result := &sqltypes.Result{
-		Fields:       sqltypes.MakeTestFields("keyspace_id", "varbinary"),
+		Fields:       sqltypes.MakeTestFields("id|keyspace_id", "bigint|varbinary"),
 		RowsAffected: uint64(numRows),
 	}
 	for i := 0; i < numRows; i++ {
 		result.Rows = append(result.Rows, []sqltypes.Value{
+			sqltypes.NewInt64(int64(i + 1)),
 			sqltypes.NewVarBinary(strconv.Itoa(i + 1)),
 		})
+	}
+	return result
+}
+
+// create lookup result with many to many mapping
+func makeTestResultLookup(numRows []int) *sqltypes.Result {
+	total := 0
+	for _, t := range numRows {
+		total += t
+	}
+	result := &sqltypes.Result{
+		Fields:       sqltypes.MakeTestFields("id|keyspace_id", "bigint|varbinary"),
+		RowsAffected: uint64(total),
+	}
+	for i, row := range numRows {
+		for j := 0; j < row; j++ {
+			result.Rows = append(result.Rows, []sqltypes.Value{
+				sqltypes.NewInt64(int64(i + 1)),
+				sqltypes.NewVarBinary(strconv.Itoa(j + 1)),
+			})
+		}
 	}
 	return result
 }

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -86,8 +86,8 @@ func TestLookupHashMap(t *testing.T) {
 
 	// Test conversion fail.
 	vc.result = sqltypes.MakeTestResult(
-		sqltypes.MakeTestFields("a", "varbinary"),
-		"notint",
+		sqltypes.MakeTestFields("b|a", "int64|varbinary"),
+		"1|notint",
 	)
 	got, err = lookuphash.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestLookupHashMapAbsent(t *testing.T) {
 
 func TestLookupHashMapNull(t *testing.T) {
 	lookuphash := createLookup(t, "lookup_hash", false)
-	vc := &vcursor{numRows: 1}
+	vc := &vcursor{numRows: 1, keys: []sqltypes.Value{sqltypes.NULL}}
 
 	got, err := lookuphash.Map(vc, []sqltypes.Value{sqltypes.NULL})
 	require.NoError(t, err)

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -72,7 +72,7 @@ func TestLookupHashUniqueMap(t *testing.T) {
 	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("\x16k@\xb4J\xbaK\xd6")),
-		key.DestinationKeyspaceID([]byte("\x16k@\xb4J\xbaK\xd6")),
+		key.DestinationNone{},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
@@ -98,8 +98,8 @@ func TestLookupHashUniqueMap(t *testing.T) {
 
 	// Test conversion fail.
 	vc.result = sqltypes.MakeTestResult(
-		sqltypes.MakeTestFields("a", "varbinary"),
-		"notint",
+		sqltypes.MakeTestFields("b|a", "bigint|varbinary"),
+		"1|notint",
 	)
 	got, err = lhu.Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
 	require.NoError(t, err)

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -61,7 +61,7 @@ func (lkp *lookupInternal) Init(lookupQueryParams map[string]string, autocommit,
 	// TODO @rafael: update sel and ver to support multi column vindexes. This will be done
 	// as part of face 2 of https://github.com/vitessio/vitess/issues/3481
 	// For now multi column behaves as a single column for Map and Verify operations
-	lkp.sel = fmt.Sprintf("select %s from %s where %s = :%s", lkp.To, lkp.Table, lkp.FromColumns[0], lkp.FromColumns[0])
+	lkp.sel = fmt.Sprintf("select %s, %s from %s where %s in ::%s", lkp.FromColumns[0], lkp.To, lkp.Table, lkp.FromColumns[0], lkp.FromColumns[0])
 	lkp.ver = fmt.Sprintf("select %s from %s where %s = :%s and %s = :%s", lkp.FromColumns[0], lkp.Table, lkp.FromColumns[0], lkp.FromColumns[0], lkp.To, lkp.To)
 	lkp.del = lkp.initDelStmt()
 	return nil
@@ -73,21 +73,87 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value) ([]*sql
 		return nil, fmt.Errorf("cannot perform lookup: no vcursor provided")
 	}
 	results := make([]*sqltypes.Result, 0, len(ids))
-	for _, id := range ids {
-		bindVars := map[string]*querypb.BindVariable{
-			lkp.FromColumns[0]: sqltypes.ValueBindVariable(id),
+	if !ids[0].IsIntegral() && !ids[0].IsBinary() {
+		// for non integral and binary type, fallback to send query per id
+		for _, id := range ids {
+			vars, err := sqltypes.BuildBindVariable([]interface{}{id})
+			if err != nil {
+				return nil, fmt.Errorf("lookup.Map: %v", err)
+			}
+			bindVars := map[string]*querypb.BindVariable{
+				lkp.FromColumns[0]: vars,
+			}
+			var result *sqltypes.Result
+			co := vtgatepb.CommitOrder_NORMAL
+			if lkp.Autocommit {
+				co = vtgatepb.CommitOrder_AUTOCOMMIT
+			}
+			result, err = vcursor.Execute("VindexLookup", lkp.sel, bindVars, false /* rollbackOnError */, co)
+			if err != nil {
+				return nil, fmt.Errorf("lookup.Map: %v", err)
+			}
+			rows := make([][]sqltypes.Value, 0, len(result.Rows))
+			for _, row := range result.Rows {
+				rows = append(rows, []sqltypes.Value{row[1]})
+			}
+			results = append(results, &sqltypes.Result{
+				Rows: rows,
+			})
 		}
-		var err error
-		var result *sqltypes.Result
+	} else {
+		// for integral or binary type, batch query all ids and then map them back to the input order
+		idVars := make([]interface{}, len(ids))
+		for i := range ids {
+			idVars[i] = ids[i]
+		}
+		vars, err := sqltypes.BuildBindVariable(idVars)
+		if err != nil {
+			return nil, fmt.Errorf("lookup.Map: %v", err)
+		}
+		bindVars := map[string]*querypb.BindVariable{
+			lkp.FromColumns[0]: vars,
+		}
 		co := vtgatepb.CommitOrder_NORMAL
 		if lkp.Autocommit {
 			co = vtgatepb.CommitOrder_AUTOCOMMIT
 		}
-		result, err = vcursor.Execute("VindexLookup", lkp.sel, bindVars, false /* rollbackOnError */, co)
+		result, err := vcursor.Execute("VindexLookup", lkp.sel, bindVars, false /* rollbackOnError */, co)
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Map: %v", err)
 		}
-		results = append(results, result)
+		resultMap := make(map[string][][]byte)
+		t := querypb.Type_NULL_TYPE
+		for _, row := range result.Rows {
+			t = row[1].Type()
+			val, ok := resultMap[string(row[0].Raw())]
+			if ok {
+				val = append(val, row[1].Raw())
+			} else {
+				val = [][]byte{row[1].Raw()}
+			}
+			resultMap[string(row[0].Raw())] = val
+		}
+
+		for _, id := range ids {
+			val, ok := resultMap[string(id.Raw())]
+			if ok {
+				rows := make([][]sqltypes.Value, 0, len(val))
+				for _, row := range val {
+					val, err := sqltypes.NewValue(t, row)
+					if err != nil {
+						return nil, err
+					}
+					rows = append(rows, []sqltypes.Value{val})
+				}
+				results = append(results, &sqltypes.Result{
+					Rows: rows,
+				})
+			} else {
+				results = append(results, &sqltypes.Result{
+					Rows: make([][]sqltypes.Value, 0),
+				})
+			}
+		}
 	}
 	return results, nil
 }

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -72,7 +72,7 @@ func TestLookupUniqueMap(t *testing.T) {
 	require.NoError(t, err)
 	want := []key.Destination{
 		key.DestinationKeyspaceID([]byte("1")),
-		key.DestinationKeyspaceID([]byte("1")),
+		key.DestinationNone{},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %+v, want %+v", got, want)


### PR DESCRIPTION
batch the lookup query if the column is integral or binary, otherwise have one query per key to lookup as before. so it will only query once when the there are multiple keys. 