### PR TITLE
[security] add possibility to disable pprof.

### DIFF
--- a/examples/are-you-alive/cmd/are-you-alive/main.go
+++ b/examples/are-you-alive/cmd/are-you-alive/main.go
@@ -5,6 +5,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -12,12 +18,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 	"gopkg.in/yaml.v2"
-	"math/rand"
-	"net/http"
-	"os"
-	"os/signal"
-	"sync"
 	"vitess.io/vitess/examples/are-you-alive/pkg/client"
+	"vitess.io/vitess/go/httputil2"
 )
 
 /*
@@ -208,7 +210,7 @@ func waitForCtrlC() {
 }
 
 func runPrometheus() {
-	http.Handle("/metrics", promhttp.Handler())
+	httputil2.GetMux().Handle("/metrics", promhttp.Handler())
 	logrus.Fatal(http.ListenAndServe(*prometheusMetricsAddress, nil))
 }
 

--- a/examples/are-you-alive/cmd/are-you-alive/main.go
+++ b/examples/are-you-alive/cmd/are-you-alive/main.go
@@ -19,7 +19,6 @@ import (
 	"go.uber.org/ratelimit"
 	"gopkg.in/yaml.v2"
 	"vitess.io/vitess/examples/are-you-alive/pkg/client"
-	"vitess.io/vitess/go/httputil2"
 )
 
 /*
@@ -210,7 +209,7 @@ func waitForCtrlC() {
 }
 
 func runPrometheus() {
-	httputil2.GetMux().Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	logrus.Fatal(http.ListenAndServe(*prometheusMetricsAddress, nil))
 }
 

--- a/go/cmd/vtgate/index.go
+++ b/go/cmd/vtgate/index.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"net/http"
+
+	"vitess.io/vitess/go/httputil2"
 )
 
 // This is a separate file so it can be selectively included/excluded from
@@ -25,7 +27,8 @@ import (
 
 func init() {
 	// Anything unrecognized gets redirected to the status page.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/debug/status", http.StatusFound)
 	})
 }

--- a/go/cmd/vttablet/index.go
+++ b/go/cmd/vttablet/index.go
@@ -19,7 +19,7 @@ package main
 import (
 	"net/http"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // This is a separate file so it can be selectively included/excluded from
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	// Anything unrecognized gets redirected to the status page.
-	mx := httputil2.GetMux()
+	mx := servenv.GetMux()
 	mx.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/debug/status", http.StatusFound)
 	})

--- a/go/cmd/vttablet/index.go
+++ b/go/cmd/vttablet/index.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"net/http"
+
+	"vitess.io/vitess/go/httputil2"
 )
 
 // This is a separate file so it can be selectively included/excluded from
@@ -25,7 +27,8 @@ import (
 
 func init() {
 	// Anything unrecognized gets redirected to the status page.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/debug/status", http.StatusFound)
 	})
 }

--- a/go/httputil2/httputil2.go
+++ b/go/httputil2/httputil2.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package httputil2
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"sync"
+)
+
+var (
+	muxOnce   sync.Once
+	serverMux *http.ServeMux
+)
+
+func GetMux() *http.ServeMux {
+	muxOnce.Do(func() {
+		serverMux = &http.ServeMux{}
+	})
+
+	return serverMux
+}
+
+func RegisterPprof(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof", pprof.Index)
+	mux.Handle("/debug/allocs", pprof.Handler("allocs"))
+	mux.Handle("/debug/block", pprof.Handler("block"))
+	mux.Handle("/debug/cmdline", pprof.Handler("cmdline"))
+	mux.Handle("/debug/goroutine", pprof.Handler("goroutine"))
+	mux.Handle("/debug/heap", pprof.Handler("heap"))
+	mux.Handle("/debug/mutex", pprof.Handler("mutex"))
+	mux.HandleFunc("/debug/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.Handle("/debug/threadcreate", pprof.Handler("threadcreate"))
+	mux.Handle("/debug/trace", pprof.Handler("trace"))
+}

--- a/go/httputil2/httputil2.go
+++ b/go/httputil2/httputil2.go
@@ -18,21 +18,7 @@ package httputil2
 import (
 	"net/http"
 	"net/http/pprof"
-	"sync"
 )
-
-var (
-	muxOnce   sync.Once
-	serverMux *http.ServeMux
-)
-
-func GetMux() *http.ServeMux {
-	muxOnce.Do(func() {
-		serverMux = &http.ServeMux{}
-	})
-
-	return serverMux
-}
 
 func RegisterPprof(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof", pprof.Index)

--- a/go/proc/proc.go
+++ b/go/proc/proc.go
@@ -30,7 +30,8 @@ import (
 	"syscall"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -57,8 +58,7 @@ func Wait() os.Signal {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGINT)
 
-	mx := httputil2.GetMux()
-	mx.HandleFunc(pidURL, func(r http.ResponseWriter, req *http.Request) {
+	servenv.GetMux().HandleFunc(pidURL, func(r http.ResponseWriter, req *http.Request) {
 		r.Write(strconv.AppendInt(nil, int64(os.Getpid()), 10))
 	})
 

--- a/go/proc/proc.go
+++ b/go/proc/proc.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -56,7 +57,8 @@ func Wait() os.Signal {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGINT)
 
-	http.HandleFunc(pidURL, func(r http.ResponseWriter, req *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc(pidURL, func(r http.ResponseWriter, req *http.Request) {
 		r.Write(strconv.AppendInt(nil, int64(os.Getpid()), 10))
 	})
 

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -28,7 +28,6 @@ import (
 	"time"
 	"unicode"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/servenv"
 )
@@ -101,7 +100,7 @@ func Init(prefix string) {
 
 		stats.RegisterPushBackend("opentsdb", backend)
 
-		mx := httputil2.GetMux()
+		mx := servenv.GetMux()
 		mx.HandleFunc("/debug/opentsdb", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			dataPoints := (*backend).getDataPoints()

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -28,6 +28,7 @@ import (
 	"time"
 	"unicode"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/servenv"
 )
@@ -100,7 +101,8 @@ func Init(prefix string) {
 
 		stats.RegisterPushBackend("opentsdb", backend)
 
-		http.HandleFunc("/debug/opentsdb", func(w http.ResponseWriter, r *http.Request) {
+		mx := httputil2.GetMux()
+		mx.HandleFunc("/debug/opentsdb", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			dataPoints := (*backend).getDataPoints()
 			sort.Sort(byMetric(dataPoints))

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -18,11 +18,11 @@ package prometheusbackend
 
 import (
 	"expvar"
-	"net/http"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -38,7 +38,8 @@ var (
 
 // Init initializes the Prometheus be with the given namespace.
 func Init(namespace string) {
-	http.Handle("/metrics", promhttp.Handler())
+	mx := httputil2.GetMux()
+	mx.Handle("/metrics", promhttp.Handler())
 	be.namespace = namespace
 	stats.Register(be.publishPrometheusMetric)
 }

--- a/go/stats/prometheusbackend/prometheusbackend.go
+++ b/go/stats/prometheusbackend/prometheusbackend.go
@@ -20,9 +20,10 @@ import (
 	"expvar"
 	"strings"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -38,8 +39,7 @@ var (
 
 // Init initializes the Prometheus be with the given namespace.
 func Init(namespace string) {
-	mx := httputil2.GetMux()
-	mx.Handle("/metrics", promhttp.Handler())
+	servenv.GetMux().Handle("/metrics", promhttp.Handler())
 	be.namespace = namespace
 	stats.Register(be.publishPrometheusMetric)
 }

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -130,7 +131,8 @@ func (logger *StreamLogger) Name() string {
 // ServeLogs registers the URL on which messages will be broadcast.
 // It is safe to register multiple URLs for the same StreamLogger.
 func (logger *StreamLogger) ServeLogs(url string, logf LogFormatter) {
-	http.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -29,8 +29,9 @@ import (
 	"sync"
 	"syscall"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -131,7 +132,7 @@ func (logger *StreamLogger) Name() string {
 // ServeLogs registers the URL on which messages will be broadcast.
 // It is safe to register multiple URLs for the same StreamLogger.
 func (logger *StreamLogger) ServeLogs(url string, logf LogFormatter) {
-	mx := httputil2.GetMux()
+	mx := servenv.GetMux()
 	mx.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -45,7 +45,8 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
@@ -299,7 +300,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 
 	hc.topoWatchers = topoWatchers
 	healthcheckOnce.Do(func() {
-		mx := httputil2.GetMux()
+		mx := servenv.GetMux()
 		mx.Handle("/debug/gateway", hc)
 	})
 

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -45,6 +45,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
@@ -298,7 +299,8 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 
 	hc.topoWatchers = topoWatchers
 	healthcheckOnce.Do(func() {
-		http.Handle("/debug/gateway", hc)
+		mx := httputil2.GetMux()
+		mx.Handle("/debug/gateway", hc)
 	})
 
 	// start the topo watches here

--- a/go/vt/discovery/legacy_healthcheck.go
+++ b/go/vt/discovery/legacy_healthcheck.go
@@ -50,7 +50,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"
@@ -392,7 +391,7 @@ func NewLegacyHealthCheck(retryDelay, healthCheckTimeout time.Duration) LegacyHe
 	}
 
 	healthcheckOnce.Do(func() {
-		mx := httputil2.GetMux()
+		mx := servenv.GetMux()
 		mx.Handle("/debug/gateway", hc)
 	})
 

--- a/go/vt/discovery/legacy_healthcheck.go
+++ b/go/vt/discovery/legacy_healthcheck.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"
@@ -391,7 +392,8 @@ func NewLegacyHealthCheck(retryDelay, healthCheckTimeout time.Duration) LegacyHe
 	}
 
 	healthcheckOnce.Do(func() {
-		http.Handle("/debug/gateway", hc)
+		mx := httputil2.GetMux()
+		mx.Handle("/debug/gateway", hc)
 	})
 
 	return hc

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 )
 
@@ -155,7 +154,7 @@ func (e *Exporter) URLPrefix() string {
 // url remapped from /path to /name/path. If name is empty, the request
 // is passed through to http.HandleFunc.
 func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
-	mx := httputil2.GetMux()
+	mx := GetMux()
 	if e.name == "" {
 		mx.HandleFunc(url, f)
 		return

--- a/go/vt/servenv/exporter.go
+++ b/go/vt/servenv/exporter.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/stats"
 )
 
@@ -154,8 +155,9 @@ func (e *Exporter) URLPrefix() string {
 // url remapped from /path to /name/path. If name is empty, the request
 // is passed through to http.HandleFunc.
 func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.Request)) {
+	mx := httputil2.GetMux()
 	if e.name == "" {
-		http.HandleFunc(url, f)
+		mx.HandleFunc(url, f)
 		return
 	}
 
@@ -166,7 +168,7 @@ func (e *Exporter) HandleFunc(url string, f func(w http.ResponseWriter, r *http.
 	hf := &handleFunc{f: f}
 	e.handleFuncs[url] = hf
 
-	http.HandleFunc(e.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
+	mx.HandleFunc(e.URLPrefix()+url, func(w http.ResponseWriter, r *http.Request) {
 		if f := hf.Get(); f != nil {
 			f(w, r)
 		}

--- a/go/vt/servenv/flushlogs.go
+++ b/go/vt/servenv/flushlogs.go
@@ -20,14 +20,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/logutil"
 )
 
 func init() {
 	OnInit(func() {
-		mx := httputil2.GetMux()
-		mx.HandleFunc("/debug/flushlogs", func(w http.ResponseWriter, r *http.Request) {
+		GetMux().HandleFunc("/debug/flushlogs", func(w http.ResponseWriter, r *http.Request) {
 			logutil.Flush()
 			fmt.Fprint(w, "flushed")
 		})

--- a/go/vt/servenv/flushlogs.go
+++ b/go/vt/servenv/flushlogs.go
@@ -20,12 +20,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/logutil"
 )
 
 func init() {
 	OnInit(func() {
-		http.HandleFunc("/debug/flushlogs", func(w http.ResponseWriter, r *http.Request) {
+		mx := httputil2.GetMux()
+		mx.HandleFunc("/debug/flushlogs", func(w http.ResponseWriter, r *http.Request) {
 			logutil.Flush()
 			fmt.Fprint(w, "flushed")
 		})

--- a/go/vt/servenv/liveness.go
+++ b/go/vt/servenv/liveness.go
@@ -18,6 +18,8 @@ package servenv
 
 import (
 	"net/http"
+
+	"vitess.io/vitess/go/httputil2"
 )
 
 // This file registers a handler that immediately responds with HTTP 200 OK.
@@ -29,7 +31,8 @@ import (
 // further behind on its backlog.
 
 func init() {
-	http.HandleFunc("/debug/liveness", func(rw http.ResponseWriter, r *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc("/debug/liveness", func(rw http.ResponseWriter, r *http.Request) {
 		// Do nothing. Return success immediately.
 	})
 }

--- a/go/vt/servenv/liveness.go
+++ b/go/vt/servenv/liveness.go
@@ -18,8 +18,6 @@ package servenv
 
 import (
 	"net/http"
-
-	"vitess.io/vitess/go/httputil2"
 )
 
 // This file registers a handler that immediately responds with HTTP 200 OK.
@@ -31,7 +29,7 @@ import (
 // further behind on its backlog.
 
 func init() {
-	mx := httputil2.GetMux()
+	mx := GetMux()
 	mx.HandleFunc("/debug/liveness", func(rw http.ResponseWriter, r *http.Request) {
 		// Do nothing. Return success immediately.
 	})

--- a/go/vt/servenv/mux.go
+++ b/go/vt/servenv/mux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2021 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package servenv
 
 import (
 	"net/http"
-
-	"vitess.io/vitess/go/vt/servenv"
+	"sync"
 )
 
-// This is a separate file so it can be selectively included/excluded from
-// builds to opt in/out of the redirect.
+var (
+	muxOnce   sync.Once
+	serverMux *http.ServeMux
+)
 
-func init() {
-	// Anything unrecognized gets redirected to the status page.
-	mx := servenv.GetMux()
-	mx.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/debug/status", http.StatusFound)
+func GetMux() *http.ServeMux {
+	muxOnce.Do(func() {
+		serverMux = &http.ServeMux{}
 	})
+
+	return serverMux
 }

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/event"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/proc"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -45,7 +44,7 @@ func Run(port int) {
 	if err != nil {
 		log.Exit(err)
 	}
-	go http.Serve(l, httputil2.GetMux())
+	go http.Serve(l, GetMux())
 
 	proc.Wait()
 	l.Close()

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/event"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/proc"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -44,7 +45,7 @@ func Run(port int) {
 	if err != nil {
 		log.Exit(err)
 	}
-	go http.Serve(l, nil)
+	go http.Serve(l, httputil2.GetMux())
 
 	proc.Wait()
 	l.Close()

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -94,7 +94,7 @@ func Init() {
 
 	// Register pprof handlers if pprof is enabled
 	if *enablePprof {
-		httputil2.RegisterPprof(httputil2.GetMux())
+		httputil2.RegisterPprof(GetMux())
 	}
 
 	// Add version tag to every info log

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -39,10 +39,8 @@ import (
 	"syscall"
 	"time"
 
-	// register the HTTP handlers for profiling
-	_ "net/http/pprof"
-
 	"vitess.io/vitess/go/event"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
@@ -61,6 +59,7 @@ var (
 	memProfileRate       = flag.Int("mem-profile-rate", 512*1024, "profile every n bytes allocated")
 	mutexProfileFraction = flag.Int("mutex-profile-fraction", 0, "profile every n mutex contention events (see runtime.SetMutexProfileFraction)")
 	catchSigpipe         = flag.Bool("catch-sigpipe", false, "catch and ignore SIGPIPE on stdout and stderr if specified")
+	enablePprof          = flag.Bool("pprof.enabled", true, "enable pprof for debug")
 
 	// mutex used to protect the Init function
 	mu sync.Mutex
@@ -91,6 +90,11 @@ func Init() {
 			log.Warning("Caught SIGPIPE (ignoring all future SIGPIPEs)")
 			signal.Ignore(syscall.SIGPIPE)
 		}()
+	}
+
+	// Register pprof handlers if pprof is enabled
+	if *enablePprof {
+		httputil2.RegisterPprof(httputil2.GetMux())
 	}
 
 	// Add version tag to every info log

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -140,12 +139,12 @@ func newStatusPage(name string) *statusPage {
 	}
 	sp.tmpl = template.Must(sp.reparse(nil))
 	if name == "" {
-		httputil2.GetMux().HandleFunc(StatusURLPath(), sp.statusHandler)
+		GetMux().HandleFunc(StatusURLPath(), sp.statusHandler)
 		// Debug profiles are only supported for the top level status page.
 		registerDebugBlockProfileRate()
 		registerDebugMutexProfileFraction()
 	} else {
-		httputil2.GetMux().HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
+		GetMux().HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
 	}
 	return sp
 }
@@ -250,7 +249,7 @@ func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 
 // Toggle the block profile rate to/from 100%, unless specific rate is passed in
 func registerDebugBlockProfileRate() {
-	mx := httputil2.GetMux()
+	mx := GetMux()
 	mx.HandleFunc("/debug/blockprofilerate", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)
@@ -281,7 +280,7 @@ func registerDebugBlockProfileRate() {
 
 // Toggle the mutex profiling fraction to/from 100%, unless specific fraction is passed in
 func registerDebugMutexProfileFraction() {
-	httputil2.GetMux().HandleFunc("/debug/mutexprofilefraction", func(w http.ResponseWriter, r *http.Request) {
+	GetMux().HandleFunc("/debug/mutexprofilefraction", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/servenv/status.go
+++ b/go/vt/servenv/status.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -139,12 +140,12 @@ func newStatusPage(name string) *statusPage {
 	}
 	sp.tmpl = template.Must(sp.reparse(nil))
 	if name == "" {
-		http.HandleFunc(StatusURLPath(), sp.statusHandler)
+		httputil2.GetMux().HandleFunc(StatusURLPath(), sp.statusHandler)
 		// Debug profiles are only supported for the top level status page.
 		registerDebugBlockProfileRate()
 		registerDebugMutexProfileFraction()
 	} else {
-		http.HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
+		httputil2.GetMux().HandleFunc("/"+name+StatusURLPath(), sp.statusHandler)
 	}
 	return sp
 }
@@ -249,7 +250,8 @@ func (sp *statusPage) reparse(sections []section) (*template.Template, error) {
 
 // Toggle the block profile rate to/from 100%, unless specific rate is passed in
 func registerDebugBlockProfileRate() {
-	http.HandleFunc("/debug/blockprofilerate", func(w http.ResponseWriter, r *http.Request) {
+	mx := httputil2.GetMux()
+	mx.HandleFunc("/debug/blockprofilerate", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)
 			return
@@ -279,7 +281,7 @@ func registerDebugBlockProfileRate() {
 
 // Toggle the mutex profiling fraction to/from 100%, unless specific fraction is passed in
 func registerDebugMutexProfileFraction() {
-	http.HandleFunc("/debug/mutexprofilefraction", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/debug/mutexprofilefraction", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
@@ -290,7 +289,7 @@ func main() {
 	flag.Parse()
 
 	go servenv.RunDefault()
-	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/throttlerz", http.StatusTemporaryRedirect)
 	})
 

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
@@ -289,7 +290,7 @@ func main() {
 	flag.Parse()
 
 	go servenv.RunDefault()
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/throttlerz", http.StatusTemporaryRedirect)
 	})
 

--- a/go/vt/throttler/throttlerlogz.go
+++ b/go/vt/throttler/throttlerlogz.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/logz"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 const logHeaderHTML = `
@@ -100,7 +100,7 @@ var (
 )
 
 func init() {
-	httputil2.GetMux().HandleFunc("/throttlerlogz/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/throttlerlogz/", func(w http.ResponseWriter, r *http.Request) {
 		throttlerlogzHandler(w, r, GlobalManager)
 	})
 }

--- a/go/vt/throttler/throttlerlogz.go
+++ b/go/vt/throttler/throttlerlogz.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/logz"
 )
 
@@ -99,7 +100,7 @@ var (
 )
 
 func init() {
-	http.HandleFunc("/throttlerlogz/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/throttlerlogz/", func(w http.ResponseWriter, r *http.Request) {
 		throttlerlogzHandler(w, r, GlobalManager)
 	})
 }

--- a/go/vt/throttler/throttlerz.go
+++ b/go/vt/throttler/throttlerz.go
@@ -22,7 +22,8 @@ import (
 	"net/http"
 	"strings"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -50,7 +51,7 @@ var (
 )
 
 func init() {
-	httputil2.GetMux().HandleFunc("/throttlerz/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/throttlerz/", func(w http.ResponseWriter, r *http.Request) {
 		throttlerzHandler(w, r, GlobalManager)
 	})
 }

--- a/go/vt/throttler/throttlerz.go
+++ b/go/vt/throttler/throttlerz.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -49,7 +50,7 @@ var (
 )
 
 func init() {
-	http.HandleFunc("/throttlerz/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/throttlerz/", func(w http.ResponseWriter, r *http.Request) {
 		throttlerzHandler(w, r, GlobalManager)
 	})
 }

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -133,7 +134,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(apiPath string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	http.HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -29,12 +29,12 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/schemamanager"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl"
@@ -134,7 +134,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(apiPath string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	httputil2.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/vtctld/debug_health.go
+++ b/go/vt/vtctld/debug_health.go
@@ -24,12 +24,13 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/topo"
 )
 
 // RegisterDebugHealthHandler register a debug health http endpoint for a vtcld server
 func RegisterDebugHealthHandler(ts *topo.Server) {
-	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/vtctld/debug_health.go
+++ b/go/vt/vtctld/debug_health.go
@@ -21,16 +21,17 @@ package vtctld
 import (
 	"net/http"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/topo"
 )
 
 // RegisterDebugHealthHandler register a debug health http endpoint for a vtcld server
 func RegisterDebugHealthHandler(ts *topo.Server) {
-	httputil2.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/vtctld/explorer.go
+++ b/go/vt/vtctld/explorer.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl"
@@ -173,7 +174,7 @@ func initExplorer(ts *topo.Server) {
 	})
 
 	// Redirects for explorers.
-	http.HandleFunc("/explorers/redirect", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/explorers/redirect", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			httpErrorf(w, r, "cannot parse form: %s", err)
 			return

--- a/go/vt/vtctld/explorer.go
+++ b/go/vt/vtctld/explorer.go
@@ -26,7 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl"
@@ -174,7 +174,7 @@ func initExplorer(ts *topo.Server) {
 	})
 
 	// Redirects for explorers.
-	httputil2.GetMux().HandleFunc("/explorers/redirect", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/explorers/redirect", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			httpErrorf(w, r, "cannot parse form: %s", err)
 			return

--- a/go/vt/vtctld/redirection.go
+++ b/go/vt/vtctld/redirection.go
@@ -24,7 +24,8 @@ import (
 	"net/http/httputil"
 	"strings"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
@@ -32,7 +33,7 @@ import (
 )
 
 func initVTTabletRedirection(ts *topo.Server) {
-	httputil2.GetMux().HandleFunc("/vttablet/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/vttablet/", func(w http.ResponseWriter, r *http.Request) {
 		splits := strings.SplitN(r.URL.Path, "/", 4)
 		if len(splits) < 4 {
 			log.Errorf("Invalid URL: %v", r.URL)

--- a/go/vt/vtctld/redirection.go
+++ b/go/vt/vtctld/redirection.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httputil"
 	"strings"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
@@ -31,7 +32,7 @@ import (
 )
 
 func initVTTabletRedirection(ts *topo.Server) {
-	http.HandleFunc("/vttablet/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/vttablet/", func(w http.ResponseWriter, r *http.Request) {
 		splits := strings.SplitN(r.URL.Path, "/", 4)
 		if len(splits) < 4 {
 			log.Errorf("Invalid URL: %v", r.URL)

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -27,6 +27,7 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 
 	"golang.org/x/net/context"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/acl"
@@ -123,12 +124,12 @@ func InitVtctld(ts *topo.Server) {
 		})
 
 	// Anything unrecognized gets redirected to the main app page.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, appPrefix, http.StatusFound)
 	})
 
 	// Serve the static files for the vtctld2 web app
-	http.HandleFunc(appPrefix, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(appPrefix, func(w http.ResponseWriter, r *http.Request) {
 		// Strip the prefix.
 		parts := strings.SplitN(r.URL.Path, "/", 3)
 		if len(parts) != 3 {

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -27,8 +27,8 @@ import (
 	rice "github.com/GeertJohan/go.rice"
 
 	"golang.org/x/net/context"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/topo"
@@ -124,12 +124,12 @@ func InitVtctld(ts *topo.Server) {
 		})
 
 	// Anything unrecognized gets redirected to the main app page.
-	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, appPrefix, http.StatusFound)
 	})
 
 	// Serve the static files for the vtctld2 web app
-	httputil2.GetMux().HandleFunc(appPrefix, func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc(appPrefix, func(w http.ResponseWriter, r *http.Request) {
 		// Strip the prefix.
 		parts := strings.SplitN(r.URL.Path, "/", 3)
 		if len(parts) != 3 {

--- a/go/vt/vtgate/api.go
+++ b/go/vt/vtgate/api.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -41,7 +42,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(apiPath string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	http.HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/vtgate/api.go
+++ b/go/vt/vtgate/api.go
@@ -22,9 +22,9 @@ import (
 	"net/http"
 	"strings"
 
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 // This file implements a REST-style API for the vtgate web interface.
@@ -42,7 +42,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(apiPath string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	httputil2.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc(apiPrefix+apiPath, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/sysvars"
 
 	"golang.org/x/net/context"
@@ -136,9 +137,9 @@ func NewExecutor(ctx context.Context, serv srvtopo.Server, cell string, resolver
 		stats.Publish("QueryPlanCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", e.plans.Oldest())
 		}))
-		http.Handle(pathQueryPlans, e)
-		http.Handle(pathScatterStats, e)
-		http.Handle(pathVSchema, e)
+		httputil2.GetMux().Handle(pathQueryPlans, e)
+		httputil2.GetMux().Handle(pathScatterStats, e)
+		httputil2.GetMux().Handle(pathVSchema, e)
 	})
 	return e
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/sysvars"
 
 	"golang.org/x/net/context"
@@ -137,9 +137,9 @@ func NewExecutor(ctx context.Context, serv srvtopo.Server, cell string, resolver
 		stats.Publish("QueryPlanCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", e.plans.Oldest())
 		}))
-		httputil2.GetMux().Handle(pathQueryPlans, e)
-		httputil2.GetMux().Handle(pathScatterStats, e)
-		httputil2.GetMux().Handle(pathVSchema, e)
+		servenv.GetMux().Handle(pathQueryPlans, e)
+		servenv.GetMux().Handle(pathScatterStats, e)
+		servenv.GetMux().Handle(pathVSchema, e)
 	})
 	return e
 }

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -20,7 +20,8 @@ import (
 	"flag"
 	"net/http"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/streamlog"
 )
 
@@ -44,13 +45,14 @@ var (
 func initQueryLogger(vtg *VTGate) error {
 	QueryLogger.ServeLogs(QueryLogHandler, streamlog.GetFormatter(QueryLogger))
 
-	httputil2.GetMux().HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
+	mx := servenv.GetMux()
+	mx.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
 		ch := QueryLogger.Subscribe("querylogz")
 		defer QueryLogger.Unsubscribe(ch)
 		querylogzHandler(ch, w, r)
 	})
 
-	httputil2.GetMux().HandleFunc(QueryzHandler, func(w http.ResponseWriter, r *http.Request) {
+	mx.HandleFunc(QueryzHandler, func(w http.ResponseWriter, r *http.Request) {
 		queryzHandler(vtg.executor, w, r)
 	})
 

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"net/http"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/streamlog"
 )
 
@@ -43,13 +44,13 @@ var (
 func initQueryLogger(vtg *VTGate) error {
 	QueryLogger.ServeLogs(QueryLogHandler, streamlog.GetFormatter(QueryLogger))
 
-	http.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
 		ch := QueryLogger.Subscribe("querylogz")
 		defer QueryLogger.Unsubscribe(ch)
 		querylogzHandler(ch, w, r)
 	})
 
-	http.HandleFunc(QueryzHandler, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(QueryzHandler, func(w http.ResponseWriter, r *http.Request) {
 		queryzHandler(vtg.executor, w, r)
 	})
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/tb"
@@ -226,7 +227,7 @@ func Init(ctx context.Context, serv srvtopo.Server, cell string, tabletTypesToWa
 }
 
 func (vtg *VTGate) registerDebugHealthHandler() {
-	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/tb"
@@ -227,7 +226,7 @@ func Init(ctx context.Context, serv srvtopo.Server, cell string, tabletTypesToWa
 }
 
 func (vtg *VTGate) registerDebugHealthHandler() {
-	httputil2.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
@@ -26,7 +26,8 @@ import (
 	"text/template"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -64,7 +65,7 @@ func (stats *VrLogStats) Send(detail string) {
 }
 
 func init() {
-	httputil2.GetMux().HandleFunc("/debug/vrlog", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/debug/vrlog", func(w http.ResponseWriter, r *http.Request) {
 		ch := vrLogStatsLogger.Subscribe("vrlogstats")
 		defer vrLogStatsLogger.Unsubscribe(ch)
 		vrlogStatsHandler(ch, w, r)

--- a/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vrlog.go
@@ -26,6 +26,7 @@ import (
 	"text/template"
 	"time"
 
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -63,7 +64,7 @@ func (stats *VrLogStats) Send(detail string) {
 }
 
 func init() {
-	http.HandleFunc("/debug/vrlog", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/debug/vrlog", func(w http.ResponseWriter, r *http.Request) {
 		ch := vrLogStatsLogger.Subscribe("vrlogstats")
 		defer vrLogStatsLogger.Unsubscribe(ch)
 		vrlogStatsHandler(ch, w, r)

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -88,7 +89,7 @@ var (
 )
 
 func init() {
-	http.HandleFunc("/querylogz", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/querylogz", func(w http.ResponseWriter, r *http.Request) {
 		ch := tabletenv.StatsLogger.Subscribe("querylogz")
 		defer tabletenv.StatsLogger.Unsubscribe(ch)
 		querylogzHandler(ch, w, r)

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -25,8 +25,9 @@ import (
 	"text/template"
 	"time"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -89,7 +90,7 @@ var (
 )
 
 func init() {
-	httputil2.GetMux().HandleFunc("/querylogz", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/querylogz", func(w http.ResponseWriter, r *http.Request) {
 		ch := tabletenv.StatsLogger.Subscribe("querylogz")
 		defer tabletenv.StatsLogger.Unsubscribe(ch)
 		querylogzHandler(ch, w, r)

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -24,11 +24,11 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -73,7 +73,7 @@ var (
 )
 
 func init() {
-	httputil2.GetMux().HandleFunc("/txlogz", txlogzHandler)
+	servenv.GetMux().HandleFunc("/txlogz", txlogzHandler)
 }
 
 // txlogzHandler serves a human readable snapshot of the

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"
@@ -72,7 +73,7 @@ var (
 )
 
 func init() {
-	http.HandleFunc("/txlogz", txlogzHandler)
+	httputil2.GetMux().HandleFunc("/txlogz", txlogzHandler)
 }
 
 // txlogzHandler serves a human readable snapshot of the

--- a/go/vt/worker/interactive.go
+++ b/go/vt/worker/interactive.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 )
@@ -82,7 +83,7 @@ func (wi *Instance) InitInteractiveMode() {
 	subIndexTemplate := mustParseTemplate("subIndex", subIndexHTML)
 
 	// toplevel menu
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -96,7 +97,7 @@ func (wi *Instance) InitInteractiveMode() {
 		// keep a local copy of the Command pointer for the
 		// closure.
 		pcg := cg
-		http.HandleFunc("/"+cg.Name, func(w http.ResponseWriter, r *http.Request) {
+		httputil2.GetMux().HandleFunc("/"+cg.Name, func(w http.ResponseWriter, r *http.Request) {
 			if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 				acl.SendError(w, err)
 				return
@@ -108,7 +109,7 @@ func (wi *Instance) InitInteractiveMode() {
 		for _, c := range cg.Commands {
 			// keep a local copy of the Command pointer for the closure.
 			pc := c
-			http.HandleFunc("/"+cg.Name+"/"+c.Name, func(w http.ResponseWriter, r *http.Request) {
+			httputil2.GetMux().HandleFunc("/"+cg.Name+"/"+c.Name, func(w http.ResponseWriter, r *http.Request) {
 				if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 					acl.SendError(w, err)
 					return

--- a/go/vt/worker/interactive.go
+++ b/go/vt/worker/interactive.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 )
@@ -83,7 +82,7 @@ func (wi *Instance) InitInteractiveMode() {
 	subIndexTemplate := mustParseTemplate("subIndex", subIndexHTML)
 
 	// toplevel menu
-	httputil2.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -97,7 +96,7 @@ func (wi *Instance) InitInteractiveMode() {
 		// keep a local copy of the Command pointer for the
 		// closure.
 		pcg := cg
-		httputil2.GetMux().HandleFunc("/"+cg.Name, func(w http.ResponseWriter, r *http.Request) {
+		servenv.GetMux().HandleFunc("/"+cg.Name, func(w http.ResponseWriter, r *http.Request) {
 			if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 				acl.SendError(w, err)
 				return
@@ -109,7 +108,7 @@ func (wi *Instance) InitInteractiveMode() {
 		for _, c := range cg.Commands {
 			// keep a local copy of the Command pointer for the closure.
 			pc := c
-			httputil2.GetMux().HandleFunc("/"+cg.Name+"/"+c.Name, func(w http.ResponseWriter, r *http.Request) {
+			servenv.GetMux().HandleFunc("/"+cg.Name+"/"+c.Name, func(w http.ResponseWriter, r *http.Request) {
 				if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 					acl.SendError(w, err)
 					return

--- a/go/vt/worker/status.go
+++ b/go/vt/worker/status.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/servenv"
 )
 
@@ -74,7 +75,7 @@ const workerStatusHTML = `
 func (wi *Instance) InitStatusHandling() {
 	// code to serve /status
 	workerTemplate := mustParseTemplate("worker", workerStatusHTML)
-	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -114,7 +115,7 @@ func (wi *Instance) InitStatusHandling() {
 	})
 
 	// reset handler
-	http.HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -129,7 +130,7 @@ func (wi *Instance) InitStatusHandling() {
 	})
 
 	// cancel handler
-	http.HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/worker/status.go
+++ b/go/vt/worker/status.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/servenv"
 )
 
@@ -75,7 +74,7 @@ const workerStatusHTML = `
 func (wi *Instance) InitStatusHandling() {
 	// code to serve /status
 	workerTemplate := mustParseTemplate("worker", workerStatusHTML)
-	httputil2.GetMux().HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -115,7 +114,7 @@ func (wi *Instance) InitStatusHandling() {
 	})
 
 	// reset handler
-	httputil2.GetMux().HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return
@@ -130,7 +129,7 @@ func (wi *Instance) InitStatusHandling() {
 	})
 
 	// cancel handler
-	httputil2.GetMux().HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
 			acl.SendError(w, err)
 			return

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
 )
@@ -164,7 +165,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(pattern string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -30,9 +30,9 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 const (
@@ -165,7 +165,7 @@ func httpErrorf(w http.ResponseWriter, r *http.Request, format string, args ...i
 }
 
 func handleAPI(pattern string, handlerFunc func(w http.ResponseWriter, r *http.Request) error) {
-	httputil2.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				httpErrorf(w, r, "uncaught panic: %v", x)

--- a/go/vt/workflow/websocket.go
+++ b/go/vt/workflow/websocket.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -33,7 +34,7 @@ var upgrader = websocket.Upgrader{} // use default options
 // HandleHTTPWebSocket registers the WebSocket handler.
 func (m *Manager) HandleHTTPWebSocket(pattern string) {
 	log.Infof("workflow Manager listening to websocket traffic at %v", pattern)
-	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				errMsg := fmt.Sprintf("uncaught panic: %v", x)

--- a/go/vt/workflow/websocket.go
+++ b/go/vt/workflow/websocket.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"github.com/gorilla/websocket"
 	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
-	"vitess.io/vitess/go/httputil2"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -34,7 +35,7 @@ var upgrader = websocket.Upgrader{} // use default options
 // HandleHTTPWebSocket registers the WebSocket handler.
 func (m *Manager) HandleHTTPWebSocket(pattern string) {
 	log.Infof("workflow Manager listening to websocket traffic at %v", pattern)
-	httputil2.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
 				errMsg := fmt.Sprintf("uncaught panic: %v", x)

--- a/tools/statsd.go
+++ b/tools/statsd.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"vitess.io/vitess/go/httputil2"
 )
 
 var mu sync.Mutex
@@ -32,7 +34,7 @@ var mu sync.Mutex
 const statsFileName = "stats.json"
 
 func main() {
-	http.HandleFunc("/travis/stats", func(w http.ResponseWriter, r *http.Request) {
+	httputil2.GetMux().HandleFunc("/travis/stats", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
 			test := r.FormValue("test")
 			result := r.FormValue("result")

--- a/tools/statsd.go
+++ b/tools/statsd.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/httputil2"
+	"vitess.io/vitess/go/vt/servenv"
 )
 
 var mu sync.Mutex
@@ -34,7 +34,7 @@ var mu sync.Mutex
 const statsFileName = "stats.json"
 
 func main() {
-	httputil2.GetMux().HandleFunc("/travis/stats", func(w http.ResponseWriter, r *http.Request) {
+	servenv.GetMux().HandleFunc("/travis/stats", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
 			test := r.FormValue("test")
 			result := r.FormValue("result")


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrukhin <a.petrukhin@city-mobil.ru>

## Backport
YES

## Status
**DRAFT/READY**

## Description
The main goal is to add possibility to disable /debug/pprof page when it is not required. It is done to some security issues. You can easily query '/debug/pprof/cmdline' page and get passwords from cmdline, when you use flags from cmdline.

## Related Issue(s)
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation

## Deployment Notes

## Impacted Areas in Vitess
This PR should affect nothing
