### PR TITLE
tabletserver: Escape table name when fetching columns.

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -388,6 +388,7 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 				return fmt.Errorf("check your schema, table[%s] doesn't exist", likeTable)
 			}
 			schemaQueries["select * from "+table+" where 1 != 1"] = schemaQueries["select * from "+likeTable+" where 1 != 1"]
+			schemaQueries["select * from `"+table+"` where 1 != 1"] = schemaQueries["select * from "+likeTable+" where 1 != 1"]
 			continue
 		}
 		for _, idx := range ddl.TableSpec.Indexes {
@@ -412,6 +413,9 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 			tableColumns[table][colName] = col.Type.SQLType()
 		}
 		schemaQueries["select * from "+table+" where 1 != 1"] = &sqltypes.Result{
+			Fields: rowTypes,
+		}
+		schemaQueries["select * from `"+table+"` where 1 != 1"] = &sqltypes.Result{
 			Fields: rowTypes,
 		}
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -86,7 +86,7 @@ func TestOpenAndReload(t *testing.T) {
 			mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
 		},
 	})
-	db.AddQuery("select * from test_table_03 where 1 != 1", &sqltypes.Result{
+	db.AddQuery("select * from `test_table_03` where 1 != 1", &sqltypes.Result{
 		Fields: []*querypb.Field{{
 			Name: "pk1",
 			Type: sqltypes.Int32,
@@ -98,7 +98,7 @@ func TestOpenAndReload(t *testing.T) {
 			Type: sqltypes.Int32,
 		}},
 	})
-	db.AddQuery("select * from test_table_04 where 1 != 1", &sqltypes.Result{
+	db.AddQuery("select * from `test_table_04` where 1 != 1", &sqltypes.Result{
 		Fields: []*querypb.Field{{
 			Name: "pk",
 			Type: sqltypes.Int32,
@@ -293,7 +293,7 @@ func TestOpenFailedDueToTableErr(t *testing.T) {
 			mysql.BaseShowTablesRow("test_table", false, ""),
 		},
 	})
-	db.AddQuery("select * from test_table where 1 != 1", &sqltypes.Result{
+	db.AddQuery("select * from `test_table` where 1 != 1", &sqltypes.Result{
 		// this will cause NewTable error, as it expects zero rows.
 		Fields: []*querypb.Field{
 			{

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -48,7 +49,7 @@ func LoadTable(conn *connpool.DBConn, tableName string, tableType string, commen
 }
 
 func fetchColumns(ta *Table, conn *connpool.DBConn, sqlTableName string) error {
-	qr, err := conn.Exec(tabletenv.LocalContext(), fmt.Sprintf("select * from %s where 1 != 1", sqlTableName), 0, true)
+	qr, err := conn.Exec(tabletenv.LocalContext(), fmt.Sprintf("select * from %s where 1 != 1", sqlescape.EscapeID(sqlTableName)), 0, true)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -177,7 +177,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 
 func getTestLoadTableQueries() map[string]*sqltypes.Result {
 	return map[string]*sqltypes.Result{
-		"select * from test_table where 1 != 1": {
+		"select * from `test_table` where 1 != 1": {
 			Fields: []*querypb.Field{{
 				Name: "pk",
 				Type: sqltypes.Int32,
@@ -194,7 +194,7 @@ func getTestLoadTableQueries() map[string]*sqltypes.Result {
 
 func getMessageTableQueries() map[string]*sqltypes.Result {
 	return map[string]*sqltypes.Result{
-		"select * from test_table where 1 != 1": {
+		"select * from `test_table` where 1 != 1": {
 			Fields: []*querypb.Field{{
 				Name: "id",
 				Type: sqltypes.Int64,

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -28,7 +28,7 @@ import (
 // Queries returns a default set of queries that can
 // be added to load an initial set of tables into the schema.
 func Queries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
+	queries := map[string]*sqltypes.Result{
 		"select unix_timestamp()": {
 			Fields: []*querypb.Field{{
 				Type: sqltypes.Uint64,
@@ -138,4 +138,16 @@ func Queries() map[string]*sqltypes.Result {
 		"begin":  {},
 		"commit": {},
 	}
+
+	// Duplicate some entries that should return the same result for multiple forms.
+	// We have to support both because the schema engine always escapes table names,
+	// but the query engine only escapes table names when they are escaped in the
+	// original query.
+	queries["select * from `test_table_01` where 1 != 1"] = queries["select * from test_table_01 where 1 != 1"]
+	queries["select * from `test_table_02` where 1 != 1"] = queries["select * from test_table_02 where 1 != 1"]
+	queries["select * from `test_table_03` where 1 != 1"] = queries["select * from test_table_03 where 1 != 1"]
+	queries["select * from `seq` where 1 != 1"] = queries["select * from seq where 1 != 1"]
+	queries["select * from `msg` where 1 != 1"] = queries["select * from msg where 1 != 1"]
+
+	return queries
 }

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2678,7 +2678,7 @@ func checkTabletServerState(t *testing.T, tsv *TabletServer, expectState int64) 
 }
 
 func getSupportedQueries() map[string]*sqltypes.Result {
-	return map[string]*sqltypes.Result{
+	queries := map[string]*sqltypes.Result{
 		// Queries for how row protection test (txserializer).
 		"update test_table set name_string = 'tx1' where pk = 1 and name = 1 limit 10001": {
 			RowsAffected: 1,
@@ -2811,6 +2811,15 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 		"rollback": {},
 		fmt.Sprintf(sqlReadAllRedo, "_vt", "_vt"): {},
 	}
+
+	// Duplicate some entries that should return the same result for multiple forms.
+	// We have to support both because the schema engine always escapes table names,
+	// but the query engine only escapes table names when they are escaped in the
+	// original query.
+	queries["select * from `test_table` where 1 != 1"] = queries["select * from test_table where 1 != 1"]
+	queries["select * from `msg` where 1 != 1"] = queries["select * from msg where 1 != 1"]
+
+	return queries
 }
 
 func init() {


### PR DESCRIPTION
In case the table name would otherwise collide with a keyword.