### PR TITLE
Update `operator.yaml` backup engine description 

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -1164,11 +1164,8 @@ spec:
               properties:
                 engine:
                   description: 'Engine specifies the Vitess backup engine to use,
-                    either "builtin" or "xtrabackup". Note that if you change this
-                    after a Vitess cluster is already deployed, you must roll the
-                    change out to all tablets and then take a new backup from one
-                    tablet in each shard. Otherwise, new tablets trying to restore
-                    will find that the latest backup was created with the wrong engine.
+                    either "builtin" or "xtrabackup". Restores will always be done
+                    with whichever engine created a given backup.
                     Default: builtin'
                   enum:
                   - builtin


### PR DESCRIPTION
## Description
Hi Team.

I have been testing the backup configuration and I believe the backup engine description included in `operator.yaml` is not accurate. As specified in [backupengine.go\#L41](https://github.com/vitessio/vitess/blob/58f8fbb9343817815548a3f1994e11645df8d961/go/vt/mysqlctl/backupengine.go\#L41) the restores will always be done with whichever engine created the backup.

I have successfully performed the following tests:
1. Restore a tablet with `xtrabackup` configuration in a running Shard with tablets configured with `builtin` option. The tablet is successfully restored using the existing builtin backup.
2. Backup the newly restored tablet. The backup is done using `xtrabackup` as expected.
3. Restore a tablet with `xtrabackup` configuration. The restore succeeds using the latest backup taken with `xtrabackup`.

I hope this helps. Please let me know if my understanding is not correct.

Thanks ;)