### PR TITLE
Improvements to queryz

### DIFF
--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -171,18 +171,19 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 	w.Write(queryzHeader)
 
 	queryParams := r.URL.Query()
+
+	clearCacheQp, ok := queryParams["clear_cache"]
+	if ok && len(clearCacheQp) == 1 && clearCacheQp[0] == "true" {
+		queryzResetCacheHandler(qe, w, r)
+		return
+	}
+
 	sorterQp, ok := queryParams["sort"]
 	var sortQp string
 	if !ok || len(sorterQp) == 0 {
 		sortQp = "time_per_query"
 	} else {
 		sortQp = sorterQp[0]
-	}
-
-	clearCacheQp, ok := queryParams["clear_cache"]
-	if ok && len(clearCacheQp) == 1 && clearCacheQp[0] == "true" {
-		queryzResetCacheHandler(qe, w, r)
-		return
 	}
 
 	keys := qe.plans.Keys()


### PR DESCRIPTION
* Adds supports for multiple sorters: counts per query, mysql time per query and
rows per query.
* Also exposes a way to reset the cache, so the counters can have a fresh start.
This could be useful to debug issues with unexpected changes in query patterns.
For tablets that have been running for a long time, the history outweights
potentially new queries that are being introduced. Ideally we would like some
sort of graph that shows this is in a more obvious way, but the reset is an easy
change that gives significant benefits as well.

Signed-off-by: Rafael Chacon <rafael@slack-corp.com>