### PR TITLE
vttablet: create database if not present

### DIFF
--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -223,6 +223,11 @@ func (dbcfgs *DBConfigs) AppDebugWithDB() Connector {
 	return dbcfgs.makeParams(&dbcfgs.appdebugParams, true)
 }
 
+// AllPrivsConnector returns connection parameters for appdebug with no dbname set.
+func (dbcfgs *DBConfigs) AllPrivsConnector() Connector {
+	return dbcfgs.makeParams(&dbcfgs.allprivsParams, false)
+}
+
 // AllPrivsWithDB returns connection parameters for appdebug with dbname set.
 func (dbcfgs *DBConfigs) AllPrivsWithDB() Connector {
 	return dbcfgs.makeParams(&dbcfgs.allprivsParams, true)

--- a/go/vt/dbconfigs/dbconfigs_test.go
+++ b/go/vt/dbconfigs/dbconfigs_test.go
@@ -227,6 +227,9 @@ func TestAccessors(t *testing.T) {
 	if got, want := dbc.AppWithDB().connParams.DbName, "db"; got != want {
 		t.Errorf("dbc.AppWithDB().DbName: %v, want %v", got, want)
 	}
+	if got, want := dbc.AllPrivsConnector().connParams.DbName, ""; got != want {
+		t.Errorf("dbc.AllPrivsWithDB().DbName: %v, want %v", got, want)
+	}
 	if got, want := dbc.AllPrivsWithDB().connParams.DbName, "db"; got != want {
 		t.Errorf("dbc.AllPrivsWithDB().DbName: %v, want %v", got, want)
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"golang.org/x/net/context"
@@ -40,6 +41,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
@@ -71,6 +73,9 @@ type Engine struct {
 
 	conns *connpool.Pool
 	ticks *timer.Timer
+
+	// dbCreationFailed is for preventing log spam.
+	dbCreationFailed bool
 }
 
 // NewEngine creates a new Engine.
@@ -108,6 +113,49 @@ func NewEngine(env tabletenv.Env) *Engine {
 // InitDBConfig must be called before Open.
 func (se *Engine) InitDBConfig(cp dbconfigs.Connector) {
 	se.cp = cp
+}
+
+// EnsureConnectionAndDB ensures that we can connect to mysql.
+// If tablet type is master and there is no db, then the database is created.
+// This function can be called before opening the Engine.
+func (se *Engine) EnsureConnectionAndDB(tabletType topodatapb.TabletType) error {
+	ctx := tabletenv.LocalContext()
+	conn, err := dbconnpool.NewDBConnection(ctx, se.env.Config().DB.AppWithDB())
+	if err == nil {
+		conn.Close()
+		se.dbCreationFailed = false
+		return nil
+	}
+	if tabletType != topodatapb.TabletType_MASTER {
+		return err
+	}
+	if merr, isSQLErr := err.(*mysql.SQLError); !isSQLErr || merr.Num != mysql.ERBadDb {
+		return err
+	}
+
+	// We are master and db is not found. Let's create it.
+	// We use allprivs instead of DBA because we want db create to fail if we're read-only.
+	conn, err = dbconnpool.NewDBConnection(ctx, se.env.Config().DB.AllPrivsConnector())
+	if err != nil {
+		return vterrors.Wrap(err, "allprivs connection failed")
+	}
+	defer conn.Close()
+
+	dbname := se.env.Config().DB.DBName
+	_, err = conn.ExecuteFetch(fmt.Sprintf("create database if not exists `%s`", dbname), 1, false)
+	if err != nil {
+		if !se.dbCreationFailed {
+			// This is the first failure.
+			log.Errorf("db creation failed for %v: %v, will keep retrying", dbname, err)
+			se.dbCreationFailed = true
+		}
+		return err
+	}
+
+	se.dbCreationFailed = false
+	log.Infof("db %v created", dbname)
+	se.dbCreationFailed = false
+	return nil
 }
 
 // Open initializes the Engine. Calling Open on an already


### PR DESCRIPTION
This change addresses the use where we are initializing an externally managed mysql server, but which is empty. In this case, we should create the database.

I've implemented the db creation in the tabletserver. This means that ISM also does not need to create the database. However, this change causes ISM to hang (waiting for semi-sync) because the db creation happens before the replicas are pointed at the master. To work around this, I've moved the enforcement of semi-sync until after the db is created.

This change opens up two corner cases, both of which are unlikely in a production environment:
* Between the time that a tablet became master and semi-sync is enforced, an app can rush in and write data that does not meet the durability criteria. This is an unlikely scenario and low risk scenario because we are just initializing the cluster, and everything will converge to the right state after the replicas are wired up.
* A failure in the operation could result in a tablet being master, but semi-sync not being set. In this case, the ISM command will receive an error. This gives the operator the opportunity for an operator to go remedy the system, ideally by doing another reparent.

Finally, this is temporary. Within the next few PRs, ISM will be replaced by a version that happens automatically within vttablet itself.