### PR TITLE
Serialise/deserialise the AST

### DIFF
--- a/go/vt/sqlparser/ast_deserialize.go
+++ b/go/vt/sqlparser/ast_deserialize.go
@@ -1,0 +1,178 @@
+package sqlparser
+
+import (
+	"fmt"
+)
+
+func Deserialize(in []byte) Statement {
+	d := &deserializer{buf: in}
+
+	return d.deserializeStatement()
+}
+
+type deserializer struct {
+	buf []byte
+	pos int
+}
+
+func (d *deserializer) deserializeStatement() Statement {
+	b := d.readByte()
+	switch b {
+	case tSelect:
+		cache := d.readBoolRef()
+		bools := d.readBools()
+		distinct := bools[0]
+		straightJoinHint := bools[1]
+		sqlCalcFoundRows := bools[2]
+		nils := d.readBools()
+		var expressions SelectExprs
+		if !nils[1] {
+			exprSize := d.readVint()
+			expressions = make(SelectExprs, exprSize)
+			for i := 0; i < exprSize; i++ {
+				expressions[i] = d.deserializeSelectExpr()
+			}
+		}
+		var tableExprs TableExprs
+		if !nils[1] {
+			fromSize := d.readVint()
+			tableExprs = make(TableExprs, fromSize)
+			for i := 0; i < fromSize; i++ {
+				tableExprs[i] = d.deserializeTableExpr()
+			}
+		}
+
+		return &Select{
+			Cache:            cache,
+			Distinct:         distinct,
+			StraightJoinHint: straightJoinHint,
+			SQLCalcFoundRows: sqlCalcFoundRows,
+			Comments:         nil,
+			SelectExprs:      expressions,
+			From:             tableExprs,
+		}
+	default:
+		panic(fmt.Sprintf("unknown type %d", b))
+	}
+}
+
+func (d *deserializer) readVint() int {
+	b := d.readByte()
+	switch {
+	case b < 0xfb:
+		return int(b)
+	case b == 0xfc:
+		return int(d.readInt16())
+	case b == 0xfe:
+		return d.readInt()
+	}
+	panic(b)
+}
+
+func (d *deserializer) readByte() byte {
+	return d.buf[d.nextPos()]
+}
+
+func (d *deserializer) readBools() []bool {
+	res := make([]bool, 8)
+	byt := d.readByte()
+	for i := 0; i < 8; i++ {
+		b := (byt & (1 << i)) == 0
+		res[i] = !b
+	}
+	return res
+}
+
+func (d *deserializer) readBoolRef() *bool {
+	b := d.readByte()
+	if b == 0xff {
+		return nil
+	}
+
+	res := b == 0x01
+	return &res
+}
+
+func (d *deserializer) nextPos() int {
+	p := d.pos
+	d.pos = d.pos + 1
+	return p
+}
+
+func (d *deserializer) readByteSlice() []byte {
+	size := d.readVint()
+	startPos := d.pos
+	d.pos = d.pos + size
+	return d.buf[startPos:d.pos]
+}
+
+func (d *deserializer) deserializeColdIdent() ColIdent {
+	val := string(d.readByteSlice())
+	return ColIdent{
+		val: val,
+	}
+}
+
+func (d *deserializer) deserializeSelectExpr() SelectExpr {
+	b := d.readByte()
+	if b == 0 {
+		return nil
+	}
+	switch b {
+	case tAliasedExpr:
+		return &AliasedExpr{
+			As:   d.deserializeColdIdent(),
+			Expr: d.deserializeExpr(),
+		}
+	default:
+		panic("unknown SelectExpr")
+	}
+}
+
+func (d *deserializer) deserializeExpr() Expr {
+	b := d.readByte()
+	switch b {
+	case tLiteral:
+		typ := ValType(d.readByte())
+		val := d.readByteSlice()
+		return &Literal{
+			Type: typ,
+			Val:  val,
+		}
+	}
+	panic("oh noes")
+}
+
+func (d *deserializer) readInt() int {
+	b := d.buf[d.pos : d.pos+4]
+	d.pos = d.pos + 4
+	return int(b[0]) |
+		int(b[1])<<8 |
+		int(b[2])<<16 |
+		int(b[3])<<24
+}
+
+func (d *deserializer) readInt16() int16 {
+	b1 := d.readByte()
+	b2 := d.readByte()
+	return int16(b1) | int16(b2)<<8
+}
+
+func (d *deserializer) deserializeTableExpr() TableExpr {
+	switch d.readByte() {
+	case tAliasedTableExpr:
+		expr := d.deserializeSimpleTableExpr()
+		return &AliasedTableExpr{Expr: expr}
+	}
+	panic("not implemented")
+}
+
+func (d *deserializer) deserializeSimpleTableExpr() SimpleTableExpr {
+	switch d.readByte() {
+	case tTableName:
+		val := string(d.readByteSlice())
+		return TableName{Name: TableIdent{v: val}}
+	}
+
+	panic("not implemented")
+}

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -130,7 +130,7 @@ type ShowTablesOpt struct {
 }
 
 // ValType specifies the type for Literal.
-type ValType int
+type ValType byte
 
 // These are the possible Valtype values.
 // HexNum represents a 0x... value. It cannot

--- a/go/vt/sqlparser/ast_serialize.go
+++ b/go/vt/sqlparser/ast_serialize.go
@@ -1,0 +1,162 @@
+package sqlparser
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func Serialize(in Statement) ([]byte, error) {
+	s := serializer{}
+
+	s.serialize(in)
+	return s.buf.Bytes(), nil
+}
+
+const (
+	// statement implementations
+	tSelect byte = iota
+)
+const (
+	// SelectExpr implementations
+	tAliasedExpr byte = iota
+)
+const (
+	// Expr implementations
+	tLiteral byte = iota
+)
+const (
+	// TableExpr implementations
+	tAliasedTableExpr byte = iota
+)
+const (
+	// SimpleTableExpr implementations
+	tTableName byte = iota
+)
+
+type serializer struct {
+	buf bytes.Buffer
+}
+
+func (s *serializer) serialize(in SQLNode) {
+	switch node := in.(type) {
+	case *Literal:
+		s.putByte(tLiteral)
+		s.putByte(byte(node.Type))
+		s.putByteSlice(node.Val)
+	case *Select:
+		s.putByte(tSelect)
+		s.putRefBool(node.Cache)
+		s.putBools(node.Distinct, node.SQLCalcFoundRows, node.SQLCalcFoundRows)
+		s.encodeNullableFields(node.Comments, node.SelectExprs, node.From, node.Where, node.GroupBy, node.Having, node.OrderBy, node.Limit)
+		if node.SelectExprs != nil {
+			s.serialize(node.SelectExprs)
+		}
+		if node.From != nil {
+			s.serialize(node.From)
+		}
+	case SelectExprs:
+		s.putVInt(len(node)) // size of slice
+		for _, e := range node {
+			s.serialize(e)
+		}
+	case *AliasedExpr:
+		s.putByte(tAliasedExpr) // type
+		s.serialize(node.As)
+		s.serialize(node.Expr)
+	case ColIdent:
+		s.putString(node.val)
+	case TableExprs:
+		s.putVInt(len(node)) // size of slice
+		for _, e := range node {
+			s.serialize(e)
+		}
+	case *AliasedTableExpr:
+		s.putByte(tAliasedTableExpr)
+		s.serialize(node.Expr)
+	case TableName:
+		s.putByte(tTableName)
+		s.putString(node.Name.v)
+
+	default:
+		panic(fmt.Sprintf("unknown type: %T", node))
+	}
+}
+
+func (s *serializer) encodeNullableFields(fields ...interface{}) {
+	bools := make([]bool, len(fields))
+	for i, f := range fields {
+		if isNilValue(f) {
+			bools[i] = true
+		}
+	}
+	s.putBools(bools...)
+}
+
+func (s *serializer) putBools(p ...bool) {
+	var res byte
+	for i, b := range p {
+		if b {
+			res |= 1 << i
+		}
+	}
+	s.putByte(res)
+}
+
+func (s *serializer) putString(in string) {
+	s.putByteSlice([]byte(in))
+}
+
+func (s *serializer) putByteSlice(in []byte) {
+	s.putVInt(len(in)) // size of slice
+	s.buf.Write(in)
+}
+
+func (s *serializer) putByte(b byte) {
+	s.buf.Write([]byte{b})
+}
+
+func (s *serializer) putInt(v int) {
+	s.buf.Write([]byte{
+		byte(v),
+		byte(v >> 8),
+		byte(v >> 16),
+		byte(v >> 24),
+	})
+}
+
+func (s *serializer) putInt16(v int16) {
+	s.buf.Write([]byte{
+		byte(v),
+		byte(v >> 8),
+	})
+}
+
+// serializes an int with as few bytes as possible
+func (s *serializer) putVInt(v int) {
+	switch {
+	case v < 0xfb:
+		s.putByte(byte(v))
+	case v >= 0xfc && v < 0xffff:
+		s.putByte(0xfc)
+		s.putInt16(int16(v))
+	default:
+		s.putByte(0xfe)
+		s.putInt(v)
+	}
+}
+
+func (s *serializer) putRefBool(b *bool) {
+	if b == nil {
+		s.putByte(0xff)
+		return
+	}
+	s.putBool(*b)
+}
+
+func (s *serializer) putBool(b bool) {
+	if b {
+		s.putByte(1)
+	} else {
+		s.putByte(0)
+	}
+}

--- a/go/vt/sqlparser/ast_serialize_test.go
+++ b/go/vt/sqlparser/ast_serialize_test.go
@@ -1,0 +1,51 @@
+package sqlparser
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/test/utils"
+)
+
+var sql = "select distinct 42 as foobar from dual"
+var stmt, _ = Parse(sql)
+var btes, _ = Serialize(stmt)
+
+func TestFirstRoundTrip(t *testing.T) {
+	var mustMatch = utils.MustMatchFn(
+		[]interface{}{ // types with unexported fields
+			TableIdent{},
+		},
+		[]string{}, // ignored fields
+	)
+
+	bytes, err := Serialize(stmt)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(bytes), len(sql), "byte size vs query size")
+	fmt.Println(hex.Dump(bytes))
+	output := Deserialize(bytes)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	mustMatch(t, stmt, output, "serialize round trip")
+}
+func BenchmarkParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stmt, _ := Parse(sql)
+		if stmt == nil {
+			b.Fail()
+		}
+	}
+}
+func BenchmarkDeserialize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stmt := Deserialize(btes)
+		if stmt == nil {
+			b.Fail()
+		}
+	}
+}

--- a/go/vt/sqlparser/visitorgen/struct_producer.go
+++ b/go/vt/sqlparser/visitorgen/struct_producer.go
@@ -76,7 +76,7 @@ func ToVisitorPlan(input *SourceInformation) *VisitorPlan {
 		stroct, isStruct := input.structs[typ.rawTypeName()]
 		if isStruct {
 			for _, f := range stroct.fields {
-				switchit.Fields = append(switchit.Fields, trySingleItem(input, f, typ)...)
+				switchit.Fields = append(switchit.Fields, extractVisitorFields(input, f, typ)...)
 			}
 		} else {
 			itemType := input.getItemTypeOfArray(typ)
@@ -94,7 +94,7 @@ func ToVisitorPlan(input *SourceInformation) *VisitorPlan {
 	return &output
 }
 
-func trySingleItem(input *SourceInformation, f *Field, typ Type) []VisitorItem {
+func extractVisitorFields(input *SourceInformation, f *Field, typ Type) []VisitorItem {
 	if input.isSQLNode(f.typ) {
 		return []VisitorItem{&SingleFieldItem{
 			StructType: typ,

--- a/go/vt/sqlparser/visitorgen/transformer_test.go
+++ b/go/vt/sqlparser/visitorgen/transformer_test.go
@@ -30,7 +30,7 @@ func TestSimplestAst(t *testing.T) {
 
 		type NodeStruct struct {}
 
-		func (*NodeStruct) iNode{}
+		func (*NodeStruct) iNode() {}
 	*/
 	input := &SourceFile{
 		lines: []Sast{


### PR DESCRIPTION
The idea is that when we need to pass a query over the wire, instead of turning the AST into a string and then parsing it on the other side, we can serialise the AST into a byte slice. Preliminary tests show that the performance difference between the two modes is big enough that it might be worth exploring more.

```
BenchmarkParse-16             	  272614	      4326 ns/op
BenchmarkDeserialize-16       	 3161701	       361 ns/op
```