### PR TITLE
ensure tests for discoverygateway

### DIFF
--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -205,7 +205,9 @@ func createCluster() (*cluster.LocalProcessCluster, int) {
 		// Long timeout in case failover is slow.
 		"-buffer_window", "10m",
 		"-buffer_max_failover_duration", "10m",
-		"-buffer_min_time_between_failovers", "20m"}
+		"-buffer_min_time_between_failovers", "20m",
+		// Use legacy gateway. tabletgateway test is at go/test/endtoend/tabletgateway/buffer/buffer_test.go
+		"-gateway_implementation", "discoverygateway"}
 
 	// Start vtgate
 	if err := clusterInstance.StartVtgate(); err != nil {


### PR DESCRIPTION
We have `cellAlias` and `buffer` tests for `tabletgateway` under `go/test/endtoend/tabletgateway`, so the tests under `go/test/endtoend/vtgate` can continue to use `discoverygateway`.
Also fixed `TestAddAliasWhileVtgateUp` which was failing with tabletgateway.

Signed-off-by: deepthi <deepthi@planetscale.com>