### PR TITLE
upstream s3 ListBackups bug fix for vtbackup_cleaner

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -215,7 +215,14 @@ func (bs *S3BackupStorage) ListBackups(ctx context.Context, dir string) ([]backu
 		return nil, err
 	}
 
-	searchPrefix := objName(dir, "")
+	var searchPrefix *string
+	if dir == "/" {
+		searchPrefix = objName("")
+	} else {
+		searchPrefix = objName(dir, "")
+	}
+	log.Infof("objName: %v", searchPrefix)
+
 	query := &s3.ListObjectsV2Input{
 		Bucket:    bucket,
 		Delimiter: &delimiter,


### PR DESCRIPTION
Updates the s3 ListAllBackups() function to to work from the root directory 

Signed-off-by: Yujie Zhu <yujiezhu718@gmail.com>