### PR TITLE
Zero autoinc mode

### DIFF
--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -283,7 +283,7 @@ func shouldGenerate(v sqltypes.Value) bool {
 	// Unless the NO_AUTO_VALUE_ON_ZERO sql mode is active in mysql, it also
 	// treats 0 as a value that should generate a new ID.
 	if *seqAutoValueOnZero {
-		n, err := sqltypes.ToUint64(v)
+		n, err := evalengine.ToUint64(v)
 		if err == nil && n == 0 {
 			return true
 		}

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,6 +39,8 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
+
+var seqAutoValueOnZero = flag.Bool("seq-auto-value-on-zero", false, "For sequences, act as if NO_AUTO_VALUE_ON_ZERO is not set")
 
 var _ Primitive = (*Insert)(nil)
 
@@ -273,6 +276,22 @@ func (ins *Insert) execInsertSharded(vcursor VCursor, bindVars map[string]*query
 	return result, nil
 }
 
+func shouldGenerate(v sqltypes.Value) bool {
+	if v.IsNull() {
+		return true
+	}
+	// Unless the NO_AUTO_VALUE_ON_ZERO sql mode is active in mysql, it also
+	// treats 0 as a value that should generate a new ID.
+	if *seqAutoValueOnZero {
+		n, err := sqltypes.ToUint64(v)
+		if err == nil && n == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // processGenerate generates new values using a sequence if necessary.
 // If no value was generated, it returns 0. Values are generated only
 // for cases where none are supplied.
@@ -289,7 +308,7 @@ func (ins *Insert) processGenerate(vcursor VCursor, bindVars map[string]*querypb
 	}
 	count := int64(0)
 	for _, val := range resolved {
-		if val.IsNull() {
+		if shouldGenerate(val) {
 			count++
 		}
 	}
@@ -319,7 +338,7 @@ func (ins *Insert) processGenerate(vcursor VCursor, bindVars map[string]*querypb
 	// Fill the holes where no value was supplied.
 	cur := insertID
 	for i, v := range resolved {
-		if v.IsNull() {
+		if shouldGenerate(v) {
 			bindVars[SeqVarName+strconv.Itoa(i)] = sqltypes.Int64BindVariable(cur)
 			cur++
 		} else {

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -83,24 +83,23 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 				{Value: sqltypes.NULL},
 				{Value: sqltypes.NewInt64(2)},
 				{Value: sqltypes.NULL},
-				{Value: sqltypes.NewInt64(0)},
+				{Value: sqltypes.NewInt64(3)},
 			},
 		},
 	}
 
-	vc := &loggingVCursor{
-		shards: []string{"0"},
-		results: []*sqltypes.Result{
-			sqltypes.MakeTestResult(
-				sqltypes.MakeTestFields(
-					"nextval",
-					"int64",
-				),
-				"4",
+	vc := newDMLTestVCursor("0")
+	vc.results = []*sqltypes.Result{
+		sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields(
+				"nextval",
+				"int64",
 			),
-			{InsertID: 1},
-		},
+			"4",
+		),
+		{InsertID: 1},
 	}
+
 	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
 	if err != nil {
 		t.Fatal(err)
@@ -111,7 +110,7 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 		`ExecuteStandalone dummy_generate n: type:INT64 value:"2"  ks2 0`,
 		// Fill those values into the insert.
 		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
-		`ExecuteMultiShard ks.0: dummy_insert {__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"4" __seq2: type:INT64 value:"2" __seq3: type:INT64 value:"5" __seq4: type:INT64 value:"0" } true true`,
+		`ExecuteMultiShard ks.0: dummy_insert {__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"4" __seq2: type:INT64 value:"2" __seq3: type:INT64 value:"5" __seq4: type:INT64 value:"3" } true true`,
 	})
 
 	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerate.

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -83,6 +83,65 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 				{Value: sqltypes.NULL},
 				{Value: sqltypes.NewInt64(2)},
 				{Value: sqltypes.NULL},
+				{Value: sqltypes.NewInt64(0)},
+			},
+		},
+	}
+
+	vc := &loggingVCursor{
+		shards: []string{"0"},
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields(
+					"nextval",
+					"int64",
+				),
+				"4",
+			),
+			{InsertID: 1},
+		},
+	}
+	result, err := ins.Execute(vc, map[string]*querypb.BindVariable{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vc.ExpectLog(t, []string{
+		// Fetch two sequence value.
+		`ResolveDestinations ks2 [] Destinations:DestinationAnyShard()`,
+		`ExecuteStandalone dummy_generate n: type:INT64 value:"2"  ks2 0`,
+		// Fill those values into the insert.
+		`ResolveDestinations ks [] Destinations:DestinationAllShards()`,
+		`ExecuteMultiShard ks.0: dummy_insert {__seq0: type:INT64 value:"1" __seq1: type:INT64 value:"4" __seq2: type:INT64 value:"2" __seq3: type:INT64 value:"5" __seq4: type:INT64 value:"0" } true true`,
+	})
+
+	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerate.
+	expectResult(t, "Execute", result, &sqltypes.Result{InsertID: 4})
+}
+
+func TestInsertUnshardedGenerate_Zeros(t *testing.T) {
+	*seqAutoValueOnZero = true
+	defer func() { *seqAutoValueOnZero = false }()
+
+	ins := NewQueryInsert(
+		InsertUnsharded,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: false,
+		},
+		"dummy_insert",
+	)
+	ins.Generate = &Generate{
+		Keyspace: &vindexes.Keyspace{
+			Name:    "ks2",
+			Sharded: false,
+		},
+		Query: "dummy_generate",
+		Values: sqltypes.PlanValue{
+			Values: []sqltypes.PlanValue{
+				{Value: sqltypes.NewInt64(1)},
+				{Value: sqltypes.NewInt64(0)},
+				{Value: sqltypes.NewInt64(2)},
+				{Value: sqltypes.NewInt64(0)},
 				{Value: sqltypes.NewInt64(3)},
 			},
 		},

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -118,9 +118,6 @@ func TestInsertUnshardedGenerate(t *testing.T) {
 }
 
 func TestInsertUnshardedGenerate_Zeros(t *testing.T) {
-	*seqAutoValueOnZero = true
-	defer func() { *seqAutoValueOnZero = false }()
-
 	ins := NewQueryInsert(
 		InsertUnsharded,
 		&vindexes.Keyspace{


### PR DESCRIPTION
This adds support to generate a sequence value when a 0 is passed instead of just null. This is the default behavior for MySQL.

Also need to look into detecting when sql_mode has been set to  NO_AUTO_VALUE_ON_ZERO and handle that accordingly. I'm not sure the best way to go about that so any guidance there would be appreciated.

Ref https://github.com/vitessio/vitess/pull/4751