### PR TITLE
tm: call setReadOnly inside ChangeTabletType

### DIFF
--- a/go/test/endtoend/tabletmanager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_test.go
@@ -46,15 +46,11 @@ func TestEnsureDB(t *testing.T) {
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("TabletExternallyReparented", tablet.Alias)
 	require.NoError(t, err)
 
-	// It will still fail because the db is read-only.
-	assert.Equal(t, "NOT_SERVING", tablet.VttabletProcess.GetTabletStatus())
+	// It goes SERVING because TER calls ChangeTabletType which will also set the database to read-write
+	assert.Equal(t, "SERVING", tablet.VttabletProcess.GetTabletStatus())
 	status := tablet.VttabletProcess.GetStatusDetails()
-	assert.Contains(t, status, "read-only")
+	assert.Contains(t, status, "Serving")
 
-	// Switch to read-write and verify that that we go serving.
-	_ = clusterInstance.VtctlclientProcess.ExecuteCommand("SetReadWrite", tablet.Alias)
-	err = tablet.VttabletProcess.WaitForTabletType("SERVING")
-	require.NoError(t, err)
 	killTablets(t, tablet)
 }
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -244,10 +244,6 @@ func (tm *TabletManager) InitMaster(ctx context.Context) (string, error) {
 	// Set the server read-write, from now on we can accept real
 	// client writes. Note that if semi-sync replication is enabled,
 	// we'll still need some replicas to be able to commit transactions.
-	if err := tm.MysqlDaemon.SetReadOnly(false); err != nil {
-		return "", err
-	}
-
 	if err := tm.changeTypeLocked(ctx, topodatapb.TabletType_MASTER); err != nil {
 		return "", err
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -741,12 +741,6 @@ func (tm *TabletManager) PromoteReplica(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// We call SetReadOnly only after the topo has been updated to avoid
-	// situations where two tablets are master at the DB level but not at the vitess level
-	if err := tm.MysqlDaemon.SetReadOnly(false); err != nil {
-		return "", err
-	}
-
 	return mysql.EncodePosition(pos), nil
 }
 

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -163,6 +163,11 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 		if err != nil {
 			return err
 		}
+		// We call SetReadOnly only after the topo has been updated to avoid
+		// situations where two tablets are master at the DB level but not at the vitess level
+		if err := ts.tm.MysqlDaemon.SetReadOnly(false); err != nil {
+			return err
+		}
 
 		ts.tablet.Type = tabletType
 		ts.tablet.MasterTermStartTime = masterTermStartTime


### PR DESCRIPTION
During PlannedReparents, it is possible that a tablet advertises itself as MASTER while mysql is still read_only because `ChangeTabletType` triggers a health broadcast. 
This PR adds a call to `SetReadOnly` inside `ChangeTabletType` when the new tablet_type is MASTER.
Remove the call from `PromoteReplica` since it is no longer needed there.

Signed-off-by: deepthi <deepthi@planetscale.com>