### PR TITLE
[draft] Add support for lookup vindex value encoders

### DIFF
--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -241,7 +241,7 @@ type LookupUnique struct {
 //   autocommit: setting this to "true" will cause deletes to be ignored.
 //   write_only: in this mode, Map functions return the full keyrange causing a full scatter.
 func NewLookupUnique(name string, m map[string]string) (Vindex, error) {
-	lu := &LookupUnique{name: name, encoder: nil}
+	lu := &LookupUnique{name: name}
 
 	autocommit, err := boolFromMap(m, "autocommit")
 	if err != nil {

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -42,8 +42,9 @@ func init() {
 	RegisterValueEncoder("numeric_uint64", numericUint64)
 }
 
-// RegisterValueEncoder will link an encoder that can be used on
-// lookup_unique hashes.
+// RegisterValueEncoder will define an encoder that can be used on
+// lookup & lookup_unique vindexes when resolving a keyspace ID from
+// another table's column content.
 func RegisterValueEncoder(name string, fn ValueEncoderFunc) {
 	if _, ok := valueEncoders[name]; ok {
 		panic(fmt.Sprintf("%s is already registered", name))
@@ -366,6 +367,6 @@ func numericUint64(input sqltypes.Value) ([]byte, error) {
 		return nil, fmt.Errorf("numericUint64: couldn't parse bytes: %v", err)
 	}
 	vBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(vBytes, v)
+	binary.PutUvarint(vBytes, v)
 	return vBytes, nil
 }

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -359,6 +359,6 @@ func numericUint64(input sqltypes.Value) ([]byte, error) {
 		return nil, fmt.Errorf("numericUint64: couldn't parse bytes: %v", err)
 	}
 	vBytes := make([]byte, 8)
-	binary.PutUvarint(vBytes, v)
+	binary.BigEndian.PutUint64(vBytes, v)
 	return vBytes, nil
 }

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -361,6 +361,8 @@ func (lu *LookupUnique) MarshalJSON() ([]byte, error) {
 }
 
 func numericUint64(input sqltypes.Value) ([]byte, error) {
+	// If attempting to cherry-pick this into a build <= 6.0 this needs to be
+	// rewritten as sqltypes.ToUint64
 	v, err := evalengine.ToUint64(input)
 	if err != nil {
 		return nil, fmt.Errorf("numericUint64: couldn't parse bytes: %v", err)

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 var (
@@ -310,7 +311,6 @@ func (lu *LookupUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([]key.Destin
 		case 0:
 			out = append(out, key.DestinationNone{})
 		case 1:
-			out = append(out, key.DestinationKeyspaceID(result.Rows[0][0].ToBytes()))
 			value := result.Rows[0][0]
 			if lu.encoder != nil {
 				encodedBytes, err := lu.encoder(value)
@@ -361,7 +361,7 @@ func (lu *LookupUnique) MarshalJSON() ([]byte, error) {
 }
 
 func numericUint64(input sqltypes.Value) ([]byte, error) {
-	v, err := sqltypes.ToUint64(input)
+	v, err := evalengine.ToUint64(input)
 	if err != nil {
 		return nil, fmt.Errorf("numericUint64: couldn't parse bytes: %v", err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -37,7 +37,7 @@ type lookupInternal struct {
 	Autocommit    bool     `json:"autocommit,omitempty"`
 	Upsert        bool     `json:"upsert,omitempty"`
 	IgnoreNulls   bool     `json:"ignore_nulls,omitempty"`
-	Encoder       []string `json:"encoder,omitempty"`
+	Encoder       string   `json:"encoder,omitempty"`
 	sel, ver, del string
 }
 
@@ -55,17 +55,8 @@ func (lkp *lookupInternal) Init(lookupQueryParams map[string]string, autocommit,
 	if err != nil {
 		return err
 	}
-	var encoders []string
-	if strings.TrimSpace(lookupQueryParams["encoder"]) != "" {
-		for _, enc := range strings.Split(lookupQueryParams["encoder"], ",") {
-			encoders = append(encoders, strings.TrimSpace(enc))
-		}
-	}
-	lkp.Encoder = encoders
-	if encoders != nil && len(lkp.Encoder) != len(lkp.FromColumns) {
-		return fmt.Errorf("Expected one encoder per from column (%v), got %v", len(lkp.FromColumns), len(lkp.Encoder))
-	}
 
+	lkp.Encoder = strings.TrimSpace(lookupQueryParams["encoder"])
 	lkp.Autocommit = autocommit
 	lkp.Upsert = upsert
 

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -37,6 +37,7 @@ type lookupInternal struct {
 	Autocommit    bool     `json:"autocommit,omitempty"`
 	Upsert        bool     `json:"upsert,omitempty"`
 	IgnoreNulls   bool     `json:"ignore_nulls,omitempty"`
+	Encoder       []string `json:"encoder,omitempty"`
 	sel, ver, del string
 }
 
@@ -53,6 +54,16 @@ func (lkp *lookupInternal) Init(lookupQueryParams map[string]string, autocommit,
 	lkp.IgnoreNulls, err = boolFromMap(lookupQueryParams, "ignore_nulls")
 	if err != nil {
 		return err
+	}
+	var encoders []string
+	if strings.TrimSpace(lookupQueryParams["encoder"]) != "" {
+		for _, enc := range strings.Split(lookupQueryParams["encoder"], ",") {
+			encoders = append(encoders, strings.TrimSpace(enc))
+		}
+	}
+	lkp.Encoder = encoders
+	if encoders != nil && len(lkp.Encoder) != len(lkp.FromColumns) {
+		return fmt.Errorf("Expected one encoder per from column (%v), got %v", len(lkp.FromColumns), len(lkp.Encoder))
 	}
 
 	lkp.Autocommit = autocommit

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -134,31 +134,15 @@ func TestLookupNonUniqueNewWithEncoders(t *testing.T) {
 		"table":   "t",
 		"from":    "fromc,fromc2",
 		"to":      "toc",
-		"encoder": "nop,numeric_uint64",
+		"encoder": "numeric_uint64",
 	})
 	if err != nil {
 		t.Fatal(fmt.Sprintf("Failed to construct LookupNonUnique with encoder: %v", err))
 	}
 
-	encCount := len(lu.(*LookupNonUnique).encoders)
-	if encCount != 2 {
-		t.Errorf("Expected two encoders defined for LookupNonUnique vindex, got %v", encCount)
-	}
-}
-
-func TestLookupNonUniqueNewWithTooFewEncoders(t *testing.T) {
-	ln, err := CreateVindex("lookup", "lookup", map[string]string{
-		"table":   "t",
-		"from":    "fromc,fromc2",
-		"to":      "toc",
-		"encoder": "numeric_uint64",
-	})
-	if err == nil {
-		t.Fatal("Expected to fail constructing a LookupNonUnique when not enough encoding function provided")
-	}
-
-	if ln != nil {
-		t.Errorf("Expected no LookupNonUnique when passed bad arguments")
+	encoder := lu.(*LookupNonUnique).encoder
+	if encoder == nil {
+		t.Errorf("Expected encoder defined for LookupNonUnique vindex, got none")
 	}
 }
 
@@ -227,7 +211,7 @@ func TestLookupNonUniqueMapWithEncoders(t *testing.T) {
 		"table":   "t",
 		"from":    "fromc,fromc2",
 		"to":      "toc",
-		"encoder": "nop,numeric_uint64",
+		"encoder": "numeric_uint64",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -240,15 +224,16 @@ func TestLookupNonUniqueMapWithEncoders(t *testing.T) {
 		t.Error(err)
 	}
 
+	k1Bytes, _ := numericUint64(sqltypes.NewUint64(uint64(1)))
 	k2Bytes, _ := numericUint64(sqltypes.NewUint64(uint64(2)))
 
 	want := []key.Destination{
 		key.DestinationKeyspaceIDs([][]byte{
-			[]byte("1"),
+			k1Bytes,
 			k2Bytes,
 		}),
 		key.DestinationKeyspaceIDs([][]byte{
-			[]byte("1"),
+			k1Bytes,
 			k2Bytes,
 		}),
 	}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -258,6 +258,23 @@ func TestLookupNonUniqueMapWithEncoders(t *testing.T) {
 	}
 }
 
+func TestLookupNonUniqueNewHandlesMissingEncoder(t *testing.T) {
+	lu, err := CreateVindex("lookup", "lookup", map[string]string{
+		"table":   "t",
+		"from":    "fromc",
+		"to":      "toc",
+		"encoder": "encoder_bad_name",
+	})
+
+	if err == nil {
+		t.Errorf("expected error when constructing Lookup referencing an unknown encoder")
+	}
+
+	if lu != nil {
+		t.Errorf("Lookup returned, should be nil")
+	}
+}
+
 func TestLookupNonUniqueMapWithErrorEncoder(t *testing.T) {
 	lu, err := CreateVindex("lookup", "lookup", map[string]string{
 		"table":   "t",

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -172,6 +172,31 @@ func TestLookupUniqueMapWithEncoder(t *testing.T) {
 	}
 }
 
+func TestLookupUniqueMapWithErrorEncoder(t *testing.T) {
+	lu, err := CreateVindex("lookup_unique", "lu_with_encoder", map[string]string{
+		"table":   "t",
+		"from":    "fromc",
+		"to":      "toc",
+		"encoder": "encoder_err",
+	})
+	if err != nil {
+		t.Fatal("Unable to create lookup_unique vindex")
+	}
+
+	vc := &vcursor{numRows: 1}
+	got, err := lu.(SingleColumn).Map(
+		vc,
+		[]sqltypes.Value{sqltypes.NewUint64(uint64(1))},
+	)
+	if err == nil {
+		t.Errorf("Lookup.Map did return an error, expected an error")
+	}
+
+	if got != nil {
+		t.Errorf("Lookup.Map returned a key.Destination, expected nil")
+	}
+}
+
 func TestLookupUniqueMapWriteOnly(t *testing.T) {
 	lookupUnique := createLookup(t, "lookup_unique", true)
 	vc := &vcursor{numRows: 0}


### PR DESCRIPTION
## Description

We have a table that we'd like to use as a `lookup_unique` vindex, it has a schema similar to the following

```
CREATE TABLE objects (
    id int(10) NOT NULL,
    shard_id int(10) NOT NULL,
    PRYMARY KEY (id)
)
```

and we initially defined the vindex as such:

```
"vindexes": {
    "object_lookup_idx": {
        "type": "lookup_unique",
        "params": {
            "from": "id",
            "table": "objects",
            "to": "shard_id"
        }
    }
}
```

As currently implemented a `lookup[_unique]` vindex will take the bytes without any alteration and use that as the keyspace ID: `key.DestinationKeyspaceID(result.Rows[0][0].ToBytes()`.

This is problematic because mysql renders INTs that it's sending over the wire as a string ([ref](https://vitess.slack.com/archives/CMDJ2KFEZ/p1594473376236400)) so if you store 1000 in the `shard_id` field it will be treated as `"1000"` (`[]byte{31, 0, 0, 0}` instead of `[]byte{1}`) when constructing the keyspace ID and send the queries to a surprising shard.

### Change

This changes introduces the ability to register an encoder that can be specified as part of the vindex resolution process and provides a simple registered implementations:

- `numeric_uint64` -- an encoder that converts a value from the mysql wire protocol to a keyspace 

After this is merged we will be able to define the index like so:

```
"vindexes": {
    "object_lookup_idx": {
        "type": "lookup_unique",
        "params": {
            "from": "id",
            "table": "objects",
            "to": "shard_id",
            "encoder": "numeric_uint64"
        }
    }
}
```

and have our shard_id mapping work as expected.

## Testing

A bit WIP but, thus far, Unit testing