### PR TITLE
Adding CI test for CODEOWNERS coverage

### DIFF
--- a/.github/workflows/check_codeowners.yml
+++ b/.github/workflows/check_codeowners.yml
@@ -1,0 +1,21 @@
+name: check_codeowners
+on: [pull_request]
+jobs:
+
+  build:
+    name: Check codeowners
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Run codeowners check
+      run: |
+        OUTPUT_FILE=/tmp/files-not-owned
+        tools/check_codeowners.sh > $OUTPUT_FILE
+        if [ -s "$OUTPUT_FILE" ] ; then
+          echo "# $(wc -l "$OUTPUT_FILE") files not covered by CODEOWNERS:"
+          cat "$OUTPUT_FILE"
+          exit 1
+        fi

--- a/tools/check_codeowners.sh
+++ b/tools/check_codeowners.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+find . -type f | grep -v '^./.git' | while read -r f ; do git check-ignore "$f" || echo "$f" ; done | while read -r f ; do
+  # A file not ignored by .gitignore. Let's check if it's covered by CODEOWNERS
+  f="${f#"."}"
+  grep -E "^/" .github/CODEOWNERS | awk '{print $1}' | while read -r p ; do
+    case "$f" in
+      $p) ;;       # Perfect math. All good.
+      $p/*) ;;     # Prefix (path) match. All good.
+      *) exit 1 ;; # No match: an error
+    esac
+  done && exit 0
+  # If we're stil here, then that means no CODEOWNER was found for file $f
+  echo "$f" 
+done > /dev/null 

--- a/tools/check_codeowners.sh
+++ b/tools/check_codeowners.sh
@@ -12,4 +12,4 @@ find . -type f | grep -v '^./.git' | while read -r f ; do git check-ignore "$f" 
   done && exit 0
   # If we're stil here, then that means no CODEOWNER was found for file $f
   echo "$f" 
-done > /dev/null 
+done


### PR DESCRIPTION
Closes https://github.com/vitessio/vitess/issues/6838

This PR adds a CI test, `check_codeowners` that verifies each file in this repo is owned by at least one codeowners.

Our [CODEOWNERS](https://github.com/vitessio/vitess/blob/master/.github/CODEOWNERS) has a default fallback: 

https://github.com/vitessio/vitess/blob/870ef4df2694c4ea6b4ec0ad9912ccb8e4f082ba/.github/CODEOWNERS#L1

This trivially means every file is covered, so the CI test ignores this trivial ownership, and requires an explicit ownership for a specific file or a specific directory prefix.