### PR TITLE
Revert "Docker - upgrade to Debian Buster (release-8.0)"

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,21 +1,34 @@
-FROM golang:1.13-buster
+FROM golang:1.13-stretch
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # TODO(mberlin): Group these to make it easier to understand which library actually requires them.
-    ant \
+    automake \
+    bison \
+    bzip2 \
     chromium \
     curl \
-    default-jdk \
-    etcd \
     g++ \
     git \
+    libgconf-2-4 \
+    libtool \
     make \
-    maven \
+    openjdk-8-jdk \
     software-properties-common \
+    virtualenv \
     unzip \
+    xvfb \
     zip \
+    libz-dev \
+    ant \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Maven 3.1+
+RUN mkdir -p /vt/src/vitess.io/vitess/dist && \
+    cd /vt/src/vitess.io/vitess/dist && \
+    curl -sL --connect-timeout 10 --retry 3 \
+        http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar -xz && \
+    mv apache-maven-3.3.9 maven
 
 # Set up Vitess environment (equivalent to '. dev.env')
 ENV VTROOT /vt/src/vitess.io/vitess

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mariadb103
+++ b/docker/bootstrap/Dockerfile.mariadb103
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MariaDB 10.3
 RUN apt-key adv --no-tty --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8 \
-    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian buster main' \
+    && add-apt-repository 'deb [arch=amd64] http://ftp.osuosl.org/pub/mariadb/repo/10.3/debian stretch main' \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        mariadb-server-10.3 \
        libmariadb-dev \

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -1,16 +1,10 @@
 FROM vitess/bootstrap:common
 
 # Install MySQL 5.6
-#
-# Unfortunately we need to keep the 'stretch' repo from Oracle as there's no official support
-# for MySQL 5.6 for Debian Buster: https://bugs.mysql.com/bug.php?id=101055
-#
-# I think it's fine as MySQL 5.6 will be EOL pretty soon (February 5, 2021)
-#
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
     add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -3,9 +3,9 @@ FROM vitess/bootstrap:common
 # Install MySQL 5.7
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
     for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.7' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -2,9 +2,9 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --recv-keys --keyserver ha.pool.sks-keyservers.net 8C718D3B5072E1F5 && break; done && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ buster mysql-8.0' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' && \
     for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list && \
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -1,19 +1,8 @@
 FROM vitess/bootstrap:common
 
 # Install Percona 5.6
-#
-# Unfortunately we need to keep the 'stretch' repo from Percona as there's no official support
-# for MySQL 5.6 for Debian Buster
-#
-# I think it's fine as MySQL 5.6 will be EOL pretty soon (February 5, 2021)
-#
-# Also, for the 'percona-xtrabackup-24' package we need to specificly target the
-# 'buster' repository as the 'stretch' package requires 'libcurl3' that is not present
-# in Debian Buster.
-#
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
     add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
-    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \
@@ -21,8 +10,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     } | debconf-set-selections && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 && \
-    apt-get install -y -t buster percona-xtrabackup-24 && \
+        percona-server-server-5.6 libperconaserverclient18.1-dev rsync libev4 percona-xtrabackup-24 && \
     rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 5.7
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done && \
-    add-apt-repository 'deb http://repo.percona.com/apt buster main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
@@ -11,7 +11,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
     apt-get update && \
     apt-get install -y --no-install-recommends \
         percona-server-server-5.7 \
-	libperconaserverclient20-dev percona-xtrabackup-24 && \
+	libperconaserverclient18.1-dev percona-xtrabackup-24 && \
     rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install Percona 8.0
 RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --recv-keys 9334A25F8507EFA5 && break; done \
-    && echo 'deb http://repo.percona.com/ps-80/apt buster main' > /etc/apt/sources.list.d/percona.list && \
+    && echo 'deb http://repo.percona.com/ps-80/apt stretch main' > /etc/apt/sources.list.d/percona.list && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \
@@ -19,7 +19,7 @@ RUN for i in $(seq 1 10); do apt-key adv --no-tty --keyserver keys.gnupg.net --r
 	rsync \
 	libev4 \
 #    && rm -f /etc/apt/sources.list.d/percona.list \
-    && echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list \
+    && echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list \
 #    { \
 #        echo debconf debconf/frontend select Noninteractive; \
 #        echo percona-server-server-8.0 percona-server-server/root_password password 'unused'; \

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -30,7 +30,7 @@ USER vitess
 RUN make install PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/Dockerfile.testing
+++ b/docker/lite/Dockerfile.testing
@@ -30,7 +30,7 @@ USER vitess
 RUN make install-testing PREFIX=/vt/install
 
 # Start over and build the final image.
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 # Install dependencies
 COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -126,30 +126,30 @@ add_apt_key 9334A25F8507EFA5
 # Add extra apt repositories for MySQL.
 case "${FLAVOR}" in
 mysql56)
-    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.6' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' > /etc/apt/sources.list.d/mysql.list
     ;;
 mysql57)
-    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-5.7' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' > /etc/apt/sources.list.d/mysql.list
     ;;
 mysql80)
-    echo 'deb http://repo.mysql.com/apt/debian/ buster mysql-8.0' > /etc/apt/sources.list.d/mysql.list
+    echo 'deb http://repo.mysql.com/apt/debian/ stretch mysql-8.0' > /etc/apt/sources.list.d/mysql.list
     ;;
 mariadb)
-    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/debian buster main' > /etc/apt/sources.list.d/mariadb.list
+    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.2/debian stretch main' > /etc/apt/sources.list.d/mariadb.list
     ;;
 mariadb103)
-    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian buster main' > /etc/apt/sources.list.d/mariadb.list
+    echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian stretch main' > /etc/apt/sources.list.d/mariadb.list
     ;;
 esac
 
 # Add extra apt repositories for Percona Server and/or Percona XtraBackup.
 case "${FLAVOR}" in
 mysql56|mysql57|mysql80|percona|percona57)
-    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list
     ;;
 percona80)
-    echo 'deb http://repo.percona.com/apt buster main' > /etc/apt/sources.list.d/percona.list
-    echo 'deb http://repo.percona.com/ps-80/apt buster main' > /etc/apt/sources.list.d/percona80.list
+    echo 'deb http://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list
+    echo 'deb http://repo.percona.com/ps-80/apt stretch main' > /etc/apt/sources.list.d/percona80.list
     ;;
 esac
 

--- a/docker/orchestrator/build.sh
+++ b/docker/orchestrator/build.sh
@@ -23,7 +23,7 @@ script="go get vitess.io/vitess/go/cmd/vtctlclient && \
   go install github.com/openark/orchestrator/go/cmd/orchestrator"
 
 echo "Building orchestrator..."
-docker run -ti --name=vt_orc_build golang:1.14.4-buster bash -c "$script"
+docker run -ti --name=vt_orc_build golang:1.14.4-stretch bash -c "$script"
 docker cp vt_orc_build:/go/bin/orchestrator $tmpdir
 docker cp vt_orc_build:/go/bin/vtctlclient $tmpdir
 docker cp vt_orc_build:/go/src/github.com/openark/orchestrator/resources $tmpdir


### PR DESCRIPTION
Reverts vitessio/vitess#6888

docker/lite builds are broken with this PR. We need some additional changes on top to get them working again.
For 8.0 we will go back to stretch and stay on go 1.13. 