### PR TITLE
Handle consistent lookup vindex when in single transaction mode is set

### DIFF
--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -127,7 +127,24 @@ create table t7_xxhash_idx(
 	phone bigint,
 	keyspace_id varbinary(50),
 	primary key(phone, keyspace_id)
-) Engine=InnoDB;`
+) Engine=InnoDB;
+
+CREATE TABLE txn_unique_constraints (
+  id                varchar(100) NOT NULL ,
+  txn_id            varchar(50) NOT NULL,
+  unique_constraint varchar(100) NOT NULL,
+  created_on        timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_txn_unique_constraint (unique_constraint),
+  KEY idx_txn_unique_constraints_txn_id (txn_id),
+  KEY idx_txn_unique_constraints_created_on (created_on)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE uniqueConstraint_vdx(
+  unique_constraint VARCHAR(50) NOT NULL,
+  keyspace_id       VARBINARY(50) NOT NULL,
+ PRIMARY KEY(unique_constraint)
+);`
 
 	VSchema = `
 {
@@ -201,6 +218,16 @@ create table t7_xxhash_idx(
         "ignore_nulls": "true"
       },
       "owner": "t7_xxhash"
+    },
+    "uniqueConstraint_vdx": {
+      "type": "consistent_lookup_unique",
+      "params": {
+        "table": "uniqueConstraint_vdx",
+        "from": "unique_constraint",
+        "to": "keyspace_id",
+        "autocommit": "true"
+      },
+      "owner": "txn_unique_constraints"
     }
   },
   "tables": {
@@ -351,6 +378,32 @@ create table t7_xxhash_idx(
         {
           "column": "phone",
           "name": "unicode_loose_xxhash"
+        }
+      ]
+    },
+    "txn_unique_constraints": {
+      "column_vindexes": [
+        {
+          "column": "txn_id",
+          "name": "unicode_loose_md5"
+        },
+        {
+          "column": "unique_constraint",
+          "name": "uniqueConstraint_vdx"
+        }
+      ],
+      "columns": [
+        {
+          "name": "txn_id",
+          "type": "VARCHAR"
+        }
+      ]
+    },
+    "uniqueConstraint_vdx": {
+      "column_vindexes": [
+        {
+          "column": "unique_constraint",
+          "name": "unicode_loose_md5"
         }
       ]
     }

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -163,7 +163,7 @@ func (t noopVCursor) StreamExecuteMulti(query string, rss []*srvtopo.ResolvedSha
 	panic("unimplemented")
 }
 
-func (t noopVCursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error) {
+func (t noopVCursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -75,7 +75,7 @@ type (
 		StreamExecuteMulti(query string, rss []*srvtopo.ResolvedShard, bindVars []map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error
 
 		// Keyspace ID level functions.
-		ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error)
+		ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error)
 
 		// Resolver methods, from key.Destination to srvtopo.ResolvedShard.
 		// Will replace all of the Topo functions.

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -364,8 +364,11 @@ func (vc *vcursorImpl) StreamExecuteMulti(query string, rss []*srvtopo.ResolvedS
 }
 
 // ExecuteKeyspaceID is part of the engine.VCursor interface.
-func (vc *vcursorImpl) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error) {
+func (vc *vcursorImpl) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error) {
 	atomic.AddUint32(&vc.logStats.ShardQueries, 1)
+	vc.safeSession.SetCommitOrder(co)
+	defer vc.safeSession.SetCommitOrder(vtgatepb.CommitOrder_NORMAL)
+
 	rss, _, err := vc.ResolveDestinations(keyspace, nil, []key.Destination{key.DestinationKeyspaceID(ksid)})
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -286,7 +286,7 @@ func (lu *clCommon) handleDup(vcursor VCursor, values []sqltypes.Value, ksid []b
 	case 1:
 		existingksid := qr.Rows[0][0].ToBytes()
 		// Lock the target row using normal transaction priority.
-		qr, err = vcursor.ExecuteKeyspaceID(lu.keyspace, existingksid, lu.lockOwnerQuery, bindVars, false /* rollbackOnError */, false /* autocommit */)
+		qr, err = vcursor.ExecuteKeyspaceID(lu.keyspace, existingksid, lu.lockOwnerQuery, bindVars, false /* rollbackOnError */, false /* autocommit */, vtgatepb.CommitOrder_PRE)
 		if err != nil {
 			return err
 		}
@@ -347,10 +347,6 @@ func (lu *clCommon) generateLockOwner() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "select %s from %s", lu.ownerColumns[0], lu.ownerTable)
 	lu.addWhere(&buf, lu.ownerColumns)
-	// We can lock in share mode because we only want to check
-	// if the row exists. We still need to lock to make us wait
-	// in case a previous transaction is creating it.
-	fmt.Fprintf(&buf, " lock in share mode")
 	return buf.String()
 }
 

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -277,7 +277,7 @@ func TestConsistentLookupCreateThenUpdate(t *testing.T) {
 	vc.verifyLog(t, []string{
 		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
-		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc test1}] false",
+		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 [{fromc1 1} {fromc2 2} {toc test1}] false",
 		"ExecutePre update t set toc=:toc where fromc1 = :fromc1 and fromc2 = :fromc2 [{fromc1 1} {fromc2 2} {toc test1}] true",
 	})
 }
@@ -302,7 +302,7 @@ func TestConsistentLookupCreateThenSkipUpdate(t *testing.T) {
 	vc.verifyLog(t, []string{
 		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc 1}] false",
-		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc 1}] false",
+		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 [{fromc1 1} {fromc2 2} {toc 1}] false",
 	})
 }
 
@@ -326,7 +326,7 @@ func TestConsistentLookupCreateThenDupkey(t *testing.T) {
 	vc.verifyLog(t, []string{
 		"ExecutePre insert into t(fromc1, fromc2, toc) values(:fromc1_0, :fromc2_0, :toc_0) [{fromc1_0 1} {fromc2_0 2} {toc_0 test1}] true",
 		"ExecutePre select toc from t where fromc1 = :fromc1 and fromc2 = :fromc2 for update [{fromc1 1} {fromc2 2} {toc test1}] false",
-		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 lock in share mode [{fromc1 1} {fromc2 2} {toc test1}] false",
+		"ExecuteKeyspaceID select fc1 from `dot.t1` where fc1 = :fromc1 and fc2 = :fromc2 [{fromc1 1} {fromc2 2} {toc test1}] false",
 	})
 }
 
@@ -535,7 +535,7 @@ func (vc *loggingVCursor) Execute(method string, query string, bindvars map[stri
 	return vc.execute(name, query, bindvars, rollbackOnError)
 }
 
-func (vc *loggingVCursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error) {
+func (vc *loggingVCursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error) {
 	return vc.execute("ExecuteKeyspaceID", query, bindVars, rollbackOnError)
 }
 

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -66,7 +66,7 @@ func (vc *vcursor) Execute(method string, query string, bindvars map[string]*que
 	return vc.execute(method, query, bindvars, rollbackOnError)
 }
 
-func (vc *vcursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error) {
+func (vc *vcursor) ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error) {
 	return vc.execute("ExecuteKeyspaceID", query, bindVars, rollbackOnError)
 }
 

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -36,7 +36,7 @@ import (
 // can use this interface to execute lookup queries.
 type VCursor interface {
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, rollbackOnError bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error)
-	ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool) (*sqltypes.Result, error)
+	ExecuteKeyspaceID(keyspace string, ksid []byte, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError, autocommit bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error)
 	InTransactionAndIsDML() bool
 }
 


### PR DESCRIPTION
* Use PRE commit order for owner row checking.
* Removed `lock in share mode` from the owner query as this is check to find any existing record and lock is not needed as we fail the query if we find the record is present.

Fixes: #6518 