### PR TITLE
vttablet: fast and reliable state transitions

### DIFF
--- a/config/tablet/default.yaml
+++ b/config/tablet/default.yaml
@@ -84,8 +84,8 @@ healthcheck:
   unhealthyThresholdSeconds: 7200 # unhealthy_threshold
 
 gracePeriods:
-  transactionShutdownSeconds: 0 # transaction_shutdown_grace_period
-  transitionSeconds: 0          # serving_state_grace_period
+  shutdownSeconds:   0 # shutdown_grace_period
+  transitionSeconds: 0 # serving_state_grace_period
 
 replicationTracker:
   mode: disable                    # enable_replication_reporter

--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -75,8 +75,7 @@ var (
     <td width="25%" border="">
       <a href="/healthz">Health Check</a></br>
       <a href="/debug/health">Query Service Health Check</a></br>
-      <a href="/oltpqueryz/">Real-time OLTP Queries</a></br>
-      <a href="/olapqueryz/">Real-time OLAP Queries</a></br>
+      <a href="/livequeryz/">Real-time Queries</a></br>
       <a href="/debug/status_details">JSON Status Details</a></br>
     </td>
   </tr>

--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -65,7 +65,6 @@ var (
       <a href="/debug/tablet_plans">Schema&nbsp;Query&nbsp;Plans</a></br>
       <a href="/debug/query_stats">Schema&nbsp;Query&nbsp;Stats</a></br>
       <a href="/queryz">Query&nbsp;Stats</a></br>
-      <a href="/streamqueryz">Streaming&nbsp;Query&nbsp;Stats</a></br>
     </td>
     <td width="25%" border="">
       <a href="/debug/consolidations">Consolidations</a></br>
@@ -76,7 +75,8 @@ var (
     <td width="25%" border="">
       <a href="/healthz">Health Check</a></br>
       <a href="/debug/health">Query Service Health Check</a></br>
-      <a href="/streamqueryz">Current Stream Queries</a></br>
+      <a href="/oltpqueryz/">Real-time OLTP Queries</a></br>
+      <a href="/olapqueryz/">Real-time OLAP Queries</a></br>
       <a href="/debug/status_details">JSON Status Details</a></br>
     </td>
   </tr>

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -21,48 +21,48 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNumbered(t *testing.T) {
+func TestNumberedGeneral(t *testing.T) {
 	id := int64(0)
 	p := NewNumbered()
 
-	var err error
-	if err = p.Register(id, id, true); err != nil {
-		t.Errorf("Error %v", err)
-	}
-	if err = p.Register(id, id, true); err.Error() != "already present" {
-		t.Errorf("want 'already present', got '%v'", err)
-	}
+	err := p.Register(id, id, true)
+	require.NoError(t, err)
+
+	err = p.Register(id, id, true)
+	assert.Contains(t, "already present", err.Error())
+
 	var v interface{}
-	if v, err = p.Get(id, "test"); err != nil {
-		t.Errorf("Error %v", err)
-	}
-	if v.(int64) != id {
-		t.Errorf("want %v, got %v", id, v.(int64))
-	}
-	if _, err = p.Get(id, "test1"); err.Error() != "in use: test" {
-		t.Errorf("want 'in use: test', got '%v'", err)
-	}
+	v, err = p.Get(id, "test")
+	require.NoError(t, err)
+	assert.Equal(t, id, v.(int64))
+
+	_, err = p.Get(id, "test1")
+	assert.Contains(t, "in use: test", err.Error())
+
 	p.Put(id, true)
-	if _, err = p.Get(1, "test2"); err.Error() != "not found" {
-		t.Errorf("want 'not found', got '%v'", err)
-	}
+	_, err = p.Get(1, "test2")
+	assert.Contains(t, "not found", err.Error())
 	p.Unregister(1, "test") // Should not fail
 	p.Unregister(0, "test")
 	// p is now empty
 
 	if _, err = p.Get(0, "test3"); !(strings.HasPrefix(err.Error(), "ended at") && strings.HasSuffix(err.Error(), "(test)")) {
-		t.Errorf("want prefix 'ended at' and suffix '(test'), got '%v'", err)
+		t.Errorf("want prefix 'ended at' and suffix '(test)', got '%v'", err)
 	}
 
+	id = 0
 	p.Register(id, id, true)
-	id++
+	id = 1
 	p.Register(id, id, true)
-	id++
+	id = 2
 	p.Register(id, id, false)
 	time.Sleep(300 * time.Millisecond)
-	id++
+	id = 3
 	p.Register(id, id, true)
 	time.Sleep(100 * time.Millisecond)
 
@@ -103,6 +103,20 @@ func TestNumbered(t *testing.T) {
 		p.Unregister(2, "test")
 	}()
 	p.WaitForEmpty()
+}
+
+func TestNumberedGetByFilter(t *testing.T) {
+	p := NewNumbered()
+	p.Register(1, 1, true)
+	p.Register(2, 2, true)
+	p.Register(3, 3, true)
+	p.Get(1, "locked")
+
+	vals := p.GetByFilter("filtered", func(v interface{}) bool {
+		return v.(int) <= 2
+	})
+	want := []interface{}{2}
+	assert.Equal(t, want, vals)
 }
 
 /*

--- a/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
@@ -42,7 +42,7 @@ func TestFallbackSecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/livequeryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.
@@ -97,7 +97,7 @@ func TestDenyAllSecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/livequeryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.
@@ -129,7 +129,7 @@ func TestReadOnlySecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/livequeryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.

--- a/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
@@ -42,7 +42,7 @@ func TestFallbackSecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/streamqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.
@@ -97,7 +97,7 @@ func TestDenyAllSecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/streamqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.
@@ -129,7 +129,7 @@ func TestReadOnlySecurityPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// It should deny ADMIN role.
-	url := fmt.Sprintf("http://localhost:%d/streamqueryz/terminate", mTablet.HTTPPort)
+	url := fmt.Sprintf("http://localhost:%d/olapqueryz/terminate", mTablet.HTTPPort)
 	assertNotAllowedURLTest(t, url)
 
 	// It should deny MONITORING role.

--- a/go/timer/sleep_context.go
+++ b/go/timer/sleep_context.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"time"
+)
+
+// SleepContext sleeps for the specified time period.
+// If the context expires early, it returns an error.
+func SleepContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/go/timer/sleep_context_test.go
+++ b/go/timer/sleep_context_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleepContext(t *testing.T) {
+	ctx := context.Background()
+	start := time.Now()
+	err := SleepContext(ctx, 10*time.Millisecond)
+	require.NoError(t, err)
+	assert.True(t, time.Since(start) > 10*time.Millisecond, time.Since(start))
+	assert.True(t, time.Since(start) < 100*time.Millisecond, time.Since(start))
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	start = time.Now()
+	err = SleepContext(ctx, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.True(t, time.Since(start) > 10*time.Millisecond, time.Since(start))
+	assert.True(t, time.Since(start) < 100*time.Millisecond, time.Since(start))
+}

--- a/go/vt/logz/logz_utils.go
+++ b/go/vt/logz/logz_utils.go
@@ -18,7 +18,7 @@ limitations under the License.
 // a sortable table on a webpage.
 //
 // It is used by many internal vttablet pages e.g. /queryz, /querylogz, /schemaz
-// /olapqueryz, oltpqueryz or /txlogz.
+// /livequeryz or /txlogz.
 //
 // See tabletserver/querylogz.go for an example how to use it.
 package logz

--- a/go/vt/logz/logz_utils.go
+++ b/go/vt/logz/logz_utils.go
@@ -18,7 +18,7 @@ limitations under the License.
 // a sortable table on a webpage.
 //
 // It is used by many internal vttablet pages e.g. /queryz, /querylogz, /schemaz
-// /streamqueryz or /txlogz.
+// /olapqueryz, oltpqueryz or /txlogz.
 //
 // See tabletserver/querylogz.go for an example how to use it.
 package logz

--- a/go/vt/vttablet/endtoend/framework/livequeryz.go
+++ b/go/vt/vttablet/endtoend/framework/livequeryz.go
@@ -23,8 +23,8 @@ import (
 	"time"
 )
 
-// OLAPQuery contains the streaming query info.
-type OLAPQuery struct {
+// LiveQuery contains the streaming query info.
+type LiveQuery struct {
 	Type              string
 	Query             string
 	ContextHTML       string
@@ -36,9 +36,9 @@ type OLAPQuery struct {
 }
 
 // OLAPQueryz returns the contents of /livequeryz?format=json.
-// as a []OLAPQuery. The function returns an empty list on error.
-func OLAPQueryz() []OLAPQuery {
-	var out []OLAPQuery
+// as a []LiveQuery. The function returns an empty list on error.
+func LiveQueryz() []LiveQuery {
+	var out []LiveQuery
 	response, err := http.Get(fmt.Sprintf("%s/livequeryz?format=json", ServerAddress))
 	if err != nil {
 		return out

--- a/go/vt/vttablet/endtoend/framework/olapqueryz.go
+++ b/go/vt/vttablet/endtoend/framework/olapqueryz.go
@@ -25,6 +25,7 @@ import (
 
 // OLAPQuery contains the streaming query info.
 type OLAPQuery struct {
+	Type              string
 	Query             string
 	ContextHTML       string
 	Start             time.Time
@@ -34,11 +35,11 @@ type OLAPQuery struct {
 	ShowTerminateLink bool
 }
 
-// OLAPQueryz returns the contents of /olapqueryz?format=json.
+// OLAPQueryz returns the contents of /livequeryz?format=json.
 // as a []OLAPQuery. The function returns an empty list on error.
 func OLAPQueryz() []OLAPQuery {
 	var out []OLAPQuery
-	response, err := http.Get(fmt.Sprintf("%s/olapqueryz?format=json", ServerAddress))
+	response, err := http.Get(fmt.Sprintf("%s/livequeryz?format=json", ServerAddress))
 	if err != nil {
 		return out
 	}
@@ -49,7 +50,7 @@ func OLAPQueryz() []OLAPQuery {
 
 // StreamTerminate terminates the specified streaming query.
 func StreamTerminate(connID int) error {
-	response, err := http.Get(fmt.Sprintf("%s/olapqueryz/terminate?format=json&connID=%d", ServerAddress, connID))
+	response, err := http.Get(fmt.Sprintf("%s/livequeryz/terminate?format=json&connID=%d", ServerAddress, connID))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/endtoend/framework/olapqueryz.go
+++ b/go/vt/vttablet/endtoend/framework/olapqueryz.go
@@ -23,8 +23,8 @@ import (
 	"time"
 )
 
-// StreamQuery contains the streaming query info.
-type StreamQuery struct {
+// OLAPQuery contains the streaming query info.
+type OLAPQuery struct {
 	Query             string
 	ContextHTML       string
 	Start             time.Time
@@ -34,11 +34,11 @@ type StreamQuery struct {
 	ShowTerminateLink bool
 }
 
-// StreamQueryz returns the contents of /streamqueryz?format=json.
-// as a []StreamQuery. The function returns an empty list on error.
-func StreamQueryz() []StreamQuery {
-	var out []StreamQuery
-	response, err := http.Get(fmt.Sprintf("%s/streamqueryz?format=json", ServerAddress))
+// OLAPQueryz returns the contents of /olapqueryz?format=json.
+// as a []OLAPQuery. The function returns an empty list on error.
+func OLAPQueryz() []OLAPQuery {
+	var out []OLAPQuery
+	response, err := http.Get(fmt.Sprintf("%s/olapqueryz?format=json", ServerAddress))
 	if err != nil {
 		return out
 	}
@@ -49,7 +49,7 @@ func StreamQueryz() []StreamQuery {
 
 // StreamTerminate terminates the specified streaming query.
 func StreamTerminate(connID int) error {
-	response, err := http.Get(fmt.Sprintf("%s/streamqueryz/terminate?format=json&connID=%d", ServerAddress, connID))
+	response, err := http.Get(fmt.Sprintf("%s/olapqueryz/terminate?format=json&connID=%d", ServerAddress, connID))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 	"time"
 
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/yaml2"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -111,6 +113,9 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams, dbName string)
 	config.TwoPCCoordinatorAddress = "fake"
 	config.HotRowProtection.Mode = tabletenv.Enable
 	config.TrackSchemaVersions = true
+	config.GracePeriods.ShutdownSeconds = 2
+	gotBytes, _ := yaml2.Marshal(config)
+	log.Infof("Config:\n%s", gotBytes)
 	return StartCustomServer(connParams, connAppDebugParams, dbName, config)
 }
 

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -101,10 +101,10 @@ func TestStreamTerminate(t *testing.T) {
 		nil,
 		func(*sqltypes.Result) error {
 			if !called {
-				queries := framework.StreamQueryz()
+				queries := framework.OLAPQueryz()
 				if l := len(queries); l != 1 {
 					t.Errorf("len(queries): %d, want 1", l)
-					return errors.New("no queries from StreamQueryz")
+					return errors.New("no queries from OLAPQueryz")
 				}
 				err := framework.StreamTerminate(queries[0].ConnID)
 				if err != nil {

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -101,10 +101,10 @@ func TestStreamTerminate(t *testing.T) {
 		nil,
 		func(*sqltypes.Result) error {
 			if !called {
-				queries := framework.OLAPQueryz()
+				queries := framework.LiveQueryz()
 				if l := len(queries); l != 1 {
 					t.Errorf("len(queries): %d, want 1", l)
-					return errors.New("no queries from OLAPQueryz")
+					return errors.New("no queries from LiveQueryz")
 				}
 				err := framework.StreamTerminate(queries[0].ConnID)
 				if err != nil {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
@@ -231,6 +233,34 @@ func TestDBConnKill(t *testing.T) {
 	}
 }
 
+// TestDBConnClose tests that an Exec returns immediately if a connection
+// is asynchronously killed (and closed) in the middle of an execution.
+func TestDBConnClose(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	connPool := newPool()
+	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
+	defer connPool.Close()
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
+	require.NoError(t, err)
+	defer dbConn.Close()
+
+	query := "sleep"
+	db.AddQuery(query, &sqltypes.Result{})
+	db.SetBeforeFunc(query, func() {
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	start := time.Now()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		dbConn.Kill("test kill", 0)
+	}()
+	_, err = dbConn.Exec(context.Background(), query, 1, false)
+	assert.Contains(t, err.Error(), "(errno 2013) due to")
+	assert.True(t, time.Since(start) < 100*time.Millisecond, "%v %v", time.Since(start), 100*time.Millisecond)
+}
+
 func TestDBNoPoolConnKill(t *testing.T) {
 	db := fakesqldb.New(t)
 	connPool := newPool()
@@ -329,4 +359,34 @@ func TestDBConnStream(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Error: '%v', must contain '%s'", err, want)
 	}
+}
+
+func TestDBConnStreamKill(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	sql := "select * from test_table limit 1000"
+	expectedResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Type: sqltypes.VarChar},
+		},
+	}
+	db.AddQuery(sql, expectedResult)
+	connPool := newPool()
+	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
+	defer connPool.Close()
+	dbConn, err := NewDBConn(context.Background(), connPool, db.ConnParams())
+	require.NoError(t, err)
+	defer dbConn.Close()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		dbConn.Kill("test kill", 0)
+	}()
+
+	err = dbConn.Stream(context.Background(), sql, func(r *sqltypes.Result) error {
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	}, 10, querypb.ExecuteOptions_ALL)
+
+	assert.Contains(t, err.Error(), "(errno 2013) due to")
 }

--- a/go/vt/vttablet/tabletserver/livequeryz.go
+++ b/go/vt/vttablet/tabletserver/livequeryz.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	streamqueryzHeader = []byte(`<thead>
+	livequeryzHeader = []byte(`<thead>
 		<tr>
 			<th>Query</th>
 			<th>Context</th>
@@ -40,20 +40,19 @@ var (
 		</tr>
         </thead>
 	`)
-	// TODO(sougou): livequeryz in the URL should be parameterized.
-	streamqueryzTmpl = template.Must(template.New("example").Parse(`
+	livequeryzTmpl = template.Must(template.New("example").Parse(`
 		<tr>
 			<td>{{.Query}}</td>
 			<td>{{.ContextHTML}}</td>
 			<td>{{.Duration}}</td>
 			<td>{{.Start}}</td>
 			<td>{{.ConnID}}</td>
-			<td><a href='/livequeryz/terminate?connID={{.ConnID}}'>Terminate</a></td>
+			<td><a href='terminate?connID={{.ConnID}}'>Terminate</a></td>
 		</tr>
 	`))
 )
 
-func streamQueryzHandler(queryList *QueryList, w http.ResponseWriter, r *http.Request) {
+func livequeryzHandler(queryList *QueryList, w http.ResponseWriter, r *http.Request) {
 	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 		acl.SendError(w, err)
 		return
@@ -76,15 +75,15 @@ func streamQueryzHandler(queryList *QueryList, w http.ResponseWriter, r *http.Re
 	}
 	logz.StartHTMLTable(w)
 	defer logz.EndHTMLTable(w)
-	w.Write(streamqueryzHeader)
+	w.Write(livequeryzHeader)
 	for i := range rows {
-		if err := streamqueryzTmpl.Execute(w, rows[i]); err != nil {
-			log.Errorf("streamlogz: couldn't execute template: %v", err)
+		if err := livequeryzTmpl.Execute(w, rows[i]); err != nil {
+			log.Errorf("livequeryz: couldn't execute template: %v", err)
 		}
 	}
 }
 
-func streamQueryzTerminateHandler(queryList *QueryList, w http.ResponseWriter, r *http.Request) {
+func livequeryzTerminateHandler(queryList *QueryList, w http.ResponseWriter, r *http.Request) {
 	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 		acl.SendError(w, err)
 		return
@@ -103,5 +102,5 @@ func streamQueryzTerminateHandler(queryList *QueryList, w http.ResponseWriter, r
 		http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 		return
 	}
-	streamQueryzHandler(queryList, w, r)
+	livequeryzHandler(queryList, w, r)
 }

--- a/go/vt/vttablet/tabletserver/livequeryz_test.go
+++ b/go/vt/vttablet/tabletserver/livequeryz_test.go
@@ -24,42 +24,42 @@ import (
 	"golang.org/x/net/context"
 )
 
-func TestStreamQueryzHandlerJSON(t *testing.T) {
+func TestLiveQueryzHandlerJSON(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/streamqueryz?format=json", nil)
+	req, _ := http.NewRequest("GET", "/oltpqueryz/?format=json", nil)
 
 	queryList := NewQueryList()
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
-	streamQueryzHandler(queryList, resp, req)
+	livequeryzHandler(queryList, resp, req)
 }
 
-func TestStreamQueryzHandlerHTTP(t *testing.T) {
+func TestLiveQueryzHandlerHTTP(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/streamqueryz", nil)
+	req, _ := http.NewRequest("GET", "/oltpqueryz/", nil)
 
 	queryList := NewQueryList()
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
-	streamQueryzHandler(queryList, resp, req)
+	livequeryzHandler(queryList, resp, req)
 }
 
-func TestStreamQueryzHandlerHTTPFailedInvalidForm(t *testing.T) {
+func TestLiveQueryzHandlerHTTPFailedInvalidForm(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/streamqueryz", nil)
+	req, _ := http.NewRequest("POST", "/oltpqueryz/", nil)
 
-	streamQueryzHandler(NewQueryList(), resp, req)
+	livequeryzHandler(NewQueryList(), resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)
 	}
 }
 
-func TestStreamQueryzHandlerTerminateConn(t *testing.T) {
+func TestLiveQueryzHandlerTerminateConn(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/streamqueryz/terminate?connID=1", nil)
+	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=1", nil)
 
 	queryList := NewQueryList()
 	testConn := &testConn{id: 1}
@@ -67,39 +67,39 @@ func TestStreamQueryzHandlerTerminateConn(t *testing.T) {
 	if testConn.IsKilled() {
 		t.Fatalf("conn should still be alive")
 	}
-	streamQueryzTerminateHandler(queryList, resp, req)
+	livequeryzTerminateHandler(queryList, resp, req)
 	if !testConn.IsKilled() {
 		t.Fatalf("conn should be killed")
 	}
 }
 
-func TestStreamQueryzHandlerTerminateFailedInvalidConnID(t *testing.T) {
+func TestLiveQueryzHandlerTerminateFailedInvalidConnID(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/streamqueryz/terminate?connID=invalid", nil)
+	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=invalid", nil)
 
-	streamQueryzTerminateHandler(NewQueryList(), resp, req)
+	livequeryzTerminateHandler(NewQueryList(), resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)
 	}
 }
 
-func TestStreamQueryzHandlerTerminateFailedKnownConnID(t *testing.T) {
+func TestLiveQueryzHandlerTerminateFailedKnownConnID(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/streamqueryz/terminate?connID=10", nil)
+	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=10", nil)
 
-	streamQueryzTerminateHandler(NewQueryList(), resp, req)
+	livequeryzTerminateHandler(NewQueryList(), resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)
 	}
 }
 
-func TestStreamQueryzHandlerTerminateFailedInvalidForm(t *testing.T) {
+func TestLiveQueryzHandlerTerminateFailedInvalidForm(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/streamqueryz/terminate?inva+lid=2", nil)
+	req, _ := http.NewRequest("POST", "/oltpqueryz//terminate?inva+lid=2", nil)
 
-	streamQueryzTerminateHandler(NewQueryList(), resp, req)
+	livequeryzTerminateHandler(NewQueryList(), resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)

--- a/go/vt/vttablet/tabletserver/livequeryz_test.go
+++ b/go/vt/vttablet/tabletserver/livequeryz_test.go
@@ -26,31 +26,31 @@ import (
 
 func TestLiveQueryzHandlerJSON(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/oltpqueryz/?format=json", nil)
+	req, _ := http.NewRequest("GET", "/livequeryz/?format=json", nil)
 
-	queryList := NewQueryList()
+	queryList := NewQueryList("test")
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
-	livequeryzHandler(queryList, resp, req)
+	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
 
 func TestLiveQueryzHandlerHTTP(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/oltpqueryz/", nil)
+	req, _ := http.NewRequest("GET", "/livequeryz/", nil)
 
-	queryList := NewQueryList()
+	queryList := NewQueryList("test")
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 1}))
 	queryList.Add(NewQueryDetail(context.Background(), &testConn{id: 2}))
 
-	livequeryzHandler(queryList, resp, req)
+	livequeryzHandler([]*QueryList{queryList}, resp, req)
 }
 
 func TestLiveQueryzHandlerHTTPFailedInvalidForm(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/oltpqueryz/", nil)
+	req, _ := http.NewRequest("POST", "/livequeryz/", nil)
 
-	livequeryzHandler(NewQueryList(), resp, req)
+	livequeryzHandler([]*QueryList{NewQueryList("test")}, resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)
@@ -59,15 +59,15 @@ func TestLiveQueryzHandlerHTTPFailedInvalidForm(t *testing.T) {
 
 func TestLiveQueryzHandlerTerminateConn(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=1", nil)
+	req, _ := http.NewRequest("GET", "/livequeryz//terminate?connID=1", nil)
 
-	queryList := NewQueryList()
+	queryList := NewQueryList("test")
 	testConn := &testConn{id: 1}
 	queryList.Add(NewQueryDetail(context.Background(), testConn))
 	if testConn.IsKilled() {
 		t.Fatalf("conn should still be alive")
 	}
-	livequeryzTerminateHandler(queryList, resp, req)
+	livequeryzTerminateHandler([]*QueryList{queryList}, resp, req)
 	if !testConn.IsKilled() {
 		t.Fatalf("conn should be killed")
 	}
@@ -75,20 +75,9 @@ func TestLiveQueryzHandlerTerminateConn(t *testing.T) {
 
 func TestLiveQueryzHandlerTerminateFailedInvalidConnID(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=invalid", nil)
+	req, _ := http.NewRequest("GET", "/livequeryz//terminate?connID=invalid", nil)
 
-	livequeryzTerminateHandler(NewQueryList(), resp, req)
-	if resp.Code != http.StatusInternalServerError {
-		t.Fatalf("http call should fail and return code: %d, but got: %d",
-			http.StatusInternalServerError, resp.Code)
-	}
-}
-
-func TestLiveQueryzHandlerTerminateFailedKnownConnID(t *testing.T) {
-	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/oltpqueryz//terminate?connID=10", nil)
-
-	livequeryzTerminateHandler(NewQueryList(), resp, req)
+	livequeryzTerminateHandler([]*QueryList{NewQueryList("test")}, resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)
@@ -97,9 +86,9 @@ func TestLiveQueryzHandlerTerminateFailedKnownConnID(t *testing.T) {
 
 func TestLiveQueryzHandlerTerminateFailedInvalidForm(t *testing.T) {
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/oltpqueryz//terminate?inva+lid=2", nil)
+	req, _ := http.NewRequest("POST", "/livequeryz//terminate?inva+lid=2", nil)
 
-	livequeryzTerminateHandler(NewQueryList(), resp, req)
+	livequeryzTerminateHandler([]*QueryList{NewQueryList("test")}, resp, req)
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("http call should fail and return code: %d, but got: %d",
 			http.StatusInternalServerError, resp.Code)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -710,10 +710,6 @@ func (qre *QueryExecutor) execStreamSQL(conn *connpool.DBConn, sql string, callb
 		return callback(result)
 	}
 
-	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.ql.Add(qd)
-	defer qre.tsv.ql.Remove(qd)
-
 	start := time.Now()
 	err := conn.Stream(ctx, sql, callBackClosingSpan, int(qre.tsv.qe.streamBufferSize.Get()), sqltypes.IncludeFieldsOrDefault(qre.options))
 	qre.logStats.AddRewrittenSQL(sql, start)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -203,9 +203,9 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 	case planbuilder.PlanUpdateLimit, planbuilder.PlanDeleteLimit:
 		return qre.execDMLLimit(conn)
 	case planbuilder.PlanSet, planbuilder.PlanOtherRead, planbuilder.PlanOtherAdmin:
-		return qre.execSQL(conn, qre.query, true)
+		return qre.execStatefulConn(conn, qre.query, true)
 	case planbuilder.PlanSavepoint, planbuilder.PlanRelease, planbuilder.PlanSRollback:
-		return qre.execSQL(conn, qre.query, true)
+		return qre.execStatefulConn(conn, qre.query, true)
 	case planbuilder.PlanSelect, planbuilder.PlanSelectLock, planbuilder.PlanSelectImpossible, planbuilder.PlanShowTables:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
@@ -259,7 +259,11 @@ func (qre *QueryExecutor) Stream(callback func(*sqltypes.Result) error) error {
 		conn = dbConn
 	}
 
-	return qre.streamFetch(conn, qre.plan.FullQuery, qre.bindVars, callback)
+	sql, _, err := qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars)
+	if err != nil {
+		return err
+	}
+	return qre.execStreamSQL(conn, sql, callback)
 }
 
 // MessageStream streams messages from a message table.
@@ -376,7 +380,7 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (*sqltypes.Result, e
 		}
 	}()
 
-	result, err := qre.execSQL(conn, qre.query, true)
+	result, err := qre.execStatefulConn(conn, qre.query, true)
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +396,7 @@ func (qre *QueryExecutor) execDDL(conn *StatefulConnection) (*sqltypes.Result, e
 }
 
 func (qre *QueryExecutor) execLoad(conn *StatefulConnection) (*sqltypes.Result, error) {
-	result, err := qre.execSQL(conn, qre.query, true)
+	result, err := qre.execStatefulConn(conn, qre.query, true)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +433,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 	if t.SequenceInfo.NextVal == 0 || t.SequenceInfo.NextVal+inc > t.SequenceInfo.LastVal {
 		_, err := qre.execAsTransaction(func(conn *StatefulConnection) (*sqltypes.Result, error) {
 			query := fmt.Sprintf("select next_id, cache from %s where id = 0 for update", sqlparser.String(tableName))
-			qr, err := qre.execSQL(conn, query, false)
+			qr, err := qre.execStatefulConn(conn, query, false)
 			if err != nil {
 				return nil, err
 			}
@@ -464,7 +468,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 			}
 			query = fmt.Sprintf("update %s set next_id = %d where id = 0", sqlparser.String(tableName), newLast)
 			conn.TxProperties().RecordQuery(query)
-			_, err = qre.execSQL(conn, query, false)
+			_, err = qre.execStatefulConn(conn, query, false)
 			if err != nil {
 				return nil, err
 			}
@@ -504,7 +508,12 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		return nil, err
 	}
 	defer conn.Recycle()
-	return qre.dbConnFetch(conn, qre.plan.FullQuery, qre.bindVars)
+
+	sql, _, err := qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars)
+	if err != nil {
+		return nil, err
+	}
+	return qre.execDBConn(conn, sql, true)
 }
 
 func (qre *QueryExecutor) execDMLLimit(conn *StatefulConnection) (*sqltypes.Result, error) {
@@ -542,7 +551,7 @@ func (qre *QueryExecutor) execOther() (*sqltypes.Result, error) {
 		return nil, err
 	}
 	defer conn.Recycle()
-	return qre.execSQL(conn, qre.query, true)
+	return qre.execDBConn(conn, qre.query, true)
 }
 
 func (qre *QueryExecutor) getConn() (*connpool.DBConn, error) {
@@ -593,7 +602,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 				q.Err = err
 			} else {
 				defer conn.Recycle()
-				q.Result, q.Err = qre.execSQL(conn, sql, false)
+				q.Result, q.Err = qre.execDBConn(conn, sql, false)
 			}
 		} else {
 			logStats.QuerySources |= tabletenv.QuerySourceConsolidator
@@ -611,7 +620,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 		return nil, err
 	}
 	defer conn.Recycle()
-	res, err := qre.execSQL(conn, sql, false)
+	res, err := qre.execDBConn(conn, sql, false)
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +633,7 @@ func (qre *QueryExecutor) txFetch(conn *StatefulConnection, record bool) (*sqlty
 	if err != nil {
 		return nil, err
 	}
-	qr, err := qre.execSQL(conn, sql, true)
+	qr, err := qre.execStatefulConn(conn, sql, true)
 	if err != nil {
 		return nil, err
 	}
@@ -633,24 +642,6 @@ func (qre *QueryExecutor) txFetch(conn *StatefulConnection, record bool) (*sqlty
 		conn.TxProperties().RecordQuery(sql)
 	}
 	return qr, nil
-}
-
-// dbConnFetch fetches from a connpool.DBConn.
-func (qre *QueryExecutor) dbConnFetch(conn *connpool.DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	sql, _, err := qre.generateFinalSQL(parsedQuery, bindVars)
-	if err != nil {
-		return nil, err
-	}
-	return qre.execSQL(conn, sql, true)
-}
-
-// streamFetch performs a streaming fetch.
-func (qre *QueryExecutor) streamFetch(conn *connpool.DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error {
-	sql, _, err := qre.generateFinalSQL(parsedQuery, bindVars)
-	if err != nil {
-		return err
-	}
-	return qre.execStreamSQL(conn, sql, callback)
 }
 
 func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable) (string, string, error) {
@@ -677,23 +668,28 @@ func (qre *QueryExecutor) getSelectLimit() int64 {
 	return maxRows
 }
 
-// executor is an abstraction for reusing code in execSQL.
-type executor interface {
-	Exec(ctx context.Context, query string, maxrows int, wantfields bool) (*sqltypes.Result, error)
-	Current() string
-	ID() int64
-	Kill(message string, elapsed time.Duration) error
-}
-
-func (qre *QueryExecutor) execSQL(conn executor, sql string, wantfields bool) (*sqltypes.Result, error) {
-	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.execSQL")
+func (qre *QueryExecutor) execDBConn(conn *connpool.DBConn, sql string, wantfields bool) (*sqltypes.Result, error) {
+	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.execDBConn")
 	defer span.Finish()
 
 	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.oltpql.Add(qd)
-	defer qre.tsv.oltpql.Remove(qd)
+	qre.tsv.statefulql.Add(qd)
+	defer qre.tsv.statefulql.Remove(qd)
+
+	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Get()), wantfields)
+}
+
+func (qre *QueryExecutor) execStatefulConn(conn *StatefulConnection, sql string, wantfields bool) (*sqltypes.Result, error) {
+	span, ctx := trace.NewSpan(qre.ctx, "QueryExecutor.execStatefulConn")
+	defer span.Finish()
+
+	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
+
+	qd := NewQueryDetail(qre.logStats.Ctx, conn)
+	qre.tsv.statelessql.Add(qd)
+	defer qre.tsv.statelessql.Remove(qd)
 
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Get()), wantfields)
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -675,8 +675,8 @@ func (qre *QueryExecutor) execDBConn(conn *connpool.DBConn, sql string, wantfiel
 	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.statefulql.Add(qd)
-	defer qre.tsv.statefulql.Remove(qd)
+	qre.tsv.statelessql.Add(qd)
+	defer qre.tsv.statelessql.Remove(qd)
 
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Get()), wantfields)
 }
@@ -688,8 +688,8 @@ func (qre *QueryExecutor) execStatefulConn(conn *StatefulConnection, sql string,
 	defer qre.logStats.AddRewrittenSQL(sql, time.Now())
 
 	qd := NewQueryDetail(qre.logStats.Ctx, conn)
-	qre.tsv.statelessql.Add(qd)
-	defer qre.tsv.statelessql.Remove(qd)
+	qre.tsv.statefulql.Add(qd)
+	defer qre.tsv.statefulql.Remove(qd)
 
 	return conn.Exec(ctx, sql, int(qre.tsv.qe.maxResultSize.Get()), wantfields)
 }

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -38,7 +38,7 @@ type QueryDetail struct {
 type killable interface {
 	Current() string
 	ID() int64
-	Kill(message string, startTime time.Duration) error
+	Kill(message string, elapsed time.Duration) error
 }
 
 // NewQueryDetail creates a new QueryDetail
@@ -77,7 +77,7 @@ func (ql *QueryList) Terminate(connID int64) error {
 	defer ql.mu.Unlock()
 	qd := ql.queryDetails[connID]
 	if qd == nil {
-		return fmt.Errorf("query %v not found", connID)
+		return fmt.Errorf("query %v not found; %+v", connID, ql)
 	}
 	qd.conn.Kill("QueryList.Terminate()", time.Since(qd.start))
 	return nil

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tabletserver
 
 import (
-	"fmt"
 	"html/template"
 	"sort"
 	"sync"
@@ -50,13 +49,18 @@ func NewQueryDetail(ctx context.Context, conn killable) *QueryDetail {
 
 // QueryList holds a thread safe list of QueryDetails
 type QueryList struct {
+	name string
+
 	mu           sync.Mutex
 	queryDetails map[int64]*QueryDetail
 }
 
 // NewQueryList creates a new QueryList
-func NewQueryList() *QueryList {
-	return &QueryList{queryDetails: make(map[int64]*QueryDetail)}
+func NewQueryList(name string) *QueryList {
+	return &QueryList{
+		name:         name,
+		queryDetails: make(map[int64]*QueryDetail),
+	}
 }
 
 // Add adds a QueryDetail to QueryList
@@ -74,15 +78,15 @@ func (ql *QueryList) Remove(qd *QueryDetail) {
 }
 
 // Terminate updates the query status and kills the connection
-func (ql *QueryList) Terminate(connID int64) error {
+func (ql *QueryList) Terminate(connID int64) bool {
 	ql.mu.Lock()
 	defer ql.mu.Unlock()
 	qd := ql.queryDetails[connID]
 	if qd == nil {
-		return fmt.Errorf("query %v not found; %+v", connID, ql)
+		return false
 	}
 	qd.conn.Kill("QueryList.Terminate()", time.Since(qd.start))
-	return nil
+	return true
 }
 
 // TerminateAll terminates all queries and kills the MySQL connections
@@ -96,6 +100,7 @@ func (ql *QueryList) TerminateAll() {
 
 // QueryDetailzRow is used for rendering QueryDetail in a template
 type QueryDetailzRow struct {
+	Type              string
 	Query             string
 	ContextHTML       template.HTML
 	Start             time.Time
@@ -111,16 +116,16 @@ func (a byStartTime) Len() int           { return len(a) }
 func (a byStartTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byStartTime) Less(i, j int) bool { return a[i].Start.Before(a[j].Start) }
 
-// GetQueryzRows returns a list of QueryDetailzRow sorted by start time
-func (ql *QueryList) GetQueryzRows() []QueryDetailzRow {
+// AppendQueryzRows returns a list of QueryDetailzRow sorted by start time
+func (ql *QueryList) AppendQueryzRows(rows []QueryDetailzRow) []QueryDetailzRow {
 	ql.mu.Lock()
-	rows := []QueryDetailzRow{}
 	for _, qd := range ql.queryDetails {
 		query := qd.conn.Current()
 		if *streamlog.RedactDebugUIQueries {
 			query, _ = sqlparser.RedactSQLQuery(query)
 		}
 		row := QueryDetailzRow{
+			Type:        ql.name,
 			Query:       query,
 			ContextHTML: callinfo.HTMLFromContext(qd.ctx),
 			Start:       qd.start,

--- a/go/vt/vttablet/tabletserver/query_list_test.go
+++ b/go/vt/vttablet/tabletserver/query_list_test.go
@@ -43,7 +43,7 @@ func (tc *testConn) IsKilled() bool {
 }
 
 func TestQueryList(t *testing.T) {
-	ql := NewQueryList()
+	ql := NewQueryList("test")
 	connID := int64(1)
 	qd := NewQueryDetail(context.Background(), &testConn{id: connID})
 	ql.Add(qd)
@@ -56,7 +56,7 @@ func TestQueryList(t *testing.T) {
 	qd2 := NewQueryDetail(context.Background(), &testConn{id: conn2ID})
 	ql.Add(qd2)
 
-	rows := ql.GetQueryzRows()
+	rows := ql.AppendQueryzRows(nil)
 	if len(rows) != 2 || rows[0].ConnID != 1 || rows[1].ConnID != 2 {
 		t.Errorf("wrong rows returned %v", rows)
 	}

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -92,8 +92,9 @@ type stateManager struct {
 
 	requests sync.WaitGroup
 
-	// ql does not have an Open or Close.
-	ql *QueryList
+	// QueryList does not have an Open or Close.
+	oltpql *QueryList
+	olapql *QueryList
 
 	// Open must be done in forward order.
 	// Close must be done in reverse order.
@@ -142,7 +143,6 @@ type (
 	queryEngine interface {
 		Open() error
 		IsMySQLReachable() error
-		StopServing()
 		Close()
 	}
 
@@ -501,7 +501,8 @@ func (sm *stateManager) unserveCommon() {
 	sm.throttler.Close()
 	sm.messager.Close()
 	sm.te.Close()
-	sm.qe.StopServing()
+	log.Info("Killing all OLAP queries")
+	sm.olapql.TerminateAll()
 	sm.tracker.Close()
 	sm.requests.Wait()
 }

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -148,8 +148,8 @@ type (
 	}
 
 	txEngine interface {
-		AcceptReadWrite() error
-		AcceptReadOnly() error
+		AcceptReadWrite()
+		AcceptReadOnly()
 		Close()
 	}
 
@@ -426,9 +426,7 @@ func (sm *stateManager) serveMaster() error {
 	// that most workloads don't use read-only transactions. If this becomes
 	// a common use case, we'll have to seperate out the transaction
 	// queries from oltpql and kill them here for a faster transition.
-	if err := sm.te.AcceptReadWrite(); err != nil {
-		return err
-	}
+	sm.te.AcceptReadWrite()
 	sm.messager.Open()
 	sm.throttler.Open()
 	sm.tableGC.Open()
@@ -468,9 +466,7 @@ func (sm *stateManager) serveNonMaster(wantTabletType topodatapb.TabletType) err
 		return err
 	}
 
-	if err := sm.te.AcceptReadOnly(); err != nil {
-		return err
-	}
+	sm.te.AcceptReadOnly()
 	sm.rt.MakeNonMaster()
 	sm.watcher.Open()
 	sm.setState(wantTabletType, StateServing)

--- a/go/vt/vttablet/tabletserver/state_manager.go
+++ b/go/vt/vttablet/tabletserver/state_manager.go
@@ -92,6 +92,9 @@ type stateManager struct {
 
 	requests sync.WaitGroup
 
+	// ql does not have an Open or Close.
+	ql *QueryList
+
 	// Open must be done in forward order.
 	// Close must be done in reverse order.
 	// All Close functions must be called before Open.

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -362,13 +362,11 @@ func TestStateManagerNotConnectedType(t *testing.T) {
 type delayedTxEngine struct {
 }
 
-func (te *delayedTxEngine) AcceptReadWrite() error {
-	return nil
+func (te *delayedTxEngine) AcceptReadWrite() {
 }
 
-func (te *delayedTxEngine) AcceptReadOnly() error {
+func (te *delayedTxEngine) AcceptReadOnly() {
 	time.Sleep(50 * time.Millisecond)
-	return nil
 }
 
 func (te *delayedTxEngine) Close() {
@@ -812,16 +810,14 @@ type testTxEngine struct {
 	testOrderState
 }
 
-func (te *testTxEngine) AcceptReadWrite() error {
+func (te *testTxEngine) AcceptReadWrite() {
 	te.order = order.Add(1)
 	te.state = testStateMaster
-	return nil
 }
 
-func (te *testTxEngine) AcceptReadOnly() error {
+func (te *testTxEngine) AcceptReadOnly() {
 	te.order = order.Add(1)
 	te.state = testStateNonMaster
-	return nil
 }
 
 func (te *testTxEngine) Close() {

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -664,8 +664,8 @@ func newTestStateManager(t *testing.T) *stateManager {
 	config := tabletenv.NewDefaultConfig()
 	env := tabletenv.NewEnv(config, "StateManagerTest")
 	sm := &stateManager{
-		oltpql:      NewQueryList(),
-		olapql:      NewQueryList(),
+		oltpql:      NewQueryList("oltp"),
+		olapql:      NewQueryList("olap"),
 		hs:          newHealthStreamer(env, topodatapb.TabletAlias{}),
 		se:          &testSchemaEngine{},
 		rt:          &testReplTracker{lag: 1 * time.Second},

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -53,7 +53,7 @@ type StatefulConnection struct {
 	enforceTimeout bool
 }
 
-//Properties contains meta information about the connection
+// Properties contains meta information about the connection
 type Properties struct {
 	EffectiveCaller *vtrpcpb.CallerID
 	ImmediateCaller *querypb.VTGateCallerID
@@ -68,12 +68,12 @@ func (sc *StatefulConnection) Close() {
 	}
 }
 
-//IsClosed returns true when the connection is still operational
+// IsClosed returns true when the connection is still operational
 func (sc *StatefulConnection) IsClosed() bool {
 	return sc.dbConn == nil || sc.dbConn.IsClosed()
 }
 
-//IsInTransaction returns true when the connection has tx state
+// IsInTransaction returns true when the connection has tx state
 func (sc *StatefulConnection) IsInTransaction() bool {
 	return sc.txProps != nil
 }
@@ -134,18 +134,18 @@ func (sc *StatefulConnection) unlock(updateTime bool) {
 	if sc.dbConn.IsClosed() {
 		sc.Releasef("unlocked closed connection")
 	} else {
-		sc.pool.markAsNotInUse(sc.ConnID, updateTime)
+		sc.pool.markAsNotInUse(sc, updateTime)
 	}
 }
 
-//Release is used when the connection will not be used ever again.
-//The underlying dbConn is removed so that this connection cannot be used by mistake.
+// Release is used when the connection will not be used ever again.
+// The underlying dbConn is removed so that this connection cannot be used by mistake.
 func (sc *StatefulConnection) Release(reason tx.ReleaseReason) {
 	sc.Releasef(reason.String())
 }
 
-//Releasef is used when the connection will not be used ever again.
-//The underlying dbConn is removed so that this connection cannot be used by mistake.
+// Releasef is used when the connection will not be used ever again.
+// The underlying dbConn is removed so that this connection cannot be used by mistake.
 func (sc *StatefulConnection) Releasef(reasonFormat string, a ...interface{}) {
 	if sc.dbConn == nil {
 		return
@@ -156,7 +156,7 @@ func (sc *StatefulConnection) Releasef(reasonFormat string, a ...interface{}) {
 	sc.logReservedConn()
 }
 
-//Renew the existing connection with new connection id.
+// Renew the existing connection with new connection id.
 func (sc *StatefulConnection) Renew() error {
 	err := sc.pool.renewConn(sc)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,6 +175,21 @@ func (sc *StatefulConnection) String() string {
 	)
 }
 
+// Current returns the currently executing query
+func (sc *StatefulConnection) Current() string {
+	return sc.dbConn.Current()
+}
+
+// ID returns the mysql connection ID
+func (sc *StatefulConnection) ID() int64 {
+	return sc.dbConn.ID()
+}
+
+// Kill kills the currently executing query and connection
+func (sc *StatefulConnection) Kill(reason string, elapsed time.Duration) error {
+	return sc.dbConn.Kill(reason, elapsed)
+}
+
 // TxProperties returns the transactional properties of the connection
 func (sc *StatefulConnection) TxProperties() *tx.Properties {
 	return sc.txProps

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,32 +175,32 @@ func (sc *StatefulConnection) String() string {
 	)
 }
 
-//TxProperties returns the transactional properties of the connection
+// TxProperties returns the transactional properties of the connection
 func (sc *StatefulConnection) TxProperties() *tx.Properties {
 	return sc.txProps
 }
 
-//ID returns the identifier for this connection
-func (sc *StatefulConnection) ID() tx.ConnID {
+// ReservedID returns the identifier for this connection
+func (sc *StatefulConnection) ReservedID() tx.ConnID {
 	return sc.ConnID
 }
 
-//UnderlyingDBConn returns the underlying database connection
+// UnderlyingDBConn returns the underlying database connection
 func (sc *StatefulConnection) UnderlyingDBConn() *connpool.DBConn {
 	return sc.dbConn
 }
 
-//CleanTxState cleans out the current transaction state
+// CleanTxState cleans out the current transaction state
 func (sc *StatefulConnection) CleanTxState() {
 	sc.txProps = nil
 }
 
-//Stats implements the tx.IStatefulConnection interface
+// Stats implements the tx.IStatefulConnection interface
 func (sc *StatefulConnection) Stats() *tabletenv.Stats {
 	return sc.env.Stats()
 }
 
-//Taint taints the existing connection.
+// Taint taints the existing connection.
 func (sc *StatefulConnection) Taint(ctx context.Context, stats *servenv.TimingsWrapper) error {
 	if sc.dbConn == nil {
 		return vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "connection is closed")
@@ -223,12 +223,12 @@ func (sc *StatefulConnection) Taint(ctx context.Context, stats *servenv.TimingsW
 	return nil
 }
 
-//IsTainted tells us whether this connection is tainted
+// IsTainted tells us whether this connection is tainted
 func (sc *StatefulConnection) IsTainted() bool {
 	return sc.tainted
 }
 
-//LogTransaction logs transaction related stats
+// LogTransaction logs transaction related stats
 func (sc *StatefulConnection) LogTransaction(reason tx.ReleaseReason) {
 	if sc.txProps == nil {
 		return //Nothing to log as no transaction exists on this connection.
@@ -250,7 +250,7 @@ func (sc *StatefulConnection) LogTransaction(reason tx.ReleaseReason) {
 	tabletenv.TxLogger.Send(sc)
 }
 
-//logReservedConn logs reserved connection related stats.
+// logReservedConn logs reserved connection related stats.
 func (sc *StatefulConnection) logReservedConn() {
 	if sc.reservedProps == nil {
 		return //Nothing to log as this connection is not reserved.

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -33,9 +33,20 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
-//StatefulConnectionPool keeps track of currently and future active connections
-//it's used whenever the session has some state that requires a dedicated connection
+const (
+	scpClosed = int64(iota)
+	scpOpen
+	scpKillingNonTx
+	scpKillingAll
+)
+
+// StatefulConnectionPool keeps track of currently and future active connections
+// it's used whenever the session has some state that requires a dedicated connection
 type StatefulConnectionPool struct {
+	env tabletenv.Env
+
+	state sync2.AtomicInt64
+
 	// conns is the 'regular' pool. By default, connections
 	// are pulled from here for starting transactions.
 	conns *connpool.Pool
@@ -47,7 +58,6 @@ type StatefulConnectionPool struct {
 	foundRowsPool *connpool.Pool
 	active        *pools.Numbered
 	lastID        sync2.AtomicInt64
-	env           tabletenv.Env
 }
 
 //NewStatefulConnPool creates an ActivePool
@@ -72,6 +82,7 @@ func (sf *StatefulConnectionPool) Open(appParams, dbaParams, appDebugParams dbco
 	foundRowsParam.EnableClientFoundRows()
 	appParams = dbconfigs.New(foundRowsParam)
 	sf.foundRowsPool.Open(appParams, dbaParams, appDebugParams)
+	sf.state.Set(scpOpen)
 }
 
 // Close closes the TxPool. A closed pool can be reopened.
@@ -89,6 +100,29 @@ func (sf *StatefulConnectionPool) Close() {
 	}
 	sf.conns.Close()
 	sf.foundRowsPool.Close()
+	sf.state.Set(scpClosed)
+}
+
+// ShutdownNonTx enters the state where all non-transactional connections are killed.
+// InUse connections will be killed as they are returned.
+func (sf *StatefulConnectionPool) ShutdownNonTx() {
+	sf.state.Set(scpKillingNonTx)
+	conns := mapToTxConn(sf.active.GetByFilter("kill non-tx", func(sc interface{}) bool {
+		return !sc.(*StatefulConnection).IsInTransaction()
+	}))
+	for _, sc := range conns {
+		sc.Releasef("kill non-tx")
+	}
+}
+
+// ShutdownAll enters the state where all connections are to be killed.
+// It returns all connections that are not in use. They must be rolled back
+// by the caller (TxPool). InUse connections will be killed as they are returned.
+func (sf *StatefulConnectionPool) ShutdownAll() []*StatefulConnection {
+	sf.state.Set(scpKillingAll)
+	return mapToTxConn(sf.active.GetByFilter("kill non-tx", func(sc interface{}) bool {
+		return true
+	}))
 }
 
 // AdjustLastID adjusts the last transaction id to be at least
@@ -103,6 +137,7 @@ func (sf *StatefulConnectionPool) AdjustLastID(id int64) {
 
 // GetOutdated returns a list of connections that are older than age.
 // It does not return any connections that are in use.
+// TODO(sougou): deprecate.
 func (sf *StatefulConnectionPool) GetOutdated(age time.Duration, purpose string) []*StatefulConnection {
 	return mapToTxConn(sf.active.GetOutdated(age, purpose))
 }
@@ -131,8 +166,8 @@ func (sf *StatefulConnectionPool) GetAndLock(id int64, reason string) (*Stateful
 	return conn.(*StatefulConnection), nil
 }
 
-//NewConn creates a new StatefulConnection. It will be created from either the normal pool or
-//the found_rows pool, depending on the options provided
+// NewConn creates a new StatefulConnection. It will be created from either the normal pool or
+// the found_rows pool, depending on the options provided
 func (sf *StatefulConnectionPool) NewConn(ctx context.Context, options *querypb.ExecuteOptions) (*StatefulConnection, error) {
 
 	var conn *connpool.DBConn
@@ -169,7 +204,7 @@ func (sf *StatefulConnectionPool) NewConn(ctx context.Context, options *querypb.
 	return sf.GetAndLock(sfConn.ConnID, "new connection")
 }
 
-//ForAllTxProperties executes a function an every connection that has a not-nil TxProperties
+// ForAllTxProperties executes a function an every connection that has a not-nil TxProperties
 func (sf *StatefulConnectionPool) ForAllTxProperties(f func(*tx.Properties)) {
 	for _, connection := range mapToTxConn(sf.active.GetAll()) {
 		props := connection.txProps
@@ -184,9 +219,22 @@ func (sf *StatefulConnectionPool) unregister(id tx.ConnID, reason string) {
 	sf.active.Unregister(id, reason)
 }
 
-//markAsNotInUse marks the connection as not in use at the moment
-func (sf *StatefulConnectionPool) markAsNotInUse(id tx.ConnID, updateTime bool) {
-	sf.active.Put(id, updateTime)
+// markAsNotInUse marks the connection as not in use at the moment
+func (sf *StatefulConnectionPool) markAsNotInUse(sc *StatefulConnection, updateTime bool) {
+	switch sf.state.Get() {
+	case scpKillingNonTx:
+		if !sc.IsInTransaction() {
+			sc.Releasef("kill non-tx")
+			return
+		}
+	case scpKillingAll:
+		if sc.IsInTransaction() {
+			sc.Close()
+		}
+		sc.Releasef("kill all")
+		return
+	}
+	sf.active.Put(sc.ConnID, updateTime)
 }
 
 // Capacity returns the pool capacity.
@@ -194,7 +242,7 @@ func (sf *StatefulConnectionPool) Capacity() int {
 	return int(sf.conns.Capacity())
 }
 
-//renewConn unregister and registers with new id.
+// renewConn unregister and registers with new id.
 func (sf *StatefulConnectionPool) renewConn(sc *StatefulConnection) error {
 	sf.active.Unregister(sc.ConnID, "renew existing connection")
 	sc.ConnID = sf.lastID.Add(1)

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool_test.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool_test.go
@@ -82,6 +82,70 @@ func TestActivePoolForAllTxProps(t *testing.T) {
 	require.True(t, conn3.txProps.LogToFile, "connection missed")
 }
 
+func TestStatefulPoolShutdownNonTx(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	pool := newActivePool()
+	pool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
+
+	// conn1 non-tx, not in use.
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{})
+	require.NoError(t, err)
+	conn1.Taint(ctx, nil)
+	conn1.Unlock()
+
+	// conn2 tx, not in use.
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{})
+	require.NoError(t, err)
+	conn2.Taint(ctx, nil)
+	conn2.txProps = &tx.Properties{}
+	conn2.Unlock()
+
+	// conn3 non-tx, in use.
+	conn3, err := pool.NewConn(ctx, &querypb.ExecuteOptions{})
+	require.NoError(t, err)
+	conn3.Taint(ctx, nil)
+
+	// After ShutdownNonTx, conn1 should be closed, but not conn3.
+	pool.ShutdownNonTx()
+	assert.Equal(t, int64(2), pool.active.Size())
+	assert.True(t, conn1.IsClosed())
+	assert.False(t, conn3.IsClosed())
+
+	// conn3 should get closed on Unlock.
+	conn3.Unlock()
+	assert.True(t, conn3.IsClosed())
+
+	// conn2 should be unaffected.
+	assert.False(t, conn2.IsClosed())
+}
+
+func TestStatefulPoolShutdownAll(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	pool := newActivePool()
+	pool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
+
+	// conn1 not in use
+	conn1, err := pool.NewConn(ctx, &querypb.ExecuteOptions{})
+	require.NoError(t, err)
+	conn1.txProps = &tx.Properties{}
+	conn1.Unlock()
+
+	// conn2 in use.
+	conn2, err := pool.NewConn(ctx, &querypb.ExecuteOptions{})
+	require.NoError(t, err)
+	conn2.txProps = &tx.Properties{}
+
+	conns := pool.ShutdownAll()
+	wantconns := []*StatefulConnection{conn1}
+	assert.Equal(t, wantconns, conns)
+
+	// conn2 should get closed on Unlock.
+	conn2.Unlock()
+	assert.True(t, conn2.IsClosed())
+}
+
 func TestActivePoolGetConnNonExistentTransaction(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -83,8 +83,7 @@ var (
     <td width="25%" border="">
       <a href="{{.Prefix}}/healthz">Health Check</a></br>
       <a href="{{.Prefix}}/debug/health">Query Service Health Check</a></br>
-      <a href="/oltpqueryz/">Real-time OLTP Queries</a></br>
-      <a href="/olapqueryz/">Real-time OLAP Queries</a></br>
+      <a href="/livequeryz/">Real-time Queries</a></br>
       <a href="{{.Prefix}}/debug/status_details">JSON Status Details</a></br>
     </td>
   </tr>

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -73,7 +73,6 @@ var (
       <a href="{{.Prefix}}/debug/tablet_plans">Schema&nbsp;Query&nbsp;Plans</a></br>
       <a href="{{.Prefix}}/debug/query_stats">Schema&nbsp;Query&nbsp;Stats</a></br>
       <a href="{{.Prefix}}/queryz">Query&nbsp;Stats</a></br>
-      <a href="{{.Prefix}}/streamqueryz">Streaming&nbsp;Query&nbsp;Stats</a></br>
     </td>
     <td width="25%" border="">
       <a href="{{.Prefix}}/debug/consolidations">Consolidations</a></br>
@@ -84,7 +83,8 @@ var (
     <td width="25%" border="">
       <a href="{{.Prefix}}/healthz">Health Check</a></br>
       <a href="{{.Prefix}}/debug/health">Query Service Health Check</a></br>
-      <a href="{{.Prefix}}/streamqueryz">Current Stream Queries</a></br>
+      <a href="/oltpqueryz/">Real-time OLTP Queries</a></br>
+      <a href="/olapqueryz/">Real-time OLAP Queries</a></br>
       <a href="{{.Prefix}}/debug/status_details">JSON Status Details</a></br>
     </td>
   </tr>

--- a/go/vt/vttablet/tabletserver/stream_queryz.go
+++ b/go/vt/vttablet/tabletserver/stream_queryz.go
@@ -40,6 +40,7 @@ var (
 		</tr>
         </thead>
 	`)
+	// TODO(sougou): livequeryz in the URL should be parameterized.
 	streamqueryzTmpl = template.Must(template.New("example").Parse(`
 		<tr>
 			<td>{{.Query}}</td>
@@ -47,7 +48,7 @@ var (
 			<td>{{.Duration}}</td>
 			<td>{{.Start}}</td>
 			<td>{{.ConnID}}</td>
-			<td><a href='/streamqueryz/terminate?connID={{.ConnID}}'>Terminate</a></td>
+			<td><a href='/livequeryz/terminate?connID={{.ConnID}}'>Terminate</a></td>
 		</tr>
 	`))
 )

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -93,7 +93,8 @@ func init() {
 	flag.IntVar(&currentConfig.MessagePostponeParallelism, "queryserver-config-message-postpone-cap", defaultConfig.MessagePostponeParallelism, "query server message postpone cap is the maximum number of messages that can be postponed at any given time. Set this number to substantially lower than transaction cap, so that the transaction pool isn't exhausted by the message subsystem.")
 	flag.IntVar(&deprecatedFoundRowsPoolSize, "client-found-rows-pool-size", 0, "DEPRECATED: queryserver-config-transaction-cap will be used instead.")
 	SecondsVar(&currentConfig.Oltp.TxTimeoutSeconds, "queryserver-config-transaction-timeout", defaultConfig.Oltp.TxTimeoutSeconds, "query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value")
-	SecondsVar(&currentConfig.GracePeriods.TransactionShutdownSeconds, "transaction_shutdown_grace_period", defaultConfig.GracePeriods.TransactionShutdownSeconds, "how long to wait (in seconds) for transactions to complete during graceful shutdown.")
+	SecondsVar(&currentConfig.GracePeriods.ShutdownSeconds, "shutdown_grace_period", defaultConfig.GracePeriods.ShutdownSeconds, "how long to wait (in seconds) for queries and transactions to complete during graceful shutdown.")
+	SecondsVar(&currentConfig.GracePeriods.ShutdownSeconds, "transaction_shutdown_grace_period", defaultConfig.GracePeriods.ShutdownSeconds, "DEPRECATED: use shutdown_grace_period instead.")
 	flag.IntVar(&currentConfig.Oltp.MaxRows, "queryserver-config-max-result-size", defaultConfig.Oltp.MaxRows, "query server max result size, maximum number of rows allowed to return from vttablet for non-streaming queries.")
 	flag.IntVar(&currentConfig.Oltp.WarnRows, "queryserver-config-warn-result-size", defaultConfig.Oltp.WarnRows, "query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this")
 	flag.IntVar(&deprecatedMaxDMLRows, "queryserver-config-max-dml-rows", 0, "query server max dml rows per statement, maximum number of rows allowed to return at a time for an update or delete with either 1) an equality where clauses on primary keys, or 2) a subselect statement. For update and delete statements in above two categories, vttablet will split the original query into multiple small queries based on this configuration value. ")
@@ -305,8 +306,8 @@ type HealthcheckConfig struct {
 // GracePeriodsConfig contains various grace periods.
 // TODO(sougou): move lameduck here?
 type GracePeriodsConfig struct {
-	TransactionShutdownSeconds Seconds `json:"transactionShutdownSeconds,omitempty"`
-	TransitionSeconds          Seconds `json:"transitionSeconds,omitempty"`
+	ShutdownSeconds   Seconds `json:"shutdownSeconds,omitempty"`
+	TransitionSeconds Seconds `json:"transitionSeconds,omitempty"`
 }
 
 // ReplicationTrackerConfig contains the config for the replication tracker.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1509,20 +1509,20 @@ func (tsv *TabletServer) registerQueryzHandler() {
 }
 
 func (tsv *TabletServer) registerStreamQueryzHandlers() {
-	tsv.exporter.HandleFunc("/streamqueryz", func(w http.ResponseWriter, r *http.Request) {
-		streamQueryzHandler(tsv.qe.streamQList, w, r)
+	tsv.exporter.HandleFunc("/olapqueryz/", func(w http.ResponseWriter, r *http.Request) {
+		livequeryzHandler(tsv.qe.streamQList, w, r)
 	})
-	tsv.exporter.HandleFunc("/streamqueryz/terminate", func(w http.ResponseWriter, r *http.Request) {
-		streamQueryzTerminateHandler(tsv.qe.streamQList, w, r)
+	tsv.exporter.HandleFunc("/olapqueryz/terminate", func(w http.ResponseWriter, r *http.Request) {
+		livequeryzTerminateHandler(tsv.qe.streamQList, w, r)
 	})
 }
 
 func (tsv *TabletServer) registerQueryListHandlers() {
-	tsv.exporter.HandleFunc("/livequeryz", func(w http.ResponseWriter, r *http.Request) {
-		streamQueryzHandler(tsv.ql, w, r)
+	tsv.exporter.HandleFunc("/oltpqueryz/", func(w http.ResponseWriter, r *http.Request) {
+		livequeryzHandler(tsv.ql, w, r)
 	})
-	tsv.exporter.HandleFunc("/livequeryz/terminate", func(w http.ResponseWriter, r *http.Request) {
-		streamQueryzTerminateHandler(tsv.ql, w, r)
+	tsv.exporter.HandleFunc("/oltpqueryz/terminate", func(w http.ResponseWriter, r *http.Request) {
+		livequeryzTerminateHandler(tsv.ql, w, r)
 	})
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -474,6 +474,36 @@ func TestTabletServerCommitPrepared(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSmallerTimeout(t *testing.T) {
+	testcases := []struct {
+		t1, t2, want time.Duration
+	}{{
+		t1:   0,
+		t2:   0,
+		want: 0,
+	}, {
+		t1:   0,
+		t2:   1 * time.Millisecond,
+		want: 1 * time.Millisecond,
+	}, {
+		t1:   1 * time.Millisecond,
+		t2:   0,
+		want: 1 * time.Millisecond,
+	}, {
+		t1:   1 * time.Millisecond,
+		t2:   2 * time.Millisecond,
+		want: 1 * time.Millisecond,
+	}, {
+		t1:   2 * time.Millisecond,
+		t2:   1 * time.Millisecond,
+		want: 1 * time.Millisecond,
+	}}
+	for _, tcase := range testcases {
+		got := smallerTimeout(tcase.t1, tcase.t2)
+		assert.Equal(t, tcase.want, got, tcase.t1, tcase.t2)
+	}
+}
+
 func TestTabletServerReserveConnection(t *testing.T) {
 	db, tsv := setupTabletServerTest(t, "")
 	defer tsv.StopService()

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -107,7 +107,7 @@ func NewTxEngine(env tabletenv.Env) *TxEngine {
 	config := env.Config()
 	te := &TxEngine{
 		env:                 env,
-		shutdownGracePeriod: config.GracePeriods.TransactionShutdownSeconds.Get(),
+		shutdownGracePeriod: config.GracePeriods.ShutdownSeconds.Get(),
 		reservedConnStats:   env.Exporter().NewTimings("ReservedConnections", "Reserved connections stats", "operation"),
 	}
 	limiter := txlimiter.New(env)

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -248,7 +248,7 @@ func (te *TxEngine) Begin(ctx context.Context, preQueries []string, reservedID i
 		return 0, "", err
 	}
 	defer conn.UnlockUpdateTime()
-	return conn.ID(), beginSQL, err
+	return conn.ReservedID(), beginSQL, err
 }
 
 // Commit commits the specified transaction and renews connection id if one exists.
@@ -577,7 +577,7 @@ func (te *TxEngine) ReserveBegin(ctx context.Context, options *querypb.ExecuteOp
 		conn.Release(tx.ConnInitFail)
 		return 0, err
 	}
-	return conn.ID(), nil
+	return conn.ReservedID(), nil
 }
 
 //Reserve creates a reserved connection and returns the id to it
@@ -590,7 +590,7 @@ func (te *TxEngine) Reserve(ctx context.Context, options *querypb.ExecuteOptions
 			return 0, vterrors.Wrap(err, "TxEngine.Reserve")
 		}
 		defer conn.Unlock()
-		return conn.ID(), nil
+		return conn.ReservedID(), nil
 	}
 
 	conn, err := te.txPool.GetAndLock(txID, "to reserve")
@@ -603,7 +603,7 @@ func (te *TxEngine) Reserve(ctx context.Context, options *querypb.ExecuteOptions
 	if err != nil {
 		return 0, vterrors.Wrap(err, "TxEngine.Reserve")
 	}
-	return conn.ID(), nil
+	return conn.ReservedID(), nil
 }
 
 //Reserve creates a reserved connection and returns the id to it

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -140,8 +140,7 @@ func TestTxEngineClose(t *testing.T) {
 	te.Close()
 	assert.Less(t, int64(50*time.Millisecond), int64(time.Since(start)))
 	assert.EqualValues(t, 1, te.txPool.env.Stats().KillCounters.Counts()["Transactions"])
-	assert.EqualValues(t, 2, te.txPool.env.Stats().KillCounters.Counts()["ReservedConnection"])
-
+	assert.EqualValues(t, 1, te.txPool.env.Stats().KillCounters.Counts()["ReservedConnection"])
 }
 
 func TestTxEngineBegin(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -47,7 +47,7 @@ func TestTxEngineClose(t *testing.T) {
 	config.DB = newDBConfigs(db)
 	config.TxPool.Size = 10
 	config.Oltp.TxTimeoutSeconds = 0.1
-	config.GracePeriods.TransactionShutdownSeconds = 0
+	config.GracePeriods.ShutdownSeconds = 0
 	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest"))
 
 	// Normal close.
@@ -515,7 +515,7 @@ func setupTxEngine(db *fakesqldb.DB) *TxEngine {
 	config.DB = newDBConfigs(db)
 	config.TxPool.Size = 10
 	config.Oltp.TxTimeoutSeconds = 0.1
-	config.GracePeriods.TransactionShutdownSeconds = 0
+	config.GracePeriods.ShutdownSeconds = 0
 	te := NewTxEngine(tabletenv.NewEnv(config, "TabletServerTest"))
 	return te
 }

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -102,7 +102,7 @@ func TestTxEngineClose(t *testing.T) {
 	c.Unlock()
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		_, err := te.txPool.GetAndLock(c.ID(), "return")
+		_, err := te.txPool.GetAndLock(c.ReservedID(), "return")
 		assert.NoError(t, err)
 		te.txPool.RollbackAndRelease(ctx, c)
 	}()

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -112,11 +112,10 @@ func (tp *TxPool) AdjustLastID(id int64) {
 	tp.scp.AdjustLastID(id)
 }
 
-// RollbackNonBusy rolls back all transactions that are not in use.
-// Transactions can be in use for situations like executing statements
-// or in prepared state.
-func (tp *TxPool) RollbackNonBusy(ctx context.Context) {
-	for _, v := range tp.scp.GetOutdated(time.Duration(0), "for transition") {
+// Shutdown immediately rolls back all transactions that are not in use.
+// In-use connections will be closed when they are unlocked (not in use).
+func (tp *TxPool) Shutdown(ctx context.Context) {
+	for _, v := range tp.scp.ShutdownAll() {
 		tp.RollbackAndRelease(ctx, v)
 	}
 }

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -120,7 +120,7 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 	conn2.Unlock() // this marks conn2 as NonBusy
 
 	// This should rollback only txid2.
-	txPool.RollbackNonBusy(ctx)
+	txPool.Shutdown(ctx)
 
 	// committing tx1 should not be an issue
 	_, err = txPool.Commit(ctx, conn1)
@@ -220,8 +220,8 @@ func TestTxPoolBeginWithError(t *testing.T) {
 		Principal: "principle",
 	}
 
-	ctxWithCallerId := callerid.NewContext(ctx, ef, im)
-	_, _, err := txPool.Begin(ctxWithCallerId, &querypb.ExecuteOptions{}, false, 0, nil)
+	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
+	_, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error: rejected")
 	require.Equal(t, vtrpcpb.Code_UNKNOWN, vterrors.Code(err), "wrong error code for Begin error")
@@ -395,10 +395,10 @@ func TestTxTimeoutKillsTransactions(t *testing.T) {
 		Principal: "principle",
 	}
 
-	ctxWithCallerId := callerid.NewContext(ctx, ef, im)
+	ctxWithCallerID := callerid.NewContext(ctx, ef, im)
 
 	// Start transaction.
-	conn, _, err := txPool.Begin(ctxWithCallerId, &querypb.ExecuteOptions{}, false, 0, nil)
+	conn, _, err := txPool.Begin(ctxWithCallerID, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 	conn.Unlock()
 

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -48,7 +48,7 @@ func TestTxPoolExecuteCommit(t *testing.T) {
 	conn, _, err := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	require.NoError(t, err)
 
-	id := conn.ID()
+	id := conn.ReservedID()
 	conn.Unlock()
 
 	// get the connection and execute a query on it
@@ -127,7 +127,7 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trying to get back to conn2 should not work since the transaction has been rolled back
-	_, err = txPool.GetAndLock(conn2.ID(), "")
+	_, err = txPool.GetAndLock(conn2.ReservedID(), "")
 	require.Error(t, err)
 
 	conn1.Release(tx.TxCommit)
@@ -319,7 +319,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 	db, txPool, _, _ := setup(t)
 	defer db.Close()
 	conn1, _, _ := txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
-	id := conn1.ID()
+	id := conn1.ReservedID()
 	conn1.Unlock()
 	txPool.Close()
 
@@ -341,7 +341,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 
 	conn1, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
-	id = conn1.ID()
+	id = conn1.ReservedID()
 	_, err := txPool.Commit(ctx, conn1)
 	require.NoError(t, err)
 
@@ -356,7 +356,7 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 
 	conn1, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
 	conn1.Unlock()
-	id = conn1.ID()
+	id = conn1.ReservedID()
 	time.Sleep(20 * time.Millisecond)
 
 	assertErrorMatch(id, "exceeded timeout: 1ms")


### PR DESCRIPTION
Fixes #6982 

## Robust query kill
* dbconn.go: query killer closes the connection before killing the server side query.
* A different non-connection error is returned, which causes the code to not retry. But the error contains `errno 2013` which clients can interpret as a killed connection.

## StatefulConnection: ID -> ReservedID
The StatefulConnection had its own ID function that was hiding the underlying ID from dbConn. It has been renamed so that a StatefulConnection can be given to the QueryList for killing connections on demand.

## Multiple Query Lists
* The previous streamQList in queryEngine has been replaced by three distinct lists: olapql, statelessql and statefulql, and they are all in TabletServer.
  * olapql is same as the previous streamQList.
  * statelessql is for queries from the regular conn pool
  * statefulql is for queries from the stateful pool
* The previous /stream_queryz URL has been renamed to /livequeryz. This URL now shows queries executing from all three query lists. An additional column has been added to show the pool of the query.
* Changed the displayer to redact values if the redact flag is set.

## TransactionShutdownSeconds -> ShutdownSeconds
This variable has been renamed to reflect the new meaning. The old flag continues to exist for backward compatibility and sets the same underlying variable.

## timer.SleepContext
This has become a common pattern. So, I created this wrapper. We can later change other places to leverage this new function.

## StateManager handles the grace period
* If a transition is going from master to non-master or non-serving, the state manager enforces the grace period. If grace period is exceeded, stateful and stateless connections are killed, which allows the transactions to close and all pending requests to terminate. This will cause a prompt shut down.
* If a transition is going from non-master to master, then stateful queries are immediately shutdown, which is enough for the tx pool to go read-write.

## TxEngine simplified
The TxEngine had a race condition where it was possible for a `Begin` to slip through after shutdown has been initiated. The code was also too complex because it was trying to handle some unnecessary concurrency. There is no need for concurrency because the state manager enforces synchronization of calls. The refactored code is much simpler and avoids the Begin race.

## pools.Numbered.GetByFilter
It was necessary for the tx pool to extract just the non-transactional connections from the stateful pool so that they are released first. I added a new GetByFilter function that can be used to get specific connections as defined by the filter func.

## StatefulConnectionPool shutdown modes
* ShutdownNonTx should be first called. It releases all idle non-transactional connections. Non-idle connections are released as soon as they are unlocked.
* ShutdownAll is called next. It returns the list of idle transactions so the caller (TxPool) rolls them back. The rest of the connections are closed and released by the stateful pool as they are returned

## TxEngine shuts down in two phases
* In immediate mode, the two-phase shutdown is called back to back.
* In normal mode, the non-tx shutdown is called first. After the grace period elapses, the All shutdown is invoked. This timing will coincide with the state manager's kill of all queries. This should cause the tx pool to be closed immediately.

## Query timeout
If a query is executed in a transaction, its time out is now the minimum of the query timeout and the transaction timeout.