### PR TITLE
fix ListBackups for gcp and az to work with root directory

### DIFF
--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -276,14 +276,19 @@ func (bs *AZBlobBackupStorage) containerURL() (*azblob.ContainerURL, error) {
 
 // ListBackups implements BackupStorage.
 func (bs *AZBlobBackupStorage) ListBackups(ctx context.Context, dir string) ([]backupstorage.BackupHandle, error) {
-	log.Infof("ListBackups: [azblob] container: %s, directory: %v", *containerName, objName(dir, ""))
+	var searchPrefix string
+	if dir == "/" {
+		searchPrefix = "/"
+	} else {
+		searchPrefix = objName(dir, "")
+	}
+
+	log.Infof("ListBackups: [azblob] container: %s, directory: %v", *containerName, searchPrefix)
 
 	containerURL, err := bs.containerURL()
 	if err != nil {
 		return nil, err
 	}
-
-	searchPrefix := objName(dir, "")
 
 	result := make([]backupstorage.BackupHandle, 0)
 	var subdirs []string

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -132,7 +132,14 @@ func (bs *GCSBackupStorage) ListBackups(ctx context.Context, dir string) ([]back
 
 	// List prefixes that begin with dir (i.e. list subdirs).
 	var subdirs []string
-	searchPrefix := objName(dir, "" /* include trailing slash */)
+
+	var searchPrefix string
+	if dir == "/" {
+		searchPrefix = ""
+	} else {
+		searchPrefix = objName(dir, "" /* include trailing slash */)
+	}
+
 	query := &storage.Query{
 		Delimiter: "/",
 		Prefix:    searchPrefix,


### PR DESCRIPTION
fixes the search prefix to prevent it from becoming `//` when the directory is at root
Similar to #6732 

Signed-off-by: Yujie Zhu <yujiezhu718@gmail.com>