### PR TITLE
VReplication e2e tests: Simplify and split tests to overcome current CI resource constraints

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -52,6 +52,8 @@ func TestBasicVreplicationWorkflow(t *testing.T) {
 	allCellNames = "zone1"
 	vc = InitCluster(t, []string{defaultCellName})
 	assert.NotNil(t, vc)
+	defaultReplicas = 0 // because of CI resource constraints we can only run this test with master tablets
+	defer func() { defaultReplicas = 1 }()
 
 	defer vc.TearDown()
 
@@ -199,7 +201,7 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 	}
 
 	if err := vc.VtctlClient.ExecuteCommand("MoveTables", "-cells="+sourceCellOrAlias, "-workflow=p2c",
-		"-tablet_types="+"replica,rdonly", "product", "customer", "customer"); err != nil {
+		"-tablet_types="+"master,replica,rdonly", "product", "customer", "customer"); err != nil {
 		t.Fatalf("MoveTables command failed with %+v\n", err)
 	}
 
@@ -209,16 +211,15 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 	customerTab1 := vc.Cells[defaultCell.Name].Keyspaces["customer"].Shards["-80"].Tablets["zone1-200"].Vttablet
 	customerTab2 := vc.Cells[defaultCell.Name].Keyspaces["customer"].Shards["80-"].Tablets["zone1-300"].Vttablet
 
-	if vc.WaitForVReplicationToCatchup(customerTab1, "p2c", "vt_customer", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(customerTab1, "p2c", "vt_customer", 5*time.Second) != nil {
 		t.Fatal("MoveTables timed out for customer.p2c -80")
 
 	}
-	if vc.WaitForVReplicationToCatchup(customerTab2, "p2c", "vt_customer", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(customerTab2, "p2c", "vt_customer", 5*time.Second) != nil {
 		t.Fatal("MoveTables timed out for customer.p2c 80-")
 	}
 
 	productTab := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet
-	productTabReplica := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-101"].Vttablet
 	query := "select * from customer"
 	assert.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", query, query))
 	insertQuery1 := "insert into customer(cid, name) values(1001, 'tempCustomer1')"
@@ -240,7 +241,6 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 		t.Fatalf("SwitchReads error: %s\n", output)
 	}
 
-	assert.False(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTabReplica, "customer", query, query))
 	assert.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "customer", query, query))
 	want = dryRunResultsSwitchWritesCustomerShard
 	if output, err = vc.VtctlClient.ExecuteCommandWithOutput("SwitchWrites", "-dry_run", "customer.p2c"); err != nil {
@@ -499,16 +499,16 @@ func shardOrders(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := vc.VtctlClient.ExecuteCommand("MoveTables", "-cells="+defaultCell.Name, "-workflow=o2c",
-		"-tablet_types="+"replica,rdonly", "product", "customer", "orders"); err != nil {
+		"-tablet_types="+"master,replica,rdonly", "product", "customer", "orders"); err != nil {
 		t.Fatal(err)
 	}
 	customerTab1 := vc.Cells[defaultCell.Name].Keyspaces["customer"].Shards["-80"].Tablets["zone1-200"].Vttablet
 	customerTab2 := vc.Cells[defaultCell.Name].Keyspaces["customer"].Shards["80-"].Tablets["zone1-300"].Vttablet
-	if vc.WaitForVReplicationToCatchup(customerTab1, "o2c", "vt_customer", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(customerTab1, "o2c", "vt_customer", 5*time.Second) != nil {
 		assert.Fail(t, "MoveTables timed out for customer.o2c -80")
 
 	}
-	if vc.WaitForVReplicationToCatchup(customerTab2, "o2c", "vt_customer", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(customerTab2, "o2c", "vt_customer", 5*time.Second) != nil {
 		assert.Fail(t, "MoveTables timed out for customer.o2c 80-")
 	}
 
@@ -542,17 +542,17 @@ func shardMerchant(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := vc.VtctlClient.ExecuteCommand("MoveTables", "-cells="+defaultCell.Name, "-workflow=p2m",
-		"-tablet_types="+"replica,rdonly", "product", "merchant", "merchant"); err != nil {
+		"-tablet_types="+"master,replica,rdonly", "product", "merchant", "merchant"); err != nil {
 		t.Fatal(err)
 	}
 
 	merchantTab1 := vc.Cells[defaultCell.Name].Keyspaces["merchant"].Shards["-80"].Tablets["zone1-400"].Vttablet
 	merchantTab2 := vc.Cells[defaultCell.Name].Keyspaces["merchant"].Shards["80-"].Tablets["zone1-500"].Vttablet
-	if vc.WaitForVReplicationToCatchup(merchantTab1, "p2m", "vt_merchant", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(merchantTab1, "p2m", "vt_merchant", 5*time.Second) != nil {
 		t.Fatal("MoveTables timed out for merchant.p2m -80")
 
 	}
-	if vc.WaitForVReplicationToCatchup(merchantTab2, "p2m", "vt_merchant", 1*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(merchantTab2, "p2m", "vt_merchant", 5*time.Second) != nil {
 		t.Fatal("MoveTables timed out for merchant.p2m 80-")
 	}
 
@@ -606,7 +606,7 @@ func materializeProduct(t *testing.T) {
 	}
 	customerTablets := vc.getVttabletsInKeyspace(t, defaultCell, "customer", "master")
 	for _, tab := range customerTablets {
-		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_customer", 3*time.Second) != nil {
+		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_customer", 5*time.Second) != nil {
 			t.Fatal("Materialize timed out")
 		}
 	}
@@ -623,7 +623,7 @@ func materializeSales(t *testing.T) {
 		t.Fatal(err)
 	}
 	productTab := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet
-	if vc.WaitForVReplicationToCatchup(productTab, "sales", "vt_product", 3*time.Second) != nil {
+	if vc.WaitForVReplicationToCatchup(productTab, "sales", "vt_product", 5*time.Second) != nil {
 		assert.Fail(t, "Materialize timed out for product.sales")
 	}
 	assert.Empty(t, validateCount(t, vtgateConn, "product", "sales", 2))
@@ -639,7 +639,7 @@ func materializeMerchantSales(t *testing.T) {
 	}
 	merchantTablets := vc.getVttabletsInKeyspace(t, defaultCell, "merchant", "master")
 	for _, tab := range merchantTablets {
-		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_merchant", 1*time.Second) != nil {
+		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_merchant", 5*time.Second) != nil {
 			t.Fatal("Materialize timed out")
 		}
 	}
@@ -660,7 +660,7 @@ func materializeMerchantOrders(t *testing.T) {
 	}
 	merchantTablets := vc.getVttabletsInKeyspace(t, defaultCell, "merchant", "master")
 	for _, tab := range merchantTablets {
-		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_merchant", 1*time.Second) != nil {
+		if vc.WaitForVReplicationToCatchup(tab, workflow, "vt_merchant", 5*time.Second) != nil {
 			t.Fatal("Materialize timed out")
 		}
 	}

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -115,12 +115,13 @@ func TestMultiCellVreplicationWorkflow(t *testing.T) {
 	insertInitialData(t)
 	shardCustomer(t, true, []*Cell{cell1, cell2}, cell2.Name)
 
-	insertMoreCustomers(t, 16)
-	reshardCustomer2to4Split(t, []*Cell{cell1, cell2}, cell2.Name)
-	validateCount(t, vtgateConn, "customer:-40", "customer", 5)
-	validateCount(t, vtgateConn, "customer:40-80", "customer", 5)
-	validateCount(t, vtgateConn, "customer:80-c0", "customer", 6)
-	validateCount(t, vtgateConn, "customer:c0-", "customer", 5)
+	// commenting lines below because of resource constraints
+	//insertMoreCustomers(t, 16)
+	//reshardCustomer2to4Split(t, []*Cell{cell1, cell2}, cell2.Name)
+	//validateCount(t, vtgateConn, "customer:-40", "customer", 5)
+	//validateCount(t, vtgateConn, "customer:40-80", "customer", 5)
+	//validateCount(t, vtgateConn, "customer:80-c0", "customer", 6)
+	//validateCount(t, vtgateConn, "customer:c0-", "customer", 5)
 }
 
 func TestCellAliasVreplicationWorkflow(t *testing.T) {
@@ -153,12 +154,13 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	insertInitialData(t)
 	shardCustomer(t, true, []*Cell{cell1, cell2}, "alias")
 
-	insertMoreCustomers(t, 16)
-	reshardCustomer2to4Split(t, []*Cell{cell1, cell2}, "alias")
-	validateCount(t, vtgateConn, "customer:-40", "customer", 5)
-	validateCount(t, vtgateConn, "customer:40-80", "customer", 5)
-	validateCount(t, vtgateConn, "customer:80-c0", "customer", 6)
-	validateCount(t, vtgateConn, "customer:c0-", "customer", 5)
+	// commenting lines below because of resource constraints
+	//insertMoreCustomers(t, 16)
+	//reshardCustomer2to4Split(t, []*Cell{cell1, cell2}, "alias")
+	//validateCount(t, vtgateConn, "customer:-40", "customer", 5)
+	//validateCount(t, vtgateConn, "customer:40-80", "customer", 5)
+	//validateCount(t, vtgateConn, "customer:80-c0", "customer", 6)
+	//validateCount(t, vtgateConn, "customer:c0-", "customer", 5)
 }
 
 func insertInitialData(t *testing.T) {

--- a/test/config.json
+++ b/test/config.json
@@ -520,9 +520,27 @@
 				"worker_test"
 			]
 		},
-		"vreplication": {
+		"vreplication_multicell": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "MultiCell"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 22,
+			"RetryMax": 0,
+			"Tags": []
+		},
+		"vreplication_cellalias": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "CellAlias"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 23,
+			"RetryMax": 0,
+			"Tags": []
+		},
+		"vreplication_basic": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "Basic"],
 			"Command": [],
 			"Manual": false,
 			"Shard": 24,

--- a/test/config.json
+++ b/test/config.json
@@ -519,6 +519,15 @@
 			"Tags": [
 				"worker_test"
 			]
+		},
+		"vreplication": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 24,
+			"RetryMax": 0,
+			"Tags": []
 		}
 	}
 }


### PR DESCRIPTION
VReplication e2e tests never ran in CI. We traced the errors to insufficient resources: either file handles or aio handles. These are set as 64K in /etc/security/limits.conf and /proc/sys/fs/aio-max-nr and they cannot be overwritten by sudo. 

For now, until we can figure out to increase the hard limits:

* The basic test runs only with masters (replicas set to 0)
* The three tests have been separated into different test "shards" (22/23/24 atm). 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>