### PR TITLE
fix error: cannot run Select on table "dual"

### DIFF
--- a/go/test/endtoend/onlineddl/onlineddl_test.go
+++ b/go/test/endtoend/onlineddl/onlineddl_test.go
@@ -206,7 +206,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = testAlterTable(t, alterTableThrottlingStatement, "gh-ost --max-load=Threads_running=1", "vtgate", "ghost_col")
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "gh-ost --max-load=Threads_running=1", "vtgate", "ghost_col")
 			}()
 		}
 		wg.Wait()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -361,6 +361,12 @@ func (qre *QueryExecutor) checkAccess(authorized *tableacl.ACLResult, tableName 
 			qre.tsv.Stats().TableaclPseudoDenied.Add(statsKey, 1)
 			return nil
 		}
+
+		// Skip ACL check for queries against the dummy dual table
+		if tableName == "dual" {
+			return nil
+		}
+
 		if qre.tsv.qe.strictTableACL {
 			errStr := fmt.Sprintf("table acl error: %q %v cannot run %v on table %q", callerID.Username, callerID.Groups, qre.plan.PlanID, tableName)
 			qre.tsv.Stats().TableaclDenied.Add(statsKey, 1)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -816,9 +816,8 @@ func TestQueryExecutorTableAclDualTableExempt(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 
-	username := "Sleve McDichael"
 	callerID := &querypb.VTGateCallerID{
-		Username: username,
+		Username: "basic_username",
 	}
 	ctx := callerid.NewContext(context.Background(), nil, callerID)
 
@@ -848,6 +847,14 @@ func TestQueryExecutorTableAclDualTableExempt(t *testing.T) {
 
 	// table acl should be ignored when querying against dual table
 	query = "select @@version_comment from dual limit 1"
+	ctx = callerid.NewContext(context.Background(), nil, callerID)
+	qre = newTestQueryExecutor(ctx, tsv, query, 0)
+	_, err = qre.Execute()
+	if err != nil {
+		t.Fatalf("qre.Execute: %v, want: nil", err)
+	}
+
+	query = "(select 0 as x from dual where 1 != 1) union (select 1 as y from dual where 1 != 1)"
 	ctx = callerid.NewContext(context.Background(), nil, callerID)
 	qre = newTestQueryExecutor(ctx, tsv, query, 0)
 	_, err = qre.Execute()
@@ -1245,6 +1252,20 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 				{sqltypes.NewVarBinary("fakedb server")},
 			},
 			RowsAffected: 1,
+		},
+		"(select 0 as x from dual where 1 != 1) union (select 1 as y from dual where 1 != 1)": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			Rows:         [][]sqltypes.Value{},
+			RowsAffected: 0,
+		},
+		"(select 0 as x from dual where 1 != 1) union (select 1 as y from dual where 1 != 1) limit 10001": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			Rows:         [][]sqltypes.Value{},
+			RowsAffected: 0,
 		},
 		mysql.BaseShowTables: {
 			Fields: mysql.BaseShowTablesFields,


### PR DESCRIPTION
Signed-off-by: Andrei Sura <andrei.sura@sharpspring.com>

This pr is fixing an issue encountered when executing a query involving the dual table (there was a previous pr which fixed a similar issue but it seems that it does not address all code paths)

- as `root` this query works
```
select 0 as x union select 1;
+---+
| x |
+---+
| 0 |
| 1 |
+---+
```

- as a simple user I get the following error
```
vttablet: rpc error: code = PermissionDenied desc = table acl error: "xyz" [] cannot run Select on table "dual" (CallerID: xyz)
```
