### PR TITLE
Fix unit test error

### DIFF
--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package netutil
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
 	"reflect"
@@ -56,7 +57,7 @@ func testUniformity(t *testing.T, size int, margin float64) {
 	rand.Seed(1)
 	data := make([]*net.SRV, size)
 	for i := 0; i < size; i++ {
-		data[i] = &net.SRV{Target: string('a' + i), Weight: 1}
+		data[i] = &net.SRV{Target: fmt.Sprintf("%c", 'a'+i), Weight: 1}
 	}
 	checkDistribution(t, data, margin)
 }


### PR DESCRIPTION
Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>

I get the error when I run the unit test: 
```
go/netutil/netutil_test.go:59:30: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	vitess.io/vitess/go/netutil [build failed]
FAIL
```

go version: go1.15.2 linux/amd64