### PR TITLE
Vtexplain: migrate to new healthcheck

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -470,7 +470,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 
 }
 
-// Subscribe adds a listener. Only used for testing right now
+// Subscribe adds a listener. Used by vtgate buffer to learn about master changes.
 func (hc *HealthCheckImpl) Subscribe() chan *TabletHealth {
 	hc.subMu.Lock()
 	defer hc.subMu.Unlock()
@@ -479,7 +479,7 @@ func (hc *HealthCheckImpl) Subscribe() chan *TabletHealth {
 	return c
 }
 
-// Unsubscribe removes a listener. Only used for testing right now
+// Unsubscribe removes a listener.
 func (hc *HealthCheckImpl) Unsubscribe(c chan *TabletHealth) {
 	hc.subMu.Lock()
 	defer hc.subMu.Unlock()

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -51,28 +51,6 @@ func initTest(mode string, opts *Options, t *testing.T) {
 	require.NoError(t, err, "vtexplain Init error\n%s", string(schema))
 }
 
-func TestVTExplainWithNewHealthCheck(t *testing.T) {
-	schema, err := ioutil.ReadFile("testdata/test-healthcheck-schema.sql")
-	require.NoError(t, err)
-
-	vSchema, err := ioutil.ReadFile("testdata/test-healthcheck-vschema.json")
-	require.NoError(t, err)
-
-	opts := &Options{
-		ReplicationMode: "ROW",
-		NumShards:       2,
-		Normalize:       true,
-		StrictDDL:       true,
-		ExecutionMode:   ModeMulti,
-	}
-
-	err = Init(string(vSchema), string(schema), opts)
-	require.NoError(t, err, "vtexplain Init error\n%s", string(schema))
-
-	_, err = Run("SELECT * from t1")
-	require.NoError(t, err)
-}
-
 func testExplain(testcase string, opts *Options, t *testing.T) {
 	modes := []string{
 		ModeMulti,
@@ -175,7 +153,7 @@ func TestErrors(t *testing.T) {
 
 		{
 			SQL: "SELECT * FROM table_not_in_schema",
-			Err: "target: ks_unsharded.-.master, used tablet: explainCell-0 (ks_unsharded/-): unknown error: unable to resolve table name table_not_in_schema",
+			Err: "unknown error: unable to resolve table name table_not_in_schema",
 		},
 	}
 

--- a/go/vt/vtexplain/vtexplain_topo.go
+++ b/go/vt/vtexplain/vtexplain_topo.go
@@ -43,6 +43,8 @@ type ExplainTopo struct {
 
 	// Number of shards for sharded keyspaces
 	NumShards int
+
+	TopoServer *topo.Server
 }
 
 func (et *ExplainTopo) getSrvVSchema() *vschemapb.SrvVSchema {
@@ -56,7 +58,7 @@ func (et *ExplainTopo) getSrvVSchema() *vschemapb.SrvVSchema {
 
 // GetTopoServer is part of the srvtopo.Server interface
 func (et *ExplainTopo) GetTopoServer() (*topo.Server, error) {
-	return nil, nil
+	return et.TopoServer, nil
 }
 
 // GetSrvKeyspaceNames is part of the srvtopo.Server interface.

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -22,6 +22,8 @@ package vtexplain
 import (
 	"fmt"
 
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -42,7 +44,7 @@ import (
 var (
 	explainTopo    *ExplainTopo
 	vtgateExecutor *vtgate.Executor
-	healthCheck    *discovery.FakeLegacyHealthCheck
+	healthCheck    *discovery.FakeHealthCheck
 
 	vtgateSession = &vtgatepb.Session{
 		TargetString: "",
@@ -52,9 +54,10 @@ var (
 
 func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 	explainTopo = &ExplainTopo{NumShards: opts.NumShards}
-	healthCheck = discovery.NewFakeLegacyHealthCheck()
+	explainTopo.TopoServer = memorytopo.NewServer(vtexplainCell)
+	healthCheck = discovery.NewFakeHealthCheck()
 
-	resolver := newFakeResolver(opts, healthCheck, explainTopo, vtexplainCell)
+	resolver := newFakeResolver(opts, explainTopo, vtexplainCell)
 
 	err := buildTopology(opts, vSchemaStr, opts.NumShards)
 	if err != nil {
@@ -70,19 +73,19 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 	return nil
 }
 
-func newFakeResolver(opts *Options, hc discovery.LegacyHealthCheck, serv srvtopo.Server, cell string) *vtgate.Resolver {
+func newFakeResolver(opts *Options, serv srvtopo.Server, cell string) *vtgate.Resolver {
 	ctx := context.Background()
 	// change this back after fixing vtexplain to work with new healthcheck
 	// gw := vtgate.GatewayCreator()(ctx, hc, serv, cell, 3)
-	gw := vtgate.NewDiscoveryGateway(ctx, hc, serv, cell, 3)
-	gw.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_REPLICA})
+	gw := vtgate.NewTabletGateway(ctx, healthCheck, serv, cell)
+	_ = gw.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_REPLICA})
 
 	txMode := vtgatepb.TransactionMode_MULTI
 	if opts.ExecutionMode == ModeTwoPC {
 		txMode = vtgatepb.TransactionMode_TWOPC
 	}
 	tc := vtgate.NewTxConn(gw, txMode)
-	sc := vtgate.NewLegacyScatterConn("", tc, gw, hc)
+	sc := vtgate.NewScatterConn("", tc, gw)
 	srvResolver := srvtopo.NewResolver(serv, gw, cell)
 	return vtgate.NewResolver(srvResolver, serv, cell, sc)
 }

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -75,8 +75,6 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 
 func newFakeResolver(opts *Options, serv srvtopo.Server, cell string) *vtgate.Resolver {
 	ctx := context.Background()
-	// change this back after fixing vtexplain to work with new healthcheck
-	// gw := vtgate.GatewayCreator()(ctx, hc, serv, cell, 3)
 	gw := vtgate.NewTabletGateway(ctx, healthCheck, serv, cell)
 	_ = gw.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_REPLICA})
 

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -87,7 +87,7 @@ func newTablet(opts *Options, t *topodatapb.Tablet) *explainTablet {
 	}
 
 	// XXX much of this is cloned from the tabletserver tests
-	tsv := tabletserver.NewTabletServer(topoproto.TabletAliasString(t.Alias), config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
+	tsv := tabletserver.NewTabletServer(topoproto.TabletAliasString(t.Alias), config, memorytopo.NewServer(""), *t.Alias)
 
 	tablet := explainTablet{db: db, tsv: tsv}
 	db.Handler = &tablet

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -63,6 +63,7 @@ create table test_partitioned (
 	tablet := newTablet(defaultTestOpts(), &topodatapb.Tablet{
 		Keyspace: "test_keyspace",
 		Shard:    "-80",
+		Alias:    &topodatapb.TabletAlias{},
 	})
 	se := tablet.tsv.SchemaEngine()
 	tables := se.GetSchema()

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -40,7 +40,7 @@ func TestVStreamEvents(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 
@@ -114,7 +114,7 @@ func TestVStreamChunks(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 	sbc1 := hc.AddTestTablet("aa", "1.1.1.1", 1002, name, "20-40", topodatapb.TabletType_MASTER, true, 1, nil)
@@ -184,7 +184,7 @@ func TestVStreamMulti(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 	sbc1 := hc.AddTestTablet("aa", "1.1.1.1", 1002, name, "20-40", topodatapb.TabletType_MASTER, true, 1, nil)
@@ -243,7 +243,7 @@ func TestVStreamRetry(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 
@@ -282,7 +282,7 @@ func TestVStreamHeartbeat(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 
@@ -330,7 +330,7 @@ func TestVStreamJournalOneToMany(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 	sbc1 := hc.AddTestTablet("aa", "1.1.1.1", 1002, name, "-10", topodatapb.TabletType_MASTER, true, 1, nil)
@@ -435,7 +435,7 @@ func TestVStreamJournalManyToOne(t *testing.T) {
 	// Variable names are maintained like in OneToMany, but order is different.
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 	sbc1 := hc.AddTestTablet("aa", "1.1.1.1", 1002, name, "-10", topodatapb.TabletType_MASTER, true, 1, nil)
@@ -544,7 +544,7 @@ func TestVStreamJournalNoMatch(t *testing.T) {
 
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	sbc0 := hc.AddTestTablet("aa", "1.1.1.1", 1001, name, "-20", topodatapb.TabletType_MASTER, true, 1, nil)
 
@@ -670,7 +670,7 @@ func TestVStreamJournalPartialMatch(t *testing.T) {
 	// Variable names are maintained like in OneToMany, but order is different.1
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	_ = hc.AddTestTablet("aa", "1.1.1.1", 1002, name, "-10", topodatapb.TabletType_MASTER, true, 1, nil)
 	sbc2 := hc.AddTestTablet("aa", "1.1.1.1", 1003, name, "10-20", topodatapb.TabletType_MASTER, true, 1, nil)
@@ -748,7 +748,7 @@ func TestVStreamJournalPartialMatch(t *testing.T) {
 func TestResolveVStreamParams(t *testing.T) {
 	name := "TestVStream"
 	_ = createSandbox(name)
-	hc := discovery.NewFakeLegacyHealthCheck()
+	hc := discovery.NewFakeHealthCheck()
 	vsm := newTestVStreamManager(hc, new(sandboxTopo), "aa")
 	testcases := []struct {
 		input  *binlogdatapb.VGtid
@@ -872,8 +872,8 @@ func TestResolveVStreamParams(t *testing.T) {
 	}
 }
 
-func newTestVStreamManager(hc discovery.LegacyHealthCheck, serv srvtopo.Server, cell string) *vstreamManager {
-	gw := NewDiscoveryGateway(context.Background(), hc, serv, cell, 3)
+func newTestVStreamManager(hc discovery.HealthCheck, serv srvtopo.Server, cell string) *vstreamManager {
+	gw := NewTabletGateway(context.Background(), hc, serv, cell)
 	srvResolver := srvtopo.NewResolver(serv, gw, cell)
 	return newVStreamManager(srvResolver, serv, cell)
 }

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -302,9 +302,9 @@ func (sm *stateManager) StartRequest(ctx context.Context, target *querypb.Target
 	if target != nil {
 		switch {
 		case target.Keyspace != sm.target.Keyspace:
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v", target.Keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v does not match expected %v", target.Keyspace, sm.target.Keyspace)
 		case target.Shard != sm.target.Shard:
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v", target.Shard)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v does not match expected %v", target.Shard, sm.target.Shard)
 		case target.TabletType != sm.target.TabletType:
 			for _, otherType := range sm.alsoAllow {
 				if target.TabletType == otherType {
@@ -337,9 +337,9 @@ func (sm *stateManager) VerifyTarget(ctx context.Context, target *querypb.Target
 	if target != nil {
 		switch {
 		case target.Keyspace != sm.target.Keyspace:
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v", target.Keyspace)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid keyspace %v does not match expected %v", target.Keyspace, sm.target.Keyspace)
 		case target.Shard != sm.target.Shard:
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v", target.Shard)
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid shard %v does not match expected %v", target.Shard, sm.target.Shard)
 		case target.TabletType != sm.target.TabletType:
 			for _, otherType := range sm.alsoAllow {
 				if target.TabletType == otherType {


### PR DESCRIPTION
Fixes #6460 
vtexplain will now use TabletGateway with the new healthcheck.
Also migrated vstream tests to use new healthcheck.