### PR TITLE
Flaky test: attempt to fix TestConnection in go/test/endtoend/messaging

### DIFF
--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -331,6 +331,7 @@ func TestConnection(t *testing.T) {
 	_, err = stream.MessageStream(userKeyspace, "", nil, name)
 	require.Nil(t, err)
 	// validate client count of vttablet
+	time.Sleep(time.Second)
 	assert.Equal(t, 1, getClientCount(shard0Master))
 	assert.Equal(t, 1, getClientCount(shard1Master))
 	// second connection with vtgate, secont connection
@@ -340,6 +341,7 @@ func TestConnection(t *testing.T) {
 	_, err = stream1.MessageStream(userKeyspace, "", nil, name)
 	require.Nil(t, err)
 	// validate client count of vttablet
+	time.Sleep(time.Second)
 	assert.Equal(t, 2, getClientCount(shard0Master))
 	assert.Equal(t, 2, getClientCount(shard1Master))
 


### PR DESCRIPTION
There seems to be an intrinsic race in the message manager's TestConnection test due to the goroutine in stream.MessageStream. Added sleeps before validations to see if that will fix the flakiness.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>