### PR TITLE
[8.0] OnlineDDL bugfix: make sure schema is applied on tablet

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -579,3 +579,20 @@ func IsConnErr(err error) bool {
 	}
 	return false
 }
+
+// IsSchemaApplyError returns true when given error is a MySQL error applying schema change
+func IsSchemaApplyError(err error) bool {
+	merr, isSQLErr := err.(*SQLError)
+	if !isSQLErr {
+		return false
+	}
+	switch merr.Num {
+	case
+		ERDupKeyName,
+		ERCantDropFieldOrKey,
+		ERTableExists,
+		ERDupFieldName:
+		return true
+	}
+	return false
+}

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -18,8 +18,6 @@ package onlineddl
 
 import (
 	"fmt"
-
-	"vitess.io/vitess/go/vt/withddl"
 )
 
 const (
@@ -52,7 +50,6 @@ const (
 		KEY status_idx (migration_status, liveness_timestamp),
 		KEY cleanup_status_idx (cleanup_timestamp, migration_status)
 	) engine=InnoDB DEFAULT CHARSET=utf8mb4`
-	sqlValidationQuery         = `select 1 from %s.schema_migrations limit 1`
 	sqlScheduleSingleMigration = `UPDATE %s.schema_migrations
 		SET
 			migration_status='ready',
@@ -201,7 +198,7 @@ var (
 	sqlDropOnlineDDLUser = `DROP USER IF EXISTS %s`
 )
 
-var withDDL = withddl.New([]string{
+var applyDDL = []string{
 	fmt.Sprintf(sqlCreateSidecarDB, "_vt"),
 	fmt.Sprintf(sqlCreateSchemaMigrationsTable, "_vt"),
-})
+}


### PR DESCRIPTION
This fixes a bug where the `master` tablet may be `read_only` when attempting to apply the online DDL schema (`_vt.schema_migrations` table).

With this PR we ensure schema is deployed before any online DDL operation.

It's noteworthy that we move away from `WithDDL`, which was meant to solve this exact problem, but is not strict enough. For this PR, we choose a smaller fix, but later on we may want to improve upon `WithDDL`.

This should be merged in `8.0`.