### PR TITLE
Remove shard session held in vtgate for reserved connection on connection failure

### DIFF
--- a/go/test/endtoend/vtgate/setstatement/sysvar_test.go
+++ b/go/test/endtoend/vtgate/setstatement/sysvar_test.go
@@ -227,7 +227,7 @@ func TestStartTxAndSetSystemVariableAndThenSuccessfulCommit(t *testing.T) {
 	assertMatches(t, conn, "select @@sql_safe_updates", "[[INT64(1)]]")
 }
 
-func TestSetSystemVarWithConnError(t *testing.T) {
+func TestSetSystemVarAutocommitWithConnError(t *testing.T) {
 	vtParams := mysql.ConnParams{
 		Host: "localhost",
 		Port: clusterInstance.VtgateMySQLPort,
@@ -259,7 +259,43 @@ func TestSetSystemVarWithConnError(t *testing.T) {
 	// subsequent queries on -80 will pass
 	assertMatches(t, conn, "select id from test where id = 2", "[]")
 	assertMatches(t, conn, "insert into test (id, val1) values (2, null)", "[]")
-	assertMatches(t, conn, "select id from test where id = 2", "[[INT64(2)]]")
+	assertMatches(t, conn, "select id, @@sql_safe_updates from test where id = 2", "[[INT64(2) INT64(1)]]")
+}
+
+func TestSetSystemVarInTxWithConnError(t *testing.T) {
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	checkedExec(t, conn, "delete from test")
+	checkedExec(t, conn, "insert into test (id, val1) values (1, null), (4, null)")
+
+	checkedExec(t, conn, "set sql_safe_updates = 1") // this should force us into a reserved connection
+	qr := checkedExec(t, conn, "select connection_id() from test where id = 4")
+	checkedExec(t, conn, "begin")
+	checkedExec(t, conn, "insert into test (id, val1) values (2, null)")
+
+	// kill the mysql connection shard which has transaction open.
+	vttablet1 := clusterInstance.Keyspaces[0].Shards[1].MasterTablet() // 80-
+	_, err = vttablet1.VttabletProcess.QueryTablet(fmt.Sprintf("kill %s", qr.Rows[0][0].ToString()), keyspaceName, false)
+	require.NoError(t, err)
+
+	// query to -80 shard should pass and remain in transaction.
+	assertMatches(t, conn, "select id, val1 from test where id = 2", "[[INT64(2) NULL]]")
+	checkedExec(t, conn, "rollback")
+	assertMatches(t, conn, "select id, val1 from test where id = 2", "[]")
+
+	// first query to 80- shard will fail
+	_, err = exec(t, conn, "select @@sql_safe_updates from test where id = 4")
+	require.Error(t, err)
+
+	// subsequent queries on 80- will pass
+	assertMatches(t, conn, "select id, @@sql_safe_updates from test where id = 4", "[[INT64(4) INT64(1)]]")
 }
 
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {

--- a/go/test/endtoend/vtgate/setstatement/sysvar_test.go
+++ b/go/test/endtoend/vtgate/setstatement/sysvar_test.go
@@ -227,6 +227,41 @@ func TestStartTxAndSetSystemVariableAndThenSuccessfulCommit(t *testing.T) {
 	assertMatches(t, conn, "select @@sql_safe_updates", "[[INT64(1)]]")
 }
 
+func TestSetSystemVarWithConnError(t *testing.T) {
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	checkedExec(t, conn, "delete from test")
+	checkedExec(t, conn, "insert into test (id, val1) values (1, null), (4, null)")
+
+	checkedExec(t, conn, "set sql_safe_updates = 1") // this should force us into a reserved connection
+	assertMatches(t, conn, "select id from test order by id", "[[INT64(1)] [INT64(4)]]")
+	qr := checkedExec(t, conn, "select connection_id() from test where id = 1")
+
+	// kill the mysql connection shard which has transaction open.
+	vttablet1 := clusterInstance.Keyspaces[0].Shards[0].MasterTablet() // -80
+	_, err = vttablet1.VttabletProcess.QueryTablet(fmt.Sprintf("kill %s", qr.Rows[0][0].ToString()), keyspaceName, false)
+	require.NoError(t, err)
+
+	// first query to 80- shard should pass
+	assertMatches(t, conn, "select id, val1 from test where id = 4", "[[INT64(4) NULL]]")
+
+	// first query to -80 shard will fail
+	_, err = exec(t, conn, "insert into test (id, val1) values (2, null)")
+	require.Error(t, err)
+
+	// subsequent queries on -80 will pass
+	assertMatches(t, conn, "select id from test where id = 2", "[]")
+	assertMatches(t, conn, "insert into test (id, val1) values (2, null)", "[]")
+	assertMatches(t, conn, "select id from test where id = 2", "[[INT64(2)]]")
+}
+
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
 	qr, err := exec(t, conn, query)

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -359,6 +359,11 @@ func TestLegaceHealthCheckFailsOnReservedConnections(t *testing.T) {
 
 func executeOnShards(t *testing.T, res *srvtopo.Resolver, keyspace string, sc *ScatterConn, session *SafeSession, destinations []key.Destination) {
 	t.Helper()
+	require.Empty(t, executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations))
+}
+
+func executeOnShardsReturnsErr(t *testing.T, res *srvtopo.Resolver, keyspace string, sc *ScatterConn, session *SafeSession, destinations []key.Destination) error {
+	t.Helper()
 	rss, _, err := res.ResolveDestinations(ctx, keyspace, topodatapb.TabletType_REPLICA, nil, destinations)
 	require.NoError(t, err)
 
@@ -372,7 +377,7 @@ func executeOnShards(t *testing.T, res *srvtopo.Resolver, keyspace string, sc *S
 	}
 
 	_, errs := sc.ExecuteMultiShard(ctx, rss, queries, session, false, false)
-	require.Empty(t, errs)
+	return vterrors.Aggregate(errs)
 }
 
 func TestMultiExecs(t *testing.T) {

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -396,3 +396,51 @@ func (session *SafeSession) ResetAll() {
 	session.PostSessions = nil
 	session.LockSession = nil
 }
+
+//ResetShard reset the shard session for the provided tablet alias.
+func (session *SafeSession) ResetShard(tabletAlias *topodatapb.TabletAlias) error {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	// Always append, in order for rollback to succeed.
+	switch session.commitOrder {
+	case vtgatepb.CommitOrder_NORMAL:
+		newSessions, err := removeShard(tabletAlias, session.ShardSessions)
+		if err != nil {
+			return err
+		}
+		session.ShardSessions = newSessions
+	case vtgatepb.CommitOrder_PRE:
+		newSessions, err := removeShard(tabletAlias, session.PreSessions)
+		if err != nil {
+			return err
+		}
+		session.PreSessions = newSessions
+	case vtgatepb.CommitOrder_POST:
+		newSessions, err := removeShard(tabletAlias, session.PostSessions)
+		if err != nil {
+			return err
+		}
+		session.PostSessions = newSessions
+	default:
+		// Should be unreachable
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "BUG: SafeSession.ResetShard: unexpected commitOrder")
+	}
+	return nil
+}
+
+func removeShard(tabletAlias *topodatapb.TabletAlias, sessions []*vtgatepb.Session_ShardSession) ([]*vtgatepb.Session_ShardSession, error) {
+	idx := -1
+	for i, session := range sessions {
+		if proto.Equal(session.TabletAlias, tabletAlias) {
+			if session.TransactionId != 0 {
+				return nil, vterrors.New(vtrpcpb.Code_INTERNAL, "BUG: SafeSession.ResetShard: in transaction")
+			}
+			idx = i
+		}
+	}
+	if idx == -1 {
+		return sessions, nil
+	}
+	return append(sessions[:idx], sessions[idx+1:]...), nil
+}

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -177,6 +177,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 				err     error
 				opts    *querypb.ExecuteOptions
 				alias   *topodatapb.TabletAlias
+				qs      queryservice.QueryService
 			)
 			transactionID := info.transactionID
 			reservedID := info.reservedID
@@ -192,7 +193,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 				}
 			}
 
-			qs, err := getQueryService(rs, info)
+			qs, err = getQueryService(rs, info)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -202,7 +202,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 			case nothing:
 				innerqr, err = qs.Execute(ctx, rs.Target, queries[i].Sql, queries[i].BindVariables, info.transactionID, info.reservedID, opts)
 				if err != nil {
-					resetShardSession(info, err, session)
+					checkAndResetShardSession(info, err, session)
 					return nil, err
 				}
 			case begin:
@@ -241,7 +241,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	return qr, allErrors.GetErrors()
 }
 
-func resetShardSession(info *shardActionInfo, err error, session *SafeSession) {
+func checkAndResetShardSession(info *shardActionInfo, err error, session *SafeSession) {
 	if info.reservedID != 0 && info.transactionID == 0 {
 		sqlErr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
 		if sqlErr.Number() == mysql.CRServerGone || sqlErr.Number() == mysql.CRServerLost {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/mysql"
+
 	"github.com/gogo/protobuf/proto"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -190,36 +192,30 @@ func (stc *ScatterConn) ExecuteMultiShard(
 				}
 			}
 
+			qs, err := getQueryService(rs, info)
+			if err != nil {
+				return nil, err
+			}
+
 			switch info.actionNeeded {
 			case nothing:
-				qs, err := getQueryService(rs, info)
-				if err != nil {
-					return nil, err
-				}
 				innerqr, err = qs.Execute(ctx, rs.Target, queries[i].Sql, queries[i].BindVariables, info.transactionID, info.reservedID, opts)
 				if err != nil {
+					resetShardSession(info, err, session)
 					return nil, err
 				}
 			case begin:
-				qs, err := getQueryService(rs, info)
-				if err != nil {
-					return nil, err
-				}
 				innerqr, transactionID, alias, err = qs.BeginExecute(ctx, rs.Target, session.Savepoints, queries[i].Sql, queries[i].BindVariables, info.reservedID, opts)
 				if err != nil {
 					return info.updateTransactionID(transactionID, alias), err
 				}
 			case reserve:
-				qs, err := getQueryService(rs, info)
-				if err != nil {
-					return nil, err
-				}
 				innerqr, reservedID, alias, err = qs.ReserveExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, info.transactionID, opts)
 				if err != nil {
 					return info.updateReservedID(reservedID, alias), err
 				}
 			case reserveBegin:
-				innerqr, transactionID, reservedID, alias, err = rs.Gateway.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, opts)
+				innerqr, transactionID, reservedID, alias, err = qs.ReserveBeginExecute(ctx, rs.Target, session.SetPreQueries(), queries[i].Sql, queries[i].BindVariables, opts)
 				if err != nil {
 					return info.updateTransactionAndReservedID(transactionID, reservedID, alias), err
 				}
@@ -242,6 +238,15 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	}
 
 	return qr, allErrors.GetErrors()
+}
+
+func resetShardSession(info *shardActionInfo, err error, session *SafeSession) {
+	if info.reservedID != 0 && info.transactionID == 0 {
+		sqlErr := mysql.NewSQLErrorFromError(err).(*mysql.SQLError)
+		if sqlErr.Number() == mysql.CRServerGone || sqlErr.Number() == mysql.CRServerLost {
+			session.ResetShard(info.alias)
+		}
+	}
 }
 
 func getQueryService(rs *srvtopo.ResolvedShard, info *shardActionInfo) (queryservice.QueryService, error) {

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -104,6 +104,8 @@ type SandboxConn struct {
 
 	sExecMu sync.Mutex
 	execMu  sync.Mutex
+
+	ShardErr error
 }
 
 var _ queryservice.QueryService = (*SandboxConn)(nil) // compile-time interface check
@@ -124,6 +126,9 @@ func (sbc *SandboxConn) getError() error {
 		}
 		sbc.MustFailCodes[code] = count - 1
 		return vterrors.New(code, fmt.Sprintf("%v error", code))
+	}
+	if sbc.ShardErr != nil {
+		return sbc.ShardErr
 	}
 	return nil
 }


### PR DESCRIPTION
When a reserved connection is used in transaction it is natural to call rollback/commit when a query execution failed.
But, when a reserved connection is used in non-transaction/autocommit mode, VTGate needs to handle to case to release the held reserved connection in session, to move forward on next query and recreate the reserved connection with correct settings.