### PR TITLE
Optimise struct field layout

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -128,13 +128,16 @@ type BinlogEvent interface {
 // This structure is passed to subsequent event types to let them know how to
 // parse themselves.
 type BinlogFormat struct {
-	// FormatVersion is the version number of the binlog file format.
-	// We only support version 4.
-	FormatVersion uint16
+	// HeaderSizes is an array of sizes of the headers for each message.
+	HeaderSizes []byte
 
 	// ServerVersion is the name of the MySQL server version.
 	// It starts with something like 5.6.33-xxxx.
 	ServerVersion string
+
+	// FormatVersion is the version number of the binlog file format.
+	// We only support version 4.
+	FormatVersion uint16
 
 	// HeaderLength is the size in bytes of event headers other
 	// than FORMAT_DESCRIPTION_EVENT. Almost always 19.
@@ -143,9 +146,6 @@ type BinlogFormat struct {
 	// ChecksumAlgorithm is the ID number of the binlog checksum algorithm.
 	// See three possible values below.
 	ChecksumAlgorithm byte
-
-	// HeaderSizes is an array of sizes of the headers for each message.
-	HeaderSizes []byte
 }
 
 // IsZero returns true if the BinlogFormat has not been initialized.


### PR DESCRIPTION
Using the tool https://github.com/orijtech/structslop, I got this recommendation. 

```
~/dev/vitess/go/mysql/binlog_event.go:130:19: struct has size 56 (size class 64), could be 48 (size class 48), you'll save 25.00% if you rearrange it to:
struct {
	HeaderSizes       []byte
	ServerVersion     string
	FormatVersion     uint16
	HeaderLength      byte
	ChecksumAlgorithm byte
}

~/dev/vitess/go/mysql/conn.go:81:11: struct has size 240 (size class 240), could be 224 (size class 224), you'll save 6.67% if you rearrange it to:
struct {
	fields                 []*query.Field
	schemaName             string
	ClientData             interface{}
	conn                   net.Conn
	flavor                 flavor
	ServerVersion          string
	User                   string
	UserData               Getter
	bufferedReader         *bufio.Reader
	flushTimer             *time.Timer
	currentEphemeralPolicy int
	currentEphemeralBuffer *[]byte
	listener               *Listener
	bufferedWriter         *bufio.Writer
	PrepareData            map[uint32]*PrepareData
	bufMu                  sync.Mutex
	Capabilities           uint32
	closed                 sync2.AtomicBool
	ConnectionID           uint32
	StatementID            uint32
	StatusFlags            uint16
	CharacterSet           uint8
	sequence               uint8
}

~/dev/vitess/go/mysql/conn.go:187:18: struct has size 88 (size class 96), could be 80 (size class 80), you'll save 16.67% if you rearrange it to:
struct {
	ParamsType  []int32
	ColumnNames []string
	PrepareStmt string
	BindVars    map[string]*query.BindVariable
	StatementID uint32
	ParamsCount uint16
}

~/dev/vitess/go/mysql/server.go:122:15: struct has size 136 (size class 144), could be 128 (size class 128), you'll save 11.11% if you rearrange it to:
struct {
	authServer               AuthServer
	handler                  Handler
	listener                 net.Listener
	ServerVersion            string
	TLSConfig                atomic.Value
	SlowConnectWarnThreshold sync2.AtomicDuration
	connReadBufferSize       int
	connWriteTimeout         time.Duration
	connReadTimeout          time.Duration
	connectionID             uint32
	AllowClearTextWithoutTLS sync2.AtomicBool
	shutdown                 sync2.AtomicBool
	RequireSecureTransport   bool
}
```
