### PR TITLE
Bug which caused the connection to not close in case of error writing an error packet

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -947,14 +947,14 @@ func (c *Conn) handleComStmtSendLongData(data []byte) bool {
 	prepare, ok := c.PrepareData[stmtID]
 	if !ok {
 		err := fmt.Errorf("got wrong statement id from client %v, statement ID(%v) is not found from record", c.ConnectionID, stmtID)
-		return !c.writeErrorPacketFromErrorAndLog(err)
+		return c.writeErrorPacketFromErrorAndLog(err)
 	}
 
 	if prepare.BindVars == nil ||
 		prepare.ParamsCount == uint16(0) ||
 		paramID >= prepare.ParamsCount {
 		err := fmt.Errorf("invalid parameter Number from client %v, statement: %v", c.ConnectionID, prepare.PrepareStmt)
-		return !c.writeErrorPacketFromErrorAndLog(err)
+		return c.writeErrorPacketFromErrorAndLog(err)
 	}
 
 	chunk := make([]byte, len(chunkData))
@@ -990,7 +990,7 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 	}
 
 	if err != nil {
-		return !c.writeErrorPacketFromErrorAndLog(err)
+		return c.writeErrorPacketFromErrorAndLog(err)
 	}
 
 	fieldSent := false
@@ -1065,14 +1065,15 @@ func (c *Conn) handleComPrepare(handler Handler, data []byte) bool {
 
 	var queries []string
 	if c.Capabilities&CapabilityClientMultiStatements != 0 {
-		queries, err := sqlparser.SplitStatementToPieces(query)
+		var err error
+		queries, err = sqlparser.SplitStatementToPieces(query)
 		if err != nil {
 			log.Errorf("Conn %v: Error splitting query: %v", c, err)
-			return !c.writeErrorPacketFromErrorAndLog(err)
+			return c.writeErrorPacketFromErrorAndLog(err)
 		}
 		if len(queries) != 1 {
 			log.Errorf("Conn %v: can not prepare multiple statements", c, err)
-			return !c.writeErrorPacketFromErrorAndLog(err)
+			return c.writeErrorPacketFromErrorAndLog(err)
 		}
 	} else {
 		queries = []string{query}
@@ -1121,7 +1122,7 @@ func (c *Conn) handleComPrepare(handler Handler, data []byte) bool {
 	fld, err := handler.ComPrepare(c, queries[0], bindVars)
 
 	if err != nil {
-		return !c.writeErrorPacketFromErrorAndLog(err)
+		return c.writeErrorPacketFromErrorAndLog(err)
 	}
 
 	if err := c.writePrepare(fld, c.PrepareData[c.StatementID]); err != nil {
@@ -1194,7 +1195,7 @@ func (c *Conn) handleComQuery(handler Handler, data []byte) (kontinue bool) {
 		queries, err = sqlparser.SplitStatementToPieces(query)
 		if err != nil {
 			log.Errorf("Conn %v: Error splitting query: %v", c, err)
-			return !c.writeErrorPacketFromErrorAndLog(err)
+			return c.writeErrorPacketFromErrorAndLog(err)
 		}
 	} else {
 		queries = []string{query}
@@ -1215,7 +1216,7 @@ func (c *Conn) handleComQuery(handler Handler, data []byte) (kontinue bool) {
 }
 
 func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
-	fieldSent := false
+	callbackCalled := false
 	// sendFinished is set if the response should just be an OK packet.
 	sendFinished := false
 
@@ -1229,8 +1230,8 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 			return io.EOF
 		}
 
-		if !fieldSent {
-			fieldSent = true
+		if !callbackCalled {
+			callbackCalled = true
 
 			if len(qr.Fields) == 0 {
 				sendFinished = true
@@ -1259,8 +1260,8 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 		return c.writeRows(qr)
 	})
 
-	// If no field was sent, we expect an error.
-	if !fieldSent {
+	// If callback was not called, we expect an error.
+	if !callbackCalled {
 		// This is just a failsafe. Should never happen.
 		if err == nil || err == io.EOF {
 			err = NewSQLErrorFromError(errors.New("unexpected: query ended without no results and no error"))

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -482,6 +482,65 @@ func TestInitDbAgainstWrongDbDoesNotDropConnection(t *testing.T) {
 	require.EqualValues(t, data[0], ErrPacket) // we should see the error here
 }
 
+func TestConnectionErrorWhileWritingComQuery(t *testing.T) {
+	// Set the conn for the server connection to the simulated connection which always returns an error on writing
+	sConn := newConn(testConn{
+		writeToPass: []bool{false, true},
+		pos:         -1,
+		queryPacket: []byte{0x21, 0x00, 0x00, 0x00, ComQuery, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x40, 0x40, 0x76, 0x65, 0x72, 0x73,
+			0x69, 0x6f, 0x6e, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x20, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x20, 0x31},
+	})
+
+	// this handler will return an error on the first run, and fail the test if it's run more times
+	errorString := make([]byte, 17000)
+	handler := &singleRun{t: t, err: fmt.Errorf(string(errorString))}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "we should beak the connection in case of error writing error packet")
+}
+
+func TestConnectionErrorWhileWritingComStmtSendLongData(t *testing.T) {
+	// Set the conn for the server connection to the simulated connection which always returns an error on writing
+	sConn := newConn(testConn{
+		writeToPass: []bool{false, true},
+		pos:         -1,
+		queryPacket: []byte{0x21, 0x00, 0x00, 0x00, ComStmtSendLongData, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x40, 0x40, 0x76, 0x65, 0x72, 0x73,
+			0x69, 0x6f, 0x6e, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x20, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x20, 0x31},
+	})
+
+	// this handler will return an error on the first run, and fail the test if it's run more times
+	handler := &singleRun{t: t, err: fmt.Errorf("not used")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "we should beak the connection in case of error writing error packet")
+}
+
+func TestConnectionErrorWhileWritingComPrepare(t *testing.T) {
+	// Set the conn for the server connection to the simulated connection which always returns an error on writing
+	sConn := newConn(testConn{
+		writeToPass: []bool{false},
+		pos:         -1,
+		queryPacket: []byte{0x01, 0x00, 0x00, 0x00, ComPrepare},
+	})
+	sConn.Capabilities = sConn.Capabilities | CapabilityClientMultiStatements
+	// this handler will return an error on the first run, and fail the test if it's run more times
+	handler := &singleRun{t: t, err: fmt.Errorf("not used")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "we should beak the connection in case of error writing error packet")
+}
+
+func TestConnectionErrorWhileWritingComStmtExecute(t *testing.T) {
+	// Set the conn for the server connection to the simulated connection which always returns an error on writing
+	sConn := newConn(testConn{
+		writeToPass: []bool{false},
+		pos:         -1,
+		queryPacket: []byte{0x21, 0x00, 0x00, 0x00, ComStmtExecute, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x40, 0x40, 0x76, 0x65, 0x72, 0x73,
+			0x69, 0x6f, 0x6e, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e, 0x74, 0x20, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x20, 0x31},
+	})
+	// this handler will return an error on the first run, and fail the test if it's run more times
+	handler := &singleRun{t: t, err: fmt.Errorf("not used")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "we should beak the connection in case of error writing error packet")
+}
+
 type singleRun struct {
 	hasRun bool
 	t      *testing.T
@@ -522,3 +581,64 @@ func (h *singleRun) ComResetConnection(*Conn) {
 }
 
 var _ Handler = (*singleRun)(nil)
+
+type testConn struct {
+	writeToPass []bool
+	pos         int
+	queryPacket []byte
+}
+
+func (t testConn) Read(b []byte) (n int, err error) {
+	for j, i := range t.queryPacket {
+		b[j] = i
+	}
+	return len(b), nil
+}
+
+func (t testConn) Write(b []byte) (n int, err error) {
+	t.pos = t.pos + 1
+	if t.writeToPass[t.pos] {
+		return 0, nil
+	}
+	return 0, fmt.Errorf("error in writing to connection")
+}
+
+func (t testConn) Close() error {
+	panic("implement me")
+}
+
+func (t testConn) LocalAddr() net.Addr {
+	panic("implement me")
+}
+
+func (t testConn) RemoteAddr() net.Addr {
+	return mockAddress{s: "a"}
+}
+
+func (t testConn) SetDeadline(t1 time.Time) error {
+	panic("implement me")
+}
+
+func (t testConn) SetReadDeadline(t1 time.Time) error {
+	panic("implement me")
+}
+
+func (t testConn) SetWriteDeadline(t1 time.Time) error {
+	panic("implement me")
+}
+
+var _ net.Conn = (*testConn)(nil)
+
+type mockAddress struct {
+	s string
+}
+
+func (m mockAddress) Network() string {
+	return m.s
+}
+
+func (m mockAddress) String() string {
+	return m.s
+}
+
+var _ net.Addr = (*mockAddress)(nil)


### PR DESCRIPTION
In case we encounter an error while writing an error packet, we should close the connection. Also if we are able to write the error packet successfully we should keep the connection open for further requests.