### PR TITLE
helm/docker: fix Docker builds + tag 7.0.2

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/base:${VT_BASE_VER} AS base
 

--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
-ARG ORC_VER
-
+ARG VT_BASE_VER=latest
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
 FROM debian:buster-slim
+ARG ORC_VER='3.2.3'
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/pmm-client/Dockerfile
+++ b/docker/k8s/pmm-client/Dockerfile
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
-ARG PMM_CLIENT_VER
-
+ARG VT_BASE_VER=latest
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 
 FROM debian:buster-slim
+ARG PMM_CLIENT_VER='1.17.4'
 
 RUN apt-get update && \
    apt-get upgrade -qq && \

--- a/docker/k8s/vtbackup/Dockerfile
+++ b/docker/k8s/vtbackup/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/docker/k8s/vtworker/Dockerfile
+++ b/docker/k8s/vtworker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VT_BASE_VER
+ARG VT_BASE_VER=latest
 
 FROM vitess/k8s:${VT_BASE_VER} AS k8s
 

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -1,43 +1,68 @@
 #!/bin/bash
+set -ex
 
-vt_base_version=v7.0.1
-orchestrator_version=3.2.3
-pmm_client_version=1.17.4
+vt_base_version='v7.0.2'
+orchestrator_version='3.2.3'
+pmm_client_version='1.17.4'
 
 docker pull vitess/base:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/k8s:$vt_base_version-buster .
+docker tag vitess/k8s:$vt_base_version-buster vitess/k8s:$vt_base_version
 docker push vitess/k8s:$vt_base_version-buster
+docker push vitess/k8s:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtgate:$vt_base_version-buster vtgate
+docker tag vitess/vtgate:$vt_base_version-buster vitess/vtgate:$vt_base_version
 docker push vitess/vtgate:$vt_base_version-buster
+docker push vitess/vtgate:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vttablet:$vt_base_version-buster vttablet
+docker tag vitess/vttablet:$vt_base_version-buster vitess/vttablet:$vt_base_version
 docker push vitess/vttablet:$vt_base_version-buster
+docker push vitess/vttablet:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/mysqlctld:$vt_base_version-buster mysqlctld
+docker tag vitess/mysqlctld:$vt_base_version-buster vitess/mysqlctld:$vt_base_version
 docker push vitess/mysqlctld:$vt_base_version-buster
+docker push vitess/mysqlctld:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctl:$vt_base_version-buster vtctl
+docker tag vitess/vtctl:$vt_base_version-buster vitess/vtctl:$vt_base_version
 docker push vitess/vtctl:$vt_base_version-buster
+docker push vitess/vtctl:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctlclient:$vt_base_version-buster vtctlclient
+docker tag vitess/vtctlclient:$vt_base_version-buster vitess/vtctlclient:$vt_base_version
 docker push vitess/vtctlclient:$vt_base_version-buster
+docker push vitess/vtctlclient:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctld:$vt_base_version-buster vtctld
+docker tag vitess/vtctld:$vt_base_version-buster vitess/vtctld:$vt_base_version
 docker push vitess/vtctld:$vt_base_version-buster
+docker push vitess/vtctld:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtworker:$vt_base_version-buster vtworker
+docker tag vitess/vtworker:$vt_base_version-buster vitess/vtworker:$vt_base_version
 docker push vitess/vtworker:$vt_base_version-buster
+docker push vitess/vtworker:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logrotate:$vt_base_version-buster logrotate
+docker tag vitess/logrotate:$vt_base_version-buster vitess/logrotate:$vt_base_version
 docker push vitess/logrotate:$vt_base_version-buster
+docker push vitess/logrotate:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/logtail:$vt_base_version-buster logtail
+docker tag vitess/logtail:$vt_base_version-buster vitess/logtail:$vt_base_version
 docker push vitess/logtail:$vt_base_version-buster
+docker push vitess/logtail:$vt_base_version
 
 docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg PMM_CLIENT_VER=$pmm_client_version -t vitess/pmm-client:v$pmm_client_version-buster pmm-client
+docker tag vitess/pmm-client:v$pmm_client_version-buster vitess/pmm-client:v$pmm_client_version
 docker push vitess/pmm-client:v$pmm_client_version-buster
+docker push vitess/pmm-client:v$pmm_client_version
 
-docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg PMM_CLIENT_VER=$pmm_client_version -t vitess/orchestrator:v$orchestrator_version-buster orchestrator
+docker build --build-arg VT_BASE_VER=$vt_base_version --build-arg ORC_VER=$orchestrator_version -t vitess/orchestrator:v$orchestrator_version-buster orchestrator
+docker tag vitess/orchestrator:v$orchestrator_version-buster vitess/orchestrator:v$orchestrator_version
 docker push vitess/orchestrator:v$orchestrator_version-buster
+docker push vitess/orchestrator:v$orchestrator_version


### PR DESCRIPTION
Without ARG defaults, automated docker builds are failing. This also tags the 7.0.2 release.