### PR TITLE
healthcheck: use isIncluded correctly to fix replica/rdonly routing bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.4.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gorilla/websocket v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -442,24 +442,27 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 		}
 	}
 	if !trivialNonMasterUpdate {
-		if shr.Target.TabletType != topodata.TabletType_MASTER {
+		// we re-sort the healthy tablet list whenever we get a health update for tablets we can route to
+		// tablets from other cells for non-master targets should not trigger a re-sort
+		// they should also be excluded from healthy list
+		if shr.Target.TabletType != topodata.TabletType_MASTER && hc.isIncluded(shr.Target.TabletType, shr.TabletAlias) {
 			all := hc.healthData[targetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
 				// only tablets in same cell / cellAlias are included in healthy list
-				if hc.isIncluded(shr) {
+				if hc.isIncluded(s.Tablet.Type, s.Tablet.Alias) {
 					allArray = append(allArray, s)
 				}
 			}
 			hc.healthy[targetKey] = FilterStatsByReplicationLag(allArray)
 		}
-		if targetChanged && currentTarget.TabletType != topodata.TabletType_MASTER { // also recompute old target's healthy list
+		if targetChanged && currentTarget.TabletType != topodata.TabletType_MASTER && hc.isIncluded(shr.Target.TabletType, shr.TabletAlias) { // also recompute old target's healthy list
 			oldTargetKey := hc.keyFromTarget(currentTarget)
 			all := hc.healthData[oldTargetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
 				// only tablets in same cell / cellAlias are included in healthy list
-				if hc.isIncluded(shr) {
+				if hc.isIncluded(s.Tablet.Type, s.Tablet.Alias) {
 					allArray = append(allArray, s)
 				}
 			}
@@ -716,14 +719,14 @@ func (hc *HealthCheckImpl) getAliasByCell(cell string) string {
 	return alias
 }
 
-func (hc *HealthCheckImpl) isIncluded(shr *query.StreamHealthResponse) bool {
-	if shr.Target.TabletType == topodata.TabletType_MASTER {
+func (hc *HealthCheckImpl) isIncluded(tabletType topodata.TabletType, tabletAlias *topodata.TabletAlias) bool {
+	if tabletType == topodata.TabletType_MASTER {
 		return true
 	}
-	if shr.TabletAlias.Cell == hc.cell {
+	if tabletAlias.Cell == hc.cell {
 		return true
 	}
-	if hc.getAliasByCell(shr.TabletAlias.Cell) == hc.getAliasByCell(hc.cell) {
+	if hc.getAliasByCell(tabletAlias.Cell) == hc.getAliasByCell(hc.cell) {
 		return true
 	}
 	return false

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -386,8 +386,8 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 		log.Infof("We have no health data for tablet: %v, it might have been deleted already", tabletAlias)
 		return
 	}
-	// calling this will end the context associated with th.checkConn
-	// which will call finalizeConn, which will close the connection
+	// Calling this will end the context associated with th.checkConn,
+	// which will call finalizeConn, which will close the connection.
 	th.cancelFunc()
 	delete(hc.healthByAlias, tabletAlias)
 	// delete from map by keyspace.shard.tabletType
@@ -442,14 +442,14 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 		}
 	}
 	if !trivialNonMasterUpdate {
-		// we re-sort the healthy tablet list whenever we get a health update for tablets we can route to
-		// tablets from other cells for non-master targets should not trigger a re-sort
-		// they should also be excluded from healthy list
+		// We re-sort the healthy tablet list whenever we get a health update for tablets we can route to.
+		// Tablets from other cells for non-master targets should not trigger a re-sort;
+		// they should also be excluded from healthy list.
 		if shr.Target.TabletType != topodata.TabletType_MASTER && hc.isIncluded(shr.Target.TabletType, shr.TabletAlias) {
 			all := hc.healthData[targetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
-				// only tablets in same cell / cellAlias are included in healthy list
+				// Only tablets in same cell / cellAlias are included in healthy list.
 				if hc.isIncluded(s.Tablet.Type, s.Tablet.Alias) {
 					allArray = append(allArray, s)
 				}
@@ -461,7 +461,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 			all := hc.healthData[oldTargetKey]
 			allArray := make([]*TabletHealth, 0, len(all))
 			for _, s := range all {
-				// only tablets in same cell / cellAlias are included in healthy list
+				// Only tablets in same cell / cellAlias are included in healthy list.
 				if hc.isIncluded(s.Tablet.Type, s.Tablet.Alias) {
 					allArray = append(allArray, s)
 				}


### PR DESCRIPTION
In a multi-cell scenario, we want to exclude REPLICA/RDONLY tablets in other cells from vtgate routing.
There was a bug in the logic in healthcheck that excludes these tablets. Whenever there was a healthcheck update for a tablet in "another" cell, all tablets in the healthy list were being dropped out.
Tested manually using a multi-cell cluster. An endtoend test will be added in a separate PR.

Signed-off-by: deepthi <deepthi@planetscale.com>