### PR TITLE
fix-7036: issues with `weight_string(x as x) order by x`

### DIFF
--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -584,6 +584,17 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 				return true
 			}
 			var cmp int
+			//	--- FAIL: TestSelectScatterOrderByVarChar (0.00s)
+			//panic: runtime error: index out of range [2] with length 2 [recovered]
+			//panic: runtime error: index out of range [2] with length 2
+			//
+			//	goroutine 566 [running]:
+			//	testing.tRunner.func1(0xc0004e7400)
+			//	/opt/hostedtoolcache/go/1.13.15/x64/src/testing/testing.go:874 +0x3a3
+			//	panic(0xf469e0, 0xc000d207c0)
+			//	/opt/hostedtoolcache/go/1.13.15/x64/src/runtime/panic.go:679 +0x1b2
+			//	vitess.io/vitess/go/vt/vtgate/engine.(*Route).sort.func1(0x6, 0x0, 0xc000b90ec0)
+			//	/home/runner/work/vitess/vitess/go/vt/vtgate/engine/route.go:587 +0x262
 			cmp, err = evalengine.NullsafeCompare(out.Rows[i][order.Col], out.Rows[j][order.Col])
 			if err != nil {
 				return true

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1659,6 +1659,7 @@ func (e *Executor) handlePrepare(ctx context.Context, safeSession *SafeSession, 
 		skipQueryPlanCache(safeSession),
 		logStats,
 	)
+	log.Info(">>>>> handlePrepare plan got : %v", plan)
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1285,6 +1285,12 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	gotResult, err := executorExec(executor, query, nil)
 	require.NoError(t, err)
 
+	// verify wrapping with `weight_string` works
+	queryAs := "select col1, textcol as textcol from user order by textcol desc limit 1"
+	gotResultAs, errAs := executorExec(executor, queryAs, nil)
+	t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
+	require.NoError(t, errAs)
+
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "select col1, textcol, weight_string(textcol) from user order by textcol desc",
 		BindVariables: map[string]*querypb.BindVariable{},

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1282,17 +1282,21 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	executor := NewExecutor(context.Background(), serv, cell, resolver, false, testBufferSize, testCacheSize)
 
 	query := "select col1, textcol from user order by textcol desc"
+	prepResult, prepErr := executorPrepare(executor, query, nil)
+	t.Logf(">>> prepResult: %v, prepErr: %v", prepResult, prepErr)
 	gotResult, err := executorExec(executor, query, nil)
 	require.NoError(t, err)
 
 	// verify wrapping with `weight_string` works
-	queryAs := "select col1, textcol as textcol from user order by textcol desc"
+	//queryAs := "select col1, textcol as textcol from user order by textcol desc"
 	//gotResultAs, errAs := executorExec(executor, queryAs, nil)
 	//t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
-	qfResult, errAs := executorPrepare(executor, queryAs, nil)
-	t.Logf("errAs: %v", errAs)
-	t.Logf("queryAs: %v, qfResult: %v", queryAs, qfResult)
-	require.NoError(t, errAs)
+
+	//qfResult, errAs := executorPrepare(executor, queryAs, nil)
+	//t.Logf("errAs: %v", errAs)
+	//t.Logf("queryAs: %v, qfResult: %v", queryAs, qfResult)
+	//t.Logf("queryAs: %v, qfResult: %v", queryAs, qfResult)
+	//require.NoError(t, errAs)
 
 	wantQueries := []*querypb.BoundQuery{{
 		Sql:           "select col1, textcol, weight_string(textcol) from user order by textcol desc",

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1290,6 +1290,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	//gotResultAs, errAs := executorExec(executor, queryAs, nil)
 	//t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
 	qfResult, errAs := executorPrepare(executor, queryAs, nil)
+	t.Logf("errAs: %v", errAs)
 	t.Logf("queryAs: %v, qfResult: %v", queryAs, qfResult)
 	require.NoError(t, errAs)
 

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1286,7 +1286,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify wrapping with `weight_string` works
-	queryAs := "select col1, textcol as textcol from user order by textcol desc limit 1"
+	queryAs := "select col1, textcol as textcol2 from user order by textcol2 desc"
 	gotResultAs, errAs := executorExec(executor, queryAs, nil)
 	t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
 	require.NoError(t, errAs)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1287,8 +1287,10 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 
 	// verify wrapping with `weight_string` works
 	queryAs := "select col1, textcol as textcol from user order by textcol desc"
-	_, errAs := executorExec(executor, queryAs, nil)
+	//gotResultAs, errAs := executorExec(executor, queryAs, nil)
 	//t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
+	qfResult, errAs := executorPrepare(executor, queryAs, nil)
+	t.Logf("queryAs: %v, qfResult: %v", queryAs, qfResult)
 	require.NoError(t, errAs)
 
 	wantQueries := []*querypb.BoundQuery{{

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1282,8 +1282,8 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	executor := NewExecutor(context.Background(), serv, cell, resolver, false, testBufferSize, testCacheSize)
 
 	query := "select col1, textcol from user order by textcol desc"
-	prepResult, prepErr := executorPrepare(executor, query, nil)
-	t.Logf(">>> prepResult: %v, prepErr: %v", prepResult, prepErr)
+	//prepResult, prepErr := executorPrepare(executor, query, nil)
+	//t.Logf(">>> prepResult: %v, prepErr: %v", prepResult, prepErr)
 	gotResult, err := executorExec(executor, query, nil)
 	require.NoError(t, err)
 

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -1286,9 +1286,9 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify wrapping with `weight_string` works
-	queryAs := "select col1, textcol as textcol2 from user order by textcol2 desc"
-	gotResultAs, errAs := executorExec(executor, queryAs, nil)
-	t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
+	queryAs := "select col1, textcol as textcol from user order by textcol desc"
+	_, errAs := executorExec(executor, queryAs, nil)
+	//t.Logf("queryAs: %v, gotResultAs: %v", queryAs, gotResultAs)
 	require.NoError(t, errAs)
 
 	wantQueries := []*querypb.BoundQuery{{

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1312,20 +1312,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 				Type: sqltypes.Int64,
 			}},
 		},
-
-		// verify wrapping with `weight_string(dtid as dtid)
-		//"select dtid as dtid, state from _vt.dt_state where dtid = 'aa' order by dtid asc limit 1": {
-		//	// aabbccdd
-		//	Fields: []*querypb.Field{
-		//		{Type: sqltypes.VarBinary},
-		//		{Type: sqltypes.Uint64},
-		//	},
-		//	Rows: [][]sqltypes.Value{{
-		//		sqltypes.NewVarBinary("aa"),
-		//		sqltypes.NewInt64(int64(querypb.TransactionState_PREPARE)),
-		//	}},
-		//	RowsAffected: 1,
-		//},
 		"begin":    {},
 		"commit":   {},
 		"rollback": {},

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1312,6 +1312,20 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 				Type: sqltypes.Int64,
 			}},
 		},
+
+		// verify wrapping with `weight_string(dtid as dtid)
+		//"select dtid as dtid, state from _vt.dt_state where dtid = 'aa' order by dtid asc limit 1": {
+		//	// aabbccdd
+		//	Fields: []*querypb.Field{
+		//		{Type: sqltypes.VarBinary},
+		//		{Type: sqltypes.Uint64},
+		//	},
+		//	Rows: [][]sqltypes.Value{{
+		//		sqltypes.NewVarBinary("aa"),
+		//		sqltypes.NewInt64(int64(querypb.TransactionState_PREPARE)),
+		//	}},
+		//	RowsAffected: 1,
+		//},
 		"begin":    {},
 		"commit":   {},
 		"rollback": {},

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1042,7 +1042,7 @@ func wrapWeightString(expr sqlparser.SelectExpr) *sqlparser.AliasedExpr {
 
 	return &sqlparser.AliasedExpr{
 		Expr: &sqlparser.FuncExpr{
-			Name:  sqlparser.NewColIdent("weight_string"),
+			Name: sqlparser.NewColIdent("weight_string"),
 			//Exprs: []sqlparser.SelectExpr{expr},
 			Exprs: []sqlparser.SelectExpr{exprAliased},
 		},

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1036,15 +1036,18 @@ FuncExpr struct {
 */
 
 func wrapWeightString(expr sqlparser.SelectExpr) *sqlparser.AliasedExpr {
-	exprAliased := &sqlparser.AliasedExpr{
-		Expr: expr.(*sqlparser.AliasedExpr).Expr,
-	}
+	//exprAliased := &sqlparser.AliasedExpr{
+	//	Expr: expr.(*sqlparser.AliasedExpr).Expr,
+	//}
 
 	return &sqlparser.AliasedExpr{
 		Expr: &sqlparser.FuncExpr{
 			Name: sqlparser.NewColIdent("weight_string"),
-			//Exprs: []sqlparser.SelectExpr{expr},
-			Exprs: []sqlparser.SelectExpr{exprAliased},
+			Exprs: []sqlparser.SelectExpr{
+				&sqlparser.AliasedExpr{
+					Expr: expr.(*sqlparser.AliasedExpr).Expr,
+				},
+			},
 		},
 	}
 }

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1020,15 +1020,30 @@ func isFuncKeyrange(expr sqlparser.Expr) bool {
 	return ok && funcExpr.Name.EqualString("in_keyrange")
 }
 
+/*
+// SelectExpr represents a SELECT expression.
+SelectExpr interface {
+	iSelectExpr()
+	SQLNode
+}
+
+FuncExpr struct {
+	Qualifier TableIdent
+	Name      ColIdent
+	Distinct  bool
+	Exprs     SelectExprs
+}
+*/
+
 func wrapWeightString(expr sqlparser.SelectExpr) *sqlparser.AliasedExpr {
+	//exprAliased := &sqlparser.AliasedExpr{
+	//	Expr: expr.(*sqlparser.AliasedExpr).Expr,
+	//}
+
 	return &sqlparser.AliasedExpr{
 		Expr: &sqlparser.FuncExpr{
-			Name: sqlparser.NewColIdent("weight_string"),
-			Exprs: []sqlparser.SelectExpr{
-				&sqlparser.AliasedExpr{
-					Expr: expr.(*sqlparser.AliasedExpr).Expr,
-				},
-			},
+			Name:  sqlparser.NewColIdent("weight_string"),
+			Exprs: []sqlparser.SelectExpr{expr},
 		},
 	}
 }

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -1036,14 +1036,15 @@ FuncExpr struct {
 */
 
 func wrapWeightString(expr sqlparser.SelectExpr) *sqlparser.AliasedExpr {
-	//exprAliased := &sqlparser.AliasedExpr{
-	//	Expr: expr.(*sqlparser.AliasedExpr).Expr,
-	//}
+	exprAliased := &sqlparser.AliasedExpr{
+		Expr: expr.(*sqlparser.AliasedExpr).Expr,
+	}
 
 	return &sqlparser.AliasedExpr{
 		Expr: &sqlparser.FuncExpr{
 			Name:  sqlparser.NewColIdent("weight_string"),
-			Exprs: []sqlparser.SelectExpr{expr},
+			//Exprs: []sqlparser.SelectExpr{expr},
+			Exprs: []sqlparser.SelectExpr{exprAliased},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Andrei Sura <andrei.sura@sharpspring.com>

## Backport
YES | NO

## Status
**IN DEVELOPMENT**

## Description
sorting by aliased varchar columns does not work.
Example: 
```
select col1, textcol as textcol from user order by textcol desc limit
```


## Related Issue(s)
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation

## Deployment Notes
Notes regarding deployment of the contained body of work.  These should note any
db migrations, etc.

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
