### PR TITLE
Add only expr of aliasedExpr to weightstring function

### DIFF
--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -295,11 +295,17 @@ func (rb *route) SupplyWeightString(colNumber int) (weightcolNumber int, err err
 		return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected AST struct for query")
 	}
 
+	aliasExpr, ok := s.SelectExprs[colNumber].(*sqlparser.AliasedExpr)
+	if !ok {
+		return 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected AST struct for query %T", s.SelectExprs[colNumber])
+	}
 	expr := &sqlparser.AliasedExpr{
 		Expr: &sqlparser.FuncExpr{
 			Name: sqlparser.NewColIdent("weight_string"),
 			Exprs: []sqlparser.SelectExpr{
-				s.SelectExprs[colNumber],
+				&sqlparser.AliasedExpr{
+					Expr: aliasExpr.Expr,
+				},
 			},
 		},
 	}

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -182,10 +182,10 @@
 
 # scatter aggregate with memory sort and order by number, reuse weight_string
 # we have to use a meaningless construct to test this.
-"select textcol1, count(*) k from user group by textcol1 order by textcol1, k, textcol1"
+"select textcol1 as t, count(*) k from user group by textcol1 order by textcol1, k, textcol1"
 {
   "QueryType": "SELECT",
-  "Original": "select textcol1, count(*) k from user group by textcol1 order by textcol1, k, textcol1",
+  "Original": "select textcol1 as t, count(*) k from user group by textcol1 order by textcol1, k, textcol1",
   "Instructions": {
     "OperatorType": "Sort",
     "Variant": "Memory",
@@ -205,9 +205,9 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select textcol1, count(*) as k, weight_string(textcol1) from user where 1 != 1 group by textcol1",
+            "FieldQuery": "select textcol1 as t, count(*) as k, weight_string(textcol1) from user where 1 != 1 group by textcol1",
             "OrderBy": "2 ASC, 2 ASC",
-            "Query": "select textcol1, count(*) as k, weight_string(textcol1) from user group by textcol1 order by textcol1 asc, textcol1 asc",
+            "Query": "select textcol1 as t, count(*) as k, weight_string(textcol1) from user group by textcol1 order by textcol1 asc, textcol1 asc",
             "Table": "user"
           }
         ]


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

## Backport
NO

## Status
**READY**

## Description
Currently we add aliasedExpr as is to the weightstring function this causes issue for aliased columns

## Related Issue(s)
List related PRs against other branches:
Fixes #7036 

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving
