### PR TITLE
build: remove chromium hard-coding

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -6,7 +6,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     automake \
     bison \
     bzip2 \
-    chromium=70.0.3538.110-1~deb9u1 \
+    chromium \
     curl \
     g++ \
     git \


### PR DESCRIPTION
That version isn't supported any more. Hopefully, whatever problem
the default version had is fixed by now.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>