### PR TITLE
VReplication: allow invalid (zero) values in date columns

### DIFF
--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -80,7 +80,7 @@ func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbcon
 	for _, query := range queryList {
 		log.Infof("exec %s", limitString(redactMasterPassword(query), LogQueryLengthLimit))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
-			log.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
+			log.Warningf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 		}
 	}

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -96,6 +96,7 @@ func (mysqld *Mysqld) FetchSuperQuery(ctx context.Context, query string) (*sqlty
 	defer conn.Recycle()
 	log.V(6).Infof("fetch %v", query)
 	qr, err := mysqld.executeFetchContext(ctx, conn, query, 10000, true)
+
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -467,7 +467,6 @@ func TestPlayerCopyTablesWithFK(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"/insert into _vt.vreplication",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"select @@foreign_key_checks;",
 		"select @@foreign_key_checks, @@sql_mode;",
 		// Create the list of tables to copy and transition to Copying state.
 		"begin",

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -74,6 +74,7 @@ func TestCopyTablesWithInvalidDates(t *testing.T) {
 
 	expectDBClientQueries(t, []string{
 		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message='Picked source tablet.*",
 		// Create the list of tables to copy and transition to Copying state.
 		"begin",
 		"/insert into _vt.copy_state",

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -31,7 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
 
-func TestPlayerCopyTablesWithInvalidDates(t *testing.T) {
+func TestCopyTablesWithInvalidDates(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{

--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -93,7 +93,13 @@ func (vc *vdbClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, 
 // Execute is ExecuteFetch without the maxrows.
 func (vc *vdbClient) Execute(query string) (*sqltypes.Result, error) {
 	// Number of rows should never exceed relayLogMaxSize.
-	return vc.ExecuteFetch(query, relayLogMaxSize)
+	log.Infof("Executing %s", query)
+	rs, err := vc.ExecuteFetch(query, relayLogMaxSize)
+	if err != nil {
+		log.Infof("ExecuteFetch error: %s", err)
+		return nil, err
+	}
+	return rs, err
 }
 
 func (vc *vdbClient) ExecuteWithRetry(ctx context.Context, query string) (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -38,6 +38,7 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
+
 func TestPlayerInvalidDates(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -19,8 +19,8 @@ package vreplication
 import (
 	"flag"
 	"fmt"
-	"strconv"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -37,6 +38,81 @@ import (
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
+func TestPlayerInvalidDates(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		"create table src1(id int, dt date, primary key(id))",
+		fmt.Sprintf("create table %s.dst1(id int, dt date, primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src1",
+		fmt.Sprintf("drop table %s.dst1", vrepldb),
+	})
+	pos := masterPosition(t)
+	execStatements(t, []string{"set sql_mode='';insert into src1 values(1, '0000-00-00');set sql_mode='STRICT_TRANS_TABLES';"})
+	env.SchemaEngine.Reload(context.Background())
+
+	// default mysql flavor allows invalid dates: so disallow explicitly for this test
+	if err := env.Mysqld.ExecuteSuperQuery(context.Background(), "SET @@global.sql_mode=CONCAT(@@global.sql_mode, ',NO_ZERO_DATE,NO_ZERO_IN_DATE')"); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+	}
+	defer func() {
+		if err := env.Mysqld.ExecuteSuperQuery(context.Background(), "SET @@global.sql_mode=REPLACE(@@global.sql_mode, ',NO_ZERO_DATE,NO_ZERO_IN_DATE','')"); err != nil {
+			fmt.Fprintf(os.Stderr, "%v", err)
+		}
+	}()
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst1",
+			Filter: "select * from src1",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, pos)
+	defer cancel()
+	testcases := []struct {
+		input  string
+		output string
+		table  string
+		data   [][]string
+	}{{
+		input:  "select 1 from dual",
+		output: "insert into dst1(id,dt) values (1,'0000-00-00')",
+		table:  "dst1",
+		data: [][]string{
+			{"1", "0000-00-00"},
+		},
+	}, {
+		input:  "insert into src1 values (2, '2020-01-01')",
+		output: "insert into dst1(id,dt) values (2,'2020-01-01')",
+		table:  "dst1",
+		data: [][]string{
+			{"1", "0000-00-00"},
+			{"2", "2020-01-01"},
+		},
+	}}
+
+	for _, tcases := range testcases {
+		execStatements(t, []string{tcases.input})
+		output := []string{
+			tcases.output,
+		}
+		expectNontxQueries(t, output)
+
+		if tcases.table != "" {
+			// without the sleep there is a flakiness where row inserted by vreplication is not visible to vdbclient
+			time.Sleep(100 * time.Millisecond)
+			expectData(t, tcases.table, tcases.data)
+		}
+	}
+}
 
 func TestVReplicationTimeUpdated(t *testing.T) {
 	ctx := context.Background()

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterOptions(t *testing.T) {
+	type TestCase struct {
+		currentOptions  string
+		optionsToRemove []string
+		optionsToAdd    []string
+		newOptions      string
+	}
+	tcases := []*TestCase{
+		{
+			"TRADITIONAL,NO_ZERO_IN_DATE,NO_ZERO_DATE,SOME_OPTION",
+			[]string{"TRADITIONAL", "NO_ZERO_DATE", "NO_ZERO_IN_DATE"},
+			[]string{"ALLOW_INVALID_DATES"},
+			"SOME_OPTION,ALLOW_INVALID_DATES",
+		},
+		{
+			"STRICT_TRANS_TABLE,NO_ZERO_IN_DATE,NO_ZERO_DATE",
+			[]string{"TRADITIONAL", "NO_ZERO_DATE", "NO_ZERO_IN_DATE"},
+			[]string{"ALLOW_INVALID_DATES"},
+			"STRICT_TRANS_TABLE,ALLOW_INVALID_DATES",
+		},
+	}
+	for _, tcase := range tcases {
+		require.Equal(t, tcase.newOptions, filterOptions(tcase.currentOptions, tcase.optionsToRemove, tcase.optionsToAdd))
+	}
+}


### PR DESCRIPTION
While migrating with MoveTables, it is likely that the source database allowed zero values in dates (like 0000-00-00). The default connection options treat these as invalid and vreplication fails on rows with zero date values at the moment. The user's app will work fine since they will (presumably) be setting the connection options in the app (or globally) to allow invalid dates. 

We need to relax the sql options to allow invalid dates during all phases of vreplication since we will find invalid dates both during copy as well as when we stream (the 'replicate' phase).

Signed-off-by: Rohit Nayak <rohit@planetscale.com>