### PR TITLE
Update Vitess v8.0 images

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,10 +8,10 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v6.0.20-20200429
-    vtgate: vitess/lite:v6.0.20-20200429
-    vttablet: vitess/lite:v6.0.20-20200429
-    vtbackup: vitess/lite:v6.0.20-20200429
+    vtctld: vitess/lite:v8.0.0
+    vtgate: vitess/lite:v8.0.0
+    vttablet: vitess/lite:v8.0.0
+    vtbackup: vitess/lite:v8.0.0
     mysqld:
       mysql56Compatible: vitess/lite:v6.0.20-20200429
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,10 +4,10 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v6.0.20-20200429
-    vtgate: vitess/lite:v6.0.20-20200429
-    vttablet: vitess/lite:v6.0.20-20200429
-    vtbackup: vitess/lite:v6.0.20-20200429
+    vtctld: vitess/lite:v8.0.0
+    vtgate: vitess/lite:v8.0.0
+    vttablet: vitess/lite:v8.0.0
+    vtbackup: vitess/lite:v8.0.0
     mysqld:
       mysql56Compatible: vitess/lite:v6.0.20-20200429
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vtgate: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vttablet: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vtbackup: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
+    vtctld: vitess/lite:v8.0.0
+    vtgate: vitess/lite:v8.0.0
+    vttablet: vitess/lite:v8.0.0
+    vtbackup: vitess/lite:v8.0.0
     mysqld:
-      mysql56Compatible: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
+      mysql56Compatible: vitess/lite:v8.0.0
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,10 +4,10 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vtgate: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vttablet: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
-    vtbackup: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
+    vtctld: vitess/lite:v8.0.0
+    vtgate: vitess/lite:v8.0.0
+    vttablet: vitess/lite:v8.0.0
+    vtbackup: vitess/lite:v8.0.0
     mysqld:
       mysql56Compatible: us.gcr.io/planetscale-vitess/lite:2020-04-24.228e6fe
     mysqldExporter: prom/mysqld-exporter:v0.11.0

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5773,7 +5773,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: vitess-operator
-        image: planetscale/vitess-operator:v2.0.0
+        image: planetscale/vitess-operator:latest
         imagePullPolicy: IfNotPresent
         name: vitess-operator
         resources:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5773,7 +5773,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: vitess-operator
-        image: planetscale/vitess-operator:latest
+        image: planetscale/vitess-operator:v2.2.0
         imagePullPolicy: IfNotPresent
         name: vitess-operator
         resources:


### PR DESCRIPTION
Signed-off-by: Alkin Tezuysal <alkin.tezuysal@gmail.com>

## Backport
NO

## Status
READY

## Description
Change images to 
```images:
    vtctld: vitess/lite:v8.0.0
    vtgate: vitess/lite:v8.0.0
    vttablet: vitess/lite:v8.0.0
    vtbackup: vitess/lite:v8.0.0
    mysqld:
      mysql56Compatible: vitess/lite:v6.0.20-20200429
    mysqldExporter: prom/mysqld-exporter:v0.11.0
```
## Related Issue(s)
List related PRs against other branches:

## Todos
- [ X ] Tests
- [ ] Documentation

## Deployment Notes
Please verify Operator vs Vitess version compatibility.

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ X]  Cluster Management
- [ ]  Build 
