### PR TITLE
Add vtctl to make install-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ install: build
 install-local: build
 	# binaries
 	mkdir -p "$${PREFIX}/bin"
-	cp "$${VTROOT}/bin/"{mysqlctl,mysqlctld,vtorc,vtctld,vtctlclient,vtgate,vttablet,vtworker,vtbackup} "$${PREFIX}/bin/"
+	cp "$${VTROOT}/bin/"{mysqlctl,mysqlctld,vtorc,vtctl,vtctld,vtctlclient,vtgate,vttablet,vtworker,vtbackup} "$${PREFIX}/bin/"
 
 
 # install copies the files needed to run test Vitess using vtcombo into the given directory tree.


### PR DESCRIPTION
Hi, thanks for this project! This adds `vtctl` to `make install-local` (noticed it was missing when following the [Getting Started](https://vitess.io/docs/get-started/local/) docs).