### PR TITLE
helm & docker/k8s update

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -1,25 +1,27 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/base AS base
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/base:${VT_BASE_VER} AS base
+
+FROM debian:buster-slim
 
 # TODO: remove when https://github.com/vitessio/vitess/issues/3553 is fixed
 RUN apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install mysql-client -qq --no-install-recommends && \
+   apt-get install default-mysql-client -qq --no-install-recommends && \
    apt-get autoremove && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*

--- a/docker/k8s/logrotate/Dockerfile
+++ b/docker/k8s/logrotate/Dockerfile
@@ -1,18 +1,18 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ADD logrotate.conf /vt/logrotate.conf
 

--- a/docker/k8s/logtail/Dockerfile
+++ b/docker/k8s/logtail/Dockerfile
@@ -1,18 +1,18 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ENV TAIL_FILEPATH /dev/null
 
@@ -21,7 +21,7 @@ ADD tail.sh /vt/tail.sh
 RUN mkdir -p /vt && \
    apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install mysql-client -qq --no-install-recommends && \
+   apt-get install default-mysql-client -qq --no-install-recommends && \
    apt-get autoremove -qq && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/* && \

--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -1,27 +1,30 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
+ARG ORC_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 RUN apt-get update && \
    apt-get upgrade -qq && \
    apt-get install wget ca-certificates jq -qq --no-install-recommends && \
-   wget https://github.com/openark/orchestrator/releases/download/v3.1.1/orchestrator_3.1.0_amd64.deb && \
-   dpkg -i orchestrator_3.1.0_amd64.deb && \
-   rm orchestrator_3.1.0_amd64.deb && \
+   wget https://github.com/openark/orchestrator/releases/download/v${ORC_VER}/orchestrator_${ORC_VER}_amd64.deb && \
+   dpkg -i orchestrator_${ORC_VER}_amd64.deb && \
+   rm orchestrator_${ORC_VER}_amd64.deb && \
    apt-get purge wget -qq && \
    apt-get autoremove -qq && \
    apt-get clean && \

--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -1,27 +1,30 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
+ARG PMM_CLIENT_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 RUN apt-get update && \
    apt-get upgrade -qq && \
    apt-get install procps wget ca-certificates -qq --no-install-recommends && \
-   wget https://www.percona.com/redir/downloads/pmm-client/1.17.0/binary/debian/stretch/x86_64/pmm-client_1.17.0-1.stretch_amd64.deb && \
-   dpkg -i pmm-client_1.17.0-1.stretch_amd64.deb && \
-   rm pmm-client_1.17.0-1.stretch_amd64.deb && \
+   wget https://www.percona.com/redir/downloads/pmm-client/${PMM_CLIENT_VER}/binary/debian/buster/x86_64/pmm-client_${PMM_CLIENT_VER}-1.buster_amd64.deb && \
+   dpkg -i pmm-client_${PMM_CLIENT_VER}-1.buster_amd64.deb && \
+   rm pmm-client_${PMM_CLIENT_VER}-1.buster_amd64.deb && \
    apt-get purge wget ca-certificates -qq && \
    apt-get autoremove -qq && \
    apt-get clean && \

--- a/docker/k8s/vtbackup/Dockerfile
+++ b/docker/k8s/vtbackup/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtexplain/Dockerfile
+++ b/docker/k8s/vtexplain/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 
 FROM vitess/base AS base
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -1,25 +1,27 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # TODO: remove when https://github.com/vitessio/vitess/issues/3553 is fixed
 RUN apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install wget mysql-client jq -qq --no-install-recommends && \
+   apt-get install wget default-mysql-client jq -qq --no-install-recommends && \
    apt-get autoremove && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*

--- a/docker/k8s/vtworker/Dockerfile
+++ b/docker/k8s/vtworker/Dockerfile
@@ -1,20 +1,22 @@
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/k8s AS k8s
+ARG VT_BASE_VER
 
-FROM debian:stretch-slim
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)
 ENV VTROOT /vt

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -1,51 +1,43 @@
 #!/bin/bash
 
-version_tag=1.0.7-5
+vt_base_version=v7.0.1
+orchestrator_version=3.2.3
+pmm_client_version=1.17.4
 
-docker pull vitess/k8s:latest
-docker tag vitess/k8s:latest vitess/k8s:helm-$version_tag
-docker push vitess/k8s:helm-$version_tag
+docker pull vitess/base:$vt_base_version
 
-docker pull vitess/vtgate:latest
-docker tag vitess/vtgate:latest vitess/vtgate:helm-$version_tag
-docker push vitess/vtgate:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/k8s:$vt_base_version-buster .
+docker push vitess/k8s:$vt_base_version-buster
 
-docker pull vitess/vttablet:latest
-docker tag vitess/vttablet:latest vitess/vttablet:helm-$version_tag
-docker push vitess/vttablet:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtgate:$vt_base_version-buster vtgate
+docker push vitess/vtgate:$vt_base_version-buster
 
-docker pull vitess/mysqlctld:latest
-docker tag vitess/mysqlctld:latest vitess/mysqlctld:helm-$version_tag
-docker push vitess/mysqlctld:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vttablet:$vt_base_version-buster vttablet
+docker push vitess/vttablet:$vt_base_version-buster
 
-docker pull vitess/vtctl:latest
-docker tag vitess/vtctl:latest vitess/vtctl:helm-$version_tag
-docker push vitess/vtctl:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/mysqlctld:$vt_base_version-buster mysqlctld
+docker push vitess/mysqlctld:$vt_base_version-buster
 
-docker pull vitess/vtctlclient:latest
-docker tag vitess/vtctlclient:latest vitess/vtctlclient:helm-$version_tag
-docker push vitess/vtctlclient:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctl:$vt_base_version-buster vtctl
+docker push vitess/vtctl:$vt_base_version-buster
 
-docker pull vitess/vtctld:latest
-docker tag vitess/vtctld:latest vitess/vtctld:helm-$version_tag
-docker push vitess/vtctld:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctlclient:$vt_base_version-buster vtctlclient
+docker push vitess/vtctlclient:$vt_base_version-buster
 
-docker pull vitess/vtworker:latest
-docker tag vitess/vtworker:latest vitess/vtworker:helm-$version_tag
-docker push vitess/vtworker:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctld:$vt_base_version-buster vtctld
+docker push vitess/vtctld:$vt_base_version-buster
 
-docker pull vitess/logrotate:latest
-docker tag vitess/logrotate:latest vitess/logrotate:helm-$version_tag
-docker push vitess/logrotate:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtworker:$vt_base_version-buster vtworker
+docker push vitess/vtworker:$vt_base_version-buster
 
-docker pull vitess/logtail:latest
-docker tag vitess/logtail:latest vitess/logtail:helm-$version_tag
-docker push vitess/logtail:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logrotate:$vt_base_version-buster logrotate
+docker push vitess/logrotate:$vt_base_version-buster
 
-docker pull vitess/pmm-client:latest
-docker tag vitess/pmm-client:latest vitess/pmm-client:helm-$version_tag
-docker push vitess/pmm-client:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logtail:$vt_base_version-buster logtail
+docker push vitess/logtail:$vt_base_version-buster
 
-docker pull vitess/orchestrator:latest
-docker tag vitess/orchestrator:latest vitess/orchestrator:helm-$version_tag
-docker push vitess/orchestrator:helm-$version_tag
+docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg PMM_CLIENT_VER=$pmm_client_version -t vitess/pmm-client:v$pmm_client_version-buster pmm-client
+docker push vitess/pmm-client:v$pmm_client_version-buster
+
+docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg PMM_CLIENT_VER=$pmm_client_version -t vitess/orchestrator:v$orchestrator_version-buster orchestrator
+docker push vitess/orchestrator:v$orchestrator_version-buster


### PR DESCRIPTION
- upgrade from stretch to buster, also cleans up extra spaces and enables build args for release orchestration
- before this, releases weren't deterministic and weren't even coordinated between image repos. This cleans it up, plus uses new docker ARGs to automate the release