### PR TITLE
Add timeout for mysqld_shutdown

### DIFF
--- a/go/vt/hook/hook.go
+++ b/go/vt/hook/hook.go
@@ -128,12 +128,12 @@ func (hook *Hook) findHook(ctx context.Context) (*exec.Cmd, int, error) {
 	return cmd, HOOK_SUCCESS, nil
 }
 
-// Execute tries to execute the Hook and returns a HookResult.
-func (hook *Hook) Execute() (result *HookResult) {
+// ExecuteContext tries to execute the Hook with the given context and returns a HookResult.
+func (hook *Hook) ExecuteContext(ctx context.Context) (result *HookResult) {
 	result = &HookResult{}
 
 	// Find the hook.
-	cmd, status, err := hook.findHook(context.Background())
+	cmd, status, err := hook.findHook(ctx)
 	if err != nil {
 		result.ExitStatus = status
 		result.Stderr = err.Error() + "\n"
@@ -161,6 +161,11 @@ func (hook *Hook) Execute() (result *HookResult) {
 	log.Infof("hook: result is %v", result.String())
 
 	return result
+}
+
+// Execute tries to execute the Hook and returns a HookResult.
+func (hook *Hook) Execute() (result *HookResult) {
+	return hook.ExecuteContext(context.Background())
 }
 
 // ExecuteOptional executes an optional hook, logs if it doesn't

--- a/go/vt/hook/hook_test.go
+++ b/go/vt/hook/hook_test.go
@@ -1,0 +1,39 @@
+package hook
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vtenv "vitess.io/vitess/go/vt/env"
+)
+
+func TestExecuteContext(t *testing.T) {
+	vtroot, err := vtenv.VtRoot()
+	require.NoError(t, err)
+
+	sleep, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+
+	sleepHookPath := path.Join(vtroot, "vthook", "sleep")
+	require.NoError(t, os.Symlink(sleep, sleepHookPath))
+	defer func() {
+		require.NoError(t, os.Remove(sleepHookPath))
+	}()
+
+	h := NewHook("sleep", []string{"5"})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
+	defer cancel()
+
+	hr := h.ExecuteContext(ctx)
+	assert.Equal(t, HOOK_TIMEOUT_ERROR, hr.ExitStatus)
+
+	h.Parameters = []string{"0.1"}
+	hr = h.Execute()
+	assert.Equal(t, HOOK_SUCCESS, hr.ExitStatus)
+}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -49,7 +49,10 @@ const (
 )
 
 var (
-	builtinBackupMysqldDeadline = flag.Duration("builtinbackup_mysqld_deadline", time.Minute, "how long to wait for mysqld to shutdown at the start of the backup")
+	// BuiltinBackupMysqldDeadline is how long ExecuteBackup should wait for response from mysqld.Shutdown.
+	// It can later be extended for other calls to mysqld during backup functions.
+	// Exported for testing.
+	BuiltinBackupMysqldDeadline = flag.Duration("builtinbackup_mysqld_deadline", 10*time.Minute, "how long to wait for mysqld to shutdown at the start of the backup")
 )
 
 // BuiltinBackupEngine encapsulates the logic of the builtin engine
@@ -187,7 +190,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 	params.Logger.Infof("using replication position: %v", replicationPosition)
 
 	// shutdown mysqld
-	shutdownCtx, cancel := context.WithTimeout(ctx, *builtinBackupMysqldDeadline)
+	shutdownCtx, cancel := context.WithTimeout(ctx, *BuiltinBackupMysqldDeadline)
 	err = params.Mysqld.Shutdown(shutdownCtx, params.Cnf, true)
 	defer cancel()
 	if err != nil {

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -49,10 +49,10 @@ const (
 )
 
 var (
-	// BuiltinBackupMysqldDeadline is how long ExecuteBackup should wait for response from mysqld.Shutdown.
+	// BuiltinBackupMysqldTimeout is how long ExecuteBackup should wait for response from mysqld.Shutdown.
 	// It can later be extended for other calls to mysqld during backup functions.
 	// Exported for testing.
-	BuiltinBackupMysqldDeadline = flag.Duration("builtinbackup_mysqld_deadline", 10*time.Minute, "how long to wait for mysqld to shutdown at the start of the backup")
+	BuiltinBackupMysqldTimeout = flag.Duration("builtinbackup_mysqld_timeout", 10*time.Minute, "how long to wait for mysqld to shutdown at the start of the backup")
 )
 
 // BuiltinBackupEngine encapsulates the logic of the builtin engine
@@ -190,7 +190,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 	params.Logger.Infof("using replication position: %v", replicationPosition)
 
 	// shutdown mysqld
-	shutdownCtx, cancel := context.WithTimeout(ctx, *BuiltinBackupMysqldDeadline)
+	shutdownCtx, cancel := context.WithTimeout(ctx, *BuiltinBackupMysqldTimeout)
 	err = params.Mysqld.Shutdown(shutdownCtx, params.Cnf, true)
 	defer cancel()
 	if err != nil {

--- a/go/vt/mysqlctl/builtinbackupengine_test.go
+++ b/go/vt/mysqlctl/builtinbackupengine_test.go
@@ -1,0 +1,135 @@
+// Package mysqlctl_test is the blackbox tests for package mysqlctl.
+// Tests that need to use fakemysqldaemon must be written as blackbox tests;
+// since fakemysqldaemon imports mysqlctl, importing fakemysqldaemon in
+// a `package mysqlctl` test would cause a circular import.
+package mysqlctl_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
+	"vitess.io/vitess/go/vt/mysqlctl/filebackupstorage"
+	"vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vttime"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vttablet/faketmclient"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+)
+
+func setBuiltinBackupMysqldDeadline(t time.Duration) time.Duration {
+	old := *mysqlctl.BuiltinBackupMysqldDeadline
+	mysqlctl.BuiltinBackupMysqldDeadline = &t
+
+	return old
+}
+
+func createBackupDir(root string, dirs ...string) error {
+	for _, dir := range dirs {
+		if err := os.MkdirAll(path.Join(root, dir), 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestExecuteBackup(t *testing.T) {
+	// Set up local backup directory
+	backupRoot := "testdata/builtinbackup_test"
+	*filebackupstorage.FileBackupStorageRoot = backupRoot
+	require.NoError(t, createBackupDir(backupRoot, "innodb", "log", "datadir"))
+	defer os.RemoveAll(backupRoot)
+
+	ctx := context.Background()
+
+	// Set up topo
+	keyspace, shard := "mykeyspace", "-80"
+	ts := memorytopo.NewServer("cell1")
+	defer ts.Close()
+
+	require.NoError(t, ts.CreateKeyspace(ctx, keyspace, &topodata.Keyspace{}))
+	require.NoError(t, ts.CreateShard(ctx, keyspace, shard))
+
+	tablet := topo.NewTablet(100, "cell1", "mykeyspace-00-80-0100")
+	tablet.Keyspace = keyspace
+	tablet.Shard = shard
+
+	require.NoError(t, ts.CreateTablet(ctx, tablet))
+
+	_, err := ts.UpdateShardFields(ctx, keyspace, shard, func(si *topo.ShardInfo) error {
+		si.MasterAlias = &topodata.TabletAlias{Uid: 100, Cell: "cell1"}
+
+		now := time.Now()
+		si.MasterTermStartTime = &vttime.Time{Seconds: int64(now.Second()), Nanoseconds: int32(now.Nanosecond())}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Set up tm client
+	// Note that using faketmclient.NewFakeTabletManagerClient will cause infinite recursion :shrug:
+	tmclient.RegisterTabletManagerClientFactory("grpc",
+		func() tmclient.TabletManagerClient { return &faketmclient.FakeTabletManagerClient{} },
+	)
+
+	be := &mysqlctl.BuiltinBackupEngine{}
+
+	// Configure a tight deadline to force a timeout
+	oldDeadline := setBuiltinBackupMysqldDeadline(time.Second)
+	defer setBuiltinBackupMysqldDeadline(oldDeadline)
+
+	bh := filebackupstorage.FileBackupHandle{}
+
+	// Spin up a fake daemon to be used in backups. It needs to be allowed to receive:
+	//  "STOP SLAVE", "START SLAVE", in that order.
+	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(fakesqldb.New(t))
+	mysqld.ExpectedExecuteSuperQueryList = []string{"STOP SLAVE", "START SLAVE"}
+	// mysqld.ShutdownTime = time.Minute
+
+	ok, err := be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+		Logger: logutil.NewConsoleLogger(),
+		Mysqld: mysqld,
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		HookExtraEnv: map[string]string{},
+		TopoServer:   ts,
+		Keyspace:     keyspace,
+		Shard:        shard,
+	}, &bh)
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	mysqld.ExpectedExecuteSuperQueryCurrent = 0 // resest the index of what queries we've run
+	mysqld.ShutdownTime = time.Minute           // reminder that shutdownDeadline is 1s
+
+	ok, err = be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+		Logger: logutil.NewConsoleLogger(),
+		Mysqld: mysqld,
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		HookExtraEnv: map[string]string{},
+		TopoServer:   ts,
+		Keyspace:     keyspace,
+		Shard:        shard,
+	}, &bh)
+
+	assert.Error(t, err)
+	assert.False(t, ok)
+}

--- a/go/vt/mysqlctl/builtinbackupengine_test.go
+++ b/go/vt/mysqlctl/builtinbackupengine_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func setBuiltinBackupMysqldDeadline(t time.Duration) time.Duration {
-	old := *mysqlctl.BuiltinBackupMysqldDeadline
-	mysqlctl.BuiltinBackupMysqldDeadline = &t
+	old := *mysqlctl.BuiltinBackupMysqldTimeout
+	mysqlctl.BuiltinBackupMysqldTimeout = &t
 
 	return old
 }

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -48,6 +48,14 @@ type FakeMysqlDaemon struct {
 	// Running is used by Start / Shutdown
 	Running bool
 
+	// StartupTime is used to simulate mysqlds that take some time to respond
+	// to a "start" command. It is used by Start.
+	StartupTime time.Duration
+
+	// ShutdownTime is used to simulate mysqlds that take some time to respond
+	// to a "stop" request (i.e. a wedged systemd unit). It is used by Shutdown.
+	ShutdownTime time.Duration
+
 	// MysqlPort will be returned by GetMysqlPort(). Set to -1 to
 	// return an error.
 	MysqlPort sync2.AtomicInt32
@@ -181,6 +189,15 @@ func (fmd *FakeMysqlDaemon) Start(ctx context.Context, cnf *mysqlctl.Mycnf, mysq
 	if fmd.Running {
 		return fmt.Errorf("fake mysql daemon already running")
 	}
+
+	if fmd.StartupTime > 0 {
+		select {
+		case <-time.After(fmd.StartupTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	fmd.Running = true
 	return nil
 }
@@ -190,6 +207,15 @@ func (fmd *FakeMysqlDaemon) Shutdown(ctx context.Context, cnf *mysqlctl.Mycnf, w
 	if !fmd.Running {
 		return fmt.Errorf("fake mysql daemon not running")
 	}
+
+	if fmd.ShutdownTime > 0 {
+		select {
+		case <-time.After(fmd.ShutdownTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	fmd.Running = false
 	return nil
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -512,7 +512,7 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 
 	// try the mysqld shutdown hook, if any
 	h := hook.NewSimpleHook("mysqld_shutdown")
-	hr := h.Execute()
+	hr := h.ExecuteContext(ctx)
 	switch hr.ExitStatus {
 	case hook.HOOK_SUCCESS:
 		// hook exists and worked, we can keep going


### PR DESCRIPTION
Resolves #6848 

Notable changes:
- hooks can now be passed contexts via the `ExecuteContext` method. All hooks are now implemented with `exec.CommandContext` under the hood instead of `exec.Command`. Current callers are unaffected, and can opt in to switching over at their discretion.
- adds a new `HookResult.ExitStatus` type for hooks that exceed their context deadline/timeout.
- `FakeMysqlDaemon.Start()` and `FakeMysqlDaemon.Shutdown()` are configurable via the `FakeMysqlDaemon.StartupTime` and `FakeMysqlDaemon.ShutdownTime` respectively, to artificially cause delay in tests.
