### PR TITLE
Allow multiple blacklists for master

### DIFF
--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -461,16 +461,18 @@ func (si *ShardInfo) updateMasterTabletControl(tc *topodatapb.Shard_TabletContro
 			return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, blTablesNotPresent)
 		}
 		var newBlacklist []string
-		for _, blt := range tc.BlacklistedTables {
-			mustDelete := false
-			for _, table := range tables {
-				if blt == table {
-					mustDelete = true
-					break
+		if len(tables) != 0 { // legacy uses
+			for _, blt := range tc.BlacklistedTables {
+				mustDelete := false
+				for _, table := range tables {
+					if blt == table {
+						mustDelete = true
+						break
+					}
 				}
-			}
-			if !mustDelete {
-				newBlacklist = append(newBlacklist, blt)
+				if !mustDelete {
+					newBlacklist = append(newBlacklist, blt)
+				}
 			}
 		}
 		tc.BlacklistedTables = newBlacklist

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -44,6 +44,12 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
+const (
+	blTablesAlreadyPresent = "one or more tables are already present in the blacklist"
+	blTablesNotPresent     = "cannot remove tables since one or more do not exist in the blacklist"
+	blNoCellsForMaster     = "you cannot specify cells for a master's tablet control"
+)
+
 // Functions for dealing with shard representations in topology.
 
 // addCells will merge both cells list, settling on nil if either list is empty
@@ -393,8 +399,12 @@ func (si *ShardInfo) UpdateSourceBlacklistedTables(ctx context.Context, tabletTy
 	if err := CheckKeyspaceLocked(ctx, si.keyspace); err != nil {
 		return err
 	}
+	if tabletType == topodatapb.TabletType_MASTER && len(cells) > 0 {
+		return fmt.Errorf(blNoCellsForMaster)
+	}
 	tc := si.GetTabletControl(tabletType)
 	if tc == nil {
+
 		// handle the case where the TabletControl object is new
 		if remove {
 			// we try to remove from something that doesn't exist,
@@ -412,6 +422,13 @@ func (si *ShardInfo) UpdateSourceBlacklistedTables(ctx context.Context, tabletTy
 		return nil
 	}
 
+	if tabletType == topodatapb.TabletType_MASTER {
+		if err := si.updateMasterTabletControl(tc, remove, tables); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	// we have an existing record, check table lists matches and
 	if remove {
 		si.removeCellsFromTabletControl(tc, tabletType, cells)
@@ -425,17 +442,65 @@ func (si *ShardInfo) UpdateSourceBlacklistedTables(ctx context.Context, tabletTy
 	return nil
 }
 
+func (si *ShardInfo) updateMasterTabletControl(tc *topodatapb.Shard_TabletControl, remove bool, tables []string) error {
+	var newTables []string
+	for _, table := range tables {
+		exists := false
+		for _, blt := range tc.BlacklistedTables {
+			if blt == table {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			newTables = append(newTables, table)
+		}
+	}
+	if remove {
+		if len(newTables) != 0 {
+			return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, blTablesNotPresent)
+		}
+		var newBlacklist []string
+		for _, blt := range tc.BlacklistedTables {
+			mustDelete := false
+			for _, table := range tables {
+				if blt == table {
+					mustDelete = true
+					break
+				}
+			}
+			if !mustDelete {
+				newBlacklist = append(newBlacklist, blt)
+			}
+		}
+		tc.BlacklistedTables = newBlacklist
+		if len(tc.BlacklistedTables) == 0 {
+			si.removeTabletTypeFromTabletControl(topodatapb.TabletType_MASTER)
+		}
+		return nil
+	}
+	if len(newTables) != len(tables) {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, blTablesAlreadyPresent)
+	}
+	tc.BlacklistedTables = append(tc.BlacklistedTables, tables...)
+	return nil
+}
+
+func (si *ShardInfo) removeTabletTypeFromTabletControl(tabletType topodatapb.TabletType) {
+	var tabletControls []*topodatapb.Shard_TabletControl
+	for _, tc := range si.TabletControls {
+		if tc.TabletType != tabletType {
+			tabletControls = append(tabletControls, tc)
+		}
+	}
+	si.TabletControls = tabletControls
+}
+
 func (si *ShardInfo) removeCellsFromTabletControl(tc *topodatapb.Shard_TabletControl, tabletType topodatapb.TabletType, cells []string) {
 	result := removeCellsFromList(cells, tc.Cells)
 	if len(result) == 0 {
 		// we don't have any cell left, we need to clear this record
-		var tabletControls []*topodatapb.Shard_TabletControl
-		for _, tc := range si.TabletControls {
-			if tc.TabletType != tabletType {
-				tabletControls = append(tabletControls, tc)
-			}
-		}
-		si.TabletControls = tabletControls
+		si.removeTabletTypeFromTabletControl(tabletType)
 	} else {
 		tc.Cells = result
 	}

--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"golang.org/x/net/context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -100,6 +102,57 @@ func lockedKeyspaceContext(keyspace string) context.Context {
 			keyspace: {},
 		},
 	})
+}
+
+func addToBlacklist(ctx context.Context, si *ShardInfo, tabletType topodatapb.TabletType, cells, tables []string) error {
+	if err := si.UpdateSourceBlacklistedTables(ctx, tabletType, cells, false, tables); err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeFromBlacklist(ctx context.Context, si *ShardInfo, tabletType topodatapb.TabletType, cells, tables []string) error {
+	if err := si.UpdateSourceBlacklistedTables(ctx, tabletType, cells, true, tables); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateBlacklist(t *testing.T, si *ShardInfo, tabletType topodatapb.TabletType, cells, tables []string) {
+	tc := si.GetTabletControl(tabletType)
+	require.ElementsMatch(t, tc.Cells, cells)
+	require.ElementsMatch(t, tc.BlacklistedTables, tables)
+}
+
+func TestUpdateSourceMasterBlacklistedTables(t *testing.T) {
+	master := topodatapb.TabletType_MASTER
+	si := NewShardInfo("ks", "sh", &topodatapb.Shard{}, nil)
+	ctx := lockedKeyspaceContext("ks")
+	t1, t2, t3, t4 := "t1", "t2", "t3", "t4"
+	tables1 := []string{t1, t2}
+	tables2 := []string{t3, t4}
+
+	require.NoError(t, addToBlacklist(ctx, si, master, nil, tables1))
+	validateBlacklist(t, si, master, nil, tables1)
+
+	require.NoError(t, addToBlacklist(ctx, si, master, nil, tables2))
+	validateBlacklist(t, si, master, nil, append(tables1, tables2...))
+
+	require.Error(t, addToBlacklist(ctx, si, master, nil, tables2), blTablesAlreadyPresent)
+	require.Error(t, addToBlacklist(ctx, si, master, nil, []string{t1}), blTablesAlreadyPresent)
+
+	require.NoError(t, removeFromBlacklist(ctx, si, master, nil, tables2))
+	validateBlacklist(t, si, master, nil, tables1)
+
+	require.Error(t, removeFromBlacklist(ctx, si, master, nil, tables2), blTablesNotPresent)
+	require.Error(t, removeFromBlacklist(ctx, si, master, nil, []string{t3}), blTablesNotPresent)
+	validateBlacklist(t, si, master, nil, tables1)
+
+	require.NoError(t, removeFromBlacklist(ctx, si, master, nil, []string{t1}))
+	require.NoError(t, removeFromBlacklist(ctx, si, master, nil, []string{t2}))
+	require.Nil(t, si.GetTabletControl(master))
+
+	require.Error(t, addToBlacklist(ctx, si, master, []string{"cell"}, tables1), blNoCellsForMaster)
 }
 
 func TestUpdateSourceBlacklistedTables(t *testing.T) {

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -401,7 +401,7 @@ func (ts *Server) UpdateDisableQueryService(ctx context.Context, keyspace string
 		return err
 	}
 
-	// The caller intents to update all cells in this case
+	// The caller intends to update all cells in this case
 	if len(cells) == 0 {
 		cells, err = ts.GetCellInfoNames(ctx)
 		if err != nil {


### PR DESCRIPTION
https://github.com/vitessio/vitess/issues/6793

MoveTables adds a TabletControl record for the master, blacklisting the participating tables for all cells. Multiple MoveTables workflows might be active. User can SwitchWrites on multiple workflow while retaining the blacklists until they are ready to DropSources. Currently only one list is allowed per tablet type in a keyspace.

Legacy workflows do not use the MASTER tablet type, while the new workflow only uses the MASTER. So the change in this PR supplements the existing logic: no mods to existing logic.

We allow the master blacklist for a keyspace to be table-oriented: user can ask for sets of tables to be added or removed from the blacklist. Adding a table to the blacklist which already contain this table is an error since a table cannot be part of multiple workflows.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>