### PR TITLE
add sequence table support for vtexplain

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -371,7 +371,12 @@ func initTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) error {
 	showTableRows := make([][]sqltypes.Value, 0, 4)
 	for _, ddl := range ddls {
 		table := ddl.GetTable().Name.String()
-		showTableRows = append(showTableRows, mysql.BaseShowTablesRow(table, false, ""))
+		options := ""
+		spec := ddl.GetTableSpec()
+		if spec != nil && strings.Contains(spec.Options, "vitess_sequence") {
+			options = "vitess_sequence"
+		}
+		showTableRows = append(showTableRows, mysql.BaseShowTablesRow(table, false, options))
 	}
 	schemaQueries[mysql.BaseShowTables] = &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -42,6 +44,13 @@ create table t3 (
 create table t4 like t3;
 
 create table t5 (like t2);
+
+create table t1_seq(
+  id int,
+  next_id bigint,
+  cache bigint,
+  primary key(id)
+) comment 'vitess_sequence';
 
 create table test_partitioned (
 	id bigint,
@@ -113,6 +122,11 @@ create table test_partitioned (
 
 	if t5.HasPrimary() || len(t5.PKColumns) != 0 {
 		t.Errorf("expected !HasPrimary && t5.PKColumns == [] got %v", t5.PKColumns)
+	}
+
+	seq := tables["t1_seq"]
+	if seq.Type != schema.Sequence {
+		t.Errorf("expected t1_seq to be a sequence table but is type %v", seq.Type)
 	}
 }
 


### PR DESCRIPTION
## Backport
 NO

## Status
**READY**

## Description
Adds support for detecting sequence tables via the required comment. Works transparently and what a user expects so I don't think it requires extra docs. Added a unit test for it.

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/6919

## Todos
- [x ] Tests
- [x ] Documentation

Makes feature work as expected so no need for extra docs.

## Deployment Notes
None

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [x] VTExplain
