### PR TITLE
Removed sqlparser.preview to set logstats stmtType and use plan.type

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1216,10 +1216,11 @@ func TestExecutorDDL(t *testing.T) {
 			sbc1.ExecCount.Set(0)
 			sbc2.ExecCount.Set(0)
 			sbclookup.ExecCount.Set(0)
-
+			stmtType := "DDL"
 			_, err := executor.Execute(ctx, "TestExecute", NewSafeSession(&vtgatepb.Session{TargetString: tc.targetStr}), stmt, nil)
 			if tc.hasNoKeyspaceErr {
 				require.EqualError(t, err, "keyspace not specified", "expect query to fail")
+				stmtType = "" // For error case, plan is not generated to query log will not contain any stmtType.
 			} else {
 				require.NoError(t, err)
 			}
@@ -1233,7 +1234,7 @@ func TestExecutorDDL(t *testing.T) {
 				t.Errorf("stmt: %s\ntc: %+v\n-want,+got:\n%s", stmt, tc, diff)
 			}
 
-			testQueryLog(t, logChan, "TestExecute", "DDL", stmt, tc.shardQueryCnt)
+			testQueryLog(t, logChan, "TestExecute", stmtType, stmt, tc.shardQueryCnt)
 		}
 	}
 }

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -62,7 +62,7 @@ func (e *Executor) newExecute(ctx context.Context, safeSession *SafeSession, sql
 	if err == planbuilder.ErrPlanNotSupported {
 		return 0, nil, err
 	}
-	execStart := e.logPlanningFinished(logStats, sql)
+	execStart := e.logPlanningFinished(logStats, plan)
 
 	if err != nil {
 		safeSession.ClearWarnings()
@@ -205,9 +205,11 @@ func (e *Executor) logExecutionEnd(logStats *LogStats, execStart time.Time, plan
 	return errCount
 }
 
-func (e *Executor) logPlanningFinished(logStats *LogStats, sql string) time.Time {
+func (e *Executor) logPlanningFinished(logStats *LogStats, plan *engine.Plan) time.Time {
 	execStart := time.Now()
-	logStats.StmtType = sqlparser.Preview(sql).String()
+	if plan != nil {
+		logStats.StmtType = plan.Type.String()
+	}
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	return execStart
 }


### PR DESCRIPTION
plan type will be used to set logstats stmtType instead of a preview call to avoid string manipulation calls.