### PR TITLE
Update VReplication Timestamp w/ Heartbeat

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -613,6 +613,17 @@ func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTime
 		encodeString(mysql.EncodePosition(pos)), timeUpdated, uid)
 }
 
+// GenerateUpdateTime returns a statement to update time_updated and transaction_timestamp in the
+// _vt.vreplication table.
+func GenerateUpdateTime(uid uint32, timeUpdated int64, txTimestamp int64) (string, error) {
+	if timeUpdated == 0 || txTimestamp == 0 {
+		return "", fmt.Errorf("invalid timeUpdated or txTimestamp supplied")
+	}
+	return fmt.Sprintf(
+		"update _vt.vreplication set time_updated=%v, transaction_timestamp=%v where id=%v",
+		timeUpdated, txTimestamp, uid), nil
+}
+
 // StartVReplication returns a statement to start the replication.
 func StartVReplication(uid uint32) string {
 	return fmt.Sprintf(

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -580,7 +580,12 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		stats.Send(fmt.Sprintf("%v", event.Journal))
 		return io.EOF
 	case binlogdatapb.VEventType_HEARTBEAT:
-		// No-op: heartbeat timings are calculated in outer loop.
+		if !vp.vr.dbClient.InTransaction {
+			_, err := vp.updatePos(event.Timestamp)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -243,6 +243,21 @@ func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 	return posReached, nil
 }
 
+func (vp *vplayer) updateTime(ts int64) (err error) {
+	update, err := binlogplayer.GenerateUpdateTime(vp.vr.id, time.Now().Unix(), ts)
+	if err != nil {
+		return err
+	}
+	if _, err := vp.vr.dbClient.Execute(update); err != nil {
+		return fmt.Errorf("error %v updating time", err)
+	}
+	vp.unsavedEvent = nil
+	vp.timeLastSaved = time.Now()
+	return nil
+}
+
+// applyEvents is the main thread that applies the events. It has the following use
+
 // applyEvents is the main thread that applies the events. It has the following use
 // cases to take into account:
 // * Normal transaction that has row mutations. In this case, the transaction
@@ -581,7 +596,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		return io.EOF
 	case binlogdatapb.VEventType_HEARTBEAT:
 		if !vp.vr.dbClient.InTransaction {
-			_, err := vp.updatePos(event.Timestamp)
+			err := vp.updateTime(event.Timestamp)
 			if err != nil {
 				return err
 			}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -300,6 +300,8 @@ type ReplicationStatus struct {
 	MaxReplicationLag int64
 	// DbName represents the db_name column from the _vt.vreplication table.
 	DBName string
+	// TransactionTimestamp represents the transaction_timestamp column from the _vt.vreplication table.
+	TransactionTimestamp int64
 	// TimeUpdated represents the time_updated column from the _vt.vreplication table.
 	TimeUpdated int64
 	// Message represents the message column from the _vt.vreplication table.
@@ -311,7 +313,7 @@ type ReplicationStatus struct {
 
 func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqltypes.Value, master *topo.TabletInfo) (*ReplicationStatus, string, error) {
 	var err error
-	var id, maxReplicationLag, timeUpdated int64
+	var id, maxReplicationLag, timeUpdated, transactionTimestamp int64
 	var state, dbName, pos, stopPos, message string
 	var bls binlogdatapb.BinlogSource
 	id, err = evalengine.ToInt64(row[0])
@@ -333,19 +335,24 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqlty
 	if err != nil {
 		return nil, "", err
 	}
-	message = row[8].ToString()
+	transactionTimestamp, err = evalengine.ToInt64(row[8])
+	if err != nil {
+		return nil, "", err
+	}
+	message = row[9].ToString()
 	status := &ReplicationStatus{
-		Shard:             master.Shard,
-		Tablet:            master.AliasString(),
-		ID:                id,
-		Bls:               bls,
-		Pos:               pos,
-		StopPos:           stopPos,
-		State:             state,
-		DBName:            dbName,
-		MaxReplicationLag: maxReplicationLag,
-		TimeUpdated:       timeUpdated,
-		Message:           message,
+		Shard:                master.Shard,
+		Tablet:               master.AliasString(),
+		ID:                   id,
+		Bls:                  bls,
+		Pos:                  pos,
+		StopPos:              stopPos,
+		State:                state,
+		DBName:               dbName,
+		MaxReplicationLag:    maxReplicationLag,
+		TransactionTimestamp: transactionTimestamp,
+		TimeUpdated:          timeUpdated,
+		Message:              message,
 	}
 	status.CopyState, err = wr.getCopyState(ctx, master, id)
 	if err != nil {
@@ -361,7 +368,7 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 	rsr.ShardStatuses = make(map[string]*ShardReplicationStatus)
 	rsr.Workflow = workflow
 	var results map[*topo.TabletInfo]*querypb.QueryResult
-	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, message from _vt.vreplication"
+	query := "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message from _vt.vreplication"
 	results, err := wr.runVexec(ctx, workflow, keyspace, query, false)
 	if err != nil {
 		return nil, err

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -396,8 +396,7 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 			rsrStatus = append(rsrStatus, status)
 
 			transactionTimestamp := time.Unix(status.TransactionTimestamp, 0)
-			timeUpdated := time.Unix(status.TimeUpdated, 0)
-			replicationLag := timeUpdated.Sub(transactionTimestamp)
+			replicationLag := time.Since(transactionTimestamp)
 			if replicationLag.Seconds() > float64(rsr.MaxVReplicationLag) {
 				rsr.MaxVReplicationLag = int64(replicationLag.Seconds())
 			}

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -205,6 +205,7 @@ func TestWorkflowListStreams(t *testing.T) {
 			"80-"
 		]
 	},
+	"MaxVReplicationLag": 1234,
 	"ShardStatuses": {
 		"-80/zone1-0000000200": {
 			"MasterReplicationStatuses": [

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -228,6 +228,7 @@ func TestWorkflowListStreams(t *testing.T) {
 					"State": "Copying",
 					"MaxReplicationLag": 0,
 					"DBName": "vt_target",
+					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
 					"Message": "",
 					"CopyState": [
@@ -263,6 +264,7 @@ func TestWorkflowListStreams(t *testing.T) {
 					"State": "Copying",
 					"MaxReplicationLag": 0,
 					"DBName": "vt_target",
+					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
 					"Message": "",
 					"CopyState": [

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -144,11 +144,11 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		env.tmc.setVRResults(master.tablet, "insert into _vt.vreplication(state, workflow, db_name) values ('Running', 'wk1', 'ks1'), ('Stopped', 'wk1', 'ks1')", &sqltypes.Result{RowsAffected: 2})
 
 		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|message",
-			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|varchar"),
-			fmt.Sprintf("1|%v|pos||0|Running|vt_target|1234|", bls),
+			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|message",
+			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|int64|varchar"),
+			fmt.Sprintf("1|%v|pos||0|Running|vt_target|1234|0|", bls),
 		)
-		env.tmc.setVRResults(master.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, message from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
+		env.tmc.setVRResults(master.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
 		env.tmc.setVRResults(
 			master.tablet,
 			"select source, pos from _vt.vreplication where db_name='vt_target' and workflow='wrWorkflow'",


### PR DESCRIPTION
This PR:

1. Updates `_vt.vreplication` row timestamp w/ each heartbeat that happens outside of a transaction. This improves the accuracy of the transaction_timestamp recorded for each `_vt.vreplication` row, and allows anyone inspecting the `_vt.vreplication` table to get an accurate read on replication lag.
2. Adds MaxVReplicationLag to `Workflow Show` subcommand, which displays the maximum vreplication lag seen across all shards.
3. Updates tests accordingly.