### PR TITLE
Rewrite SHOW TABLES

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -283,7 +283,9 @@ func TestShowTablesWithWhereClause(t *testing.T) {
 	require.Nil(t, err)
 	defer conn.Close()
 
-	assertMatches(t, conn, "show tables from ks where Tables_in_ks='t5'", `[[VARCHAR("t5")]]`)
+	assertMatches(t, conn, "show tables from ks where Tables_in_ks='t6'", `[[VARCHAR("t6")]]`)
+	exec(t, conn, "begin")
+	assertMatches(t, conn, "show tables from ks where Tables_in_ks='t3'", `[[VARCHAR("t3")]]`)
 }
 
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -276,6 +276,16 @@ func TestXXHash(t *testing.T) {
 	assertMatches(t, conn, "select phone, keyspace_id from t7_xxhash_idx", `[]`)
 }
 
+func TestShowTablesWithWhereClause(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	assertMatches(t, conn, "show tables from ks where Tables_in_ks='t5'", `[[VARCHAR("t5")]]`)
+}
+
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
 	qr := exec(t, conn, query)

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -508,6 +508,13 @@ func NewColIdent(str string) ColIdent {
 	}
 }
 
+// NewColName makes a new ColName
+func NewColName(str string) *ColName {
+	return &ColName{
+		Name: NewColIdent(str),
+	}
+}
+
 //NewSelect is used to create a select statement
 func NewSelect(comments Comments, exprs SelectExprs, selectOptions []string, from TableExprs, where *Where, groupBy GroupBy, having *Where) *Select {
 	var cache *bool

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -630,14 +630,7 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		}
 		sql = sqlparser.String(show)
 	case sqlparser.KeywordString(sqlparser.TABLES):
-		if show.ShowTablesOpt != nil && show.ShowTablesOpt.DbName != "" {
-			if destKeyspace == "" {
-				// Change "show tables from <keyspace>" to "show tables" directed to that keyspace.
-				destKeyspace = show.ShowTablesOpt.DbName
-			}
-			show.ShowTablesOpt.DbName = ""
-		}
-		sql = sqlparser.String(show)
+		destKeyspace, sql = handleShowTables(show, destKeyspace)
 	case sqlparser.KeywordString(sqlparser.DATABASES), "vitess_keyspaces", "keyspaces":
 		keyspaces, err := e.resolver.resolver.GetAllKeyspaces(ctx)
 		if err != nil {
@@ -825,6 +818,19 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 
 	// Any other show statement is passed through
 	return e.handleOther(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats, ignoreMaxMemoryRows)
+}
+
+func handleShowTables(show *sqlparser.Show, destKeyspace string) (string, string) {
+	if show.ShowTablesOpt != nil && show.ShowTablesOpt.DbName != "" {
+		if destKeyspace == "" {
+			// Change "show tables from <keyspace>" to "show tables" directed to that keyspace.
+			destKeyspace = show.ShowTablesOpt.DbName
+		}
+		show.ShowTablesOpt.DbName = ""
+	}
+
+	sql := sqlparser.String(show)
+	return destKeyspace, sql
 }
 
 func (e *Executor) showTablets() (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -130,17 +130,19 @@ func analyzeInsert(ins *sqlparser.Insert, tables map[string]*schema.Table) (plan
 func analyzeShowTables(show *sqlparser.Show, dbName string) {
 	// rewrite WHERE clause if it exists
 	// `where Tables_in_Keyspace` => `where Tables_in_DbName`
-	filter := show.ShowTablesOpt.Filter.Filter
-	if filter != nil {
-		sqlparser.Rewrite(filter, func(cursor *sqlparser.Cursor) bool {
-			switch n := cursor.Node().(type) {
-			case *sqlparser.ColName:
-				if n.Qualifier.IsEmpty() && strings.HasPrefix(n.Name.Lowered(), "tables_in_") {
-					cursor.Replace(sqlparser.NewColName("Tables_in_" + dbName))
+	if show.ShowTablesOpt != nil && show.ShowTablesOpt.Filter != nil {
+		filter := show.ShowTablesOpt.Filter.Filter
+		if filter != nil {
+			sqlparser.Rewrite(filter, func(cursor *sqlparser.Cursor) bool {
+				switch n := cursor.Node().(type) {
+				case *sqlparser.ColName:
+					if n.Qualifier.IsEmpty() && strings.HasPrefix(n.Name.Lowered(), "tables_in_") {
+						cursor.Replace(sqlparser.NewColName("Tables_in_" + dbName))
+					}
 				}
-			}
-			return true
-		}, nil)
+				return true
+			}, nil)
+		}
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package planbuilder
 
 import (
+	"strings"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -123,6 +125,23 @@ func analyzeInsert(ins *sqlparser.Insert, tables map[string]*schema.Table) (plan
 	tableName := sqlparser.GetTableName(ins.Table)
 	plan.Table = tables[tableName.String()]
 	return plan, nil
+}
+
+func analyzeShowTables(show *sqlparser.Show, dbName string) {
+	// rewrite WHERE clause if it exists
+	// `where Tables_in_Keyspace` => `where Tables_in_DbName`
+	filter := show.ShowTablesOpt.Filter.Filter
+	if filter != nil {
+		sqlparser.Rewrite(filter, func(cursor *sqlparser.Cursor) bool {
+			switch n := cursor.Node().(type) {
+			case *sqlparser.ColName:
+				if n.Qualifier.IsEmpty() && strings.HasPrefix(n.Name.Lowered(), "tables_in_") {
+					cursor.Replace(sqlparser.NewColName("Tables_in_" + dbName))
+				}
+			}
+			return true
+		}, nil)
+	}
 }
 
 func analyzeSet(set *sqlparser.Set) (plan *Plan) {

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -72,7 +72,7 @@ func TestPlan(t *testing.T) {
 			var err error
 			statement, err := sqlparser.Parse(tcase.input)
 			if err == nil {
-				plan, err = Build(statement, testSchema, false)
+				plan, err = Build(statement, testSchema, false, "dbName")
 			}
 			PassthroughDMLs = false
 
@@ -109,7 +109,7 @@ func TestPlanPoolUnsafe(t *testing.T) {
 			statement, err := sqlparser.Parse(tcase.input)
 			require.NoError(t, err)
 			// In Pooled Connection, plan building will fail.
-			plan, err = Build(statement, testSchema, false /* isReservedConn */)
+			plan, err = Build(statement, testSchema, false /* isReservedConn */, "dbName")
 			require.Error(t, err)
 			out := err.Error()
 			if out != tcase.output {
@@ -123,7 +123,7 @@ func TestPlanPoolUnsafe(t *testing.T) {
 				fmt.Printf("\"%s\"\n%s\n\n", tcase.input, out)
 			}
 			// In Reserved Connection, plan will be built.
-			plan, err = Build(statement, testSchema, true /* isReservedConn */)
+			plan, err = Build(statement, testSchema, true /* isReservedConn */, "dbName")
 			require.NoError(t, err)
 			require.NotEmpty(t, plan)
 		})
@@ -141,7 +141,7 @@ func TestPlanInReservedConn(t *testing.T) {
 			var err error
 			statement, err := sqlparser.Parse(tcase.input)
 			if err == nil {
-				plan, err = Build(statement, testSchema, true)
+				plan, err = Build(statement, testSchema, true, "dbName")
 			}
 			PassthroughDMLs = false
 
@@ -192,7 +192,7 @@ func TestCustom(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Got error: %v, parsing sql: %v", err.Error(), tcase.input)
 				}
-				plan, err := Build(statement, schem, false)
+				plan, err := Build(statement, schem, false, "dbName")
 				var out string
 				if err != nil {
 					out = err.Error()

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -787,3 +787,19 @@ options:PassthroughDMLs
 # syntax error
 "syntax error"
 "syntax error at position 7 near 'syntax'"
+
+# show tables #1
+"show tables like 'key%'"
+{
+  "PlanID": "ShowTables",
+  "TableName":"",
+  "FullQuery": "show tables like 'key%'"
+}
+
+# show tables #2
+"show tables where Tables_in_keyspace='apa'"
+{
+  "PlanID": "ShowTables",
+  "TableName":"",
+  "FullQuery": "show tables where Tables_in_dbName = 'apa'"
+}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -309,7 +309,7 @@ func (qe *QueryEngine) GetPlan(ctx context.Context, logStats *tabletenv.LogStats
 	if err != nil {
 		return nil, err
 	}
-	splan, err := planbuilder.Build(statement, qe.tables, isReservedConn)
+	splan, err := planbuilder.Build(statement, qe.tables, isReservedConn, qe.env.Config().DB.DBName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -121,7 +121,7 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 	}
 
 	switch qre.plan.PlanID {
-	case planbuilder.PlanSelect, planbuilder.PlanSelectImpossible:
+	case planbuilder.PlanSelect, planbuilder.PlanSelectImpossible, planbuilder.PlanShowTables:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
 		qr, err := qre.execSelect()
@@ -203,7 +203,7 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 		return qre.execSQL(conn, qre.query, true)
 	case planbuilder.PlanSavepoint, planbuilder.PlanRelease, planbuilder.PlanSRollback:
 		return qre.execSQL(conn, qre.query, true)
-	case planbuilder.PlanSelect, planbuilder.PlanSelectLock, planbuilder.PlanSelectImpossible:
+	case planbuilder.PlanSelect, planbuilder.PlanSelectLock, planbuilder.PlanSelectImpossible, planbuilder.PlanShowTables:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
 		qr, err := qre.txFetch(conn, false)


### PR DESCRIPTION
When writing a query using SHOW TABLES, a common query is something :

```
SHOW TABLES FROM keyspace WHERE Tables_in_keyspace = 'table'
```

because the underlying database does not always use the same database name as the keyspace name, we need to rewrite the query before sending it down to MySQL.

Fixes #6446