### PR TITLE
[8.0] Disable reserved connections by default

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -71,7 +71,7 @@ var (
 	warnPayloadSize    = flag.Int("warn_payload_size", 0, "The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.")
 
 	// Put set-passthrough under a flag.
-	sysVarSetEnabled = flag.Bool("enable_system_settings", true, "This will enable the system settings to be changed per session at the database connection level")
+	sysVarSetEnabled = flag.Bool("enable_system_settings", false, "This will enable the system settings to be changed per session at the database connection level")
 	// lockHeartbeatTime is used to set the next heartbeat time.
 	lockHeartbeatTime = flag.Duration("lock_heartbeat_time", 5*time.Second, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 )


### PR DESCRIPTION
We are still not recommending users to enable reserved connections. 

Only enable it while you do something that you know needs reserved connections, such as an installation or to do a report.

If you by accident execute a SET statement during the setup of a connection with Vitess, so that all your connections end up needing reserved connections, you loose the benefits of connection pooling and this will put a heavy burden on your tablets.