### PR TITLE
Pad non-fractional part of DECIMAL type

### DIFF
--- a/go/mysql/binlog_event_rbr.go
+++ b/go/mysql/binlog_event_rbr.go
@@ -700,7 +700,7 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, styp querypb.Typ
 		// now the full digits, 32 bits each, 9 digits
 		for i := 0; i < intg0; i++ {
 			val = binary.BigEndian.Uint32(d[pos : pos+4])
-			fmt.Fprintf(txt, "%9d", val)
+			fmt.Fprintf(txt, "%09d", val)
 			pos += 4
 		}
 

--- a/go/mysql/binlog_event_rbr_test.go
+++ b/go/mysql/binlog_event_rbr_test.go
@@ -469,6 +469,12 @@ func TestCellLengthAndData(t *testing.T) {
 		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
 			[]byte("1234567890.0001")),
 	}, {
+		typ:      TypeNewDecimal,
+		metadata: 20<<8 | 2, // DECIMAL(20,2)
+		data:     []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0, 0x01, 0x0a},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("000000000000000001.10")),
+	}, {
 		typ:      TypeBlob,
 		metadata: 1,
 		data:     []byte{0x3, 'a', 'b', 'c'},


### PR DESCRIPTION
with zeroes when extracting from binlogs, or DECIMAL
types with non-fractional part > 9 digits may
end up vreplicated as a broken number with
a space.

Previously submitted as #6183 ;  added testcase
and reproduced by using a column of type
DECIMAL(20,2) and value 1.10 

Signed-off-by: Jacques Grove <aquarapid@gmail.com>