### PR TITLE
Reverts delete by destination owned vindexes

### DIFF
--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -83,7 +83,7 @@ func (del *Delete) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVar
 	case In:
 		return del.execDeleteIn(vcursor, bindVars)
 	case Scatter:
-		return del.execDeleteByDestination(vcursor, bindVars, key.DestinationAllShards{})
+		return del.execDeleteScatter(vcursor, bindVars, key.DestinationAllShards{})
 	case ByDestination:
 		return del.execDeleteByDestination(vcursor, bindVars, del.TargetDestination)
 	default:
@@ -164,6 +164,28 @@ func (del *Delete) execDeleteByDestination(vcursor VCursor, bindVars map[string]
 	// At the moment this will leave orphaned rows in the owned vindex.
 	// However when using this functionality we are assuming the user
 	// is intending to bypass V3 functionality.
+	return execMultiShard(vcursor, rss, queries, del.MultiShardAutocommit)
+}
+
+func (del *Delete) execDeleteScatter(vcursor VCursor, bindVars map[string]*querypb.BindVariable, dest key.Destination) (*sqltypes.Result, error) {
+	rss, _, err := vcursor.ResolveDestinations(del.Keyspace.Name, nil, []key.Destination{dest})
+	if err != nil {
+		return nil, vterrors.Wrap(err, "execDeleteScatter")
+	}
+
+	queries := make([]*querypb.BoundQuery, len(rss))
+	for i := range rss {
+		queries[i] = &querypb.BoundQuery{
+			Sql:           del.Query,
+			BindVariables: bindVars,
+		}
+	}
+	if len(del.Table.Owned) > 0 {
+		err = del.deleteVindexEntries(vcursor, bindVars, rss)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return execMultiShard(vcursor, rss, queries, del.MultiShardAutocommit)
 }
 

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -160,12 +160,10 @@ func (del *Delete) execDeleteByDestination(vcursor VCursor, bindVars map[string]
 			BindVariables: bindVars,
 		}
 	}
-	if len(del.Table.Owned) > 0 {
-		err = del.deleteVindexEntries(vcursor, bindVars, rss)
-		if err != nil {
-			return nil, err
-		}
-	}
+	// TODO @rafael: Add supports for owned vindexes here.
+	// At the moment this will leave orphaned rows in the owned vindex.
+	// However when using this functionality we are assuming the user
+	// is intending to bypass V3 functionality.
 	return execMultiShard(vcursor, rss, queries, del.MultiShardAutocommit)
 }
 


### PR DESCRIPTION
* Currently this functionality introduces a bug. Let's remove it for now while
  we implement a proper fix.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>