### PR TITLE
Fix missed rename in onlineddl_test

### DIFF
--- a/go/test/endtoend/onlineddl/onlineddl_test.go
+++ b/go/test/endtoend/onlineddl/onlineddl_test.go
@@ -206,7 +206,7 @@ func TestSchemaChange(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = testAlterTable(t, alterTableThrottlingStatement, "gh-ost --max-load=Threads_running=1", "vtgate", "ghost_col")
+				_ = testOnlineDDLStatement(t, alterTableThrottlingStatement, "gh-ost --max-load=Threads_running=1", "vtgate", "ghost_col")
 			}()
 		}
 		wg.Wait()


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Backport
NO

## Status
**READY**

## Description
Fix missed rename in onlineddl_test

## Related Issue(s)
List related PRs against other branches:
https://github.com/vitessio/vitess/commit/7703097743218d2a0b64351df71947ebbdc2f673

## Todos
- [ ] Tests
- [ ] Documentation

## Deployment Notes

None.

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
