### PR TITLE
Fix bugs around error handling and connection closing

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -831,7 +831,7 @@ func (c *Conn) handleNextCommand(handler Handler) (kontinue bool) {
 			delete(c.PrepareData, stmtID)
 		}
 	case ComStmtReset:
-		c.stmtReset(data)
+		return c.stmtReset(data)
 	case ComResetConnection:
 		// Clean up and reset the connection
 		c.recycleReadPacket()

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -307,10 +307,9 @@ func TestMultiStatement(t *testing.T) {
 	err := cConn.WriteComQuery("select 1;select 2")
 	require.NoError(t, err)
 
-	expectedErr := fmt.Errorf("execution failed")
-	handler := &singleRun{t: t, err: expectedErr}
-	err = sConn.handleNextCommand(handler)
-	require.Same(t, expectedErr, err)
+	handler := &singleRun{t: t, err: fmt.Errorf("execution failed")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, res)
 
 	data, err := cConn.ReadPacket()
 	require.NoError(t, err)

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -628,9 +628,9 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 	}
 
 	for i := 0; i < count; i++ {
-		err := sConn.handleNextCommand(&handler)
-		if err != nil {
-			t.Fatalf("error handling command: %v", err)
+		kontinue := sConn.handleNextCommand(&handler)
+		if !kontinue {
+			t.Fatalf("error handling command")
 		}
 	}
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -470,8 +470,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	}
 
 	for {
-		err := c.handleNextCommand(l.handler)
-		if err != nil {
+		kontinue := c.handleNextCommand(l.handler)
+		if !kontinue {
 			return
 		}
 	}


### PR DESCRIPTION
Solves a couple of different problems.

1. When doing multi-statement queries, Vitess would answer all the queries in a single packet, compared to MySQL, which returns an OK/error packet per query that was run.
2. Vitess would not stop running queries in a multi-statement query when a query failed, which is very different from what MySQL does.

Fixes #6747

Here follows tcp capture of two multistatement queries before this change.

```
On MySQL:

Query

0000   02 00 00 00 45 00 00 64 00 00 40 00 40 06 00 00   ....E..d..@.@...
0010   7f 00 00 01 7f 00 00 01 f6 5f 0c ea dd ac 8b 28   ........._.....(
0020   ef bf 80 8e 80 18 18 e5 fe 58 00 00 01 01 08 0a   .........X......
0030   4b 65 43 a9 4b 65 43 a9 2c 00 00 00 03 53 45 4c   KeC.KeC.,....SEL
0040   45 43 54 20 34 32 3b 20 53 45 4c 45 43 54 20 2a   ECT 42; SELECT *
0050   20 66 72 6f 6d 20 70 72 6f 64 75 63 74 3b 73 65    from product;se
0060   6c 65 63 74 20 34 33 3b                           lect 43;

First response:

0000   02 00 00 00 45 00 00 67 00 00 40 00 40 06 00 00   ....E..g..@.@...
0010   7f 00 00 01 7f 00 00 01 0c ea f6 5f ef bf 80 8e   ..........._....
0020   dd ac 8b 58 80 18 18 e4 fe 5b 00 00 01 01 08 0a   ...X.....[......
0030   4b 65 43 a9 4b 65 43 a9 01 00 00 01 01 18 00 00   KeC.KeC.........
0040   02 03 64 65 66 00 00 00 02 34 32 00 0c 3f 00 02   ..def....42..?..
0050   00 00 00 08 81 00 00 00 00 03 00 00 03 02 34 32   ..............42
0060   07 00 00 04 fe 00 00 08 00 00 00                  ...........

Second response:

0000   02 00 00 00 45 00 00 63 00 00 40 00 40 06 00 00   ....E..c..@.@...
0010   7f 00 00 01 7f 00 00 01 0c ea f6 5f ef bf 80 c1   ..........._....
0020   dd ac 8b 58 80 18 18 e4 fe 57 00 00 01 01 08 0a   ...X.....W......
0030   4b 65 43 a9 4b 65 43 a9 2b 00 00 05 ff 7a 04 23   KeC.KeC.+....z.#
0040   34 32 53 30 32 54 61 62 6c 65 20 27 74 65 73 74   42S02Table 'test
0050   2e 70 72 6f 64 75 63 74 27 20 64 6f 65 73 6e 27   .product' doesn'
0060   74 20 65 78 69 73 74                              t exist

Third response:

0000   02 00 00 00 45 00 00 39 00 00 40 00 40 06 00 00   ....E..9..@.@...
0010   7f 00 00 01 7f 00 00 01 f6 5f 0c ea dd ac 8b 58   ........._.....X
0020   ef bf 80 f0 80 18 18 e4 fe 2d 00 00 01 01 08 0a   .........-......
0030   4b 65 43 a9 4b 65 43 a9 01 00 00 00 01            KeC.KeC......


On Vitess:

Query:

0000   1e 00 00 00 60 02 c2 a3 00 62 06 40 00 00 00 00   ....`....b.@....
0010   00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00   ................
0020   00 00 00 00 00 00 00 00 00 00 00 01 c5 19 1b 0f   ................
0030   04 b7 9d 4c 20 a5 c6 57 80 18 18 e1 00 6a 00 00   ...L ..W.....j..
0040   01 01 08 0a 14 65 8d ca 14 65 8d ca 3e 00 00 00   .....e...e..>...
0050   03 53 45 4c 45 43 54 20 34 32 3b 20 53 45 4c 45   .SELECT 42; SELE
0060   43 54 20 2a 20 66 72 6f 6d 20 70 72 6f 64 75 63   CT * from produc
0070   74 3b 69 6e 73 65 72 74 20 69 6e 74 6f 20 74 28   t;insert into t(
0080   61 29 76 61 6c 75 65 73 28 31 32 33 29 3b         a)values(123);

Response:

0000   1e 00 00 00 60 0d 78 e8 00 dc 06 40 00 00 00 00   ....`.x....@....
0010   00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00   ................
0020   00 00 00 00 00 00 00 00 00 00 00 01 1b 0f c5 19   ................
0030   20 a5 c6 57 04 b7 9d 8e 80 18 18 dc 00 e4 00 00    ..W............
0040   01 01 08 0a 14 65 8d ca 14 65 8d ca 01 00 00 01   .....e...e......
0050   01 1b 00 00 02 03 64 65 66 00 00 00 05 3a 76 74   ......def....:vt
0060   67 31 00 0c 00 00 00 00 00 00 08 00 00 00 00 00   g1..............
0070   03 00 00 03 02 34 32 07 00 00 04 fe 00 00 09 00   .....42.........
0080   00 00 42 00 00 05 ff 51 04 23 48 59 30 30 30 76   ..B....Q.#HY000v
0090   74 67 61 74 65 3a 20 68 74 74 70 3a 2f 2f 61 6e   tgate: http://an
00a0   64 72 65 73 73 2d 6d 62 70 3a 36 39 32 35 2f 3a   dress-mbp:6925/:
00b0   20 74 61 62 6c 65 20 70 72 6f 64 75 63 74 20 6e    table product n
00c0   6f 74 20 66 6f 75 6e 64 3c 00 00 06 ff 51 04 23   ot found<....Q.#
00d0   48 59 30 30 30 76 74 67 61 74 65 3a 20 68 74 74   HY000vtgate: htt
00e0   70 3a 2f 2f 61 6e 64 72 65 73 73 2d 6d 62 70 3a   p://andress-mbp:
00f0   36 39 32 35 2f 3a 20 74 61 62 6c 65 20 74 20 6e   6925/: table t n
0100   6f 74 20 66 6f 75 6e 64                           ot found


```
