### PR TITLE
Online DDL endtoend tests to support MacOS

### DIFF
--- a/go/test/endtoend/onlineddl/onlineddl_test.go
+++ b/go/test/endtoend/onlineddl/onlineddl_test.go
@@ -114,6 +114,7 @@ func TestMain(m *testing.M) {
 
 		clusterInstance.VtTabletExtraArgs = []string{
 			"-migration_check_interval", "5s",
+			"-gh-ost-path", os.Getenv("VITESS_ENDTOEND_GH_OST_PATH"), // leave env variable empty/unset to get the default behavior. Override in Mac.
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"-ddl_strategy", "gh-ost",


### PR DESCRIPTION

## Backport
NO

## Status
ready

## Description

The existing `endtoend/online_ddl` tests use `gh-ost`, and assume they run on `Linux/amd64`: the `gh-ost` binary used is self extracted from VTTablet.

However, some of our developers use MacOS; the `gh-ost` binray compiled to `Linux/amd64` will not run on MacOS. 

Developers can now set the system variable `VITESS_ENDTOEND_GH_OST_PATH` to the fullpath of their `gh-ost` binary (compiled to `Darwin`).

If you're running on `Linux/amd64` you don't need to do anything.

## Related Issue(s)

tracking: #6926 

## Todos
- [ ] Tests
- [ ] Documentation


## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 


cc @GuptaManan100 