### PR TITLE
clean up plan building test cases

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -807,3 +807,11 @@
     ]
   }
 }
+
+# ambiguous LIMIT
+"select id from user limit 1 union all select id from music limit 1"
+"Incorrect usage of UNION and LIMIT - add parens to disambiguate your query (errno 1221) (sqlstate 21000)"
+
+# different number of columns
+"select id, 42 from user where id = 1 union all select id from user where id = 5"
+"The used SELECT statements have a different number of columns (errno 1222) (sqlstate 21000) during query: select id, 42 from user where id = 1 union all select id from user where id = 5"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -346,17 +346,9 @@
 "(select 1 from user order by 1 desc) order by 1 asc limit 2"
 "can't do ORDER BY on top of ORDER BY"
 
-# different number of columns
-"select id, 42 from user where id = 1 union all select id from user where id = 5"
-"The used SELECT statements have a different number of columns (errno 1222) (sqlstate 21000) during query: select id, 42 from user where id = 1 union all select id from user where id = 5"
-
 # ambiguous ORDER BY
 "select id from user order by id union all select id from music order by id desc"
 "Incorrect usage of UNION and ORDER BY - add parens to disambiguate your query (errno 1221) (sqlstate 21000)"
-
-# ambiguous LIMIT
-"select id from user limit 1 union all select id from music limit 1"
-"Incorrect usage of UNION and LIMIT - add parens to disambiguate your query (errno 1221) (sqlstate 21000)"
 
 # select get_lock with non-dual table
 "select get_lock('xyz', 10) from user"


### PR DESCRIPTION
Some of the queries in the `unsupported_queries.txt` file were queries that will never be supported. These have been moved out from this file.