### PR TITLE
Rewrite equality comparisons

### DIFF
--- a/go/vt/sqlparser/expression_rewriting_test.go
+++ b/go/vt/sqlparser/expression_rewriting_test.go
@@ -29,98 +29,79 @@ type myTestCase struct {
 }
 
 func TestRewrites(in *testing.T) {
-	tests := []myTestCase{
-		{
-			in:       "SELECT 42",
-			expected: "SELECT 42",
-			// no bindvar needs
-		},
-		{
-			in:       "SELECT last_insert_id()",
-			expected: "SELECT :__lastInsertId as `last_insert_id()`",
-			liid:     true,
-		},
-		{
-			in:       "SELECT database()",
-			expected: "SELECT :__vtdbname as `database()`",
-			db:       true,
-		},
-		{
-			in:       "SELECT database() from test",
-			expected: "SELECT database() from test",
-			// no bindvar needs
-		},
-		{
-			in:       "SELECT last_insert_id() as test",
-			expected: "SELECT :__lastInsertId as test",
-			liid:     true,
-		},
-		{
-			in:       "SELECT last_insert_id() + database()",
-			expected: "SELECT :__lastInsertId + :__vtdbname as `last_insert_id() + database()`",
-			db:       true, liid: true,
-		},
-		{
-			in:       "select (select database()) from test",
-			expected: "select (select database() from dual) from test",
-			// no bindvar needs
-		},
-		{
-			in:       "select (select database() from dual) from test",
-			expected: "select (select database() from dual) from test",
-			// no bindvar needs
-		},
-		{
-			in:       "select (select database() from dual) from dual",
-			expected: "select (select :__vtdbname as `database()` from dual) as `(select database() from dual)` from dual",
-			db:       true,
-		},
-		{
-			in:       "select id from user where database()",
-			expected: "select id from user where database()",
-			// no bindvar needs
-		},
-		{
-			in:       "select table_name from information_schema.tables where table_schema = database()",
-			expected: "select table_name from information_schema.tables where table_schema = database()",
-			// no bindvar needs
-		},
-		{
-			in:       "select schema()",
-			expected: "select :__vtdbname as `schema()`",
-			db:       true,
-		},
-		{
-			in:        "select found_rows()",
-			expected:  "select :__vtfrows as `found_rows()`",
-			foundRows: true,
-		},
-		{
-			in:       "select @`x y`",
-			expected: "select :__vtudvx_y as `@``x y``` from dual",
-			udv:      1,
-		},
-		{
-			in:       "select id from t where id = @x and val = @y",
-			expected: "select id from t where id = :__vtudvx and val = :__vtudvy",
-			db:       false, udv: 2,
-		},
-		{
-			in:       "insert into t(id) values(@xyx)",
-			expected: "insert into t(id) values(:__vtudvxyx)",
-			db:       false, udv: 1,
-		},
-		{
-			in:       "select row_count()",
-			expected: "select :__vtrcount as `row_count()`",
-			rowCount: true,
-		},
-		{
-			in:       "SELECT lower(database())",
-			expected: "SELECT lower(:__vtdbname) as `lower(database())`",
-			db:       true,
-		},
-	}
+	tests := []myTestCase{{
+		in:       "SELECT 42",
+		expected: "SELECT 42",
+		// no bindvar needs
+	}, {
+		in:       "SELECT last_insert_id()",
+		expected: "SELECT :__lastInsertId as `last_insert_id()`",
+		liid:     true,
+	}, {
+		in:       "SELECT database()",
+		expected: "SELECT :__vtdbname as `database()`",
+		db:       true,
+	}, {
+		in:       "SELECT database() from test",
+		expected: "SELECT database() from test",
+		// no bindvar needs
+	}, {
+		in:       "SELECT last_insert_id() as test",
+		expected: "SELECT :__lastInsertId as test",
+		liid:     true,
+	}, {
+		in:       "SELECT last_insert_id() + database()",
+		expected: "SELECT :__lastInsertId + :__vtdbname as `last_insert_id() + database()`",
+		db:       true, liid: true,
+	}, {
+		in:       "select (select database()) from test",
+		expected: "select (select database() from dual) from test",
+		// no bindvar needs
+	}, {
+		in:       "select (select database() from dual) from test",
+		expected: "select (select database() from dual) from test",
+		// no bindvar needs
+	}, {
+		in:       "select (select database() from dual) from dual",
+		expected: "select (select :__vtdbname as `database()` from dual) as `(select database() from dual)` from dual",
+		db:       true,
+	}, {
+		in:       "select id from user where database()",
+		expected: "select id from user where database()",
+		// no bindvar needs
+	}, {
+		in:       "select table_name from information_schema.tables where table_schema = database()",
+		expected: "select table_name from information_schema.tables where table_schema = database()",
+		// no bindvar needs
+	}, {
+		in:       "select schema()",
+		expected: "select :__vtdbname as `schema()`",
+		db:       true,
+	}, {
+		in:        "select found_rows()",
+		expected:  "select :__vtfrows as `found_rows()`",
+		foundRows: true,
+	}, {
+		in:       "select @`x y`",
+		expected: "select :__vtudvx_y as `@``x y``` from dual",
+		udv:      1,
+	}, {
+		in:       "select id from t where id = @x and val = @y",
+		expected: "select id from t where id = :__vtudvx and val = :__vtudvy",
+		db:       false, udv: 2,
+	}, {
+		in:       "insert into t(id) values(@xyx)",
+		expected: "insert into t(id) values(:__vtudvxyx)",
+		db:       false, udv: 1,
+	}, {
+		in:       "select row_count()",
+		expected: "select :__vtrcount as `row_count()`",
+		rowCount: true,
+	}, {
+		in:       "SELECT lower(database())",
+		expected: "SELECT lower(:__vtdbname) as `lower(database())`",
+		db:       true,
+	}}
 
 	for _, tc := range tests {
 		in.Run(tc.in, func(t *testing.T) {

--- a/go/vt/sqlparser/expression_rewriting_test.go
+++ b/go/vt/sqlparser/expression_rewriting_test.go
@@ -101,6 +101,12 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT lower(database())",
 		expected: "SELECT lower(:__vtdbname) as `lower(database())`",
 		db:       true,
+	}, {
+		in:       "SELECT * FROM t WHERE 42 = col",
+		expected: "SELECT * FROM t WHERE col = 42",
+	}, {
+		in:       "SELECT * FROM t WHERE (col1,col2) = ('apa', 42)",
+		expected: "SELECT * FROM t WHERE col1 = 'apa' and col2 = 42",
 	}}
 
 	for _, tc := range tests {

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -19,6 +19,8 @@ package planbuilder
 import (
 	"errors"
 
+	querypb "vitess.io/vitess/go/vt/proto/query"
+
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/key"
@@ -269,7 +271,7 @@ func Build(query string, vschema ContextVSchema) (*engine.Plan, error) {
 	if err != nil {
 		return nil, err
 	}
-	result, err := sqlparser.RewriteAST(stmt)
+	result, err := sqlparser.PrepareAST(stmt, make(map[string]*querypb.BindVariable), "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -282,11 +282,11 @@ func (rb *route) Wireup(bldr builder, jt *jointab) error {
 		switch node := node.(type) {
 		case *sqlparser.Select:
 			if len(node.SelectExprs) == 0 {
-				node.SelectExprs = sqlparser.SelectExprs([]sqlparser.SelectExpr{
+				node.SelectExprs = []sqlparser.SelectExpr{
 					&sqlparser.AliasedExpr{
 						Expr: sqlparser.NewIntVal([]byte{'1'}),
 					},
-				})
+				}
 			}
 		case *sqlparser.ComparisonExpr:
 			if node.Operator == sqlparser.EqualStr {
@@ -660,11 +660,7 @@ func (rb *route) computeEqualPlan(pb *primitiveBuilder, comparison *sqlparser.Co
 
 	vindex = pb.st.Vindex(left, rb)
 	if vindex == nil {
-		left, right = right, left
-		vindex = pb.st.Vindex(left, rb)
-		if vindex == nil {
-			return engine.SelectScatter, nil, nil
-		}
+		return engine.SelectScatter, nil, nil
 	}
 	if !rb.exprIsValue(right) {
 		return engine.SelectScatter, nil, nil


### PR DESCRIPTION
This helps to simplify the planner - instead of looking for the different alternatives, the planner can assume the input query is normalised and easy to work with.