### PR TITLE
INFORMATION_SCHEMA.TABLE_SCHEMA comparison with dynamic value bugfix

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -2115,3 +2115,20 @@
 # non-existent table on right of join
 "select c from user join t"
 "table t not found"
+
+# information schema query that uses table_schema
+"select column_name from information_schema.columns where table_schema = (select schema())"
+{
+  "QueryType": "SELECT",
+  "Original": "select column_name from information_schema.columns where table_schema = (select schema())",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select column_name from information_schema.`columns` where 1 != 1",
+    "Query": "select column_name from information_schema.`columns` where table_schema = (select schema() from dual)"
+  }
+}


### PR DESCRIPTION
When we encounter a comparison with `table_schema` in the `WHERE` clause of an information_schema query, we extract the other side of the comparison and turn it into an `evalengine` expression. These expressions can be evaluated on the vtgate, and Vitess uses this information to figure out where it needs to send the query.

The issue here is when Vitess fails to transform the expression from an AST expression to a `evalengine` expression. 
Instead of failing the query, we should just not do that particular rewrite 

Fixes #6827 