### PR TITLE
Add vttablet flag `-queryserver-config-truncate-error-len`.

### DIFF
--- a/config/tablet/default.yaml
+++ b/config/tablet/default.yaml
@@ -105,6 +105,7 @@ queryCacheSize: 5000                     # queryserver-config-query-cache-size
 schemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time
 watchReplication: false                  # watch_replication_stream
 terseErrors: false                       # queryserver-config-terse-errors
+truncateErrorLen: 0                      # queryserver-config-truncate-error-len
 messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap
 cacheResultFields: true                  # enable-query-plan-field-caching
 

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -119,6 +119,7 @@ func init() {
 	flag.BoolVar(&currentConfig.EnableTableACLDryRun, "queryserver-config-enable-table-acl-dry-run", defaultConfig.EnableTableACLDryRun, "If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results")
 	flag.StringVar(&currentConfig.TableACLExemptACL, "queryserver-config-acl-exempt-acl", defaultConfig.TableACLExemptACL, "an acl that exempt from table acl checking (this acl is free to access any vitess tables).")
 	flag.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in returned errors")
+	flag.IntVar(&currentConfig.TruncateErrorLen, "queryserver-config-truncate-error-len", defaultConfig.TruncateErrorLen, "truncate errors if they are above this value (0 means do not truncate)")
 	flag.StringVar(&deprecatedPoolNamePrefix, "pool-name-prefix", "", "Deprecated")
 	flag.BoolVar(&currentConfig.WatchReplication, "watch_replication_stream", false, "When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.")
 	flag.BoolVar(&currentConfig.TrackSchemaVersions, "track_schema_versions", false, "When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position")
@@ -254,6 +255,8 @@ type TabletConfig struct {
 	WatchReplication            bool    `json:"watchReplication,omitempty"`
 	TrackSchemaVersions         bool    `json:"trackSchemaVersions,omitempty"`
 	TerseErrors                 bool    `json:"terseErrors,omitempty"`
+	TruncateErrorLen            int     `json:"truncateErrorLen,omitempty"`
+
 	MessagePostponeParallelism  int     `json:"messagePostponeParallelism,omitempty"`
 	CacheResultFields           bool    `json:"cacheResultFields,omitempty"`
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1741,6 +1741,28 @@ func TestTerseErrorsNonSQLError(t *testing.T) {
 	}
 }
 
+func TestTruncateErrorLen(t *testing.T) {
+	config := tabletenv.NewDefaultConfig()
+	config.TruncateErrorLen = 8
+	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), topodatapb.TabletAlias{})
+	tl := newTestLogger()
+	defer tl.Close()
+	err := tsv.convertAndLogError(
+		ctx,
+		"select 42 from dual",
+		nil,
+		vterrors.Errorf(vtrpcpb.Code_INTERNAL, "Looooooooooooooong error"),
+		nil,
+	)
+	want := "Looooooo"
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), want)
+	want = "Sql: \"select 42 from dual\", BindVars: {}"
+	if !strings.Contains(tl.getLog(0), want) {
+		t.Errorf("error log %s, want '%s'", tl.getLog(0), want)
+	}
+}
+
 func TestTerseErrorsBindVars(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	config.TerseErrors = true


### PR DESCRIPTION
Unlike vanilla MySQL, Vitess sometimes includes client SQL in error
responses leading to potentially large response packets. This
confuses some clients such as PHP's PDO driver. (A bug has been filed
with PHP[0] for this behavior.)

We avoid this edge case by truncating large error messages via this
flag.

[0] https://bugs.php.net/bug.php?id=78797

Signed-off-by: Adam Saponara <as@php.net>