### PR TITLE
vttablet: action lock needed to update mysql port

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -582,6 +582,12 @@ func (tm *TabletManager) findMysqlPort(retryInterval time.Duration) {
 		if err != nil {
 			continue
 		}
+		// We need to get the action lock to make sure no one
+		// else is updating the tablet.
+		if err := tm.lock(tm.BatchCtx); err != nil {
+			continue
+		}
+		defer tm.unlock()
 		log.Infof("Identified mysql port: %v", mport)
 		tm.pubMu.Lock()
 		tm.tablet.MysqlPort = mport


### PR DESCRIPTION
The restore function races with the mysql port finder, and sometimes
ends up overwriting the port with its own empty cached value.

This "big hammer" fix makes the port finder wait till it gets the
action lock before updating the mysql port. In a later cleanup,
we can use a more subtle method.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>