### PR TITLE
query consolidator: fix to ignore leading margin comments

### DIFF
--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -279,12 +279,12 @@ func TestConsolidation(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
-			query := fmt.Sprintf("select sleep(%v) from dual /* query: 1 */", sleep)
+			query := fmt.Sprintf("/* query: 1 */ select sleep(%v) from dual /* query: 1 */", sleep)
 			framework.NewClient().Execute(query, nil)
 			wg.Done()
 		}()
 		go func() {
-			query := fmt.Sprintf("select sleep(%v) from dual /* query: 2 */", sleep)
+			query := fmt.Sprintf("/* query: 2 */ select sleep(%v) from dual /* query: 2 */", sleep)
 			framework.NewClient().Execute(query, nil)
 			wg.Done()
 		}()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -655,8 +655,8 @@ func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, b
 	if err != nil {
 		return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%s", err)
 	}
+	withoutComments := query
 	buf.WriteString(query)
-	withoutComments := buf.String()
 	buf.WriteString(qre.marginComments.Trailing)
 	fullSQL := buf.String()
 	return fullSQL, withoutComments, nil


### PR DESCRIPTION
When I originally added support for leading margin comments I made a mistake in this code:
https://github.com/vitessio/vitess/pull/3892/files#diff-799d4762d9e64026cb623db2defeb53209df055a99c1106f535006a89e7b812aR851

The code has become much more clear now, but at the time I ended up including the leading comment in a value
that should have been the query without comments.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>