### PR TITLE
Fix reserved connection in autocommit mode on DML

### DIFF
--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -230,11 +230,11 @@ func TestSetSystemVariableAndThenSuccessfulAutocommitDML(t *testing.T) {
 	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
 
 	checkedExec(t, conn, `update test set val2 = 2 where val1 is null`)
-	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) NULL INT64(2)]]`)
+	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) NULL INT32(2)]]`)
 	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
 
 	checkedExec(t, conn, `update test set val1 = 'text' where val1 is null`)
-	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) VARCHAR("text") INT64(2)]]`)
+	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) VARCHAR("text") INT32(2)]]`)
 	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
 
 	checkedExec(t, conn, `delete from test where val1 = 'text'`)

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -212,6 +212,36 @@ func TestSetSystemVariableAndThenSuccessfulTx(t *testing.T) {
 	assertMatches(t, conn, "select @@sql_safe_updates", "[[INT64(1)]]")
 }
 
+func TestSetSystemVariableAndThenSuccessfulAutocommitDML(t *testing.T) {
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+	checkedExec(t, conn, `delete from test`)
+
+	checkedExec(t, conn, `set sql_safe_updates = 1`)
+
+	checkedExec(t, conn, `insert into test (id, val1) values (80, null)`)
+	assertMatches(t, conn, `select id, val1 from test`, `[[INT64(80) NULL]]`)
+	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
+
+	checkedExec(t, conn, `update test set val2 = 2 where val1 is null`)
+	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) NULL INT64(2)]]`)
+	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
+
+	checkedExec(t, conn, `update test set val1 = 'text' where val1 is null`)
+	assertMatches(t, conn, `select id, val1, val2 from test`, `[[INT64(80) VARCHAR("text") INT64(2)]]`)
+	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
+
+	checkedExec(t, conn, `delete from test where val1 = 'text'`)
+	assertMatches(t, conn, `select id, val1, val2 from test`, `[]`)
+	assertMatches(t, conn, `select @@sql_safe_updates`, `[[INT64(1)]]`)
+}
+
 func TestStartTxAndSetSystemVariableAndThenSuccessfulCommit(t *testing.T) {
 	vtParams := mysql.ConnParams{
 		Host: "localhost",

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -219,7 +219,10 @@ func (session *SafeSession) AppendOrUpdate(shardSession *vtgatepb.Session_ShardS
 	session.mu.Lock()
 	defer session.mu.Unlock()
 
-	if session.autocommitState == autocommitted {
+	// additional check of transaction id is required
+	// as now in autocommit mode there can be session due to reserved connection
+	// that needs to be stored as shard session.
+	if session.autocommitState == autocommitted && shardSession.TransactionId != 0 {
 		// Should be unreachable
 		return vterrors.New(vtrpcpb.Code_INTERNAL, "BUG: SafeSession.AppendOrUpdate: unexpected autocommit state")
 	}


### PR DESCRIPTION
Issue:
If there is any session system variable settings applied on Vitess which needs to be handled through reserved connection.
Then a followed up dml can fail with error
 `BUG: SafeSession.AppendOrUpdate: unexpected autocommit state `
This happens because the reserved connection is not short lived and needs to be stored in shard session so the same connection be used for future queries for the current session which have the applied system settings.
