### PR TITLE
Named columns and convenience SQL query interface

### DIFF
--- a/go/sqltypes/named_result.go
+++ b/go/sqltypes/named_result.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"errors"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var (
+	// ErrNoSuchField indicates a search for a value by an unknown field/column name
+	ErrNoSuchField = errors.New("No such field in RowNamedValues")
+)
+
+// RowNamedValues contains a row's values as a map based on Field (aka table column) name
+type RowNamedValues map[string]Value
+
+// ToString returns the named field as string
+func (r RowNamedValues) ToString(fieldName string) (string, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToString(), nil
+	}
+	return "", ErrNoSuchField
+}
+
+// AsString returns the named field as string, or default value if nonexistent/error
+func (r RowNamedValues) AsString(fieldName string, def string) string {
+	if v, err := r.ToString(fieldName); err == nil {
+		return v
+	}
+	return def
+}
+
+// ToInt64 returns the named field as int64
+func (r RowNamedValues) ToInt64(fieldName string) (int64, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToInt64()
+	}
+	return 0, ErrNoSuchField
+}
+
+// AsInt64 returns the named field as int64, or default value if nonexistent/error
+func (r RowNamedValues) AsInt64(fieldName string, def int64) int64 {
+	if v, err := r.ToInt64(fieldName); err == nil {
+		return v
+	}
+	return def
+}
+
+// ToUint64 returns the named field as uint64
+func (r RowNamedValues) ToUint64(fieldName string) (uint64, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToUint64()
+	}
+	return 0, ErrNoSuchField
+}
+
+// AsUint64 returns the named field as uint64, or default value if nonexistent/error
+func (r RowNamedValues) AsUint64(fieldName string, def uint64) uint64 {
+	if v, err := r.ToUint64(fieldName); err == nil {
+		return v
+	}
+	return def
+}
+
+// ToBool returns the named field as bool
+func (r RowNamedValues) ToBool(fieldName string) (bool, error) {
+	if v, ok := r[fieldName]; ok {
+		return v.ToBool()
+	}
+	return false, ErrNoSuchField
+}
+
+// AsBool returns the named field as bool, or default value if nonexistent/error
+func (r RowNamedValues) AsBool(fieldName string, def bool) bool {
+	if v, err := r.ToBool(fieldName); err == nil {
+		return v
+	}
+	return def
+}
+
+// NamedResult represents a query result with named values as opposed to ordinal values.
+type NamedResult struct {
+	Fields       []*querypb.Field `json:"fields"`
+	RowsAffected uint64           `json:"rows_affected"`
+	InsertID     uint64           `json:"insert_id"`
+	Rows         []RowNamedValues `json:"rows"`
+}
+
+// ToNamedResult converts a Result struct into a new NamedResult struct
+func ToNamedResult(result *Result) (r *NamedResult) {
+	if result == nil {
+		return r
+	}
+	r = &NamedResult{
+		Fields:       result.Fields,
+		RowsAffected: result.RowsAffected,
+		InsertID:     result.InsertID,
+	}
+	columnOrdinals := make(map[int]string)
+	for i, field := range result.Fields {
+		columnOrdinals[i] = field.Name
+	}
+	r.Rows = make([]RowNamedValues, len(result.Rows))
+	for rowIndex, row := range result.Rows {
+		namedRow := make(RowNamedValues)
+		for i, value := range row {
+			namedRow[columnOrdinals[i]] = value
+		}
+		r.Rows[rowIndex] = namedRow
+	}
+	return r
+}
+
+// Row assumes this result has exactly one row, and returns it, or else returns nil.
+// It is useful for queries like:
+// - select count(*) from ...
+// - select @@read_only
+// - select UNIX_TIMESTAMP() from dual
+func (r *NamedResult) Row() RowNamedValues {
+	if len(r.Rows) != 1 {
+		return nil
+	}
+	return r.Rows[0]
+}

--- a/go/sqltypes/named_result_test.go
+++ b/go/sqltypes/named_result_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func TestToNamedResult(t *testing.T) {
+	in := &Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: Int64,
+		}, {
+			Name: "status",
+			Type: VarChar,
+		}},
+		InsertID:     1,
+		RowsAffected: 2,
+		Rows: [][]Value{
+			{TestValue(Int64, "0"), TestValue(VarChar, "s0")},
+			{TestValue(Int64, "1"), TestValue(VarChar, "s1")},
+			{TestValue(Int64, "2"), TestValue(VarChar, "s2")},
+		},
+	}
+	named := in.Named()
+	for i := range in.Rows {
+		{
+			want := in.Rows[i][0]
+			got := named.Rows[i]["id"]
+			if !reflect.DeepEqual(want, got) {
+				t.Errorf("Named:%+v\n, want:%+v\n", got, want)
+			}
+			wantAs := int64(i)
+			gotAs := named.Rows[i].AsInt64("id", 0)
+			if gotAs != wantAs {
+				t.Errorf("Named:%+v\n, want:%+v\n", gotAs, wantAs)
+			}
+		}
+		{
+			want := in.Rows[i][1]
+			got := named.Rows[i]["status"]
+			if !reflect.DeepEqual(want, got) {
+				t.Errorf("Named:%+v\n, want:%+v\n", got, want)
+			}
+			wantAs := fmt.Sprintf("s%d", i)
+			gotAs := named.Rows[i].AsString("status", "notfound")
+			if gotAs != wantAs {
+				t.Errorf("Named:%+v\n, want:%+v\n", gotAs, wantAs)
+			}
+		}
+	}
+}

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -218,3 +218,8 @@ func (result *Result) AppendResult(src *Result) {
 	}
 	result.Rows = append(result.Rows, src.Rows...)
 }
+
+// Named returns a NamedResult based on this struct
+func (result *Result) Named() *NamedResult {
+	return ToNamedResult(result)
+}

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -20,6 +20,7 @@ package sqltypes
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -37,6 +38,9 @@ var (
 	DontEscape = byte(255)
 
 	nullstr = []byte("null")
+
+	// ErrIncompatibleTypeCast indicates a casting problem
+	ErrIncompatibleTypeCast = errors.New("Cannot convert value to desired type")
 )
 
 // BinWriter interface is used for encoding values.
@@ -201,6 +205,39 @@ func (v Value) ToBytes() []byte {
 // Len returns the length.
 func (v Value) Len() int {
 	return len(v.val)
+}
+
+// ToInt64 returns the value as MySQL would return it as a int64.
+func (v Value) ToInt64() (int64, error) {
+	if !v.IsIntegral() {
+		return 0, ErrIncompatibleTypeCast
+	}
+
+	return strconv.ParseInt(v.ToString(), 10, 64)
+}
+
+// ToUint64 returns the value as MySQL would return it as a uint64.
+func (v Value) ToUint64() (uint64, error) {
+	if !v.IsIntegral() {
+		return 0, ErrIncompatibleTypeCast
+	}
+
+	return strconv.ParseUint(v.ToString(), 10, 64)
+}
+
+// ToBool returns the value as a bool value
+func (v Value) ToBool() (bool, error) {
+	i, err := v.ToInt64()
+	if err != nil {
+		return false, err
+	}
+	switch i {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	}
+	return false, ErrIncompatibleTypeCast
 }
 
 // ToString returns the value as MySQL would return it as string.

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -336,6 +336,65 @@ func TestAccessors(t *testing.T) {
 	if v.IsBinary() {
 		t.Error("v.IsBinary: true, want false")
 	}
+	{
+		i, err := v.ToInt64()
+		if err != nil {
+			t.Errorf("v.ToInt64: got error: %+v, want no error", err)
+		}
+		if i != 1 {
+			t.Errorf("v.ToInt64=%+v, want 1", i)
+		}
+	}
+	{
+		i, err := v.ToUint64()
+		if err != nil {
+			t.Errorf("v.ToUint64: got error: %+v, want no error", err)
+		}
+		if i != 1 {
+			t.Errorf("v.ToUint64=%+v, want 1", i)
+		}
+	}
+	{
+		b, err := v.ToBool()
+		if err != nil {
+			t.Errorf("v.ToBool: got error: %+v, want no error", err)
+		}
+		if !b {
+			t.Errorf("v.ToBool=%+v, want true", b)
+		}
+	}
+}
+
+func TestAccessorsNegative(t *testing.T) {
+	v := TestValue(Int64, "-1")
+	if v.ToString() != "-1" {
+		t.Errorf("v.String=%s, want -1", v.ToString())
+	}
+	if v.IsNull() {
+		t.Error("v.IsNull: true, want false")
+	}
+	if !v.IsIntegral() {
+		t.Error("v.IsIntegral: false, want true")
+	}
+	{
+		i, err := v.ToInt64()
+		if err != nil {
+			t.Errorf("v.ToInt64: got error: %+v, want no error", err)
+		}
+		if i != -1 {
+			t.Errorf("v.ToInt64=%+v, want -1", i)
+		}
+	}
+	{
+		if _, err := v.ToUint64(); err == nil {
+			t.Error("v.ToUint64: got no error, want error")
+		}
+	}
+	{
+		if _, err := v.ToBool(); err == nil {
+			t.Error("v.ToUint64: got no error, want error")
+		}
+	}
 }
 
 func TestToBytesAndString(t *testing.T) {


### PR DESCRIPTION
This PR offers a more modern interface to SQL query results based on named columns, as well as convenience methods for casting result values into popular types. Some breakdown:

# Convenience methods in `Value`

Previously, after `select`ing an integer column, the process to convert it to `int64` was:
```golang
	tm, err := conn.Exec(ctx, "SELECT UNIX_TIMESTAMP()", 1, false)
	if err != nil { /* ... */ }
	if len(tm.Rows) != 1 || len(tm.Rows[0]) != 1 || tm.Rows[0][0].IsNull() { /* ... */ }
	i, err := evalengine.ToInt64(tm.Rows[0][0])
	if err != nil { /* ... */ }
```

New convenience methods support the following:
```golang
	tm, err := conn.Exec(ctx, "SELECT UNIX_TIMESTAMP()", 1, false)
	if err != nil { /* ... */ }
	if len(tm.Rows) != 1 || len(tm.Rows[0]) != 1 || tm.Rows[0][0].IsNull() { /* ... */ }
	i, err := tm.Rows[0][0].ToInt64()
	if err != nil { /* ... */ }
```

There is no longer a need to call an external `evalengine` function.

supported convenience methods are:

- `ToInt64()`
- `ToUint64()`
- `ToBool()`
- `ToString()` pre-existed.

# A new type: `NamedResult`

`Result` type now has a `Named()` method that returns a `NamedResult` type. It has same fields, insert ID, rows affected as `Result`. It has same Rows data, but the data is an array of maps, where value is found by column name as opposed to ordinal position.

Again iterating on the above example:
```golang
	tm, err := conn.Exec(ctx, "SELECT UNIX_TIMESTAMP() as ts", 1, true)
	if err != nil { /* ... */ }
	named := tm.Named()
	if len(named.Rows) != 1 || len(named.Rows[0]) != 1 { /* ... */ }
	i, err := tm.Rows[0]["ts"].ToInt64()
	if err != nil { /* ... */ }
```

Note:

- You must pass `true` in `conn.Exec()` to get field names
- `tm.Rows[0]["ts"]` means "column `ts` in first row", and now the ordinal of the column is unimportant. In this particular example we return a single column, so maybe this example is underwhelming, but in a result set with 10 columns, names are a safer approach to access columns than ordinals.

# Convenience methods in `NamedResult`:

We further make access more convenient like so:
```golang
	i, err := tm.Rows[0].ToInt64("ts")
	if err != nil { /* ... */ }
```
or
```golang
	i := tm.Rows[0].AsInt64("ts", 0)
```

- `.ToInt64("ts")` is a syntactic sugar shortcut
- `.AsInt64("ts", 0)` provides default value (`0` in this case) and returns with no error. If column does not exist, or if there's a casting error, the function returns the default value silently.

We likewise have `ToString`, `AsString`, `ToUint64`, `AsUint64`, `ToBool`, `AsBool` functions.

# Single `Row()`

Single row queries are common. Examples:

- `SELECT UNIX_TIMESTAMP()`
- `SELECT @@global.read_only, @@global.gtid_mode`
- `SELECT COUNT(*) FROM my_table WHERE status=1`

The `Row()` function returns the first and single row in a result set, or `nil` if this isn't a single row result set. 

Again iterating on our example:
```golang
	tm, err := conn.Exec(ctx, "SELECT UNIX_TIMESTAMP() as ts", 1, true)
	if err != nil { /* ... */ }
	row := tm.Named().Row()
	if row == nil { /* ... */ }
	i, err := row.ToInt64("ts")
	if err != nil { /* ... */ }
```

# Optimistic example

When we `SELECT UNIX_TIMESTAMP()` it is _safe to assume_ that the query either returns with an error, **or** returns with a single row that has a single integer column. Therefore, we can cleanup the above code to read:

```golang
	tm, err := conn.Exec(ctx, "SELECT UNIX_TIMESTAMP() as ts", 1, true)
	if err != nil { /* ... */ }
	i := tm.Named().Row().AsInt64("ts", 0)
```