### PR TITLE
Replace vitess:base with vitess:lite images for docker-compose services

### DIFF
--- a/examples/compose/config/init_db.sql
+++ b/examples/compose/config/init_db.sql
@@ -1,0 +1,77 @@
+# This file is executed immediately after mysql_install_db,
+# to initialize a fresh data directory.
+###############################################################################
+# Equivalent of mysql_secure_installation
+###############################################################################
+# Changes during the init db should not make it to the binlog.
+# They could potentially create errant transactions on replicas.
+SET sql_log_bin = 0;
+# Remove anonymous users.
+DELETE FROM mysql.user WHERE User = '';
+# Disable remote root access (only allow UNIX socket).
+DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove test database.
+DROP DATABASE IF EXISTS test;
+###############################################################################
+# Vitess defaults
+###############################################################################
+# Vitess-internal database.
+CREATE DATABASE IF NOT EXISTS _vt;
+# Note that definitions of local_metadata and shard_metadata should be the same
+# as in production which is defined in go/vt/mysqlctl/metadata_tables.go.
+CREATE TABLE IF NOT EXISTS _vt.local_metadata (
+  name VARCHAR(255) NOT NULL,
+  value VARCHAR(255) NOT NULL,
+  db_name VARBINARY(255) NOT NULL,
+  PRIMARY KEY (db_name, name)
+  ) ENGINE=InnoDB;
+CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
+  name VARCHAR(255) NOT NULL,
+  value MEDIUMBLOB NOT NULL,
+  db_name VARBINARY(255) NOT NULL,
+  PRIMARY KEY (db_name, name)
+  ) ENGINE=InnoDB;
+# Admin user with all privileges.
+CREATE USER 'vt_dba'@'localhost';
+GRANT ALL ON *.* TO 'vt_dba'@'localhost';
+GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';
+# User for app traffic, with global read-write access.
+CREATE USER 'vt_app'@'localhost';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+  ON *.* TO 'vt_app'@'localhost';
+# User for app debug traffic, with global read access.
+CREATE USER 'vt_appdebug'@'localhost';
+GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';
+# User for administrative operations that need to be executed as non-SUPER.
+# Same permissions as vt_app here.
+CREATE USER 'vt_allprivs'@'localhost';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+  ON *.* TO 'vt_allprivs'@'localhost';
+# User for slave replication connections.
+# TODO: Should we set a password on this since it allows remote connections?
+CREATE USER 'vt_repl'@'%';
+GRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';
+# User for Vitess filtered replication (binlog player).
+# Same permissions as vt_app.
+CREATE USER 'vt_filtered'@'localhost';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+  ON *.* TO 'vt_filtered'@'localhost';
+# User for Orchestrator (https://github.com/openark/orchestrator).
+# TODO: Reenable when the password is randomly generated.
+CREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';
+GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
+  ON *.* TO 'orc_client_user'@'%';
+GRANT SELECT
+  ON _vt.* TO 'orc_client_user'@'%';
+FLUSH PRIVILEGES;
+RESET SLAVE ALL;
+RESET MASTER;

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -41,7 +41,7 @@ services:
         -workflow_manager_use_election \
         -service_map 'grpc-vtctl' \
         -backup_storage_implementation file \
-        -file_backup_storage_root /vt/backups \
+        -file_backup_storage_root /vt/vtdataroot/backups \
         -logtostderr=true \
         -port $WEB_PORT \
         -grpc_port $GRPC_PORT

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -30,22 +30,21 @@ services:
       - consul1
 
   vtctld:
-    image: vitess/base
+    image: vitess/lite
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
-    command: ["sh", "-c", " $$VTROOT/bin/vtctld \
+    command: ["sh", "-c", " /vt/bin/vtctld \
         $TOPOLOGY_FLAGS \
         -cell $CELL \
         -workflow_manager_init \
         -workflow_manager_use_election \
         -service_map 'grpc-vtctl' \
         -backup_storage_implementation file \
-        -file_backup_storage_root $$VTDATAROOT/backups \
+        -file_backup_storage_root /vt/backups \
         -logtostderr=true \
         -port $WEB_PORT \
-        -grpc_port $GRPC_PORT \
-        -pid_file $$VTDATAROOT/tmp/vtctld.pid
+        -grpc_port $GRPC_PORT
         "]
     depends_on:
       - consul1
@@ -53,12 +52,12 @@ services:
       - consul3
 
   vtgate:
-    image: vitess/base
+    image: vitess/lite
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
       - "15306:$MYSQL_PORT"
-    command: ["sh", "-c", "$$VTROOT/bin/vtgate \
+    command: ["sh", "-c", "/vt/bin/vtgate \
         $TOPOLOGY_FLAGS \
         -logtostderr=true \
         -port $WEB_PORT \
@@ -68,9 +67,8 @@ services:
         -cell $CELL \
         -cells_to_watch $CELL \
         -tablet_types_to_wait MASTER,REPLICA \
-        -gateway_implementation discoverygateway \
         -service_map 'grpc-vtgateservice' \
-        -pid_file $$VTDATAROOT/tmp/vtgate.pid \
+        -enable_system_settings=true \
         "]
     volumes:
       - ".:/script"
@@ -84,7 +82,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/base
+    image: vitess/lite
     command:
     - sh
     - -c
@@ -108,7 +106,7 @@ services:
         condition: service_healthy
 
   vttablet101:
-    image: vitess/base
+    image: vitess/lite
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -134,13 +132,13 @@ services:
     depends_on:
       - vtctld
     healthcheck:
-      test: ["CMD-SHELL","curl localhost:$$WEB_PORT/debug/health"]
+      test: ["CMD-SHELL","curl -s --fail --show-error localhost:$$WEB_PORT/debug/health"]
       interval: 30s
       timeout: 10s
       retries: 15
 
   vttablet102:
-    image: vitess/base
+    image: vitess/lite
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -164,13 +162,13 @@ services:
       - vtctld
       - vttablet101
     healthcheck:
-      test: ["CMD-SHELL","curl localhost:$$WEB_PORT/debug/health"]
+      test: ["CMD-SHELL","curl -s --fail --show-error localhost:$$WEB_PORT/debug/health"]
       interval: 30s
       timeout: 10s
       retries: 15
 
   vttablet103:
-    image: vitess/base
+    image: vitess/lite
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -194,7 +192,7 @@ services:
       - vtctld
       - vttablet101
     healthcheck:
-      test: ["CMD-SHELL","curl localhost:$$WEB_PORT/debug/health"]
+      test: ["CMD-SHELL","curl -s --fail --show-error localhost:$$WEB_PORT/debug/health"]
       interval: 30s
       timeout: 10s
       retries: 15

--- a/examples/compose/schemaload.sh
+++ b/examples/compose/schemaload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright 2019 The Vitess Authors.
+# Copyright 2020 The Vitess Authors.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ schema_files=${SCHEMA_FILES:-'create_messages.sql create_tokens.sql'}
 vschema_file=${VSCHEMA_FILE:-'default_vschema.json'}
 load_file=${POST_LOAD_FILE:-''}
 external_db=${EXTERNAL_DB:-'0'}
+export PATH=/vt/bin:$PATH
 
 sleep $sleeptime
 
@@ -40,6 +41,8 @@ if [ ! -f schema_run ]; then
   vtctlclient -server vtctld:$GRPC_PORT ApplyVSchema -vschema_file /script/${vschema_file} $KEYSPACE || \
   vtctlclient -server vtctld:$GRPC_PORT ApplyVSchema -vschema "$(cat /script/${vschema_file})" $KEYSPACE
   
+  echo "List All Tablets"
+  vtctlclient -server vtctld:$GRPC_PORT ListAllTablets
   echo "Get Master Tablets"
   master_tablets=$(vtctlclient -server vtctld:$GRPC_PORT ListAllTablets | awk '$4 == "master" { print $1 }')
   for master_tablet in $master_tablets; do
@@ -53,7 +56,7 @@ if [ ! -f schema_run ]; then
     mysql --port=15306 --host=vtgate < /script/$load_file
   fi
 
-  touch schema_run
-  echo "Time: $(date). SchemaLoad completed at $(date "+%FT%T") " >> schema_run
+  touch /vt/schema_run
+  echo "Time: $(date). SchemaLoad completed at $(date "+%FT%T") " >> /vt/schema_run
   echo "Done Loading Schema at $(date "+%FT%T")"
 fi


### PR DESCRIPTION
This PR replaces the huge `vitess: base` images >2G with the `vitess:lite` image.
The objective is to make it quicker for someone to spin up a docker-compose example.
A secondary objective is to mirror operator design and discard the `InitShardMaster` introduced [here](https://github.com/vitessio/vitess/pull/6584) by implementing orchestrator.
@sougou @shlomi-noach @deepthi 