### PR TITLE
Updates enforcement policy to match the one from the client

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -86,7 +86,7 @@ var (
 
 	// EnforcementPolicy MinTime that sets the keepalive enforcement policy on the server.
 	// This is the minimum amount of time a client should wait before sending a keepalive ping.
-	GRPCKeepAliveEnforcementPolicyMinTime = flag.Duration("grpc_server_keepalive_enforcement_policy_min_time", 5*time.Minute, "gRPC server minimum keepalive time")
+	GRPCKeepAliveEnforcementPolicyMinTime = flag.Duration("grpc_server_keepalive_enforcement_policy_min_time", 10*time.Second, "gRPC server minimum keepalive time")
 
 	// EnforcementPolicy PermitWithoutStream - If true, server allows keepalive pings
 	// even when there are no active streams (RPCs). If false, and client sends ping when


### PR DESCRIPTION
# Desc
* Makes sure grpc_server_keepalive_enforcement_policy_min_time has a value that is compatible with grpc_keepalive_timeout. The value for the timeouts was recently change, but the enforcement policy was not updated. 
* Fixes this issue: https://github.com/vitessio/vitess/pull/5922#issuecomment-672269584
## Tests
* I did not test this PR. but I think CI should be sufficient. 