### PR TITLE
Vtctld Workflow Command: fix error state in Workflow Show

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -315,7 +315,7 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	output := []string{
 		"begin",
 		"rollback",
-		"/update _vt.vreplication set message='filter rules are not supported for SBR",
+		"/update _vt.vreplication set message='Error: filter rules are not supported for SBR",
 	}
 
 	execStatements(t, input)
@@ -1429,7 +1429,7 @@ func TestPlayerDDL(t *testing.T) {
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
 		"alter table t1 add column val2 varchar(128)",
-		"/update _vt.vreplication set message='Duplicate",
+		"/update _vt.vreplication set message='Error: Duplicate",
 	})
 	cancel()
 
@@ -2165,7 +2165,7 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 
 	streamerEngine.Close()
 	expectDBClientQueries(t, []string{
-		"/update _vt.vreplication set message='vstream ended'",
+		"/update _vt.vreplication set message='Error: vstream ended'",
 	})
 	streamerEngine.Open()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -122,7 +122,7 @@ func (vr *vreplicator) Replicate(ctx context.Context) error {
 	err := vr.replicate(ctx)
 	if err != nil {
 		log.Errorf("Replicate error: %s", err.Error())
-		if err := vr.setMessage(err.Error()); err != nil {
+		if err := vr.setMessage(fmt.Sprintf("Error: %s", err.Error())); err != nil {
 			log.Errorf("Failed to set error state: %v", err)
 		}
 	}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -540,7 +540,7 @@ func (wr *Wrangler) ShowWorkflow(ctx context.Context, workflow, keyspace string)
 }
 
 func updateState(message, state string, cs []copyState, timeUpdated int64) string {
-	if message != "" {
+	if strings.Contains(strings.ToLower(message), "error") {
 		state = "Error"
 	} else if state == "Running" && len(cs) > 0 {
 		state = "Copying"

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -163,9 +163,11 @@ func TestVExec(t *testing.T) {
 }
 
 func TestWorkflowStatusUpdate(t *testing.T) {
-	require.Equal(t, "Error", updateState("master tablet not contactable", "Running", nil, 0))
+	require.Equal(t, "Running", updateState("for vdiff", "Running", nil, int64(time.Now().Second())))
+	require.Equal(t, "Running", updateState("", "Running", nil, int64(time.Now().Second())))
 	require.Equal(t, "Lagging", updateState("", "Running", nil, int64(time.Now().Second())-100))
 	require.Equal(t, "Copying", updateState("", "Running", []copyState{{Table: "t1", LastPK: "[[INT64(10)]]"}}, int64(time.Now().Second())))
+	require.Equal(t, "Error", updateState("error: master tablet not contactable", "Running", nil, 0))
 }
 
 func TestWorkflowListStreams(t *testing.T) {


### PR DESCRIPTION
Show Error state for a Running or Stopped workflow only if the message column in _vt.vreplication contains the string error since it is also used by other apps like vdiff for alert messages. Currently it shows Error if message is non-empty.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>