### PR TITLE
Fixing flaky 'srvtopo' unit test

### DIFF
--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -308,7 +308,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 
 	time.Sleep(*srvTopoCacheTTL)
 
-	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2)
+	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*3)
 	_, err = rs.GetSrvKeyspace(timeoutCtx, "test_cell", "test_ks")
 	wantErr := "timed out waiting for keyspace"
 	if err == nil || err.Error() != wantErr {


### PR DESCRIPTION
`go test -race -count=1 vitess.io/vitess/go/vt/srvtopo` is flaky, and fails like so:

```
2020-10-14T11:17:11.5726369Z E1014 11:17:10.168248   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: node doesn't exist: keyspaces/test_ks/SrvKeyspace
2020-10-14T11:17:11.5728431Z E1014 11:17:10.169190   30408 resilient_server.go:470] WatchSrvKeyspace clearing cached entry for test_cell/test_ks
2020-10-14T11:17:11.5730299Z E1014 11:17:10.219883   30408 resilient_server.go:503] WatchSrvKeyspace failed for test_cell/test_ks: node doesn't exist: keyspaces/test_ks/SrvKeyspace
2020-10-14T11:17:11.5732385Z E1014 11:17:10.260842   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: node doesn't exist: keyspaces/test_ks/SrvKeyspace
2020-10-14T11:17:11.5733626Z E1014 11:17:10.302009   30408 resilient_server.go:503] WatchSrvKeyspace failed for test_cell/test_ks: test topo error
2020-10-14T11:17:11.5734676Z E1014 11:17:10.342861   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: test topo error
2020-10-14T11:17:11.5735746Z E1014 11:17:10.383078   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: test topo error
2020-10-14T11:17:11.5736952Z E1014 11:17:10.424124   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: test topo error
2020-10-14T11:17:11.5737958Z E1014 11:17:10.424148   30408 resilient_server.go:470] WatchSrvKeyspace clearing cached entry for test_cell/test_ks
2020-10-14T11:17:11.5738969Z E1014 11:17:10.566348   30408 resilient_server.go:503] WatchSrvKeyspace failed for test_cell/test_ks: another test topo error
2020-10-14T11:17:11.5741196Z E1014 11:17:10.607209   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: another test topo error
2020-10-14T11:17:11.5742545Z E1014 11:17:10.647999   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: another test topo error
2020-10-14T11:17:11.5743942Z E1014 11:17:10.688656   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: another test topo error
2020-10-14T11:17:11.5745058Z E1014 11:17:10.688685   30408 resilient_server.go:470] WatchSrvKeyspace clearing cached entry for test_cell/test_ks
2020-10-14T11:17:11.5746309Z E1014 11:17:10.729455   30408 resilient_server.go:503] WatchSrvKeyspace failed for test_cell/test_ks: test topo error with factory locked
2020-10-14T11:17:11.5747663Z E1014 11:17:10.809672   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: test topo error with factory locked
2020-10-14T11:17:11.5748813Z E1014 11:17:10.910367   30408 resilient_server.go:503] WatchSrvKeyspace failed for test_cell/test_ks: force long test error
2020-10-14T11:17:11.5751037Z --- FAIL: TestGetSrvKeyspace (0.84s)
2020-10-14T11:17:11.5753513Z ##[error]    resilient_server_test.go:315: expected error 'timed out waiting for keyspace', got '<nil>'
2020-10-14T11:17:11.5757856Z E1014 11:17:11.010163   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/test_ks: force long test error
2020-10-14T11:17:11.5759834Z E1014 11:17:11.010230   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/unknown_ks: node doesn't exist: keyspaces/unknown_ks/SrvKeyspace
2020-10-14T11:17:11.5761019Z E1014 11:17:11.010277   30408 resilient_server.go:470] WatchSrvKeyspace clearing cached entry for test_cell/unknown_ks
2020-10-14T11:17:11.5762551Z E1014 11:17:11.120462   30408 resilient_server.go:467] Initial WatchSrvKeyspace failed for test_cell/unknown_ks: node doesn't exist: keyspaces/unknown_ks/SrvKeyspace
2020-10-14T11:17:11.5763806Z E1014 11:17:11.120496   30408 resilient_server.go:470] WatchSrvKeyspace clearing cached entry for test_cell/unknown_ks
2020-10-14T11:17:11.5765089Z W1014 11:17:11.151216   30408 resilient_server.go:566] Error while watching vschema for cell test_cell (will wait 5s before retrying): node doesn't exist: SrvVSchema
2020-10-14T11:17:11.5766453Z W1014 11:17:11.211481   30408 resilient_server.go:314] GetSrvKeyspaceNames(context.Background, test_cell) failed: force test error (keeping cached value: [test_ks test_ks2])
2020-10-14T11:17:11.5767786Z W1014 11:17:11.241740   30408 resilient_server.go:314] GetSrvKeyspaceNames(context.Background, test_cell) failed: force test error (keeping cached value: [test_ks test_ks2])
2020-10-14T11:17:11.5769034Z E1014 11:17:11.344934   30408 resilient_server.go:316] GetSrvKeyspaceNames(context.Background, test_cell) failed: force test error (cached value expired)
2020-10-14T11:17:11.5770816Z E1014 11:17:11.566042   30408 resilient_server.go:316] GetSrvKeyspaceNames(context.Background.WithDeadline(2020-10-14 11:17:11.565051138 +0000 UTC m=+1.400781296 [-1.002737ms]), test_cell) failed: force long test error (cached value expired)
2020-10-14T11:17:11.5771802Z FAIL
2020-10-14T11:17:11.5772459Z FAIL	vitess.io/vitess/go/vt/srvtopo	1.427s
```

the problem is that the test expects `'timed out waiting for keyspace'`, but gets no error. The test assumes that waiting `*srvTopoCacheRefresh*2` is enough for TTL to expire.

Locally on my laptop this is always the case and the test never fails. But in GitHub CI this seems to break.

In this PR I attempt to fix this by first increasing the timeout from `*2` to `*3`. Mind you, the default value for `srvTopoCacheRefresh` is just `1s`.
