### PR TITLE
Build protos via docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ ifndef NOBANNER
 	echo $$(date): Compiling proto definitions
 endif
 	docker build -t proto-builder -f docker/proto/Dockerfile .
-	docker run --rm -v $(pwd)/go/vt/proto/:/go/vt/proto/ proto-builder
+	docker run --rm --mount type=bind,src=$(shell pwd)/go/vt/proto/,dst=/go/vt/proto/ proto-builder
 
 # Helper targets for building Docker images.
 # Please read docker/README.md to understand the different available images.

--- a/Makefile
+++ b/Makefile
@@ -156,13 +156,14 @@ ifndef NOBANNER
 endif
 
 # TODO(sougou): find a better way around this temp hack.
-VTTOP=$(VTROOT)/../../..
 $(PROTO_GO_OUTS): install_protoc-gen-go proto/*.proto
 	for name in $(PROTO_SRC_NAMES); do \
-		cd $(VTTOP)/src && \
-		$(VTROOT)/bin/protoc --go_out=plugins=grpc:. -Ivitess.io/vitess/proto vitess.io/vitess/proto/$${name}.proto && \
+		$(VTROOT)/bin/protoc --go_out=plugins=grpc:. -Iproto proto/$${name}.proto && \
+		mkdir -p $(VTROOT)/go/vt/proto/$${name} && \
+		mv vitess.io/vitess/go/vt/proto/$${name}/$${name}.pb.go $(VTROOT)/go/vt/proto/$${name}/ && \
 		goimports -w $(VTROOT)/go/vt/proto/$${name}/$${name}.pb.go; \
 	done
+	rm -rf vitess.io
 
 # Helper targets for building Docker images.
 # Please read docker/README.md to understand the different available images.

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ PROTO_GO_OUTS = $(foreach name, $(PROTO_SRC_NAMES), go/vt/proto/$(name)/$(name).
 # This rule rebuilds all the go files from the proto definitions for gRPC.
 proto: $(PROTO_GO_OUTS)
 
+docker-proto:
+	docker build -t proto-builder -f docker/proto/Dockerfile .
+	docker run --rm -v $(shell pwd)/go/vt/proto/:/go/vt/proto/ proto-builder
+
 ifndef NOBANNER
 	echo $$(date): Compiling proto definitions
 endif

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,8 @@ ifndef NOBANNER
 endif
 	docker build -t proto-builder -f docker/proto/Dockerfile .
 	docker run --rm --mount type=bind,src=$(shell pwd)/go/vt/proto/,dst=/go/vt/proto/ proto-builder
+	# Because we're bind mounting, they'll get created by root:root in the proto-builder.
+	sudo chown -R $(shell id -u):$(shell id -g) ./go/vt/proto/
 
 # Helper targets for building Docker images.
 # Please read docker/README.md to understand the different available images.

--- a/docker/proto/Dockerfile
+++ b/docker/proto/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PR
     mv /protoc/bin/protoc /usr/local/bin/ && \
     rm -rf protoc-${PROTOC_VERSION}-linux-x86_64.zip
 
-ADD proto/ proto
+ADD proto proto
 
 # Build proto/$x.proto files into /go/vt/proto/$x/$x.pb.go
-CMD [ "proto/build.sh" ]
+CMD [ "./proto/build.sh" ]

--- a/docker/proto/Dockerfile
+++ b/docker/proto/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.14-buster
+
+ARG PROTOC_VERSION=3.12.4
+
+# Install depedencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        unzip \
+        wget && \
+    go get \
+        golang.org/x/tools/cmd/goimports \
+        github.com/golang/protobuf/protoc-gen-go && \
+    go install \
+        golang.org/x/tools/cmd/goimports \
+        github.com/golang/protobuf/protoc-gen-go
+
+# Download protoc
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /protoc && \
+    mv /protoc/bin/protoc /usr/local/bin/ && \
+    rm -rf protoc-${PROTOC_VERSION}-linux-x86_64.zip
+
+ADD proto/ proto
+
+# Build proto/$x.proto files into /go/vt/proto/$x/$x.pb.go
+CMD [ "proto/build.sh" ]

--- a/docker/proto/Dockerfile
+++ b/docker/proto/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.14-buster
 
-ARG PROTOC_VERSION=3.12.4
-
 # Install depedencies
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -9,13 +7,24 @@ RUN apt-get update && \
         ca-certificates \
         curl \
         unzip \
-        wget && \
-    go get \
+        wget
+
+ARG PROTOC_GEN_GO_VERSION=v1.3.2
+
+# Need to set up a module in order to install a specific version of protoc-gen-go.
+#   1. The `go get package@version` syntax is only supported in module mode.
+#   2. In module mode, `go get` is unsupported outside of a module.
+# These two things together force us to do this quick hack.
+#
+# See https://github.com/golang/go/issues/24250 as just one of many issues on the subject.
+RUN mkdir proto-builder && \
+    cd proto-builder && \
+    go mod init proto-builder && \
+    GO111MODULE=on go get \
         golang.org/x/tools/cmd/goimports \
-        github.com/golang/protobuf/protoc-gen-go && \
-    go install \
-        golang.org/x/tools/cmd/goimports \
-        github.com/golang/protobuf/protoc-gen-go
+        github.com/golang/protobuf/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
+
+ARG PROTOC_VERSION=3.12.4
 
 # Download protoc
 RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \

--- a/proto/build.sh
+++ b/proto/build.sh
@@ -6,7 +6,7 @@ do
 
   echo "Building $name.proto ..."
   dir="vt/proto/$name"
-  mkdir -p "./$dir"
+  mkdir -p "./$dir" && chmod 755 "./$dir"
 
   protoc --go_out=plugins=grpc:. -Iproto "proto/$name.proto"
   mv "vitess.io/vitess/go/$dir/$name.pb.go" "./$dir/$name.pb.go"

--- a/proto/build.sh
+++ b/proto/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+for file in proto/*.proto
+do
+  name="$(basename "$file" | cut -d. -f1)"
+
+  echo "Building $name.proto ..."
+  dir="vt/proto/$name"
+  mkdir -p "./$dir"
+
+  protoc --go_out=plugins=grpc:. -Iproto "proto/$name.proto"
+  mv "vitess.io/vitess/go/$dir/$name.pb.go" "./$dir/$name.pb.go"
+  goimports -w "./$dir/$name.pb.go"
+done
+
+rm -rf vitess.io


### PR DESCRIPTION
This PR creates a dockerfile and build script for generating the go code from the .proto files.

I was playing around with the protos locally when I discovered that `make proto` did not work with the way I had cloned vitess (I think) (errors like `/bin/bash: line 0: cd: /../../../src: No such file or directory`).

After poking at it for a bit, I ended up deciding (but let me know if you think differently!) that going with a dockerized solution would probably be simpler to maintain. The main benefits I see are that we pin the version of `protoc` (we could also pin `protoc-gen-go` and `goimports` if we wanted) and that it doesn't rely on VTTOP or VTROOT in any way; you just need a vitess checkout and docker installed.

Testing:

```
❯ make proto
Mon Aug 10 13:41:59 EDT 2020: Compiling proto definitions
Sending build context to Docker daemon  210.3MB
Step 1/8 : FROM golang:1.14-buster
 ---> baaca3151cdb
Step 2/8 : RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         build-essential         ca-certificates         curl         unzip         wget
 ---> Using cache
 ---> b5fc7362d68c
Step 3/8 : ARG PROTOC_GEN_GO_VERSION=v1.3.1
 ---> Using cache
 ---> 4c3b0629bd2f
Step 4/8 : RUN mkdir proto-builder &&     cd proto-builder &&     go mod init proto-builder &&     GO111MODULE=on go get         golang.org/x/tools/cmd/goimports         github.com/golang/protobuf/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
 ---> Using cache
 ---> 1eba290a1f52
Step 5/8 : ARG PROTOC_VERSION=3.12.4
 ---> Using cache
 ---> 21ade038f4b4
Step 6/8 : RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip &&     unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /protoc &&     mv /protoc/bin/protoc /usr/local/bin/ &&     rm -rf protoc-${PROTOC_VERSION}-linux-x86_64.zip
 ---> Using cache
 ---> c30391a299f6
Step 7/8 : ADD proto proto
 ---> Using cache
 ---> 1a616f2d15ad
Step 8/8 : CMD [ "./proto/build.sh" ]
 ---> Using cache
 ---> 0fe79cf99c36
Successfully built 0fe79cf99c36
Successfully tagged proto-builder:latest
Building automation.proto ...
Building automationservice.proto ...
Building binlogdata.proto ...
Building binlogservice.proto ...
Building logutil.proto ...
Building mysqlctl.proto ...
Building query.proto ...
Building queryservice.proto ...
Building replicationdata.proto ...
Building tableacl.proto ...
Building tabletmanagerdata.proto ...
Building tabletmanagerservice.proto ...
Building throttlerdata.proto ...
Building throttlerservice.proto ...
Building topodata.proto ...
Building vschema.proto ...
Building vtctldata.proto ...
Building vtctlservice.proto ...
Building vtgate.proto ...
Building vtgateservice.proto ...
Building vtrpc.proto ...
Building vttest.proto ...
Building vttime.proto ...
Building vtworkerdata.proto ...
Building vtworkerservice.proto ...
Building workflow.proto ...
```

~~I'm not sure what version of protoc was used to generate these last time, because I definitely see changes, [vtgate.pb.go, for example](https://gist.github.com/ajm188/a92a3f406401d04129f09e08fc9c36cd). I would guess pinning the protoc version lower could let us merge this change _without_ impacting the protos (and then later we can bump the version and update the protos :D)~~

I pinned proto-gen-go to 1.3.2 (found [here](https://github.com/vitessio/vitess/blob/master/go.mod#L28)), and now the only diff is the following in go/vt/proto/binlogdata/binlogdata.pb.go:

```diff
diff --git a/go/vt/proto/binlogdata/binlogdata.pb.go b/go/vt/proto/binlogdata/binlogdata.pb.go
index 5df50ab9d..75a2108d4 100644
--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -1383,9 +1383,6 @@ func (m *VEvent) GetJournal() *Journal {
 
 func (m *VEvent) GetDml() string {
        if m != nil {
-               if m.Statement != "" {
-                       return m.Statement
-               }
                return m.Dml
        }
        return ""
```
