### PR TITLE
Fix unit test error

### DIFF
--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -45,7 +45,7 @@ func testLogf(w io.Writer, params url.Values, m interface{}) error {
 }
 
 func TestHTTP(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When I run unit test:
```
go test -timeout 30s vitess.io/vitess/go/streamlog -run ^TestHTTP$

--- FAIL: TestHTTP (0.01s)
    go/streamlog/streamlog_flaky_test.go:66: Get "http://[::]:35873/log": EOF
FAIL
FAIL	vitess.io/vitess/go/streamlog	0.008s
FAIL
```

go version go1.15.2 linux/amd64

Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>