### PR TITLE
VRepl Collations: find collations for char primary keys and cast comparison during catchup

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -57,6 +57,7 @@ var (
 	vrepldb               = "vrepl"
 	globalDBQueries       = make(chan string, 1000)
 	testForeignKeyQueries = false
+	doNotLogDBQueries     = false
 )
 
 type LogExpectation struct {
@@ -392,6 +393,9 @@ func (dbc *realDBClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Resu
 		return nil, nil
 	}
 	qr, err := dbc.conn.ExecuteFetch(query, 10000, true)
+	if doNotLogDBQueries {
+		return qr, err
+	}
 	if !strings.HasPrefix(query, "select") && !strings.HasPrefix(query, "set") && !dbc.nolog {
 		globalDBQueries <- query
 	} else if testForeignKeyQueries && strings.Contains(query, "foreign_key_checks") { //allow select/set for foreign_key_checks

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -46,7 +46,7 @@ type ReplicatorPlan struct {
 	VStreamFilter *binlogdatapb.Filter
 	TargetTables  map[string]*TablePlan
 	TablePlans    map[string]*TablePlan
-	tableKeys     map[string][]*TableKey
+	PKInfoMap     map[string][]*PrimaryKeyInfo
 }
 
 // buildExecution plan uses the field info as input and the partially built
@@ -86,9 +86,9 @@ func (rp *ReplicatorPlan) buildExecutionPlan(fieldEvent *binlogdatapb.FieldEvent
 // requires us to wait for the field info sent by the source.
 func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Result, fields []*querypb.Field) (*TablePlan, error) {
 	tpb := &tablePlanBuilder{
-		name:     sqlparser.NewTableIdent(tableName),
-		lastpk:   lastpk,
-		tableKey: rp.tableKeys[tableName],
+		name:    sqlparser.NewTableIdent(tableName),
+		lastpk:  lastpk,
+		pkInfos: rp.PKInfoMap[tableName],
 	}
 	for _, field := range fields {
 		colName := sqlparser.NewColIdent(field.Name)
@@ -104,7 +104,7 @@ func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Res
 		tpb.colExprs = append(tpb.colExprs, cexpr)
 	}
 	// The following actions are a subset of buildTablePlan.
-	if err := tpb.analyzePK(rp.tableKeys); err != nil {
+	if err := tpb.analyzePK(rp.PKInfoMap); err != nil {
 		return nil, err
 	}
 	return tpb.generate(), nil

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -666,8 +666,8 @@ func TestBuildPlayerPlan(t *testing.T) {
 		err: "group by expression is not allowed to reference an aggregate expression: a",
 	}}
 
-	tableKeys := map[string][]*TableKey{
-		"t1": {&TableKey{Name: "c1"}},
+	PrimaryKeyInfos := map[string][]*PrimaryKeyInfo{
+		"t1": {&PrimaryKeyInfo{Name: "c1"}},
 	}
 
 	copyState := map[string]*sqltypes.Result{
@@ -681,7 +681,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 	}
 
 	for _, tcase := range testcases {
-		plan, err := buildReplicatorPlan(tcase.input, tableKeys, nil)
+		plan, err := buildReplicatorPlan(tcase.input, PrimaryKeyInfos, nil)
 		gotPlan, _ := json.Marshal(plan)
 		wantPlan, _ := json.Marshal(tcase.plan)
 		if string(gotPlan) != string(wantPlan) {
@@ -695,7 +695,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			t.Errorf("Filter err(%v): %s, want %v", tcase.input, gotErr, tcase.err)
 		}
 
-		plan, err = buildReplicatorPlan(tcase.input, tableKeys, copyState)
+		plan, err = buildReplicatorPlan(tcase.input, PrimaryKeyInfos, copyState)
 		if err != nil {
 			continue
 		}
@@ -708,9 +708,9 @@ func TestBuildPlayerPlan(t *testing.T) {
 }
 
 func TestBuildPlayerPlanNoDup(t *testing.T) {
-	tableKeys := map[string][]*TableKey{
-		"t1": {&TableKey{Name: "c1"}},
-		"t2": {&TableKey{Name: "c2"}},
+	PrimaryKeyInfos := map[string][]*PrimaryKeyInfo{
+		"t1": {&PrimaryKeyInfo{Name: "c1"}},
+		"t2": {&PrimaryKeyInfo{Name: "c2"}},
 	}
 	input := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -721,7 +721,7 @@ func TestBuildPlayerPlanNoDup(t *testing.T) {
 			Filter: "select * from t",
 		}},
 	}
-	_, err := buildReplicatorPlan(input, tableKeys, nil)
+	_, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
 	want := "more than one target for source table t"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("buildReplicatorPlan err: %v, must contain: %v", err, want)
@@ -729,9 +729,9 @@ func TestBuildPlayerPlanNoDup(t *testing.T) {
 }
 
 func TestBuildPlayerPlanExclude(t *testing.T) {
-	tableKeys := map[string][]*TableKey{
-		"t1": {&TableKey{Name: "c1"}},
-		"t2": {&TableKey{Name: "c2"}},
+	PrimaryKeyInfos := map[string][]*PrimaryKeyInfo{
+		"t1": {&PrimaryKeyInfo{Name: "c1"}},
+		"t2": {&PrimaryKeyInfo{Name: "c2"}},
 	}
 	input := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -742,7 +742,7 @@ func TestBuildPlayerPlanExclude(t *testing.T) {
 			Filter: "",
 		}},
 	}
-	plan, err := buildReplicatorPlan(input, tableKeys, nil)
+	plan, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
 	assert.NoError(t, err)
 
 	want := &TestReplicatorPlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -666,8 +666,8 @@ func TestBuildPlayerPlan(t *testing.T) {
 		err: "group by expression is not allowed to reference an aggregate expression: a",
 	}}
 
-	tableKeys := map[string][]string{
-		"t1": {"c1"},
+	tableKeys := map[string][]*TableKey{
+		"t1": {&TableKey{Name: "c1"}},
 	}
 
 	copyState := map[string]*sqltypes.Result{
@@ -708,9 +708,9 @@ func TestBuildPlayerPlan(t *testing.T) {
 }
 
 func TestBuildPlayerPlanNoDup(t *testing.T) {
-	tableKeys := map[string][]string{
-		"t1": {"c1"},
-		"t2": {"c2"},
+	tableKeys := map[string][]*TableKey{
+		"t1": {&TableKey{Name: "c1"}},
+		"t2": {&TableKey{Name: "c2"}},
 	}
 	input := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{
@@ -729,9 +729,9 @@ func TestBuildPlayerPlanNoDup(t *testing.T) {
 }
 
 func TestBuildPlayerPlanExclude(t *testing.T) {
-	tableKeys := map[string][]string{
-		"t1": {"c1"},
-		"t2": {"c2"},
+	tableKeys := map[string][]*TableKey{
+		"t1": {&TableKey{Name: "c1"}},
+		"t2": {&TableKey{Name: "c2"}},
 	}
 	input := &binlogdatapb.Filter{
 		Rules: []*binlogdatapb.Rule{{

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -48,6 +48,7 @@ type tablePlanBuilder struct {
 	onInsert   insertType
 	pkCols     []*colExpr
 	lastpk     *sqltypes.Result
+	tableKey   []*TableKey
 }
 
 // colExpr describes the processing to be performed to
@@ -114,7 +115,7 @@ const (
 // The TablePlan built is a partial plan. The full plan for a table is built
 // when we receive field information from events or rows sent by the source.
 // buildExecutionPlan is the function that builds the full plan.
-func buildReplicatorPlan(filter *binlogdatapb.Filter, tableKeys map[string][]string, copyState map[string]*sqltypes.Result) (*ReplicatorPlan, error) {
+func buildReplicatorPlan(filter *binlogdatapb.Filter, tableKeys map[string][]*TableKey, copyState map[string]*sqltypes.Result) (*ReplicatorPlan, error) {
 	plan := &ReplicatorPlan{
 		VStreamFilter: &binlogdatapb.Filter{FieldEventMode: filter.FieldEventMode},
 		TargetTables:  make(map[string]*TablePlan),
@@ -173,7 +174,7 @@ func MatchTable(tableName string, filter *binlogdatapb.Filter) (*binlogdatapb.Ru
 	return nil, nil
 }
 
-func buildTablePlan(tableName, filter string, tableKeys map[string][]string, lastpk *sqltypes.Result) (*TablePlan, error) {
+func buildTablePlan(tableName, filter string, tableKeys map[string][]*TableKey, lastpk *sqltypes.Result) (*TablePlan, error) {
 	query := filter
 	// generate equivalent select statement if filter is empty or a keyrange.
 	switch {
@@ -222,6 +223,7 @@ func buildTablePlan(tableName, filter string, tableKeys map[string][]string, las
 		},
 		selColumns: make(map[string]bool),
 		lastpk:     lastpk,
+		tableKey:   tableKeys[tableName],
 	}
 
 	if err := tpb.analyzeExprs(sel.SelectExprs); err != nil {
@@ -247,12 +249,12 @@ func buildTablePlan(tableName, filter string, tableKeys map[string][]string, las
 	}
 
 	sendRule.Filter = sqlparser.String(tpb.sendSelect)
-	tablePlan := tpb.generate(tableKeys)
+	tablePlan := tpb.generate()
 	tablePlan.SendRule = sendRule
 	return tablePlan, nil
 }
 
-func (tpb *tablePlanBuilder) generate(tableKeys map[string][]string) *TablePlan {
+func (tpb *tablePlanBuilder) generate() *TablePlan {
 	refmap := make(map[string]bool)
 	for _, cexpr := range tpb.pkCols {
 		for k := range cexpr.references {
@@ -450,13 +452,13 @@ func (tpb *tablePlanBuilder) analyzeGroupBy(groupBy sqlparser.GroupBy) error {
 }
 
 // analyzePK builds tpb.pkCols.
-func (tpb *tablePlanBuilder) analyzePK(tableKeys map[string][]string) error {
+func (tpb *tablePlanBuilder) analyzePK(tableKeys map[string][]*TableKey) error {
 	pkcols, ok := tableKeys[tpb.name.String()]
 	if !ok {
 		return fmt.Errorf("table %s not found in schema", tpb.name)
 	}
 	for _, pkcol := range pkcols {
-		cexpr := tpb.findCol(sqlparser.NewColIdent(pkcol))
+		cexpr := tpb.findCol(sqlparser.NewColIdent(pkcol.Name))
 		if cexpr == nil {
 			return fmt.Errorf("primary key column %s not found in select list", pkcol)
 		}
@@ -669,17 +671,40 @@ func (tpb *tablePlanBuilder) generateWhere(buf *sqlparser.TrackedBuffer, bvf *bi
 	}
 }
 
+func (tpb *tablePlanBuilder) getCharsetAndCollation(pkname string) (charSet string, collation string) {
+	for _, tableKey := range tpb.tableKey {
+		if strings.EqualFold(tableKey.Name, pkname) {
+			if tableKey.CharSet != "" {
+				charSet = fmt.Sprintf(" _%s ", tableKey.CharSet)
+			}
+			if tableKey.Collation != "" {
+				collation = fmt.Sprintf(" COLLATE %s ", tableKey.Collation)
+			}
+		}
+	}
+	return charSet, collation
+}
+
 func (tpb *tablePlanBuilder) generatePKConstraint(buf *sqlparser.TrackedBuffer, bvf *bindvarFormatter) {
+	type charSetCollation struct {
+		charSet   string
+		collation string
+	}
+	var charSetCollations []*charSetCollation
 	separator := "("
 	for _, pkname := range tpb.lastpk.Fields {
-		buf.Myprintf("%s%v", separator, &sqlparser.ColName{Name: sqlparser.NewColIdent(pkname.Name)})
+		charSet, collation := tpb.getCharsetAndCollation(pkname.Name)
+		charSetCollations = append(charSetCollations, &charSetCollation{charSet: charSet, collation: collation})
+		buf.Myprintf("%s%s%v%s", separator, charSet, &sqlparser.ColName{Name: sqlparser.NewColIdent(pkname.Name)}, collation)
 		separator = ","
 	}
 	separator = ") <= ("
-	for _, val := range tpb.lastpk.Rows[0] {
+	for i, val := range tpb.lastpk.Rows[0] {
 		buf.WriteString(separator)
+		buf.WriteString(charSetCollations[i].charSet)
 		separator = ","
 		val.EncodeSQL(buf)
+		buf.WriteString(charSetCollations[i].collation)
 	}
 	buf.WriteString(")")
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -259,6 +259,9 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 		_, err = vc.tablePlan.applyBulkInsert(rows, func(sql string) (*sqltypes.Result, error) {
 			start := time.Now()
 			qr, err := vc.vr.dbClient.ExecuteWithRetry(ctx, sql)
+			if err != nil {
+				return nil, err
+			}
 			vc.vr.stats.QueryTimings.Record("copy", start)
 
 			vc.vr.stats.CopyRowCount.Add(int64(qr.RowsAffected))

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -55,7 +55,7 @@ func newVCopier(vr *vreplicator) *vcopier {
 func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 	defer vc.vr.dbClient.Rollback()
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.tableKeys, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 	log.Infof("Copying table %s, lastpk: %v", tableName, copyState[tableName])
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.tableKeys, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -32,145 +30,9 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
 
-func testCollations(t *testing.T, charSet string, collation string, chars []string, charsInOrder []string) {
-	defer deleteTablet(addTablet(100))
-
-	savedPacketSize := *vstreamer.PacketSize
-	// PacketSize of 1 byte will send at most one row at a time.
-	*vstreamer.PacketSize = 1
-	defer func() { *vstreamer.PacketSize = savedPacketSize }()
-
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
-
-	savedWaitRetryTime := waitRetryTime
-	// waitRetry time should be very low to cause the wait loop to execute multipel times.
-	waitRetryTime = 10 * time.Millisecond
-	defer func() { waitRetryTime = savedWaitRetryTime }()
-
-	execStatements(t, []string{
-		fmt.Sprintf("create table src(idc varchar(20) CHARACTER SET %s COLLATE %s, val varchar(10), primary key(idc))", charSet, collation),
-		fmt.Sprintf("insert into src values('%s', '%s'), ('%s', '%s')", chars[0], chars[0], chars[1], chars[1]),
-		fmt.Sprintf("create table %s.dst(idc varchar(20) CHARACTER SET %s COLLATE %s, val varchar(10), primary key(idc))", vrepldb, charSet, collation),
-	})
-	defer execStatements(t, []string{
-		"drop table src",
-		fmt.Sprintf("drop table %s.dst", vrepldb),
-	})
-	env.SchemaEngine.Reload(context.Background())
-
-	count := 0
-	vstreamRowsSendHook = func(ctx context.Context) {
-		defer func() { count++ }()
-		// Allow the first two calls to go through: field info and one row.
-		if count <= 1 {
-			return
-		}
-		// Insert a row with PK which is < the lastPK till now because of the utf8mb4 collation
-		execStatements(t, []string{
-			fmt.Sprintf("insert into src values('%s', '%s')", chars[2], chars[2]),
-		})
-		// Wait for context to expire and then send the row.
-		// This will cause the copier to abort and go back to catchup mode.
-		<-ctx.Done()
-		// Do this no more than once.
-		vstreamRowsSendHook = nil
-	}
-
-	vstreamHook = func(context.Context) {
-		// Sleeping 50ms guarantees that the catchup wait loop executes multiple times.
-		// This is because waitRetryTime is set to 10ms.
-		time.Sleep(50 * time.Millisecond)
-		// Do this no more than once.
-		vstreamHook = nil
-	}
-
-	filter := &binlogdatapb.Filter{
-		Rules: []*binlogdatapb.Rule{{
-			Match:  "dst",
-			Filter: "select * from src",
-		}},
-	}
-
-	bls := &binlogdatapb.BinlogSource{
-		Keyspace: env.KeyspaceName,
-		Shard:    env.ShardName,
-		Filter:   filter,
-		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
-	}
-
-	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.VReplicationInit, playerEngine.dbName)
-	qr, err := playerEngine.Exec(query)
-	id := uint32(qr.InsertID)
-	require.NoError(t, err)
-	defer func() {
-		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", id)
-		if _, err := playerEngine.Exec(query); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	var getDestCount = func() int {
-		query = fmt.Sprintf("select count(*) from %s.dst", vrepldb)
-		qr, err = env.Mysqld.FetchSuperQuery(context.Background(), query)
-		require.NoError(t, err)
-		require.True(t, len(qr.Rows) == 1 && len(qr.Rows[0]) == 1)
-		count, err := evalengine.ToInt64(qr.Rows[0][0])
-		require.NoError(t, err)
-		return int(count)
-	}
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if getDestCount() == len(chars) || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	require.Equal(t, 3, getDestCount())
-
-	var expectedData [][]string
-	for _, c := range charsInOrder {
-		expectedData = append(expectedData, []string{c, c})
-	}
-	expectData(t, "dst", expectedData)
-}
-
-// TestPlayerCopyCollations tests the copy/catchup phase for a table with a varchar primary key with character collations
-func TestPlayerCopyCollations(t *testing.T) {
-	doNotLogDBQueries = true
-	defer func() {
-		doNotLogDBQueries = false
-	}()
-	type tCase struct {
-		charSet      string
-		collation    string
-		chars        []string
-		charsInOrder []string
-	}
-	testCases := []tCase{
-		{"utf8mb4", "utf8mb4_bin", []string{"a", "b", "A"}, []string{"A", "a", "b"}},
-		{"latin1", "latin1_general_ci", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
-		{"big5", "big5_chinese_ci", []string{"人", "己", "于"}, []string{"人", "于", "己"}}, //??
-		{"big5", "big5_chinese_ci", []string{"人", "于", "己"}, []string{"人", "于", "己"}},
-		{"big5", "big5_chinese_ci", []string{"三", "二", "一"}, []string{"一", "二", "三"}}, //1,2,3
-		{"big5", "big5_chinese_ci", []string{"一", "二", "三"}, []string{"一", "二", "三"}},
-		{"utf8mb4", "utf8mb4_bin", []string{"a", "b", "A"}, []string{"A", "a", "b"}},
-		{"utf32", "utf32_esperanto_ci", []string{"Ĵ", "Ŭ", "Ĉ"}, []string{"Ĉ", "Ĵ", "Ŭ"}}, //per wikipedia
-		{"utf32", "utf32_esperanto_ci", []string{"Ĉ", "Ĵ", "Ŭ"}, []string{"Ĉ", "Ĵ", "Ŭ"}},
-		{"eucjpms", "eucjpms_japanese_ci", []string{"あ", "い", "う"}, []string{"あ", "い", "う"}}, //A,I,U, Hiragana
-		{"eucjpms", "eucjpms_japanese_ci", []string{"あ", "い", "う"}, []string{"あ", "い", "う"}},
-	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s/%s", tc.charSet, tc.collation), func(t *testing.T) {
-			testCollations(t, tc.charSet, tc.collation, tc.chars, tc.charsInOrder)
-		})
-	}
-}
-
-// TestPlayerCopyVarcharPK tests the copy/catchup phase for a table with a varchar primary key with character collations
-func TestPlayerCopyVarcharPK(t *testing.T) {
+// TestPlayerCopyVarcharPKCaseInsensitive tests the copy/catchup phase for a table with a varchar primary key
+// which is case insensitive.
+func TestPlayerCopyVarcharPKCaseInsensitive(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	savedPacketSize := *vstreamer.PacketSize
@@ -190,7 +52,7 @@ func TestPlayerCopyVarcharPK(t *testing.T) {
 
 	execStatements(t, []string{
 		"create table src(idc varchar(20), val int, primary key(idc))",
-		"insert into src values('a', 1), ('b', 2)",
+		"insert into src values('a', 1), ('c', 2)",
 		fmt.Sprintf("create table %s.dst(idc varchar(20), val int, primary key(idc))", vrepldb),
 	})
 	defer execStatements(t, []string{
@@ -208,7 +70,7 @@ func TestPlayerCopyVarcharPK(t *testing.T) {
 		}
 		// Insert a row with PK which is < the lastPK till now because of the utf8mb4 collation
 		execStatements(t, []string{
-			"insert into src values('c', 3)",
+			"insert into src values('B', 3)",
 		})
 		// Wait for context to expire and then send the row.
 		// This will cause the copier to abort and go back to catchup mode.
@@ -258,23 +120,24 @@ func TestPlayerCopyVarcharPK(t *testing.T) {
 		"/update _vt.vreplication set state='Copying'",
 		"insert into dst(idc,val) values ('a',1)",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"a\\" > ' where vrepl_id=.*`,
-		`/insert into dst\(idc,val\) select 'c', 3 from dual where \( .* 'c' COLLATE .* \) <= \( .* 'a' COLLATE .* \)`,
-		"insert into dst(idc,val) values ('b',2)",
-		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"b\\" > ' where vrepl_id=.*`,
-		"insert into dst(idc,val) values ('c',3)",
+		`/insert into dst\(idc,val\) select 'B', 3 from dual where \( .* 'B' COLLATE .* \) <= \( .* 'a' COLLATE .* \)`,
+		"insert into dst(idc,val) values ('B',3)",
+		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"B\\" > ' where vrepl_id=.*`,
+		"insert into dst(idc,val) values ('c',2)",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"c\\" > ' where vrepl_id=.*`,
 		"/delete from _vt.copy_state.*dst",
 		"/update _vt.vreplication set state='Running'",
 	})
 	expectData(t, "dst", [][]string{
 		{"a", "1"},
-		{"b", "2"},
-		{"c", "3"},
+		{"B", "3"},
+		{"c", "2"},
 	})
 }
 
-// TestPlayerCopyVarcharPKCaseSensitiveCollation tests the copy/catchup phase for a table with a varchar primary key with character collations
-func TestPlayerCopyVarcharPKCaseSensitiveCollation(t *testing.T) {
+// TestPlayerCopyVarcharPKCaseSensitiveCollation tests the copy/catchup phase for a table with varbinary columns
+// (which has a case sensitive collation with upper case alphabets below lower case in sort order)
+func TestPlayerCopyVarcharCompositePKCaseSensitiveCollation(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	savedPacketSize := *vstreamer.PacketSize
@@ -293,9 +156,9 @@ func TestPlayerCopyVarcharPKCaseSensitiveCollation(t *testing.T) {
 	defer func() { waitRetryTime = savedWaitRetryTime }()
 
 	execStatements(t, []string{
-		"create table src(id int, idc varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, idc2 varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, val int, primary key(id,idc,idc2))",
-		"insert into src values(1, 'a', 'a', 1), (1, 'b', 'b', 2)",
-		fmt.Sprintf("create table %s.dst(id int, idc varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, idc2 varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin, val int, primary key(id,idc,idc2))", vrepldb),
+		"create table src(id int, idc varbinary(20), idc2 varbinary(20), val int, primary key(id,idc,idc2))",
+		"insert into src values(1, 'a', 'a', 1), (1, 'c', 'c', 2)",
+		fmt.Sprintf("create table %s.dst(id int, idc varbinary(20), idc2 varbinary(20), val int, primary key(id,idc,idc2))", vrepldb),
 	})
 	defer execStatements(t, []string{
 		"drop table src",
@@ -312,7 +175,7 @@ func TestPlayerCopyVarcharPKCaseSensitiveCollation(t *testing.T) {
 		}
 		// Insert a row with PK which is < the lastPK till now because of the utf8mb4 collation
 		execStatements(t, []string{
-			"insert into src values(1, 'A', 'A', 3)",
+			"insert into src values(1, 'B', 'B', 3)",
 		})
 		// Wait for context to expire and then send the row.
 		// This will cause the copier to abort and go back to catchup mode.
@@ -362,16 +225,16 @@ func TestPlayerCopyVarcharPKCaseSensitiveCollation(t *testing.T) {
 		"/update _vt.vreplication set state='Copying'",
 		"insert into dst(id,idc,idc2,val) values (1,'a','a',1)",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > fields:<name:\\"idc\\" type:VARBINARY > fields:<name:\\"idc2\\" type:VARBINARY > rows:<lengths:1 lengths:1 lengths:1 values:\\"1aa\\" > ' where vrepl_id=.*`,
-		`insert into dst(id,idc,idc2,val) select 1, 'A', 'A', 3 from dual where (1, _utf8mb4 'A' COLLATE utf8mb4_bin , _utf8mb4 'A' COLLATE utf8mb4_bin ) <= (1, _utf8mb4 'a' COLLATE utf8mb4_bin , _utf8mb4 'a' COLLATE utf8mb4_bin )`,
-		"insert into dst(id,idc,idc2,val) values (1,'b','b',2)",
-		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > fields:<name:\\"idc\\" type:VARBINARY > fields:<name:\\"idc2\\" type:VARBINARY > rows:<lengths:1 lengths:1 lengths:1 values:\\"1bb\\" > ' where vrepl_id=.*`,
+		`insert into dst(id,idc,idc2,val) select 1, 'B', 'B', 3 from dual where (1,'B','B') <= (1,'a','a')`,
+		"insert into dst(id,idc,idc2,val) values (1,'c','c',2)",
+		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > fields:<name:\\"idc\\" type:VARBINARY > fields:<name:\\"idc2\\" type:VARBINARY > rows:<lengths:1 lengths:1 lengths:1 values:\\"1cc\\" > ' where vrepl_id=.*`,
 		"/delete from _vt.copy_state.*dst",
 		"/update _vt.vreplication set state='Running'",
 	})
 	expectData(t, "dst", [][]string{
-		{"1", "A", "A", "3"},
+		{"1", "B", "B", "3"},
 		{"1", "a", "a", "1"},
-		{"1", "b", "b", "2"},
+		{"1", "c", "c", "2"},
 	})
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -120,7 +120,7 @@ func TestPlayerCopyVarcharPK(t *testing.T) {
 		"/update _vt.vreplication set state='Copying'",
 		"insert into dst(idc,val) values ('a',1)",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"a\\" > ' where vrepl_id=.*`,
-		`insert into dst(idc,val) select 'c', 3 from dual where ( _utf8 'c' COLLATE utf8_general_ci ) <= ( _utf8 'a' COLLATE utf8_general_ci )`,
+		`/insert into dst\(idc,val\) select 'c', 3 from dual where \( .* 'c' COLLATE .* \) <= \( .* 'a' COLLATE .* \)`,
 		"insert into dst(idc,val) values ('b',2)",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"idc\\" type:VARCHAR > rows:<lengths:1 values:\\"b\\" > ' where vrepl_id=.*`,
 		"insert into dst(idc,val) values ('c',3)",

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -101,7 +101,7 @@ func (vp *vplayer) play(ctx context.Context) error {
 		return nil
 	}
 
-	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.tableKeys, vp.copyState)
+	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.pkInfoMap, vp.copyState)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Initial implementation for handling charset collations during the catchup phase of vreplication. 

We cast the values on both the lhs and rhs to the charset and collation of the columns in the catchup query.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>