### PR TITLE
(prototype) orc: limit to one keyspace and shard

### DIFF
--- a/go/test/endtoend/orchestrator/orc_test.go
+++ b/go/test/endtoend/orchestrator/orc_test.go
@@ -475,8 +475,8 @@ func checkInsertedValues(t *testing.T, tablet *cluster.Vttablet, index int) erro
 
 func validateTopology(t *testing.T, cluster *cluster.LocalProcessCluster, pingTablets bool) {
 	if pingTablets {
-		err := cluster.VtctlclientProcess.ExecuteCommand("Validate", "-ping-tablets=true")
-		require.NoError(t, err)
+		out, err := cluster.VtctlclientProcess.ExecuteCommandWithOutput("Validate", "-ping-tablets=true")
+		require.NoError(t, err, out)
 	} else {
 		err := cluster.VtctlclientProcess.ExecuteCommand("Validate")
 		require.NoError(t, err)

--- a/go/test/endtoend/orchestrator/test_config.json
+++ b/go/test/endtoend/orchestrator/test_config.json
@@ -5,5 +5,7 @@
   "MySQLReplicaUser": "vt_repl",
   "MySQLReplicaPassword": "",
   "RecoveryPeriodBlockSeconds": 1,
-  "InstancePollSeconds": 1
+  "InstancePollSeconds": 1,
+  "Keyspace": "ks",
+  "Shard": "0"
 }

--- a/go/vt/orchestrator/config/config.go
+++ b/go/vt/orchestrator/config/config.go
@@ -255,6 +255,8 @@ type Configuration struct {
 	MaxConcurrentReplicaOperations             int               // Maximum number of concurrent operations on replicas
 	InstanceDBExecContextTimeoutSeconds        int               // Timeout on context used while calling ExecContext on instance database
 	LockShardTimeoutSeconds                    int               // Timeout on context used to lock shard. Should be a small value because we should fail-fast
+	Keyspace                                   string            // Keyspace that this instance is watching
+	Shard                                      string            // Shard that this instance is watching
 }
 
 // ToJSONString will marshal this configuration as JSON
@@ -429,6 +431,9 @@ func newConfiguration() *Configuration {
 }
 
 func (this *Configuration) postReadAdjustments() error {
+	if this.Keyspace == "" || this.Shard == "" {
+		log.Fatalf("Keyspace and Shard are required")
+	}
 	if this.MySQLOrchestratorCredentialsConfigFile != "" {
 		mySQLConfig := struct {
 			Client struct {


### PR DESCRIPTION
DO NOT MERGE yet.
This is not meant to go into 8.0.

Limit an orchestrator instance to managing one keyspace/shard.
Right now keyspace and shard are specified in the config file. This may not be a very user-friendly way of specifying them. We can explore the pros and cons of config file vs command line args.

Signed-off-by: deepthi <deepthi@planetscale.com>