### PR TITLE
fix flakey TestParallelRunnerApprovalFirstRunningSecondRunning test

### DIFF
--- a/go/vt/workflow/parallel_runner_test.go
+++ b/go/vt/workflow/parallel_runner_test.go
@@ -560,7 +560,7 @@ func triggerAction(ctx context.Context, m *Manager, nodePath, actionName string)
 
 func setupNotifications(m *Manager) (chan []byte, int, error) {
 	// Set up notifications channel to monitor UI updates.
-	notifications := make(chan []byte, 10)
+	notifications := make(chan []byte, 100)
 	_, index, err := m.NodeManager().GetAndWatchFullTree(notifications)
 	if err != nil {
 		return nil, -1, fmt.Errorf("GetAndWatchTree Failed: %v", err)


### PR DESCRIPTION
Fix for https://github.com/vitessio/vitess/issues/6948

The double close is due to a close when the buffered channel is blocked:

https://github.com/vitessio/vitess/blob/a3e3e0aa26de0e78d6b2d4e3b36e978ddcafdba8/go/vt/workflow/node.go#L387

Increasing the channel's buffer size dramatically certainly isn't a bulletproof fix, but I was not able to reproduce the issue after this change.