### PR TITLE
Change tracker to use allprivs instead of dba

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
@@ -90,7 +90,7 @@ func (ec *externalConnector) Get(name string) (*mysqlConnector, error) {
 	c.se = schema.NewEngine(c.env)
 	c.vstreamer = vstreamer.NewEngine(c.env, nil, c.se, "")
 	c.vstreamer.InitDBConfig("")
-	c.se.InitDBConfig(c.env.Config().DB.DbaWithDB())
+	c.se.InitDBConfig(c.env.Config().DB.AllPrivsWithDB())
 
 	// Open
 	if err := c.se.Open(); err != nil {


### PR DESCRIPTION
This PR just changes the db user to allprivs instead of dba to prevent inadvertent writes into schema_version when a tablet transitions from master to replica.

We have a separate issue where reparent tests are failing with tracker on. But on further investigation it looks like that those tests are not setting up and tearing down the cluster correctly leading to tablets resuming from their earlier state and binlogs being thus in unexpected states. That is being fixed in #6726  and if any related tracker bugs are found we will fix them as part of that issue.  

Signed-off-by: Rohit Nayak <rohit@planetscale.com>