### PR TITLE
Mini: fix tablet hostname

### DIFF
--- a/docker/mini/vttablet-mini-up.sh
+++ b/docker/mini/vttablet-mini-up.sh
@@ -44,7 +44,7 @@ vttablet \
  -log_dir $VTDATAROOT/tmp \
  -log_queries_to_file $VTDATAROOT/tmp/$tablet_logfile \
  -tablet-path $alias \
- -tablet_hostname "$tablet_hostname" \
+ -tablet_hostname "$hostname" \
  -init_db_name_override "$keyspace" \
  -init_keyspace $keyspace \
  -init_shard $shard \


### PR DESCRIPTION
So that this container can work with a non-host network

Signed-off-by:  <avovk@recurly.com>

I have a docker network and MySQL running in a container on that network.
Using the following `docker run`:

```
docker run -it --hostname vitess --name vitess -e "TOPOLOGY_SERVER=db:3306" -e "TOPOLOGY_USER=root" -e "TOPOLOGY_PASSWORD=dev" -e "MYSQL_SCHEMA=development" --network="development" vitess/mini:latest
```


I kept running into timeouts from `vtctlclient`. 
```
vitess@23cc1adb9441:/$ vtctlclient TabletExternallyReparented zone1-0000000100
E0729 23:04:55.257453     914 main.go:67] remote error: rpc error: code = Unavailable desc = transport is closing
```

Finally, identified that `hostname:port` for that command were not the ones where `vttablet` was listening.


I retested this using `--network=<custom>` and `--network=host`.