### PR TITLE
Allow system table to be set as default database

### DIFF
--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -131,9 +131,9 @@ func TestConnectWithSystemSchema(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()
 	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
-		vtParams := vtParams
-		vtParams.DbName = dbname
-		conn, err := mysql.Connect(ctx, &vtParams)
+		connParams := vtParams
+		connParams.DbName = dbname
+		conn, err := mysql.Connect(ctx, &connParams)
 		require.NoError(t, err)
 		conn.Close()
 	}
@@ -158,25 +158,25 @@ func TestSystemSchemaQueryWithoutQualifier(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	queryWithQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type " +
-		"from information_schema.tables t " +
-		"join information_schema.columns c " +
-		"on c.table_schema = t.table_schema and c.table_name = t.table_name " +
+	queryWithQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type "+
+		"from information_schema.tables t "+
+		"join information_schema.columns c "+
+		"on c.table_schema = t.table_schema and c.table_name = t.table_name "+
 		"where t.table_schema = '%s' and c.table_schema = '%s'", KeyspaceName, KeyspaceName)
 	qr1 := exec(t, conn, queryWithQualifier)
 
-	queryWithoutQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type " +
-		"from tables t " +
-		"join columns c " +
-		"on c.table_schema = t.table_schema and c.table_name = t.table_name " +
+	queryWithoutQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type "+
+		"from tables t "+
+		"join columns c "+
+		"on c.table_schema = t.table_schema and c.table_name = t.table_name "+
 		"where t.table_schema = '%s' and c.table_schema = '%s'", KeyspaceName, KeyspaceName)
 	exec(t, conn, "use information_schema")
 	qr2 := exec(t, conn, queryWithoutQualifier)
 	require.Equal(t, qr1, qr2)
 
-	vtParams := vtParams
-	vtParams.DbName = "information_schema"
-	conn2, err := mysql.Connect(ctx, &vtParams)
+	connParams := vtParams
+	connParams.DbName = "information_schema"
+	conn2, err := mysql.Connect(ctx, &connParams)
 	require.NoError(t, err)
 	defer conn2.Close()
 

--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -18,6 +18,7 @@ package vtgate
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,4 +125,61 @@ func TestFKConstraintUsingInformationSchema(t *testing.T) {
 
 	query := "select fk.referenced_table_name as to_table, fk.referenced_column_name as primary_key, fk.column_name as `column`, fk.constraint_name as name, rc.update_rule as on_update, rc.delete_rule as on_delete from information_schema.referential_constraints as rc join information_schema.key_column_usage as fk using (constraint_schema, constraint_name) where fk.referenced_column_name is not null and fk.table_schema = database() and fk.table_name = 't7_fk' and rc.constraint_schema = database() and rc.table_name = 't7_fk'"
 	assertMatches(t, conn, query, `[[VARCHAR("t7_xxhash") VARCHAR("uid") VARCHAR("t7_uid") VARCHAR("t7_fk_ibfk_1") VARCHAR("CASCADE") VARCHAR("SET NULL")]]`)
+}
+
+func TestConnectWithSystemSchema(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
+		vtParams := vtParams
+		vtParams.DbName = dbname
+		conn, err := mysql.Connect(ctx, &vtParams)
+		require.NoError(t, err)
+		conn.Close()
+	}
+}
+
+func TestUseSystemSchema(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
+		conn, err := mysql.Connect(ctx, &vtParams)
+		require.NoError(t, err)
+
+		exec(t, conn, fmt.Sprintf("use %s", dbname))
+		conn.Close()
+	}
+}
+
+func TestSystemSchemaQueryWithoutQualifier(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	queryWithQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type " +
+		"from information_schema.tables t " +
+		"join information_schema.columns c " +
+		"on c.table_schema = t.table_schema and c.table_name = t.table_name " +
+		"where t.table_schema = '%s' and c.table_schema = '%s'", KeyspaceName, KeyspaceName)
+	qr1 := exec(t, conn, queryWithQualifier)
+
+	queryWithoutQualifier := fmt.Sprintf("select t.table_schema,t.table_name,c.column_name,c.column_type " +
+		"from tables t " +
+		"join columns c " +
+		"on c.table_schema = t.table_schema and c.table_name = t.table_name " +
+		"where t.table_schema = '%s' and c.table_schema = '%s'", KeyspaceName, KeyspaceName)
+	exec(t, conn, "use information_schema")
+	qr2 := exec(t, conn, queryWithoutQualifier)
+	require.Equal(t, qr1, qr2)
+
+	vtParams := vtParams
+	vtParams.DbName = "information_schema"
+	conn2, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	qr3 := exec(t, conn2, queryWithoutQualifier)
+	require.Equal(t, qr2, qr3)
 }

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -112,7 +112,7 @@ const (
 )
 
 func (er *expressionRewriter) rewriteAliasedExpr(node *AliasedExpr) (*BindVarNeeds, error) {
-	inner := newExpressionRewriter("")
+	inner := newExpressionRewriter(er.keyspace)
 	inner.shouldRewriteDatabaseFunc = er.shouldRewriteDatabaseFunc
 	tmp := Rewrite(node.Expr, inner.rewrite, nil)
 	newExpr, ok := tmp.(Expr)

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -162,6 +162,9 @@ func (er *expressionRewriter) rewrite(cursor *Cursor) bool {
 	case JoinCondition:
 		er.rewriteJoinCondition(cursor, node)
 	case *AliasedTableExpr:
+		if !SystemSchema(er.keyspace) {
+			break
+		}
 		aliasTableName, ok := node.Expr.(TableName)
 		if !ok {
 			return true
@@ -300,4 +303,12 @@ func (er *expressionRewriter) unnestSubQueries(cursor *Cursor, subquery *Subquer
 
 func bindVarExpression(name string) Expr {
 	return NewArgument([]byte(":" + name))
+}
+
+// SystemSchema returns true if the schema passed is system schema
+func SystemSchema(schema string) bool {
+	return strings.EqualFold(schema, "information_schema") ||
+		strings.EqualFold(schema, "performance_schema") ||
+		strings.EqualFold(schema, "sys") ||
+		strings.EqualFold(schema, "mysql")
 }

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -33,16 +33,16 @@ type RewriteASTResult struct {
 }
 
 // PrepareAST will normalize the query
-func PrepareAST(in Statement, bindVars map[string]*querypb.BindVariable, prefix string, parameterize bool) (*RewriteASTResult, error) {
+func PrepareAST(in Statement, bindVars map[string]*querypb.BindVariable, prefix string, parameterize bool, keyspace string) (*RewriteASTResult, error) {
 	if parameterize {
 		Normalize(in, bindVars, prefix)
 	}
-	return RewriteAST(in)
+	return RewriteAST(in, keyspace)
 }
 
 // RewriteAST rewrites the whole AST, replacing function calls and adding column aliases to queries
-func RewriteAST(in Statement) (*RewriteASTResult, error) {
-	er := newExpressionRewriter()
+func RewriteAST(in Statement, keyspace string) (*RewriteASTResult, error) {
+	er := newExpressionRewriter(keyspace)
 	er.shouldRewriteDatabaseFunc = shouldRewriteDatabaseFunc(in)
 	setRewriter := &setNormalizer{}
 	out, ok := Rewrite(in, er.rewrite, setRewriter.rewriteSetComingUp).(Statement)
@@ -86,10 +86,12 @@ type expressionRewriter struct {
 
 	// we need to know this to make a decision if we can safely rewrite JOIN USING => JOIN ON
 	hasStarInSelect bool
+
+	keyspace string
 }
 
-func newExpressionRewriter() *expressionRewriter {
-	return &expressionRewriter{bindVars: &BindVarNeeds{}}
+func newExpressionRewriter(keyspace string) *expressionRewriter {
+	return &expressionRewriter{bindVars: &BindVarNeeds{}, keyspace: keyspace}
 }
 
 const (
@@ -110,7 +112,7 @@ const (
 )
 
 func (er *expressionRewriter) rewriteAliasedExpr(node *AliasedExpr) (*BindVarNeeds, error) {
-	inner := newExpressionRewriter()
+	inner := newExpressionRewriter("")
 	inner.shouldRewriteDatabaseFunc = er.shouldRewriteDatabaseFunc
 	tmp := Rewrite(node.Expr, inner.rewrite, nil)
 	newExpr, ok := tmp.(Expr)
@@ -157,50 +159,62 @@ func (er *expressionRewriter) rewrite(cursor *Cursor) bool {
 		}
 	case *Subquery:
 		er.unnestSubQueries(cursor, node)
-
 	case JoinCondition:
-		if node.Using != nil && !er.hasStarInSelect {
-			joinTableExpr, ok := cursor.Parent().(*JoinTableExpr)
-			if !ok {
-				// this is not possible with the current AST
-				break
-			}
-			leftTable, leftOk := joinTableExpr.LeftExpr.(*AliasedTableExpr)
-			rightTable, rightOk := joinTableExpr.RightExpr.(*AliasedTableExpr)
-			if !(leftOk && rightOk) {
-				// we only deal with simple FROM A JOIN B USING queries at the moment
-				break
-			}
-			lft, err := leftTable.TableName()
-			if err != nil {
-				er.err = err
-				break
-			}
-			rgt, err := rightTable.TableName()
-			if err != nil {
-				er.err = err
-				break
-			}
-			newCondition := JoinCondition{}
-			for _, colIdent := range node.Using {
-				lftCol := NewColNameWithQualifier(colIdent.String(), lft)
-				rgtCol := NewColNameWithQualifier(colIdent.String(), rgt)
-				cmp := &ComparisonExpr{
-					Operator: EqualOp,
-					Left:     lftCol,
-					Right:    rgtCol,
-				}
-				if newCondition.On == nil {
-					newCondition.On = cmp
-				} else {
-					newCondition.On = &AndExpr{Left: newCondition.On, Right: cmp}
-				}
-			}
-			cursor.Replace(newCondition)
+		er.rewriteJoinCondition(cursor, node)
+	case *AliasedTableExpr:
+		aliasTableName, ok := node.Expr.(TableName)
+		if !ok {
+			return true
 		}
-
+		if er.keyspace != "" && aliasTableName.Qualifier.IsEmpty() {
+			aliasTableName.Qualifier = NewTableIdent(er.keyspace)
+			node.Expr = aliasTableName
+			cursor.Replace(node)
+		}
 	}
 	return true
+}
+
+func (er *expressionRewriter) rewriteJoinCondition(cursor *Cursor, node JoinCondition) {
+	if node.Using != nil && !er.hasStarInSelect {
+		joinTableExpr, ok := cursor.Parent().(*JoinTableExpr)
+		if !ok {
+			// this is not possible with the current AST
+			return
+		}
+		leftTable, leftOk := joinTableExpr.LeftExpr.(*AliasedTableExpr)
+		rightTable, rightOk := joinTableExpr.RightExpr.(*AliasedTableExpr)
+		if !(leftOk && rightOk) {
+			// we only deal with simple FROM A JOIN B USING queries at the moment
+			return
+		}
+		lft, err := leftTable.TableName()
+		if err != nil {
+			er.err = err
+			return
+		}
+		rgt, err := rightTable.TableName()
+		if err != nil {
+			er.err = err
+			return
+		}
+		newCondition := JoinCondition{}
+		for _, colIdent := range node.Using {
+			lftCol := NewColNameWithQualifier(colIdent.String(), lft)
+			rgtCol := NewColNameWithQualifier(colIdent.String(), rgt)
+			cmp := &ComparisonExpr{
+				Operator: EqualOp,
+				Left:     lftCol,
+				Right:    rgtCol,
+			}
+			if newCondition.On == nil {
+				newCondition.On = cmp
+			} else {
+				newCondition.On = &AndExpr{Left: newCondition.On, Right: cmp}
+			}
+		}
+		cursor.Replace(newCondition)
+	}
 }
 
 func (er *expressionRewriter) sysVarRewrite(cursor *Cursor, node *ColName) {

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -172,7 +172,7 @@ func TestRewrites(in *testing.T) {
 			stmt, err := Parse(tc.in)
 			require.NoError(err)
 
-			result, err := RewriteAST(stmt, "")
+			result, err := RewriteAST(stmt, "ks") // passing `ks` just to test that no rewriting happens as it is not system schema
 			require.NoError(err)
 
 			expected, err := Parse(tc.expected)
@@ -209,22 +209,22 @@ func TestRewritesWithDefaultKeyspace(in *testing.T) {
 		expected: "SELECT x.col as c from x.test", // no change
 	}, {
 		in:       "SELECT 1 from test",
-		expected: "SELECT 1 from ks.test",
+		expected: "SELECT 1 from sys.test",
 	}, {
 		in:       "SELECT 1 from test as t",
-		expected: "SELECT 1 from ks.test as t",
+		expected: "SELECT 1 from sys.test as t",
 	}, {
 		in:       "SELECT 1 from `test 24` as t",
-		expected: "SELECT 1 from ks.`test 24` as t",
+		expected: "SELECT 1 from sys.`test 24` as t",
 	}, {
 		in:       "SELECT 1, (select 1 from test) from x.y",
-		expected: "SELECT 1, (select 1 from ks.test) from x.y",
+		expected: "SELECT 1, (select 1 from sys.test) from x.y",
 	}, {
 		in:       "SELECT 1 from (select 2 from test) t",
-		expected: "SELECT 1 from (select 2 from ks.test) t",
+		expected: "SELECT 1 from (select 2 from sys.test) t",
 	}, {
 		in:       "SELECT 1 from test where exists (select 2 from test)",
-		expected: "SELECT 1 from ks.test where exists (select 2 from ks.test)",
+		expected: "SELECT 1 from sys.test where exists (select 2 from sys.test)",
 	}}
 
 	for _, tc := range tests {
@@ -233,7 +233,7 @@ func TestRewritesWithDefaultKeyspace(in *testing.T) {
 			stmt, err := Parse(tc.in)
 			require.NoError(err)
 
-			result, err := RewriteAST(stmt, "ks")
+			result, err := RewriteAST(stmt, "sys")
 			require.NoError(err)
 
 			expected, err := Parse(tc.expected)

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -172,7 +172,7 @@ func TestRewrites(in *testing.T) {
 			stmt, err := Parse(tc.in)
 			require.NoError(err)
 
-			result, err := RewriteAST(stmt)
+			result, err := RewriteAST(stmt, "")
 			require.NoError(err)
 
 			expected, err := Parse(tc.expected)
@@ -196,6 +196,52 @@ func TestRewrites(in *testing.T) {
 			assert.Equal(tc.rawGTID, result.NeedsSysVar(sysvars.ReadAfterWriteGTID.Name), "should need rawGTID")
 			assert.Equal(tc.rawTimeout, result.NeedsSysVar(sysvars.ReadAfterWriteTimeOut.Name), "should need rawTimeout")
 			assert.Equal(tc.sessTrackGTID, result.NeedsSysVar(sysvars.SessionTrackGTIDs.Name), "should need sessTrackGTID")
+		})
+	}
+}
+
+func TestRewritesWithDefaultKeyspace(in *testing.T) {
+	tests := []myTestCase{{
+		in:       "SELECT 1 from x.test",
+		expected: "SELECT 1 from x.test", // no change
+	}, {
+		in:       "SELECT x.col as c from x.test",
+		expected: "SELECT x.col as c from x.test", // no change
+	}, {
+		in:       "SELECT 1 from test",
+		expected: "SELECT 1 from ks.test",
+	}, {
+		in:       "SELECT 1 from test as t",
+		expected: "SELECT 1 from ks.test as t",
+	}, {
+		in:       "SELECT 1 from `test 24` as t",
+		expected: "SELECT 1 from ks.`test 24` as t",
+	}, {
+		in:       "SELECT 1, (select 1 from test) from x.y",
+		expected: "SELECT 1, (select 1 from ks.test) from x.y",
+	}, {
+		in:       "SELECT 1 from (select 2 from test) t",
+		expected: "SELECT 1 from (select 2 from ks.test) t",
+	}, {
+		in:       "SELECT 1 from test where exists (select 2 from test)",
+		expected: "SELECT 1 from ks.test where exists (select 2 from ks.test)",
+	}}
+
+	for _, tc := range tests {
+		in.Run(tc.in, func(t *testing.T) {
+			require := require.New(t)
+			stmt, err := Parse(tc.in)
+			require.NoError(err)
+
+			result, err := RewriteAST(stmt, "ks")
+			require.NoError(err)
+
+			expected, err := Parse(tc.expected)
+			require.NoError(err, "test expectation does not parse [%s]", tc.expected)
+
+			s := String(expected)
+			assert := assert.New(t)
+			assert.Equal(s, String(result.AST))
 		})
 	}
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -433,7 +433,7 @@ func (e *Executor) handleSet(ctx context.Context, sql string, logStats *LogStats
 	if err != nil {
 		return nil, err
 	}
-	rewrittenAST, err := sqlparser.PrepareAST(stmt, nil, "vtg", false)
+	rewrittenAST, err := sqlparser.PrepareAST(stmt, nil, "vtg", false, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1361,7 +1361,7 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments sqlparser.
 	// Normalize if possible and retry.
 	if (e.normalize && sqlparser.CanNormalize(stmt)) || sqlparser.IsSetStatement(stmt) {
 		parameterize := e.normalize // the public flag is called normalize
-		result, err := sqlparser.PrepareAST(stmt, bindVars, "vtg", parameterize)
+		result, err := sqlparser.PrepareAST(stmt, bindVars, "vtg", parameterize, vcursor.keyspace)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -53,14 +53,14 @@ type truncater interface {
 	SetTruncateColumnCount(int)
 }
 
-// Build builds a plan for a query based on the specified vschema.
+// TestBuilder builds a plan for a query based on the specified vschema.
 // This method is only used from tests
-func Build(query string, vschema ContextVSchema) (*engine.Plan, error) {
+func TestBuilder(query string, vschema ContextVSchema) (*engine.Plan, error) {
 	stmt, err := sqlparser.Parse(query)
 	if err != nil {
 		return nil, err
 	}
-	result, err := sqlparser.RewriteAST(stmt)
+	result, err := sqlparser.RewriteAST(stmt, "")
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -179,7 +179,7 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 	}
 	sel := &sqlparser.Select{From: sqlparser.TableExprs([]sqlparser.TableExpr{tableExpr})}
 
-	if systemTable(tableName.Qualifier.String()) {
+	if sqlparser.SystemSchema(tableName.Qualifier.String()) {
 		ks, err := pb.vschema.AnyKeyspace()
 		if err != nil {
 			return err

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -366,7 +366,7 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vschemaWrapper) {
 		fail := false
 		for tcase := range iterateExecFile(filename) {
 			t.Run(tcase.comments, func(t *testing.T) {
-				plan, err := Build(tcase.input, vschema)
+				plan, err := TestBuilder(tcase.input, vschema)
 
 				out := getPlanOrErrorOutput(err, plan)
 

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -17,8 +17,6 @@ limitations under the License.
 package planbuilder
 
 import (
-	"strings"
-
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -190,7 +188,7 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 				return
 			}
 		case sqlparser.TableName:
-			if !systemTable(node.Qualifier.String()) {
+			if !sqlparser.SystemSchema(node.Qualifier.String()) {
 				node.Name.Format(buf)
 				return
 			}
@@ -204,13 +202,6 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 	rb.eroute.Query = buf.ParsedQuery().Query
 	rb.eroute.FieldQuery = rb.generateFieldQuery(rb.Select, jt)
 	return nil
-}
-
-func systemTable(qualifier string) bool {
-	return strings.EqualFold(qualifier, "information_schema") ||
-		strings.EqualFold(qualifier, "performance_schema") ||
-		strings.EqualFold(qualifier, "sys") ||
-		strings.EqualFold(qualifier, "mysql")
 }
 
 // procureValues procures and converts the input into
@@ -252,7 +243,7 @@ func (rb *route) generateFieldQuery(sel sqlparser.SelectStatement, jt *jointab) 
 				return
 			}
 		case sqlparser.TableName:
-			if !systemTable(node.Qualifier.String()) {
+			if !sqlparser.SystemSchema(node.Qualifier.String()) {
 				node.Name.Format(buf)
 				return
 			}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -451,7 +451,7 @@ func (vc *vcursorImpl) SetTarget(target string) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := vc.vschema.Keyspaces[keyspace]; keyspace != "" && !ok {
+	if _, ok := vc.vschema.Keyspaces[keyspace]; !ignoreKeyspace(keyspace) && !ok {
 		return mysql.NewSQLError(mysql.ERBadDb, mysql.SSSyntaxErrorOrAccessViolation, "Unknown database '%s'", keyspace)
 	}
 
@@ -460,6 +460,17 @@ func (vc *vcursorImpl) SetTarget(target string) error {
 	}
 	vc.safeSession.SetTargetString(target)
 	return nil
+}
+
+func ignoreKeyspace(keyspace string) bool {
+	return keyspace == "" || systemSchema(keyspace)
+}
+
+func systemSchema(schema string) bool {
+	return strings.EqualFold(schema, "information_schema") ||
+		strings.EqualFold(schema, "performance_schema") ||
+		strings.EqualFold(schema, "sys") ||
+		strings.EqualFold(schema, "mysql")
 }
 
 func (vc *vcursorImpl) SetUDV(key string, value interface{}) error {

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -275,7 +275,7 @@ func (vc *vcursorImpl) FindTableOrVindex(name sqlparser.TableName) (*vindexes.Ta
 // if there is one. If the keyspace specified in the target cannot be
 // identified, it returns an error.
 func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
-	if vc.keyspace == "" {
+	if ignoreKeyspace(vc.keyspace) {
 		return nil, errNoKeyspace
 	}
 	ks, ok := vc.vschema.Keyspaces[vc.keyspace]

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -463,14 +463,7 @@ func (vc *vcursorImpl) SetTarget(target string) error {
 }
 
 func ignoreKeyspace(keyspace string) bool {
-	return keyspace == "" || systemSchema(keyspace)
-}
-
-func systemSchema(schema string) bool {
-	return strings.EqualFold(schema, "information_schema") ||
-		strings.EqualFold(schema, "performance_schema") ||
-		strings.EqualFold(schema, "sys") ||
-		strings.EqualFold(schema, "mysql")
+	return keyspace == "" || sqlparser.SystemSchema(keyspace)
 }
 
 func (vc *vcursorImpl) SetUDV(key string, value interface{}) error {


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

## Backport
NO

## Status
**READY**

## Description
This PR allows setting system schema as default database name on connect or with `use` statement. 

## Related Issue(s)
List related PRs against other branches:
Fixes #7146 

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving
