### PR TITLE
VStreamer: handle SET statements in the binlog stream

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -51,8 +51,6 @@ type Env struct {
 	Dbcfgs       *dbconfigs.DBConfigs
 	Mysqld       *mysqlctl.Mysqld
 	SchemaEngine *schema.Engine
-
-	Flavor string
 }
 
 // Init initializes an Env.
@@ -96,7 +94,6 @@ func Init() (*Env, error) {
 		os.RemoveAll(te.cluster.Config.SchemaDir)
 		return nil, fmt.Errorf("could not launch mysql: %v", err)
 	}
-	te.Flavor = te.cluster.Env.Flavor()
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
 	config := tabletenv.NewDefaultConfig()
 	config.DB = te.Dbcfgs

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -51,6 +51,8 @@ type Env struct {
 	Dbcfgs       *dbconfigs.DBConfigs
 	Mysqld       *mysqlctl.Mysqld
 	SchemaEngine *schema.Engine
+
+	Flavor string
 }
 
 // Init initializes an Env.
@@ -94,7 +96,7 @@ func Init() (*Env, error) {
 		os.RemoveAll(te.cluster.Config.SchemaDir)
 		return nil, fmt.Errorf("could not launch mysql: %v", err)
 	}
-
+	te.Flavor = te.cluster.Env.Flavor()
 	te.Dbcfgs = dbconfigs.NewTestDBConfigs(te.cluster.MySQLConnParams(), te.cluster.MySQLAppDebugConnParams(), te.cluster.DbName())
 	config := tabletenv.NewDefaultConfig()
 	config.DB = te.Dbcfgs

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -316,7 +316,6 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 
 // parseEvent parses an event from the binlog and converts it to a list of VEvents.
 func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, error) {
-
 	if !ev.IsValid() {
 		return nil, fmt.Errorf("can't parse binlog event: invalid data: %#v", ev)
 	}
@@ -383,6 +382,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 		}
 		// Insert/Delete/Update are supported only to be used in the context of external mysql streams where source databases
 		// could be using SBR. Vitess itself will never run into cases where it needs to consume non rbr statements.
+
 		switch cat := sqlparser.Preview(q.SQL); cat {
 		case sqlparser.StmtInsert:
 			mustSend := mustSendStmt(q, params.DbName)
@@ -455,7 +455,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 					Statement: q.SQL,
 				})
 			}
-		case sqlparser.StmtOther, sqlparser.StmtPriv:
+		case sqlparser.StmtOther, sqlparser.StmtPriv, sqlparser.StmtSet:
 			// These are either:
 			// 1) DBA statements like REPAIR that can be ignored.
 			// 2) Privilege-altering statements like GRANT/REVOKE
@@ -535,6 +535,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 		if err != nil {
 			return nil, err
 		}
+
 	}
 	for _, vevent := range vevents {
 		vevent.Timestamp = int64(ev.Timestamp())

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -55,14 +55,17 @@ func TestSetStatement(t *testing.T) {
 		"drop table t1",
 	})
 	engine.se.Reload(context.Background())
+	queries := []string{
+		"begin",
+		"insert into t1 values (1, 'aaa')",
+		"commit",
+	}
+	if !strings.Contains(strings.ToLower(env.Flavor), "mariadb") {
+		queries = append(queries, "set global log_builtin_as_identified_by_password=1")
+	}
+	queries = append(queries, "SET PASSWORD FOR 'vt_appdebug'@'localhost'='*CDE65254CC57BC0C3D0A85509B5CEA654126BF56'")
 	testcases := []testcase{{
-		input: []string{
-			"begin",
-			"insert into t1 values (1, 'aaa')",
-			"commit",
-			"set global log_builtin_as_identified_by_password=1", // without this the set password is converted to an alter user
-			"SET PASSWORD FOR 'vt_appdebug'@'localhost'='*CDE65254CC57BC0C3D0A85509B5CEA654126BF56'",
-		},
+		input: queries,
 		output: [][]string{{
 			`begin`,
 			`type:FIELD field_event:<table_name:"t1" fields:<name:"id" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id" column_length:11 charset:63 > fields:<name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63 > > `,

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -43,18 +43,13 @@ type testcase struct {
 	output [][]string
 }
 
-func isMariaDB(t *testing.T) bool {
-	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), "select version()")
+func checkIfOptionIsSupported(t *testing.T, variable string) bool {
+	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), fmt.Sprintf("show variables like '%s'", variable))
 	require.NoError(t, err)
 	require.NotNil(t, qr)
-	require.NotNil(t, qr.Rows)
-	require.NotEqual(t, len(qr.Rows), 0)
-	version := qr.Rows[0][0].String()
-	if strings.Contains(strings.ToLower(version), "mariadb") {
-		log.Infof("Flavor IS MariaDB\n")
+	if qr.Rows != nil && len(qr.Rows) == 1 {
 		return true
 	}
-	log.Infof("Flavor is NOT MariaDB\n")
 	return false
 }
 
@@ -62,6 +57,11 @@ func TestSetStatement(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip()
+	}
+	if !checkIfOptionIsSupported(t, "log_builtin_as_identified_by_password") {
+		// the combination of setting this option and support for "set password" only works on a few flavors
+		log.Info("Cannot test SetStatement on this flavor")
+		return
 	}
 
 	execStatements(t, []string{
@@ -75,11 +75,9 @@ func TestSetStatement(t *testing.T) {
 		"begin",
 		"insert into t1 values (1, 'aaa')",
 		"commit",
+		"set global log_builtin_as_identified_by_password=1",
+		"SET PASSWORD FOR 'vt_appdebug'@'localhost'='*AA17DA66C7C714557F5485E84BCAFF2C209F2F53'", //select password('vtappdebug_password');
 	}
-	if !isMariaDB(t) {
-		queries = append(queries, "set global log_builtin_as_identified_by_password=1")
-	}
-	queries = append(queries, "SET PASSWORD FOR 'vt_appdebug'@'localhost'='*CDE65254CC57BC0C3D0A85509B5CEA654126BF56'")
 	testcases := []testcase{{
 		input: queries,
 		output: [][]string{{

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -61,9 +61,7 @@ func TestSetStatement(t *testing.T) {
 			"insert into t1 values (1, 'aaa')",
 			"commit",
 			"set global log_builtin_as_identified_by_password=1", // without this the set password is converted to an alter user
-			"SET PASSWORD FOR 'vt_appdebug'@'localhost'='abc123'",
-			"set global log_builtin_as_identified_by_password=0",
-			"SET PASSWORD FOR 'vt_appdebug'@'localhost'='abc124'",
+			"SET PASSWORD FOR 'vt_appdebug'@'localhost'='*CDE65254CC57BC0C3D0A85509B5CEA654126BF56'",
 		},
 		output: [][]string{{
 			`begin`,
@@ -74,9 +72,6 @@ func TestSetStatement(t *testing.T) {
 		}, {
 			`gtid`,
 			`other`,
-		}, {
-			`gtid`,
-			`ddl`,
 		}},
 	}}
 	runCases(t, nil, testcases, "current", nil)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -43,7 +43,23 @@ type testcase struct {
 	output [][]string
 }
 
+func isMariaDB(t *testing.T) bool {
+	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), "select version()")
+	require.NoError(t, err)
+	require.NotNil(t, qr)
+	require.NotNil(t, qr.Rows)
+	require.NotEqual(t, len(qr.Rows), 0)
+	version := qr.Rows[0][0].String()
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		log.Infof("Flavor IS MariaDB\n")
+		return true
+	}
+	log.Infof("Flavor is NOT MariaDB\n")
+	return false
+}
+
 func TestSetStatement(t *testing.T) {
+
 	if testing.Short() {
 		t.Skip()
 	}
@@ -60,7 +76,7 @@ func TestSetStatement(t *testing.T) {
 		"insert into t1 values (1, 'aaa')",
 		"commit",
 	}
-	if !strings.Contains(strings.ToLower(env.Flavor), "mariadb") {
+	if !isMariaDB(t) {
 		queries = append(queries, "set global log_builtin_as_identified_by_password=1")
 	}
 	queries = append(queries, "SET PASSWORD FOR 'vt_appdebug'@'localhost'='*CDE65254CC57BC0C3D0A85509B5CEA654126BF56'")

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -85,6 +85,9 @@ type Environment interface {
 	// any temporary data in the environment. Environments that can
 	// last through several test runs do not need to implement it.
 	TearDown() error
+
+	// Flavor is set to the MySQL Server flavor used for testing
+	Flavor() string
 }
 
 // LocalTestEnv is an Environment implementation for local testing
@@ -94,6 +97,7 @@ type LocalTestEnv struct {
 	TmpPath      string
 	DefaultMyCnf []string
 	Env          []string
+	MySQLFlavor  string
 }
 
 // DefaultMySQLFlavor is the MySQL flavor used by vttest when MYSQL_FLAVOR is not
@@ -202,6 +206,11 @@ func (env *LocalTestEnv) TearDown() error {
 	return os.RemoveAll(env.TmpPath)
 }
 
+// Flavor implements Flavor for LocalTestEnv.
+func (env *LocalTestEnv) Flavor() string {
+	return env.MySQLFlavor
+}
+
 func tmpdir(dataroot string) (dir string, err error) {
 	dir, err = ioutil.TempDir(dataroot, "vttest")
 	return
@@ -257,6 +266,7 @@ func NewLocalTestEnvWithDirectory(flavor string, basePort int, directory string)
 		BasePort:     basePort,
 		TmpPath:      directory,
 		DefaultMyCnf: mycnf,
+		MySQLFlavor:  flavor,
 		Env: []string{
 			fmt.Sprintf("VTDATAROOT=%s", directory),
 			fmt.Sprintf("MYSQL_FLAVOR=%s", flavor),

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -85,9 +85,6 @@ type Environment interface {
 	// any temporary data in the environment. Environments that can
 	// last through several test runs do not need to implement it.
 	TearDown() error
-
-	// Flavor is set to the MySQL Server flavor used for testing
-	Flavor() string
 }
 
 // LocalTestEnv is an Environment implementation for local testing
@@ -97,7 +94,6 @@ type LocalTestEnv struct {
 	TmpPath      string
 	DefaultMyCnf []string
 	Env          []string
-	MySQLFlavor  string
 }
 
 // DefaultMySQLFlavor is the MySQL flavor used by vttest when MYSQL_FLAVOR is not
@@ -206,11 +202,6 @@ func (env *LocalTestEnv) TearDown() error {
 	return os.RemoveAll(env.TmpPath)
 }
 
-// Flavor implements Flavor for LocalTestEnv.
-func (env *LocalTestEnv) Flavor() string {
-	return env.MySQLFlavor
-}
-
 func tmpdir(dataroot string) (dir string, err error) {
 	dir, err = ioutil.TempDir(dataroot, "vttest")
 	return
@@ -266,7 +257,6 @@ func NewLocalTestEnvWithDirectory(flavor string, basePort int, directory string)
 		BasePort:     basePort,
 		TmpPath:      directory,
 		DefaultMyCnf: mycnf,
-		MySQLFlavor:  flavor,
 		Env: []string{
 			fmt.Sprintf("VTDATAROOT=%s", directory),
 			fmt.Sprintf("MYSQL_FLAVOR=%s", flavor),


### PR DESCRIPTION
There are certain SET statements that seem to make it to the binlogs. One reported by a user is the "SET PASSWORD" query. 
Currently vstreamer throws an error in the logs if it encounters a SET. Note that data replication is not affected. However this
causes errors in the logs. 

We are going to send an OTHER event just like for DBA commands like REPAIR or ACL ones like GRANT/REVOKE. 

A few interesting points which caused challenges while testing:
* SET PASSWORD has been removed in 8.0.11 and above
* An option log_builtin_as_identified_by_password has to be set. Otherwise a SET PASSWORD goes into the binlogs as
an ALTER ... This seems to be off by default
* On MariaDB the default seems to be to pass the SET PASSWORD through. They do not have that variable.

So for simplicity the test only runs if log_builtin_as_identified_by_password is supported (for our CI that would be the 56 and 57 flavors).

Signed-off-by: Rohit Nayak <rohit@planetscale.com>