### PR TITLE
cache only dml and select plans

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -114,6 +114,16 @@ func CanNormalize(stmt Statement) bool {
 	return false
 }
 
+// CachePlan takes Statement and returns true if the query plan should be cached
+func CachePlan(stmt Statement) bool {
+	switch stmt.(type) {
+	case *Select, *Union, *ParenSelect,
+		*Insert, *Update, *Delete:
+		return true
+	}
+	return false
+}
+
 //IsSetStatement takes Statement and returns if the statement is set statement.
 func IsSetStatement(stmt Statement) bool {
 	switch stmt.(type) {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1319,7 +1319,7 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments sqlparser.
 	if err != nil {
 		return nil, err
 	}
-	if !skipQueryPlanCache && !sqlparser.SkipQueryPlanCacheDirective(statement) && plan.Instructions != nil {
+	if !skipQueryPlanCache && !sqlparser.SkipQueryPlanCacheDirective(statement) && sqlparser.CachePlan(statement) {
 		e.plans.Set(planKey, plan)
 	}
 	return plan, nil


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

## Backport
NO

## Status
**READY**

## Description
Caching plans other than select and dml queries does not give any plan benefits. Those queries are mostly that needs to be  re-planned.

## Related Issue(s)
List related PRs against other branches:
TBD

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [X]  Query Serving
