### PR TITLE
Perform Fast Shutdowns

### DIFF
--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -101,6 +101,10 @@ func (sf *StatefulConnectionPool) AdjustLastID(id int64) {
 	}
 }
 
+func (sf *StatefulConnectionPool) GetAll() []*StatefulConnection {
+	return mapToTxConn(sf.active.GetAll())
+}
+
 // GetOutdated returns a list of connections that are older than age.
 // It does not return any connections that are in use.
 func (sf *StatefulConnectionPool) GetOutdated(age time.Duration, purpose string) []*StatefulConnection {

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -490,6 +490,7 @@ outer:
 // including the prepared ones.
 // This is used for transitioning from a master to a non-master
 // serving type.
+/*
 func (te *TxEngine) rollbackTransactions() {
 	te.rollbackPrepared()
 	ctx := tabletenv.LocalContext()
@@ -499,6 +500,7 @@ func (te *TxEngine) rollbackTransactions() {
 	// have to be revisited.
 	te.txPool.RollbackNonBusy(ctx)
 }
+*/
 
 func (te *TxEngine) rollbackPrepared() {
 	ctx := tabletenv.LocalContext()

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -394,9 +394,9 @@ func (te *TxEngine) shutdown(immediate bool) {
 			close(rollbackDone)
 		}()
 		if immediate {
-			// Immediately rollback everything and return.
-			log.Info("Immediate shutdown: rolling back now.")
-			te.rollbackTransactions()
+			// Immediately close everything and return.
+			log.Info("Immediate shutdown: hard closing all connections now.")
+			te.txPool.CloseAllConnections()
 			return
 		}
 		if te.shutdownGracePeriod <= 0 {
@@ -409,8 +409,9 @@ func (te *TxEngine) shutdown(immediate bool) {
 		defer tmr.Stop()
 		select {
 		case <-tmr.C:
-			log.Info("Grace period exceeded: rolling back now.")
-			te.rollbackTransactions()
+			log.Info("Grace period exceeded: ending all transactions now.")
+			te.txPool.CloseAllConnections()
+			return
 		case <-poolEmpty:
 			// The pool cleared before the timer kicked in. Just return.
 			log.Info("Transactions completed before grace period: shutting down.")

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -111,7 +111,8 @@ func TestTxEngineClose(t *testing.T) {
 	assert.Less(t, int64(10*time.Millisecond), int64(time.Since(start)))
 	assert.Greater(t, int64(25*time.Millisecond), int64(time.Since(start)))
 
-	// Immediate close, but connection is in use.
+	// Immediate close with connection is in use which should be
+	// immediately closed
 	te.open()
 	c, _, err = te.txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
@@ -123,9 +124,6 @@ func TestTxEngineClose(t *testing.T) {
 	te.shutdown(true)
 	if diff := time.Since(start); diff > 250*time.Millisecond {
 		t.Errorf("Close time: %v, must be under 0.25s", diff)
-	}
-	if diff := time.Since(start); diff < 100*time.Millisecond {
-		t.Errorf("Close time: %v, must be over 0.1", diff)
 	}
 
 	// Normal close with Reserved connection timeout wait.

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -116,7 +116,7 @@ func TestTxEngineClose(t *testing.T) {
 	c, _, err = te.txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		_, err = c.Exec(ctx, "select sleep(30)", 10, true)
 		te.txPool.RollbackAndRelease(ctx, c)
 	}()
 	start = time.Now()

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -99,6 +99,19 @@ func (tp *TxPool) Open(appParams, dbaParams, appDebugParams dbconfigs.Connector)
 	tp.ticks.Start(func() { tp.transactionKiller() })
 }
 
+// Close all connections in the pool, even if they have open
+// transactions
+func (tp *TxPool) CloseAllConnections() {
+	for _, conn := range tp.scp.GetAll() {
+		thing := "connection"
+		if conn.IsInTransaction() {
+			thing = "transaction"
+		}
+		log.Warningf("killing %s: %s", thing, conn.String())
+		conn.Releasef("closing all connections")
+	}
+}
+
 // Close closes the TxPool. A closed pool can be reopened.
 func (tp *TxPool) Close() {
 	tp.ticks.Stop()


### PR DESCRIPTION
## Problem
There are various times -- most notably when performing a [`PlannedReparentShard`](https://vitess.io/docs/reference/programs/vtctl/shards/#plannedreparentshard) operation for planned maintenance -- that you want the tablet to shutdown as quickly as possible. You should be able to get this by [passing the immediate flag to `TxEngine.shutdown()`](https://github.com/vitessio/vitess/blob/master/go/vt/vttablet/tabletserver/tx_engine.go#L374-L380) or when doing a shutdown and [having hit the `transaction_shutdown_grace_period`](https://github.com/vitessio/vitess/blob/master/go/vt/vttablet/tabletserver/tx_engine.go#L408-L417).

Today, in both cases we _do not_ immediately shutdown as one might expect. Instead [we attempt to _explicitly_ rollback all transactions via a `rollback` statement](https://github.com/vitessio/vitess/blob/master/go/vt/vttablet/tabletserver/tx_pool.go#L115-L122). On busy systems with potentially long running multi-statement transactions and transactional statements, the current behavior causes reparents to fail. So we unnecessarily fail to complete the requested operation and cause a period of downtime -- where the master tablet for this shard is not serving any traffic while demoted as part of the reparent attempt -- in the process.

## Solution
When immediate shutdown has been requested or we have hit the defined `transaction_shutdown_grace_period` we should implicitly rollback the transactions by closing the connections. This patch attempts to do that.