### PR TITLE
VDiff: fix panic for tables with a unicode_loose_md5 vindex

### DIFF
--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -4,7 +4,7 @@ var (
 	initialProductSchema = `
 create table product(pid int, description varbinary(128), primary key(pid));
 create table customer(cid int, name varbinary(128),	primary key(cid));
-create table merchant(mname varchar(128), category varchar(128), primary key(mname));
+create table merchant(mname varchar(128), category varchar(128), primary key(mname)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table orders(oid int, cid int, pid int, mname varchar(128), price int, primary key(oid));
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -358,7 +358,6 @@ func (df *vdiff) buildTablePlan(table *tabletmanagerdatapb.TableDefinition, quer
 
 	var orderby sqlparser.OrderBy
 	for _, pk := range table.PrimaryKeyColumns {
-		log.Infof("vdiff: pk %s", pk)
 		found := false
 		for i, selExpr := range targetSelect.SelectExprs {
 			expr := selExpr.(*sqlparser.AliasedExpr).Expr


### PR DESCRIPTION
A customer had an issue while running VDiff after MoveTables. VDiff panic-ed due to an invalid cast while dealing with the weight_string() that is generated as part of the vdiff plan, which is a FuncExpr type and not a Colname. 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>