### PR TITLE
action_respository: no need for http.Request

### DIFF
--- a/go/vt/vtctld/action_repository.go
+++ b/go/vt/vtctld/action_repository.go
@@ -54,11 +54,11 @@ func (ar *ActionResult) error(text string) {
 // some action on a Topology object. It should return a message for
 // the user or an empty string in case there's nothing interesting to
 // be communicated.
-type actionKeyspaceMethod func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (output string, err error)
+type actionKeyspaceMethod func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (output string, err error)
 
-type actionShardMethod func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (output string, err error)
+type actionShardMethod func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (output string, err error)
 
-type actionTabletMethod func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (output string, err error)
+type actionTabletMethod func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (output string, err error)
 
 type actionTabletRecord struct {
 	role   string
@@ -67,8 +67,6 @@ type actionTabletRecord struct {
 
 // ActionRepository is a repository of actions that can be performed
 // on a {Keyspace,Shard,Tablet}.
-// Note that the registered action methods will be passed an *http.Request
-// on which ParseForm() has already succeeded.
 type ActionRepository struct {
 	keyspaceActions map[string]actionKeyspaceMethod
 	shardActions    map[string]actionShardMethod
@@ -106,7 +104,7 @@ func (ar *ActionRepository) RegisterTabletAction(name, role string, method actio
 }
 
 // ApplyKeyspaceAction applies the provided action to the keyspace.
-func (ar *ActionRepository) ApplyKeyspaceAction(ctx context.Context, actionName, keyspace string, r *http.Request) *ActionResult {
+func (ar *ActionRepository) ApplyKeyspaceAction(ctx context.Context, actionName, keyspace string) *ActionResult {
 	result := &ActionResult{Name: actionName, Parameters: keyspace}
 
 	action, ok := ar.keyspaceActions[actionName]
@@ -117,7 +115,7 @@ func (ar *ActionRepository) ApplyKeyspaceAction(ctx context.Context, actionName,
 
 	ctx, cancel := context.WithTimeout(ctx, *actionTimeout)
 	wr := wrangler.New(logutil.NewConsoleLogger(), ar.ts, tmclient.NewTabletManagerClient())
-	output, err := action(ctx, wr, keyspace, r)
+	output, err := action(ctx, wr, keyspace)
 	cancel()
 	if err != nil {
 		result.error(err.Error())
@@ -128,7 +126,7 @@ func (ar *ActionRepository) ApplyKeyspaceAction(ctx context.Context, actionName,
 }
 
 // ApplyShardAction applies the provided action to the shard.
-func (ar *ActionRepository) ApplyShardAction(ctx context.Context, actionName, keyspace, shard string, r *http.Request) *ActionResult {
+func (ar *ActionRepository) ApplyShardAction(ctx context.Context, actionName, keyspace, shard string) *ActionResult {
 	// if the shard name contains a '-', we assume it's the
 	// name for a ranged based shard, so we lower case it.
 	if strings.Contains(shard, "-") {
@@ -144,7 +142,7 @@ func (ar *ActionRepository) ApplyShardAction(ctx context.Context, actionName, ke
 
 	ctx, cancel := context.WithTimeout(ctx, *actionTimeout)
 	wr := wrangler.New(logutil.NewConsoleLogger(), ar.ts, tmclient.NewTabletManagerClient())
-	output, err := action(ctx, wr, keyspace, shard, r)
+	output, err := action(ctx, wr, keyspace, shard)
 	cancel()
 	if err != nil {
 		result.error(err.Error())
@@ -178,7 +176,7 @@ func (ar *ActionRepository) ApplyTabletAction(ctx context.Context, actionName st
 	// run the action
 	ctx, cancel := context.WithTimeout(ctx, *actionTimeout)
 	wr := wrangler.New(logutil.NewConsoleLogger(), ar.ts, tmclient.NewTabletManagerClient())
-	output, err := action.method(ctx, wr, tabletAlias, r)
+	output, err := action.method(ctx, wr, tabletAlias)
 	cancel()
 	if err != nil {
 		result.error(err.Error())

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -233,7 +233,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			if action == "" {
 				return nil, errors.New("a POST request must specify action")
 			}
-			return actions.ApplyKeyspaceAction(ctx, action, keyspace, r), nil
+			return actions.ApplyKeyspaceAction(ctx, action, keyspace), nil
 		default:
 			return nil, fmt.Errorf("unsupported HTTP method: %v", r.Method)
 		}
@@ -323,7 +323,7 @@ func initAPI(ctx context.Context, ts *topo.Server, actions *ActionRepository, re
 			if action == "" {
 				return nil, errors.New("must specify action")
 			}
-			return actions.ApplyShardAction(ctx, action, keyspace, shard, r), nil
+			return actions.ApplyShardAction(ctx, action, keyspace, shard), nil
 		}
 
 		// Get the shard record.

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -102,15 +102,15 @@ func TestAPI(t *testing.T) {
 
 	// Populate fake actions.
 	actionRepo.RegisterKeyspaceAction("TestKeyspaceAction",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
 			return "TestKeyspaceAction Result", nil
 		})
 	actionRepo.RegisterShardAction("TestShardAction",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (string, error) {
 			return "TestShardAction Result", nil
 		})
 	actionRepo.RegisterTabletAction("TestTabletAction", "",
-		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (string, error) {
 			return "TestTabletAction Result", nil
 		})
 

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -53,49 +53,49 @@ func InitVtctld(ts *topo.Server) {
 
 	// keyspace actions
 	actionRepo.RegisterKeyspaceAction("ValidateKeyspace",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
 			return "", wr.ValidateKeyspace(ctx, keyspace, false)
 		})
 
 	actionRepo.RegisterKeyspaceAction("ValidateSchemaKeyspace",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
 			return "", wr.ValidateSchemaKeyspace(ctx, keyspace, nil, false, false)
 		})
 
 	actionRepo.RegisterKeyspaceAction("ValidateVersionKeyspace",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
 			return "", wr.ValidateVersionKeyspace(ctx, keyspace)
 		})
 
 	actionRepo.RegisterKeyspaceAction("ValidatePermissionsKeyspace",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
 			return "", wr.ValidatePermissionsKeyspace(ctx, keyspace)
 		})
 
 	// shard actions
 	actionRepo.RegisterShardAction("ValidateShard",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (string, error) {
 			return "", wr.ValidateShard(ctx, keyspace, shard, false)
 		})
 
 	actionRepo.RegisterShardAction("ValidateSchemaShard",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (string, error) {
 			return "", wr.ValidateSchemaShard(ctx, keyspace, shard, nil, false)
 		})
 
 	actionRepo.RegisterShardAction("ValidateVersionShard",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (string, error) {
 			return "", wr.ValidateVersionShard(ctx, keyspace, shard)
 		})
 
 	actionRepo.RegisterShardAction("ValidatePermissionsShard",
-		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, keyspace, shard string) (string, error) {
 			return "", wr.ValidatePermissionsShard(ctx, keyspace, shard)
 		})
 
 	// tablet actions
 	actionRepo.RegisterTabletAction("Ping", "",
-		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (string, error) {
 			ti, err := wr.TopoServer().GetTablet(ctx, tabletAlias)
 			if err != nil {
 				return "", err
@@ -104,7 +104,7 @@ func InitVtctld(ts *topo.Server) {
 		})
 
 	actionRepo.RegisterTabletAction("RefreshState", acl.ADMIN,
-		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (string, error) {
 			ti, err := wr.TopoServer().GetTablet(ctx, tabletAlias)
 			if err != nil {
 				return "", err
@@ -113,12 +113,12 @@ func InitVtctld(ts *topo.Server) {
 		})
 
 	actionRepo.RegisterTabletAction("DeleteTablet", acl.ADMIN,
-		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (string, error) {
 			return "", wr.DeleteTablet(ctx, tabletAlias, false)
 		})
 
 	actionRepo.RegisterTabletAction("ReloadSchema", acl.ADMIN,
-		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias, r *http.Request) (string, error) {
+		func(ctx context.Context, wr *wrangler.Wrangler, tabletAlias *topodatapb.TabletAlias) (string, error) {
 			return "", wr.ReloadSchema(ctx, tabletAlias)
 		})
 


### PR DESCRIPTION
I was working on an internal POC when I needed to refactor some code around `actions_repository.go`; I noticed something that bothered me: most action functions received `http.Request`. It bothered me because I wanted to be able to run some actions irrespective of `http`. After looking deeper, I noticed no existing action uses the `http.Request`.

So this PR is code cleanup for removing `http.Request` from function signatures and callers, without affecting app logic.