### PR TITLE
Convert usages of DDL struct to DDLStatement interface

### DIFF
--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -128,8 +128,8 @@ func (exec *TabletExecutor) Validate(ctx context.Context, sqls []string) error {
 	return err
 }
 
-func (exec *TabletExecutor) parseDDLs(sqls []string) ([]*sqlparser.DDL, []sqlparser.DBDDLStatement, error) {
-	parsedDDLs := make([]*sqlparser.DDL, 0)
+func (exec *TabletExecutor) parseDDLs(sqls []string) ([]sqlparser.DDLStatement, []sqlparser.DBDDLStatement, error) {
+	parsedDDLs := make([]sqlparser.DDLStatement, 0)
 	parsedDBDDLs := make([]sqlparser.DBDDLStatement, 0)
 	for _, sql := range sqls {
 		stat, err := sqlparser.Parse(sql)
@@ -137,7 +137,7 @@ func (exec *TabletExecutor) parseDDLs(sqls []string) ([]*sqlparser.DDL, []sqlpar
 			return nil, nil, fmt.Errorf("failed to parse sql: %s, got error: %v", sql, err)
 		}
 		switch ddl := stat.(type) {
-		case *sqlparser.DDL:
+		case sqlparser.DDLStatement:
 			parsedDDLs = append(parsedDDLs, ddl)
 		case sqlparser.DBDDLStatement:
 			parsedDBDDLs = append(parsedDBDDLs, ddl)
@@ -151,11 +151,11 @@ func (exec *TabletExecutor) parseDDLs(sqls []string) ([]*sqlparser.DDL, []sqlpar
 }
 
 // IsOnlineSchemaDDL returns true if the query is an online schema change DDL
-func (exec *TabletExecutor) isOnlineSchemaDDL(ddl *sqlparser.DDL) (isOnline bool, strategy schema.DDLStrategy, options string) {
+func (exec *TabletExecutor) isOnlineSchemaDDL(ddl sqlparser.DDLStatement) (isOnline bool, strategy schema.DDLStrategy, options string) {
 	if ddl == nil {
 		return false, strategy, options
 	}
-	if ddl.Action != sqlparser.AlterDDLAction {
+	if ddl.GetAction() != sqlparser.AlterDDLAction {
 		return false, strategy, options
 	}
 	strategy, options, _ = schema.ParseDDLStrategy(exec.ddlStrategy)
@@ -169,7 +169,7 @@ func (exec *TabletExecutor) isOnlineSchemaDDL(ddl *sqlparser.DDL) (isOnline bool
 // to be a big schema change and will be rejected.
 //   1. Alter more than 100,000 rows.
 //   2. Change a table with more than 2,000,000 rows (Drops are fine).
-func (exec *TabletExecutor) detectBigSchemaChanges(ctx context.Context, parsedDDLs []*sqlparser.DDL) (bool, error) {
+func (exec *TabletExecutor) detectBigSchemaChanges(ctx context.Context, parsedDDLs []sqlparser.DDLStatement) (bool, error) {
 	// exec.tablets is guaranteed to have at least one element;
 	// Otherwise, Open should fail and executor should fail.
 	masterTabletInfo := exec.tablets[0]
@@ -188,13 +188,13 @@ func (exec *TabletExecutor) detectBigSchemaChanges(ctx context.Context, parsedDD
 			// Since this is an online schema change, there is no need to worry about big changes
 			continue
 		}
-		switch ddl.Action {
+		switch ddl.GetAction() {
 		case sqlparser.DropDDLAction, sqlparser.CreateDDLAction, sqlparser.TruncateDDLAction, sqlparser.RenameDDLAction:
 			continue
 		}
-		tableName := ddl.Table.Name.String()
+		tableName := ddl.GetTable().Name.String()
 		if rowCount, ok := tableWithCount[tableName]; ok {
-			if rowCount > 100000 && ddl.Action == sqlparser.AlterDDLAction {
+			if rowCount > 100000 && ddl.GetAction() == sqlparser.AlterDDLAction {
 				return true, fmt.Errorf(
 					"big schema change detected. Disable check with -allow_long_unavailability. ddl: %s alters a table with more than 100 thousand rows", sqlparser.String(ddl))
 			}
@@ -257,8 +257,8 @@ func (exec *TabletExecutor) Execute(ctx context.Context, sqls []string) *Execute
 		isOnlineDDL, strategy, options := exec.isOnlineSchemaDDL(nil)
 		tableName := ""
 		switch ddl := stat.(type) {
-		case *sqlparser.DDL:
-			tableName = ddl.Table.Name.String()
+		case sqlparser.DDLStatement:
+			tableName = ddl.GetTable().Name.String()
 			isOnlineDDL, strategy, options = exec.isOnlineSchemaDDL(ddl)
 		}
 		exec.wr.Logger().Infof("Received DDL request. strategy=%+v", strategy)

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -266,7 +266,7 @@ func TestIsOnlineSchemaDDL(t *testing.T) {
 		stmt, err := sqlparser.Parse(ts.query)
 		assert.NoError(t, err)
 
-		ddl, ok := stmt.(*sqlparser.DDL)
+		ddl, ok := stmt.(sqlparser.DDLStatement)
 		assert.True(t, ok)
 
 		isOnlineDDL, strategy, options := e.isOnlineSchemaDDL(ddl)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -61,6 +61,13 @@ type (
 		IsFullyParsed() bool
 		GetTable() TableName
 		GetAction() DDLAction
+		GetOptLike() *OptLike
+		GetTableSpec() *TableSpec
+		GetVindexSpec() *VindexSpec
+		GetFromTables() TableNames
+		GetToTables() TableNames
+		GetAutoIncSpec() *AutoIncSpec
+		GetVindexCols() []ColIdent
 		AffectedTables() TableNames
 		SetTable(qualifier string, name string)
 		Statement
@@ -411,6 +418,76 @@ func (node *DDL) GetTable() TableName {
 // GetAction implements the DDLStatement interface
 func (node *CreateIndex) GetAction() DDLAction {
 	return AlterDDLAction
+}
+
+// GetOptLike implements the DDLStatement interface
+func (node *DDL) GetOptLike() *OptLike {
+	return node.OptLike
+}
+
+// GetOptLike implements the DDLStatement interface
+func (node *CreateIndex) GetOptLike() *OptLike {
+	return nil
+}
+
+// GetTableSpec implements the DDLStatement interface
+func (node *DDL) GetTableSpec() *TableSpec {
+	return node.TableSpec
+}
+
+// GetTableSpec implements the DDLStatement interface
+func (node *CreateIndex) GetTableSpec() *TableSpec {
+	return nil
+}
+
+// GetVindexSpec implements the DDLStatement interface
+func (node *DDL) GetVindexSpec() *VindexSpec {
+	return node.VindexSpec
+}
+
+// GetVindexSpec implements the DDLStatement interface
+func (node *CreateIndex) GetVindexSpec() *VindexSpec {
+	return nil
+}
+
+// GetFromTables implements the DDLStatement interface
+func (node *DDL) GetFromTables() TableNames {
+	return node.FromTables
+}
+
+// GetFromTables implements the DDLStatement interface
+func (node *CreateIndex) GetFromTables() TableNames {
+	return nil
+}
+
+// GetToTables implements the DDLStatement interface
+func (node *DDL) GetToTables() TableNames {
+	return node.ToTables
+}
+
+// GetToTables implements the DDLStatement interface
+func (node *CreateIndex) GetToTables() TableNames {
+	return nil
+}
+
+// GetAutoIncSpec implements the DDLStatement interface
+func (node *DDL) GetAutoIncSpec() *AutoIncSpec {
+	return node.AutoIncSpec
+}
+
+// GetAutoIncSpec implements the DDLStatement interface
+func (node *CreateIndex) GetAutoIncSpec() *AutoIncSpec {
+	return nil
+}
+
+// GetVindexCols implements the DDLStatement interface
+func (node *DDL) GetVindexCols() []ColIdent {
+	return node.VindexCols
+}
+
+// GetVindexCols implements the DDLStatement interface
+func (node *CreateIndex) GetVindexCols() []ColIdent {
+	return nil
 }
 
 // GetAction implements the DDLStatement interface

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -177,7 +177,7 @@ func TestSetLimit(t *testing.T) {
 func TestDDL(t *testing.T) {
 	testcases := []struct {
 		query    string
-		output   *DDL
+		output   DDLStatement
 		affected []string
 	}{{
 		query: "create table a",
@@ -244,7 +244,7 @@ func TestDDL(t *testing.T) {
 		for _, t := range tcase.affected {
 			want = append(want, TableName{Name: NewTableIdent(t)})
 		}
-		if affected := got.(*DDL).AffectedTables(); !reflect.DeepEqual(affected, want) {
+		if affected := got.(DDLStatement).AffectedTables(); !reflect.DeepEqual(affected, want) {
 			t.Errorf("Affected(%s): %v, want %v", tcase.query, affected, want)
 		}
 	}

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -60,7 +60,7 @@ func newNormalizer(stmt Statement, bindVars map[string]*querypb.BindVariable, pr
 func (nz *normalizer) WalkStatement(cursor *Cursor) bool {
 	switch node := cursor.Node().(type) {
 	// no need to normalize the statement types
-	case *Set, *Show, *Begin, *Commit, *Rollback, *Savepoint, *SetTransaction, *DDL, *SRollback, *Release, *OtherAdmin, *OtherRead:
+	case *Set, *Show, *Begin, *Commit, *Rollback, *Savepoint, *SetTransaction, DDLStatement, *SRollback, *Release, *OtherAdmin, *OtherRead:
 		return false
 	case *Select:
 		Rewrite(node, nz.WalkSelect, nil)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2767,7 +2767,7 @@ func commandApplyVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		if err != nil {
 			return fmt.Errorf("error parsing vschema statement `%s`: %v", *sql, err)
 		}
-		ddl, ok := stmt.(*sqlparser.DDL)
+		ddl, ok := stmt.(sqlparser.DDLStatement)
 		if !ok {
 			return fmt.Errorf("error parsing vschema statement `%s`: not a ddl statement", *sql)
 		}

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -181,8 +181,8 @@ func Stop() {
 	}
 }
 
-func parseSchema(sqlSchema string, opts *Options) ([]*sqlparser.DDL, error) {
-	parsedDDLs := make([]*sqlparser.DDL, 0, 16)
+func parseSchema(sqlSchema string, opts *Options) ([]sqlparser.DDLStatement, error) {
+	parsedDDLs := make([]sqlparser.DDLStatement, 0, 16)
 	for {
 		sql, rem, err := sqlparser.SplitStatement(sqlSchema)
 		sqlSchema = rem
@@ -210,16 +210,16 @@ func parseSchema(sqlSchema string, opts *Options) ([]*sqlparser.DDL, error) {
 				continue
 			}
 		}
-		ddl, ok := stmt.(*sqlparser.DDL)
+		ddl, ok := stmt.(sqlparser.DDLStatement)
 		if !ok {
 			log.Infof("ignoring non-DDL statement: %s", sql)
 			continue
 		}
-		if ddl.Action != sqlparser.CreateDDLAction {
-			log.Infof("ignoring %s table statement", ddl.Action.ToString())
+		if ddl.GetAction() != sqlparser.CreateDDLAction {
+			log.Infof("ignoring %s table statement", ddl.GetAction().ToString())
 			continue
 		}
-		if ddl.TableSpec == nil && ddl.OptLike == nil {
+		if ddl.GetTableSpec() == nil && ddl.GetOptLike() == nil {
 			log.Errorf("invalid create table statement: %s", sql)
 			continue
 		}

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -116,7 +116,7 @@ func (t noopVCursor) ShardSession() []*srvtopo.ResolvedShard {
 	panic("implement me")
 }
 
-func (t noopVCursor) ExecuteVSchema(keyspace string, vschemaDDL *sqlparser.DDL) error {
+func (t noopVCursor) ExecuteVSchema(keyspace string, vschemaDDL sqlparser.DDLStatement) error {
 	panic("implement me")
 }
 
@@ -281,7 +281,7 @@ func (f *loggingVCursor) ShardSession() []*srvtopo.ResolvedShard {
 	return nil
 }
 
-func (f *loggingVCursor) ExecuteVSchema(string, *sqlparser.DDL) error {
+func (f *loggingVCursor) ExecuteVSchema(string, sqlparser.DDLStatement) error {
 	panic("implement me")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -84,7 +84,7 @@ type (
 		// Will replace all of the Topo functions.
 		ResolveDestinations(keyspace string, ids []*querypb.Value, destinations []key.Destination) ([]*srvtopo.ResolvedShard, [][]*querypb.Value, error)
 
-		ExecuteVSchema(keyspace string, vschemaDDL *sqlparser.DDL) error
+		ExecuteVSchema(keyspace string, vschemaDDL sqlparser.DDLStatement) error
 
 		SubmitOnlineDDL(onlineDDl *schema.OnlineDDL) error
 

--- a/go/vt/vtgate/engine/vschema_ddl.go
+++ b/go/vt/vtgate/engine/vschema_ddl.go
@@ -31,7 +31,7 @@ var _ Primitive = (*AlterVSchema)(nil)
 type AlterVSchema struct {
 	Keyspace *vindexes.Keyspace
 
-	DDL *sqlparser.DDL
+	DDL sqlparser.DDLStatement
 
 	noTxNeeded
 
@@ -60,7 +60,7 @@ func (v *AlterVSchema) GetKeyspaceName() string {
 
 //GetTableName implements the Primitive interface
 func (v *AlterVSchema) GetTableName() string {
-	return v.DDL.Table.Name.String()
+	return v.DDL.GetTable().Name.String()
 }
 
 //Execute implements the Primitive interface

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -103,7 +103,7 @@ func (vc *vcursorImpl) GetKeyspace() string {
 	return vc.keyspace
 }
 
-func (vc *vcursorImpl) ExecuteVSchema(keyspace string, vschemaDDL *sqlparser.DDL) error {
+func (vc *vcursorImpl) ExecuteVSchema(keyspace string, vschemaDDL sqlparser.DDLStatement) error {
 	srvVschema := vc.vm.GetCurrentSrvVschema()
 	if srvVschema == nil {
 		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "vschema not loaded")
@@ -117,8 +117,8 @@ func (vc *vcursorImpl) ExecuteVSchema(keyspace string, vschemaDDL *sqlparser.DDL
 
 	// Resolve the keyspace either from the table qualifier or the target keyspace
 	var ksName string
-	if !vschemaDDL.Table.IsEmpty() {
-		ksName = vschemaDDL.Table.Qualifier.String()
+	if !vschemaDDL.GetTable().IsEmpty() {
+		ksName = vschemaDDL.GetTable().Qualifier.String()
 	}
 	if ksName == "" {
 		ksName = keyspace

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -197,16 +197,12 @@ func mustSendDDL(query mysql.Query, dbname string, filter *binlogdatapb.Filter) 
 		if !stmt.GetTable().IsEmpty() {
 			return tableMatches(stmt.GetTable(), dbname, filter)
 		}
-		ddlStmt, isDDL := stmt.(*sqlparser.DDL)
-		if !isDDL {
-			return false
-		}
-		for _, table := range ddlStmt.FromTables {
+		for _, table := range stmt.GetFromTables() {
 			if tableMatches(table, dbname, filter) {
 				return true
 			}
 		}
-		for _, table := range ddlStmt.ToTables {
+		for _, table := range stmt.GetToTables() {
 			if tableMatches(table, dbname, filter) {
 				return true
 			}

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -950,9 +950,9 @@ func stripTableConstraints(ddl string) (string, error) {
 
 	stripConstraints := func(cursor *sqlparser.Cursor) bool {
 		switch node := cursor.Node().(type) {
-		case *sqlparser.DDL:
-			if node.TableSpec != nil {
-				node.TableSpec.Constraints = nil
+		case sqlparser.DDLStatement:
+			if node.GetTableSpec() != nil {
+				node.GetTableSpec().Constraints = nil
 			}
 		}
 		return true


### PR DESCRIPTION
All the occurences of DDL struct have been converted to DDLStatement interface. This is done so that further addition of newer constructs to DDLStatement interface does not affect the current functionality. The end goal is to remove the various functions added to the interface in this PR and convert them to a type switch for specific constructs.