### PR TITLE
healthcheck: should receive healthcheck updates from all tablets in cells_to_watch

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -313,10 +313,6 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 // It does not block on making connection.
 // name is an optional tag for the tablet, e.g. an alternative address.
 func (hc *HealthCheckImpl) AddTablet(tablet *topodata.Tablet) {
-	// check whether we should really add this tablet
-	if !hc.isIncluded(tablet) {
-		return
-	}
 	// check whether grpc port is present on tablet, if not return
 	if tablet.PortMap["grpc"] == 0 {
 		return
@@ -368,9 +364,6 @@ func (hc *HealthCheckImpl) AddTablet(tablet *topodata.Tablet) {
 // RemoveTablet removes the tablet, and stops the health check.
 // It does not block.
 func (hc *HealthCheckImpl) RemoveTablet(tablet *topodata.Tablet) {
-	if !hc.isIncluded(tablet) {
-		return
-	}
 	hc.deleteTablet(tablet)
 }
 
@@ -453,7 +446,10 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 			all := hc.healthData[targetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
-				allArray = append(allArray, s)
+				// only tablets in same cell / cellAlias are included in healthy list
+				if hc.isIncluded(shr) {
+					allArray = append(allArray, s)
+				}
 			}
 			hc.healthy[targetKey] = FilterStatsByReplicationLag(allArray)
 		}
@@ -462,7 +458,10 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 			all := hc.healthData[oldTargetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
-				allArray = append(allArray, s)
+				// only tablets in same cell / cellAlias are included in healthy list
+				if hc.isIncluded(shr) {
+					allArray = append(allArray, s)
+				}
 			}
 			hc.healthy[oldTargetKey] = FilterStatsByReplicationLag(allArray)
 		}
@@ -703,10 +702,8 @@ func (hc *HealthCheckImpl) keyFromTablet(tablet *topodata.Tablet) keyspaceShardT
 	return keyspaceShardTabletType(fmt.Sprintf("%s.%s.%s", tablet.Keyspace, tablet.Shard, topoproto.TabletTypeLString(tablet.Type)))
 }
 
+// getAliasByCell should only be called while holding hc.mu
 func (hc *HealthCheckImpl) getAliasByCell(cell string) string {
-	hc.mu.Lock()
-	defer hc.mu.Unlock()
-
 	if alias, ok := hc.cellAliases[cell]; ok {
 		return alias
 	}
@@ -719,14 +716,14 @@ func (hc *HealthCheckImpl) getAliasByCell(cell string) string {
 	return alias
 }
 
-func (hc *HealthCheckImpl) isIncluded(tablet *topodata.Tablet) bool {
-	if tablet.Type == topodata.TabletType_MASTER {
+func (hc *HealthCheckImpl) isIncluded(shr *query.StreamHealthResponse) bool {
+	if shr.Target.TabletType == topodata.TabletType_MASTER {
 		return true
 	}
-	if tablet.Alias.Cell == hc.cell {
+	if shr.TabletAlias.Cell == hc.cell {
 		return true
 	}
-	if hc.getAliasByCell(tablet.Alias.Cell) == hc.getAliasByCell(hc.cell) {
+	if hc.getAliasByCell(shr.TabletAlias.Cell) == hc.getAliasByCell(hc.cell) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Healthcheck was incorrectly excluding non-local cell tablets. This fix ensures that healthcheck will connect to and monitor all tablets in `cells_to_watch`. However, only tablets that are MASTER/local cell/same cell alias will be stored in the list of healthy tablets.
Fixes #6846 

Testing:
- added unit tests
- manually tested with local multi-cell cluster

Signed-off-by: deepthi <deepthi@planetscale.com>