### PR TITLE
Refactor: Cleanup Noisy Workflow Logging

### DIFF
--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -176,7 +176,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
 
-	_, err := wr.ShowWorkflow(ctx, workflow, keyspace)
+	_, err := wr.WorkflowAction(ctx, workflow, keyspace, "show", false)
 	require.Nil(t, err)
 	want := `{
 	"Workflow": "wrWorkflow",


### PR DESCRIPTION
This PR cleans up noisy logging related to workflow methods, and moves printing logic up a level so that direct Wrangler method calls aren't printing output intended purely for vtctl command use from a console.