### PR TITLE
Unnest simple subqueries

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -371,6 +371,17 @@ func TestUseStmtInOLAP(t *testing.T) {
 	}
 }
 
+func TestInformationSchemaWithSubquery(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result := exec(t, conn, "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = (SELECT SCHEMA()) AND TABLE_NAME = 'not_exists'")
+	assert.Empty(t, result.Rows)
+}
+
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
 	qr := exec(t, conn, query)

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -41,7 +41,7 @@ func RewriteAST(in Statement) (*RewriteASTResult, error) {
 	er := newExpressionRewriter()
 	er.shouldRewriteDatabaseFunc = shouldRewriteDatabaseFunc(in)
 	setRewriter := &setNormalizer{}
-	out, ok := Rewrite(in, er.goingDown, setRewriter.rewriteSetComingUp).(Statement)
+	out, ok := Rewrite(in, er.rewrite, setRewriter.rewriteSetComingUp).(Statement)
 	if !ok {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "statement rewriting returned a non statement: %s", String(out))
 	}

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlparser
+
+import (
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+// RewriteASTResult contains the rewritten ast and meta information about it
+type RewriteASTResult struct {
+	*BindVarNeeds
+	AST Statement // The rewritten AST
+}
+
+// PrepareAST will normalize the query
+func PrepareAST(in Statement, bindVars map[string]*querypb.BindVariable, prefix string, parameterize bool) (*RewriteASTResult, error) {
+	if parameterize {
+		Normalize(in, bindVars, prefix)
+	}
+	return RewriteAST(in)
+}
+
+// RewriteAST rewrites the whole AST, replacing function calls and adding column aliases to queries
+func RewriteAST(in Statement) (*RewriteASTResult, error) {
+	er := newExpressionRewriter()
+	er.shouldRewriteDatabaseFunc = shouldRewriteDatabaseFunc(in)
+	setRewriter := &setNormalizer{}
+	out, ok := Rewrite(in, er.goingDown, setRewriter.rewriteSetComingUp).(Statement)
+	if !ok {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "statement rewriting returned a non statement: %s", String(out))
+	}
+	if setRewriter.err != nil {
+		return nil, setRewriter.err
+	}
+
+	r := &RewriteASTResult{
+		AST:          out,
+		BindVarNeeds: er.bindVars,
+	}
+	return r, nil
+}

--- a/go/vt/sqlparser/bind_var_needs.go
+++ b/go/vt/sqlparser/bind_var_needs.go
@@ -22,6 +22,7 @@ type BindVarNeeds struct {
 	NeedSystemVariable,
 	// NeedUserDefinedVariables keeps track of all user defined variables a query is using
 	NeedUserDefinedVariables []string
+	otherRewrites bool
 }
 
 //MergeWith adds bind vars needs coming from sub scopes
@@ -56,8 +57,13 @@ func (bvn *BindVarNeeds) NeedsSysVar(name string) bool {
 	return contains(bvn.NeedSystemVariable, name)
 }
 
+func (bvn *BindVarNeeds) NoteRewrite() {
+	bvn.otherRewrites = true
+}
+
 func (bvn *BindVarNeeds) HasRewrites() bool {
-	return len(bvn.NeedFunctionResult) > 0 ||
+	return bvn.otherRewrites ||
+		len(bvn.NeedFunctionResult) > 0 ||
 		len(bvn.NeedUserDefinedVariables) > 0 ||
 		len(bvn.NeedSystemVariable) > 0
 }

--- a/go/vt/sqlparser/rewriter_api.go
+++ b/go/vt/sqlparser/rewriter_api.go
@@ -88,4 +88,5 @@ func (c *Cursor) Parent() SQLNode { return c.parent }
 // replace the object with something of the wrong type, or the visitor will panic.
 func (c *Cursor) Replace(newNode SQLNode) {
 	c.replacer(newNode, c.parent)
+	c.node = newNode
 }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -875,8 +875,27 @@
     },
     "TargetTabletType": "MASTER",
     "MultiShardAutocommit": false,
-    "Query": "insert into unsharded values ((select 1 from dual), 1)",
+    "Query": "insert into unsharded values (1, 1)",
     "TableName": "unsharded"
+  }
+}
+
+# sharded insert subquery in insert value
+"insert into user(id, val) values((select 1), 1)"
+{
+  "QueryType": "INSERT",
+  "Original": "insert into user(id, val) values((select 1), 1)",
+  "Instructions": {
+    "OperatorType": "Insert",
+    "Variant": "Sharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "MASTER",
+    "MultiShardAutocommit": false,
+    "Query": "insert into user(id, val, Name, Costly) values (:_Id_0, 1, :_Name_0, :_Costly_0)",
+    "TableName": "user"
   }
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -282,10 +282,6 @@
 "insert into user(id) select 1 from dual"
 "unsupported: insert into select"
 
-# sharded insert subquery in insert value
-"insert into user(id, val) values((select 1), 1)"
-"unsupported: subquery in insert values"
-
 # sharded replace no vindex
 "replace into user(val) values(1, 'foo')"
 "unsupported: REPLACE INTO with sharded schema"


### PR DESCRIPTION
This PR adds logic to simplify subquery expressions that are simple to unnest.

If a query contains an expression looking something like:

```
SELECT * FROM user WHERE col = (SELECT 42)
```

this PR will unnest that subquery so that the query that is planned is instead:

```
SELECT * FROM user WHERE col = 42
```


Fixes #6827