### PR TITLE
Add more test cases for TestIgnoreMaxPayloadSizeDirective

### DIFF
--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -397,14 +397,21 @@ func TestIgnoreMaxPayloadSizeDirective(t *testing.T) {
 		{"insert /*vt+ IGNORE_MAX_PAYLOAD_SIZE=1 */ into user(id) values (1), (2)", true},
 		{"insert into user(id) values (1), (2)", false},
 		{"update /*vt+ IGNORE_MAX_PAYLOAD_SIZE=1 */ users set name=1", true},
+		{"update users set name=1", false},
 		{"select /*vt+ IGNORE_MAX_PAYLOAD_SIZE=1 */ * from users", true},
+		{"select * from users", false},
 		{"delete /*vt+ IGNORE_MAX_PAYLOAD_SIZE=1 */ from users", true},
+		{"delete from users", false},
+		{"show /*vt+ IGNORE_MAX_PAYLOAD_SIZE=1 */ create table users", false},
+		{"show create table users", false},
 	}
 
 	for _, test := range testCases {
-		stmt, _ := Parse(test.query)
-		got := IgnoreMaxPayloadSizeDirective(stmt)
-		assert.Equalf(t, test.expected, got, fmt.Sprintf("IgnoreMaxPayloadSizeDirective(stmt) returned %v but expected %v", got, test.expected))
+		t.Run(test.query, func(t *testing.T) {
+			stmt, _ := Parse(test.query)
+			got := IgnoreMaxPayloadSizeDirective(stmt)
+			assert.Equalf(t, test.expected, got, fmt.Sprintf("IgnoreMaxPayloadSizeDirective(stmt) returned %v but expected %v", got, test.expected))
+		})
 	}
 }
 


### PR DESCRIPTION
### Overview
This PR incorporates feedback from a [previous PR](https://github.com/vitessio/vitess/pull/6430) to add more test cases for `TestIgnoreMaxPayloadSizeDirective`.  The changes introduced in this PR account for more failure cases for this particular unit test (on par with the coverage in `TestIgnoreMaxMaxMemoryRowsDirective`). 

