### PR TITLE
Make sure to check all GROUP BY columns

### DIFF
--- a/go/vt/vtgate/planbuilder/grouping.go
+++ b/go/vt/vtgate/planbuilder/grouping.go
@@ -50,8 +50,8 @@ func planGroupBy(pb *primitiveBuilder, input logicalPlan, groupBy sqlparser.Grou
 		node.Select.(*sqlparser.Select).GroupBy = groupBy
 		return node, nil
 	case *orderedAggregate:
-		colNumber := -1
 		for _, expr := range groupBy {
+			colNumber := -1
 			switch e := expr.(type) {
 			case *sqlparser.ColName:
 				c := e.Metadata.(*column)

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -909,6 +909,34 @@
   }
 }
 
+# scatter aggregate multiple group by columns inverse order
+"select a, b, count(*) from user group by b, a"
+{
+  "QueryType": "SELECT",
+  "Original": "select a, b, count(*) from user group by 2, 1",
+  "Instructions": {
+    "OperatorType": "Aggregate",
+    "Variant": "Ordered",
+    "Aggregates": "count(2)",
+    "Distinct": "false",
+    "GroupBy": "1, 0",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by 2, 1",
+        "OrderBy": "1 ASC, 0 ASC",
+        "Query": "select a, b, count(*) from user group by 2, 1 order by b asc, a asc",
+        "Table": "user"
+      }
+    ]
+  }
+}
+
 # scatter aggregate group by column number
 "select col from user group by 1"
 {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -913,7 +913,7 @@
 "select a, b, count(*) from user group by b, a"
 {
   "QueryType": "SELECT",
-  "Original": "select a, b, count(*) from user group by 2, 1",
+  "Original": "select a, b, count(*) from user group by b, a",
   "Instructions": {
     "OperatorType": "Aggregate",
     "Variant": "Ordered",
@@ -928,9 +928,9 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by 2, 1",
+        "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by b, a",
         "OrderBy": "1 ASC, 0 ASC",
-        "Query": "select a, b, count(*) from user group by 2, 1 order by b asc, a asc",
+        "Query": "select a, b, count(*) from user group by b, a order by b asc, a asc",
         "Table": "user"
       }
     ]

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -389,6 +389,10 @@
   }
 }
 
+# group by must only reference expressions in the select list
+"select col, count(*) from user group by col, baz"
+"unsupported: in scatter query: group by column must reference column in SELECT list"
+
 # group by a non-unique vindex column should use an OrderdAggregate primitive
 "select name, count(*) from user group by name"
 {


### PR DESCRIPTION
A bug in the code allowed any expression to be accepted, as long as the first expression in the GROUP BY list is valid.