### PR TITLE
Updated pull request template to add more clarity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,23 @@
-## Backport
-YES | NO
-
-## Status
-**DRAFT/READY/IN DEVELOPMENT/HOLD**
+<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->
 
 ## Description
-A few sentences describing the overall goals of the pull request's commits.
+<!-- A few sentences describing the overall goals of the pull request's commits. -->
 
 ## Related Issue(s)
-List related PRs against other branches:
+<!-- List related issues and pull requests: -->
 
-## Todos
-- [ ] Tests
-- [ ] Documentation
+- 
+
+## Checklist
+- [ ] Should this PR be backported?
+- [ ] Tests were added or are not required
+- [ ] Documentation was added or is not required
 
 ## Deployment Notes
-Notes regarding deployment of the contained body of work.  These should note any
-db migrations, etc.
+<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
 
 ## Impacted Areas in Vitess
-List general components of the application that this PR will affect:
+Components that this PR will affect:
 
 - [ ]  Query Serving
 - [ ]  VReplication


### PR DESCRIPTION
Followup to an internal discussion, I've made some changes to the pull request template:

- Removed "Status" section. If the PR is a draft, then the developer should "create draft pull request", this is a built in GitHub feature.
- Aggregated "Backport" together with tests & documentation checkboxes. Everything is in a checkbox
- Clarified "test" and "documentation" meaning
- Turned most instruction to HTML comment. The developer will be able to read them. Most (in my experience) submissions may forget/neglect to actually modify those instructions. So having them as comment means they're readable upon submission, but hidden after submission.

cc @deepthi @askdba 