### PR TITLE
add support for unary expression in order by column

### DIFF
--- a/go/vt/vtgate/planbuilder/memory_sort.go
+++ b/go/vt/vtgate/planbuilder/memory_sort.go
@@ -60,6 +60,18 @@ func newMemorySort(plan logicalPlan, orderBy sqlparser.OrderBy) (*memorySort, er
 					break
 				}
 			}
+		case *sqlparser.UnaryExpr:
+			colName, ok := expr.Expr.(*sqlparser.ColName)
+			if !ok {
+				return nil, fmt.Errorf("unsupported: memory sort: complex order by expression: %s", sqlparser.String(expr))
+			}
+			c := colName.Metadata.(*column)
+			for i, rc := range ms.ResultColumns() {
+				if rc.column == c {
+					colNumber = i
+					break
+				}
+			}
 		default:
 			return nil, fmt.Errorf("unsupported: memory sort: complex order by expression: %s", sqlparser.String(expr))
 		}

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -491,3 +491,60 @@
     ]
   }
 }
+
+# unary expression
+"select a from user order by binary a desc"
+{
+  "QueryType": "SELECT",
+  "Original": "select a from user order by binary a desc",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select a from user where 1 != 1",
+    "OrderBy": "0 DESC",
+    "Query": "select a from user order by binary a desc",
+    "Table": "user"
+  }
+}
+
+# unary expression in join query
+"select u.a from user u join music m on u.a = m.a order by binary a desc"
+{
+  "QueryType": "SELECT",
+  "Original": "select u.a from user u join music m on u.a = m.a order by binary a desc",
+  "Instructions": {
+    "OperatorType": "Join",
+    "Variant": "Join",
+    "JoinColumnIndexes": "-1",
+    "TableName": "user_music",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select u.a from user as u where 1 != 1",
+        "OrderBy": "0 DESC",
+        "Query": "select u.a from user as u order by binary a desc",
+        "Table": "user"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from music as m where 1 != 1",
+        "Query": "select 1 from music as m where m.a = :u_a",
+        "Table": "music"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

## Backport
NO

## Status
**READY**

## Description
Add support for unary expression in order by column

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving
