### PR TITLE
fix #7048 for SelectNone in StreamExecute route engine

### DIFF
--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -318,6 +318,8 @@ func (route *Route) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.
 		rss, bvs, err = route.paramsSelectIn(vcursor, bindVars)
 	case SelectMultiEqual:
 		rss, bvs, err = route.paramsSelectMultiEqual(vcursor, bindVars)
+	case SelectNone:
+		rss, bvs, err = nil, nil, nil
 	default:
 		return fmt.Errorf("query %q cannot be used for streaming", route.Query)
 	}

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -270,14 +270,10 @@ func TestSelectNone(t *testing.T) {
 	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
 
 	vc.Rewind()
-
-	result, err = sel.Execute(vc, map[string]*querypb.BindVariable{}, true)
+	result, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
-	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [] Destinations:DestinationAnyShard()`,
-		`ExecuteMultiShard ks.-20: dummy_select_field {} false false`,
-	})
-	expectResult(t, "sel.Execute", result, &sqltypes.Result{})
+	require.Empty(t, vc.log)
+	expectResult(t, "sel.StreamExecute", result, nil)
 }
 
 func TestSelectEqualUniqueScatter(t *testing.T) {


### PR DESCRIPTION
## Backport
NO

## Status
READY

## Description
SelectNone opcode was not handled for StreamExecute. This PR fixes it.

## Related Issue(s)
#7048 

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [x]  Query Serving
