### PR TITLE
Make VReplication relay log size & rows configurable.

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -92,8 +92,8 @@ func (vc *vdbClient) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, 
 
 // Execute is ExecuteFetch without the maxrows.
 func (vc *vdbClient) Execute(query string) (*sqltypes.Result, error) {
-	// Number of rows should never exceed relayLogMaxSize.
-	return vc.ExecuteFetch(query, relayLogMaxSize)
+	// Number of rows should never exceed relayLogMaxItems.
+	return vc.ExecuteFetch(query, *relayLogMaxItems)
 }
 
 func (vc *vdbClient) ExecuteWithRetry(ctx context.Context, query string) (*sqltypes.Result, error) {
@@ -128,8 +128,8 @@ func (vc *vdbClient) Retry() (*sqltypes.Result, error) {
 			}
 			continue
 		}
-		// Number of rows should never exceed relayLogMaxSize.
-		result, err := vc.DBClient.ExecuteFetch(q, relayLogMaxSize)
+		// Number of rows should never exceed relayLogMaxItems.
+		result, err := vc.DBClient.ExecuteFetch(q, *relayLogMaxItems)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -136,7 +136,7 @@ func (vp *vplayer) fetchAndApply(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	relay := newRelayLog(ctx, relayLogMaxItems, relayLogMaxSize)
+	relay := newRelayLog(ctx, *relayLogMaxItems, *relayLogMaxSize)
 
 	streamErr := make(chan error, 1)
 	go func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1900,11 +1900,11 @@ func TestPlayerRelayLogMaxSize(t *testing.T) {
 			case 0:
 				savedSize := relayLogMaxSize
 				defer func() { relayLogMaxSize = savedSize }()
-				relayLogMaxSize = 10
+				*relayLogMaxSize = 10
 			case 1:
 				savedLen := relayLogMaxItems
 				defer func() { relayLogMaxItems = savedLen }()
-				relayLogMaxItems = 2
+				*relayLogMaxItems = 2
 			}
 
 			execStatements(t, []string{

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -44,7 +44,7 @@ var (
 	idleTimeout         = 1100 * time.Millisecond
 	dbLockRetryDelay    = 1 * time.Second
 	relayLogMaxSize     = flag.Int("relay_log_max_size", 250000, "Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time.")
-	relayLogMaxItems    = flag.Int("relay_log_max_items", 1000, "Maximum number of rows for VReplication target buffering.")
+	relayLogMaxItems    = flag.Int("relay_log_max_items", 5000, "Maximum number of rows for VReplication target buffering.")
 	copyTimeout         = 1 * time.Hour
 	replicaLagTolerance = 10 * time.Second
 )

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vreplication
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"time"
@@ -42,8 +43,8 @@ var (
 	// between the two timeouts.
 	idleTimeout         = 1100 * time.Millisecond
 	dbLockRetryDelay    = 1 * time.Second
-	relayLogMaxSize     = 30000
-	relayLogMaxItems    = 1000
+	relayLogMaxSize     = flag.Int("relay_log_max_size", 250000, "Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time.")
+	relayLogMaxItems    = flag.Int("relay_log_max_items", 1000, "Maximum number of rows for VReplication target buffering.")
 	copyTimeout         = 1 * time.Hour
 	replicaLagTolerance = 10 * time.Second
 )

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -38,7 +38,7 @@ import (
 )
 
 // PacketSize is the suggested packet size for VReplication streamer.
-var PacketSize = flag.Int("vstream_packet_size", 30000, "Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount.")
+var PacketSize = flag.Int("vstream_packet_size", 250000, "Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount.")
 
 // HeartbeatTime is set to slightly below 1s, compared to idleTimeout
 // set by VPlayer at slightly above 1s. This minimizes conflicts


### PR DESCRIPTION
* Make default relay log size signficantly larger,
  30k -> 250k. Improves performance tables with
  larger rows significantly.
* Fix bug where we were fetching MaxSize instead of
  MaxItems number of rows from VReplication source.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>