### PR TITLE
Pulling bootstrap resources from vitess-resources

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -187,7 +187,7 @@ install_k3s() {
   # This is how we'd download directly from source:
   # download_url=https://github.com/rancher/k3s/releases/download
   # wget -O  $dest "$download_url/$version/$file"
-  wget -O  $dest "https://github.com/vitessio/vitess-resources/releases/download/v1.0/$version/$file"
+  wget -O  $dest "https://github.com/vitessio/vitess-resources/releases/download/v1.0/$file-$version"
   chmod +x $dest
   ln -snf  $dest "$VTROOT/bin/k3s"
 }
@@ -229,12 +229,12 @@ install_chromedriver() {
   if [ "$(arch)" == "aarch64" ] ; then
       os=$(cat /etc/*release | grep "^ID=" | cut -d '=' -f 2)
       case $os in
-          ubuntu|debian)
-              sudo apt-get update -y && sudo apt install -y --no-install-recommends unzip libglib2.0-0 libnss3 libx11-6
-	      ;;
-	  centos|fedora)
-	      sudo yum update -y && yum install -y libX11 unzip wget
-	      ;;
+        ubuntu|debian)
+          sudo apt-get update -y && sudo apt install -y --no-install-recommends unzip libglib2.0-0 libnss3 libx11-6
+        ;;
+        centos|fedora)
+          sudo yum update -y && yum install -y libX11 unzip wget
+        ;;
       esac
       echo "For Arm64, using prebuilt binary from electron (https://github.com/electron/electron/) of version 76.0.3809.126"
       wget https://github.com/electron/electron/releases/download/v6.0.3/chromedriver-v6.0.3-linux-arm64.zip

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,7 +107,7 @@ install_protoc() {
 
   # This is how we'd download directly from source:
   # wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
-  wget "https://github.com/vitessio/vitess-resources/raw/main/protoc/protoc-$version-$platform-${target}.zip"
+  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/protoc-$version-$platform-${target}.zip"
   unzip "protoc-$version-$platform-${target}.zip"
   ln -snf "$dist/bin/protoc" "$VTROOT/bin/protoc"
 }
@@ -121,7 +121,7 @@ install_zookeeper() {
   zk="zookeeper-$version"
   # This is how we'd download directly from source:
   # wget "https://archive.apache.org/dist/zookeeper/$zk/$zk.tar.gz"
-  wget "https://github.com/vitessio/vitess-resources/raw/main/zk/${zk}.tar.gz"
+  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/${zk}.tar.gz"
   tar -xzf "$zk.tar.gz"
   ant -f "$zk/build.xml" package
   ant -f "$zk/zookeeper-contrib/zookeeper-contrib-fatjar/build.xml" jar
@@ -153,7 +153,7 @@ install_etcd() {
   # This is how we'd download directly from source:
   # download_url=https://github.com/etcd-io/etcd/releases/download
   # wget "$download_url/$version/$file"
-  wget "https://github.com/vitessio/vitess-resources/raw/main/etcd/${file}"
+  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/${file}"
   if [ "$ext" = "tar.gz" ]; then
     tar xzf "$file"
   else
@@ -181,14 +181,17 @@ install_k3s() {
       *)   echo "WARNING: unsupported architecture, the k8s topology will not be available for local examples."; return;;
   esac
 
-  download_url=https://github.com/rancher/k3s/releases/download
   file="k3s${target}"
 
   local dest="$dist/k3s${target}-${version}-${platform}"
-  wget -O  $dest "$download_url/$version/$file"
+  # This is how we'd download directly from source:
+  # download_url=https://github.com/rancher/k3s/releases/download
+  # wget -O  $dest "$download_url/$version/$file"
+  wget -O  $dest "https://github.com/vitessio/vitess-resources/releases/download/v1.0/$version/$file"
   chmod +x $dest
   ln -snf  $dest "$VTROOT/bin/k3s"
 }
+
 
 # Download and install consul, link consul binary into our root.
 install_consul() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -119,7 +119,7 @@ function install_zookeeper() {
   local dist="$2"
 
   zk="zookeeper-$version"
-  wget "https://archive.apache.org/dist/zookeeper/$zk/$zk.tar.gz"
+  wget "https://github.com/vitessio/vitess-resources/raw/main/zk/${zk}.tar.gz"
   tar -xzf "$zk.tar.gz"
   ant -f "$zk/build.xml" package
   ant -f "$zk/zookeeper-contrib/zookeeper-contrib-fatjar/build.xml" jar

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,8 +209,10 @@ install_consul() {
       *)   echo "ERROR: unsupported architecture"; exit 1;;
   esac
 
-  download_url=https://releases.hashicorp.com/consul
-  wget "${download_url}/${version}/consul_${version}_${platform}_${target}.zip"
+  # This is how we'd download directly from source:
+  # download_url=https://releases.hashicorp.com/consul
+  # wget "${download_url}/${version}/consul_${version}_${platform}_${target}.zip"
+  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/consul_${version}_${platform}_${target}.zip"
   unzip "consul_${version}_${platform}_${target}.zip"
   ln -snf "$dist/consul" "$VTROOT/bin/consul"
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,9 @@ BUILD_JAVA=${BUILD_JAVA:-1}
 BUILD_CONSUL=${BUILD_CONSUL:-1}
 BUILD_CHROME=${BUILD_CHROME:-1}
 
+VITESS_RESOURCES_DOWNLOAD_BASE_URL="https://github.com/vitessio/vitess-resources/releases/download"
+VITESS_RESOURCES_RELEASE="v1.0"
+VITESS_RESOURCES_DOWNLOAD_URL="${VITESS_RESOURCES_DOWNLOAD_BASE_URL}/${VITESS_RESOURCES_RELEASE}"
 #
 # 0. Initialization and helper methods.
 #
@@ -107,7 +110,7 @@ install_protoc() {
 
   # This is how we'd download directly from source:
   # wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
-  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/protoc-$version-$platform-${target}.zip"
+  wget "${VITESS_RESOURCES_DOWNLOAD_URL}/protoc-$version-$platform-${target}.zip"
   unzip "protoc-$version-$platform-${target}.zip"
   ln -snf "$dist/bin/protoc" "$VTROOT/bin/protoc"
 }
@@ -121,7 +124,7 @@ install_zookeeper() {
   zk="zookeeper-$version"
   # This is how we'd download directly from source:
   # wget "https://archive.apache.org/dist/zookeeper/$zk/$zk.tar.gz"
-  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/${zk}.tar.gz"
+  wget "${VITESS_RESOURCES_DOWNLOAD_URL}/${zk}.tar.gz"
   tar -xzf "$zk.tar.gz"
   ant -f "$zk/build.xml" package
   ant -f "$zk/zookeeper-contrib/zookeeper-contrib-fatjar/build.xml" jar
@@ -153,7 +156,7 @@ install_etcd() {
   # This is how we'd download directly from source:
   # download_url=https://github.com/etcd-io/etcd/releases/download
   # wget "$download_url/$version/$file"
-  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/${file}"
+  wget "${VITESS_RESOURCES_DOWNLOAD_URL}/${file}"
   if [ "$ext" = "tar.gz" ]; then
     tar xzf "$file"
   else
@@ -187,7 +190,7 @@ install_k3s() {
   # This is how we'd download directly from source:
   # download_url=https://github.com/rancher/k3s/releases/download
   # wget -O  $dest "$download_url/$version/$file"
-  wget -O  $dest "https://github.com/vitessio/vitess-resources/releases/download/v1.0/$file-$version"
+  wget -O  $dest "${VITESS_RESOURCES_DOWNLOAD_URL}/$file-$version"
   chmod +x $dest
   ln -snf  $dest "$VTROOT/bin/k3s"
 }
@@ -212,7 +215,7 @@ install_consul() {
   # This is how we'd download directly from source:
   # download_url=https://releases.hashicorp.com/consul
   # wget "${download_url}/${version}/consul_${version}_${platform}_${target}.zip"
-  wget "https://github.com/vitessio/vitess-resources/releases/download/v1.0/consul_${version}_${platform}_${target}.zip"
+  wget "${VITESS_RESOURCES_DOWNLOAD_URL}/consul_${version}_${platform}_${target}.zip"
   unzip "consul_${version}_${platform}_${target}.zip"
   ln -snf "$dist/consul" "$VTROOT/bin/consul"
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,7 +105,9 @@ function install_protoc() {
       *)   echo "ERROR: unsupported architecture"; exit 1;;
   esac
 
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
+  # This is how we'd download directly from source:
+  # wget https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platform-${target}.zip
+  wget "https://github.com/vitessio/vitess-resources/raw/main/protoc/protoc-$version-$platform-${target}.zip"
   unzip "protoc-$version-$platform-${target}.zip"
   ln -snf "$dist/bin/protoc" "$VTROOT/bin/protoc"
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -119,6 +119,8 @@ function install_zookeeper() {
   local dist="$2"
 
   zk="zookeeper-$version"
+  # This is how we'd download directly from source:
+  # wget "https://archive.apache.org/dist/zookeeper/$zk/$zk.tar.gz"
   wget "https://github.com/vitessio/vitess-resources/raw/main/zk/${zk}.tar.gz"
   tar -xzf "$zk.tar.gz"
   ant -f "$zk/build.xml" package


### PR DESCRIPTION
A new repository, https://github.com/vitessio/vitess-resources, was created so as to mirror various resources needed by the Vitess build/bootstrap process. Instead of relying on those resources to exists in their original locations (e.g. `apache.,org`), we put them in https://github.com/vitessio/vitess-resources and fetch it from there.

This is an ongoing process; we'll iterate some resources one by one.