### PR TITLE
Reverse workflow: update cells/tablet_types

### DIFF
--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -40,8 +40,8 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 )
 
-const vreplQueryks = "select id, source, message from _vt.vreplication where workflow='test' and db_name='vt_ks'"
-const vreplQueryks2 = "select id, source, message from _vt.vreplication where workflow='test' and db_name='vt_ks2'"
+const vreplQueryks = "select id, source, message, cell, tablet_types from _vt.vreplication where workflow='test' and db_name='vt_ks'"
+const vreplQueryks2 = "select id, source, message, cell, tablet_types from _vt.vreplication where workflow='test' and db_name='vt_ks2'"
 
 type testMigraterEnv struct {
 	ts              *topo.Server
@@ -166,11 +166,11 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 					}},
 				},
 			}
-			rows = append(rows, fmt.Sprintf("%d|%v|", j+1, bls))
+			rows = append(rows, fmt.Sprintf("%d|%v|||", j+1, bls))
 		}
 		tme.dbTargetClients[i].addInvariant(vreplQueryks2, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-			"id|source|message",
-			"int64|varchar|varchar"),
+			"id|source|message|cell|tablet_types",
+			"int64|varchar|varchar|varchar|varchar"),
 			rows...),
 		)
 	}
@@ -279,11 +279,11 @@ func newTestShardMigrater(ctx context.Context, t *testing.T, sourceShards, targe
 					}},
 				},
 			}
-			rows = append(rows, fmt.Sprintf("%d|%v|", j+1, bls))
+			rows = append(rows, fmt.Sprintf("%d|%v|||", j+1, bls))
 		}
 		tme.dbTargetClients[i].addInvariant(vreplQueryks, sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-			"id|source|message",
-			"int64|varchar|varchar"),
+			"id|source|message|cell|tablet_types",
+			"int64|varchar|varchar|varchar|varchar"),
 			rows...),
 		)
 	}

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -116,7 +116,7 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 					}},
 				},
 			}
-			rows = append(rows, fmt.Sprintf("%d|%v|", j+1, bls))
+			rows = append(rows, fmt.Sprintf("%d|%v|||", j+1, bls))
 			position := vdiffStopPosition
 			if pos := positions[sourceShard+shard]; pos != "" {
 				position = pos
@@ -134,10 +134,10 @@ func newTestVDiffEnv(sourceShards, targetShards []string, query string, position
 		// migrater buildMigrationTargets
 		env.tmc.setVRResults(
 			master.tablet,
-			"select id, source, message from _vt.vreplication where workflow='vdiffTest' and db_name='vt_target'",
+			"select id, source, message, cell, tablet_types from _vt.vreplication where workflow='vdiffTest' and db_name='vt_target'",
 			sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-				"id|source|message",
-				"int64|varchar|varchar"),
+				"id|source|message|cell|tablet_types",
+				"int64|varchar|varchar|varchar|varchar"),
 				rows...,
 			),
 		)

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -95,13 +95,13 @@ func TestVExec(t *testing.T) {
 	var result *sqltypes.Result
 	var testCases []*TestCase
 	result = sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-		"id|source|message",
-		"int64|varchar|varchar"),
-		"1|keyspace:\"source\" shard:\"0\" filter:<rules:<match:\"t1\" > >|",
+		"id|source|message|cell|tablet_types",
+		"int64|varchar|varchar|varchar|varchar"),
+		"1|keyspace:\"source\" shard:\"0\" filter:<rules:<match:\"t1\" > >|||",
 	)
 	testCases = append(testCases, &TestCase{
 		name:   "select",
-		query:  "select id, source, message from _vt.vreplication",
+		query:  "select id, source, message, cell, tablet_types from _vt.vreplication",
 		result: result,
 	})
 	result = &sqltypes.Result{

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -114,7 +114,7 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 					}},
 				},
 			}
-			rows = append(rows, fmt.Sprintf("%d|%v|", j+1, bls))
+			rows = append(rows, fmt.Sprintf("%d|%v|||", j+1, bls))
 			position := testStopPosition
 			if pos := positions[sourceShard+shard]; pos != "" {
 				position = pos
@@ -130,10 +130,10 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		// migrater buildMigrationTargets
 		env.tmc.setVRResults(
 			master.tablet,
-			"select id, source, message from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'",
+			"select id, source, message, cell, tablet_types from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'",
 			sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-				"id|source|message",
-				"int64|varchar|varchar"),
+				"id|source|message|cell|tablet_types",
+				"int64|varchar|varchar|varchar|varchar"),
 				rows...,
 			),
 		)


### PR DESCRIPTION
VReplication creates a reverse workflow on SwitchWrites so that it is possible to revert a MoveTables or Reshard. However the cell/tablet_types columns in _vt.vreplication are currently not updated with the options provided on the command line.

This PR fixes that:
* we use the same tablet_types in the reverse workflow 
* we use the same cells list, except: if the source and target keyspaces are different and the forward workflow included the 
target's cell (but not the source's) we use the source cell instead.

We chose this approach instead of adding more cli options to specify tablet_types/cells for the reverse workflow as a simpler initial implementation. We can add the extra options if we find valid use-cases for it.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

