### PR TITLE
vttablet: don't shutdown on too many connections

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package mysql
 
+import "strings"
+
 const (
 	// MaxPacketSize is the maximum payload length of a packet
 	// the server supports.
@@ -602,9 +604,22 @@ func IsNum(typ uint8) bool {
 
 // IsConnErr returns true if the error is a connection error.
 func IsConnErr(err error) bool {
+	if IsTooManyConnectionsErr(err) {
+		return false
+	}
 	if sqlErr, ok := err.(*SQLError); ok {
 		num := sqlErr.Number()
 		return (num >= CRUnknownError && num <= CRNamedPipeStateError) || num == ERQueryInterrupted
+	}
+	return false
+}
+
+// IsTooManyConnectionsErr returns true if the error is due to too many connections.
+func IsTooManyConnectionsErr(err error) bool {
+	if sqlErr, ok := err.(*SQLError); ok {
+		if sqlErr.Number() == CRServerHandshakeErr && strings.Contains(sqlErr.Message, "Too many connections") {
+			return true
+		}
 	}
 	return false
 }

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache"
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/sync2"
@@ -372,6 +373,9 @@ func (qe *QueryEngine) ClearQueryPlanCache() {
 func (qe *QueryEngine) IsMySQLReachable() error {
 	conn, err := dbconnpool.NewDBConnection(context.TODO(), qe.env.Config().DB.AppWithDB())
 	if err != nil {
+		if mysql.IsTooManyConnectionsErr(err) {
+			return nil
+		}
 		return err
 	}
 	conn.Close()


### PR DESCRIPTION
Fixes #7038

This change makes IsConnErr treat "Too man connections" as a normal
error, allowing vttablet to continue serving. The same check is also
added to IsMySQLReachable in case it happens to get called through
a different code path.

The error code returned by mysql (2012) is more generic. So, we also
have to check for the specific substring.

It's hard to reliably test this using automated testing. Instead, I
manually created a state where mysql ran out of connections, verified
that vttablet did shut down, and also verified that vttablet continued
to serve after this fix.

Signed-off-by: Sugu Sougoumarane <ssougou@gmail.com>