### PR TITLE
Move allow_alias option in MySqlFlag enum to precede the aliased IDs

### DIFF
--- a/proto/query.proto
+++ b/proto/query.proto
@@ -70,6 +70,8 @@ message EventToken {
 
 // Flags sent from the MySQL C API
 enum MySqlFlag {
+  option allow_alias = true;
+  
   EMPTY = 0;
   NOT_NULL_FLAG = 1;
   PRI_KEY_FLAG = 2;
@@ -90,8 +92,6 @@ enum MySqlFlag {
   GROUP_FLAG = 32768;
   UNIQUE_FLAG = 65536;
   BINCMP_FLAG = 131072;
-
-  option allow_alias = true;
 }
 
 // Flag allows us to qualify types by their common properties.


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Backport
NO

## Status
**READY**

## Description
So. This is a little bit embarassing!

For [VTAdmin](https://github.com/vitessio/vitess/issues/7117) (and our internal tool), we use the [protobufjs](https://github.com/protobufjs/protobuf.js) library to generate TypeScript types and bindings from Vitess protos. 

Unfortunately, protobufjs has a "quirk" with the `allow_alias` option, where the option _must_ appear before aliased IDs (otherwise you get a compilation error). Given that the proto3 spec does not specify order mattering, I think it's safe to assume that this is a bug in protobufjs. I've ticketed this here: https://github.com/protobufjs/protobuf.js/issues/1521  I'm... not entirely sure how easy the fix will be.

In the meantime, this PR does the dumb-but-simple thing of moving this one (1) `allow_alias` option to the top of the `MySqlFlag` enum so that protobufjs can compile. 😬

In order to test this, I re-ran `make proto` against this branch and verified that no diff was generated. Please let me know if I should test this any other way. 🙇‍♀️ 

## Related Issue(s)
List related PRs against other branches: N/A

## Todos
- [ ] Tests (N/A)
- [ ] Documentation (N/A)

## Deployment Notes
N/A

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 
