### PR TITLE
use ephemeral buffer when reading rows

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1445,7 +1445,7 @@ func ParseErrorPacket(data []byte) error {
 	pos++
 
 	// SQL state is 5 bytes
-	sqlState, pos, ok := readBytes(data, pos, 5)
+	sqlState, pos, ok := readBytesCopy(data, pos, 5)
 	if !ok {
 		return NewSQLError(CRUnknownError, SSUnknownSQLState, "invalid error packet sqlState: %v", data)
 	}


### PR DESCRIPTION
## Description
Use an ephemeral buffer when reading from mysql in the tablet `ReadQueryResult`.

## Details
Simple change to use an ephemeral buffer instead of allocating a new one for each read. This should save on GC.
