### PR TITLE
tabletserver: Fix conn pool leak in schema engine.

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -117,7 +117,18 @@ func (se *Engine) Open() error {
 	}
 
 	ctx := tabletenv.LocalContext()
+
+	// The function we're in is supposed to be idempotent, but this conns.Open()
+	// call is not itself idempotent. Therefore, if we return for any reason
+	// without marking ourselves as open, we need to call conns.Close() so the
+	// pools aren't leaked the next time we call Open().
 	se.conns.Open(se.cp, se.cp, se.cp)
+	defer func() {
+		if !se.isOpen {
+			se.conns.Close()
+		}
+	}()
+
 	se.tables = map[string]*Table{
 		"dual": NewTable("dual"),
 	}


### PR DESCRIPTION
We would leak the old pools if we failed to finish later steps of opening the schema engine.