### PR TITLE
Allow custom image tags in compose

### DIFF
--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -281,9 +281,9 @@ vitess/examples/compose$ (export CS=vttablet101; ./lvtctl.sh <args> )
 ```
 
 ## Custom Image Tags
-You  may specify a custom `vitess:lite` image tag by setting the evnironment variable `VITESS_TAG`.
+You  may specify a custom `vitess:lite` image tag by setting the evnironment variable `VITESS_TAG`.  
 This is optional and defaults to the `latest` tag. Example;
-* Set `VITESS_TAG=8.0.0` in your `.env` befor running `docker-compose up -d`
+* Set `VITESS_TAG=8.0.0` in your `.env` before running `docker-compose up -d`
 * Run `VITESS_TAG=8.0.0; docker-compose up -d`
 
 

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -280,6 +280,13 @@ To run against a specific compose service/container, use the environment variabl
 vitess/examples/compose$ (export CS=vttablet101; ./lvtctl.sh <args> )
 ```
 
+## Custom Image Tags
+You  may specify a custom `vitess:lite` image tag by setting the evnironment variable `VITESS_TAG`.
+This is optional and defaults to the `latest` tag. Example;
+* Set `VITESS_TAG=8.0.0` in your `.env` befor running `docker-compose up -d`
+* Run `VITESS_TAG=8.0.0; docker-compose up -d`
+
+
 ## Reference
 Checkout this excellent post about [The Life of a Vitess Cluster](https://vitess.io/blog/2020-04-27-life-of-a-cluster/)
 

--- a/examples/compose/docker-compose.beginners.yml
+++ b/examples/compose/docker-compose.beginners.yml
@@ -58,7 +58,7 @@ services:
       - "3306"
 
   vtctld:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15000:$WEB_PORT"
       - "$GRPC_PORT"
@@ -83,7 +83,7 @@ services:
         condition: service_healthy
 
   vtgate:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15099:$WEB_PORT"
       - "$GRPC_PORT"
@@ -113,7 +113,7 @@ services:
         condition: service_healthy
 
   schemaload:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     command:
     - sh
     - -c
@@ -137,7 +137,7 @@ services:
         condition: service_healthy
 
   vttablet100:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15100:$WEB_PORT"
       - "$GRPC_PORT"
@@ -169,7 +169,7 @@ services:
       retries: 15
 
   vttablet101:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15101:$WEB_PORT"
       - "$GRPC_PORT"
@@ -201,7 +201,7 @@ services:
       retries: 15
 
   vttablet102:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15102:$WEB_PORT"
       - "$GRPC_PORT"
@@ -233,7 +233,7 @@ services:
       retries: 15
 
   vttablet103:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15103:$WEB_PORT"
       - "$GRPC_PORT"
@@ -265,7 +265,7 @@ services:
       retries: 15
 
   vtorc:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     command: ["sh", "-c", "/script/vtorc-up.sh"]
     depends_on:
       - vtctld
@@ -293,7 +293,7 @@ services:
       retries: 15
 
   vreplication:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/tablet.yml
+++ b/examples/compose/tablet.yml
@@ -1,0 +1,24 @@
+externalConnections:
+  erpl:
+    flavor: FilePos
+    host: external_db_host
+    port: 3306
+    dbName: commerce
+    app:
+      user: external_db_user
+      password: external_db_password
+    dba:
+      user: external_db_user
+      password: external_db_password
+    filtered:
+      user: external_db_user
+      password: external_db_password
+    repl:
+      user: external_db_user
+      password: external_db_password
+    appdebug:
+      user: external_db_user
+      password: external_db_password
+    allprivs:
+      user: external_db_user
+      password: external_db_password

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -532,7 +532,7 @@ func generateDefaultShard(tabAlias int, shard string, keyspaceData keyspaceInfo,
 - op: add
   path: /services/init_shard_master%[2]d
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     command: ["sh", "-c", "/vt/bin/vtctlclient %[5]s InitShardMaster -force %[4]s/%[3]s %[6]s-%[2]d "]
     %[1]s
 `, dependsOn, aliases[0], shard, keyspaceData.keyspace, opts.topologyFlags, opts.cell)
@@ -564,7 +564,7 @@ func generateExternalmaster(
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15%[1]d:%[3]d"
       - "%[4]d"
@@ -626,7 +626,7 @@ func generateDefaultTablet(tabAlias int, shard, role, keyspace string, dbInfo ex
 - op: add
   path: /services/vttablet%[1]d
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
     - "15%[1]d:%[4]d"
     - "%[5]d"
@@ -664,7 +664,7 @@ func generateVtctld(opts vtOptions) string {
 - op: add
   path: /services/vtctld
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15000:%[1]d"
       - "%[2]d"
@@ -697,7 +697,7 @@ func generateVtgate(opts vtOptions) string {
 - op: add
   path: /services/vtgate
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "15099:%[1]d"
       - "%[2]d"
@@ -727,7 +727,7 @@ func generateVtwork(opts vtOptions) string {
 - op: add
   path: /services/vtwork
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     ports:
       - "%[1]d"
       - "%[2]d"
@@ -754,7 +754,7 @@ func generateVtorc(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vtorc
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - ".:/script"
     environment:
@@ -779,7 +779,7 @@ func generateVreplication(dbInfo externalDbInfo, opts vtOptions) string {
 - op: add
   path: /services/vreplication
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - ".:/script"
     environment:
@@ -817,7 +817,7 @@ func generateSchemaload(
 - op: add
   path: /services/schemaload_%[7]s
   value:
-    image: vitess/lite
+    image: vitess/lite:${VITESS_TAG:-latest}
     volumes:
       - ".:/script"
     environment:

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -130,7 +130,6 @@ if [ $tablet_role = "externalmaster" ]; then
                       -db_filtered_password $DB_PASS \
                       -db_repl_user $DB_USER \
                       -db_repl_password $DB_PASS \
-                      -init_populate_metadata=true \
                       -enable_replication_reporter=false \
                       -enforce_strict_trans_tables=false \
                       -track_schema_versions=true \


### PR DESCRIPTION
This PR allows one to define the `vitess:lite` image to be used when running the compose stack.
The env variable to be set is `VITESS_TAG`
@sougou 