### PR TITLE
Redact password

### DIFF
--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -225,7 +225,7 @@ func redactPassword(input string) string {
 		if j == -1 {
 			return input
 		}
-		input = input[:i+len(masterPasswordStart)] + strings.Repeat("*", j) + input[i+len(masterPasswordStart)+j:]
+		input = input[:i+len(masterPasswordStart)] + strings.Repeat("*", 4) + input[i+len(masterPasswordStart)+j:]
 	}
 	// We also check if we have any password keyword in the query
 	i = strings.Index(input, passwordStart)
@@ -236,5 +236,5 @@ func redactPassword(input string) string {
 	if j == -1 {
 		return input
 	}
-	return input[:i+len(passwordStart)] + strings.Repeat("*", j) + input[i+len(passwordStart)+j:]
+	return input[:i+len(passwordStart)] + strings.Repeat("*", 4) + input[i+len(passwordStart)+j:]
 }

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -78,10 +78,10 @@ func limitString(s string, limit int) string {
 func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbconnpool.PooledDBConnection, queryList []string) error {
 	const LogQueryLengthLimit = 200
 	for _, query := range queryList {
-		log.Infof("exec %s", limitString(redactMasterPassword(query), LogQueryLengthLimit))
+		log.Infof("exec %s", limitString(redactPassword(query), LogQueryLengthLimit))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
-			log.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
-			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactMasterPassword(query), redactMasterPassword(err.Error()))
+			log.Errorf("ExecuteFetch(%v) failed: %v", redactPassword(query), redactPassword(err.Error()))
+			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactPassword(query), redactPassword(err.Error()))
 		}
 	}
 	return nil
@@ -213,16 +213,28 @@ func (mysqld *Mysqld) fetchVariables(ctx context.Context, pattern string) (map[s
 const (
 	masterPasswordStart = "  MASTER_PASSWORD = '"
 	masterPasswordEnd   = "',\n"
+	passwordStart       = " PASSWORD = '"
+	passwordEnd         = "'"
 )
 
-func redactMasterPassword(input string) string {
+func redactPassword(input string) string {
 	i := strings.Index(input, masterPasswordStart)
+	// We have master password in the query, try to redact it
+	if i != -1 {
+		j := strings.Index(input[i+len(masterPasswordStart):], masterPasswordEnd)
+		if j == -1 {
+			return input
+		}
+		input = input[:i+len(masterPasswordStart)] + strings.Repeat("*", j) + input[i+len(masterPasswordStart)+j:]
+	}
+	// We also check if we have any password keyword in the query
+	i = strings.Index(input, passwordStart)
 	if i == -1 {
 		return input
 	}
-	j := strings.Index(input[i+len(masterPasswordStart):], masterPasswordEnd)
+	j := strings.Index(input[i+len(passwordStart):], passwordEnd)
 	if j == -1 {
 		return input
 	}
-	return input[:i+len(masterPasswordStart)] + strings.Repeat("*", j) + input[i+len(masterPasswordStart)+j:]
+	return input[:i+len(passwordStart)] + strings.Repeat("*", j) + input[i+len(passwordStart)+j:]
 }

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func testRedacted(t *testing.T, source, expected string) {
-	if r := redactMasterPassword(source); r != expected {
-		t.Errorf("redactMasterPassword bad result: %v\nWas expecting:%v", r, expected)
+	if r := redactPassword(source); r != expected {
+		t.Errorf("redactPassword bad result: %v\nWas expecting:%v", r, expected)
 	}
 }
 
@@ -55,4 +55,28 @@ func TestRedactMasterPassword(t *testing.T) {
 	testRedacted(t, `CHANGE MASTER TO
   MASTER_PASSWORD = 'AAA`, `CHANGE MASTER TO
   MASTER_PASSWORD = 'AAA`)
+}
+
+func TestRedactPassword(t *testing.T) {
+	// regular case
+	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = 'AAA'`,
+		`START xxx USER = 'vt_repl', PASSWORD = '***'`)
+
+	// empty password
+	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = ''`,
+		`START xxx USER = 'vt_repl', PASSWORD = ''`)
+
+	// no end match
+	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = 'AAA`,
+		`START xxx USER = 'vt_repl', PASSWORD = 'AAA`)
+
+	// both master password and password
+	testRedacted(t, `START xxx
+  MASTER_PASSWORD = 'AAA',
+  PASSWORD = 'BBB'
+`,
+		`START xxx
+  MASTER_PASSWORD = '***',
+  PASSWORD = '***'
+`)
 }

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -34,7 +34,7 @@ func TestRedactMasterPassword(t *testing.T) {
   MASTER_CONNECT_RETRY = 1
 `,
 		`CHANGE MASTER TO
-  MASTER_PASSWORD = '***',
+  MASTER_PASSWORD = '****',
   MASTER_CONNECT_RETRY = 1
 `)
 
@@ -44,7 +44,7 @@ func TestRedactMasterPassword(t *testing.T) {
   MASTER_CONNECT_RETRY = 1
 `,
 		`CHANGE MASTER TO
-  MASTER_PASSWORD = '',
+  MASTER_PASSWORD = '****',
   MASTER_CONNECT_RETRY = 1
 `)
 
@@ -60,11 +60,11 @@ func TestRedactMasterPassword(t *testing.T) {
 func TestRedactPassword(t *testing.T) {
 	// regular case
 	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = 'AAA'`,
-		`START xxx USER = 'vt_repl', PASSWORD = '***'`)
+		`START xxx USER = 'vt_repl', PASSWORD = '****'`)
 
 	// empty password
 	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = ''`,
-		`START xxx USER = 'vt_repl', PASSWORD = ''`)
+		`START xxx USER = 'vt_repl', PASSWORD = '****'`)
 
 	// no end match
 	testRedacted(t, `START xxx USER = 'vt_repl', PASSWORD = 'AAA`,
@@ -76,7 +76,7 @@ func TestRedactPassword(t *testing.T) {
   PASSWORD = 'BBB'
 `,
 		`START xxx
-  MASTER_PASSWORD = '***',
-  PASSWORD = '***'
+  MASTER_PASSWORD = '****',
+  PASSWORD = '****'
 `)
 }


### PR DESCRIPTION
Signed-off-by: crowu <y.wu4515@gmail.com>

## Backport
YES 

## Status
READY

## Description
If we do any SQL commend with password, Vitess will log it. And currently vitess only redact master password.

This PR tries to redact any password in the SQL query so that people won't see it as plain text in the log

## Related Issue(s)
List related PRs against other branches:
This addresses https://github.com/vitessio/vitess/issues/7197:

## Todos
- [x] Tests
- [ ] Documentation

## Deployment Notes
NA

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
