### PR TITLE
Fix parsing of online-ddl command line options

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -49,6 +49,8 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+
+	"github.com/google/shlex"
 )
 
 var (
@@ -474,7 +476,8 @@ curl -s 'http://localhost:%d/schema-migration/report-status?uuid=%s&status=%s&dr
 			fmt.Sprintf(`--panic-flag-file=%s`, e.ghostPanicFlagFileName(onlineDDL.UUID)),
 			fmt.Sprintf(`--execute=%t`, execute),
 		}
-		args = append(args, strings.Fields(onlineDDL.Options)...)
+		opts, _ := shlex.Split(onlineDDL.Options)
+		args = append(args, opts...)
 		_, err := execCmd("bash", args, os.Environ(), "/tmp", nil, nil)
 		return err
 	}
@@ -701,7 +704,8 @@ export MYSQL_PWD
 				`--no-drop-old-table`,
 			)
 		}
-		args = append(args, strings.Fields(onlineDDL.Options)...)
+		opts, _ := shlex.Split(onlineDDL.Options)
+		args = append(args, opts...)
 		_, err = execCmd("bash", args, os.Environ(), "/tmp", nil, nil)
 		return err
 	}


### PR DESCRIPTION
Co-submission of https://github.com/vitessio/vitess/pull/6899, going into `master`.

In the following statement:
```
ALTER WITH 'gh-ost' '--throttle-query="SELECT SLEEP(1)"' TABLE t DROP COLUMN c
```

the current behavior wrongly parses the command line options as `'--throttle-query="SELECT` and `SLEEP(1)"`, because of the space, ignoring the quotes. This PR fixes that by using a more sophisticated parser.
