### PR TITLE
tablet streaming health fix: never silently skip health state changes

### DIFF
--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletserver
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"vitess.io/vitess/go/history"
+	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -39,6 +41,8 @@ var (
 	blpFunc = vreplication.StatusSummary
 
 	errUnintialized = "tabletserver uninitialized"
+
+	streamHealthBufferSize = flag.Uint("stream_health_buffer_size", 20, "max streaming health entries to buffer per streaming health client")
 )
 
 // healthStreamer streams health information to callers.
@@ -115,7 +119,10 @@ func (hs *healthStreamer) Stream(ctx context.Context, callback func(*querypb.Str
 			return nil
 		case <-hsCtx.Done():
 			return vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "tabletserver is shutdown")
-		case shr := <-ch:
+		case shr, ok := <-ch:
+			if !ok {
+				return vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "stream health buffer overflowed. client should reconnect for up-to-date status")
+			}
 			if err := callback(shr); err != nil {
 				if err == io.EOF {
 					return nil
@@ -134,7 +141,7 @@ func (hs *healthStreamer) register() (chan *querypb.StreamHealthResponse, contex
 		return nil, nil
 	}
 
-	ch := make(chan *querypb.StreamHealthResponse, 1)
+	ch := make(chan *querypb.StreamHealthResponse, *streamHealthBufferSize)
 	hs.clients[ch] = struct{}{}
 
 	// Send the current state immediately.
@@ -176,6 +183,21 @@ func (hs *healthStreamer) ChangeState(tabletType topodatapb.TabletType, terTimes
 		select {
 		case ch <- shr:
 		default:
+			// We can't block this state change on broadcasting to a streaming health client, but we
+			// also don't want to silently fail to inform a streaming health client of a state change
+			// because it can allow a vtgate to get wedged in a state where it's wrong about whether
+			// a tablet is healthy and can't automatically recover (see
+			//  https://github.com/vitessio/vitess/issues/5445). If we can't send a health update
+			// to this client we'll close() the channel which will ultimate fail the streaming health
+			// RPC and cause vtgates to reconnect.
+			//
+			// An alternative approach for streaming health would be to force a periodic broadcast even
+			// when there hasn't been an update and/or move away from using channels toward a model where
+			// old updates can be purged from the buffer in favor of more recent updates (since only the
+			// most recent health state really matters to gates).
+			log.Warning("A streaming health buffer is full. Closing the channel")
+			close(ch)
+			delete(hs.clients, ch)
 		}
 	}
 	hs.history.Add(&historyRecord{
@@ -187,7 +209,7 @@ func (hs *healthStreamer) ChangeState(tabletType topodatapb.TabletType, terTimes
 	})
 }
 
-func (hs *healthStreamer) ApppendDetails(details []*kv) []*kv {
+func (hs *healthStreamer) AppendDetails(details []*kv) []*kv {
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 	if hs.state.Target.TabletType == topodatapb.TabletType_MASTER {

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -654,7 +654,7 @@ func (sm *stateManager) isServingLocked() bool {
 	return sm.state == StateServing && sm.wantState == StateServing && sm.replHealthy && !sm.lameduck
 }
 
-func (sm *stateManager) ApppendDetails(details []*kv) []*kv {
+func (sm *stateManager) AppendDetails(details []*kv) []*kv {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -246,8 +246,8 @@ func (tsv *TabletServer) AddStatusPart() {
 		} else {
 			status.Latest = &historyRecord{}
 		}
-		status.Details = tsv.sm.ApppendDetails(nil)
-		status.Details = tsv.hs.ApppendDetails(status.Details)
+		status.Details = tsv.sm.AppendDetails(nil)
+		status.Details = tsv.hs.AppendDetails(status.Details)
 		rates := tsv.stats.QPSRates.Get()
 		if qps, ok := rates["All"]; ok && len(qps) > 0 {
 			status.CurrentQPS = qps[0]
@@ -257,8 +257,8 @@ func (tsv *TabletServer) AddStatusPart() {
 
 	tsv.exporter.HandleFunc("/debug/status_details", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		details := tsv.sm.ApppendDetails(nil)
-		details = tsv.hs.ApppendDetails(details)
+		details := tsv.sm.AppendDetails(nil)
+		details = tsv.hs.AppendDetails(details)
 		b, err := json.MarshalIndent(details, "", " ")
 		if err != nil {
 			w.Write([]byte(err.Error()))


### PR DESCRIPTION
Today, if vtgate is slow to receive health updates from a tablet the tablet may
simply throw away the most recent status update instead of buffering it.

Since there's no periodic forced state push and discarded state is the most
recent one, this creates a possibility that a gate can permenently and incorrectly
believe that a tablet is not serving. You could have a healthy master tablet and a
gate that doesn't believe it's healthy and the only fix today would be to do an
operation and restart the gate.

The fix in this PR is to cancel the streaming health RPC if the buffer overflows rather
than discarding the most recent state update. Whenever the gate or its network connection
gets unwedged it'll realize that the streaming health RPC is canceled and open up a new
streaming health RPC where it will get a recent, accurate state.

Fixes https://github.com/vitessio/vitess/issues/5445

Signed-off-by: David Weitzman <dweitzman@pinterest.com>