### PR TITLE
Minimum example of test pollution.

### DIFF
--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -102,6 +102,13 @@ func TestMtlsAuth(t *testing.T) {
 	assertColumnVindex(t, cluster, columnVindex{keyspace: "test_keyspace", table: "test_table", vindex: "my_vdx", vindexType: "hash", column: "id"})
 	assertColumnVindex(t, cluster, columnVindex{keyspace: "app_customer", table: "customers", vindex: "hash", vindexType: "hash", column: "id"})
 }
+func TestPollution(t *testing.T) {
+	cluster, err := startCluster()
+	defer cluster.TearDown()
+	args := os.Args
+	defer resetFlags(args)
+	assert.NoError(t, err)
+}
 
 func TestMtlsAuthUnaothorizedFails(t *testing.T) {
 	// Our test root.


### PR DESCRIPTION
> So there's some test pollution in vttestserver_test.go. I thought I had introduced it, but it's actually something with the mTLS tests. When my test was at the bottom of the file, it would hang forever. 

Originally posted at https://github.com/vitessio/vitess/pull/7121#issuecomment-739982580