### PR TITLE
tx limiter: fix quota leak if Begin() errors or if the tx killer runs

### DIFF
--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -19,9 +19,11 @@ package tabletserver
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/callerid"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -29,8 +31,6 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/vt/vttablet/tabletserver/txlimiter"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
@@ -40,7 +40,7 @@ import (
 )
 
 func TestTxPoolExecuteCommit(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	sql := "select 'this is a query'"
@@ -74,7 +74,7 @@ func TestTxPoolExecuteCommit(t *testing.T) {
 }
 
 func TestTxPoolExecuteRollback(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	conn, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
@@ -92,7 +92,7 @@ func TestTxPoolExecuteRollback(t *testing.T) {
 }
 
 func TestTxPoolExecuteRollbackOnClosedConn(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	conn, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
@@ -109,7 +109,7 @@ func TestTxPoolExecuteRollbackOnClosedConn(t *testing.T) {
 }
 
 func TestTxPoolRollbackNonBusy(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	// start two transactions, and mark one of them as unused
@@ -135,7 +135,7 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 }
 
 func TestTxPoolTransactionIsolation(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	c2, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED}, false, 0, nil)
@@ -146,7 +146,7 @@ func TestTxPoolTransactionIsolation(t *testing.T) {
 }
 
 func TestTxPoolAutocommit(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 
 	// Start a transaction with autocommit. This will ensure that the executor does not send begin/commit statements
@@ -192,7 +192,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2006_Transient(t *testing.T) {
 func primeTxPoolWithConnection(t *testing.T) (*fakesqldb.DB, *TxPool) {
 	t.Helper()
 	db := fakesqldb.New(t)
-	txPool := newTxPool()
+	txPool, _ := newTxPool()
 	// Set the capacity to 1 to ensure that the db connection is reused.
 	txPool.scp.conns.SetCapacity(1)
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
@@ -209,17 +209,42 @@ func primeTxPoolWithConnection(t *testing.T) (*fakesqldb.DB, *TxPool) {
 }
 
 func TestTxPoolBeginWithError(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, limiter, closer := setup(t)
 	defer closer()
 	db.AddRejectedQuery("begin", errRejected)
-	_, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+
+	im := &querypb.VTGateCallerID{
+		Username: "user",
+	}
+	ef := &vtrpcpb.CallerID{
+		Principal: "principle",
+	}
+
+	ctxWithCallerId := callerid.NewContext(ctx, ef, im)
+	_, _, err := txPool.Begin(ctxWithCallerId, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error: rejected")
 	require.Equal(t, vtrpcpb.Code_UNKNOWN, vterrors.Code(err), "wrong error code for Begin error")
+
+	// Regression test for #6727: make sure the tx limiter is decremented if grabbing a connection
+	// errors for whatever reason.
+	require.Equal(t,
+		[]fakeLimiterEntry{
+			{
+				immediate: im,
+				effective: ef,
+				isRelease: false,
+			},
+			{
+				immediate: im,
+				effective: ef,
+				isRelease: true,
+			},
+		}, limiter.Actions())
 }
 
 func TestTxPoolBeginWithPreQueryError(t *testing.T) {
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 	db.AddRejectedQuery("pre_query", errRejected)
 	_, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, []string{"pre_query"})
@@ -230,7 +255,7 @@ func TestTxPoolBeginWithPreQueryError(t *testing.T) {
 
 func TestTxPoolCancelledContextError(t *testing.T) {
 	// given
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 	ctx, cancel := context.WithCancel(ctx)
 	cancel()
@@ -251,7 +276,7 @@ func TestTxPoolWaitTimeoutError(t *testing.T) {
 	env.Config().TxPool.MaxWaiters = 0
 	env.Config().TxPool.TimeoutSeconds = 1
 	// given
-	db, txPool, closer := setupWithEnv(t, env)
+	db, txPool, _, closer := setupWithEnv(t, env)
 	defer closer()
 
 	// lock the only connection in the pool.
@@ -272,7 +297,7 @@ func TestTxPoolWaitTimeoutError(t *testing.T) {
 
 func TestTxPoolRollbackFailIsPassedThrough(t *testing.T) {
 	sql := "alter table test_table add test_column int"
-	db, txPool, closer := setup(t)
+	db, txPool, _, closer := setup(t)
 	defer closer()
 	db.AddRejectedQuery("rollback", errRejected)
 
@@ -291,7 +316,7 @@ func TestTxPoolRollbackFailIsPassedThrough(t *testing.T) {
 }
 
 func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
-	db, txPool, _ := setup(t)
+	db, txPool, _, _ := setup(t)
 	defer db.Close()
 	conn1, _, _ := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	id := conn1.ID()
@@ -312,7 +337,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 
 	assertErrorMatch(id, "pool closed")
 
-	txPool = newTxPool()
+	txPool, _ = newTxPool()
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 
 	conn1, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
@@ -324,7 +349,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 
 	assertErrorMatch(id, "transaction committed")
 
-	txPool = newTxPool()
+	txPool, _ = newTxPool()
 	txPool.SetTimeout(1 * time.Millisecond)
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
@@ -338,7 +363,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 }
 
 func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
-	_, txPool, closer := setup(t)
+	_, txPool, _, closer := setup(t)
 	defer closer()
 
 	startingStray := txPool.env.Stats().InternalErrors.Counts()["StrayTransactions"]
@@ -354,13 +379,59 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 	require.Equal(t, 0, txPool.scp.Capacity())
 }
 
-func newTxPool() *TxPool {
+func TestTxTimeoutKillsTransactions(t *testing.T) {
+	env := newEnv("TabletServerTest")
+	env.Config().TxPool.Size = 1
+	env.Config().TxPool.MaxWaiters = 0
+	env.Config().Oltp.TxTimeoutSeconds = 1
+	_, txPool, limiter, closer := setupWithEnv(t, env)
+	defer closer()
+	startingKills := txPool.env.Stats().KillCounters.Counts()["Transactions"]
+
+	im := &querypb.VTGateCallerID{
+		Username: "user",
+	}
+	ef := &vtrpcpb.CallerID{
+		Principal: "principle",
+	}
+
+	ctxWithCallerId := callerid.NewContext(ctx, ef, im)
+
+	// Start transaction.
+	conn, _, err := txPool.Begin(ctxWithCallerId, &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err)
+	conn.Unlock()
+
+	// Let it time out and get killed by the tx killer.
+	time.Sleep(1200 * time.Millisecond)
+
+	// Verify that the tx killer rand.
+	require.Equal(t, int64(1), txPool.env.Stats().KillCounters.Counts()["Transactions"]-startingKills)
+
+	// Regression test for #6727: make sure the tx limiter is decremented when the tx killer closes
+	// a transaction.
+	require.Equal(t,
+		[]fakeLimiterEntry{
+			{
+				immediate: im,
+				effective: ef,
+				isRelease: false,
+			},
+			{
+				immediate: im,
+				effective: ef,
+				isRelease: true,
+			},
+		}, limiter.Actions())
+}
+
+func newTxPool() (*TxPool, *fakeLimiter) {
 	return newTxPoolWithEnv(newEnv("TabletServerTest"))
 }
 
-func newTxPoolWithEnv(env tabletenv.Env) *TxPool {
-	limiter := &txlimiter.TxAllowAll{}
-	return NewTxPool(env, limiter)
+func newTxPoolWithEnv(env tabletenv.Env) (*TxPool, *fakeLimiter) {
+	limiter := &fakeLimiter{}
+	return NewTxPool(env, limiter), limiter
 }
 
 func newEnv(exporterName string) tabletenv.Env {
@@ -376,27 +447,67 @@ func newEnv(exporterName string) tabletenv.Env {
 	return env
 }
 
-func setup(t *testing.T) (*fakesqldb.DB, *TxPool, func()) {
+type fakeLimiterEntry struct {
+	immediate *querypb.VTGateCallerID
+	effective *vtrpcpb.CallerID
+	isRelease bool
+}
+
+type fakeLimiter struct {
+	actions []fakeLimiterEntry
+	mu      sync.Mutex
+}
+
+func (fl *fakeLimiter) Get(immediate *querypb.VTGateCallerID, effective *vtrpcpb.CallerID) bool {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	fl.actions = append(fl.actions, fakeLimiterEntry{
+		immediate: immediate,
+		effective: effective,
+		isRelease: false,
+	})
+	return true
+}
+
+func (fl *fakeLimiter) Release(immediate *querypb.VTGateCallerID, effective *vtrpcpb.CallerID) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	fl.actions = append(fl.actions, fakeLimiterEntry{
+		immediate: immediate,
+		effective: effective,
+		isRelease: true,
+	})
+}
+
+func (fl *fakeLimiter) Actions() []fakeLimiterEntry {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	result := make([]fakeLimiterEntry, len(fl.actions))
+	copy(result, fl.actions)
+	return result
+}
+
+func setup(t *testing.T) (*fakesqldb.DB, *TxPool, *fakeLimiter, func()) {
 	db := fakesqldb.New(t)
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 
-	txPool := newTxPool()
+	txPool, limiter := newTxPool()
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 
-	return db, txPool, func() {
+	return db, txPool, limiter, func() {
 		txPool.Close()
 		db.Close()
 	}
 }
 
-func setupWithEnv(t *testing.T, env tabletenv.Env) (*fakesqldb.DB, *TxPool, func()) {
+func setupWithEnv(t *testing.T, env tabletenv.Env) (*fakesqldb.DB, *TxPool, *fakeLimiter, func()) {
 	db := fakesqldb.New(t)
 	db.AddQueryPattern(".*", &sqltypes.Result{})
 
-	txPool := newTxPoolWithEnv(env)
+	txPool, limiter := newTxPoolWithEnv(env)
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 
-	return db, txPool, func() {
+	return db, txPool, limiter, func() {
 		txPool.Close()
 		db.Close()
 	}


### PR DESCRIPTION
The transaction limiter reduces a caller ID's quota within the transaction
pool to some fraction of the overall pool size. We've found it useful for
tightening the blast radius when a single client starts to have long
transactions for whatever reason.

We noticed in a development enviornment that the tx limiter was preventing
any new transactions for a particular caller ID even though no transactions
for that user were already in progress.

I'm not too familiar with this code, although it seems a bit brittle. In this PR
I've tried to make sure that if there's an error grabbing a connection from the
connection pool or if a connection is killed by the transaction killer, tx limiter
quota is restored.

I'd love for anyone who is to take a close look at this.

It seems possible that killed transactions were also previously not logged, and
this might fix that too?...

See https://github.com/vitessio/vitess/issues/6727

Signed-off-by: David Weitzman <dweitzman@pinterest.com>