### PR TITLE
Add realtime health stats to vtctld /api/keyspace/ks/tablets API

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -87,7 +87,7 @@ type TabletWithStatsAndURL struct {
 	URL                 string                  `json:"url,omitempty"`
 }
 
-func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats) *TabletWithStatsAndURL {
+func newTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats) *TabletWithStatsAndURL {
 	tablet := &TabletWithStatsAndURL{
 		Alias:               t.Alias,
 		Hostname:            t.Hostname,
@@ -291,7 +291,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 				if err != nil {
 					return nil, err
 				}
-				tablet := NewTabletWithStatsAndURL(t.Tablet, realtimeStats)
+				tablet := newTabletWithStatsAndURL(t.Tablet, realtimeStats)
 				tablets = append(tablets, tablet)
 			}
 		}
@@ -464,7 +464,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			return nil, err
 		}
 
-		return NewTabletWithStatsAndURL(t.Tablet, nil), nil
+		return newTabletWithStatsAndURL(t.Tablet, nil), nil
 	})
 
 	// Healthcheck real time status per (cell, keyspace, tablet type, metric).

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -42,6 +42,7 @@ import (
 
 	"vitess.io/vitess/go/vt/mysqlctl"
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/proto/vttime"
 )
@@ -60,8 +61,16 @@ const (
 	jsonContentType = "application/json; charset=utf-8"
 )
 
-// TabletWithURL wraps topo.Tablet and adds a URL property.
-type TabletWithURL struct {
+// TabletStats represents realtime stats from a discovery.LegacyTabletStats struct.
+type TabletStats struct {
+	LastError     string                 `json:"last_error,omitempty"`
+	RealtimeStats *querypb.RealtimeStats `json:"realtime,omitempty"`
+	Serving       bool                   `json:"serving,omitempty"`
+	Up            bool                   `json:"up,omitempty"`
+}
+
+// TabletWithStatsAndURL wraps topo.Tablet, adding a URL property and optional realtime stats.
+type TabletWithStatsAndURL struct {
 	Alias               *topodatapb.TabletAlias `json:"alias,omitempty"`
 	Hostname            string                  `json:"hostname,omitempty"`
 	PortMap             map[string]int32        `json:"port_map,omitempty"`
@@ -74,7 +83,46 @@ type TabletWithURL struct {
 	MysqlHostname       string                  `json:"mysql_hostname,omitempty"`
 	MysqlPort           int32                   `json:"mysql_port,omitempty"`
 	MasterTermStartTime *vttime.Time            `json:"master_term_start_time,omitempty"`
+	Stats               *TabletStats            `json:"stats,omitempty"`
 	URL                 string                  `json:"url,omitempty"`
+}
+
+func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats) (*TabletWithStatsAndURL, error) {
+	tablet := &TabletWithStatsAndURL{
+		Alias:               t.Alias,
+		Hostname:            t.Hostname,
+		PortMap:             t.PortMap,
+		Keyspace:            t.Keyspace,
+		Shard:               t.Shard,
+		KeyRange:            t.KeyRange,
+		Type:                t.Type,
+		DbNameOverride:      t.DbNameOverride,
+		Tags:                t.Tags,
+		MysqlHostname:       t.MysqlHostname,
+		MysqlPort:           t.MysqlPort,
+		MasterTermStartTime: t.MasterTermStartTime,
+	}
+
+	if *proxyTablets {
+		tablet.URL = fmt.Sprintf("/vttablet/%s-%d/debug/status", t.Alias.Cell, t.Alias.Uid)
+	} else {
+		tablet.URL = "http://" + netutil.JoinHostPort(t.Hostname, t.PortMap["vt"])
+	}
+
+	if realtimeStats != nil {
+		if stats, err := realtimeStats.tabletStats(tablet.Alias); err == nil {
+			tablet.Stats = &TabletStats{
+				RealtimeStats: stats.Stats,
+				Serving:       stats.Serving,
+				Up:            stats.Up,
+			}
+			if stats.LastError != nil {
+				tablet.Stats.LastError = stats.LastError.Error()
+			}
+		}
+	}
+
+	return tablet, nil
 }
 
 func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...interface{}) {
@@ -218,10 +266,23 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 				return nil, err
 			}
 		}
-		tablets := [](*topodatapb.Tablet){}
+
+		if err := r.ParseForm(); err != nil {
+			return nil, err
+		}
+		cell := r.FormValue("cell")
+		cells := r.FormValue("cells")
+		filterCells := []string{} // empty == all cells
+		if cell != "" {
+			filterCells = []string{cell} // single cell
+		} else if cells != "" {
+			filterCells = strings.Split(cells, ",") // list of cells
+		}
+
+		tablets := [](*TabletWithStatsAndURL){}
 		for _, shard := range shardNames {
 			// Get tablets for this shard.
-			tabletAliases, err := ts.FindAllTabletAliasesInShard(ctx, keyspace, shard)
+			tabletAliases, err := ts.FindAllTabletAliasesInShardByCell(ctx, keyspace, shard, filterCells)
 			if err != nil && !topo.IsErrType(err, topo.PartialResult) {
 				return nil, err
 			}
@@ -230,7 +291,11 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 				if err != nil {
 					return nil, err
 				}
-				tablets = append(tablets, t.Tablet)
+				tablet, err := NewTabletWithStatsAndURL(t.Tablet, realtimeStats)
+				if err != nil {
+					return nil, err
+				}
+				tablets = append(tablets, tablet)
 			}
 		}
 		return tablets, nil
@@ -402,26 +467,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			return nil, err
 		}
 
-		tab := &TabletWithURL{
-			Alias:               t.Alias,
-			Hostname:            t.Hostname,
-			PortMap:             t.PortMap,
-			Keyspace:            t.Keyspace,
-			Shard:               t.Shard,
-			KeyRange:            t.KeyRange,
-			Type:                t.Type,
-			DbNameOverride:      t.DbNameOverride,
-			Tags:                t.Tags,
-			MysqlHostname:       t.MysqlHostname,
-			MysqlPort:           t.MysqlPort,
-			MasterTermStartTime: t.MasterTermStartTime,
-		}
-		if *proxyTablets {
-			tab.URL = fmt.Sprintf("/vttablet/%s-%d/debug/status", t.Alias.Cell, t.Alias.Uid)
-		} else {
-			tab.URL = "http://" + netutil.JoinHostPort(t.Hostname, t.PortMap["vt"])
-		}
-		return tab, nil
+		return NewTabletWithStatsAndURL(t.Tablet, nil)
 	})
 
 	// Healthcheck real time status per (cell, keyspace, tablet type, metric).

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -87,7 +87,7 @@ type TabletWithStatsAndURL struct {
 	URL                 string                  `json:"url,omitempty"`
 }
 
-func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats) (*TabletWithStatsAndURL, error) {
+func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats) *TabletWithStatsAndURL {
 	tablet := &TabletWithStatsAndURL{
 		Alias:               t.Alias,
 		Hostname:            t.Hostname,
@@ -122,7 +122,7 @@ func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats
 		}
 	}
 
-	return tablet, nil
+	return tablet
 }
 
 func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...interface{}) {
@@ -291,10 +291,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 				if err != nil {
 					return nil, err
 				}
-				tablet, err := NewTabletWithStatsAndURL(t.Tablet, realtimeStats)
-				if err != nil {
-					return nil, err
-				}
+				tablet := NewTabletWithStatsAndURL(t.Tablet, realtimeStats)
 				tablets = append(tablets, tablet)
 			}
 		}
@@ -467,7 +464,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			return nil, err
 		}
 
-		return NewTabletWithStatsAndURL(t.Tablet, nil)
+		return NewTabletWithStatsAndURL(t.Tablet, nil), nil
 	})
 
 	// Healthcheck real time status per (cell, keyspace, tablet type, metric).

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -63,10 +63,10 @@ const (
 
 // TabletStats represents realtime stats from a discovery.LegacyTabletStats struct.
 type TabletStats struct {
-	LastError     string                 `json:"last_error,omitempty"`
-	RealtimeStats *querypb.RealtimeStats `json:"realtime,omitempty"`
-	Serving       bool                   `json:"serving,omitempty"`
-	Up            bool                   `json:"up,omitempty"`
+	LastError string                 `json:"last_error,omitempty"`
+	Realtime  *querypb.RealtimeStats `json:"realtime,omitempty"`
+	Serving   bool                   `json:"serving"`
+	Up        bool                   `json:"up"`
 }
 
 // TabletWithStatsAndURL wraps topo.Tablet, adding a URL property and optional realtime stats.
@@ -112,9 +112,9 @@ func NewTabletWithStatsAndURL(t *topodatapb.Tablet, realtimeStats *realtimeStats
 	if realtimeStats != nil {
 		if stats, err := realtimeStats.tabletStats(tablet.Alias); err == nil {
 			tablet.Stats = &TabletStats{
-				RealtimeStats: stats.Stats,
-				Serving:       stats.Serving,
-				Up:            stats.Up,
+				Realtime: stats.Stats,
+				Serving:  stats.Serving,
+				Up:       stats.Up,
 			}
 			if stats.LastError != nil {
 				tablet.Stats.LastError = stats.LastError.Error()

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -75,22 +75,28 @@ func TestAPI(t *testing.T) {
 	ts.SaveVSchema(ctx, "ks1", vs)
 
 	tablet1 := topodatapb.Tablet{
-		Alias:    &topodatapb.TabletAlias{Cell: "cell1", Uid: 100},
-		Keyspace: "ks1",
-		Shard:    "-80",
-		Type:     topodatapb.TabletType_REPLICA,
-		KeyRange: &topodatapb.KeyRange{Start: nil, End: []byte{0x80}},
-		PortMap:  map[string]int32{"vt": 100},
+		Alias:         &topodatapb.TabletAlias{Cell: "cell1", Uid: 100},
+		Keyspace:      "ks1",
+		Shard:         "-80",
+		Type:          topodatapb.TabletType_REPLICA,
+		KeyRange:      &topodatapb.KeyRange{Start: nil, End: []byte{0x80}},
+		PortMap:       map[string]int32{"vt": 100},
+		Hostname:      "mysql1-cell1.test.net",
+		MysqlHostname: "mysql1-cell1.test.net",
+		MysqlPort:     int32(3306),
 	}
 	ts.CreateTablet(ctx, &tablet1)
 
 	tablet2 := topodatapb.Tablet{
-		Alias:    &topodatapb.TabletAlias{Cell: "cell2", Uid: 200},
-		Keyspace: "ks1",
-		Shard:    "-80",
-		Type:     topodatapb.TabletType_REPLICA,
-		KeyRange: &topodatapb.KeyRange{Start: nil, End: []byte{0x80}},
-		PortMap:  map[string]int32{"vt": 200},
+		Alias:         &topodatapb.TabletAlias{Cell: "cell2", Uid: 200},
+		Keyspace:      "ks1",
+		Shard:         "-80",
+		Type:          topodatapb.TabletType_REPLICA,
+		KeyRange:      &topodatapb.KeyRange{Start: nil, End: []byte{0x80}},
+		PortMap:       map[string]int32{"vt": 200},
+		Hostname:      "mysql2-cell2.test.net",
+		MysqlHostname: "mysql2-cell2.test.net",
+		MysqlPort:     int32(3306),
 	}
 	ts.CreateTablet(ctx, &tablet2)
 
@@ -133,6 +139,7 @@ func TestAPI(t *testing.T) {
 				"cell": "cell1",
 				"uid": 100
 			},
+			"hostname": "mysql1-cell1.test.net",
 			"port_map": {
 				"vt": 100
 			},
@@ -142,6 +149,8 @@ func TestAPI(t *testing.T) {
 				"end": "gA=="
 			},
 			"type": 2,
+			"mysql_hostname": "mysql1-cell1.test.net",
+			"mysql_port": 3306,
 			"stats": {
 				"realtime": {
 					"seconds_behind_master": 100
@@ -149,13 +158,14 @@ func TestAPI(t *testing.T) {
 				"serving": true,
 				"up": true
 			},
-			"url": "http://:100"
+			"url": "http://mysql1-cell1.test.net:100"
 		},
 		{
 			"alias": {
 				"cell": "cell2",
 				"uid": 200
 			},
+			"hostname": "mysql2-cell2.test.net",
 			"port_map": {
 				"vt": 200
 			},
@@ -165,7 +175,9 @@ func TestAPI(t *testing.T) {
 				"end": "gA=="
 			},
 			"type": 2,
-			"url": "http://:200"
+			"mysql_hostname": "mysql2-cell2.test.net",
+			"mysql_port": 3306,
+			"url": "http://mysql2-cell2.test.net:200"
 		}
 	]`
 
@@ -194,6 +206,7 @@ func TestAPI(t *testing.T) {
 					"cell": "cell1",
 					"uid": 100
 				},
+				"hostname": "mysql1-cell1.test.net",
 				"port_map": {
 					"vt": 100
 				},
@@ -203,6 +216,8 @@ func TestAPI(t *testing.T) {
 					"end": "gA=="
 				},
 				"type": 2,
+				"mysql_hostname": "mysql1-cell1.test.net",
+				"mysql_port": 3306,
 				"stats": {
 					"realtime": {
 						"seconds_behind_master": 100
@@ -210,7 +225,7 @@ func TestAPI(t *testing.T) {
 					"serving": true,
 					"up": true
 				},
-				"url": "http://:100"
+				"url": "http://mysql1-cell1.test.net:100"
 			}
 		]`},
 		{"GET", "keyspace/ks1/tablets/?cells=cell3", "", `[]`},
@@ -220,6 +235,7 @@ func TestAPI(t *testing.T) {
 					"cell": "cell2",
 					"uid": 200
 				},
+				"hostname": "mysql2-cell2.test.net",
 				"port_map": {
 					"vt": 200
 				},
@@ -229,7 +245,9 @@ func TestAPI(t *testing.T) {
 					"end": "gA=="
 				},
 				"type": 2,
-				"url": "http://:200"
+				"mysql_hostname": "mysql2-cell2.test.net",
+				"mysql_port": 3306,
+				"url": "http://mysql2-cell2.test.net:200"
 			}
 		]`},
 		{"GET", "keyspace/ks1/tablets/?cell=cell3", "", `[]`},
@@ -288,6 +306,7 @@ func TestAPI(t *testing.T) {
 		{"GET", "tablets/?shard=ks1%2F80-&cell=cell1", "", `[]`},
 		{"GET", "tablets/cell1-100", "", `{
 				"alias": {"cell": "cell1", "uid": 100},
+				"hostname": "mysql1-cell1.test.net",
 				"port_map": {"vt": 100},
 				"keyspace": "ks1",
 				"shard": "-80",
@@ -295,7 +314,9 @@ func TestAPI(t *testing.T) {
 					"end": "gA=="
 				},
 				"type": 2,
-				"url":"http://:100"
+				"mysql_hostname": "mysql1-cell1.test.net",
+				"mysql_port": 3306,
+				"url":"http://mysql1-cell1.test.net:100"
 			}`},
 		{"GET", "tablets/nonexistent-999", "", "404 page not found"},
 		{"POST", "tablets/cell1-100?action=TestTabletAction", "", `{

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -126,6 +126,49 @@ func TestAPI(t *testing.T) {
 	realtimeStats.StatsUpdate(ts5)
 	realtimeStats.StatsUpdate(ts6)
 
+	// all-tablets response for keyspace/ks1/tablets/ endpoints
+	keyspaceKs1AllTablets := `[
+		{
+			"alias": {
+				"cell": "cell1",
+				"uid": 100
+			},
+			"port_map": {
+				"vt": 100
+			},
+			"keyspace": "ks1",
+			"shard": "-80",
+			"key_range": {
+				"end": "gA=="
+			},
+			"type": 2,
+			"stats": {
+				"realtime": {
+					"seconds_behind_master": 100
+				},
+				"serving": true,
+				"up": true
+			},
+			"url": "http://:100"
+		},
+		{
+			"alias": {
+				"cell": "cell2",
+				"uid": 200
+			},
+			"port_map": {
+				"vt": 200
+			},
+			"keyspace": "ks1",
+			"shard": "-80",
+			"key_range": {
+				"end": "gA=="
+			},
+			"type": 2,
+			"url": "http://:200"
+		}
+	]`
+
 	// Test cases.
 	table := []struct {
 		method, path, body, want string
@@ -138,6 +181,58 @@ func TestAPI(t *testing.T) {
 
 		// Cells
 		{"GET", "cells", "", `["cell1","cell2"]`},
+
+		// Keyspace
+		{"GET", "keyspace/doesnt-exist/tablets/", "", ``},
+		{"GET", "keyspace/ks1/tablets/", "", keyspaceKs1AllTablets},
+		{"GET", "keyspace/ks1/tablets/-80", "", keyspaceKs1AllTablets},
+		{"GET", "keyspace/ks1/tablets/80-", "", `[]`},
+		{"GET", "keyspace/ks1/tablets/?cells=cell1,cell2", "", keyspaceKs1AllTablets},
+		{"GET", "keyspace/ks1/tablets/?cells=cell1", "", `[
+			{
+				"alias": {
+					"cell": "cell1",
+					"uid": 100
+				},
+				"port_map": {
+					"vt": 100
+				},
+				"keyspace": "ks1",
+				"shard": "-80",
+				"key_range": {
+					"end": "gA=="
+				},
+				"type": 2,
+				"stats": {
+					"realtime": {
+						"seconds_behind_master": 100
+					},
+					"serving": true,
+					"up": true
+				},
+				"url": "http://:100"
+			}
+		]`},
+		{"GET", "keyspace/ks1/tablets/?cells=cell3", "", `[]`},
+		{"GET", "keyspace/ks1/tablets/?cell=cell2", "", `[
+			{
+				"alias": {
+					"cell": "cell2",
+					"uid": 200
+				},
+				"port_map": {
+					"vt": 200
+				},
+				"keyspace": "ks1",
+				"shard": "-80",
+				"key_range": {
+					"end": "gA=="
+				},
+				"type": 2,
+				"url": "http://:200"
+			}
+		]`},
+		{"GET", "keyspace/ks1/tablets/?cell=cell3", "", `[]`},
 
 		// Keyspaces
 		{"GET", "keyspaces", "", `["ks1", "ks3"]`},


### PR DESCRIPTION
_(A continuation of https://github.com/vitessio/vitess/pull/6524, abandoned due to `git rebase` issues 🤞)_

This PR adds realtime health stats to the vtctld `/api/keyspace/<ks>/tablets/<shard>` HTTP API endpoint. This extends the PR @shlomi-noach made in https://github.com/vitessio/vitess/pull/4232

The tablet health metrics are needed for [`github.com/github/freno`](https://github.com/github/freno) to understand if a `vttablet` is ready for probes for replication lag. In today's implementation that looks for any tablet-type == `REPLICA` it is possible for an unhealthy `vttablet` _(replication is `STOP SLAVE`'d, mysqld crashed, etc)_ to continue to be probed by Freno because it is unable to detect tablet health from the current API endpoint

This PR also adds a `cell` and `cells` (CSV list) query parameter for filtering the output by Vitess Cell. Let me know if you'd prefer this to be part of the URL path vs a query param. This is useful [when you're only interested in grabbing specific cells](https://github.com/github/freno/pull/124)

Example `GET` calls:
1. `GET /api/keyspace/<ks>/tablets/?cell=cell1`
1. `GET /api/keyspace/<ks>/tablets/?cells=cell1,cell2`
1. `GET /api/keyspace/<ks>/tablets/<shard>?cell=cell1`
1. `GET /api/keyspace/<ks>/tablets/<shard>?cells=cell1,cell2`

Lastly, this PR adds unit tests for `GET /api/keyspace/<ks>/tablets/`

~~I've made this a work in progress PR for @sougou / @shlomi-noach / @deepthi to review. After we agree on the approach I can complete the unit testing, add suggestions, etc~~

cc @sougou / @shlomi-noach / @deepthi / @tomkrouper / @drogart 