### PR TITLE
tablet_picker: keep trying to find a tablet until context expires

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -124,8 +124,8 @@ func InitCluster(t *testing.T, cellNames []string) *VitessCluster {
 		globalConfig.topoPort, globalConfig.hostname, globalConfig.tmpDir)
 	vc.Vtctld = vtctld
 	assert.NotNil(t, vc.Vtctld)
-	// use first cell as `-cell` and all cells as `-cells_to_watch`
-	vc.Vtctld.Setup(cellNames[0], "-cells_to_watch", strings.Join(cellNames, ","))
+	// use first cell as `-cell`
+	vc.Vtctld.Setup(cellNames[0])
 
 	vc.Vtctl = cluster.VtctlProcessInstance(globalConfig.topoPort, globalConfig.hostname)
 	assert.NotNil(t, vc.Vtctl)

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -85,9 +85,10 @@ func TestHealthCheck(t *testing.T) {
 	mustMatch(t, want, result, "Wrong TabletHealth data")
 
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.5},
 	}
@@ -121,9 +122,10 @@ func TestHealthCheck(t *testing.T) {
 
 	// TabletType changed, should get both old and new event
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
@@ -150,9 +152,10 @@ func TestHealthCheck(t *testing.T) {
 
 	// Serving & RealtimeStats changed
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             false,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     false,
+
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
@@ -170,11 +173,13 @@ func TestHealthCheck(t *testing.T) {
 
 	// HealthError
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
+
+		RealtimeStats: &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -219,11 +224,13 @@ func TestHealthCheckStreamError(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -265,20 +272,23 @@ func TestHealthCheckVerifiesTabletAlias(t *testing.T) {
 
 	// Immediately after AddTablet() there will be the first notification.
 	want := &TabletHealth{
-		Tablet:              tablet,
-		Target:              &querypb.Target{Keyspace: "k", Shard: "s"},
-		Serving:             false,
+		Tablet:  tablet,
+		Target:  &querypb.Target{Keyspace: "k", Shard: "s"},
+		Serving: false,
+
 		MasterTermStartTime: 0,
 	}
 	result := <-resultChan
 	mustMatch(t, want, result, "Wrong TabletHealth data")
 
 	input <- &querypb.StreamHealthResponse{
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		TabletAlias:                         &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
-		Serving:                             true,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		TabletAlias: &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 10,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -316,17 +326,20 @@ func TestHealthCheckCloseWaitsForGoRoutines(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
-		Tablet:              tablet,
-		Target:              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:             true,
-		Stats:               &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		Tablet:  tablet,
+		Target:  &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving: true,
+		Stats:   &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
 		MasterTermStartTime: 0,
 	}
 	input <- shr
@@ -375,11 +388,13 @@ func TestHealthCheckTimeout(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -439,11 +454,13 @@ func TestGetHealthyTablets(t *testing.T) {
 	assert.Empty(t, a, "wrong result, expected empty list")
 
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want := []*TabletHealth{{
 		Tablet:              tablet,
@@ -460,11 +477,13 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// update health with a change that won't change health array
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 2, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 2, CpuUsage: 0.2},
 	}
 	input <- shr
 	// wait for result before checking
@@ -475,11 +494,13 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// update stats with a change that will change health array
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 35, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 35, CpuUsage: 0.2},
 	}
 	want = []*TabletHealth{{
 		Tablet:              tablet,
@@ -505,11 +526,13 @@ func TestGetHealthyTablets(t *testing.T) {
 	<-resultChan
 
 	shr2 := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet2.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet2.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	want2 := []*TabletHealth{{
 		Tablet:              tablet,
@@ -535,11 +558,13 @@ func TestGetHealthyTablets(t *testing.T) {
 	mustMatch(t, want2, a, "unexpected result")
 
 	shr2 = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet2.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             false,
+		TabletAlias: tablet2.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     false,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	input2 <- shr2
 	// wait for result
@@ -549,11 +574,13 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// second tablet turns into a master
 	shr2 = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet2.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving:                             true,
+		TabletAlias: tablet2.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 10,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
 	}
 	input2 <- shr2
 	// wait for result
@@ -575,11 +602,13 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// reparent: old replica goes into master
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 20,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
 	}
 	input <- shr
 	<-resultChan
@@ -640,11 +669,13 @@ func TestAliases(t *testing.T) {
 	}
 
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias:                         tablet.Alias,
-		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:                             true,
+		TabletAlias: tablet.Alias,
+		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:     true,
+
 		TabletExternallyReparentedTimestamp: 0,
-		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+
+		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	want := []*TabletHealth{{
 		Tablet:              tablet,
@@ -766,6 +797,9 @@ func TestDebugURLFormatting(t *testing.T) {
 }
 
 func tabletDialer(tablet *topodatapb.Tablet, _ grpcclient.FailFast) (queryservice.QueryService, error) {
+	muConnMap.Lock()
+	defer muConnMap.Unlock()
+
 	key := TabletToMapKey(tablet)
 	if qs, ok := connMap[key]; ok {
 		return qs, nil
@@ -794,6 +828,8 @@ type fakeConn struct {
 }
 
 func createFakeConn(tablet *topodatapb.Tablet, c chan *querypb.StreamHealthResponse) *fakeConn {
+	muConnMap.Lock()
+	defer muConnMap.Unlock()
 	key := TabletToMapKey(tablet)
 	conn := &fakeConn{
 		QueryService: fakes.ErrorQueryService,
@@ -866,6 +902,8 @@ func createFixedHealthConn(tablet *topodatapb.Tablet, fixedResult *querypb.Strea
 		tablet:       tablet,
 		fixedResult:  fixedResult,
 	}
+	muConnMap.Lock()
+	defer muConnMap.Unlock()
 	connMap[key] = conn
 	return conn
 }

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -48,6 +48,9 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
+var connMap map[string]*fakeConn
+var connMapMu sync.Mutex
+
 func init() {
 	tabletconn.RegisterDialer("fake_gateway", tabletDialer)
 
@@ -55,6 +58,7 @@ func init() {
 	if err := flag.Set("tablet_protocol", "fake_gateway"); err != nil {
 		log.Errorf("failed to set flag \"tablet_protocol\" to \"fake_gateway\":%v", err)
 	}
+	connMap = make(map[string]*fakeConn)
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -122,10 +126,9 @@ func TestHealthCheck(t *testing.T) {
 
 	// TabletType changed, should get both old and new event
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
@@ -152,10 +155,9 @@ func TestHealthCheck(t *testing.T) {
 
 	// Serving & RealtimeStats changed
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     false,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             false,
 		TabletExternallyReparentedTimestamp: 0,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
@@ -173,13 +175,11 @@ func TestHealthCheck(t *testing.T) {
 
 	// HealthError
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
+		RealtimeStats:                       &querypb.RealtimeStats{HealthError: "some error", SecondsBehindMaster: 1, CpuUsage: 0.3},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -224,13 +224,11 @@ func TestHealthCheckStreamError(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -272,23 +270,20 @@ func TestHealthCheckVerifiesTabletAlias(t *testing.T) {
 
 	// Immediately after AddTablet() there will be the first notification.
 	want := &TabletHealth{
-		Tablet:  tablet,
-		Target:  &querypb.Target{Keyspace: "k", Shard: "s"},
-		Serving: false,
-
+		Tablet:              tablet,
+		Target:              &querypb.Target{Keyspace: "k", Shard: "s"},
+		Serving:             false,
 		MasterTermStartTime: 0,
 	}
 	result := <-resultChan
 	mustMatch(t, want, result, "Wrong TabletHealth data")
 
 	input <- &querypb.StreamHealthResponse{
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		TabletAlias: &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
-		Serving:     true,
-
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		TabletAlias:                         &topodatapb.TabletAlias{Uid: 20, Cell: "cellb"},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 10,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -326,13 +321,11 @@ func TestHealthCheckCloseWaitsForGoRoutines(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
 		Tablet:  tablet,
@@ -388,13 +381,11 @@ func TestHealthCheckTimeout(t *testing.T) {
 
 	// one tablet after receiving a StreamHealthResponse
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want = &TabletHealth{
 		Tablet:              tablet,
@@ -454,13 +445,11 @@ func TestGetHealthyTablets(t *testing.T) {
 	assert.Empty(t, a, "wrong result, expected empty list")
 
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
 	want := []*TabletHealth{{
 		Tablet:              tablet,
@@ -477,13 +466,11 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// update health with a change that won't change health array
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 2, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 2, CpuUsage: 0.2},
 	}
 	input <- shr
 	// wait for result before checking
@@ -494,13 +481,11 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// update stats with a change that will change health array
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 35, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 35, CpuUsage: 0.2},
 	}
 	want = []*TabletHealth{{
 		Tablet:              tablet,
@@ -526,13 +511,11 @@ func TestGetHealthyTablets(t *testing.T) {
 	<-resultChan
 
 	shr2 := &querypb.StreamHealthResponse{
-		TabletAlias: tablet2.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet2.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	want2 := []*TabletHealth{{
 		Tablet:              tablet,
@@ -558,13 +541,11 @@ func TestGetHealthyTablets(t *testing.T) {
 	mustMatch(t, want2, a, "unexpected result")
 
 	shr2 = &querypb.StreamHealthResponse{
-		TabletAlias: tablet2.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     false,
-
+		TabletAlias:                         tablet2.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             false,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	input2 <- shr2
 	// wait for result
@@ -602,13 +583,11 @@ func TestGetHealthyTablets(t *testing.T) {
 
 	// reparent: old replica goes into master
 	shr = &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 20,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 0, CpuUsage: 0.2},
 	}
 	input <- shr
 	<-resultChan
@@ -669,13 +648,11 @@ func TestAliases(t *testing.T) {
 	}
 
 	shr := &querypb.StreamHealthResponse{
-		TabletAlias: tablet.Alias,
-		Target:      &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
-		Serving:     true,
-
+		TabletAlias:                         tablet.Alias,
+		Target:                              &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA},
+		Serving:                             true,
 		TabletExternallyReparentedTimestamp: 0,
-
-		RealtimeStats: &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
+		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 10, CpuUsage: 0.2},
 	}
 	want := []*TabletHealth{{
 		Tablet:              tablet,
@@ -797,8 +774,8 @@ func TestDebugURLFormatting(t *testing.T) {
 }
 
 func tabletDialer(tablet *topodatapb.Tablet, _ grpcclient.FailFast) (queryservice.QueryService, error) {
-	muConnMap.Lock()
-	defer muConnMap.Unlock()
+	connMapMu.Lock()
+	defer connMapMu.Unlock()
 
 	key := TabletToMapKey(tablet)
 	if qs, ok := connMap[key]; ok {
@@ -828,8 +805,8 @@ type fakeConn struct {
 }
 
 func createFakeConn(tablet *topodatapb.Tablet, c chan *querypb.StreamHealthResponse) *fakeConn {
-	muConnMap.Lock()
-	defer muConnMap.Unlock()
+	connMapMu.Lock()
+	defer connMapMu.Unlock()
 	key := TabletToMapKey(tablet)
 	conn := &fakeConn{
 		QueryService: fakes.ErrorQueryService,
@@ -902,8 +879,8 @@ func createFixedHealthConn(tablet *topodatapb.Tablet, fixedResult *querypb.Strea
 		tablet:       tablet,
 		fixedResult:  fixedResult,
 	}
-	muConnMap.Lock()
-	defer muConnMap.Unlock()
+	connMapMu.Lock()
+	defer connMapMu.Unlock()
 	connMap[key] = conn
 	return conn
 }

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -34,6 +34,10 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
+var (
+	tabletPickerRetryDelay = 30 * time.Second
+)
+
 // TabletPicker gives a simplified API for picking tablets.
 type TabletPicker struct {
 	ts          *topo.Server
@@ -62,84 +66,109 @@ func NewTabletPicker(ts *topo.Server, cells []string, keyspace, shard, tabletTyp
 // All tablets that belong to tp.cells are evaluated and one is
 // chosen at random
 func (tp *TabletPicker) PickForStreaming(ctx context.Context) (*topodatapb.Tablet, error) {
-	candidates := tp.getAllTablets(ctx)
-	if len(candidates) == 0 {
-		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "no tablets available for cells:%v, keyspace/shard:%v/%v, tablet types:%v", tp.cells, tp.keyspace, tp.shard, tp.tabletTypes)
-	}
+	// keep trying at intervals (tabletPickerRetryDelay) until a tablet is found
+	// or the context is canceled
 	for {
-		idx := 0
-		// if there is only one candidate we use that, otherwise we find one randomly
-		if len(candidates) > 1 {
-			idx = rand.Intn(len(candidates))
+		select {
+		case <-ctx.Done():
+			return nil, vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
+		default:
 		}
-		alias := candidates[idx]
-		// get tablet
-		ti, err := tp.ts.GetTablet(ctx, alias)
-		if err != nil {
-			log.Warningf("unable to get tablet for alias %v", alias)
-			candidates = append(candidates[:idx], candidates[idx+1:]...)
-			if len(candidates) == 0 {
-				break
+		candidates := tp.getMatchingTablets(ctx)
+		if len(candidates) == 0 {
+			// if no candidates were found, sleep and try again
+			time.Sleep(tabletPickerRetryDelay)
+			continue
+		}
+		// try at most len(candidate) times to find a healthy tablet
+		for i := 0; i < len(candidates); i++ {
+			idx := rand.Intn(len(candidates))
+			ti := candidates[idx]
+			// get tablet
+			// try to connect to tablet
+			conn, err := tabletconn.GetDialer()(ti.Tablet, true)
+			if err != nil {
+				log.Warningf("unable to connect to tablet for alias %v", ti.Alias)
+				candidates = append(candidates[:idx], candidates[idx+1:]...)
+				if len(candidates) == 0 {
+					break
+				}
+				continue
 			}
-			continue
+			// OK to use ctx here because it is not actually used by the underlying Close implementation
+			_ = conn.Close(ctx)
+			return ti.Tablet, nil
 		}
-		if !topoproto.IsTypeInList(ti.Tablet.Type, tp.tabletTypes) {
-			// tablet is not of one of the desired types
-			continue
-		}
-
-		// try to connect to tablet
-		conn, err := tabletconn.GetDialer()(ti.Tablet, true)
-		if err != nil {
-			log.Warningf("unable to connect to tablet for alias %v", alias)
-			candidates = append(candidates[:idx], candidates[idx+1:]...)
-			if len(candidates) == 0 {
-				break
-			}
-			continue
-		}
-		_ = conn.Close(ctx)
-		return ti.Tablet, nil
 	}
-	return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "can't find any healthy source tablet for keyspace/shard:%v/%v tablet types:%v", tp.keyspace, tp.shard, tp.tabletTypes)
 }
 
-func (tp *TabletPicker) getAllTablets(ctx context.Context) []*topodatapb.TabletAlias {
+// getMatchingTablets returns a list of TabletInfo for tablets
+// that match the cells, keyspace, shard and tabletTypes for this TabletPicker
+func (tp *TabletPicker) getMatchingTablets(ctx context.Context) []*topo.TabletInfo {
 	// Special handling for MASTER tablet type
 	// Since there is only one master, we ignore cell and find the master
-	result := make([]*topodatapb.TabletAlias, 0)
+	aliases := make([]*topodatapb.TabletAlias, 0)
 	if len(tp.tabletTypes) == 1 && tp.tabletTypes[0] == topodatapb.TabletType_MASTER {
-		si, err := tp.ts.GetShard(ctx, tp.keyspace, tp.shard)
+		shortCtx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+		defer cancel()
+		si, err := tp.ts.GetShard(shortCtx, tp.keyspace, tp.shard)
 		if err != nil {
-			return result
+			return nil
 		}
-		result = append(result, si.MasterAlias)
-		return result
-	}
-	actualCells := make([]string, 0)
-	for _, cell := range tp.cells {
-		// check if cell is actually an alias
-		// non-blocking read so that this is fast
-		alias, err := tp.ts.GetCellsAlias(ctx, cell, false)
-		if err != nil {
-			// either cellAlias doesn't exist or it isn't a cell alias at all. In that case assume it is a cell
-			actualCells = append(actualCells, cell)
-		} else {
-			actualCells = append(actualCells, alias.Cells...)
+		aliases = append(aliases, si.MasterAlias)
+	} else {
+		actualCells := make([]string, 0)
+		for _, cell := range tp.cells {
+			// check if cell is actually an alias
+			// non-blocking read so that this is fast
+			shortCtx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+			defer cancel()
+			alias, err := tp.ts.GetCellsAlias(shortCtx, cell, false)
+			if err != nil {
+				// either cellAlias doesn't exist or it isn't a cell alias at all. In that case assume it is a cell
+				actualCells = append(actualCells, cell)
+			} else {
+				actualCells = append(actualCells, alias.Cells...)
+			}
 		}
-	}
-	for _, cell := range actualCells {
-		sri, err := tp.ts.GetShardReplication(ctx, cell, tp.keyspace, tp.shard)
-		if err != nil {
-			log.Warningf("error %v from GetShardReplication for %v %v %v", err, cell, tp.keyspace, tp.shard)
-			continue
-		}
+		for _, cell := range actualCells {
+			shortCtx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+			defer cancel()
+			// match cell, keyspace and shard
+			sri, err := tp.ts.GetShardReplication(shortCtx, cell, tp.keyspace, tp.shard)
+			if err != nil {
+				log.Warningf("error %v from GetShardReplication for %v %v %v", err, cell, tp.keyspace, tp.shard)
+				continue
+			}
 
-		for _, node := range sri.Nodes {
-			result = append(result, node.TabletAlias)
+			for _, node := range sri.Nodes {
+				aliases = append(aliases, node.TabletAlias)
+			}
 		}
 	}
-	return result
+
+	if len(aliases) == 0 {
+		return nil
+	}
+	shortCtx, cancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
+	defer cancel()
+	tabletMap, err := tp.ts.GetTabletMap(shortCtx, aliases)
+	if err != nil {
+		log.Warningf("error fetching tablets from topo: %v", err)
+		return nil
+	}
+	tablets := make([]*topo.TabletInfo, 0, len(aliases))
+	for _, tabletAlias := range aliases {
+		tabletInfo, ok := tabletMap[topoproto.TabletAliasString(tabletAlias)]
+		if !ok {
+			// tablet disappeared on us (GetTabletMap ignores
+			// topo.ErrNoNode), just echo a warning
+			log.Warningf("failed to load tablet %v", tabletAlias)
+		} else if topoproto.IsTypeInList(tabletInfo.Type, tp.tabletTypes) {
+			tablets = append(tablets, tabletInfo)
+		}
+	}
+	return tablets
 }
 
 func init() {

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -53,6 +53,9 @@ func NewTabletPicker(ts *topo.Server, cells []string, keyspace, shard, tabletTyp
 	if err != nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "failed to parse list of tablet types: %v", tabletTypesStr)
 	}
+	if keyspace == "" || shard == "" || len(cells) == 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Keyspace, Shard and cells must be provided")
+	}
 	return &TabletPicker{
 		ts:          ts,
 		cells:       cells,

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -41,6 +41,14 @@ var (
 	tabletPickerRetryDelay = 30 * time.Second
 )
 
+func GetTabletPickerRetryDelay() time.Duration {
+	return tabletPickerRetryDelay
+}
+
+func SetTabletPickerRetryDelay(delay time.Duration) {
+	tabletPickerRetryDelay = delay
+}
+
 // TabletPicker gives a simplified API for picking tablets.
 type TabletPicker struct {
 	ts          *topo.Server
@@ -67,7 +75,7 @@ func NewTabletPicker(ts *topo.Server, cells []string, keyspace, shard, tabletTyp
 		missingFields = append(missingFields, "Cells")
 	}
 	if len(missingFields) > 0 {
-		log.Errorf("missing picker fields %s", debug.Stack())
+		log.Errorf("missing picker fields %s", debug.Stack()) //FIXME: remove after all tests run
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 			fmt.Sprintf("Missing required field(s) for tablet picker: %s", strings.Join(missingFields, ", ")))
 	}
@@ -156,6 +164,8 @@ func (tp *TabletPicker) getMatchingTablets(ctx context.Context) []*topo.TabletIn
 			// match cell, keyspace and shard
 			sri, err := tp.ts.GetShardReplication(shortCtx, cell, tp.keyspace, tp.shard)
 			if err != nil {
+				log.Errorf("missing shard in topo %s", debug.Stack()) //FIXME: remove after all tests run
+
 				log.Warningf("error %v from GetShardReplication for %v %v %v", err, cell, tp.keyspace, tp.shard)
 				continue
 			}

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -275,20 +275,55 @@ func TestPickUsingCellAlias(t *testing.T) {
 	assert.True(t, picked2)
 }
 
+func TestTabletAppearsDuringSleep(t *testing.T) {
+	te := newPickerTestEnv(t, []string{"cell"})
+	tp, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "replica")
+	require.NoError(t, err)
+
+	tabletPickerRetryDelay = 11 * time.Millisecond
+	defer func() {
+		tabletPickerRetryDelay = 30 * time.Second
+	}()
+
+	result := make(chan *topodatapb.Tablet)
+	// start picker first, then add tablet
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		tablet, err := tp.PickForStreaming(ctx)
+		assert.NoError(t, err)
+		result <- tablet
+	}()
+
+	want := addTablet(te, 100, topodatapb.TabletType_REPLICA, "cell", true, true)
+	defer deleteTablet(te, want)
+	got := <-result
+	require.NotNil(t, got, "Tablet should not be nil")
+	assert.True(t, proto.Equal(want, got), "Pick: %v, want %v", got, want)
+}
+
 func TestPickError(t *testing.T) {
 	te := newPickerTestEnv(t, []string{"cell"})
 	_, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "badtype")
 	assert.EqualError(t, err, "failed to parse list of tablet types: badtype")
 
-	tp, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "replica,rdonly")
+	tp, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "replica")
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	tabletPickerRetryDelay = 11 * time.Millisecond
+	defer func() {
+		tabletPickerRetryDelay = 30 * time.Second
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	// no tablets
+	_, err = tp.PickForStreaming(ctx)
+	require.EqualError(t, err, "context has expired")
+	// no tablets of the correct type
+	defer deleteTablet(te, addTablet(te, 200, topodatapb.TabletType_RDONLY, "cell", true, true))
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	_, err = tp.PickForStreaming(ctx)
-	require.EqualError(t, err, "no tablets available for cells:[cell], keyspace/shard:ks/0, tablet types:[REPLICA RDONLY]")
-	defer deleteTablet(te, addTablet(te, 200, topodatapb.TabletType_REPLICA, "cell", false, false))
-	_, err = tp.PickForStreaming(ctx)
-	require.EqualError(t, err, "can't find any healthy source tablet for keyspace/shard:ks/0 tablet types:[REPLICA RDONLY]")
+	require.EqualError(t, err, "context has expired")
 }
 
 type pickerTestEnv struct {

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -280,10 +280,11 @@ func TestTabletAppearsDuringSleep(t *testing.T) {
 	tp, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "replica")
 	require.NoError(t, err)
 
-	tabletPickerRetryDelay = 11 * time.Millisecond
+	delay := GetTabletPickerRetryDelay()
 	defer func() {
-		tabletPickerRetryDelay = 30 * time.Second
+		SetTabletPickerRetryDelay(delay)
 	}()
+	SetTabletPickerRetryDelay(11 * time.Millisecond)
 
 	result := make(chan *topodatapb.Tablet)
 	// start picker first, then add tablet
@@ -309,10 +310,12 @@ func TestPickError(t *testing.T) {
 
 	tp, err := NewTabletPicker(te.topoServ, te.cells, te.keyspace, te.shard, "replica")
 	require.NoError(t, err)
-	tabletPickerRetryDelay = 11 * time.Millisecond
+	delay := GetTabletPickerRetryDelay()
 	defer func() {
-		tabletPickerRetryDelay = 30 * time.Second
+		SetTabletPickerRetryDelay(delay)
 	}()
+	SetTabletPickerRetryDelay(11 * time.Millisecond)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	// no tablets

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -179,7 +181,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &legacyTestQueryService{
-			t:                        tc.t,
+			t: tc.t,
 			StreamHealthQueryService: qs,
 		})
 	}
@@ -295,6 +297,12 @@ func (sq *legacyTestQueryService) StreamExecute(ctx context.Context, target *que
 }
 
 func TestLegacySplitCloneV2(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &legacySplitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -306,6 +314,12 @@ func TestLegacySplitCloneV2(t *testing.T) {
 }
 
 func TestLegacySplitCloneV2_Throttled(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &legacySplitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -345,6 +359,12 @@ func TestLegacySplitCloneV2_Throttled(t *testing.T) {
 // TestLegacySplitCloneV2 with the additional twist that the destination masters
 // fail the first write because they are read-only and succeed after that.
 func TestLegacySplitCloneV2_RetryDueToReadonly(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &legacySplitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -374,6 +394,12 @@ func TestLegacySplitCloneV2_RetryDueToReadonly(t *testing.T) {
 // even in a period where no MASTER tablet is available according to the
 // HealthCheck instance.
 func TestLegacySplitCloneV2_NoMasterAvailable(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &legacySplitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -447,6 +473,12 @@ func TestLegacySplitCloneV2_NoMasterAvailable(t *testing.T) {
 }
 
 func TestLegacySplitCloneV3(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &legacySplitCloneTestCase{t: t}
 	tc.setUp(true /* v3 */)
 	defer tc.tearDown()

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -182,6 +182,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &legacyTestQueryService{
 			t: tc.t,
+
 			StreamHealthQueryService: qs,
 		})
 	}

--- a/go/vt/worker/multi_split_diff_test.go
+++ b/go/vt/worker/multi_split_diff_test.go
@@ -280,6 +280,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &msdSourceTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			v3:                       v3,
@@ -291,6 +292,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &msdDestinationTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			shardIndex:               0,
@@ -302,6 +304,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &msdDestinationTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			shardIndex:               1,

--- a/go/vt/worker/multi_split_diff_test.go
+++ b/go/vt/worker/multi_split_diff_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -277,7 +279,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &msdSourceTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			v3:                       v3,
@@ -288,7 +290,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs := fakes.NewStreamHealthQueryService(destRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &msdDestinationTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			shardIndex:               0,
@@ -299,7 +301,7 @@ func testMultiSplitDiff(t *testing.T, v3 bool) {
 		qs := fakes.NewStreamHealthQueryService(destRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &msdDestinationTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			shardIndex:               1,
@@ -333,5 +335,11 @@ func TestMultiSplitDiffv2(t *testing.T) {
 }
 
 func TestMultiSplitDiffv3(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	testMultiSplitDiff(t, true)
 }

--- a/go/vt/worker/split_clone_flaky_test.go
+++ b/go/vt/worker/split_clone_flaky_test.go
@@ -337,15 +337,16 @@ func newTestQueryService(t *testing.T, target querypb.Target, shqs *fakes.Stream
 		fields = v3Fields
 	}
 	return &testQueryService{
-		t:      t,
-		target: target,
+		t:              t,
+		target:         target,
+		shardIndex:     shardIndex,
+		shardCount:     shardCount,
+		alias:          alias,
+		omitKeyspaceID: omitKeyspaceID,
+		fields:         fields,
+		forceError:     make(map[int64]int),
+
 		StreamHealthQueryService: shqs,
-		shardIndex:               shardIndex,
-		shardCount:               shardCount,
-		alias:                    alias,
-		omitKeyspaceID:           omitKeyspaceID,
-		fields:                   fields,
-		forceError:               make(map[int64]int),
 	}
 }
 

--- a/go/vt/worker/split_clone_flaky_test.go
+++ b/go/vt/worker/split_clone_flaky_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"golang.org/x/net/context"
@@ -335,8 +337,8 @@ func newTestQueryService(t *testing.T, target querypb.Target, shqs *fakes.Stream
 		fields = v3Fields
 	}
 	return &testQueryService{
-		t:                        t,
-		target:                   target,
+		t:      t,
+		target: target,
 		StreamHealthQueryService: shqs,
 		shardIndex:               shardIndex,
 		shardCount:               shardCount,
@@ -521,6 +523,12 @@ var v3Fields = []*querypb.Field{
 
 // TestSplitCloneV2_Offline tests the offline phase with an empty destination.
 func TestSplitCloneV2_Offline(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -536,6 +544,12 @@ func TestSplitCloneV2_Offline(t *testing.T) {
 // --source_reader_count=10, at most 10 out of the 1000 chunk pipeplines will
 // get processed concurrently while the other pending ones are blocked.
 func TestSplitCloneV2_Offline_HighChunkCount(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUpWithConcurrency(false /* v3 */, 10, 5 /* writeQueryMaxRows */, 1000 /* rowsCount */)
 	defer tc.tearDown()
@@ -559,6 +573,12 @@ func TestSplitCloneV2_Offline_HighChunkCount(t *testing.T) {
 // TestSplitCloneV2_Offline but forces SplitClone to restart the streaming
 // query on the source before reading the last row.
 func TestSplitCloneV2_Offline_RestartStreamingQuery(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -600,6 +620,12 @@ func TestSplitCloneV2_Offline_RestartStreamingQuery(t *testing.T) {
 // TestSplitCloneV2_Offline_RestartStreamingQuery. However, the first restart
 // of the streaming query does not succeed here and instead vtworker will fail.
 func TestSplitCloneV2_Offline_FailOverStreamingQuery_NotAllowed(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUpWithConcurrency(false /* v3 */, 1, 10, splitCloneTestRowsCount)
 	defer tc.tearDown()
@@ -640,6 +666,12 @@ func TestSplitCloneV2_Offline_FailOverStreamingQuery_NotAllowed(t *testing.T) {
 // query on the source *and* failover to a different source tablet before
 // reading the last row.
 func TestSplitCloneV2_Online_FailOverStreamingQuery(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUpWithConcurrency(false /* v3 */, 1, 10, splitCloneTestRowsCount)
 	defer tc.tearDown()
@@ -695,6 +727,12 @@ func TestSplitCloneV2_Online_FailOverStreamingQuery(t *testing.T) {
 // restartable_result_reader.go where we keep retrying while no tablet may be
 // available.
 func TestSplitCloneV2_Online_TabletsUnavailableDuringRestart(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUpWithConcurrency(false /* v3 */, 1, 10, splitCloneTestRowsCount)
 	defer tc.tearDown()
@@ -743,6 +781,11 @@ func TestSplitCloneV2_Online_TabletsUnavailableDuringRestart(t *testing.T) {
 
 // TestSplitCloneV2_Online tests the online phase with an empty destination.
 func TestSplitCloneV2_Online(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -768,6 +811,12 @@ func TestSplitCloneV2_Online(t *testing.T) {
 }
 
 func TestSplitCloneV2_Online_Offline(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -800,6 +849,12 @@ func TestSplitCloneV2_Online_Offline(t *testing.T) {
 // TestSplitCloneV2_Offline, but the destination has existing data which must be
 // reconciled.
 func TestSplitCloneV2_Offline_Reconciliation(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	// We reduce the parallelism to 1 to test the order of expected
 	// insert/update/delete statements on the destination master.
@@ -860,6 +915,12 @@ func TestSplitCloneV2_Offline_Reconciliation(t *testing.T) {
 }
 
 func TestSplitCloneV2_Throttled(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -901,6 +962,12 @@ func TestSplitCloneV2_Throttled(t *testing.T) {
 // TestSplitCloneV2 with the additional twist that the destination masters
 // fail the first write because they are read-only and succeed after that.
 func TestSplitCloneV2_RetryDueToReadonly(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -931,6 +998,12 @@ func TestSplitCloneV2_RetryDueToReadonly(t *testing.T) {
 // even in a period where no MASTER tablet is available according to the
 // HealthCheck instance.
 func TestSplitCloneV2_NoMasterAvailable(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(false /* v3 */)
 	defer tc.tearDown()
@@ -998,6 +1071,12 @@ func TestSplitCloneV2_NoMasterAvailable(t *testing.T) {
 }
 
 func TestSplitCloneV3(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	tc := &splitCloneTestCase{t: t}
 	tc.setUp(true /* v3 */)
 	defer tc.tearDown()

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -274,6 +274,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &sourceTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			v3:                       v3,
@@ -285,6 +286,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &destinationTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 		})

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -169,6 +171,12 @@ func (sq *sourceTabletServer) StreamExecute(ctx context.Context, target *querypb
 // TODO(aaijazi): Create a test in which source and destination data does not match
 
 func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.TabletType) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	*useV3ReshardingMode = v3
 	ts := memorytopo.NewServer("cell1", "cell2")
 	ctx := context.Background()
@@ -265,7 +273,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(sourceRdonly.RPCServer, &sourceTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 			v3:                       v3,
@@ -276,7 +284,7 @@ func testSplitDiff(t *testing.T, v3 bool, destinationTabletType topodatapb.Table
 		qs := fakes.NewStreamHealthQueryService(destRdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(destRdonly.RPCServer, &destinationTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 			excludedTable:            excludedTable,
 		})

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -60,6 +62,12 @@ func createVerticalSplitCloneDestinationFakeDb(t *testing.T, name string, insert
 // to the destination and the offline phase won't copy any rows as the source
 // has not changed in the meantime.
 func TestVerticalSplitClone(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	ctx := context.Background()
 	wi := NewInstance(ts, "cell1", time.Second)

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -180,6 +180,7 @@ func TestVerticalSplitDiff(t *testing.T) {
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(rdonly.RPCServer, &verticalDiffTabletServer{
 			t: t,
+
 			StreamHealthQueryService: qs,
 		})
 	}

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -92,6 +94,12 @@ func (sq *verticalDiffTabletServer) StreamExecute(ctx context.Context, target *q
 // TODO(aaijazi): Create a test in which source and destination data does not match
 
 func TestVerticalSplitDiff(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	ctx := context.Background()
 	wi := NewInstance(ts, "cell1", time.Second)
@@ -171,7 +179,7 @@ func TestVerticalSplitDiff(t *testing.T) {
 		qs := fakes.NewStreamHealthQueryService(rdonly.Target())
 		qs.AddDefaultHealthResponse()
 		grpcqueryservice.Register(rdonly.RPCServer, &verticalDiffTabletServer{
-			t:                        t,
+			t: t,
 			StreamHealthQueryService: qs,
 		})
 	}

--- a/go/vt/wrangler/testlib/apply_schema_flaky_test.go
+++ b/go/vt/wrangler/testlib/apply_schema_flaky_test.go
@@ -19,6 +19,9 @@ package testlib
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -39,6 +42,12 @@ import (
 // Only if the flag is specified, potentially long running schema changes are
 // allowed.
 func TestApplySchema_AllowLongUnavailability(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	cell := "cell1"
 	db := fakesqldb.New(t)
 	defer db.Close()

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -42,6 +44,12 @@ import (
 )
 
 func TestBackupRestore(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	// Initialize our environment
 	ctx := context.Background()
 	db := fakesqldb.New(t)
@@ -214,6 +222,12 @@ func TestBackupRestore(t *testing.T) {
 }
 
 func TestRestoreUnreachableMaster(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	// Initialize our environment
 	ctx := context.Background()
 	db := fakesqldb.New(t)

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -18,6 +18,9 @@ package testlib
 
 import (
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -44,6 +47,12 @@ func TestCopySchemaShard_UseShardAsSource(t *testing.T) {
 }
 
 func copySchema(t *testing.T, useShardAsSource bool) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,6 +37,12 @@ import (
 )
 
 func TestEmergencyReparentShard(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -149,6 +157,12 @@ func TestEmergencyReparentShard(t *testing.T) {
 // TestEmergencyReparentShardMasterElectNotBest tries to emergency reparent
 // to a host that is not the latest in replication position.
 func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/discovery"
+
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
@@ -38,6 +40,12 @@ import (
 
 // TestTabletExternallyReparentedBasic tests the base cases for TER
 func TestTabletExternallyReparentedBasic(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -124,6 +132,12 @@ func TestTabletExternallyReparentedBasic(t *testing.T) {
 }
 
 func TestTabletExternallyReparentedToReplica(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -200,6 +214,12 @@ func TestTabletExternallyReparentedToReplica(t *testing.T) {
 // that if mysql is restarted on the master-elect tablet and has a different
 // port, we pick it up correctly.
 func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -279,6 +299,12 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 // TestTabletExternallyReparentedContinueOnUnexpectedMaster makes sure
 // that we ignore mysql's master if the flag is set
 func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -351,6 +377,12 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 }
 
 func TestTabletExternallyReparentedRerun(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -439,6 +471,12 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 }
 
 func TestRPCTabletExternallyReparentedDemotesMasterToConfiguredTabletType(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	flag.Set("disable_active_reparents", "true")
 	defer flag.Set("disable_active_reparents", "false")
 

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -19,6 +19,9 @@ package testlib
 import (
 	"reflect"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -35,6 +38,12 @@ import (
 )
 
 func TestMigrateServedFrom(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -20,6 +20,9 @@ import (
 	"flag"
 	"strings"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -244,6 +247,12 @@ func TestMigrateServedTypes(t *testing.T) {
 }
 
 func TestMultiShardMigrateServedTypes(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	// TODO(b/26388813): Remove the next two lines once vtctl WaitForDrain is integrated in the vtctl MigrateServed* commands.
 	flag.Set("wait_for_drain_sleep_rdonly", "0s")
 	flag.Set("wait_for_drain_sleep_replica", "0s")

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -19,6 +19,9 @@ package testlib
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -34,6 +37,12 @@ import (
 )
 
 func TestPermissions(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	// Initialize our environment
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1", "cell2")

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +39,12 @@ import (
 )
 
 func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -139,6 +148,12 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 }
 
 func TestPlannedReparentShardNoError(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -257,6 +272,12 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 }
 
 func TestPlannedReparentNoMaster(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -275,6 +296,12 @@ func TestPlannedReparentNoMaster(t *testing.T) {
 // TestPlannedReparentShardWaitForPositionFail simulates a failure of the WaitForPosition call
 // on the desired new master tablet
 func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -369,6 +396,12 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 // TestPlannedReparentShardWaitForPositionTimeout simulates a context timeout
 // during the WaitForPosition call to the desired new master
 func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -461,6 +494,12 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 }
 
 func TestPlannedReparentShardRelayLogError(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -530,6 +569,12 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 // is not replicating to start with (IO_Thread is not running) and we
 // simulate an error from the attempt to start replication
 func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -600,6 +645,12 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 // TestPlannedReparentShardPromoteReplicaFail simulates a failure of the PromoteReplica call
 // on the desired new master tablet
 func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
@@ -728,6 +779,12 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 // Simulate failure of previous PRS and oldMaster is ReadOnly
 // Verify that master correctly gets set to ReadWrite
 func TestPlannedReparentShardSameMaster(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -18,6 +18,9 @@ package testlib
 
 import (
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"golang.org/x/net/context"
 
@@ -33,6 +36,12 @@ import (
 )
 
 func TestShardReplicationStatuses(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
@@ -103,6 +112,12 @@ func TestShardReplicationStatuses(t *testing.T) {
 }
 
 func TestReparentTablet(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())

--- a/go/vt/wrangler/testlib/version_test.go
+++ b/go/vt/wrangler/testlib/version_test.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
+
+	"vitess.io/vitess/go/vt/discovery"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -55,6 +58,12 @@ func expvarHandler(gitRev *string) func(http.ResponseWriter, *http.Request) {
 }
 
 func TestVersion(t *testing.T) {
+	delay := discovery.GetTabletPickerRetryDelay()
+	defer func() {
+		discovery.SetTabletPickerRetryDelay(delay)
+	}()
+	discovery.SetTabletPickerRetryDelay(5 * time.Millisecond)
+
 	// We need to run this test with the /debug/vars version of the
 	// plugin.
 	wrangler.ResetDebugVarsGetVersion()

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -606,9 +606,9 @@ func TestShardMigrateMainflow(t *testing.T) {
 		tme.dbTargetClients[1].addQuery("select id from _vt.vreplication where db_name = 'vt_ks' and workflow = 'test'", resultid2, nil)
 		tme.dbTargetClients[0].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (1, 2)", &sqltypes.Result{}, nil)
 		tme.dbTargetClients[1].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (2)", &sqltypes.Result{}, nil)
-		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 1", runningResult2(1), nil)
-		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 2", runningResult2(2), nil)
-		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 2", runningResult2(2), nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 1", runningResult(1), nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 2", runningResult(2), nil)
+		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 2", runningResult(2), nil)
 
 		deleteReverseReplicaion()
 	}
@@ -654,9 +654,9 @@ func TestShardMigrateMainflow(t *testing.T) {
 		tme.dbTargetClients[0].addQuery("update _vt.vreplication set state = 'Stopped', message = 'stopped for cutover' where id in (2)", &sqltypes.Result{}, nil)
 		tme.dbTargetClients[1].addQuery("select id from _vt.vreplication where id = 2", resultid2, nil)
 		tme.dbTargetClients[1].addQuery("update _vt.vreplication set state = 'Stopped', message = 'stopped for cutover' where id in (2)", &sqltypes.Result{}, nil)
-		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 1", stoppedResult2(1), nil)
-		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 2", stoppedResult2(2), nil)
-		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 2", stoppedResult2(2), nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 1", stoppedResult(1), nil)
+		tme.dbTargetClients[1].addQuery("select * from _vt.vreplication where id = 2", stoppedResult(2), nil)
+		tme.dbTargetClients[0].addQuery("select * from _vt.vreplication where id = 2", stoppedResult(2), nil)
 	}
 	waitForCatchup()
 
@@ -683,12 +683,12 @@ func TestShardMigrateMainflow(t *testing.T) {
 	startReverseVReplication := func() {
 		tme.dbSourceClients[0].addQuery("select id from _vt.vreplication where db_name = 'vt_ks'", resultid34, nil)
 		tme.dbSourceClients[0].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (3, 4)", &sqltypes.Result{}, nil)
-		tme.dbSourceClients[0].addQuery("select * from _vt.vreplication where id = 3", runningResult2(3), nil)
-		tme.dbSourceClients[0].addQuery("select * from _vt.vreplication where id = 4", runningResult2(4), nil)
+		tme.dbSourceClients[0].addQuery("select * from _vt.vreplication where id = 3", runningResult(3), nil)
+		tme.dbSourceClients[0].addQuery("select * from _vt.vreplication where id = 4", runningResult(4), nil)
 		tme.dbSourceClients[1].addQuery("select id from _vt.vreplication where db_name = 'vt_ks'", resultid34, nil)
 		tme.dbSourceClients[1].addQuery("update _vt.vreplication set state = 'Running', message = '' where id in (3, 4)", &sqltypes.Result{}, nil)
-		tme.dbSourceClients[1].addQuery("select * from _vt.vreplication where id = 3", runningResult2(3), nil)
-		tme.dbSourceClients[1].addQuery("select * from _vt.vreplication where id = 4", runningResult2(4), nil)
+		tme.dbSourceClients[1].addQuery("select * from _vt.vreplication where id = 3", runningResult(3), nil)
+		tme.dbSourceClients[1].addQuery("select * from _vt.vreplication where id = 4", runningResult(4), nil)
 	}
 	startReverseVReplication()
 
@@ -1757,18 +1757,10 @@ func getResult(id int, state string, keyspace string, shard string) *sqltypes.Re
 	)
 }
 
-func stoppedResult2(id int) *sqltypes.Result {
-	return getResult(id, "Stopped", "ks", "-40")
-}
-
-func runningResult2(id int) *sqltypes.Result {
-	return getResult(id, "Running", "ks", "-40")
-}
-
 func stoppedResult(id int) *sqltypes.Result {
-	return getResult(id, "Stopped", "", "")
+	return getResult(id, "Stopped", tpChoice.keyspace, tpChoice.shard)
 }
 
 func runningResult(id int) *sqltypes.Result {
-	return getResult(id, "Running", "", "")
+	return getResult(id, "Running", tpChoice.keyspace, tpChoice.shard)
 }


### PR DESCRIPTION
There was a bug in the tablet_picker implementation which could cause it to loop forever.
1. We were not checking whether the context is still valid.
2. If there are non-zero tablets of any kind, but zero tablets of the desired type, we loop forever (see 1.)

Along with fixing the above problem, this change has a few other improvements
- Always use a short context for topo calls
- Do retry if a tablet is not found, but only after a delay.

Signed-off-by: deepthi <deepthi@planetscale.com>