### PR TITLE
SwitchWrites bug: reverse replication workflows can have wrong start positions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.3 // indirect
 	github.com/montanaflynn/stats v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.0 h1:/x0XQ6h+3U3nAyk1yx+bHPURrKa9sVVvYbuqZ7pIAtI=
 github.com/mitchellh/go-testing-interface v1.14.0/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -751,7 +751,8 @@ func (ts *trafficSwitcher) stopSourceWrites(ctx context.Context) error {
 	return ts.forAllSources(func(source *tsSource) error {
 		var err error
 		source.position, err = ts.wr.tmc.MasterPosition(ctx, source.master.Tablet)
-		ts.wr.Logger().Infof("Position for source %v:%v: %v", ts.sourceKeyspace, source.si.ShardName(), source.position)
+		ts.wr.Logger().Infof("Stopped Source Writes. Position for source %v:%v: %v",
+			ts.sourceKeyspace, source.si.ShardName(), source.position)
 		if err != nil {
 			log.Warningf("Error: %s", err)
 		}
@@ -773,39 +774,34 @@ func (ts *trafficSwitcher) changeTableSourceWrites(ctx context.Context, access a
 func (ts *trafficSwitcher) waitForCatchup(ctx context.Context, filteredReplicationWaitTime time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, filteredReplicationWaitTime)
 	defer cancel()
-
-	var mu sync.Mutex
-	return ts.forAllUids(func(target *tsTarget, uid uint32) error {
-		ts.wr.Logger().Infof("uid: %d, target master %s, target position %s, shard %s", uid,
-			target.master.AliasString(), target.position, target.si.String())
-		log.Infof("uid: %d, target master %s, target position %s, shard %s", uid,
+	// source writes have been stopped, wait for all streams on targets to catch up
+	if err := ts.forAllUids(func(target *tsTarget, uid uint32) error {
+		ts.wr.Logger().Infof("Before Catchup: uid: %d, target master %s, target position %s, shard %s", uid,
 			target.master.AliasString(), target.position, target.si.String())
 		bls := target.sources[uid]
 		source := ts.sources[bls.Shard]
-		ts.wr.Logger().Infof("waiting for keyspace:shard: %v:%v, source position %v, uid %d",
+		ts.wr.Logger().Infof("Before Catchup: waiting for keyspace:shard: %v:%v to reach source position %v, uid %d",
 			ts.targetKeyspace, target.si.ShardName(), source.position, uid)
 		if err := ts.wr.tmc.VReplicationWaitForPos(ctx, target.master.Tablet, int(uid), source.position); err != nil {
 			return err
 		}
-		log.Infof("waiting for keyspace:shard: %v:%v, source position %v, uid %d",
+		log.Infof("After catchup: target keyspace:shard: %v:%v, source position %v, uid %d",
 			ts.targetKeyspace, target.si.ShardName(), source.position, uid)
-		ts.wr.Logger().Infof("position for keyspace:shard: %v:%v reached, uid %d", ts.targetKeyspace, target.si.ShardName(), uid)
-		log.Infof("position for keyspace:shard: %v:%v reached, uid %d", ts.targetKeyspace, target.si.ShardName(), uid)
+		ts.wr.Logger().Infof("After catchup: position for keyspace:shard: %v:%v reached, uid %d",
+			ts.targetKeyspace, target.si.ShardName(), uid)
 		if _, err := ts.wr.tmc.VReplicationExec(ctx, target.master.Tablet, binlogplayer.StopVReplication(uid, "stopped for cutover")); err != nil {
 			log.Infof("error marking stopped for cutover on %s, uid %d", target.master.AliasString(), uid)
 			return err
 		}
-
-		// Need lock because a target can have multiple uids.
-		mu.Lock()
-		defer mu.Unlock()
-		if target.position != "" {
-			return nil
-		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	// all targets have caught up, record their positions for setting up reverse workflows
+	return ts.forAllTargets(func(target *tsTarget) error {
 		var err error
 		target.position, err = ts.wr.tmc.MasterPosition(ctx, target.master.Tablet)
-		ts.wr.Logger().Infof("Position for target master %s, uid %v: %v", target.master.AliasString(), uid, target.position)
-		log.Infof("Position for target master %s, uid %v: %v", target.master.AliasString(), uid, target.position)
+		ts.wr.Logger().Infof("After catchup, position for target master %s, %v", target.master.AliasString(), target.position)
 		return err
 	})
 }
@@ -898,7 +894,8 @@ func (ts *trafficSwitcher) createReverseVReplication(ctx context.Context) error 
 				Filter: filter,
 			})
 		}
-
+		log.Infof("Creating reverse workflow vreplication stream on tablet %s: workflow %s, startPos %s",
+			source.master.Alias, ts.reverseWorkflow, target.position)
 		_, err := ts.wr.VReplicationExec(ctx, source.master.Alias, binlogplayer.CreateVReplicationState(ts.reverseWorkflow, reverseBls, target.position, binlogplayer.BlpStopped, source.master.DbName()))
 		if err != nil {
 			return err
@@ -907,6 +904,7 @@ func (ts *trafficSwitcher) createReverseVReplication(ctx context.Context) error 
 		// if user has defined the cell/tablet_types parameters in the forward workflow, update the reverse workflow as well
 		updateQuery := ts.getReverseVReplicationUpdateQuery(target.master.Alias.Cell, source.master.Alias.Cell, source.master.DbName())
 		if updateQuery != "" {
+			log.Infof("Updating vreplication stream entry on %s with: %s", source.master.Alias, updateQuery)
 			_, err = ts.wr.VReplicationExec(ctx, source.master.Alias, updateQuery)
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

#### Cause

While switching writes we first stop writes on the source and then wait for the targets to catchup to the source gtid positions. We then set the position that the target reached as the start position of the reverse workflow (if requested by user).  

A target can have more than one sources. Currently the target position is determined by the getting MasterPosition from mysql when the first source stream catches up. This is a bug since other source streams that are still running can advance the target's position. In such a case we can set the start position of the reverse replication stream to be in the past. Example: we may set the startPos to be 1-53 (where the first source stream caught up) where as the server is already at 1-66 (where the second source stream caught up)

When the reverse replication streams start running they replays the events between 1-53 and 1-66, which it already has seen, potentially causing duplicate key errors in case of insert events.

We have been (un?)lucky that this bug has not been reported in production till now because it only occurs when a lot of stars align (we need multiple sources for a target, there has to be a high write QPS combined with new inserts into the source shard with the lagging stream etc). 

#### Fix

Evaluate target positions _after_ waiting for **all** source streams to catchup.

#### Tests
This PR fixes the flakiness in the e2e test where SwitchWrites can hang in waitForCatchup(). The flakiness was happening occasionally (say 2% of the time). This had been temporarily "fixed" by adding delays in the test. These artificial delays have been removed as part of this PR.

Since the bug is not reproducible consistently using the e2e tests, we also confirmed the fix by testing manually: adding a delay in the event processing in vplayer.go for one source reproduces the bug in every run. The fix in this PR causes SwitchWrites to work properly even with this instrumentation (as it should ...)

Closes #7142 

#### Impacted Areas in Vitess
- [x]  VReplication
