### PR TITLE
Allow table_schema comparisons

### DIFF
--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -331,6 +331,11 @@ func (r *rewriter) rewriteTableSchema(cursor *sqlparser.Cursor) bool {
 
 					evalExpr, err := sqlparser.Convert(parent.Right)
 					if err != nil {
+						if err == sqlparser.ErrExprNotSupported {
+							// This just means we can't rewrite this particular expression,
+							// not that we have to exit altogether
+							return true
+						}
 						r.err = err
 						return false
 					}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -2115,3 +2115,20 @@
 # non-existent table on right of join
 "select c from user join t"
 "table t not found"
+
+# information schema query that uses table_schema
+"select column_name from information_schema.columns where table_schema = (select schema())"
+{
+  "QueryType": "SELECT",
+  "Original": "select column_name from information_schema.columns where table_schema = (select schema())",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select column_name from information_schema.`columns` where 1 != 1",
+    "Query": "select column_name from information_schema.`columns` where table_schema = schema()"
+  }
+}


### PR DESCRIPTION
If we encounter a `table_schema` comparison in a information_schema query, we'll just not rewrite it when we cant evaluate the expression on vtgate

This is a cherry-pick of #6881