### PR TITLE
operator precedence must take associativity into consideration

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1564,17 +1564,17 @@ func (node Exprs) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *AndExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v and %v", node.Left, node.Right)
+	buf.astPrintf(node, "%l and %r", node.Left, node.Right)
 }
 
 // Format formats the node.
 func (node *OrExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v or %v", node.Left, node.Right)
+	buf.astPrintf(node, "%l or %r", node.Left, node.Right)
 }
 
 // Format formats the node.
 func (node *XorExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v xor %v", node.Left, node.Right)
+	buf.astPrintf(node, "%l xor %r", node.Left, node.Right)
 }
 
 // Format formats the node.
@@ -1584,7 +1584,7 @@ func (node *NotExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v %s %v", node.Left, node.Operator, node.Right)
+	buf.astPrintf(node, "%l %s %r", node.Left, node.Operator, node.Right)
 	if node.Escape != nil {
 		buf.astPrintf(node, " escape %v", node.Escape)
 	}
@@ -1592,7 +1592,7 @@ func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *RangeCond) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v %s %v and %v", node.Left, node.Operator, node.From, node.To)
+	buf.astPrintf(node, "%v %s %l and %r", node.Left, node.Operator, node.From, node.To)
 }
 
 // Format formats the node.
@@ -1665,7 +1665,7 @@ func (node ListArg) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *BinaryExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v %s %v", node.Left, node.Operator, node.Right)
+	buf.astPrintf(node, "%l %s %r", node.Left, node.Operator, node.Right)
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -142,6 +142,14 @@ func TestParens(t *testing.T) {
 		{in: "(a | b) between (5) and (7)", expected: "a | b between 5 and 7"},
 		{in: "(a and b) between (5) and (7)", expected: "(a and b) between 5 and 7"},
 		{in: "(true is true) is null", expected: "(true is true) is null"},
+		{in: "3 * (100 div 3)", expected: "3 * (100 div 3)"},
+		{in: "100 div 2 div 2", expected: "100 div 2 div 2"},
+		{in: "100 div (2 div 2)", expected: "100 div (2 div 2)"},
+		{in: "(100 div 2) div 2", expected: "100 div 2 div 2"},
+		{in: "((((((1000))))))", expected: "1000"},
+		{in: "100 - (50 + 10)", expected: "100 - (50 + 10)"},
+		{in: "100 - 50 + 10", expected: "100 - 50 + 10"},
+		{in: "true and (true and true)", expected: "true and (true and true)"},
 	}
 
 	for _, tc := range tests {

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -150,6 +150,9 @@ func TestParens(t *testing.T) {
 		{in: "100 - (50 + 10)", expected: "100 - (50 + 10)"},
 		{in: "100 - 50 + 10", expected: "100 - 50 + 10"},
 		{in: "true and (true and true)", expected: "true and (true and true)"},
+		{in: "10 - 2 - 1", expected: "10 - 2 - 1"},
+		{in: "(10 - 2) - 1", expected: "10 - 2 - 1"},
+		{in: "10 - (2 - 1)", expected: "10 - (2 - 1)"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The Vitess AST printer was not taking associativity into consideration and stripping away parenthesis when it should not.

Fixes #6734