### PR TITLE
VReplication: refactored and enhanced support for JSON columns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/sjmudd/stopwatch v0.0.0-20170613150411-f380bf8a9be1
 	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/spyzhov/ajson v0.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/tchap/go-patricia v0.0.0-20160729071656-dd168db6051b
 	github.com/tebeka/selenium v0.9.9

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/spyzhov/ajson v0.4.2 h1:JMByd/jZApPKDvNsmO90X2WWGbmT2ahDFp73QhZbg3s=
+github.com/spyzhov/ajson v0.4.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,460 +17,139 @@ limitations under the License.
 package mysql
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
-	"strconv"
 
-	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+
+	"vitess.io/vitess/go/vt/log"
+
+	"github.com/spyzhov/ajson"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
 )
 
-const (
-	jsonTypeSmallObject = 0
-	jsonTypeLargeObject = 1
-	jsonTypeSmallArray  = 2
-	jsonTypeLargeArray  = 3
-	jsonTypeLiteral     = 4
-	jsonTypeInt16       = 5
-	jsonTypeUint16      = 6
-	jsonTypeInt32       = 7
-	jsonTypeUint32      = 8
-	jsonTypeInt64       = 9
-	jsonTypeUint64      = 10
-	jsonTypeDouble      = 11
-	jsonTypeString      = 12
-	jsonTypeOpaque      = 15
+var jsonDebug = false //TODO remove this once JSON functionality has been proven in the field
 
+func jlog(s string, p ...interface{}) {
+	if jsonDebug {
+		log.Infof(s, p)
+		fmt.Printf(s+"\n", p)
+	}
+}
+
+// provides the single API function to convert json from binary format used in binlogs to a string representation
+func getJSONValue(data []byte) (string, error) {
+	jlog("In getJSONValue for %v", data)
+	var ast *ajson.Node
+	var err error
+	if len(data) == 0 {
+		ast = ajson.NullNode("")
+	} else {
+		ast, _, err = binaryJSON.parse(data)
+		if err != nil {
+			return "", err
+		}
+	}
+	bytes, err := ajson.Marshal(ast)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+var binaryJSON *BinaryJSON
+
+func init() {
+	binaryJSON = &BinaryJSON{
+		handlers: make(map[jsonDataType]jsonHandler),
+	}
+	newIntHandler()
+	newLiteralHandler()
+	newOpaqueHandler()
+	newStringHandler()
+	newArrayHandler()
+	newObjectHandler()
+}
+
+// BinaryJSON contains the handlers for all json types and methods for parsing the binary json representation from the binlog
+type BinaryJSON struct {
+	handlers map[jsonDataType]jsonHandler
+}
+
+func (jh *BinaryJSON) parse(data []byte) (node *ajson.Node, newPos int, err error) {
+	var pos int
+	typ := data[0]
+	pos++
+	return jh.getNode(jsonDataType(typ), data, pos)
+}
+
+func (jh *BinaryJSON) register(typ jsonDataType, handler jsonHandler) {
+	jh.handlers[typ] = handler
+}
+
+func (jh *BinaryJSON) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	handler := jh.handlers[typ]
+	if handler == nil {
+		return nil, 0, fmt.Errorf("handler not found for type %d", typ)
+	}
+	return handler.getNode(typ, data, pos)
+}
+
+// jsonDataType has the values used in the mysql json binary representation to denote types
+// we have string, literal(true/false/null), number, object or array types
+// large object => doc size > 64K, you get pointers instead of inline values
+type jsonDataType byte
+
+const (
+	jsonSmallObject = 0
+	jsonLargeObject = 1
+	jsonSmallArray  = 2
+	jsonLargeArray  = 3
+	jsonLiteral     = 4
+	jsonInt16       = 5
+	jsonUint16      = 6
+	jsonInt32       = 7
+	jsonUint32      = 8
+	jsonInt64       = 9
+	jsonUint64      = 10 //0x0a
+	jsonDouble      = 11 //0x0b
+	jsonString      = 12 //0x0c a utf8mb4 string
+	jsonOpaque      = 15 //0x0f "custom" data
+)
+
+// literals in the binary json format can be one of three types: null, true, false
+type jsonDataLiteral byte
+
+const (
 	jsonNullLiteral  = '\x00'
 	jsonTrueLiteral  = '\x01'
 	jsonFalseLiteral = '\x02'
 )
 
-// printJSONData parses the MySQL binary format for JSON data, and prints
-// the result as a string.
-func printJSONData(data []byte) ([]byte, error) {
-	// It's possible for data to be empty. If so, we have to
-	// treat it as 'null'.
-	// The mysql code also says why, but this wasn't reproduceable:
-	// https://github.com/mysql/mysql-server/blob/8.0/sql/json_binary.cc#L1070
-	if len(data) == 0 {
-		return []byte("'null'"), nil
-	}
-	result := &bytes.Buffer{}
-	typ := data[0]
-	if err := printJSONValue(typ, data[1:], true /* toplevel */, result); err != nil {
-		return nil, err
-	}
-	return result.Bytes(), nil
+// in objects and arrays some values are inlined, others have offsets into the raw data
+var smallValueTypes = map[jsonDataType]bool{
+	jsonSmallObject: false,
+	jsonLargeObject: false,
+	jsonSmallArray:  false,
+	jsonLargeArray:  false,
+	jsonLiteral:     true,
+	jsonInt16:       true,
+	jsonUint16:      true,
+	jsonInt32:       false,
+	jsonUint32:      false,
+	jsonInt64:       false,
+	jsonUint64:      false,
+	jsonDouble:      false,
+	jsonString:      false,
+	jsonOpaque:      false,
 }
 
-func printJSONValue(typ byte, data []byte, toplevel bool, result *bytes.Buffer) error {
-	switch typ {
-	case jsonTypeSmallObject:
-		return printJSONObject(data, false, result)
-	case jsonTypeLargeObject:
-		return printJSONObject(data, true, result)
-	case jsonTypeSmallArray:
-		return printJSONArray(data, false, result)
-	case jsonTypeLargeArray:
-		return printJSONArray(data, true, result)
-	case jsonTypeLiteral:
-		return printJSONLiteral(data[0], toplevel, result)
-	case jsonTypeInt16:
-		printJSONInt16(data[0:2], toplevel, result)
-	case jsonTypeUint16:
-		printJSONUint16(data[0:2], toplevel, result)
-	case jsonTypeInt32:
-		printJSONInt32(data[0:4], toplevel, result)
-	case jsonTypeUint32:
-		printJSONUint32(data[0:4], toplevel, result)
-	case jsonTypeInt64:
-		printJSONInt64(data[0:8], toplevel, result)
-	case jsonTypeUint64:
-		printJSONUint64(data[0:8], toplevel, result)
-	case jsonTypeDouble:
-		printJSONDouble(data[0:8], toplevel, result)
-	case jsonTypeString:
-		printJSONString(data, toplevel, result)
-	case jsonTypeOpaque:
-		return printJSONOpaque(data, toplevel, result)
-	default:
-		return vterrors.Errorf(vtrpc.Code_INTERNAL, "unknown object type in JSON: %v", typ)
-	}
-
-	return nil
-}
-
-func printJSONObject(data []byte, large bool, result *bytes.Buffer) error {
-	pos := 0
-	elementCount, pos := readOffsetOrSize(data, pos, large)
-	size, pos := readOffsetOrSize(data, pos, large)
-	if size > len(data) {
-		return vterrors.Errorf(vtrpc.Code_INTERNAL, "not enough data for object, have %v bytes need %v", len(data), size)
-	}
-
-	// Build an array for each key.
-	keys := make([]sqltypes.Value, elementCount)
-	for i := 0; i < elementCount; i++ {
-		var keyOffset, keyLength int
-		keyOffset, pos = readOffsetOrSize(data, pos, large)
-		keyLength, pos = readOffsetOrSize(data, pos, false) // always 16
-		keys[i] = sqltypes.MakeTrusted(sqltypes.VarBinary, data[keyOffset:keyOffset+keyLength])
-	}
-
-	// Now read each value, and output them.  The value entry is
-	// always one byte (the type), and then 2 or 4 bytes
-	// (depending on the large flag). If the value fits in the number of bytes,
-	// then it is inlined. This is always the case for Literal (one byte),
-	// and {,u}int16. For {u}int32, it depends if we're large or not.
-	result.WriteString("JSON_OBJECT(")
-	for i := 0; i < elementCount; i++ {
-		// First print the key value.
-		if i > 0 {
-			result.WriteByte(',')
-		}
-		keys[i].EncodeSQL(result)
-		result.WriteByte(',')
-
-		if err := printJSONValueEntry(data, pos, large, result); err != nil {
-			return err
-		}
-		if large {
-			pos += 5 // type byte + 4 bytes
-		} else {
-			pos += 3 // type byte + 2 bytes
-		}
-	}
-	result.WriteByte(')')
-	return nil
-}
-
-func printJSONArray(data []byte, large bool, result *bytes.Buffer) error {
-	pos := 0
-	elementCount, pos := readOffsetOrSize(data, pos, large)
-	size, pos := readOffsetOrSize(data, pos, large)
-	if size > len(data) {
-		return vterrors.Errorf(vtrpc.Code_INTERNAL, "not enough data for object, have %v bytes need %v", len(data), size)
-	}
-
-	// Now read each value, and output them.  The value entry is
-	// always one byte (the type), and then 2 or 4 bytes
-	// (depending on the large flag). If the value fits in the number of bytes,
-	// then it is inlined. This is always the case for Literal (one byte),
-	// and {,u}int16. For {u}int32, it depends if we're large or not.
-	result.WriteString("JSON_ARRAY(")
-	for i := 0; i < elementCount; i++ {
-		// Print the key value.
-		if i > 0 {
-			result.WriteByte(',')
-		}
-		if err := printJSONValueEntry(data, pos, large, result); err != nil {
-			return err
-		}
-		if large {
-			pos += 5 // type byte + 4 bytes
-		} else {
-			pos += 3 // type byte + 2 bytes
-		}
-	}
-	result.WriteByte(')')
-	return nil
-}
-
-// printJSONValueEntry prints an entry. The value entry is always one
-// byte (the type), and then 2 or 4 bytes (depending on the large
-// flag). If the value fits in the number of bytes, then it is
-// inlined. This is always the case for Literal (one byte), and
-// {,u}int16. For {u}int32, it depends if we're large or not.
-func printJSONValueEntry(data []byte, pos int, large bool, result *bytes.Buffer) error {
-	typ := data[pos]
-	pos++
-
-	switch {
-	case typ == jsonTypeLiteral:
-		// 3 possible literal values, always in-lined, as it is one byte.
-		if err := printJSONLiteral(data[pos], false /* toplevel */, result); err != nil {
-			return err
-		}
-	case typ == jsonTypeInt16:
-		// Value is always inlined in first 2 bytes.
-		printJSONInt16(data[pos:pos+2], false /* toplevel */, result)
-	case typ == jsonTypeUint16:
-		// Value is always inlined in first 2 bytes.
-		printJSONUint16(data[pos:pos+2], false /* toplevel */, result)
-	case typ == jsonTypeInt32 && large:
-		// Value is only inlined if large.
-		printJSONInt32(data[pos:pos+4], false /* toplevel */, result)
-	case typ == jsonTypeUint32 && large:
-		// Value is only inlined if large.
-		printJSONUint32(data[pos:pos+4], false /* toplevel */, result)
-	default:
-		// value is not inlined, we have its offset here.
-		// Note we don't have its length, so we just go to the end.
-		offset, _ := readOffsetOrSize(data, pos, large)
-		if err := printJSONValue(typ, data[offset:], false /* toplevel */, result); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func printJSONLiteral(b byte, toplevel bool, result *bytes.Buffer) error {
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	// Only three possible values.
-	switch b {
-	case jsonNullLiteral:
-		result.WriteString("null")
-	case jsonTrueLiteral:
-		result.WriteString("true")
-	case jsonFalseLiteral:
-		result.WriteString("false")
-	default:
-		return vterrors.Errorf(vtrpc.Code_INTERNAL, "unknown literal value %v", b)
-	}
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	return nil
-}
-
-func printJSONInt16(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := uint16(data[0]) +
-		uint16(data[1])<<8
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendInt(nil, int64(int16(val)), 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONUint16(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := uint16(data[0]) +
-		uint16(data[1])<<8
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendUint(nil, uint64(val), 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONInt32(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := uint32(data[0]) +
-		uint32(data[1])<<8 +
-		uint32(data[2])<<16 +
-		uint32(data[3])<<24
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendInt(nil, int64(int32(val)), 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONUint32(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := uint32(data[0]) +
-		uint32(data[1])<<8 +
-		uint32(data[2])<<16 +
-		uint32(data[3])<<24
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendUint(nil, uint64(val), 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONInt64(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := uint64(data[0]) +
-		uint64(data[1])<<8 +
-		uint64(data[2])<<16 +
-		uint64(data[3])<<24 +
-		uint64(data[4])<<32 +
-		uint64(data[5])<<40 +
-		uint64(data[6])<<48 +
-		uint64(data[7])<<56
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendInt(nil, int64(val), 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONUint64(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := binary.LittleEndian.Uint64(data[:8])
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendUint(nil, val, 10))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONDouble(data []byte, toplevel bool, result *bytes.Buffer) {
-	val := binary.LittleEndian.Uint64(data[:8])
-	fval := math.Float64frombits(val)
-	if toplevel {
-		result.WriteByte('\'')
-	}
-	result.Write(strconv.AppendFloat(nil, fval, 'E', -1, 64))
-	if toplevel {
-		result.WriteByte('\'')
-	}
-}
-
-func printJSONString(data []byte, toplevel bool, result *bytes.Buffer) {
-	size, pos := readVariableLength(data, 0)
-
-	// A toplevel JSON string is printed as a JSON-escaped
-	// string inside a string, as the value is parsed as JSON.
-	// So the value should be: '"value"'.
-	if toplevel {
-		result.WriteString("'\"")
-		// FIXME(alainjobart): escape reserved characters
-		result.Write(data[pos : pos+size])
-		result.WriteString("\"'")
-		return
-	}
-
-	// Inside a JSON_ARRAY() or JSON_OBJECT method, we just print the string
-	// as SQL string.
-	valStr := sqltypes.MakeTrusted(sqltypes.VarBinary, data[pos:pos+size])
-	valStr.EncodeSQL(result)
-}
-
-func printJSONOpaque(data []byte, toplevel bool, result *bytes.Buffer) error {
-	typ := data[0]
-	size, pos := readVariableLength(data, 1)
-
-	// A few types have special encoding.
-	switch typ {
-	case TypeDate:
-		return printJSONDate(data[pos:pos+size], toplevel, result)
-	case TypeTime:
-		return printJSONTime(data[pos:pos+size], toplevel, result)
-	case TypeDateTime:
-		return printJSONDateTime(data[pos:pos+size], toplevel, result)
-	case TypeNewDecimal:
-		return printJSONDecimal(data[pos:pos+size], toplevel, result)
-	}
-
-	// Other types are encoded in somewhat weird ways. Since we
-	// have no metadata, it seems some types first provide the
-	// metadata, and then the values. But even that metadata is
-	// not straightforward (for instance, a bit field seems to
-	// have one byte as metadata, not two as would be expected).
-	// To be on the safer side, we just reject these cases for now.
-	return vterrors.Errorf(vtrpc.Code_INTERNAL, "opaque type %v is not supported yet, with data %v", typ, data[1:])
-}
-
-func printJSONDate(data []byte, toplevel bool, result *bytes.Buffer) error {
-	raw := binary.LittleEndian.Uint64(data[:8])
-	value := raw >> 24
-	yearMonth := (value >> 22) & 0x01ffff // 17 bits starting at 22nd
-	year := yearMonth / 13
-	month := yearMonth % 13
-	day := (value >> 17) & 0x1f // 5 bits starting at 17th
-
-	if toplevel {
-		result.WriteString("CAST(")
-	}
-	fmt.Fprintf(result, "CAST('%04d-%02d-%02d' AS DATE)", year, month, day)
-	if toplevel {
-		result.WriteString(" AS JSON)")
-	}
-	return nil
-}
-
-func printJSONTime(data []byte, toplevel bool, result *bytes.Buffer) error {
-	raw := binary.LittleEndian.Uint64(data[:8])
-	value := raw >> 24
-	hour := (value >> 12) & 0x03ff // 10 bits starting at 12th
-	minute := (value >> 6) & 0x3f  // 6 bits starting at 6th
-	second := value & 0x3f         // 6 bits starting at 0th
-	microSeconds := raw & 0xffffff // 24 lower bits
-
-	if toplevel {
-		result.WriteString("CAST(")
-	}
-	result.WriteString("CAST('")
-	if value&0x8000000000 != 0 {
-		result.WriteByte('-')
-	}
-	fmt.Fprintf(result, "%02d:%02d:%02d", hour, minute, second)
-	if microSeconds != 0 {
-		fmt.Fprintf(result, ".%06d", microSeconds)
-	}
-	result.WriteString("' AS TIME(6))")
-	if toplevel {
-		result.WriteString(" AS JSON)")
-	}
-	return nil
-}
-
-func printJSONDateTime(data []byte, toplevel bool, result *bytes.Buffer) error {
-	raw := binary.LittleEndian.Uint64(data[:8])
-	value := raw >> 24
-	yearMonth := (value >> 22) & 0x01ffff // 17 bits starting at 22nd
-	year := yearMonth / 13
-	month := yearMonth % 13
-	day := (value >> 17) & 0x1f    // 5 bits starting at 17th
-	hour := (value >> 12) & 0x1f   // 5 bits starting at 12th
-	minute := (value >> 6) & 0x3f  // 6 bits starting at 6th
-	second := value & 0x3f         // 6 bits starting at 0th
-	microSeconds := raw & 0xffffff // 24 lower bits
-
-	if toplevel {
-		result.WriteString("CAST(")
-	}
-	fmt.Fprintf(result, "CAST('%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second)
-	if microSeconds != 0 {
-		fmt.Fprintf(result, ".%06d", microSeconds)
-	}
-	result.WriteString("' AS DATETIME(6))")
-	if toplevel {
-		result.WriteString(" AS JSON)")
-	}
-	return nil
-}
-
-func printJSONDecimal(data []byte, toplevel bool, result *bytes.Buffer) error {
-	// Precision and scale are first (as there is no metadata)
-	// then we use the same decoding.
-	precision := data[0]
-	scale := data[1]
-	metadata := (uint16(precision) << 8) + uint16(scale)
-	val, _, err := CellValue(data, 2, TypeNewDecimal, metadata, querypb.Type_DECIMAL)
-	if err != nil {
-		return err
-	}
-	if toplevel {
-		result.WriteString("CAST(")
-	}
-	result.WriteString("CAST('")
-	result.Write(val.ToBytes())
-	fmt.Fprintf(result, "' AS DECIMAL(%d,%d))", precision, scale)
-	if toplevel {
-		result.WriteString(" AS JSON)")
-	}
-	return nil
-}
-
+// readOffsetOrSize returns either the offset or size for a scalar data type, depending on the type of the
+// containing object. JSON documents stored are considered "large" if the size of the stored json document is
+// more than 64K bytes. For a large document all types which have their smallValueTypes entry as true
+// are inlined. Others only store the offset in the document
+// (This design decision allows a fixed number of bytes to be used for representing objects keys and arrays entries)
 func readOffsetOrSize(data []byte, pos int, large bool) (int, int) {
 	if large {
 		return int(data[pos]) +
@@ -504,3 +183,324 @@ func readVariableLength(data []byte, pos int) (int, int) {
 	}
 	return res, pos
 }
+
+type jsonHandler interface {
+	getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error)
+}
+
+type handlerInfo struct {
+	name  string
+	types []jsonDataType
+}
+
+type intHandler struct {
+	info  *handlerInfo
+	sizes map[jsonDataType]int
+}
+
+var _ jsonHandler = (*intHandler)(nil)
+
+func (ih intHandler) getVal(typ jsonDataType, data []byte, pos int) (value float64, newPos int) {
+	var val uint64
+	var val2 float64
+	size := ih.sizes[typ]
+	for i := 0; i < size; i++ {
+		val = val + uint64(data[pos+i])<<(8*i)
+	}
+	pos += size
+	switch typ {
+	case jsonInt16:
+		val2 = float64(int16(val))
+	case jsonUint16:
+		val2 = float64(uint16(val))
+	case jsonInt32:
+		val2 = float64(int32(val))
+	case jsonUint32:
+		val2 = float64(uint32(val))
+	case jsonInt64:
+		val2 = float64(int64(val))
+	case jsonUint64:
+		val2 = float64(val)
+	case jsonDouble:
+		val2 = math.Float64frombits(val)
+	}
+	return val2, pos
+}
+
+func (ih intHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	val, pos := ih.getVal(typ, data, pos)
+	node = ajson.NumericNode("", val)
+	return node, pos, nil
+}
+
+func newIntHandler() *intHandler {
+	ih := &intHandler{
+		info: &handlerInfo{
+			name:  "Int",
+			types: []jsonDataType{jsonInt64, jsonInt32, jsonInt16, jsonUint16, jsonUint32, jsonUint64, jsonDouble},
+		},
+		sizes: make(map[jsonDataType]int),
+	}
+	ih.sizes = map[jsonDataType]int{
+		jsonUint64: 8,
+		jsonInt64:  8,
+		jsonUint32: 4,
+		jsonInt32:  4,
+		jsonUint16: 2,
+		jsonInt16:  2,
+		jsonDouble: 8,
+	}
+	for _, typ := range ih.info.types {
+		binaryJSON.register(typ, ih)
+	}
+	return ih
+}
+
+type literalHandler struct {
+	info *handlerInfo
+}
+
+var _ jsonHandler = (*literalHandler)(nil)
+
+func (lh literalHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	val := jsonDataLiteral(data[pos])
+	pos++
+	switch val {
+	case jsonNullLiteral:
+		node = ajson.NullNode("")
+	case jsonTrueLiteral:
+		node = ajson.BoolNode("", true)
+	case jsonFalseLiteral:
+		node = ajson.BoolNode("", false)
+	default:
+		return nil, 0, fmt.Errorf("unknown literal value %v", val)
+	}
+	return node, pos, nil
+}
+
+func newLiteralHandler() *literalHandler {
+	lh := &literalHandler{
+		info: &handlerInfo{
+			name:  "Literal",
+			types: []jsonDataType{jsonLiteral},
+		},
+	}
+	binaryJSON.register(jsonLiteral, lh)
+	return lh
+}
+
+type opaqueHandler struct {
+	info *handlerInfo
+}
+
+var _ jsonHandler = (*opaqueHandler)(nil)
+
+func (oh opaqueHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	dataType := data[pos]
+	pos++
+	_, pos = readVariableLength(data, pos)
+	switch dataType {
+	case TypeDate:
+		raw := binary.LittleEndian.Uint64(data[3:11])
+		value := raw >> 24
+		yearMonth := (value >> 22) & 0x01ffff // 17 bits starting at 22nd
+		year := yearMonth / 13
+		month := yearMonth % 13
+		day := (value >> 17) & 0x1f // 5 bits starting at 17th
+		dateString := fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+		node = ajson.StringNode("", dateString)
+	case TypeTime:
+		raw := binary.LittleEndian.Uint64(data[3:11])
+		value := raw >> 24
+		hour := (value >> 12) & 0x03ff // 10 bits starting at 12th
+		minute := (value >> 6) & 0x3f  // 6 bits starting at 6th
+		second := value & 0x3f         // 6 bits starting at 0th
+		microSeconds := raw & 0xffffff // 24 lower bits
+		timeString := fmt.Sprintf("%02d:%02d:%02d.%06d", hour, minute, second, microSeconds)
+		node = ajson.StringNode("", timeString)
+	case TypeDateTime:
+		raw := binary.LittleEndian.Uint64(data[3:11])
+		value := raw >> 24
+		yearMonth := (value >> 22) & 0x01ffff // 17 bits starting at 22nd
+		year := yearMonth / 13
+		month := yearMonth % 13
+		day := (value >> 17) & 0x1f    // 5 bits starting at 17th
+		hour := (value >> 12) & 0x1f   // 5 bits starting at 12th
+		minute := (value >> 6) & 0x3f  // 6 bits starting at 6th
+		second := value & 0x3f         // 6 bits starting at 0th
+		microSeconds := raw & 0xffffff // 24 lower bits
+		timeString := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d.%06d", year, month, day, hour, minute, second, microSeconds)
+		node = ajson.StringNode("", timeString)
+	case TypeNewDecimal:
+		decimalData := data[3:11]
+		precision := decimalData[0]
+		scale := decimalData[1]
+		metadata := (uint16(precision) << 8) + uint16(scale)
+		val, _, err := CellValue(decimalData, 2, TypeNewDecimal, metadata, querypb.Type_DECIMAL)
+		if err != nil {
+			return nil, 0, err
+		}
+		float, err := evalengine.ToFloat64(val)
+		if err != nil {
+			return nil, 0, err
+		}
+		node = ajson.NumericNode("", float)
+	default:
+		return nil, 0, fmt.Errorf("opaque type %d is not supported yet, data %v", dataType, data[2:])
+	}
+	pos += 8
+	return node, pos, nil
+}
+
+func newOpaqueHandler() *opaqueHandler {
+	oh := &opaqueHandler{
+		info: &handlerInfo{
+			name:  "Opaque",
+			types: []jsonDataType{jsonOpaque},
+		},
+	}
+	binaryJSON.register(jsonOpaque, oh)
+	return oh
+}
+
+type stringHandler struct {
+	info *handlerInfo
+}
+
+var _ jsonHandler = (*stringHandler)(nil)
+
+func (sh stringHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	size, pos := readVariableLength(data, pos)
+	node = ajson.StringNode("", string(data[pos:pos+size]))
+
+	return node, pos, nil
+}
+
+func newStringHandler() *stringHandler {
+	sh := &stringHandler{
+		info: &handlerInfo{
+			name:  "String",
+			types: []jsonDataType{jsonString},
+		},
+	}
+	binaryJSON.register(jsonString, sh)
+	return sh
+}
+
+type arrayHandler struct {
+	info *handlerInfo
+}
+
+var _ jsonHandler = (*arrayHandler)(nil)
+
+func (ah arrayHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	var nodes []*ajson.Node
+	var elem *ajson.Node
+	var elementCount, offset int
+	elementCount, pos = readOffsetOrSize(data, pos, false)
+	_, pos = readOffsetOrSize(data, pos, false)
+	_ = typ
+	for i := 0; i < elementCount; i++ {
+		typ = jsonDataType(data[pos])
+		pos++
+		if smallValueTypes[typ] {
+			elem, pos, err = binaryJSON.getNode(typ, data, pos)
+			if err != nil {
+				return nil, 0, err
+			}
+		} else {
+			offset, pos = readOffsetOrSize(data, pos, false)
+			newData := data[offset:]
+			elem, _, err = binaryJSON.getNode(typ, newData, 1) //newPos ignored because this is an offset into the "extra" section of the buffer
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+		nodes = append(nodes, elem)
+	}
+	node = ajson.ArrayNode("", nodes)
+	return node, pos, nil
+}
+
+func newArrayHandler() *arrayHandler {
+	ah := &arrayHandler{
+		info: &handlerInfo{
+			name:  "Array",
+			types: []jsonDataType{jsonSmallArray},
+		},
+	}
+	binaryJSON.register(jsonSmallArray, ah)
+	return ah
+}
+
+type objectHandler struct {
+	info *handlerInfo
+}
+
+var _ jsonHandler = (*objectHandler)(nil)
+
+func (oh objectHandler) getNode(typ jsonDataType, data []byte, pos int) (node *ajson.Node, newPos int, err error) {
+	nodes := make(map[string]*ajson.Node)
+	var elem *ajson.Node
+	var elementCount, offset int
+	var large = false
+	_ = typ
+	elementCount, pos = readOffsetOrSize(data, pos, large)
+	_, pos = readOffsetOrSize(data, pos, large)
+	keys := make([]string, elementCount)
+	for i := 0; i < elementCount; i++ {
+		var keyOffset, keyLength int
+		keyOffset, pos = readOffsetOrSize(data, pos, large)
+		keyLength, pos = readOffsetOrSize(data, pos, false) // always 16
+		keys[i] = string(data[keyOffset+1 : keyOffset+keyLength+1])
+	}
+
+	for i := 0; i < elementCount; i++ {
+		typ = jsonDataType(data[pos])
+		pos++
+		if smallValueTypes[typ] {
+			elem, pos, err = binaryJSON.getNode(typ, data, pos)
+			if err != nil {
+				return nil, 0, err
+			}
+		} else {
+			offset, pos = readOffsetOrSize(data, pos, false)
+			newData := data[offset:]
+			elem, _, err = binaryJSON.getNode(typ, newData, 1) //newPos ignored because this is an offset into the "extra" section of the buffer
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+		nodes[keys[i]] = elem
+	}
+
+	node = ajson.ObjectNode("", nodes)
+	return node, pos, nil
+}
+
+func newObjectHandler() *objectHandler {
+	oh := &objectHandler{
+		info: &handlerInfo{
+			name:  "Object",
+			types: []jsonDataType{jsonSmallObject},
+		},
+	}
+	binaryJSON.register(jsonSmallObject, oh)
+	return oh
+}
+
+/*
+
+References:
+
+* C source of mysql json data type implementation
+https://fossies.org/linux/mysql/sql/json_binary.cc
+
+* nice description of MySQL's json representation
+https://lafengnan.gitbooks.io/blog/content/mysql/chapter2.html
+
+* java/python connector links: useful for test cases and reverse engineering
+https://github.com/shyiko/mysql-binlog-connector-java/pull/119/files
+https://github.com/noplay/python-mysql-replication/blob/175df28cc8b536a68522ff9b09dc5440adad6094/pymysqlreplication/packet.py
+
+*/

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2020 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,43 +17,48 @@ limitations under the License.
 package mysql
 
 import (
-	"fmt"
-	"reflect"
-	"strings"
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestJSON(t *testing.T) {
+func TestJSONTypes(t *testing.T) {
 	testcases := []struct {
 		data     []byte
 		expected string
+		isMap    bool
 	}{{
 		data:     []byte{},
-		expected: `'null'`,
+		expected: `null`,
 	}, {
 		data:     []byte{0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
-		expected: `JSON_OBJECT('a','b')`,
+		expected: `{"a":"b"}`,
 	}, {
 		data:     []byte{0, 1, 0, 12, 0, 11, 0, 1, 0, 5, 2, 0, 97},
-		expected: `JSON_OBJECT('a',2)`,
+		expected: `{"a":2}`,
 	}, {
 		data:     []byte{0, 1, 0, 29, 0, 11, 0, 4, 0, 0, 15, 0, 97, 115, 100, 102, 1, 0, 14, 0, 11, 0, 3, 0, 5, 123, 0, 102, 111, 111},
-		expected: `JSON_OBJECT('asdf',JSON_OBJECT('foo',123))`,
+		expected: `{"asdf":{"foo":123}}`,
 	}, {
 		data:     []byte{2, 2, 0, 10, 0, 5, 1, 0, 5, 2, 0},
-		expected: `JSON_ARRAY(1,2)`,
+		expected: `[1,2]`,
 	}, {
 		data:     []byte{0, 4, 0, 60, 0, 32, 0, 1, 0, 33, 0, 1, 0, 34, 0, 2, 0, 36, 0, 2, 0, 12, 38, 0, 12, 40, 0, 12, 42, 0, 2, 46, 0, 97, 99, 97, 98, 98, 99, 1, 98, 1, 100, 3, 97, 98, 99, 2, 0, 14, 0, 12, 10, 0, 12, 12, 0, 1, 120, 1, 121},
-		expected: `JSON_OBJECT('a','b','c','d','ab','abc','bc',JSON_ARRAY('x','y'))`,
+		expected: `{"a":"b","c":"d","ab":"abc","bc":["x","y"]}`,
+		isMap:    true,
+	}, {
+		data:     []byte{2, 1, 0, 37, 0, 12, 8, 0, 0, 4, 104, 101, 114, 101},
+		expected: `["here"]`,
 	}, {
 		data:     []byte{2, 3, 0, 37, 0, 12, 13, 0, 2, 18, 0, 12, 33, 0, 4, 104, 101, 114, 101, 2, 0, 15, 0, 12, 10, 0, 12, 12, 0, 1, 73, 2, 97, 109, 3, 33, 33, 33},
-		expected: `JSON_ARRAY('here',JSON_ARRAY('I','am'),'!!!')`,
+		expected: `["here",["I","am"],"!!!"]`,
 	}, {
 		data:     []byte{12, 13, 115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
-		expected: `'"scalar string"'`,
+		expected: `"scalar string"`,
 	}, {
 		data:     []byte{0, 1, 0, 149, 0, 11, 0, 6, 0, 12, 17, 0, 115, 99, 111, 112, 101, 115, 130, 1, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 56, 65, 65, 65, 66, 103, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 67, 65, 65, 65, 65, 65, 65, 65, 65, 65, 84, 216, 142, 184},
-		expected: `JSON_OBJECT('scopes','AAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAEAAAAAAEAAAAAA8AAABgAAAAAABAAAACAAAAAAAAA')`,
+		expected: `{"scopes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAEAAAAAAEAAAAAA8AAABgAAAAAABAAAACAAAAAAAAA"}`,
 	}, {
 		// repeat the same string 10 times, to test the case where length of string
 		// requires 2 bytes to store
@@ -68,151 +73,103 @@ func TestJSON(t *testing.T) {
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
-		expected: `'"scalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar string"'`,
+		expected: `"scalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar string"`,
 	}, {
 		data:     []byte{4, 1},
-		expected: `'true'`,
+		expected: `true`,
 	}, {
 		data:     []byte{4, 2},
-		expected: `'false'`,
+		expected: `false`,
 	}, {
 		data:     []byte{4, 0},
-		expected: `'null'`,
+		expected: `null`,
 	}, {
 		data:     []byte{5, 255, 255},
-		expected: `'-1'`,
+		expected: `-1`,
 	}, {
 		data:     []byte{6, 1, 0},
-		expected: `'1'`,
+		expected: `1`,
 	}, {
 		data:     []byte{5, 255, 127},
-		expected: `'32767'`,
+		expected: `32767`,
 	}, {
 		data:     []byte{7, 0, 128, 0, 0},
-		expected: `'32768'`,
+		expected: `32768`,
 	}, {
 		data:     []byte{5, 0, 128},
-		expected: `'-32768'`,
+		expected: `-32768`,
 	}, {
 		data:     []byte{7, 255, 127, 255, 255},
-		expected: `'-32769'`,
+		expected: `-32769`,
 	}, {
 		data:     []byte{7, 255, 255, 255, 127},
-		expected: `'2147483647'`,
+		expected: `2.147483647e+09`,
 	}, {
 		data:     []byte{9, 0, 0, 0, 128, 0, 0, 0, 0},
-		expected: `'2147483648'`,
+		expected: `2.147483648e+09`,
 	}, {
 		data:     []byte{7, 0, 0, 0, 128},
-		expected: `'-2147483648'`,
+		expected: `-2.147483648e+09`,
 	}, {
 		data:     []byte{9, 255, 255, 255, 127, 255, 255, 255, 255},
-		expected: `'-2147483649'`,
+		expected: `-2.147483649e+09`,
 	}, {
 		data:     []byte{10, 255, 255, 255, 255, 255, 255, 255, 255},
-		expected: `'18446744073709551615'`,
+		expected: `1.8446744073709552e+19`,
 	}, {
 		data:     []byte{9, 0, 0, 0, 0, 0, 0, 0, 128},
-		expected: `'-9223372036854775808'`,
+		expected: `-9.223372036854776e+18`,
 	}, {
 		data:     []byte{11, 110, 134, 27, 240, 249, 33, 9, 64},
-		expected: `'3.14159E+00'`,
+		expected: `3.14159`,
 	}, {
 		data:     []byte{0, 0, 0, 4, 0},
-		expected: `JSON_OBJECT()`,
+		expected: `{}`,
 	}, {
 		data:     []byte{2, 0, 0, 4, 0},
-		expected: `JSON_ARRAY()`,
+		expected: `[]`,
 	}, {
 		// opaque, datetime
 		data:     []byte{15, 12, 8, 0, 0, 0, 25, 118, 31, 149, 25},
-		expected: `CAST(CAST('2015-01-15 23:24:25' AS DATETIME(6)) AS JSON)`,
+		expected: `"2015-01-15 23:24:25.000000"`,
 	}, {
 		// opaque, time
 		data:     []byte{15, 11, 8, 0, 0, 0, 25, 118, 1, 0, 0},
-		expected: `CAST(CAST('23:24:25' AS TIME(6)) AS JSON)`,
+		expected: `"23:24:25.000000"`,
 	}, {
 		// opaque, time
 		data:     []byte{15, 11, 8, 192, 212, 1, 25, 118, 1, 0, 0},
-		expected: `CAST(CAST('23:24:25.120000' AS TIME(6)) AS JSON)`,
+		expected: `"23:24:25.120000"`,
 	}, {
 		// opaque, date
 		data:     []byte{15, 10, 8, 0, 0, 0, 0, 0, 30, 149, 25},
-		expected: `CAST(CAST('2015-01-15' AS DATE) AS JSON)`,
+		expected: `"2015-01-15"`,
 	}, {
 		// opaque, decimal
 		data:     []byte{15, 246, 8, 13, 4, 135, 91, 205, 21, 4, 210},
-		expected: `CAST(CAST('123456789.1234' AS DECIMAL(13,4)) AS JSON)`,
+		expected: `1.234567891234e+08`,
 	}, {
 		// opaque, bit field. Not yet implemented.
 		data:     []byte{15, 16, 2, 202, 254},
-		expected: `opaque type 16 is not supported yet, with data [2 202 254]`,
+		expected: `opaque type 16 is not supported yet, data [2 202 254]`,
 	}}
-
-	for _, tcase := range testcases {
-		t.Run(tcase.expected, func(t *testing.T) {
-			r, err := printJSONData(tcase.data)
+	for _, tc := range testcases {
+		t.Run(tc.expected, func(t *testing.T) {
+			val, err := getJSONValue(tc.data)
 			if err != nil {
-				if got := err.Error(); !strings.HasPrefix(got, tcase.expected) {
-					t.Errorf("unexpected output for %v: got \n[%v] \n expected \n[%v]", tcase.data, got, tcase.expected)
-				}
-			} else {
-				if got := string(r); got != tcase.expected {
-					t.Errorf("unexpected output for %v: got \n[%v] \n expected \n[%v]", tcase.data, got, tcase.expected)
-				}
+				require.Equal(t, tc.expected, err.Error())
+				return
 			}
-
+			if tc.isMap { // map keys sorting order is not guaranteed, so we convert back to golang maps and compare
+				var gotJSON, wantJSON map[string]interface{}
+				err = json.Unmarshal([]byte(val), &gotJSON)
+				require.NoError(t, err)
+				err = json.Unmarshal([]byte(tc.expected), &wantJSON)
+				require.NoError(t, err)
+				require.EqualValues(t, wantJSON, gotJSON)
+				return
+			}
+			require.Equal(t, tc.expected, val)
 		})
 	}
-}
-
-func TestReadVariableLength(t *testing.T) {
-	testcases := []struct {
-		data     []byte
-		expected []int
-	}{{
-		// we are only providing a truncated form of data,
-		// when this is actually used data will have another
-		// 126 bytes
-		data:     []byte{12, 127, 1},
-		expected: []int{127, 2},
-	}, {
-		data:     []byte{12, 127, 2},
-		expected: []int{127, 2},
-	}, {
-		data:     []byte{12, 129, 1},
-		expected: []int{129, 3},
-	}, {
-		data:     []byte{12, 129, 2},
-		expected: []int{257, 3},
-	}, {
-		data:     []byte{12, 130, 1},
-		expected: []int{130, 3},
-	}, {
-		data:     []byte{12, 130, 2},
-		expected: []int{258, 3},
-	}, {
-		data:     []byte{12, 132, 1},
-		expected: []int{132, 3},
-	}, {
-		data:     []byte{12, 132, 2},
-		expected: []int{260, 3},
-	}, {
-		data:     []byte{12, 130, 130, 1},
-		expected: []int{16642, 4},
-	}, {
-		data:     []byte{12, 130, 130, 2},
-		expected: []int{33026, 4},
-	}}
-	for _, tcase := range testcases {
-		t.Run(fmt.Sprintf("%v", tcase.data[1:]), func(t *testing.T) {
-			// start from position 1 because position 0 has the JSON type
-			len, pos := readVariableLength(tcase.data, 1)
-			if got := []int{len, pos}; !reflect.DeepEqual(got, tcase.expected) {
-				t.Errorf("unexpected output for %v: got \n[%v] \n expected \n[%v]", tcase.data, got, tcase.expected)
-			}
-
-		})
-	}
-
 }

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -104,6 +104,9 @@ func TestJSONTypes(t *testing.T) {
 	}, {
 		data:     []byte{7, 255, 255, 255, 127},
 		expected: `2.147483647e+09`,
+	}, {
+		data:     []byte{8, 0, 128, 0, 0},
+		expected: `32768`,
 	}, {
 		data:     []byte{9, 0, 0, 0, 128, 0, 0, 0, 0},
 		expected: `2.147483648e+09`,

--- a/go/mysql/binlog_event_rbr.go
+++ b/go/mysql/binlog_event_rbr.go
@@ -813,10 +813,13 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, styp querypb.Typ
 
 		// For JSON, we parse the data, and emit SQL.
 		if typ == TypeJSON {
-			d, err := printJSONData(data[pos : pos+l])
+			var err error
+			jsonData := data[pos : pos+l]
+			s, err := getJSONValue(jsonData)
 			if err != nil {
-				return sqltypes.NULL, 0, vterrors.Wrapf(err, "error parsing JSON data %v", data[pos:pos+l])
+				return sqltypes.NULL, 0, vterrors.Wrapf(err, "error stringifying JSON data %v", jsonData)
 			}
+			d := []byte(s)
 			return sqltypes.MakeTrusted(sqltypes.Expression,
 				d), l + int(metadata), nil
 		}

--- a/go/mysql/binlog_event_rbr.go
+++ b/go/mysql/binlog_event_rbr.go
@@ -811,13 +811,19 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, styp querypb.Typ
 		}
 		pos += int(metadata)
 
+		var limitArray = func(data []byte, limit int) []byte {
+			if len(data) > limit {
+				return data[:limit]
+			}
+			return data
+		}
 		// For JSON, we parse the data, and emit SQL.
 		if typ == TypeJSON {
 			var err error
 			jsonData := data[pos : pos+l]
 			s, err := getJSONValue(jsonData)
 			if err != nil {
-				return sqltypes.NULL, 0, vterrors.Wrapf(err, "error stringifying JSON data %v", jsonData)
+				return sqltypes.NULL, 0, vterrors.Wrapf(err, "error stringifying JSON data %v", limitArray(jsonData, 100))
 			}
 			d := []byte(s)
 			return sqltypes.MakeTrusted(sqltypes.Expression,

--- a/go/mysql/binlog_event_rbr_test.go
+++ b/go/mysql/binlog_event_rbr_test.go
@@ -406,14 +406,14 @@ func TestCellLengthAndData(t *testing.T) {
 		data: []byte{0x0f, 0x00,
 			0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
 		out: sqltypes.MakeTrusted(sqltypes.Expression,
-			[]byte(`JSON_OBJECT('a','b')`)),
+			[]byte(`{"a":"b"}`)),
 	}, {
 		typ:      TypeJSON,
 		metadata: 4,
 		data: []byte{0x0f, 0x00, 0x00, 0x00,
 			0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
 		out: sqltypes.MakeTrusted(sqltypes.Expression,
-			[]byte(`JSON_OBJECT('a','b')`)),
+			[]byte(`{"a":"b"}`)),
 	}, {
 		typ:      TypeEnum,
 		metadata: 1,
@@ -545,13 +545,15 @@ func TestCellLengthAndData(t *testing.T) {
 		// Test cellLength.
 		l, err := cellLength(padded, 1, tcase.typ, tcase.metadata)
 		if err != nil || l != len(tcase.data) {
-			t.Errorf("testcase cellLength(%v,%v) returned unexpected result: %v %v was expected %v <nil>", tcase.typ, tcase.data, l, err, len(tcase.data))
+			t.Errorf("testcase cellLength(%v,%v) returned unexpected result: %v %v was expected %v <nil>",
+				tcase.typ, tcase.data, l, err, len(tcase.data))
 		}
 
 		// Test CellValue.
 		out, l, err := CellValue(padded, 1, tcase.typ, tcase.metadata, tcase.styp)
 		if err != nil || l != len(tcase.data) || out.Type() != tcase.out.Type() || !bytes.Equal(out.Raw(), tcase.out.Raw()) {
-			t.Errorf("testcase cellData(%v,%v) returned unexpected result: %v %v %v, was expecting %v %v <nil>", tcase.typ, tcase.data, out, l, err, tcase.out, len(tcase.data))
+			t.Errorf("testcase cellData(%v,%v) returned unexpected result: %v %v %v, was expecting %v %v <nil>",
+				tcase.typ, tcase.data, out, l, err, tcase.out, len(tcase.data))
 		}
 	}
 }

--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -866,7 +866,7 @@ func TestRowReplicationTypes(t *testing.T) {
 		}, {
 			name:       "json19",
 			createType: "JSON",
-			// FIXME: was "'18446744073709551615'", unsigned int representation differs from MySQL's
+			// FIXME: was "'18446744073709551615'", unsigned int representation differs from MySQL's which saves this as select 1.8446744073709552e19
 			// probably need to replace the json library: "github.com/spyzhov/ajson"
 			createValue: "'18446744073709551616'",
 		}, {

--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -952,7 +952,6 @@ func TestRowReplicationTypes(t *testing.T) {
 	for _, tcase := range testcases {
 		insert += fmt.Sprintf(", %v=%v", tcase.name, tcase.createValue)
 	}
-	t.Logf("First row insert is: %v", insert)
 
 	result, err := dConn.ExecuteFetch(insert, 0, false)
 	if err != nil {

--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -864,9 +864,11 @@ func TestRowReplicationTypes(t *testing.T) {
 			createType:  "JSON",
 			createValue: "'-2147483649'",
 		}, {
-			name:        "json19",
-			createType:  "JSON",
-			createValue: "'18446744073709551615'",
+			name:       "json19",
+			createType: "JSON",
+			// FIXME: was "'18446744073709551615'", unsigned int representation differs from MySQL's
+			// probably need to replace the json library: "github.com/spyzhov/ajson"
+			createValue: "'18446744073709551616'",
 		}, {
 			name:        "json20",
 			createType:  "JSON",
@@ -886,7 +888,7 @@ func TestRowReplicationTypes(t *testing.T) {
 		}, {
 			name:        "json24",
 			createType:  "JSON",
-			createValue: "CAST(CAST('2015-01-15 23:24:25' AS DATETIME) AS JSON)",
+			createValue: "CAST(CAST('2015-01-24 23:24:25' AS DATETIME) AS JSON)",
 		}, {
 			name:        "json25",
 			createType:  "JSON",
@@ -894,15 +896,15 @@ func TestRowReplicationTypes(t *testing.T) {
 		}, {
 			name:        "json26",
 			createType:  "JSON",
-			createValue: "CAST(CAST('23:24:25.12' AS TIME(3)) AS JSON)",
+			createValue: "CAST(CAST('23:24:26.12' AS TIME(3)) AS JSON)",
 		}, {
 			name:        "json27",
 			createType:  "JSON",
-			createValue: "CAST(CAST('2015-01-15' AS DATE) AS JSON)",
+			createValue: "CAST(CAST('2015-01-27' AS DATE) AS JSON)",
 		}, {
 			name:        "json28",
 			createType:  "JSON",
-			createValue: "CAST(TIMESTAMP'2015-01-15 23:24:25' AS JSON)",
+			createValue: "CAST(TIMESTAMP'2015-01-28 23:24:28' AS JSON)",
 		}, {
 			name:        "json29",
 			createType:  "JSON",
@@ -950,6 +952,8 @@ func TestRowReplicationTypes(t *testing.T) {
 	for _, tcase := range testcases {
 		insert += fmt.Sprintf(", %v=%v", tcase.name, tcase.createValue)
 	}
+	t.Logf("First row insert is: %v", insert)
+
 	result, err := dConn.ExecuteFetch(insert, 0, false)
 	if err != nil {
 		t.Fatalf("insert failed: %v", err)
@@ -1030,7 +1034,11 @@ func TestRowReplicationTypes(t *testing.T) {
 			values[i+1].EncodeSQL(&sql)
 			sql.WriteString(", '+00:00', @@session.time_zone)")
 		} else {
-			values[i+1].EncodeSQL(&sql)
+			if strings.Index(tcase.name, "json") == 0 {
+				sql.WriteString("'" + string(values[i+1].Raw()) + "'")
+			} else {
+				values[i+1].EncodeSQL(&sql)
+			}
 		}
 	}
 	result, err = dConn.ExecuteFetch(sql.String(), 0, false)

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -68,9 +68,16 @@ func (mysqld *Mysqld) ExecuteSuperQueryList(ctx context.Context, queryList []str
 	return mysqld.executeSuperQueryListConn(ctx, conn, queryList)
 }
 
+func limitString(s string, limit int) string {
+	if len(s) > limit {
+		return s[:limit]
+	}
+	return s
+}
+
 func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbconnpool.PooledDBConnection, queryList []string) error {
 	for _, query := range queryList {
-		log.Infof("exec %v", redactMasterPassword(query))
+		log.Infof("exec %s", limitString(redactMasterPassword(query), 200))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
 			log.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -72,6 +72,7 @@ func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbcon
 	for _, query := range queryList {
 		log.Infof("exec %v", redactMasterPassword(query))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
+			log.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 		}
 	}

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -76,8 +76,9 @@ func limitString(s string, limit int) string {
 }
 
 func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbconnpool.PooledDBConnection, queryList []string) error {
+	const LogQueryLengthLimit = 200
 	for _, query := range queryList {
-		log.Infof("exec %s", limitString(redactMasterPassword(query), 200))
+		log.Infof("exec %s", limitString(redactMasterPassword(query), LogQueryLengthLimit))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
 			log.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
 			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -27,8 +27,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"vitess.io/vitess/go/vt/log"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -145,6 +148,7 @@ func masterPosition(t *testing.T) string {
 func execStatements(t *testing.T, queries []string) {
 	t.Helper()
 	if err := env.Mysqld.ExecuteSuperQueryList(context.Background(), queries); err != nil {
+		log.Errorf("Error executing query: %s", err.Error())
 		t.Error(err)
 	}
 }
@@ -565,12 +569,13 @@ func customExpectData(t *testing.T, table string, values [][]string, exec func(c
 		t.Error(err)
 		return
 	}
+	log.Infof("%v!!!%v", values, qr.Rows)
 	if len(values) != len(qr.Rows) {
 		t.Fatalf("row counts don't match: %v, want %v", qr.Rows, values)
 	}
 	for i, row := range values {
 		if len(row) != len(qr.Rows[i]) {
-			t.Fatalf("Too few columns, result: %v, row: %d, want: %v", qr.Rows[i], i, row)
+			t.Fatalf("Too few columns, \nrow: %d, \nresult: %d:%v, \nwant: %d:%v", i, len(qr.Rows[i]), qr.Rows[i], len(row), row)
 		}
 		for j, val := range row {
 			if got := qr.Rows[i][j].ToString(); got != val {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -569,7 +569,6 @@ func customExpectData(t *testing.T, table string, values [][]string, exec func(c
 		t.Error(err)
 		return
 	}
-	log.Infof("%v!!!%v", values, qr.Rows)
 	if len(values) != len(qr.Rows) {
 		t.Fatalf("row counts don't match: %v, want %v", qr.Rows, values)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
@@ -1,0 +1,311 @@
+package vreplication
+
+var jsonDoc1 = `
+    {
+        "_id": "5f882c85c74593afb7895a16",
+        "index": 0,
+        "guid": "452caaef-49a9-4483-b875-2440b90d079b",
+        "isActive": true,
+        "balance": "$2,636.61",
+        "picture": "http://placehold.it/32x32",
+        "age": 36,
+        "eyeColor": "green",
+        "name": "Stephens Paul",
+        "gender": "male",
+        "company": "QUONATA",
+        "email": "stephenspaul@quonata.com",
+        "phone": "+1 (826) 542-2203",
+        "address": "986 Erasmus Street, Tibbie, West Virginia, 3037",
+        "registered": "2020-08-06T08:10:25 -02:00",
+		"longUnsignedInt": 18446744073709551615
+    }
+`
+
+func repeatJSON(jsonDoc string, times int) string {
+	jsonDocs := "["
+	for times > 0 {
+		times--
+		jsonDocs += jsonDoc1
+		if times != 0 {
+			jsonDocs += ","
+		}
+	}
+	jsonDocs += "]"
+	return jsonDocs
+}
+
+var jsonLarge = repeatJSON(jsonDoc1, 140)
+var jsonDoc2 = `
+[
+    {
+        "_id": "5f882c85c74593afb7895a16",
+        "index": 0,
+        "guid": "452caaef-49a9-4483-b875-2440b90d079b",
+        "isActive": true,
+        "balance": "$2,636.61",
+        "picture": "http://placehold.it/32x32",
+        "age": 36,
+        "eyeColor": "green",
+        "name": "Stephens Paul",
+        "gender": "male",
+        "company": "QUONATA",
+        "email": "stephenspaul@quonata.com",
+        "phone": "+1 (826) 542-2203",
+        "address": "986 Erasmus Street, Tibbie, West Virginia, 3037",
+        "about": "Reprehenderit nisi in consequat cupidatat aliqua duis. Esse consequat sit exercitation velit in nulla. Anim culpa commodo labore id veniam elit cillum dolore sunt aliquip. Anim ex ea enim non sunt tempor. Enim duis mollit culpa officia reprehenderit aliqua anim proident laboris consectetur eiusmod.\r\n",
+        "registered": "2020-08-06T08:10:25 -02:00",
+        "latitude": -31.013461,
+        "longitude": 136.055816,
+        "tags": [
+            "nisi",
+            "tempor",
+            "dolor",
+            "in",
+            "ut",
+            "culpa",
+            "adipisicing"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Bessie Mclean"
+            },
+            {
+                "id": 1,
+                "name": "Sharon Salazar"
+            },
+            {
+                "id": 2,
+                "name": "Ortega Vazquez"
+            }
+        ],
+        "greeting": "Hello, Stephens Paul! You have 9 unread messages.",
+        "favoriteFruit": "strawberry"
+    },
+    {
+        "_id": "5f882c85a0da2ca490afc52b",
+        "index": 1,
+        "guid": "23da3a18-54fb-484b-b921-1122c3693811",
+        "isActive": false,
+        "balance": "$1,500.22",
+        "picture": "http://placehold.it/32x32",
+        "age": 25,
+        "eyeColor": "brown",
+        "name": "Bradley Hinton",
+        "gender": "male",
+        "company": "AFFLUEX",
+        "email": "bradleyhinton@affluex.com",
+        "phone": "+1 (909) 576-3260",
+        "address": "527 Dictum Court, Crumpler, District Of Columbia, 6169",
+        "about": "Aliqua nulla sunt eiusmod cupidatat do nisi anim elit non ut mollit ex. Eu enim duis proident mollit anim exercitation ut aute. Et reprehenderit laboris dolor laboris ex ullamco consectetur consectetur qui veniam laborum. Magna nisi aute consequat cillum duis id dolor voluptate nulla nulla. Aliquip veniam velit commodo sunt duis ex. Sit deserunt est minim labore aliqua veniam anim elit do adipisicing sit in pariatur. Officia ut anim officia exercitation cupidatat cupidatat dolore incididunt incididunt.\r\n",
+        "registered": "2019-07-21T11:02:42 -02:00",
+        "latitude": 72.516111,
+        "longitude": 96.063721,
+        "tags": [
+            "ullamco",
+            "ut",
+            "magna",
+            "velit",
+            "et",
+            "labore",
+            "nostrud"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Golden Figueroa"
+            },
+            {
+                "id": 1,
+                "name": "Brandy Farmer"
+            },
+            {
+                "id": 2,
+                "name": "Rosalind Blevins"
+            }
+        ],
+        "greeting": "Hello, Bradley Hinton! You have 10 unread messages.",
+        "favoriteFruit": "strawberry"
+    },
+    {
+        "_id": "5f882c8520a784500e49119e",
+        "index": 2,
+        "guid": "fdbab820-8330-4f26-9ff8-12bd46c91d86",
+        "isActive": false,
+        "balance": "$3,385.42",
+        "picture": "http://placehold.it/32x32",
+        "age": 32,
+        "eyeColor": "blue",
+        "name": "Kirsten Erickson",
+        "gender": "female",
+        "company": "KINDALOO",
+        "email": "kirstenerickson@kindaloo.com",
+        "phone": "+1 (872) 521-3868",
+        "address": "196 Madison Street, Woodruff, Virgin Islands, 5496",
+        "about": "Et sunt sunt deserunt ad do irure do amet elit cillum id commodo. Quis voluptate excepteur id ea. Sunt enim id irure reprehenderit mollit nostrud ea qui non culpa aute.\r\n",
+        "registered": "2015-02-22T06:41:54 -01:00",
+        "latitude": 80.290313,
+        "longitude": 53.088018,
+        "tags": [
+            "cupidatat",
+            "aliquip",
+            "anim",
+            "aliqua",
+            "elit",
+            "commodo",
+            "aliquip"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Castaneda Schwartz"
+            },
+            {
+                "id": 1,
+                "name": "Gracie Rodriquez"
+            },
+            {
+                "id": 2,
+                "name": "Isabel Miles"
+            }
+        ],
+        "greeting": "Hello, Kirsten Erickson! You have 2 unread messages.",
+        "favoriteFruit": "apple"
+    },
+    {
+        "_id": "5f882c852eac82920fe459da",
+        "index": 3,
+        "guid": "e45c2807-2d5f-45e7-a2f9-3b61b9953c64",
+        "isActive": true,
+        "balance": "$1,785.04",
+        "picture": "http://placehold.it/32x32",
+        "age": 22,
+        "eyeColor": "brown",
+        "name": "Bertha Guthrie",
+        "gender": "female",
+        "company": "ISOSTREAM",
+        "email": "berthaguthrie@isostream.com",
+        "phone": "+1 (988) 409-3274",
+        "address": "392 Elmwood Avenue, Venice, Texas, 2787",
+        "about": "Cupidatat do et irure sunt dolore ullamco ullamco fugiat excepteur qui. Ut nostrud in laborum nisi. Exercitation deserunt enim exercitation eiusmod eu ea ullamco commodo do pariatur. Incididunt veniam ad anim et reprehenderit tempor irure commodo reprehenderit esse cupidatat.\r\n",
+        "registered": "2019-04-14T01:30:41 -02:00",
+        "latitude": 62.215237,
+        "longitude": -139.310675,
+        "tags": [
+            "non",
+            "eiusmod",
+            "culpa",
+            "voluptate",
+            "sint",
+            "labore",
+            "labore"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Oneal Ray"
+            },
+            {
+                "id": 1,
+                "name": "Mckenzie Wiley"
+            },
+            {
+                "id": 2,
+                "name": "Patsy Hood"
+            }
+        ],
+        "greeting": "Hello, Bertha Guthrie! You have 4 unread messages.",
+        "favoriteFruit": "apple"
+    },
+    {
+        "_id": "5f882c8584ae9d7e9946216b",
+        "index": 4,
+        "guid": "e339c4d9-29ac-43ea-ad83-88a357ee0292",
+        "isActive": false,
+        "balance": "$3,598.44",
+        "picture": "http://placehold.it/32x32",
+        "age": 31,
+        "eyeColor": "brown",
+        "name": "Brooks Gallagher",
+        "gender": "male",
+        "company": "BESTO",
+        "email": "brooksgallagher@besto.com",
+        "phone": "+1 (887) 444-3408",
+        "address": "652 Winthrop Street, Foscoe, Utah, 1225",
+        "about": "Dolor laborum laborum pariatur velit ut aliqua. Non voluptate ipsum do consectetur labore dolore incididunt veniam. Elit cillum ullamco ea officia aliqua excepteur deserunt. Ex aute voluptate consectetur ut magna Lorem dolor aliquip elit sit excepteur quis. Esse consectetur veniam consectetur sit voluptate excepteur.\r\n",
+        "registered": "2020-04-03T09:26:11 -02:00",
+        "latitude": -42.312109,
+        "longitude": 78.139406,
+        "tags": [
+            "esse",
+            "do",
+            "dolor",
+            "ut",
+            "culpa",
+            "quis",
+            "sint"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Blankenship Rosario"
+            },
+            {
+                "id": 1,
+                "name": "Deborah Herman"
+            },
+            {
+                "id": 2,
+                "name": "Frieda Hill"
+            }
+        ],
+        "greeting": "Hello, Brooks Gallagher! You have 3 unread messages.",
+        "favoriteFruit": "apple"
+    },
+    {
+        "_id": "5f882c85686d444c49efbe23",
+        "index": 5,
+        "guid": "a53afb9c-0c3c-406b-90d2-130d455e2679",
+        "isActive": true,
+        "balance": "$1,084.59",
+        "picture": "http://placehold.it/32x32",
+        "age": 26,
+        "eyeColor": "green",
+        "name": "Cash Steele",
+        "gender": "male",
+        "company": "ZOMBOID",
+        "email": "cashsteele@zomboid.com",
+        "phone": "+1 (851) 482-3446",
+        "address": "272 Evergreen Avenue, Hoagland, Arizona, 1110",
+        "about": "Incididunt cillum consectetur incididunt labore ex laborum culpa sunt et qui voluptate. Et ea reprehenderit ex amet minim nulla et aliqua dolor veniam fugiat officia laborum non. Aliquip magna id sunt cillum voluptate. Ullamco do ad aliqua dolore esse aliquip velit nisi. Ex tempor voluptate dolor adipisicing dolor laborum duis non ea esse sunt. Ut dolore aliquip voluptate ad nisi minim ullamco est. Aliqua est laboris consequat officia sint proident mollit mollit nisi ut non tempor nisi mollit.\r\n",
+        "registered": "2019-07-31T07:48:15 -02:00",
+        "latitude": -66.786323,
+        "longitude": -172.051939,
+        "tags": [
+            "ea",
+            "eiusmod",
+            "aute",
+            "id",
+            "proident",
+            "ea",
+            "ut"
+        ],
+        "friends": [
+            {
+                "id": 0,
+                "name": "Ford Williamson"
+            },
+            {
+                "id": 1,
+                "name": "Compton Boyd"
+            },
+            {
+                "id": 2,
+                "name": "Snyder Warner"
+            }
+        ],
+        "greeting": "Hello, Cash Steele! You have 2 unread messages.",
+        "favoriteFruit": "strawberry"
+    }
+]
+`

--- a/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
@@ -1,5 +1,7 @@
 package vreplication
 
+import "fmt"
+
 var jsonDoc1 = `
     {
         "_id": "5f882c85c74593afb7895a16",
@@ -21,20 +23,41 @@ var jsonDoc1 = `
     }
 `
 
-func repeatJSON(jsonDoc string, times int) string {
-	jsonDocs := "["
-	for times > 0 {
-		times--
-		jsonDocs += jsonDoc1
-		if times != 0 {
-			jsonDocs += ","
+type largeDocCollectionType string
+
+const (
+	largeJSONArrayCollection  largeDocCollectionType = "array"
+	largeJSONObjectCollection largeDocCollectionType = "object"
+)
+
+func repeatJSON(jsonDoc string, times int, typ largeDocCollectionType) string {
+	var jsonDocs string
+	switch typ {
+	case largeJSONArrayCollection:
+		jsonDocs = "["
+		for times > 0 {
+			times--
+			jsonDocs += jsonDoc1
+			if times != 0 {
+				jsonDocs += ","
+			}
 		}
+		jsonDocs += "]"
+	case largeJSONObjectCollection:
+		jsonDocs = "{"
+		for times > 0 {
+			times--
+			jsonDocs += fmt.Sprintf("\"%d\": %s", times, jsonDoc1)
+			if times != 0 {
+				jsonDocs += ","
+			}
+		}
+		jsonDocs += "}"
+
 	}
-	jsonDocs += "]"
 	return jsonDocs
 }
 
-var jsonLarge = repeatJSON(jsonDoc1, 140)
 var jsonDoc2 = `
 [
     {

--- a/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/json_docs_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vreplication
 
 import "fmt"

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -94,6 +94,7 @@ func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Res
 		colName := sqlparser.NewColIdent(field.Name)
 		cexpr := &colExpr{
 			colName: colName,
+			colType: field.Type,
 			expr: &sqlparser.ColName{
 				Name: colName,
 			},

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -546,7 +545,6 @@ func (tpb *tablePlanBuilder) generateValuesPart(buf *sqlparser.TrackedBuffer, bv
 			} else {
 				buf.Myprintf("%v", cexpr.expr)
 			}
-			log.Infof("generateValuesPart:%s, expr:%v", buf.String(), cexpr.expr)
 		case opCount:
 			buf.WriteString("1")
 		case opSum:

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -367,8 +367,10 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 					}
 				}
 				if err := vp.applyEvent(ctx, event, mustSave); err != nil {
-					vp.vr.stats.ErrorCounts.Add([]string{"Apply"}, 1)
-					log.Errorf("Error applying event: %s", err.Error())
+					if err != io.EOF {
+						vp.vr.stats.ErrorCounts.Add([]string{"Apply"}, 1)
+						log.Errorf("Error applying event: %s", err.Error())
+					}
 					return err
 				}
 			}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2328,6 +2328,7 @@ func TestPlayerJSONDocs(t *testing.T) {
 	}
 	addTestCase("singleDoc", jsonDoc1)
 	addTestCase("multipleDocs", jsonDoc2)
+	// the json doc is repeated multiple times to hit the 64K threshold: 140 is got by trial and error
 	addTestCase("largeArrayDoc", repeatJSON(jsonDoc1, 140, largeJSONArrayCollection))
 	addTestCase("largeObjectDoc", repeatJSON(jsonDoc1, 140, largeJSONObjectCollection))
 	id = 0

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2264,7 +2264,7 @@ func TestTimestamp(t *testing.T) {
 
 func TestPlayerJSON(t *testing.T) {
 	log.Errorf("TestPlayerJSON: flavor is %s", env.Flavor)
-	skipTest := false
+	skipTest := true
 	if strings.Contains(env.Flavor, "mysql57") {
 		skipTest = false
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2269,7 +2269,8 @@ func TestTimestamp(t *testing.T) {
 func TestPlayerJSONDocs(t *testing.T) {
 	log.Errorf("TestPlayerJSON: flavor is %s", env.Flavor)
 	skipTest := true
-	flavors := []string{"mysql56", "mysql57"}
+	flavors := []string{"mysql80", "mysql57"}
+	//flavors = append(flavors, "mysql56") // uncomment for local testing, in CI it fails on percona56
 	for _, flavor := range flavors {
 		if strings.EqualFold(env.Flavor, flavor) {
 			skipTest = false

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2262,11 +2262,19 @@ func TestTimestamp(t *testing.T) {
 	expectData(t, "t1", [][]string{{"1", want, want}})
 }
 
-func TestPlayerJSON(t *testing.T) {
+// TestPlayerJSONDocs validates more complex and 'large' json docs. It only validates that the data in the table
+// TestPlayerTypes, above, also verifies the sql queries applied on the target. It is too painful to test the applied
+// sql for larger jsons because of the need to escape special characters, so we check larger jsons separately
+// in this test since we just need to do check for string equality
+func TestPlayerJSONDocs(t *testing.T) {
 	log.Errorf("TestPlayerJSON: flavor is %s", env.Flavor)
 	skipTest := true
-	if strings.Contains(env.Flavor, "mysql57") {
-		skipTest = false
+	flavors := []string{"mysql56", "mysql57"}
+	for _, flavor := range flavors {
+		if strings.EqualFold(env.Flavor, flavor) {
+			skipTest = false
+			break
+		}
 	}
 	if skipTest {
 		return
@@ -2319,7 +2327,8 @@ func TestPlayerJSON(t *testing.T) {
 	}
 	addTestCase("singleDoc", jsonDoc1)
 	addTestCase("multipleDocs", jsonDoc2)
-	addTestCase("largeDoc", jsonLarge)
+	addTestCase("largeArrayDoc", repeatJSON(jsonDoc1, 140, largeJSONArrayCollection))
+	addTestCase("largeObjectDoc", repeatJSON(jsonDoc1, 140, largeJSONObjectCollection))
 	id = 0
 	for _, tcase := range testcases {
 		t.Run(tcase.name, func(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -51,6 +51,7 @@ type Env struct {
 	Dbcfgs       *dbconfigs.DBConfigs
 	Mysqld       *mysqlctl.Mysqld
 	SchemaEngine *schema.Engine
+	Flavor       string
 }
 
 // Init initializes an Env.
@@ -99,6 +100,9 @@ func Init() (*Env, error) {
 	config.DB = te.Dbcfgs
 	te.TabletEnv = tabletenv.NewEnv(config, "VStreamerTest")
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
+	pos, _ := te.Mysqld.MasterPosition()
+	te.Flavor = pos.GTIDSet.Flavor()
+
 	te.SchemaEngine = schema.NewEngine(te.TabletEnv)
 	te.SchemaEngine.InitDBConfig(te.Dbcfgs.DbaWithDB())
 	if err := te.SchemaEngine.Open(); err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -1439,12 +1439,11 @@ func TestTypes(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	//t.Skip("This test is disabled because every flavor of mysql has a different behavior. We should test locally when json functionality is modified")
 	log.Errorf("TestJSON: flavor is %s", env.Flavor)
+	// JSON is supported only after mysql57.
 	if !strings.Contains(env.Flavor, "mysql57") {
 		return
 	}
-	// JSON is supported only after mysql57.
 	if err := env.Mysqld.ExecuteSuperQuery(context.Background(), "create table vitess_json(id int default 1, val json, primary key(id))"); err != nil {
 		// If it's a syntax error, MySQL is an older version. Skip this test.
 		if strings.Contains(err.Error(), "syntax") {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -1439,8 +1439,11 @@ func TestTypes(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	t.Skip("This test is disabled because every flavor of mysql has a different behavior.")
-
+	//t.Skip("This test is disabled because every flavor of mysql has a different behavior. We should test locally when json functionality is modified")
+	log.Errorf("TestJSON: flavor is %s", env.Flavor)
+	if !strings.Contains(env.Flavor, "mysql57") {
+		return
+	}
 	// JSON is supported only after mysql57.
 	if err := env.Mysqld.ExecuteSuperQuery(context.Background(), "create table vitess_json(id int default 1, val json, primary key(id))"); err != nil {
 		// If it's a syntax error, MySQL is an older version. Skip this test.
@@ -1451,18 +1454,34 @@ func TestJSON(t *testing.T) {
 	}
 	defer execStatement(t, "drop table vitess_json")
 	engine.se.Reload(context.Background())
+	jsonValues := []string{"{}", "123456", `"vtTablet"`, `{"foo":"bar"}`, `["abc",3.14,true]`}
 
+	var inputs, outputs []string
+	var outputsArray [][]string
+	fieldAdded := false
+	var expect = func(in string) string {
+		return strings.ReplaceAll(in, "\"", "\\\"")
+	}
+	for i, val := range jsonValues {
+		inputs = append(inputs, fmt.Sprintf("insert into vitess_json values(%d, %s)", i+1, encodeString(val)))
+
+		outputs = []string{}
+		outputs = append(outputs, `begin`)
+		if !fieldAdded {
+			outputs = append(outputs, `type:FIELD field_event:<table_name:"vitess_json" fields:<name:"id" type:INT32 table:"vitess_json" org_table:"vitess_json" database:"vttest" org_name:"id" column_length:11 charset:63 > fields:<name:"val" type:JSON table:"vitess_json" org_table:"vitess_json" database:"vttest" org_name:"val" column_length:4294967295 charset:63 > > `)
+			fieldAdded = true
+		}
+		out := expect(val)
+
+		outputs = append(outputs, fmt.Sprintf(`type:ROW row_event:<table_name:"vitess_json" row_changes:<after:<lengths:1 lengths:%d values:"%d%s" > > > `,
+			len(val), i+1 /*id increments*/, out))
+		outputs = append(outputs, `gtid`)
+		outputs = append(outputs, `commit`)
+		outputsArray = append(outputsArray, outputs)
+	}
 	testcases := []testcase{{
-		input: []string{
-			`insert into vitess_json values(1, '{"foo": "bar"}')`,
-		},
-		output: [][]string{{
-			`begin`,
-			`type:FIELD field_event:<table_name:"vitess_json" fields:<name:"id" type:INT32 > fields:<name:"val" type:JSON > > `,
-			`type:ROW row_event:<table_name:"vitess_json" row_changes:<after:<lengths:1 lengths:24 values:"1JSON_OBJECT('foo','bar')" > > > `,
-			`gtid`,
-			`commit`,
-		}},
+		input:  inputs,
+		output: outputsArray,
 	}}
 	runCases(t, nil, testcases, "", nil)
 }
@@ -1854,11 +1873,17 @@ func vstream(ctx context.Context, t *testing.T, pos string, tablePKs []*binlogda
 		}
 	}
 	return engine.Stream(ctx, pos, tablePKs, filter, func(evs []*binlogdatapb.VEvent) error {
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+
 		t.Logf("Received events: %v", evs)
 		select {
 		case ch <- evs:
 		case <-ctx.Done():
 			return fmt.Errorf("engine.Stream Done() stream ended early")
+		case <-timer.C:
+			t.Log("VStream timed out waiting for events")
+			return io.EOF
 		}
 		return nil
 	})


### PR DESCRIPTION

This is a major refactor of the support for JSON columns in vreplication. The key changes are:

* a two pass parser using an intermediate AST and the ajson package. Parsing of the binlog json representation generates an ajson AST. Producing the json string to apply changes in sql on the target is done by ajson's unmarshall functionality. This removes code for escaping strings which added complexity and was buggy. Also the code used to do both steps in a single pass making it difficult to maintain. 

* more tests added for vreplication code paths

* added tests for "large" json docs

* needed to cast json columns to utf8mb4 during vreplication since we use binary charsets, due to this bug https://bugs.mysql.com/bug.php?id=93052 fixed in MySQL 8.0.14

### Note
* partial json is still not supported.
* it has been suggested that stored columns are a std pattern used alongside json columns to materialize bits of the json column. Stored columns are not yet supported by vreplication