### PR TITLE
If workflow does not exist, it will throw an error

### DIFF
--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -279,7 +279,7 @@ func (vx *vexec) getMasterForShard(shard string) (*topo.TabletInfo, error) {
 // WorkflowAction can start/stop/delete or list streams in _vt.vreplication on all masters in the target keyspace of the workflow.
 func (wr *Wrangler) WorkflowAction(ctx context.Context, workflow, keyspace, action string, dryRun bool) (map[*topo.TabletInfo]*sqltypes.Result, error) {
 	if action == "show" {
-		ok, err := wr.CheckWorkflow(ctx,workflow,keyspace)
+		ok, err := wr.CheckWorkflow(ctx, workflow, keyspace)
 		if !ok {
 			return nil, err
 		}
@@ -531,7 +531,7 @@ func (wr *Wrangler) ListAllWorkflows(ctx context.Context, keyspace string) ([]st
 }
 
 // CheckWorkflow will checks if the workflow exist in the given keyspace.
-func (wr *Wrangler) CheckWorkflow(ctx context.Context, workflow, keyspace  string) (bool, error) {
+func (wr *Wrangler) CheckWorkflow(ctx context.Context, workflow, keyspace string) (bool, error) {
 	query := "select workflow from _vt.vreplication where workflow='" + workflow + "'"
 	results, err := wr.runVexec(ctx, "", keyspace, query, false)
 	if err != nil {
@@ -551,7 +551,7 @@ func (wr *Wrangler) CheckWorkflow(ctx context.Context, workflow, keyspace  strin
 			}
 		}
 	}
-	return false, fmt.Errorf("the workflow %s does not exist in the keyspace %s", workflow,keyspace)
+	return false, fmt.Errorf("the workflow %s does not exist in the keyspace %s", workflow, keyspace)
 }
 
 // ShowWorkflow will return all of the relevant replication related information for the given workflow.

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -166,6 +166,13 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		env.tmc.setVRResults(master.tablet, "select distinct workflow from _vt.vreplication where state != 'Stopped' and db_name = 'vt_target'", result)
 
 		result = sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+			"workflow",
+			"varchar"),
+			"wrWorkflow",
+		)
+		env.tmc.setVRResults(master.tablet, "select workflow from _vt.vreplication where workflow = 'wrWorkflow' and db_name = 'vt_target'", result)
+
+		result = sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 			"table|lastpk",
 			"varchar|varchar"),
 			"t1|pk1",


### PR DESCRIPTION
Fixes vitessio/vitess#6935 

Setup steps -
```
$ examples/local/
$ sh -x 101_initial_cluster.sh
.
.
```

In this PR, I have added a fix when if the workflow does not exist in the given keyspace, it will throw an error as follows :
```
$ vtctlclient -server localhost:15999 WorkFlow commerce.foo123 show

E1112 13:28:59.354405  270901 main.go:67] remote error: rpc error: code = Unknown desc = the workflow foo123 does not exist in the keyspace commerce
```
This is done by creating a new function `CheckWorkflow` which will check if the workflow exist in the given keyspace. If the workflow exist, it will return true 
```
// CheckWorkflow will checks if the workflow exist in the given keyspace.
func (wr *Wrangler) CheckWorkflow(ctx context.Context, workflow, keyspace string) (bool, error) {}
```
The function creates a call to the Vexec with the following query to check if the workflow presents or not - 
`select workflow from _vt.vreplication where workflow = '<workflow-name>' and db_name = 'vt_<keyspace>'`