### PR TITLE
Backport: tm: fix replmanager deadlock

### DIFF
--- a/go/sync2/semaphore.go
+++ b/go/sync2/semaphore.go
@@ -21,6 +21,7 @@ package sync2
 // cases, you just want a familiar API.
 
 import (
+	"context"
 	"time"
 )
 
@@ -57,6 +58,19 @@ func (sem *Semaphore) Acquire() bool {
 	case <-sem.slots:
 		return true
 	case <-tm.C:
+		return false
+	}
+}
+
+// AcquireContext returns true on successful acquisition, and
+// false on context expiry. Timeout is ignored.
+func (sem *Semaphore) AcquireContext(ctx context.Context) bool {
+	tm := time.NewTimer(sem.timeout)
+	defer tm.Stop()
+	select {
+	case <-sem.slots:
+		return true
+	case <-ctx.Done():
 		return false
 	}
 }

--- a/go/sync2/semaphore.go
+++ b/go/sync2/semaphore.go
@@ -65,8 +65,6 @@ func (sem *Semaphore) Acquire() bool {
 // AcquireContext returns true on successful acquisition, and
 // false on context expiry. Timeout is ignored.
 func (sem *Semaphore) AcquireContext(ctx context.Context) bool {
-	tm := time.NewTimer(sem.timeout)
-	defer tm.Stop()
 	select {
 	case <-sem.slots:
 		return true

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -91,8 +91,8 @@ func (rm *replManager) SetTabletType(tabletType topodatapb.TabletType) {
 
 func (rm *replManager) check() {
 	// We need to obtain the action lock if we're going to fix
-	// replication
-	if err := rm.tm.lock(rm.ctx); err != nil {
+	// replication, but only if the lock is available to take.
+	if !rm.tm.tryLock() {
 		return
 	}
 	defer rm.tm.unlock()

--- a/go/vt/vttablet/tabletmanager/rpc_server.go
+++ b/go/vt/vttablet/tabletmanager/rpc_server.go
@@ -34,8 +34,8 @@ import (
 // Utility functions for RPC service
 //
 
-// lock is used at the beginning of an RPC call, to lock the
-// action mutex. It returns ctx.Err() if the context expires.
+// lock is used at the beginning of an RPC call, to acquire the
+// action semaphore. It returns ctx.Err() if the context expires.
 func (tm *TabletManager) lock(ctx context.Context) error {
 	if tm.actionSema.AcquireContext(ctx) {
 		return nil

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -49,7 +49,7 @@ type tmState struct {
 	// while changing the state of the system to match these values.
 	// This can be held for many seconds while tmState connects to
 	// external components to change their state.
-	// Obtaining tm.actionMutex before calling a tmState function is
+	// Obtaining tm.actionSema before calling a tmState function is
 	// not required.
 	// Because mu can be held for long, we publish the current state
 	// of these variables into displayState, which can be accessed


### PR DESCRIPTION
of #6625 

A deadlock was found during a PRS. The root cause was a fix where we changed the replmanager to take the action lock. Otherwise, it would potentially race and conflict with other actions. But this led to a deadlock because PromoteReplica also waits for the replmanager to finish its fix.

We could have spot-fixed this for the specific use case. But in the interest of preventing other corner cases, the better fix was to change replmanager to not wait if it couldn't obtain a lock.

However, the implementation of lock with context timeout was flawed, because it wouldn't really timeout if the context expired. So, I implemented a new AcquireContext in sync2.Semaphore to, which encouraged to fix the flaky tests there.

Using the semaphore allowed me to implement a real tryLock, and replManager could use it.

Since this was a race condition, I tested it manually. The test that failed previously now passes.