### PR TITLE
Add @ajm188 + @doeg to CODEOWNERS for vtctld service files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /docker/ @derekperkins @dkhenry
 /examples/compose @shlomi-noach
 /examples/local @rohit-nayak-ps
+/go/cmd/vtctldclient @ajm188 @doeg
 /go/mysql @harshit-gangal @systay
 /go/test/endtoend/onlineddl @shlomi-noach
 /go/test/endtoend/orchestrator @deepthi @shlomi-noach
@@ -14,6 +15,10 @@
 /go/vt/schema @shlomi-noach
 /go/vt/sqlparser @harshit-gangal @systay
 /go/vt/vtctl @deepthi
+/go/vt/vtctl/vtctl.go @ajm188 @doeg
+/go/vt/vtctl/grpcvtctldclient @ajm188 @doeg
+/go/vt/vtctl/grpcvtctldserver @ajm188 @doeg
+/go/vt/vtctl/vtctldclient @ajm188 @doeg
 /go/vt/vtgate @harshit-gangal @systay
 /go/vt/vttablet/tabletmanager @deepthi @shlomi-noach
 /go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps
@@ -21,4 +26,6 @@
 /go/vt/vttablet/tabletserver @harshit-gangal @systay @shlomi-noach
 /go/vt/wrangler @deepthi @rohit-nayak-ps
 /helm/ @derekperkins @dkhenry
+/proto/vtctldata.proto @ajm188 @doeg
+/proto/vtctlservice.proto @ajm188 @doeg
 /web/vtctld2 @rohit-nayak-ps


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Backport
NO

## Status
**READY**

## Description
Over the next few weeks, @ajm188 and I will be working through the [vtctld service tickets](https://github.com/vitessio/vitess/projects/9). Concretely, we'll be posting PRs just like https://github.com/vitessio/vitess/pull/7201 for each of the commands we're migrating. 

To be super up front about the risk: our PRs _will_ be updating `go/vt/vtctl/vtctl.go`, which _could_ affect downstream Vitess deployments. Hence we're being extra careful about backwards compatibility. Our timeline and rollout for this work is described in detail in the RFC: https://github.com/vitessio/vitess/issues/7058.

## Related Issue(s)
List related PRs against other branches:

- #7128 Initial implementation of vtctld service
- #7201 Add FindAllShardsInKeyspace to vtctldserver

## Todos
- [ ] Tests
- [ ] Documentation

## Deployment Notes
N/A

## Impacted Areas in Vitess
List general components of the application that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
