### PR TITLE
POC: reducing binary size via upx

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,9 +30,13 @@ USER root
 COPY . /vt/src/vitess.io/vitess
 
 # Build Vitess
+RUN apt-get update
+RUN apt-get install -y upx
+
 RUN make build
+
+RUN find bin/ -type f -executable | while read f ; do  upx -1 $f ; upx -t $f || exit 1 ; done || exit 1
 
 # Fix permissions
 RUN chown -R vitess:vitess /vt
 USER vitess
-


### PR DESCRIPTION
Looking into [upx](https://linux.die.net/man/1/upx) as a way to reduce vitess binary size, and as result, dockerfiles size.

This work originates with complaints over the vitess dockerfiles size, and with concerns over loading even more resources into them. In this PR I used the `upx` compressor as introduced in https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/, and did not strip debug information.

I tested this on `vitess/base:latest` via `make docker_base`.

As it turns out, `upx -1` compressed our `bin/*` files at about `50%`. The total `bin/` directory reduces from `888MB` to `439MB`.

Strangely, my local docker build images do not reflect this reduction in size, and both before/after docker images are at `6.15GB`. Not sure why that is.

With regard compressed binaries:

- The way this works is that the binary is converted to a self-extracting executable
- The extracted executable is identical to the original executable, no binary changes
- do **not** use `--brute` as this does modify the binary, and tested on a `gh-ost` binary this actually broke the behavior of the binary
- When you run a compressed binary its bootstrap time increases since it needs to first decompress. e.g. testing on my laptop, `vtctl --version` runtime increases from `0.019s` to `0.21s`. That's a `10x` factor. Then again, our services are long running, and a sub-second startup time may be a worthy tradeoff. 