### PR TITLE
Remove auto-generation comment

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -19,7 +19,6 @@ limitations under the License.
 package vtctl
 
 // The following comment section contains definitions for command arguments.
-// It is parsed to generate the vtctl documentation automatically.
 /*
 COMMAND ARGUMENT DEFINITIONS
 


### PR DESCRIPTION
we no longer auto-generate docs from vtctl.go

Signed-off-by: Jacques Grove <aquarapid@gmail.com>