### PR TITLE
add skip flag that can skip comparing source & destination schema  when run splitdiff

### DIFF
--- a/go/vt/worker/split_diff_cmd.go
+++ b/go/vt/worker/split_diff_cmd.go
@@ -87,6 +87,7 @@ func commandSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSe
 	minHealthyRdonlyTablets := subFlags.Int("min_healthy_rdonly_tablets", defaultMinHealthyTablets, "minimum number of healthy RDONLY tablets before taking out one")
 	destTabletTypeStr := subFlags.String("dest_tablet_type", defaultDestTabletType, "destination tablet type (RDONLY or REPLICA) that will be used to compare the shards")
 	parallelDiffsCount := subFlags.Int("parallel_diffs_count", defaultParallelDiffsCount, "number of tables to diff in parallel")
+	skipVerify := subFlags.Bool("skip-verify", false, "skip verification of source and target schema when diff")
 	if err := subFlags.Parse(args); err != nil {
 		return nil, err
 	}
@@ -108,7 +109,7 @@ func commandSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSe
 		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "command SplitDiff invalid dest_tablet_type: %v", destTabletType)
 	}
 
-	return NewSplitDiffWorker(wr, wi.cell, keyspace, shard, uint32(*sourceUID), excludeTableArray, *minHealthyRdonlyTablets, *parallelDiffsCount, topodatapb.TabletType(destTabletType)), nil
+	return NewSplitDiffWorker(wr, wi.cell, keyspace, shard, uint32(*sourceUID), excludeTableArray, *minHealthyRdonlyTablets, *parallelDiffsCount, topodatapb.TabletType(destTabletType), *skipVerify), nil
 }
 
 // shardsWithSources returns all the shards that have SourceShards set
@@ -226,7 +227,7 @@ func interactiveSplitDiff(ctx context.Context, wi *Instance, wr *wrangler.Wrangl
 
 	// start the diff job
 	// TODO: @rafael - Add option to set destination tablet type in UI form.
-	wrk := NewSplitDiffWorker(wr, wi.cell, keyspace, shard, uint32(sourceUID), excludeTableArray, int(minHealthyRdonlyTablets), int(parallelDiffsCount), topodatapb.TabletType_RDONLY)
+	wrk := NewSplitDiffWorker(wr, wi.cell, keyspace, shard, uint32(sourceUID), excludeTableArray, int(minHealthyRdonlyTablets), int(parallelDiffsCount), topodatapb.TabletType_RDONLY, false)
 	return wrk, nil, nil, nil
 }
 


### PR DESCRIPTION
In splitClone state:
if source destination shard table has column like:
`object_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT , 
Then after copy and exec it on destination the table column will turn to like this:
`object_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ,
In that case,(mysql's behavior) when source has too many tables contains columns as `object_id`.
there will be too much differ schema fail error out put on vtworkerclient side says:
remainder of the error is truncated because gRPC has a size limit on errors.
see the pic below:
![image](https://user-images.githubusercontent.com/2297199/88534704-3ccdf580-d03b-11ea-9fec-3cf7b388e6ee.png)

This will obscure the real problem.
so add this flag assumed people already know the schema does not match and make the process going on

Signed-off-by: JohnnyThree <whereshallyoube@gmail.com>