### PR TITLE
Skip query rewriting for dual table

### DIFF
--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -169,6 +169,10 @@ func (er *expressionRewriter) rewrite(cursor *Cursor) bool {
 		if !ok {
 			return true
 		}
+		// Qualifier should not be added to dual table
+		if aliasTableName.Name.String() == "dual" {
+			break
+		}
 		if er.keyspace != "" && aliasTableName.Qualifier.IsEmpty() {
 			aliasTableName.Qualifier = NewTableIdent(er.keyspace)
 			node.Expr = aliasTableName

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -225,6 +225,12 @@ func TestRewritesWithDefaultKeyspace(in *testing.T) {
 	}, {
 		in:       "SELECT 1 from test where exists (select 2 from test)",
 		expected: "SELECT 1 from sys.test where exists (select 2 from sys.test)",
+	}, {
+		in:       "SELECT 1 from dual",
+		expected: "SELECT 1 from dual",
+	}, {
+		in:       "SELECT (select 2 from dual) from DUAL",
+		expected: "SELECT 2 as `(select 2 from dual)` from DUAL",
 	}}
 
 	for _, tc := range tests {
@@ -239,9 +245,7 @@ func TestRewritesWithDefaultKeyspace(in *testing.T) {
 			expected, err := Parse(tc.expected)
 			require.NoError(err, "test expectation does not parse [%s]", tc.expected)
 
-			s := String(expected)
-			assert := assert.New(t)
-			assert.Equal(s, String(result.AST))
+			assert.Equal(t, String(expected), String(result.AST))
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

## Backport
NO

## Status
**READY**

## Description
With the change in #7150, `dual` table should be escaped from rewriting. 

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving

