### PR TITLE
Fix unsaved event regression

### DIFF
--- a/go/test/endtoend/vreplication/helper.go
+++ b/go/test/endtoend/vreplication/helper.go
@@ -241,3 +241,14 @@ func expectNumberOfStreams(t *testing.T, vtgateConn *mysql.Conn, name string, wo
 		t.Fatalf("Incorrect streams found for %s: %s\n", name, result)
 	}
 }
+
+func printShardPositions(vc *VitessCluster, ksShards []string) {
+	for _, ksShard := range ksShards {
+		output, err := vc.VtctlClient.ExecuteCommandWithOutput("ShardReplicationPositions", ksShard)
+		if err != nil {
+			fmt.Printf("Error in ShardReplicationPositions: %v, output %v", err, output)
+		} else {
+			fmt.Printf("Position of %s: %s", ksShard, output)
+		}
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -251,8 +251,6 @@ func (vp *vplayer) updateTime(ts int64) (err error) {
 	if _, err := vp.vr.dbClient.Execute(update); err != nil {
 		return fmt.Errorf("error %v updating time", err)
 	}
-	vp.unsavedEvent = nil
-	vp.timeLastSaved = time.Now()
 	return nil
 }
 

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -741,14 +741,18 @@ func (ts *trafficSwitcher) waitForCatchup(ctx context.Context, filteredReplicati
 
 	var mu sync.Mutex
 	return ts.forAllUids(func(target *tsTarget, uid uint32) error {
+		ts.wr.Logger().Infof("uid: %d, target master %s, target position %s, shard %s", uid,
+			target.master.AliasString(), target.position, target.si.String())
 		bls := target.sources[uid]
 		source := ts.sources[bls.Shard]
-		ts.wr.Logger().Infof("waiting for keyspace:shard: %v:%v, position %v", ts.targetKeyspace, target.si.ShardName(), source.position)
+		ts.wr.Logger().Infof("waiting for keyspace:shard: %v:%v, source position %v, uid %d",
+			ts.targetKeyspace, target.si.ShardName(), source.position, uid)
 		if err := ts.wr.tmc.VReplicationWaitForPos(ctx, target.master.Tablet, int(uid), source.position); err != nil {
 			return err
 		}
-		ts.wr.Logger().Infof("position for keyspace:shard: %v:%v reached", ts.targetKeyspace, target.si.ShardName())
+		ts.wr.Logger().Infof("position for keyspace:shard: %v:%v reached, uid %d", ts.targetKeyspace, target.si.ShardName(), uid)
 		if _, err := ts.wr.tmc.VReplicationExec(ctx, target.master.Tablet, binlogplayer.StopVReplication(uid, "stopped for cutover")); err != nil {
+			log.Infof("error marking stopped for cutover on %s, uid %d", target.master.AliasString(), uid)
 			return err
 		}
 
@@ -760,7 +764,7 @@ func (ts *trafficSwitcher) waitForCatchup(ctx context.Context, filteredReplicati
 		}
 		var err error
 		target.position, err = ts.wr.tmc.MasterPosition(ctx, target.master.Tablet)
-		ts.wr.Logger().Infof("Position for uid %v: %v", uid, target.position)
+		ts.wr.Logger().Infof("Position for target master %s, uid %v: %v", target.master.AliasString(), uid, target.position)
 		return err
 	})
 }


### PR DESCRIPTION
There was a regression in https://github.com/vitessio/vitess/pull/6635 due to which unsaved events were not being saved on a heartbeat.

This resulted in SwitchWrites failing because shards where there no activity relevant to the stream would never catchup to the master position. This bug manifested when one switched back and forth between forward and reverse workflows without any
new relevant writes (matching the keyspace id) to the target shard. 

Also added more logs for observability.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>