### PR TITLE
vtgate: route using vindex for composite IN clause

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -85,6 +85,21 @@ func TestCastConvert(t *testing.T) {
 	assertMatches(t, conn, `SELECT CAST("test" AS CHAR(60))`, `[[VARCHAR("test")]]`)
 }
 
+func TestCompositeIN(t *testing.T) {
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// clean up before & after
+	exec(t, conn, "delete from t1")
+	defer exec(t, conn, "delete from t1")
+
+	exec(t, conn, "insert into t1(id1, id2) values(1, 2), (4, 5)")
+
+	// Just check for correct results. Plan generation is tested in unit tests.
+	assertMatches(t, conn, "select id1 from t1 where (id1, id2) in ((1, 2))", "[[INT64(1)]]")
+}
+
 func TestUnionAll(t *testing.T) {
 	conn, err := mysql.Connect(context.Background(), &vtParams)
 	require.NoError(t, err)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -160,6 +160,11 @@ const (
 	// clause using a Vindex. Requires: A Vindex,
 	// and a Values list.
 	SelectIN
+	// SelectMultiEqual is the opcode for routing a query
+	// based on multiple vindex input values, similar to
+	// SelectIN, but the query sent to each shard is the
+	// same.
+	SelectMultiEqual
 	// SelectScatter is for routing a scatter query
 	// to all shards of a keyspace.
 	SelectScatter
@@ -180,6 +185,7 @@ var routeName = map[RouteOpcode]string{
 	SelectEqualUnique: "SelectEqualUnique",
 	SelectEqual:       "SelectEqual",
 	SelectIN:          "SelectIN",
+	SelectMultiEqual:  "SelectMultiEqual",
 	SelectScatter:     "SelectScatter",
 	SelectNext:        "SelectNext",
 	SelectDBA:         "SelectDBA",
@@ -245,6 +251,8 @@ func (route *Route) execute(vcursor VCursor, bindVars map[string]*querypb.BindVa
 		rss, bvs, err = route.paramsSelectEqual(vcursor, bindVars)
 	case SelectIN:
 		rss, bvs, err = route.paramsSelectIn(vcursor, bindVars)
+	case SelectMultiEqual:
+		rss, bvs, err = route.paramsSelectMultiEqual(vcursor, bindVars)
 	case SelectNone:
 		rss, bvs, err = nil, nil, nil
 	default:
@@ -308,6 +316,8 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 		rss, bvs, err = route.paramsSelectEqual(vcursor, bindVars)
 	case SelectIN:
 		rss, bvs, err = route.paramsSelectIn(vcursor, bindVars)
+	case SelectMultiEqual:
+		rss, bvs, err = route.paramsSelectMultiEqual(vcursor, bindVars)
 	default:
 		return fmt.Errorf("query %q cannot be used for streaming", route.Query)
 	}
@@ -514,6 +524,22 @@ func (route *Route) paramsSelectIn(vcursor VCursor, bindVars map[string]*querypb
 		return nil, nil, vterrors.Wrap(err, "paramsSelectIn")
 	}
 	return rss, shardVars(bindVars, values), nil
+}
+
+func (route *Route) paramsSelectMultiEqual(vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {
+	keys, err := route.Values[0].ResolveList(bindVars)
+	if err != nil {
+		return nil, nil, vterrors.Wrap(err, "paramsSelectIn")
+	}
+	rss, _, err := resolveShards(vcursor, route.Vindex, route.Keyspace, keys)
+	if err != nil {
+		return nil, nil, vterrors.Wrap(err, "paramsSelectIn")
+	}
+	multiBindVars := make([]map[string]*querypb.BindVariable, len(rss))
+	for i := range multiBindVars {
+		multiBindVars[i] = bindVars
+	}
+	return rss, multiBindVars, nil
 }
 
 func resolveShards(vcursor VCursor, vindex vindexes.SingleColumn, keyspace *vindexes.Keyspace, vindexKeys []sqltypes.Value) ([]*srvtopo.ResolvedShard, [][]*querypb.Value, error) {

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -547,6 +547,55 @@ func TestSelectINNonUnique(t *testing.T) {
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }
 
+func TestSelectMultiEqual(t *testing.T) {
+	vindex, _ := vindexes.NewHash("", nil)
+	sel := NewRoute(
+		SelectMultiEqual,
+		&vindexes.Keyspace{
+			Name:    "ks",
+			Sharded: true,
+		},
+		"dummy_select",
+		"dummy_select_field",
+	)
+	sel.Vindex = vindex.(vindexes.SingleColumn)
+	sel.Values = []sqltypes.PlanValue{{
+		Values: []sqltypes.PlanValue{{
+			Value: sqltypes.NewInt64(1),
+		}, {
+			Value: sqltypes.NewInt64(2),
+		}, {
+			Value: sqltypes.NewInt64(4),
+		}},
+	}}
+
+	vc := &loggingVCursor{
+		shards:       []string{"-20", "20-"},
+		shardForKsid: []string{"-20", "-20", "20-"},
+		results:      []*sqltypes.Result{defaultSelectResult},
+	}
+	result, err := sel.Execute(vc, map[string]*querypb.BindVariable{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"  type:INT64 value:"2"  type:INT64 value:"4" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
+		`ExecuteMultiShard ks.-20: dummy_select {} ks.20-: dummy_select {} false false`,
+	})
+	expectResult(t, "sel.Execute", result, defaultSelectResult)
+
+	vc.Rewind()
+	result, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations ks [type:INT64 value:"1"  type:INT64 value:"2"  type:INT64 value:"4" ] Destinations:DestinationKeyspaceID(166b40b44aba4bd6),DestinationKeyspaceID(06e7ea22ce92708f),DestinationKeyspaceID(d2fd8867d50d2dfe)`,
+		`StreamExecuteMulti dummy_select ks.-20: {} ks.20-: {} `,
+	})
+	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
+}
+
 func TestSelectNext(t *testing.T) {
 	sel := NewRoute(
 		SelectNext,

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -629,6 +629,15 @@ func (rb *route) UpdatePlan(pb *primitiveBuilder, filter sqlparser.Expr) {
 				rb.updateRoute(opcode, vindex, values)
 			}
 		}
+	case engine.SelectMultiEqual:
+		switch opcode {
+		case engine.SelectEqualUnique, engine.SelectEqual, engine.SelectIN:
+			rb.updateRoute(opcode, vindex, values)
+		case engine.SelectMultiEqual:
+			if vindex.Cost() < rb.eroute.Vindex.Cost() {
+				rb.updateRoute(opcode, vindex, values)
+			}
+		}
 	case engine.SelectScatter:
 		switch opcode {
 		case engine.SelectEqualUnique, engine.SelectEqual, engine.SelectIN, engine.SelectNone:
@@ -687,8 +696,8 @@ func (rb *route) computeEqualPlan(pb *primitiveBuilder, comparison *sqlparser.Co
 	return engine.SelectEqual, vindex, right
 }
 
-// computeEqualPlan computes the plan for an equality constraint.
-func (rb *route) computeISPlan(pb *primitiveBuilder, comparison *sqlparser.IsExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, condition sqlparser.Expr) {
+// computeIS computes the plan for an equality constraint.
+func (rb *route) computeISPlan(pb *primitiveBuilder, comparison *sqlparser.IsExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, expr sqlparser.Expr) {
 	// we only handle IS NULL correct. IsExpr can contain other expressions as well
 	if comparison.Operator != sqlparser.IsNullOp {
 		return engine.SelectScatter, nil, nil
@@ -706,7 +715,18 @@ func (rb *route) computeISPlan(pb *primitiveBuilder, comparison *sqlparser.IsExp
 }
 
 // computeINPlan computes the plan for an IN constraint.
-func (rb *route) computeINPlan(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, condition sqlparser.Expr) {
+func (rb *route) computeINPlan(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, expr sqlparser.Expr) {
+	switch comparison.Left.(type) {
+	case *sqlparser.ColName:
+		return rb.computeSimpleINPlan(pb, comparison)
+	case sqlparser.ValTuple:
+		return rb.computeCompositeINPlan(pb, comparison)
+	}
+	return engine.SelectScatter, nil, nil
+}
+
+// computeSimpleINPlan computes the plan for a simple IN constraint.
+func (rb *route) computeSimpleINPlan(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, expr sqlparser.Expr) {
 	vindex = pb.st.Vindex(comparison.Left, rb)
 	if vindex == nil {
 		return engine.SelectScatter, nil, nil
@@ -727,6 +747,86 @@ func (rb *route) computeINPlan(pb *primitiveBuilder, comparison *sqlparser.Compa
 		return engine.SelectIN, vindex, comparison
 	}
 	return engine.SelectScatter, nil, nil
+}
+
+// computeCompositeINPlan computes the plan for a composite IN constraint.
+func (rb *route) computeCompositeINPlan(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, values sqlparser.Expr) {
+	leftTuple := comparison.Left.(sqlparser.ValTuple)
+	return rb.iterateCompositeIN(pb, comparison, nil, leftTuple)
+}
+
+// iterateCompositeIN recursively walks the LHS tuple of the IN clause looking
+// for column names. For those that match a vindex, it builds a multi-value plan
+// using the corresponding values in the RHS. It returns the best of the plans built.
+func (rb *route) iterateCompositeIN(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr, coordinates []int, tuple sqlparser.ValTuple) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, values sqlparser.Expr) {
+	opcode = engine.SelectScatter
+
+	cindex := len(coordinates)
+	coordinates = append(coordinates, 0)
+	for idx, expr := range tuple {
+		coordinates[cindex] = idx
+		switch expr := expr.(type) {
+		case sqlparser.ValTuple:
+			newOpcode, newVindex, newValues := rb.iterateCompositeIN(pb, comparison, coordinates, expr)
+			opcode, vindex, values = bestOfComposite(opcode, newOpcode, vindex, newVindex, values, newValues)
+		case *sqlparser.ColName:
+			newVindex := pb.st.Vindex(comparison.Left, rb)
+			if newVindex != nil {
+				newOpcode, newValues := rb.compositePlanForCol(pb, comparison, coordinates)
+				opcode, vindex, values = bestOfComposite(opcode, newOpcode, vindex, newVindex, values, newValues)
+			}
+		}
+	}
+	return opcode, vindex, values
+}
+
+// compositePlanForCol builds a plan for a matched column in the LHS
+// of a composite IN clause.
+func (rb *route) compositePlanForCol(pb *primitiveBuilder, comparison *sqlparser.ComparisonExpr, coordinates []int) (opcode engine.RouteOpcode, values sqlparser.Expr) {
+	rightTuple, ok := comparison.Right.(sqlparser.ValTuple)
+	if !ok {
+		return engine.SelectScatter, nil
+	}
+	retVal := make(sqlparser.ValTuple, len(rightTuple))
+	for i, rval := range rightTuple {
+		val := tupleAccess(rval, coordinates)
+		if val == nil {
+			return engine.SelectScatter, nil
+		}
+		if !rb.exprIsValue(val) {
+			return engine.SelectScatter, nil
+		}
+		retVal[i] = val
+	}
+	return engine.SelectMultiEqual, retVal
+}
+
+// tupleAccess returns the value of the expression that corresponds
+// to the specified coordinates.
+func tupleAccess(expr sqlparser.Expr, coordinates []int) sqlparser.Expr {
+	tuple, _ := expr.(sqlparser.ValTuple)
+	for _, idx := range coordinates {
+		if idx >= len(tuple) {
+			return nil
+		}
+		expr = tuple[idx]
+		tuple, _ = expr.(sqlparser.ValTuple)
+	}
+	return expr
+}
+
+// bestOfComposite returns the best of two composite IN clause plans.
+func bestOfComposite(opcode1, opcode2 engine.RouteOpcode, vindex1, vindex2 vindexes.SingleColumn, values1, values2 sqlparser.Expr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, values sqlparser.Expr) {
+	if opcode1 == engine.SelectScatter {
+		return opcode2, vindex2, values2
+	}
+	if opcode2 == engine.SelectScatter {
+		return opcode1, vindex1, values1
+	}
+	if vindex1.Cost() < vindex2.Cost() {
+		return opcode1, vindex1, values1
+	}
+	return opcode2, vindex2, values2
 }
 
 // computeNotInPlan looks for null values to produce a SelectNone if found

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -640,7 +640,7 @@ func (rb *route) UpdatePlan(pb *primitiveBuilder, filter sqlparser.Expr) {
 		}
 	case engine.SelectScatter:
 		switch opcode {
-		case engine.SelectEqualUnique, engine.SelectEqual, engine.SelectIN, engine.SelectNone:
+		case engine.SelectEqualUnique, engine.SelectEqual, engine.SelectIN, engine.SelectMultiEqual, engine.SelectNone:
 			rb.updateRoute(opcode, vindex, values)
 		}
 	}
@@ -770,7 +770,7 @@ func (rb *route) iterateCompositeIN(pb *primitiveBuilder, comparison *sqlparser.
 			newOpcode, newVindex, newValues := rb.iterateCompositeIN(pb, comparison, coordinates, expr)
 			opcode, vindex, values = bestOfComposite(opcode, newOpcode, vindex, newVindex, values, newValues)
 		case *sqlparser.ColName:
-			newVindex := pb.st.Vindex(comparison.Left, rb)
+			newVindex := pb.st.Vindex(expr, rb)
 			if newVindex != nil {
 				newOpcode, newValues := rb.compositePlanForCol(pb, comparison, coordinates)
 				opcode, vindex, values = bestOfComposite(opcode, newOpcode, vindex, newVindex, values, newValues)

--- a/go/vt/vtgate/planbuilder/route_test.go
+++ b/go/vt/vtgate/planbuilder/route_test.go
@@ -32,25 +32,27 @@ For easy reference, opcodes are:
 	SelectEqualUnique 1
 	SelectEqual       2
 	SelectIN          3
-	SelectScatter     4
-	SelectNext        5
-	SelectDBA         6
-	SelectReference   7
-	SelectNone        8
-	NumRouteOpcodes   9
+	SelectMultiEqual  4
+	SelectScatter     5
+	SelectNext        6
+	SelectDBA         7
+	SelectReference   8
+	SelectNone        9
+	NumRouteOpcodes   10
 */
 
 func TestJoinCanMerge(t *testing.T) {
 	testcases := [engine.NumRouteOpcodes][engine.NumRouteOpcodes]bool{
-		{true, false, false, false, false, false, false, true, false},
-		{false, true, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, true, true, false},
-		{true, true, true, true, true, true, true, true, true},
-		{false, false, false, false, false, false, false, true, false},
+		{true, false, false, false, false, false, false, false, true, false},
+		{false, true, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, true, true, false},
+		{true, true, true, true, true, true, true, true, true, true},
+		{false, false, false, false, false, false, false, false, true, false},
 	}
 
 	ks := &vindexes.Keyspace{}
@@ -75,15 +77,16 @@ func TestJoinCanMerge(t *testing.T) {
 
 func TestSubqueryCanMerge(t *testing.T) {
 	testcases := [engine.NumRouteOpcodes][engine.NumRouteOpcodes]bool{
-		{true, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, true, true, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, true, false},
+		{true, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, true, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, true, false},
 	}
 
 	ks := &vindexes.Keyspace{}
@@ -103,15 +106,16 @@ func TestSubqueryCanMerge(t *testing.T) {
 
 func TestUnionCanMerge(t *testing.T) {
 	testcases := [engine.NumRouteOpcodes][engine.NumRouteOpcodes]bool{
-		{true, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, true, false, false, false, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, true, false, false},
-		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, false, false},
+		{true, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, true, false, false, false, false},
+		{false, false, false, false, false, false, false, false, false, false},
+		{false, false, false, false, false, false, false, true, false, false},
+		{false, false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, false, false, false, false},
 	}
 	ks := &vindexes.Keyspace{}
 	lRoute := &route{}

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -143,6 +143,299 @@
   }
 }
 
+# Composite IN clause
+"select id from user where (name, col) in (('aa', 'bb'), ('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (name, col) in (('aa', 'bb'), ('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (name, col) in (('aa', 'bb'), ('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "aa",
+        "cc"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN clause, swapped columns
+"select id from user where (col, name) in (('aa', 'bb'), ('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (col, name) in (('aa', 'bb'), ('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (col, name) in (('aa', 'bb'), ('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "bb",
+        "dd"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN clause, choose cost within tuple
+"select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "bb",
+        "dd"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN clause, choose cost within tuple, swapped
+"select id from user where (name, costly) in (('aa', 'bb'), ('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (name, costly) in (('aa', 'bb'), ('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (name, costly) in (('aa', 'bb'), ('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "aa",
+        "cc"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN clause, choose cost
+"select id from user where (col, costly) in (('aa', 'bb')) and (col, name) in (('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (col, costly) in (('aa', 'bb')) and (col, name) in (('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (col, costly) in (('aa', 'bb')) and (col, name) in (('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "dd"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN clause vs equality
+"select id from user where (col, name) in (('aa', 'bb')) and id = 5"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (col, name) in (('aa', 'bb')) and id = 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (col, name) in (('aa', 'bb')) and id = 5",
+    "Table": "user",
+    "Values": [
+      5
+    ],
+    "Vindex": "user_index"
+  }
+}
+
+# Composite IN: multiple vindex matches
+"select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))",
+    "Table": "user",
+    "Values": [
+      [
+        "bb",
+        "dd"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN: tuple inside tuple
+"select id from user where ((col1, name), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where ((col1, name), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where ((col1, name), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
+    "Table": "user",
+    "Values": [
+      [
+        "bb",
+        "ee"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN: tuple inside tuple, but no match in tuple
+"select id from user where (name, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (name, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (name, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
+    "Table": "user",
+    "Values": [
+      [
+        "aa",
+        "dd"
+      ]
+    ],
+    "Vindex": "name_user_map"
+  }
+}
+
+# Composite IN: tuple inside tuple, mismiatched values
+"select id from user where ((col1, name), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where ((col1, name), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where ((col1, name), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
+    "Table": "user"
+  }
+}
+
+# Composite IN: RHS not tuple
+"select id from user where (col1, name) in (select * from music where music.user_id=user.id)"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (col1, name) in (select * from music where music.user_id=user.id)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (col1, name) in (select * from music where music.user_id = user.id)",
+    "Table": "user"
+  }
+}
+
+# Composite IN: RHS has no simple values
+"select id from user where (col1, name) in (('aa', 1+1))"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where (col1, name) in (('aa', 1+1))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from user where 1 != 1",
+    "Query": "select id from user where (col1, name) in (('aa', 1 + 1))",
+    "Table": "user"
+  }
+}
+
+# IN clause: LHS is neither column nor composite tuple
+"select Id from user where 1 in ('aa', 'bb')"
+{
+  "QueryType": "SELECT",
+  "Original": "select Id from user where 1 in ('aa', 'bb')",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select Id from user where 1 != 1",
+    "Query": "select Id from user where 1 in ('aa', 'bb')",
+    "Table": "user"
+  }
+}
+
 # Single table complex in clause
 "select id from user where name in (col, 'bb')"
 {
@@ -1480,4 +1773,3 @@
     "SysTableTableSchema": "VARBINARY(\"ks\")"
   }
 }
-                


### PR DESCRIPTION
Fixes #6609 

The details of the fix are explained in the issue.
* Added a new Route opcode: `SelectMultiEqual`
* The Values field for the opcode contains the list of vindex input values to route on
* The plan builder uses a different code path for composite IN clause vs. the simple case.
* The plan works for nested composites also.
* If the operand values don't match or are non-trivial, we fall back to `SelectScatter`.