### PR TITLE
e2e: deflake sharding tests

### DIFF
--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -66,20 +66,13 @@ func (vtctlclient *VtctlClientProcess) ApplyVSchema(Keyspace string, JSON string
 
 // ExecuteCommand executes any vtctlclient command
 func (vtctlclient *VtctlClientProcess) ExecuteCommand(args ...string) (err error) {
-	pArgs := []string{"-server", vtctlclient.Server}
-
-	if *isCoverage {
-		pArgs = append(pArgs, "-test.coverprofile="+getCoveragePath("vtctlclient-"+args[0]+".out"), "-test.v")
-	}
-	pArgs = append(pArgs, args...)
-	tmpProcess := exec.Command(
-		vtctlclient.Binary,
-		pArgs...,
-	)
-	log.Infof("Executing vtctlclient with command: %v", strings.Join(tmpProcess.Args, " "))
-	output, err := tmpProcess.Output()
-	if err != nil {
-		log.Errorf("Error executing %s: output %s, err %v", strings.Join(tmpProcess.Args, " "), output, err)
+	output, err := vtctlclient.ExecuteCommandWithOutput(args...)
+	if output != "" {
+		if err != nil {
+			log.Errorf("Output:\n%v", output)
+		} else {
+			log.Infof("Output:\n%v", output)
+		}
 	}
 	return err
 }

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -328,14 +328,6 @@ func checkLots(t *testing.T, vttablet cluster.Vttablet, count uint64, table stri
 	return float64(float64(totalFound) * 100 / float64(count) / 2)
 }
 
-// CheckRunningBinlogPlayer Checks binlog player is running and showing in status
-func CheckRunningBinlogPlayer(t *testing.T, vttablet cluster.Vttablet, numberOfQueries int, numberOfTxns int) {
-	status := vttablet.VttabletProcess.GetStatus()
-	assert.Contains(t, status, "VReplication state: Open")
-	assert.Contains(t, status, fmt.Sprintf("<td><b>All</b>: %d<br><b>Query</b>: %d<br><b>Transaction</b>: %d<br></td>", numberOfQueries+numberOfTxns, numberOfQueries, numberOfTxns))
-	assert.Contains(t, status, "</html>")
-}
-
 // CheckTabletQueryServices check that the query service is enabled or disabled on the specified tablets.
 func CheckTabletQueryServices(t *testing.T, vttablets []cluster.Vttablet, expectedStatus string, tabletControlEnabled bool, ci cluster.LocalProcessCluster) {
 	for _, tablet := range vttablets {

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -512,15 +512,6 @@ func TestInitialSharding(t *testing.T, keyspace *cluster.Keyspace, keyType query
 		}
 	}
 
-	if isExternal {
-		// get status for the destination master tablet, make sure we have it all
-		sharding.CheckRunningBinlogPlayer(t, *shard21.MasterTablet(), 3956, 2002)
-		sharding.CheckRunningBinlogPlayer(t, *shard22.MasterTablet(), 4048, 2002)
-	} else {
-		sharding.CheckRunningBinlogPlayer(t, *shard21.MasterTablet(), 3954, 2000)
-		sharding.CheckRunningBinlogPlayer(t, *shard22.MasterTablet(), 4046, 2000)
-	}
-
 	// check we can't migrate the master just yet
 	err = ClusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes", shard1Ks, "master")
 	require.Error(t, err)

--- a/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
+++ b/go/test/endtoend/sharding/mergesharding/mergesharding_base.go
@@ -413,9 +413,6 @@ func TestMergesharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard3Rdonly.Alias, "rdonly")
 	require.NoError(t, err)
 
-	// get status for destination master tablets, make sure we have it all
-	sharding.CheckRunningBinlogPlayer(t, *shard3Master, 300, 100)
-
 	sharding.CheckTabletQueryService(t, *shard3Master, "NOT_SERVING", false, *clusterInstance)
 	streamHealth, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput(
 		"VtTabletStreamHealth",

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -590,10 +590,6 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard3Rdonly.Alias, "rdonly")
 	require.Nil(t, err)
 
-	// get status for destination master tablets, make sure we have it all
-	sharding.CheckRunningBinlogPlayer(t, *shard2Master, 436, 216)
-	sharding.CheckRunningBinlogPlayer(t, *shard3Master, 456, 216)
-
 	// tests a failover switching serving to a different replica
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("ChangeSlaveType", shard1Replica2.Alias, "replica")
 	require.Nil(t, err)

--- a/go/test/endtoend/sharding/verticalsplit/vertical_split_test.go
+++ b/go/test/endtoend/sharding/verticalsplit/vertical_split_test.go
@@ -290,9 +290,6 @@ func TestVerticalSplit(t *testing.T) {
 		"destination_keyspace/0")
 	require.NoError(t, err)
 
-	// get status for destination master tablet, make sure we have it all
-	sharding.CheckRunningBinlogPlayer(t, destinationMasterTablet, 700, 300)
-
 	// check query service is off on destination master, as filtered
 	// replication is enabled. Even health check should not interfere.
 	destinationMasterTabletVars := destinationMasterTablet.VttabletProcess.GetVars()


### PR DESCRIPTION
The sharding tests were expecting an exact number of queries and
transactions to be processed by vreplication. But this is not
as deterministic as it used to be. All these tests are already
verifying the target using SplitDiff, which is the more reliable
way to verify correctness.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>