### PR TITLE
Change dependencies for lite builds

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -37,6 +37,7 @@ BASE_PACKAGES=(
     libcurl4
     libdbd-mysql-perl
     libev4
+    libjemalloc2
     libtcmalloc-minimal4
     procps
     rsync

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -60,25 +60,38 @@ mysql56)
     )
     ;;
 mysql57)
-    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/libmysqlclient20_5.7.31-1debian10_amd64.deb -O /tmp/libmysqlclient20_5.7.31-1debian10_amd64.deb
-    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-client_5.7.31-1debian10_amd64.deb -O /tmp/mysql-community-client_5.7.31-1debian10_amd64.deb
-    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-client_5.7.31-1debian10_amd64.deb -O /tmp/mysql-client_5.7.31-1debian10_amd64.deb
-    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-server_5.7.31-1debian10_amd64.deb -O /tmp/mysql-community-server_5.7.31-1debian10_amd64.deb
-    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-server_5.7.31-1debian10_amd64.deb -O /tmp/mysql-server_5.7.31-1debian10_amd64.deb
+    mysql57_version=5.7.31
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/libmysqlclient20_${mysql57_version}-1debian10_amd64.deb -O /tmp/libmysqlclient20_${mysql57_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-community-client_${mysql57_version}-1debian10_amd64.deb -O /tmp/mysql-community-client_${mysql57_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-client_${mysql57_version}-1debian10_amd64.deb -O /tmp/mysql-client_${mysql57_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-community-server_${mysql57_version}-1debian10_amd64.deb -O /tmp/mysql-community-server_${mysql57_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-server_${mysql57_version}-1debian10_amd64.deb -O /tmp/mysql-server_${mysql57_version}-1debian10_amd64.deb
     PACKAGES=(
-        /tmp/libmysqlclient20_5.7.31-1debian10_amd64.deb
-        /tmp/mysql-community-client_5.7.31-1debian10_amd64.deb
-        /tmp/mysql-client_5.7.31-1debian10_amd64.deb
-        /tmp/mysql-community-server_5.7.31-1debian10_amd64.deb
-        /tmp/mysql-server_5.7.31-1debian10_amd64.deb
+        /tmp/libmysqlclient20_${mysql57_version}-1debian10_amd64.deb
+        /tmp/mysql-community-client_${mysql57_version}-1debian10_amd64.deb
+        /tmp/mysql-client_${mysql57_version}-1debian10_amd64.deb
+        /tmp/mysql-community-server_${mysql57_version}-1debian10_amd64.deb
+        /tmp/mysql-server_${mysql57_version}-1debian10_amd64.deb
         percona-xtrabackup-24
     )
     ;;
 mysql80)
+    mysql8_version=8.0.21
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb -O /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-community-client_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-client_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-client_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-server_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-community-server_${mysql8_version}-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-server_${mysql8_version}-1debian10_amd64.deb -O /tmp/mysql-server_${mysql8_version}-1debian10_amd64.deb
     PACKAGES=(
-        libmysqlclient21
-        mysql-client
-        mysql-server
+        /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-community-client_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-client_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-community-server-core_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-community-server_${mysql8_version}-1debian10_amd64.deb
+        /tmp/mysql-server_${mysql8_version}-1debian10_amd64.deb
         percona-xtrabackup-80
     )
     ;;
@@ -192,3 +205,4 @@ apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 # Clean up files we won't need in the final image.
 rm -rf /var/lib/apt/lists/*
 rm -rf /var/lib/mysql/
+rm -rf /tmp/*.deb

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -34,10 +34,9 @@ BASE_PACKAGES=(
     gnupg
     libaio1
     libatomic1
-    libcurl3
+    libcurl4
     libdbd-mysql-perl
     libev4
-    libjemalloc1
     libtcmalloc-minimal4
     procps
     rsync

--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -60,10 +60,17 @@ mysql56)
     )
     ;;
 mysql57)
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/libmysqlclient20_5.7.31-1debian10_amd64.deb -O /tmp/libmysqlclient20_5.7.31-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-client_5.7.31-1debian10_amd64.deb -O /tmp/mysql-community-client_5.7.31-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-client_5.7.31-1debian10_amd64.deb -O /tmp/mysql-client_5.7.31-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-server_5.7.31-1debian10_amd64.deb -O /tmp/mysql-community-server_5.7.31-1debian10_amd64.deb
+    wget https://repo.mysql.com/apt/debian/pool/mysql-5.7/m/mysql-community/mysql-server_5.7.31-1debian10_amd64.deb -O /tmp/mysql-server_5.7.31-1debian10_amd64.deb
     PACKAGES=(
-        libmysqlclient20
-        mysql-client
-        mysql-server
+        /tmp/libmysqlclient20_5.7.31-1debian10_amd64.deb
+        /tmp/mysql-community-client_5.7.31-1debian10_amd64.deb
+        /tmp/mysql-client_5.7.31-1debian10_amd64.deb
+        /tmp/mysql-community-server_5.7.31-1debian10_amd64.deb
+        /tmp/mysql-server_5.7.31-1debian10_amd64.deb
         percona-xtrabackup-24
     )
     ;;


### PR DESCRIPTION
The lite builds are using Buster. This fixes the dependencies for that version

Signed-off-by: Dan Kozlowski <koz@planetscale.com>