### PR TITLE
Docker - upgrade to Debian Buster

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,34 +1,21 @@
-FROM golang:1.13-stretch
+FROM golang:1.13-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # TODO(mberlin): Group these to make it easier to understand which library actually requires them.
-    automake \
-    bison \
-    bzip2 \
+    ant \
     chromium \
     curl \
+    default-jdk \
+    etcd \
     g++ \
     git \
-    libgconf-2-4 \
-    libtool \
     make \
-    openjdk-8-jdk \
+    maven \
     software-properties-common \
-    virtualenv \
     unzip \
-    xvfb \
     zip \
-    libz-dev \
-    ant \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Maven 3.1+
-RUN mkdir -p /vt/src/vitess.io/vitess/dist && \
-    cd /vt/src/vitess.io/vitess/dist && \
-    curl -sL --connect-timeout 10 --retry 3 \
-        http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar -xz && \
-    mv apache-maven-3.3.9 maven
 
 # Set up Vitess environment (equivalent to '. dev.env')
 ENV VTROOT /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mariadb103
+++ b/docker/bootstrap/Dockerfile.mariadb103
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10.3
 RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8 \
-    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian stretch main' \
+    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian buster main' \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        mariadb-server-10.3 \
        libmariadb-dev \

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -1,10 +1,16 @@
 FROM vitess/bootstrap:common
 
 # Install MySQL 5.6
+#
+# Unfortunately we need to keep the 'stretch' repo from Oracle as there's no official support
+# for MySQL 5.6 for Debian Buster: https://bugs.mysql.com/bug.php?id=101055
+#
+# I think it's fine as MySQL 5.6 will be EOL pretty soon (February 5, 2021)
+#
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -3,9 +3,9 @@ FROM vitess/bootstrap:common
 # Install MySQL 5.7
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
     for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.7' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -2,9 +2,9 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-8.0' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -1,8 +1,19 @@
 FROM vitess/bootstrap:common
 
 # Install Percona 5.6
+#
+# Unfortunately we need to keep the 'stretch' repo from Percona as there's no official support
+# for MySQL 5.6 for Debian Buster
+#
+# I think it's fine as MySQL 5.6 will be EOL pretty soon (February 5, 2021)
+#
+# Also, for the 'percona-xtrabackup-24' package we need to specificly target the
+# 'buster' repository as the 'stretch' package requires 'libcurl3' that is not present
+# in Debian Buster.
+#
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
     add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \
@@ -10,7 +21,8 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     } | debconf-set-selections && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 percona-xtrabackup-24 && \
+        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 && \
+    apt-get install -y -t buster percona-xtrabackup-24 && \
     rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 5.7
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
@@ -11,7 +11,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     apt-get update && \
     apt-get install -y --no-install-recommends \
         percona-server-server-5.7 \
-	libperconaserverclient18.1-dev percona-xtrabackup-24 && \
+	libperconaserverclient20-dev percona-xtrabackup-24 && \
     rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done \
-    && echo 'deb http://repo.percona.com/ps-80/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
+    && echo 'deb http://repo.percona.com/ps-80/apt buster main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
@@ -19,7 +19,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 	rsync \
 	libev4 \
 #    && rm -f /etc/apt/sources.list.d/percona.list \
-    && echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list \
+    && echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list \
 #    { \
 #        echo debconf debconf/frontend select Noninteractive; \
 #        echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.testing
+++ b/docker/lite/Dockerfile.testing
@@ -30,7 +30,7 @@ USER vitess
 RUN make install-testing PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -126,30 +126,30 @@ add_apt_key 9334A25F8507EFA5
 # Add extra apt repositories for MySQL.
 case "${FLAVOR}" in
 mysql56)
-    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.6' > /etc/apt/sources.list.d/mysql.list
     ;;
 mysql57)
-    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.7' > /etc/apt/sources.list.d/mysql.list
     ;;
 mysql80)
-    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-8.0' > /etc/apt/sources.list.d/mysql.list
     ;;
 mariadb)
-    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/debian stretch main' > /etc/apt/sources.list.d/mariadb.list
+    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/debian buster main' > /etc/apt/sources.list.d/mariadb.list
     ;;
 mariadb103)
-    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian stretch main' > /etc/apt/sources.list.d/mariadb.list
+    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian buster main' > /etc/apt/sources.list.d/mariadb.list
     ;;
 esac
 
 # Add extra apt repositories for Percona Server and/or Percona XtraBackup.
 case "${FLAVOR}" in
 mysql56|mysql57|mysql80|percona|percona57)
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list
     ;;
 percona80)
-    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list
-    echo 'deb http://repo.percona.com/ps-80/apt stretch main' > /etc/apt/sources.list.d/percona80.list
+    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list
+    echo 'deb http://repo.percona.com/ps-80/apt buster main' > /etc/apt/sources.list.d/percona80.list
     ;;
 esac
 

--- a/docker/orchestrator/build.sh
+++ b/docker/orchestrator/build.sh
@@ -23,7 +23,7 @@ script="go get vitess.io/vitess/go/cmd/vtctlclient && \
   go install github.com/openark/orchestrator/go/cmd/orchestrator"
 
 echo "Building orchestrator..."
-docker run -ti --name=vt_orc_build golang:1.14.4-stretch bash -c "$script"
+docker run -ti --name=vt_orc_build golang:1.14.4-buster bash -c "$script"
 docker cp vt_orc_build:/go/bin/orchestrator $tmpdir
 docker cp vt_orc_build:/go/bin/vtctlclient $tmpdir
 docker cp vt_orc_build:/go/src/github.com/openark/orchestrator/resources $tmpdir


### PR DESCRIPTION
## Description 
Upgrade Docker images from Debian 9 (stretch) to Debian 10 (Buster). This PR was highly inspired by https://github.com/vitessio/vitess/pull/6129 (happy to close this if Morgan wants to complete his PR).

This PR also includes the following changes:

- move from `openjdk-8-jdk` to `default-jdk`
- removed misc dependencies no longer need
- install maven and etcd from repos

## Why
Debian Stretch is EOL since 2020-07-06 and Buster was released in July 2019. This deprecation is also blocking us from upgrading to go 1.15 https://github.com/vitessio/vitess/pull/6792

## Test plan
I'm not sure if it's enough but the build of the bootstrap images completes ✅  
<details>

```
➜  vitess git:(buster) ✗ make docker_bootstrap
building bootstrap image: common
[+] Building 132.7s (13/13) FINISHED
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load build definition from Dockerfile.common                                     0.0s
 => => transferring dockerfile: 1.63kB                                                          0.0s
 => [internal] load metadata for docker.io/library/golang:1.13-buster                           1.3s
 => CACHED [1/8] FROM docker.io/library/golang:1.13-buster@sha256:66a3f6817c129f48c9cc9b96816a  0.0s
 => [internal] load build context                                                               0.0s
 => => transferring context: 2.52kB                                                             0.0s
 => [2/8] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-instal  86.4s
 => [3/8] COPY bootstrap.sh dev.env build.env go.mod go.sum /vt/src/vitess.io/vitess/           0.1s
 => [4/8] COPY config /vt/src/vitess.io/vitess/config                                           0.0s
 => [5/8] COPY tools /vt/src/vitess.io/vitess/tools                                             0.0s
 => [6/8] RUN groupadd -r vitess && useradd -r -g vitess vitess &&     mkdir -p /vt/vtdataroot  0.4s
 => [7/8] RUN cd /vt/src/vitess.io/vitess &&  su vitess -c "/usr/local/go/bin/go mod download  23.1s
 => [8/8] RUN su vitess -c "mkdir -p /vt/src/vitess.io/vitess/bin && rm -rf /vt/bin && ln -s /  0.6s
 => exporting to image                                                                         20.5s
 => => exporting layers                                                                        20.5s
 => => writing image sha256:78d98e5dd8de19995cdedacd9be5792d359d5fb6ddbe5f00132837489dfc887d    0.0s
 => => naming to docker.io/vitess/bootstrap:common                                              0.0s
building bootstrap image: mariadb
[+] Building 138.6s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.mariadb                                    0.0s
 => => transferring dockerfile: 1.00kB                                                          0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => [1/4] FROM docker.io/vitess/bootstrap:common                                                0.0s
 => => resolve docker.io/vitess/bootstrap:common                                                0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv  23.2s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  113.1s
 => exporting to image                                                                          2.1s
 => => exporting layers                                                                         2.0s
 => => writing image sha256:684cf2f68ed14d4b98db7705c48e8fee5cac172fbe96cc13edca92180eb29f86    0.0s
 => => naming to docker.io/vitess/bootstrap:mariadb                                             0.0s
building bootstrap image: mariadb103
[+] Building 165.2s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.mariadb103                                 0.0s
 => => transferring dockerfile: 611B                                                            0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74  42.6s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  120.4s
 => exporting to image                                                                          2.1s
 => => exporting layers                                                                         2.1s
 => => writing image sha256:c6cef2f5804658c1326d77fe2eb8c08a2cc42c91ce9e58e5f2a5f3227a411ce9    0.0s
 => => naming to docker.io/vitess/bootstrap:mariadb103                                          0.0s
building bootstrap image: mysql56
[+] Building 143.9s (8/8) FINISHED
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load build definition from Dockerfile.mysql56                                    0.0s
 => => transferring dockerfile: 1.39kB                                                          0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver pool.sks-  23.2s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  118.3s
 => exporting to image                                                                          2.3s
 => => exporting layers                                                                         2.3s
 => => writing image sha256:8ff377036cd82787a2b8532f35be431c10605a272c160e445cb39e14aeab62f2    0.0s
 => => naming to docker.io/vitess/bootstrap:mysql56                                             0.0s
building bootstrap image: mysql57
[+] Building 216.1s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.mysql57                                    0.0s
 => => transferring dockerfile: 1.27kB                                                          0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-instal  29.9s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  183.5s
 => exporting to image                                                                          2.6s
 => => exporting layers                                                                         2.6s
 => => writing image sha256:6bac5de811e65e888ff032cdb0fc636e1f197d56d4698a3c5c0bcdc5e47a7c42    0.0s
 => => naming to docker.io/vitess/bootstrap:mysql57                                             0.0s
building bootstrap image: mysql80
[+] Building 180.7s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.mysql80                                    0.0s
 => => transferring dockerfile: 1.19kB                                                          0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.s  58.9s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  118.2s
 => exporting to image                                                                          3.5s
 => => exporting layers                                                                         3.5s
 => => writing image sha256:39fb8500858388aa5080a92034239cffe18f5f7c31de49b6f10e6e9d89e9c8e2    0.0s
 => => naming to docker.io/vitess/bootstrap:mysql80                                             0.0s
building bootstrap image: percona
[+] Building 167.5s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.percona                                    0.0s
 => => transferring dockerfile: 1.42kB                                                          0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv  35.0s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  130.6s
 => exporting to image                                                                          1.8s
 => => exporting layers                                                                         1.8s
 => => writing image sha256:0cb3fd21184053b63937a93aa964f7edef12d5356c97d9bba805f3bc6f4e97fb    0.0s
 => => naming to docker.io/vitess/bootstrap:percona                                             0.0s
building bootstrap image: percona57
[+] Building 141.3s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.percona57                                  0.0s
 => => transferring dockerfile: 894B                                                            0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv  33.6s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  105.3s
 => exporting to image                                                                          2.4s
 => => exporting layers                                                                         2.3s
 => => writing image sha256:082a38ec46cd1a114ceffc4b7b44cbd170efb68e288227cb2f99fbf2eaac4801    0.0s
 => => naming to docker.io/vitess/bootstrap:percona57                                           0.0s
building bootstrap image: percona80
[+] Building 613.9s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.percona80                                  0.0s
 => => transferring dockerfile: 1.58kB                                                          0.0s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 35B                                                                0.0s
 => [internal] load metadata for docker.io/vitess/bootstrap:common                              0.0s
 => CACHED [1/4] FROM docker.io/vitess/bootstrap:common                                         0.0s
 => [2/4] RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --rec  504.1s
 => [3/4] WORKDIR /vt/src/vitess.io/vitess                                                      0.0s
 => [4/4] RUN ./bootstrap.sh                                                                  105.0s
 => exporting to image                                                                          4.7s
 => => exporting layers                                                                         4.7s
 => => writing image sha256:8d657e9ac443da406417326e70b10f7d0be0e5f64032e40d8f1fbed1b9319bda    0.0s
 => => naming to docker.io/vitess/bootstrap:percona80                                           0.0s
```

</details>