### PR TITLE
VStreamer: Ignore temp tables created by onlineddl 

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	schema2 "vitess.io/vitess/go/vt/schema"
+
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -502,6 +504,10 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 			return nil, vs.buildVersionPlan(id, tm)
 		}
 		if tm.Database != "" && tm.Database != params.DbName {
+			vs.plans[id] = nil
+			return nil, nil
+		}
+		if schema2.IsInternalOperationTableName(tm.Name) { // ignore tables created by onlineddl/gh-ost/pt-osc
 			vs.plans[id] = nil
 			return nil, nil
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	schema2 "vitess.io/vitess/go/vt/schema"
+	vtschema "vitess.io/vitess/go/vt/schema"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/mysql"
@@ -507,7 +507,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 			vs.plans[id] = nil
 			return nil, nil
 		}
-		if schema2.IsInternalOperationTableName(tm.Name) { // ignore tables created by onlineddl/gh-ost/pt-osc
+		if vtschema.IsInternalOperationTableName(tm.Name) { // ignore tables created by onlineddl/gh-ost/pt-osc
 			vs.plans[id] = nil
 			return nil, nil
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -1443,6 +1443,62 @@ func TestBestEffortNameInFieldEvent(t *testing.T) {
 	runCases(t, filter, testcases, position, nil)
 }
 
+// test that vstreamer ignores tables created by OnlineDDL
+func TestInternalTables(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	filter := &binlogdatapb.Filter{
+		FieldEventMode: binlogdatapb.Filter_BEST_EFFORT,
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*/",
+		}},
+	}
+	// Modeled after vttablet endtoend compatibility tests.
+	execStatements(t, []string{
+		"create table vitess_test(id int, val varbinary(128), primary key(id))",
+		"create table _1e275eef_3b20_11eb_a38f_04ed332e05c2_20201210204529_gho(id int, val varbinary(128), primary key(id))",
+		"create table _vt_PURGE_1f9194b43b2011eb8a0104ed332e05c2_20201210194431(id int, val varbinary(128), primary key(id))",
+		"create table _product_old(id int, val varbinary(128), primary key(id))",
+	})
+	position := masterPosition(t)
+	execStatements(t, []string{
+		"insert into vitess_test values(1, 'abc')",
+		"insert into _1e275eef_3b20_11eb_a38f_04ed332e05c2_20201210204529_gho values(1, 'abc')",
+		"insert into _vt_PURGE_1f9194b43b2011eb8a0104ed332e05c2_20201210194431 values(1, 'abc')",
+		"insert into _product_old values(1, 'abc')",
+	})
+
+	defer execStatements(t, []string{
+		"drop table vitess_test",
+		"drop table _1e275eef_3b20_11eb_a38f_04ed332e05c2_20201210204529_gho",
+		"drop table _vt_PURGE_1f9194b43b2011eb8a0104ed332e05c2_20201210194431",
+		"drop table _product_old",
+	})
+	engine.se.Reload(context.Background())
+	testcases := []testcase{{
+		input: []string{
+			"insert into vitess_test values(2, 'abc')",
+		},
+		// In this case, we don't have information about vitess_test since it was renamed to vitess_test_test.
+		// information returned by binlog for val column == varchar (rather than varbinary).
+		output: [][]string{{
+			`begin`,
+			`type:FIELD field_event:<table_name:"vitess_test" fields:<name:"id" type:INT32 table:"vitess_test" org_table:"vitess_test" database:"vttest" org_name:"id" column_length:11 charset:63 > fields:<name:"val" type:VARBINARY table:"vitess_test" org_table:"vitess_test" database:"vttest" org_name:"val" column_length:128 charset:63 > > `,
+			`type:ROW row_event:<table_name:"vitess_test" row_changes:<after:<lengths:1 lengths:3 values:"1abc" > > > `,
+			`gtid`,
+			`commit`,
+		}, {`begin`, `gtid`, `commit`}, {`begin`, `gtid`, `commit`}, {`begin`, `gtid`, `commit`}, // => inserts into the three internal comments
+			{
+				`begin`,
+				`type:ROW row_event:<table_name:"vitess_test" row_changes:<after:<lengths:1 lengths:3 values:"2abc" > > > `,
+				`gtid`,
+				`commit`,
+			}},
+	}}
+	runCases(t, filter, testcases, position, nil)
+}
+
 func TestTypes(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

#### Description
Schema migrations using gh-ost/pt-osc create temporary tables as part of the artifacts created during a migration. Since events from these tables are in the binlogs, vstreamer ends up treating them as regular tables which start participating in movetables (without filters) and in resharding workflows. Their events are also streamed by the VStream API if not explicitly filtered out.

This PR uses the functionality provided by the schema migration package to identify internal tables and ignores them at the vstreamer level.

#### Related Issue(s)
Fixes issue referred to here:
https://github.com/vitessio/vitess/issues/7078#issuecomment-734924465

#### Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [x]  Schema Migration
- [x]  VReplication

