### PR TITLE
Pin mariadb to use mariadb-server-10.2

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -113,13 +113,18 @@ percona57)
 percona80)
     PACKAGES=(
         libperconaserverclient21
-	    percona-server-rocksdb
+        percona-server-rocksdb
         percona-server-server
         percona-server-tokudb
         percona-xtrabackup-80
     )
     ;;
-mariadb|mariadb103)
+mariadb)
+    PACKAGES=(
+        mariadb-server-10.2
+    )
+    ;;
+mariadb103)
     PACKAGES=(
         mariadb-server
     )


### PR DESCRIPTION
The default mariadb-server is now 10.3, pin it to 10.2 so we have the correct version

Signed-off-by: Dan Kozlowski <koz@planetscale.com>