### PR TITLE
Fix issues with missing tables in vstreams

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	debug              = true // set to true to always use local env vtdataroot for local debugging
+	debug              = false // set to true to always use local env vtdataroot for local debugging
 	originalVtdataroot string
 	vtdataroot         string
 )

--- a/go/vt/vttablet/tabletserver/binlog_watcher.go
+++ b/go/vt/vttablet/tabletserver/binlog_watcher.go
@@ -51,7 +51,7 @@ func NewBinlogWatcher(env tabletenv.Env, vs VStreamer, config *tabletenv.TabletC
 	return &BinlogWatcher{
 		env:              env,
 		vs:               vs,
-		watchReplication: config.WatchReplication,
+		watchReplication: config.WatchReplication || config.TrackSchemaVersions,
 	}
 }
 
@@ -94,7 +94,7 @@ func (blw *BinlogWatcher) process(ctx context.Context) {
 		err := blw.vs.Stream(ctx, "current", nil, filter, func(events []*binlogdatapb.VEvent) error {
 			return nil
 		})
-		log.Infof("ReplicatinWatcher VStream ended: %v, retrying in 5 seconds", err)
+		log.Infof("ReplicationWatcher VStream ended: %v, retrying in 5 seconds", err)
 		select {
 		case <-ctx.Done():
 			return

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -510,11 +510,12 @@ func (sm *stateManager) setTimeBomb() chan struct{} {
 func (sm *stateManager) setState(tabletType topodatapb.TabletType, state servingState) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-
 	if tabletType == topodatapb.TabletType_UNKNOWN {
 		tabletType = sm.wantTabletType
 	}
-	log.Infof("TabletServer transition: %v -> %v", sm.stateStringLocked(sm.target.TabletType, sm.state), sm.stateStringLocked(tabletType, state))
+	log.Infof("TabletServer transition: %v -> %v for tablet %s:%s/%s",
+		sm.stateStringLocked(sm.target.TabletType, sm.state), sm.stateStringLocked(tabletType, state),
+		sm.target.Cell, sm.target.Keyspace, sm.target.Shard)
 	sm.handleGracePeriod(tabletType)
 	sm.target.TabletType = tabletType
 	if sm.state == StateNotConnected {

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -94,6 +94,7 @@ func newUVStreamer(ctx context.Context, vse *Engine, cp dbconfigs.Connector, se 
 		MaxReplicationLag: 1 * time.Nanosecond,
 		CatchupRetryTime:  1 * time.Second,
 	}
+
 	send2 := func(evs []*binlogdatapb.VEvent) error {
 		vse.vstreamerEventsStreamed.Add(int64(len(evs)))
 		return send(evs)

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -94,7 +94,6 @@ func newUVStreamer(ctx context.Context, vse *Engine, cp dbconfigs.Connector, se 
 		MaxReplicationLag: 1 * time.Nanosecond,
 		CatchupRetryTime:  1 * time.Second,
 	}
-
 	send2 := func(evs []*binlogdatapb.VEvent) error {
 		vse.vstreamerEventsStreamed.Add(int64(len(evs)))
 		return send(evs)


### PR DESCRIPTION
Start watcher if historian is on. Currently if we set only TrackSchemaVersions on a replica the historian is never called to manage schema versions since the Replication Watcher is off by default and hence no vstreams run. This change also turns on the watcher if the historian is enabled.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>