### PR TITLE
Add a faster AST visitor when no rewriting is needed

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -27,34 +27,6 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
-// Walk calls visit on every node.
-// If visit returns true, the underlying nodes
-// are also visited. If it returns an error, walking
-// is interrupted, and the error is returned.
-func Walk(visit Visit, nodes ...SQLNode) (err error) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			return
-		}
-		switch n := r.(type) {
-		case errorOccured:
-			err = n.err
-		default:
-			panic(r)
-		}
-	}()
-
-	for _, node := range nodes {
-		__walk(visit, node)
-	}
-	return err
-}
-
-// Visit defines the signature of a function that
-// can be used to visit all nodes of a parse tree.
-type Visit func(node SQLNode) (kontinue bool, err error)
-
 // Append appends the SQLNode to the buffer.
 func Append(buf *strings.Builder, node SQLNode) {
 	tbuf := &TrackedBuffer{

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -46,7 +46,7 @@ func Walk(visit Visit, nodes ...SQLNode) (err error) {
 	}()
 
 	for _, node := range nodes {
-		walk(visit, node)
+		__walk(visit, node)
 	}
 	return err
 }

--- a/go/vt/sqlparser/rewriter.go
+++ b/go/vt/sqlparser/rewriter.go
@@ -1402,6 +1402,459 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 	a.cursor = saved
 }
 
+type errorOccured struct {
+	err error
+}
+
+func walk(visit Visit, in SQLNode) {
+
+	if in == nil || isNilValue(in) {
+		return
+	}
+
+	visitChildren, err := visit(in)
+	if err != nil {
+		panic(errorOccured{err})
+	}
+
+	if visitChildren {
+		switch n := in.(type) {
+		case nil:
+
+		case *AccessMode:
+
+		case *AliasedExpr:
+			walk(visit, n.As)
+			walk(visit, n.Expr)
+
+		case *AliasedTableExpr:
+			walk(visit, n.As)
+			walk(visit, n.Expr)
+			walk(visit, n.Hints)
+			walk(visit, n.Partitions)
+
+		case *AndExpr:
+			walk(visit, n.Left)
+			walk(visit, n.Right)
+
+		case Argument:
+
+		case *AutoIncSpec:
+			walk(visit, n.Column)
+			walk(visit, n.Sequence)
+
+		case *Begin:
+
+		case *BinaryExpr:
+			walk(visit, n.Left)
+			walk(visit, n.Right)
+
+		case BoolVal:
+
+		case *CaseExpr:
+			walk(visit, n.Else)
+			walk(visit, n.Expr)
+			for _, item := range n.Whens {
+				walk(visit, item)
+			}
+
+		case ColIdent:
+
+		case *ColName:
+			walk(visit, n.Name)
+			walk(visit, n.Qualifier)
+
+		case *CollateExpr:
+			walk(visit, n.Expr)
+
+		case *ColumnDefinition:
+			walk(visit, n.Name)
+
+		case *ColumnType:
+			walk(visit, n.Autoincrement)
+			walk(visit, n.Comment)
+			walk(visit, n.Default)
+			walk(visit, n.Length)
+			walk(visit, n.NotNull)
+			walk(visit, n.OnUpdate)
+			walk(visit, n.Scale)
+			walk(visit, n.Unsigned)
+			walk(visit, n.Zerofill)
+
+		case Columns:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case Comments:
+
+		case *Commit:
+
+		case *ComparisonExpr:
+			walk(visit, n.Escape)
+			walk(visit, n.Left)
+			walk(visit, n.Right)
+
+		case *ConstraintDefinition:
+			walk(visit, n.Details)
+
+		case *ConvertExpr:
+			walk(visit, n.Expr)
+			walk(visit, n.Type)
+
+		case *ConvertType:
+			walk(visit, n.Length)
+			walk(visit, n.Scale)
+
+		case *ConvertUsingExpr:
+			walk(visit, n.Expr)
+
+		case *CurTimeFuncExpr:
+			walk(visit, n.Fsp)
+			walk(visit, n.Name)
+
+		case *DBDDL:
+
+		case *DDL:
+			walk(visit, n.AutoIncSpec)
+			walk(visit, n.FromTables)
+			walk(visit, n.OptLike)
+			walk(visit, n.PartitionSpec)
+			walk(visit, n.Table)
+			walk(visit, n.TableSpec)
+			walk(visit, n.ToTables)
+			for _, item := range n.VindexCols {
+				walk(visit, item)
+			}
+			walk(visit, n.VindexSpec)
+
+		case *Default:
+
+		case *Delete:
+			walk(visit, n.Comments)
+			walk(visit, n.Limit)
+			walk(visit, n.OrderBy)
+			walk(visit, n.Partitions)
+			walk(visit, n.TableExprs)
+			walk(visit, n.Targets)
+			walk(visit, n.Where)
+
+		case *ExistsExpr:
+			walk(visit, n.Subquery)
+
+		case *Explain:
+			walk(visit, n.Statement)
+
+		case Exprs:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *ForeignKeyDefinition:
+			walk(visit, n.OnDelete)
+			walk(visit, n.OnUpdate)
+			walk(visit, n.ReferencedColumns)
+			walk(visit, n.ReferencedTable)
+			walk(visit, n.Source)
+
+		case *FuncExpr:
+			walk(visit, n.Exprs)
+			walk(visit, n.Name)
+			walk(visit, n.Qualifier)
+
+		case GroupBy:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *GroupConcatExpr:
+			walk(visit, n.Exprs)
+			walk(visit, n.Limit)
+			walk(visit, n.OrderBy)
+
+		case *IndexDefinition:
+			walk(visit, n.Info)
+
+		case *IndexHints:
+			for _, item := range n.Indexes {
+				walk(visit, item)
+			}
+
+		case *IndexInfo:
+			walk(visit, n.Name)
+
+		case *Insert:
+			walk(visit, n.Columns)
+			walk(visit, n.Comments)
+			walk(visit, n.OnDup)
+			walk(visit, n.Partitions)
+			walk(visit, n.Rows)
+			walk(visit, n.Table)
+
+		case *IntervalExpr:
+			walk(visit, n.Expr)
+
+		case *IsExpr:
+			walk(visit, n.Expr)
+
+		case *IsolationLevel:
+
+		case JoinCondition:
+			walk(visit, n.On)
+			walk(visit, n.Using)
+
+		case *JoinTableExpr:
+			walk(visit, n.Condition)
+			walk(visit, n.LeftExpr)
+			walk(visit, n.RightExpr)
+
+		case *Limit:
+			walk(visit, n.Offset)
+			walk(visit, n.Rowcount)
+
+		case ListArg:
+
+		case *Literal:
+
+		case *MatchExpr:
+			walk(visit, n.Columns)
+			walk(visit, n.Expr)
+
+		case Nextval:
+			walk(visit, n.Expr)
+
+		case *NotExpr:
+			walk(visit, n.Expr)
+
+		case *NullVal:
+
+		case OnDup:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *OptLike:
+			walk(visit, n.LikeTable)
+
+		case *OrExpr:
+			walk(visit, n.Left)
+			walk(visit, n.Right)
+
+		case *Order:
+			walk(visit, n.Expr)
+
+		case OrderBy:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *OtherAdmin:
+
+		case *OtherRead:
+
+		case *ParenSelect:
+			walk(visit, n.Select)
+
+		case *ParenTableExpr:
+			walk(visit, n.Exprs)
+
+		case *PartitionDefinition:
+			walk(visit, n.Limit)
+			walk(visit, n.Name)
+
+		case *PartitionSpec:
+			for _, item := range n.Definitions {
+				walk(visit, item)
+			}
+			walk(visit, n.Name)
+
+		case Partitions:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *RangeCond:
+			walk(visit, n.From)
+			walk(visit, n.Left)
+			walk(visit, n.To)
+
+		case ReferenceAction:
+
+		case *Release:
+			walk(visit, n.Name)
+
+		case *Rollback:
+
+		case *SRollback:
+			walk(visit, n.Name)
+
+		case *Savepoint:
+			walk(visit, n.Name)
+
+		case *Select:
+			walk(visit, n.Comments)
+			walk(visit, n.From)
+			walk(visit, n.GroupBy)
+			walk(visit, n.Having)
+			walk(visit, n.Limit)
+			walk(visit, n.OrderBy)
+			walk(visit, n.SelectExprs)
+			walk(visit, n.Where)
+
+		case SelectExprs:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *Set:
+			walk(visit, n.Comments)
+			walk(visit, n.Exprs)
+
+		case *SetExpr:
+			walk(visit, n.Expr)
+			walk(visit, n.Name)
+
+		case SetExprs:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *SetTransaction:
+			for _, item := range n.Characteristics {
+				walk(visit, item)
+			}
+			walk(visit, n.Comments)
+
+		case *Show:
+			walk(visit, n.OnTable)
+			walk(visit, n.ShowCollationFilterOpt)
+			walk(visit, n.Table)
+
+		case *ShowFilter:
+			walk(visit, n.Filter)
+
+		case *StarExpr:
+			walk(visit, n.TableName)
+
+		case *Stream:
+			walk(visit, n.Comments)
+			walk(visit, n.SelectExpr)
+			walk(visit, n.Table)
+
+		case *Subquery:
+			walk(visit, n.Select)
+
+		case *SubstrExpr:
+			walk(visit, n.From)
+			walk(visit, n.Name)
+			walk(visit, n.StrVal)
+			walk(visit, n.To)
+
+		case TableExprs:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case TableIdent:
+
+		case TableName:
+			walk(visit, n.Name)
+			walk(visit, n.Qualifier)
+
+		case TableNames:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *TableSpec:
+			for _, item := range n.Columns {
+				walk(visit, item)
+			}
+			for _, item := range n.Constraints {
+				walk(visit, item)
+			}
+			for _, item := range n.Indexes {
+				walk(visit, item)
+			}
+
+		case *TimestampFuncExpr:
+			walk(visit, n.Expr1)
+			walk(visit, n.Expr2)
+
+		case *UnaryExpr:
+			walk(visit, n.Expr)
+
+		case *Union:
+			walk(visit, n.FirstStatement)
+			walk(visit, n.Limit)
+			walk(visit, n.OrderBy)
+			for _, item := range n.UnionSelects {
+				walk(visit, item)
+			}
+
+		case *UnionSelect:
+			walk(visit, n.Statement)
+
+		case *Update:
+			walk(visit, n.Comments)
+			walk(visit, n.Exprs)
+			walk(visit, n.Limit)
+			walk(visit, n.OrderBy)
+			walk(visit, n.TableExprs)
+			walk(visit, n.Where)
+
+		case *UpdateExpr:
+			walk(visit, n.Expr)
+			walk(visit, n.Name)
+
+		case UpdateExprs:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *Use:
+			walk(visit, n.DBName)
+
+		case ValTuple:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case Values:
+			for _, item := range n {
+				walk(visit, item)
+			}
+
+		case *ValuesFuncExpr:
+			walk(visit, n.Name)
+
+		case VindexParam:
+			walk(visit, n.Key)
+
+		case *VindexSpec:
+			walk(visit, n.Name)
+			for _, item := range n.Params {
+				walk(visit, item)
+			}
+			walk(visit, n.Type)
+
+		case *When:
+			walk(visit, n.Cond)
+			walk(visit, n.Val)
+
+		case *Where:
+			walk(visit, n.Expr)
+
+		case *XorExpr:
+			walk(visit, n.Left)
+			walk(visit, n.Right)
+
+		default:
+			panic("unknown ast type " + reflect.TypeOf(in).String())
+		}
+	}
+}
+
 func isNilValue(i interface{}) bool {
 	valueOf := reflect.ValueOf(i)
 	kind := valueOf.Kind()

--- a/go/vt/sqlparser/rewriter.go
+++ b/go/vt/sqlparser/rewriter.go
@@ -1406,7 +1406,9 @@ type errorOccured struct {
 	err error
 }
 
-func walk(visit Visit, in SQLNode) {
+// __walk is an internal function and should NOT be called. It can panic
+// You are probably looking for Walk(visit Visit, in SQLNode)
+func __walk(visit Visit, in SQLNode) {
 
 	if in == nil || isNilValue(in) {
 		return
@@ -1424,66 +1426,66 @@ func walk(visit Visit, in SQLNode) {
 		case *AccessMode:
 
 		case *AliasedExpr:
-			walk(visit, n.As)
-			walk(visit, n.Expr)
+			__walk(visit, n.As)
+			__walk(visit, n.Expr)
 
 		case *AliasedTableExpr:
-			walk(visit, n.As)
-			walk(visit, n.Expr)
-			walk(visit, n.Hints)
-			walk(visit, n.Partitions)
+			__walk(visit, n.As)
+			__walk(visit, n.Expr)
+			__walk(visit, n.Hints)
+			__walk(visit, n.Partitions)
 
 		case *AndExpr:
-			walk(visit, n.Left)
-			walk(visit, n.Right)
+			__walk(visit, n.Left)
+			__walk(visit, n.Right)
 
 		case Argument:
 
 		case *AutoIncSpec:
-			walk(visit, n.Column)
-			walk(visit, n.Sequence)
+			__walk(visit, n.Column)
+			__walk(visit, n.Sequence)
 
 		case *Begin:
 
 		case *BinaryExpr:
-			walk(visit, n.Left)
-			walk(visit, n.Right)
+			__walk(visit, n.Left)
+			__walk(visit, n.Right)
 
 		case BoolVal:
 
 		case *CaseExpr:
-			walk(visit, n.Else)
-			walk(visit, n.Expr)
+			__walk(visit, n.Else)
+			__walk(visit, n.Expr)
 			for _, item := range n.Whens {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case ColIdent:
 
 		case *ColName:
-			walk(visit, n.Name)
-			walk(visit, n.Qualifier)
+			__walk(visit, n.Name)
+			__walk(visit, n.Qualifier)
 
 		case *CollateExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *ColumnDefinition:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case *ColumnType:
-			walk(visit, n.Autoincrement)
-			walk(visit, n.Comment)
-			walk(visit, n.Default)
-			walk(visit, n.Length)
-			walk(visit, n.NotNull)
-			walk(visit, n.OnUpdate)
-			walk(visit, n.Scale)
-			walk(visit, n.Unsigned)
-			walk(visit, n.Zerofill)
+			__walk(visit, n.Autoincrement)
+			__walk(visit, n.Comment)
+			__walk(visit, n.Default)
+			__walk(visit, n.Length)
+			__walk(visit, n.NotNull)
+			__walk(visit, n.OnUpdate)
+			__walk(visit, n.Scale)
+			__walk(visit, n.Unsigned)
+			__walk(visit, n.Zerofill)
 
 		case Columns:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case Comments:
@@ -1491,161 +1493,161 @@ func walk(visit Visit, in SQLNode) {
 		case *Commit:
 
 		case *ComparisonExpr:
-			walk(visit, n.Escape)
-			walk(visit, n.Left)
-			walk(visit, n.Right)
+			__walk(visit, n.Escape)
+			__walk(visit, n.Left)
+			__walk(visit, n.Right)
 
 		case *ConstraintDefinition:
-			walk(visit, n.Details)
+			__walk(visit, n.Details)
 
 		case *ConvertExpr:
-			walk(visit, n.Expr)
-			walk(visit, n.Type)
+			__walk(visit, n.Expr)
+			__walk(visit, n.Type)
 
 		case *ConvertType:
-			walk(visit, n.Length)
-			walk(visit, n.Scale)
+			__walk(visit, n.Length)
+			__walk(visit, n.Scale)
 
 		case *ConvertUsingExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *CurTimeFuncExpr:
-			walk(visit, n.Fsp)
-			walk(visit, n.Name)
+			__walk(visit, n.Fsp)
+			__walk(visit, n.Name)
 
 		case *DBDDL:
 
 		case *DDL:
-			walk(visit, n.AutoIncSpec)
-			walk(visit, n.FromTables)
-			walk(visit, n.OptLike)
-			walk(visit, n.PartitionSpec)
-			walk(visit, n.Table)
-			walk(visit, n.TableSpec)
-			walk(visit, n.ToTables)
+			__walk(visit, n.AutoIncSpec)
+			__walk(visit, n.FromTables)
+			__walk(visit, n.OptLike)
+			__walk(visit, n.PartitionSpec)
+			__walk(visit, n.Table)
+			__walk(visit, n.TableSpec)
+			__walk(visit, n.ToTables)
 			for _, item := range n.VindexCols {
-				walk(visit, item)
+				__walk(visit, item)
 			}
-			walk(visit, n.VindexSpec)
+			__walk(visit, n.VindexSpec)
 
 		case *Default:
 
 		case *Delete:
-			walk(visit, n.Comments)
-			walk(visit, n.Limit)
-			walk(visit, n.OrderBy)
-			walk(visit, n.Partitions)
-			walk(visit, n.TableExprs)
-			walk(visit, n.Targets)
-			walk(visit, n.Where)
+			__walk(visit, n.Comments)
+			__walk(visit, n.Limit)
+			__walk(visit, n.OrderBy)
+			__walk(visit, n.Partitions)
+			__walk(visit, n.TableExprs)
+			__walk(visit, n.Targets)
+			__walk(visit, n.Where)
 
 		case *ExistsExpr:
-			walk(visit, n.Subquery)
+			__walk(visit, n.Subquery)
 
 		case *Explain:
-			walk(visit, n.Statement)
+			__walk(visit, n.Statement)
 
 		case Exprs:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *ForeignKeyDefinition:
-			walk(visit, n.OnDelete)
-			walk(visit, n.OnUpdate)
-			walk(visit, n.ReferencedColumns)
-			walk(visit, n.ReferencedTable)
-			walk(visit, n.Source)
+			__walk(visit, n.OnDelete)
+			__walk(visit, n.OnUpdate)
+			__walk(visit, n.ReferencedColumns)
+			__walk(visit, n.ReferencedTable)
+			__walk(visit, n.Source)
 
 		case *FuncExpr:
-			walk(visit, n.Exprs)
-			walk(visit, n.Name)
-			walk(visit, n.Qualifier)
+			__walk(visit, n.Exprs)
+			__walk(visit, n.Name)
+			__walk(visit, n.Qualifier)
 
 		case GroupBy:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *GroupConcatExpr:
-			walk(visit, n.Exprs)
-			walk(visit, n.Limit)
-			walk(visit, n.OrderBy)
+			__walk(visit, n.Exprs)
+			__walk(visit, n.Limit)
+			__walk(visit, n.OrderBy)
 
 		case *IndexDefinition:
-			walk(visit, n.Info)
+			__walk(visit, n.Info)
 
 		case *IndexHints:
 			for _, item := range n.Indexes {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *IndexInfo:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case *Insert:
-			walk(visit, n.Columns)
-			walk(visit, n.Comments)
-			walk(visit, n.OnDup)
-			walk(visit, n.Partitions)
-			walk(visit, n.Rows)
-			walk(visit, n.Table)
+			__walk(visit, n.Columns)
+			__walk(visit, n.Comments)
+			__walk(visit, n.OnDup)
+			__walk(visit, n.Partitions)
+			__walk(visit, n.Rows)
+			__walk(visit, n.Table)
 
 		case *IntervalExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *IsExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *IsolationLevel:
 
 		case JoinCondition:
-			walk(visit, n.On)
-			walk(visit, n.Using)
+			__walk(visit, n.On)
+			__walk(visit, n.Using)
 
 		case *JoinTableExpr:
-			walk(visit, n.Condition)
-			walk(visit, n.LeftExpr)
-			walk(visit, n.RightExpr)
+			__walk(visit, n.Condition)
+			__walk(visit, n.LeftExpr)
+			__walk(visit, n.RightExpr)
 
 		case *Limit:
-			walk(visit, n.Offset)
-			walk(visit, n.Rowcount)
+			__walk(visit, n.Offset)
+			__walk(visit, n.Rowcount)
 
 		case ListArg:
 
 		case *Literal:
 
 		case *MatchExpr:
-			walk(visit, n.Columns)
-			walk(visit, n.Expr)
+			__walk(visit, n.Columns)
+			__walk(visit, n.Expr)
 
 		case Nextval:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *NotExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *NullVal:
 
 		case OnDup:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *OptLike:
-			walk(visit, n.LikeTable)
+			__walk(visit, n.LikeTable)
 
 		case *OrExpr:
-			walk(visit, n.Left)
-			walk(visit, n.Right)
+			__walk(visit, n.Left)
+			__walk(visit, n.Right)
 
 		case *Order:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case OrderBy:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *OtherAdmin:
@@ -1653,201 +1655,201 @@ func walk(visit Visit, in SQLNode) {
 		case *OtherRead:
 
 		case *ParenSelect:
-			walk(visit, n.Select)
+			__walk(visit, n.Select)
 
 		case *ParenTableExpr:
-			walk(visit, n.Exprs)
+			__walk(visit, n.Exprs)
 
 		case *PartitionDefinition:
-			walk(visit, n.Limit)
-			walk(visit, n.Name)
+			__walk(visit, n.Limit)
+			__walk(visit, n.Name)
 
 		case *PartitionSpec:
 			for _, item := range n.Definitions {
-				walk(visit, item)
+				__walk(visit, item)
 			}
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case Partitions:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *RangeCond:
-			walk(visit, n.From)
-			walk(visit, n.Left)
-			walk(visit, n.To)
+			__walk(visit, n.From)
+			__walk(visit, n.Left)
+			__walk(visit, n.To)
 
 		case ReferenceAction:
 
 		case *Release:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case *Rollback:
 
 		case *SRollback:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case *Savepoint:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case *Select:
-			walk(visit, n.Comments)
-			walk(visit, n.From)
-			walk(visit, n.GroupBy)
-			walk(visit, n.Having)
-			walk(visit, n.Limit)
-			walk(visit, n.OrderBy)
-			walk(visit, n.SelectExprs)
-			walk(visit, n.Where)
+			__walk(visit, n.Comments)
+			__walk(visit, n.From)
+			__walk(visit, n.GroupBy)
+			__walk(visit, n.Having)
+			__walk(visit, n.Limit)
+			__walk(visit, n.OrderBy)
+			__walk(visit, n.SelectExprs)
+			__walk(visit, n.Where)
 
 		case SelectExprs:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *Set:
-			walk(visit, n.Comments)
-			walk(visit, n.Exprs)
+			__walk(visit, n.Comments)
+			__walk(visit, n.Exprs)
 
 		case *SetExpr:
-			walk(visit, n.Expr)
-			walk(visit, n.Name)
+			__walk(visit, n.Expr)
+			__walk(visit, n.Name)
 
 		case SetExprs:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *SetTransaction:
 			for _, item := range n.Characteristics {
-				walk(visit, item)
+				__walk(visit, item)
 			}
-			walk(visit, n.Comments)
+			__walk(visit, n.Comments)
 
 		case *Show:
-			walk(visit, n.OnTable)
-			walk(visit, n.ShowCollationFilterOpt)
-			walk(visit, n.Table)
+			__walk(visit, n.OnTable)
+			__walk(visit, n.ShowCollationFilterOpt)
+			__walk(visit, n.Table)
 
 		case *ShowFilter:
-			walk(visit, n.Filter)
+			__walk(visit, n.Filter)
 
 		case *StarExpr:
-			walk(visit, n.TableName)
+			__walk(visit, n.TableName)
 
 		case *Stream:
-			walk(visit, n.Comments)
-			walk(visit, n.SelectExpr)
-			walk(visit, n.Table)
+			__walk(visit, n.Comments)
+			__walk(visit, n.SelectExpr)
+			__walk(visit, n.Table)
 
 		case *Subquery:
-			walk(visit, n.Select)
+			__walk(visit, n.Select)
 
 		case *SubstrExpr:
-			walk(visit, n.From)
-			walk(visit, n.Name)
-			walk(visit, n.StrVal)
-			walk(visit, n.To)
+			__walk(visit, n.From)
+			__walk(visit, n.Name)
+			__walk(visit, n.StrVal)
+			__walk(visit, n.To)
 
 		case TableExprs:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case TableIdent:
 
 		case TableName:
-			walk(visit, n.Name)
-			walk(visit, n.Qualifier)
+			__walk(visit, n.Name)
+			__walk(visit, n.Qualifier)
 
 		case TableNames:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *TableSpec:
 			for _, item := range n.Columns {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 			for _, item := range n.Constraints {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 			for _, item := range n.Indexes {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *TimestampFuncExpr:
-			walk(visit, n.Expr1)
-			walk(visit, n.Expr2)
+			__walk(visit, n.Expr1)
+			__walk(visit, n.Expr2)
 
 		case *UnaryExpr:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *Union:
-			walk(visit, n.FirstStatement)
-			walk(visit, n.Limit)
-			walk(visit, n.OrderBy)
+			__walk(visit, n.FirstStatement)
+			__walk(visit, n.Limit)
+			__walk(visit, n.OrderBy)
 			for _, item := range n.UnionSelects {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *UnionSelect:
-			walk(visit, n.Statement)
+			__walk(visit, n.Statement)
 
 		case *Update:
-			walk(visit, n.Comments)
-			walk(visit, n.Exprs)
-			walk(visit, n.Limit)
-			walk(visit, n.OrderBy)
-			walk(visit, n.TableExprs)
-			walk(visit, n.Where)
+			__walk(visit, n.Comments)
+			__walk(visit, n.Exprs)
+			__walk(visit, n.Limit)
+			__walk(visit, n.OrderBy)
+			__walk(visit, n.TableExprs)
+			__walk(visit, n.Where)
 
 		case *UpdateExpr:
-			walk(visit, n.Expr)
-			walk(visit, n.Name)
+			__walk(visit, n.Expr)
+			__walk(visit, n.Name)
 
 		case UpdateExprs:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *Use:
-			walk(visit, n.DBName)
+			__walk(visit, n.DBName)
 
 		case ValTuple:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case Values:
 			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}
 
 		case *ValuesFuncExpr:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 
 		case VindexParam:
-			walk(visit, n.Key)
+			__walk(visit, n.Key)
 
 		case *VindexSpec:
-			walk(visit, n.Name)
+			__walk(visit, n.Name)
 			for _, item := range n.Params {
-				walk(visit, item)
+				__walk(visit, item)
 			}
-			walk(visit, n.Type)
+			__walk(visit, n.Type)
 
 		case *When:
-			walk(visit, n.Cond)
-			walk(visit, n.Val)
+			__walk(visit, n.Cond)
+			__walk(visit, n.Val)
 
 		case *Where:
-			walk(visit, n.Expr)
+			__walk(visit, n.Expr)
 
 		case *XorExpr:
-			walk(visit, n.Left)
-			walk(visit, n.Right)
+			__walk(visit, n.Left)
+			__walk(visit, n.Right)
 
 		default:
 			panic("unknown ast type " + reflect.TypeOf(in).String())

--- a/go/vt/sqlparser/visitorgen/main/main.go
+++ b/go/vt/sqlparser/visitorgen/main/main.go
@@ -163,7 +163,9 @@ type errorOccured struct {
 	err error
 }
 
-func walk(visit Visit, in SQLNode) {
+// __walk is an internal function and should NOT be called. It can panic
+// You are probably looking for Walk(visit Visit, in SQLNode)
+func __walk(visit Visit, in SQLNode) {
 
 	if in == nil || isNilValue(in) {
 		return

--- a/go/vt/sqlparser/visitorgen/struct_producer.go
+++ b/go/vt/sqlparser/visitorgen/struct_producer.go
@@ -30,6 +30,7 @@ type (
 		asSwitchCase() string
 		asReplMethod() string
 		getFieldName() string
+		asWalkerVisit() string
 	}
 
 	// SingleFieldItem is a single field in a struct
@@ -134,6 +135,10 @@ func (s *SingleFieldItem) asSwitchCase() string {
 	return fmt.Sprintf(`		a.apply(node, n.%s, %s)`, s.FieldName, s.typeName())
 }
 
+func (s *SingleFieldItem) asWalkerVisit() string {
+	return fmt.Sprintf(`			walk(visit, n.%s)`, s.FieldName)
+}
+
 func (s *SingleFieldItem) asReplMethod() string {
 	_, isRef := s.StructType.(*Ref)
 
@@ -216,6 +221,18 @@ func (afi *ArrayFieldItem) asSwitchCase() string {
 			a.apply(node, item, replacer%sB.replace)
 			replacer%sB.inc()
 		}`, afi.FieldName, afi.typeName(), afi.FieldName, afi.FieldName, afi.FieldName, afi.FieldName, afi.FieldName)
+}
+
+func (ai *ArrayItem) asWalkerVisit() string {
+	return `			for _, item := range n {
+				walk(visit, item)
+			}`
+}
+
+func (afi *ArrayFieldItem) asWalkerVisit() string {
+	return fmt.Sprintf(`			for _, item := range n.%s {
+				walk(visit, item)
+			}`, afi.FieldName)
 }
 
 func (ai *ArrayItem) typeName() string {

--- a/go/vt/sqlparser/visitorgen/struct_producer.go
+++ b/go/vt/sqlparser/visitorgen/struct_producer.go
@@ -136,7 +136,7 @@ func (s *SingleFieldItem) asSwitchCase() string {
 }
 
 func (s *SingleFieldItem) asWalkerVisit() string {
-	return fmt.Sprintf(`			walk(visit, n.%s)`, s.FieldName)
+	return fmt.Sprintf(`			__walk(visit, n.%s)`, s.FieldName)
 }
 
 func (s *SingleFieldItem) asReplMethod() string {
@@ -152,7 +152,6 @@ func (s *SingleFieldItem) asReplMethod() string {
 	tmp := parent.(%s)
 	tmp.%s = newNode.(%s)
 }`, s.typeName(), s.StructType.toTypString(), s.FieldName, s.FieldType.toTypString())
-
 }
 
 func (ai *ArrayItem) asReplMethod() string {
@@ -225,13 +224,13 @@ func (afi *ArrayFieldItem) asSwitchCase() string {
 
 func (ai *ArrayItem) asWalkerVisit() string {
 	return `			for _, item := range n {
-				walk(visit, item)
+				__walk(visit, item)
 			}`
 }
 
 func (afi *ArrayFieldItem) asWalkerVisit() string {
 	return fmt.Sprintf(`			for _, item := range n.%s {
-				walk(visit, item)
+				__walk(visit, item)
 			}`, afi.FieldName)
 }
 

--- a/go/vt/sqlparser/visitorgen/visitor_emitter.go
+++ b/go/vt/sqlparser/visitorgen/visitor_emitter.go
@@ -36,15 +36,28 @@ func EmitReplacementMethods(vd *VisitorPlan) string {
 	return sb.String()
 }
 
-// EmitTypeSwitches is an anti-parser (a.k.a prettifier) - it takes a struct that is much like an AST,
+// EmitTypeRewriteSwitches is an anti-parser (a.k.a prettifier) - it takes a struct that is much like an AST,
 // and produces a string from it. This method will produce the switch cases needed to cover the Vitess AST.
-func EmitTypeSwitches(vd *VisitorPlan) string {
+func EmitTypeRewriteSwitches(vd *VisitorPlan) string {
 	var sb builder
 	for _, s := range vd.Switches {
 		sb.newLine()
 		sb.appendF("	case %s:", s.Type.toTypString())
 		for _, k := range s.Fields {
 			sb.appendF(k.asSwitchCase())
+		}
+	}
+
+	return sb.String()
+}
+
+func EmitTypeVisitSwitches(vd *VisitorPlan) string {
+	var sb builder
+	for _, s := range vd.Switches {
+		sb.newLine()
+		sb.appendF("\t\tcase %s:", s.Type.toTypString())
+		for _, k := range s.Fields {
+			sb.appendF(k.asWalkerVisit())
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -137,21 +137,21 @@ func planSysVarCheckIgnore(expr *sqlparser.SetExpr, schema ContextVSchema, boole
 
 func expressionOkToDelegateToTablet(e sqlparser.Expr) bool {
 	valid := true
-	sqlparser.Rewrite(e, nil, func(cursor *sqlparser.Cursor) bool {
-		switch n := cursor.Node().(type) {
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		switch n := node.(type) {
 		case *sqlparser.Subquery, *sqlparser.TimestampFuncExpr, *sqlparser.CurTimeFuncExpr:
 			valid = false
-			return false
+			return false, nil
 		case *sqlparser.FuncExpr:
 			_, ok := validFuncs[n.Name.Lowered()]
 			valid = ok
-			return ok
+			return ok, nil
 		case *sqlparser.ColName:
 			valid = n.Name.AtCount() == 2
-			return false
+			return false, nil
 		}
-		return true
-	})
+		return true, nil
+	}, e)
 	return valid
 }
 


### PR DESCRIPTION
To test the difference, two benchmarks where added. These are micro-benchmarks just for this particular method. Have not yet checked what the difference in a more holistic way.

```
BenchmarkRewriteWalk-16    	    6859	    165478 ns/op
BenchmarkCustomWalk-16     	    8398	    146581 ns/op
```