### PR TITLE
MoveTables: validate that source tables exist, move all tables 

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1910,7 +1910,7 @@ func commandMoveTables(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	cells := subFlags.String("cells", "", "Cell(s) or CellAlias(es) (comma-separated) to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from (e.g. master, replica, rdonly). Defaults to -vreplication_tablet_type parameter value for the tablet, which has the default value of replica.")
 	allTables := subFlags.Bool("all", false, "Move all tables from the source keyspace")
-	excludes := subFlags.String("exclude", "", "Tables to exclude if -all is specified")
+	excludes := subFlags.String("exclude", "", "Tables to exclude (comma-separated) if -all is specified")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1909,19 +1909,26 @@ func commandMoveTables(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	workflow := subFlags.String("workflow", "", "Workflow name. Can be any descriptive string. Will be used to later migrate traffic via SwitchReads/SwitchWrites.")
 	cells := subFlags.String("cells", "", "Cell(s) or CellAlias(es) (comma-separated) to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from (e.g. master, replica, rdonly). Defaults to -vreplication_tablet_type parameter value for the tablet, which has the default value of replica.")
+	allTables := subFlags.Bool("all", false, "Move all tables from the source keyspace")
+	excludes := subFlags.String("exclude", "", "Tables to exclude if -all is specified")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if *workflow == "" {
 		return fmt.Errorf("a workflow name must be specified")
 	}
+	if !*allTables && len(*excludes) > 0 {
+		return fmt.Errorf("you can only specify tables to exclude if all tables are to be moved (with -all)")
+	}
 	if subFlags.NArg() != 3 {
 		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
 	}
+
 	source := subFlags.Arg(0)
 	target := subFlags.Arg(1)
 	tableSpecs := subFlags.Arg(2)
-	return wr.MoveTables(ctx, *workflow, source, target, tableSpecs, *cells, *tabletTypes)
+	return wr.MoveTables(ctx, *workflow, source, target, tableSpecs, *cells, *tabletTypes, *allTables, *excludes)
 }
 
 func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1921,8 +1921,14 @@ func commandMoveTables(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	if !*allTables && len(*excludes) > 0 {
 		return fmt.Errorf("you can only specify tables to exclude if all tables are to be moved (with -all)")
 	}
-	if subFlags.NArg() != 3 {
-		return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
+	if *allTables {
+		if subFlags.NArg() != 2 {
+			return fmt.Errorf("two arguments are required: source_keyspace, target_keyspace")
+		}
+	} else {
+		if subFlags.NArg() != 3 {
+			return fmt.Errorf("three arguments are required: source_keyspace, target_keyspace, tableSpecs")
+		}
 	}
 
 	source := subFlags.Arg(0)

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -209,7 +209,7 @@ func isByteComparable(v sqltypes.Value) bool {
 		return true
 	}
 	switch v.Type() {
-	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set:
+	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set, sqltypes.TypeJSON:
 		return true
 	}
 	return false

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -452,7 +452,6 @@ func TestConsistentLookupUpdateBecauseUncomparableTypes(t *testing.T) {
 		{querypb.Type_CHAR, "some string"},
 		{querypb.Type_BIT, "some string"},
 		{querypb.Type_GEOMETRY, "some string"},
-		{querypb.Type_JSON, "some string"},
 	}
 
 	for _, val := range tests {

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -112,6 +112,10 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 				if excludeTables != "" {
 					excludeTablesList = strings.Split(excludeTables, ",")
 				}
+				err = wr.validateSourceTablesExist(ctx, sourceKeyspace, ksTables, excludeTablesList)
+				if err != nil {
+					return err
+				}
 				if len(excludeTablesList) > 0 {
 					for _, ksTable := range ksTables {
 						exclude := false
@@ -228,7 +232,7 @@ func (wr *Wrangler) validateSourceTablesExist(ctx context.Context, sourceKeyspac
 		}
 	}
 	if len(missingTables) > 0 {
-		return fmt.Errorf("tables not found in source keyspace %s: %s", sourceKeyspace, strings.Join(missingTables, ","))
+		return fmt.Errorf("table(s) not found in source keyspace %s: %s", sourceKeyspace, strings.Join(missingTables, ","))
 	}
 	return nil
 }

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -70,6 +70,12 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 
 	var vschema *vschemapb.Keyspace
 	vschema, err = wr.ts.GetVSchema(ctx, targetKeyspace)
+	if err != nil {
+		return err
+	}
+	if vschema == nil {
+		return fmt.Errorf("no vschema found for target keyspace %s", targetKeyspace)
+	}
 	if strings.HasPrefix(tableSpecs, "{") {
 		if vschema.Tables == nil {
 			vschema.Tables = make(map[string]*vschemapb.Table)

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -18,6 +18,7 @@ package wrangler
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestMigrateTables(t *testing.T) {
 	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
 
 	ctx := context.Background()
-	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1", "", "")
+	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1", "", "", false, "")
 	require.NoError(t, err)
 	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
 	require.NoError(t, err)
@@ -101,12 +102,73 @@ func TestMissingTables(t *testing.T) {
 	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
 
 	ctx := context.Background()
-	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt", "", "")
+	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt", "", "", false, "")
 	require.EqualError(t, err, "tables not found in source keyspace sourceks: tyt")
-	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt,t2,txt", "", "")
+	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt,t2,txt", "", "", false, "")
 	require.EqualError(t, err, "tables not found in source keyspace sourceks: tyt,txt")
-	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1", "", "")
+	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1", "", "", false, "")
 	require.NoError(t, err)
+}
+
+func TestMoveTablesAllAndExclude(t *testing.T) {
+	ms := &vtctldatapb.MaterializeSettings{
+		Workflow:       "workflow",
+		SourceKeyspace: "sourceks",
+		TargetKeyspace: "targetks",
+		TableSettings: []*vtctldatapb.TableMaterializeSettings{{
+			TargetTable:      "t1",
+			SourceExpression: "select * from t1",
+		}, {
+			TargetTable:      "t2",
+			SourceExpression: "select * from t2",
+		}, {
+			TargetTable:      "t3",
+			SourceExpression: "select * from t3",
+		}},
+	}
+
+	ctx := context.Background()
+	var err error
+
+	var targetTables = func(env *testMaterializerEnv) []string {
+		vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
+		require.NoError(t, err)
+		var targetTables []string
+		for table := range vschema.Keyspaces["targetks"].Tables {
+			targetTables = append(targetTables, table)
+		}
+		sort.Strings(targetTables)
+		return targetTables
+	}
+	allTables := []string{"t1", "t2", "t3"}
+	sort.Strings(allTables)
+
+	type testCase struct {
+		allTables     bool
+		excludeTables string
+		want          []string
+	}
+	testCases := []*testCase{
+		{true, "", allTables},
+		{true, "t2,t3", []string{"t1"}},
+		{true, "t1", []string{"t2", "t3"}},
+	}
+	for _, tcase := range testCases {
+		t.Run("", func(t *testing.T) {
+			env := newTestMaterializerEnv(t, ms, []string{"0"}, []string{"0"})
+			defer env.close()
+			env.tmc.expectVRQuery(100, mzCheckJournal, &sqltypes.Result{})
+			env.tmc.expectVRQuery(200, mzSelectFrozenQuery, &sqltypes.Result{})
+			env.tmc.expectVRQuery(200, insertPrefix, &sqltypes.Result{})
+			env.tmc.expectVRQuery(200, mzSelectIDQuery, &sqltypes.Result{})
+			env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
+			err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "", "", "", tcase.allTables, tcase.excludeTables)
+			require.NoError(t, err)
+			require.EqualValues(t, tcase.want, targetTables(env))
+		})
+
+	}
+
 }
 
 func TestMigrateVSchema(t *testing.T) {
@@ -129,7 +191,7 @@ func TestMigrateVSchema(t *testing.T) {
 	env.tmc.expectVRQuery(200, mzUpdateQuery, &sqltypes.Result{})
 
 	ctx := context.Background()
-	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", `{"t1":{}}`, "", "")
+	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", `{"t1":{}}`, "", "", false, "")
 	require.NoError(t, err)
 	vschema, err := env.wr.ts.GetSrvVSchema(ctx, env.cell)
 	require.NoError(t, err)

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -103,9 +103,9 @@ func TestMissingTables(t *testing.T) {
 
 	ctx := context.Background()
 	err := env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt", "", "", false, "")
-	require.EqualError(t, err, "tables not found in source keyspace sourceks: tyt")
+	require.EqualError(t, err, "table(s) not found in source keyspace sourceks: tyt")
 	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1,tyt,t2,txt", "", "", false, "")
-	require.EqualError(t, err, "tables not found in source keyspace sourceks: tyt,txt")
+	require.EqualError(t, err, "table(s) not found in source keyspace sourceks: tyt,txt")
 	err = env.wr.MoveTables(ctx, "workflow", "sourceks", "targetks", "t1", "", "", false, "")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
* Added option -all to allow all tables to be moved. It is possible to exclude some tables using the -exclude option. Currently exclude list is a csv one with table names to be excluded.
* Validate that table names provided match with those in the source



Signed-off-by: Rohit Nayak <rohit@planetscale.com>