### PR TITLE
Materialization: Do not error if tables that are not part of the stream go missing

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -118,6 +118,63 @@ func insertLotsOfData(t *testing.T, numRows int) {
 	})
 }
 
+func TestMissingTables(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	execStatements(t, []string{
+		"create table t1(id11 int, id12 int, primary key(id11))",
+		"create table shortlived(id31 int, id32 int, primary key(id31))",
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		"drop table _shortlived",
+	})
+	startPos := masterPosition(t)
+	execStatements(t, []string{
+		"insert into shortlived values (1,1), (2,2)",
+		"alter table shortlived rename to _shortlived",
+	})
+	engine.se.Reload(context.Background())
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "t1",
+			Filter: "select * from t1",
+		}},
+	}
+	testcases := []testcase{
+		{
+			input:  []string{},
+			output: [][]string{},
+		},
+
+		{
+			input: []string{
+				"insert into t1 values (101, 1010)",
+			},
+			output: [][]string{
+				{
+					"begin",
+					"gtid",
+					"commit",
+				},
+				{
+					"gtid",
+					"type:OTHER ",
+				},
+				{
+					"begin",
+					"type:FIELD field_event:<table_name:\"t1\" fields:<name:\"id11\" type:INT32 table:\"t1\" org_table:\"t1\" database:\"vttest\" org_name:\"id11\" column_length:11 charset:63 > fields:<name:\"id12\" type:INT32 table:\"t1\" org_table:\"t1\" database:\"vttest\" org_name:\"id12\" column_length:11 charset:63 > > ",
+					"type:ROW row_event:<table_name:\"t1\" row_changes:<after:<lengths:3 lengths:4 values:\"1011010\" > > > ",
+					"gtid",
+					"commit",
+				},
+			},
+		},
+	}
+	runCases(t, filter, testcases, startPos, nil)
+}
+
 func TestVStreamCopySimpleFlow(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -1657,6 +1714,7 @@ func expectLog(ctx context.Context, t *testing.T, input interface{}, ch <-chan [
 					}
 				}
 				if got := fmt.Sprintf("%v", evs[i]); got != want {
+					log.Errorf("%v (%d): event:\n%q, want\n%q", input, i, got, want)
 					t.Fatalf("%v (%d): event:\n%q, want\n%q", input, i, got, want)
 				}
 			}


### PR DESCRIPTION
Currently replication streams fail even if tables that do not participate in a migration are dropped (or renamed) during a table migration (eg. with gh-ost). This PR fixes that bug by bypassing code that was being unnecessarily called for tables that do not participate in the workflow.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>