### PR TITLE
vttablet: debug/env page to change variables in real-time

### DIFF
--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -77,6 +77,7 @@ var (
       <a href="/debug/health">Query Service Health Check</a></br>
       <a href="/livequeryz/">Real-time Queries</a></br>
       <a href="/debug/status_details">JSON Status Details</a></br>
+      <a href="/debug/env">View/Change Environment variables</a></br>
     </td>
   </tr>
 </table>

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -266,10 +266,16 @@ func changeVar(t *testing.T, name, value string) (revert func()) {
 	if !ok {
 		t.Fatalf("%s not found in: %v", name, vals)
 	}
-	vals = framework.FetchJSON(fmt.Sprintf("/debug/env?format=json&varname=%s&value=%s", name, value))
+	vals = framework.PostJSON("/debug/env?format=json", map[string]string{
+		"varname": name,
+		"value":   value,
+	})
 	verifyMapValue(t, vals, name, value)
 	return func() {
-		vals := framework.FetchJSON(fmt.Sprintf("/debug/env?format=json&varname=%s&value=%s", name, initial))
+		vals = framework.PostJSON("/debug/env?format=json", map[string]string{
+			"varname": name,
+			"value":   fmt.Sprintf("%v", initial),
+		})
 		verifyMapValue(t, vals, name, initial)
 	}
 }

--- a/go/vt/vttablet/endtoend/framework/debugvars.go
+++ b/go/vt/vttablet/endtoend/framework/debugvars.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -29,6 +30,23 @@ import (
 func FetchJSON(urlPath string) map[string]interface{} {
 	out := map[string]interface{}{}
 	response, err := http.Get(fmt.Sprintf("%s%s", ServerAddress, urlPath))
+	if err != nil {
+		return out
+	}
+	defer response.Body.Close()
+	_ = json.NewDecoder(response.Body).Decode(&out)
+	return out
+}
+
+// PostJSON performs a post and fetches JSON content from the specified URL path and returns it
+// as a map. The function returns an empty map on error.
+func PostJSON(urlPath string, values map[string]string) map[string]interface{} {
+	urlValues := url.Values{}
+	for k, v := range values {
+		urlValues.Add(k, v)
+	}
+	out := map[string]interface{}{}
+	response, err := http.PostForm(fmt.Sprintf("%s%s", ServerAddress, urlPath), urlValues)
 	if err != nil {
 		return out
 	}

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -217,8 +217,8 @@ func TestTxPoolSize(t *testing.T) {
 	defer client1.Rollback()
 	verifyIntValue(t, framework.DebugVars(), "TransactionPoolAvailable", tabletenv.NewCurrentConfig().TxPool.Size-1)
 
-	defer framework.Server.SetTxPoolSize(framework.Server.TxPoolSize())
-	framework.Server.SetTxPoolSize(1)
+	revert := changeVar(t, "TxPoolSize", "1")
+	defer revert()
 	vend := framework.DebugVars()
 	verifyIntValue(t, vend, "TransactionPoolAvailable", 0)
 	verifyIntValue(t, vend, "TransactionPoolCapacity", 1)

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"strconv"
+	"text/template"
+
+	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/vt/log"
+)
+
+var (
+	debugEnvHeader = []byte(`
+	<thead><tr>
+		<th>Variable Name</th>
+		<th>Value</th>
+		<th>Action</th>
+	</tr></thead>
+	`)
+	debugEnvRow = template.Must(template.New("debugenv").Parse(`
+	<tr><form method="POST">
+		<td>{{.VarName}}</td>
+		<td>
+			<input type="hidden" name="varname" value="{{.VarName}}"></input>
+			<input type="text" name="value" value="{{.Value}}"></input>
+		</td>
+		<td><input type="submit" name="Action" value="Modify"></input></td>
+	</form></tr>
+	`))
+)
+
+type envValue struct {
+	VarName string
+	Value   string
+}
+
+func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) {
+	if err := acl.CheckAccessHTTP(r, acl.ADMIN); err != nil {
+		acl.SendError(w, err)
+		return
+	}
+
+	varname := r.FormValue("varname")
+	value := r.FormValue("value")
+	var msg string
+	switch varname {
+	case "PoolSize":
+		ival, err := strconv.Atoi(value)
+		if err != nil {
+			msg = fmt.Sprintf("Failed setting value for PoolSize: %v", err)
+		} else {
+			tsv.SetPoolSize(ival)
+			msg = fmt.Sprintf("SetPoolSize has been executed for value: %v", value)
+		}
+	}
+
+	var vars []envValue
+	vars = append(vars, envValue{
+		VarName: "PoolSize",
+		Value:   fmt.Sprintf("%v", tsv.PoolSize()),
+	})
+
+	format := r.FormValue("format")
+	if format == "json" {
+		mvars := make(map[string]string)
+		for _, v := range vars {
+			mvars[v.VarName] = v.Value
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mvars)
+		return
+	}
+
+	// gridTable is reused from twopcz.go.
+	w.Write(gridTable)
+	w.Write([]byte("<h3>Internal Variables</h3>\n"))
+	if msg != "" {
+		w.Write([]byte(fmt.Sprintf("<b>%s</b><br /><br />\n", html.EscapeString(msg))))
+	}
+	w.Write(startTable)
+	w.Write(debugEnvHeader)
+	for _, v := range vars {
+		if err := debugEnvRow.Execute(w, v); err != nil {
+			log.Errorf("queryz: couldn't execute template: %v", err)
+		}
+	}
+	w.Write(endTable)
+}

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -59,34 +59,36 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	varname := r.FormValue("varname")
-	value := r.FormValue("value")
 	var msg string
-	setIntVal := func(f func(int)) {
-		ival, err := strconv.Atoi(value)
-		if err != nil {
-			msg = fmt.Sprintf("Failed setting value for %v: %v", varname, err)
-			return
+	if r.Method == "POST" {
+		varname := r.FormValue("varname")
+		value := r.FormValue("value")
+		setIntVal := func(f func(int)) {
+			ival, err := strconv.Atoi(value)
+			if err != nil {
+				msg = fmt.Sprintf("Failed setting value for %v: %v", varname, err)
+				return
+			}
+			f(ival)
+			msg = fmt.Sprintf("Setting %v to: %v", varname, value)
 		}
-		f(ival)
-		msg = fmt.Sprintf("Setting %v to: %v", varname, value)
-	}
-	switch varname {
-	case "PoolSize":
-		setIntVal(tsv.SetPoolSize)
-	case "StreamPoolSize":
-		setIntVal(tsv.SetStreamPoolSize)
-	case "TxPoolSize":
-		setIntVal(tsv.SetTxPoolSize)
-	case "QueryCacheCapacity":
-		setIntVal(tsv.SetQueryPlanCacheCap)
-	case "MaxResultSize":
-		setIntVal(tsv.SetMaxResultSize)
-	case "WarnResultSize":
-		setIntVal(tsv.SetWarnResultSize)
-	case "Consolidator":
-		tsv.SetConsolidatorMode(value)
-		msg = fmt.Sprintf("Setting %v to: %v", varname, value)
+		switch varname {
+		case "PoolSize":
+			setIntVal(tsv.SetPoolSize)
+		case "StreamPoolSize":
+			setIntVal(tsv.SetStreamPoolSize)
+		case "TxPoolSize":
+			setIntVal(tsv.SetTxPoolSize)
+		case "QueryCacheCapacity":
+			setIntVal(tsv.SetQueryPlanCacheCap)
+		case "MaxResultSize":
+			setIntVal(tsv.SetMaxResultSize)
+		case "WarnResultSize":
+			setIntVal(tsv.SetWarnResultSize)
+		case "Consolidator":
+			tsv.SetConsolidatorMode(value)
+			msg = fmt.Sprintf("Setting %v to: %v", varname, value)
+		}
 	}
 
 	var vars []envValue

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -150,7 +150,7 @@ type QueryEngine struct {
 
 	strictTransTables bool
 
-	consolidatorMode            string
+	consolidatorMode            sync2.AtomicString
 	enableQueryPlanFieldCaching bool
 
 	// stats
@@ -175,7 +175,7 @@ func NewQueryEngine(env tabletenv.Env, se *schema.Engine) *QueryEngine {
 
 	qe.conns = connpool.NewPool(env, "ConnPool", config.OltpReadPool)
 	qe.streamConns = connpool.NewPool(env, "StreamConnPool", config.OlapReadPool)
-	qe.consolidatorMode = config.Consolidator
+	qe.consolidatorMode.Set(config.Consolidator)
 	qe.enableQueryPlanFieldCaching = config.CacheResultFields
 	qe.consolidator = sync2.NewConsolidator()
 	qe.txSerializer = txserializer.New(env)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -602,7 +602,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 		return nil, err
 	}
 	// Check tablet type.
-	if qre.tsv.qe.consolidatorMode == tabletenv.Enable || (qre.tsv.qe.consolidatorMode == tabletenv.NotOnMaster && qre.tabletType != topodatapb.TabletType_MASTER) {
+	if cm := qre.tsv.qe.consolidatorMode.Get(); cm == tabletenv.Enable || (cm == tabletenv.NotOnMaster && qre.tabletType != topodatapb.TabletType_MASTER) {
 		q, original := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 		if original {
 			defer q.Broadcast()

--- a/go/vt/vttablet/tabletserver/status.go
+++ b/go/vt/vttablet/tabletserver/status.go
@@ -83,8 +83,9 @@ var (
     <td width="25%" border="">
       <a href="{{.Prefix}}/healthz">Health Check</a></br>
       <a href="{{.Prefix}}/debug/health">Query Service Health Check</a></br>
-      <a href="/livequeryz/">Real-time Queries</a></br>
+      <a href="{{.Prefix}}/livequeryz/">Real-time Queries</a></br>
       <a href="{{.Prefix}}/debug/status_details">JSON Status Details</a></br>
+      <a href="{{.Prefix}}/debug/env">View/Change Environment variables</a></br>
     </td>
   </tr>
 </table>

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -216,6 +216,7 @@ func NewTabletServer(name string, config *tabletenv.TabletConfig, topoServer *to
 	tsv.registerTwopczHandler()
 	tsv.registerMigrationStatusHandler()
 	tsv.registerThrottlerHandlers()
+	tsv.registerDebugEnvHandler()
 
 	return tsv
 }
@@ -1621,6 +1622,12 @@ func (tsv *TabletServer) registerThrottlerHandlers() {
 	tsv.registerThrottlerStatusHandler()
 }
 
+func (tsv *TabletServer) registerDebugEnvHandler() {
+	tsv.exporter.HandleFunc("/debug/env", func(w http.ResponseWriter, r *http.Request) {
+		debugEnvHandler(tsv, w, r)
+	})
+}
+
 // EnableHeartbeat forces heartbeat to be on or off.
 // Only to be used for testing.
 func (tsv *TabletServer) EnableHeartbeat(enabled bool) {
@@ -1642,6 +1649,9 @@ func (tsv *TabletServer) EnableHistorian(enabled bool) {
 // SetPoolSize changes the pool size to the specified value.
 // This function should only be used for testing.
 func (tsv *TabletServer) SetPoolSize(val int) {
+	if val <= 0 {
+		return
+	}
 	tsv.qe.conns.SetCapacity(val)
 }
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1647,7 +1647,6 @@ func (tsv *TabletServer) EnableHistorian(enabled bool) {
 }
 
 // SetPoolSize changes the pool size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetPoolSize(val int) {
 	if val <= 0 {
 		return
@@ -1661,7 +1660,6 @@ func (tsv *TabletServer) PoolSize() int {
 }
 
 // SetStreamPoolSize changes the pool size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetStreamPoolSize(val int) {
 	tsv.qe.streamConns.SetCapacity(val)
 }
@@ -1672,7 +1670,6 @@ func (tsv *TabletServer) StreamPoolSize() int {
 }
 
 // SetTxPoolSize changes the tx pool size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetTxPoolSize(val int) {
 	tsv.te.txPool.scp.conns.SetCapacity(val)
 }
@@ -1683,7 +1680,6 @@ func (tsv *TabletServer) TxPoolSize() int {
 }
 
 // SetTxTimeout changes the transaction timeout to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetTxTimeout(val time.Duration) {
 	tsv.te.txPool.SetTimeout(val)
 	tsv.txTimeout.Set(val)
@@ -1695,7 +1691,6 @@ func (tsv *TabletServer) TxTimeout() time.Duration {
 }
 
 // SetQueryPlanCacheCap changes the pool size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetQueryPlanCacheCap(val int) {
 	tsv.qe.SetQueryPlanCacheCap(val)
 }
@@ -1706,7 +1701,6 @@ func (tsv *TabletServer) QueryPlanCacheCap() int {
 }
 
 // SetMaxResultSize changes the max result size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetMaxResultSize(val int) {
 	tsv.qe.maxResultSize.Set(int64(val))
 }
@@ -1717,7 +1711,6 @@ func (tsv *TabletServer) MaxResultSize() int {
 }
 
 // SetWarnResultSize changes the warn result size to the specified value.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetWarnResultSize(val int) {
 	tsv.qe.warnResultSize.Set(int64(val))
 }
@@ -1734,9 +1727,16 @@ func (tsv *TabletServer) SetPassthroughDMLs(val bool) {
 }
 
 // SetConsolidatorMode sets the consolidator mode.
-// This function should only be used for testing.
 func (tsv *TabletServer) SetConsolidatorMode(mode string) {
-	tsv.qe.consolidatorMode = mode
+	switch mode {
+	case tabletenv.NotOnMaster, tabletenv.Enable, tabletenv.Disable:
+		tsv.qe.consolidatorMode.Set(mode)
+	}
+}
+
+// ConsolidatorMode returns the consolidator mode.
+func (tsv *TabletServer) ConsolidatorMode() string {
+	return tsv.qe.consolidatorMode.Get()
 }
 
 // queryAsString returns a readable version of query+bind variables.


### PR DESCRIPTION
## Backport
NO

## Status
READY

## Description
Feature implemented as specified in RFC.
Also added links to the new page from `/debug/status`

## Related Issue(s)
Fixes #7171 
Fixes #2983

## Todos
- [X] Tests
- [ ] Documentation

## Deployment Notes
None

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
