### PR TITLE
vtgate -ddl-strategy flag renamed to -ddl_strategy

### DIFF
--- a/go/test/endtoend/onlineddl/onlineddl_test.go
+++ b/go/test/endtoend/onlineddl/onlineddl_test.go
@@ -106,7 +106,7 @@ func TestMain(m *testing.M) {
 			"-migration_check_interval", "5s",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
-			"-ddl-strategy", "gh-ost",
+			"-ddl_strategy", "gh-ost",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -61,7 +61,7 @@ var (
 	_                  = flag.Bool("disable_local_gateway", false, "deprecated: if specified, this process will not route any queries to local tablets in the local cell")
 	maxMemoryRows      = flag.Int("max_memory_rows", 300000, "Maximum number of rows that will be held in memory for intermediate results as well as the final result.")
 	warnMemoryRows     = flag.Int("warn_memory_rows", 30000, "Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented.")
-	defaultDDLStrategy = flag.String("ddl-strategy", "", "Set default strategy for DDL statements. Override with @@ddl_strategy session variable")
+	defaultDDLStrategy = flag.String("ddl_strategy", "", "Set default strategy for DDL statements. Override with @@ddl_strategy session variable")
 
 	// TODO(deepthi): change these two vars to unexported and move to healthcheck.go when LegacyHealthcheck is removed
 
@@ -168,7 +168,7 @@ func Init(ctx context.Context, serv srvtopo.Server, cell string, tabletTypesToWa
 	}
 
 	if _, _, err := schema.ParseDDLStrategy(*defaultDDLStrategy); err != nil {
-		log.Fatalf("Invalid value for --ddl-strategy: %v", err.Error())
+		log.Fatalf("Invalid value for -ddl_strategy: %v", err.Error())
 	}
 	tc := NewTxConn(gw, getTxMode())
 	// ScatterConn depends on TxConn to perform forced rollbacks.


### PR DESCRIPTION
Quick followup to #7045 , this PR makes both `vtgate` and `vtctl` use same command line flag name `ddl_strategy`, which is also compatible with the session variable `@@ddl_strategy`.

Context: #6782 