### PR TITLE
Update Golang to 1.15

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/docker_test_3.yml
+++ b/.github/workflows/docker_test_3.yml
@@ -18,4 +18,4 @@ jobs:
 
     - name: Run tests which require docker - 3
       run: |
-        go run test.go -docker=true --follow -shard 26
+        GODEBUG="x509ignoreCN=0" go run test.go -docker=true --follow -shard 26

--- a/.github/workflows/docker_test_3.yml
+++ b/.github/workflows/docker_test_3.yml
@@ -18,4 +18,4 @@ jobs:
 
     - name: Run tests which require docker - 3
       run: |
-        GODEBUG="x509ignoreCN=0" go run test.go -docker=true --follow -shard 26
+        go run test.go -docker=true --follow -shard 26

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -1,0 +1,21 @@
+name: ensure_bootstrap_version
+on: [pull_request]
+jobs:
+
+  build:
+    name: Check Bootstrap Updated
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: run ensure_bootstrap_version
+      run: |
+        make ensure_bootstrap_version
+        test -z "$(git diff-index --name-only HEAD --)" || exit 1

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -18,4 +18,5 @@ jobs:
     - name: run ensure_bootstrap_version
       run: |
         make ensure_bootstrap_version
+        git status
         test -z "$(git diff-index --name-only HEAD --)" || exit 1

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ $(PROTO_GO_OUTS): install_protoc-gen-go proto/*.proto
 # This rule builds the bootstrap images for all flavors.
 DOCKER_IMAGES_FOR_TEST = mariadb mariadb103 mysql56 mysql57 mysql80 percona percona57 percona80
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
-BOOTSTRAP_VERSION=0
+BOOTSTRAP_VERSION=1
 ensure_bootstrap_version:
 	find docker/ -type f -exec sed -i "s/^\(ARG bootstrap_version\)=.*/\1=${BOOTSTRAP_VERSION}/" {} \;
 	sed -i 's/\(^.*flag.String(\"bootstrap-version\",\) *\"[^\"]\+\"/\1 \"${BOOTSTRAP_VERSION}\"/' test.go

--- a/build.env
+++ b/build.env
@@ -17,7 +17,7 @@
 source ./tools/shell_functions.inc
 
 go version >/dev/null 2>&1 || fail "Go is not installed or is not in \$PATH. See https://vitess.io/contributing/build-from-source for install instructions."
-goversion_min 1.13 || fail "Go version reported: `go version`. Version 1.13+ required. See https://vitess.io/contributing/build-from-source for install instructions."
+goversion_min 1.15 || fail "Go version reported: `go version`. Version 1.15+ required. See https://vitess.io/contributing/build-from-source for install instructions."
 
 mkdir -p dist
 mkdir -p bin

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -21,7 +21,7 @@
 # TODO(mberlin): Remove the symlink and this note once
 # https://github.com/docker/hub-feedback/issues/292 is fixed.
 
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb
+++ b/docker/base/Dockerfile.mariadb
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mariadb103
+++ b/docker/base/Dockerfile.mariadb103
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql56
+++ b/docker/base/Dockerfile.mysql56
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.mysql80
+++ b/docker/base/Dockerfile.mysql80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona
+++ b/docker/base/Dockerfile.percona
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona57
+++ b/docker/base/Dockerfile.percona57
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}"

--- a/docker/base/Dockerfile.percona80
+++ b/docker/base/Dockerfile.percona80
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}"

--- a/docker/bootstrap/CHANGELOG.md
+++ b/docker/bootstrap/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+List of changes between bootstrap image versions. 
+
+## [1] - 2020-12-18
+### Changes
+- Update bootstrap image to build binaries using golang 1.15
+    
+

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM golang:1.13-buster
+FROM golang:1.15-buster
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mariadb103"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql56"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.testing
+++ b/docker/lite/Dockerfile.testing
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql57
+++ b/docker/lite/Dockerfile.ubi7.mysql57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.mysql80
+++ b/docker/lite/Dockerfile.ubi7.mysql80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona57
+++ b/docker/lite/Dockerfile.ubi7.percona57
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona57"
 
 FROM "${image}" AS builder

--- a/docker/lite/Dockerfile.ubi7.percona80
+++ b/docker/lite/Dockerfile.ubi7.percona80
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-percona80"
 
 FROM "${image}" AS builder

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM "${image}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vitess.io/vitess
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go/storage v1.0.0
@@ -58,7 +58,6 @@ require (
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
-	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.3 // indirect
 	github.com/montanaflynn/stats v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -476,8 +476,6 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
-github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.0 h1:/x0XQ6h+3U3nAyk1yx+bHPURrKa9sVVvYbuqZ7pIAtI=
 github.com/mitchellh/go-testing-interface v1.14.0/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -33,14 +33,15 @@ import (
 // MysqlctlProcess is a generic handle for a running mysqlctl command .
 // It can be spawned manually
 type MysqlctlProcess struct {
-	Name         string
-	Binary       string
-	LogDirectory string
-	TabletUID    int
-	MySQLPort    int
-	InitDBFile   string
-	ExtraArgs    []string
-	InitMysql    bool
+	Name            string
+	Binary          string
+	LogDirectory    string
+	TabletUID       int
+	MySQLPort       int
+	InitDBFile      string
+	ExtraArgs       []string
+	InitMysql       bool
+	SecureTransport bool
 }
 
 // InitDb executes mysqlctl command to add cell info
@@ -84,35 +85,37 @@ func (mysqlctl *MysqlctlProcess) StartProcess() (*exec.Cmd, error) {
 		tmpProcess.Args = append(tmpProcess.Args, mysqlctl.ExtraArgs...)
 	}
 	if mysqlctl.InitMysql {
-		// Set up EXTRA_MY_CNF for ssl
-		sslPath := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/ssl_%010d", mysqlctl.TabletUID))
-		sslPathData := struct {
-			Dir string
-		}{
-			Dir: sslPath,
-		}
+		if mysqlctl.SecureTransport {
+			// Set up EXTRA_MY_CNF for ssl
+			sslPath := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/ssl_%010d", mysqlctl.TabletUID))
+			sslPathData := struct {
+				Dir string
+			}{
+				Dir: sslPath,
+			}
 
-		os.MkdirAll(sslPath, 0755)
-		extraMyCNF := path.Join(sslPath, "ssl.cnf")
-		fout, err := os.Create(extraMyCNF)
-		if err != nil {
-			log.Error(err)
-			return nil, err
-		}
+			os.MkdirAll(sslPath, 0755)
+			extraMyCNF := path.Join(sslPath, "ssl.cnf")
+			fout, err := os.Create(extraMyCNF)
+			if err != nil {
+				log.Error(err)
+				return nil, err
+			}
 
-		template.Must(template.New(fmt.Sprintf("%010d", mysqlctl.TabletUID)).Parse(`
+			template.Must(template.New(fmt.Sprintf("%010d", mysqlctl.TabletUID)).Parse(`
 ssl_ca={{.Dir}}/ca-cert.pem
 ssl_cert={{.Dir}}/server-001-cert.pem
 ssl_key={{.Dir}}/server-001-key.pem
 `)).Execute(fout, sslPathData)
-		if err := fout.Close(); err != nil {
-			return nil, err
+			if err := fout.Close(); err != nil {
+				return nil, err
+			}
+
+			tlstest.CreateClientServerCertPairs(sslPath)
+
+			tmpProcess.Env = append(tmpProcess.Env, "EXTRA_MY_CNF="+extraMyCNF)
+			tmpProcess.Env = append(tmpProcess.Env, "VTDATAROOT="+os.Getenv("VTDATAROOT"))
 		}
-
-		tlstest.CreateClientServerCertPairs(sslPath)
-
-		tmpProcess.Env = append(tmpProcess.Env, "EXTRA_MY_CNF="+extraMyCNF)
-		tmpProcess.Env = append(tmpProcess.Env, "VTDATAROOT="+os.Getenv("VTDATAROOT"))
 
 		tmpProcess.Args = append(tmpProcess.Args, "init",
 			"-init_db_sql_file", mysqlctl.InitDBFile)
@@ -170,6 +173,7 @@ func MysqlCtlProcessInstance(tabletUID int, mySQLPort int, tmpDirectory string) 
 	mysqlctl.MySQLPort = mySQLPort
 	mysqlctl.TabletUID = tabletUID
 	mysqlctl.InitMysql = true
+	mysqlctl.SecureTransport = false
 	return mysqlctl
 }
 

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"os"
 	"os/exec"
 	"path"
@@ -26,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/tlstest"
 )
 
 // MysqlctlProcess is a generic handle for a running mysqlctl command .
@@ -82,6 +84,36 @@ func (mysqlctl *MysqlctlProcess) StartProcess() (*exec.Cmd, error) {
 		tmpProcess.Args = append(tmpProcess.Args, mysqlctl.ExtraArgs...)
 	}
 	if mysqlctl.InitMysql {
+		// Set up EXTRA_MY_CNF for ssl
+		sslPath := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/ssl_%010d", mysqlctl.TabletUID))
+		sslPathData := struct {
+			Dir string
+		}{
+			Dir: sslPath,
+		}
+
+		os.MkdirAll(sslPath, 0755)
+		extraMyCNF := path.Join(sslPath, "ssl.cnf")
+		fout, err := os.Create(extraMyCNF)
+		if err != nil {
+			log.Error(err)
+			return nil, err
+		}
+
+		template.Must(template.New(fmt.Sprintf("%010d", mysqlctl.TabletUID)).Parse(`
+ssl_ca={{.Dir}}/ca-cert.pem
+ssl_cert={{.Dir}}/server-001-cert.pem
+ssl_key={{.Dir}}/server-001-key.pem
+`)).Execute(fout, sslPathData)
+		if err := fout.Close(); err != nil {
+			return nil, err
+		}
+
+		tlstest.CreateClientServerCertPairs(sslPath)
+
+		tmpProcess.Env = append(tmpProcess.Env, "EXTRA_MY_CNF="+extraMyCNF)
+		tmpProcess.Env = append(tmpProcess.Env, "VTDATAROOT="+os.Getenv("VTDATAROOT"))
+
 		tmpProcess.Args = append(tmpProcess.Args, "init",
 			"-init_db_sql_file", mysqlctl.InitDBFile)
 	}

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -73,6 +73,7 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 		"--initial-advertise-peer-urls", topo.PeerURL,
 		"--listen-peer-urls", topo.PeerURL,
 		"--initial-cluster", fmt.Sprintf("%s=%s", topo.Name, topo.PeerURL),
+		"--enable-v2=true",
 	)
 
 	err = createDirectory(topo.DataDirectory, 0700)
@@ -88,7 +89,8 @@ func (topo *TopoProcess) SetupEtcd() (err error) {
 
 	topo.proc.Env = append(topo.proc.Env, os.Environ()...)
 
-	log.Infof("Starting etcd with command: %v", strings.Join(topo.proc.Args, " "))
+	log.Errorf("Starting etcd with command: %v", strings.Join(topo.proc.Args, " "))
+
 	err = topo.proc.Start()
 	if err != nil {
 		return
@@ -307,7 +309,7 @@ func TopoProcessInstance(port int, peerPort int, hostname string, flavor string,
 	topo.ListenClientURL = fmt.Sprintf("http://%s:%d", topo.Host, topo.Port)
 	topo.DataDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port))
 	topo.LogDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port), "logs")
-	topo.VerifyURL = fmt.Sprintf("http://%s:%d/version", topo.Host, topo.Port)
+	topo.VerifyURL = fmt.Sprintf("http://%s:%d/v2/keys", topo.Host, topo.Port)
 	topo.PeerURL = fmt.Sprintf("http://%s:%d", hostname, peerPort)
 	return topo
 }

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -307,7 +307,7 @@ func TopoProcessInstance(port int, peerPort int, hostname string, flavor string,
 	topo.ListenClientURL = fmt.Sprintf("http://%s:%d", topo.Host, topo.Port)
 	topo.DataDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port))
 	topo.LogDirectory = path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("%s_%d", "topo", port), "logs")
-	topo.VerifyURL = fmt.Sprintf("http://%s:%d/v2/keys", topo.Host, topo.Port)
+	topo.VerifyURL = fmt.Sprintf("http://%s:%d/version", topo.Host, topo.Port)
 	topo.PeerURL = fmt.Sprintf("http://%s:%d", hostname, peerPort)
 	return topo
 }

--- a/go/test/endtoend/clustertest/main_test.go
+++ b/go/test/endtoend/clustertest/main_test.go
@@ -101,7 +101,7 @@ func TestMain(m *testing.M) {
 func testURL(t *testing.T, url string, testCaseName string) {
 	statusCode := getStatusForURL(url)
 	if got, want := statusCode, 200; got != want {
-		t.Errorf("select:\n%v want\n%v for %s", got, want, testCaseName)
+		t.Errorf("\nurl: %v\nstatus code: %v \nwant %v for %s", url, got, want, testCaseName)
 	}
 }
 

--- a/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
+++ b/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
@@ -150,6 +150,7 @@ func initializeCluster(t *testing.T) {
 	var mysqlCtlProcessList []*exec.Cmd
 	for _, shard := range clusterInstance.Keyspaces[0].Shards {
 		for _, tablet := range shard.Vttablets {
+			tablet.MysqlctlProcess.SecureTransport = true
 			proc, err := tablet.MysqlctlProcess.StartProcess()
 			require.NoError(t, err)
 			mysqlCtlProcessList = append(mysqlCtlProcessList, proc)
@@ -469,6 +470,7 @@ func tlsTestTabletRecovery(t *testing.T, tabletForBinlogs *cluster.Vttablet, loo
 
 func tlsLaunchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, tabletForBinlogs *cluster.Vttablet, lookupTimeout, restoreKeyspaceName, shardName string) {
 	tablet.MysqlctlProcess = *cluster.MysqlCtlProcessInstance(tablet.TabletUID, tablet.MySQLPort, clusterInstance.TmpDirectory)
+	tablet.MysqlctlProcess.SecureTransport = true
 	err := tablet.MysqlctlProcess.Start()
 	require.NoError(t, err)
 

--- a/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
+++ b/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
@@ -22,7 +22,9 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
+	"path"
 	"testing"
 	"time"
 
@@ -488,7 +490,7 @@ func tlsLaunchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, tabletForBi
 	tablet.VttabletProcess.Keyspace = restoreKeyspaceName
 	tablet.VttabletProcess.EnableSemiSync = true
 
-	certDir := tabletForBinlogs.VttabletProcess.Directory + "/data"
+	certDir := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/ssl_%010d", tablet.MysqlctlProcess.TabletUID))
 	tablet.VttabletProcess.ExtraArgs = []string{
 		"-disable_active_reparents",
 		"-enable_replication_reporter=false",
@@ -500,8 +502,8 @@ func tlsLaunchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, tabletForBi
 		"-binlog_port", fmt.Sprintf("%d", tabletForBinlogs.MySQLPort),
 		"-binlog_user", mysqlUserName,
 		"-binlog_password", mysqlPassword,
-		"-binlog_ssl_ca", certDir + "/ca.pem",
-		"-binlog_ssl_server_name", getCNFromCertPEM(certDir + "/server-cert.pem"),
+		"-binlog_ssl_ca", certDir + "/ca-cert.pem",
+		"-binlog_ssl_server_name", getCNFromCertPEM(certDir + "/server-001-cert.pem"),
 		"-pitr_gtid_lookup_timeout", lookupTimeout,
 		"-vreplication_healthcheck_topology_refresh", "1s",
 		"-vreplication_healthcheck_retry_delay", "1s",

--- a/go/trace/fake.go
+++ b/go/trace/fake.go
@@ -25,8 +25,10 @@ import (
 
 type noopTracingServer struct{}
 
-func (noopTracingServer) New(Span, string) Span                                     { return NoopSpan{} }
-func (noopTracingServer) NewClientSpan(parent Span, serviceName, label string) Span { return NoopSpan{} }
+func (noopTracingServer) New(Span, string) Span { return NoopSpan{} }
+func (noopTracingServer) NewClientSpan(parent Span, serviceName, label string) Span {
+	return NoopSpan{}
+}
 func (noopTracingServer) FromContext(context.Context) (Span, bool)                  { return nil, false }
 func (noopTracingServer) NewFromString(parent, label string) (Span, error)          { return NoopSpan{}, nil }
 func (noopTracingServer) NewContext(parent context.Context, _ Span) context.Context { return parent }

--- a/go/vt/topo/k8stopo/version.go
+++ b/go/vt/topo/k8stopo/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package k8stopo
 
 import (
+	"fmt"
 	"vitess.io/vitess/go/vt/topo"
 )
 
@@ -36,5 +37,5 @@ func VersionFromInt(version int64) topo.Version {
 	if version == -1 {
 		return nil
 	}
-	return KubernetesVersion(version)
+	return KubernetesVersion(fmt.Sprint(version))
 }

--- a/test.go
+++ b/test.go
@@ -75,7 +75,7 @@ For example:
 // Flags
 var (
 	flavor           = flag.String("flavor", "mysql57", "comma-separated bootstrap flavor(s) to run against (when using Docker mode). Available flavors: all,"+flavors)
-	bootstrapVersion = flag.String("bootstrap-version", "0", "the version identifier to use for the docker images")
+	bootstrapVersion = flag.String("bootstrap-version", "1", "the version identifier to use for the docker images")
 	runCount         = flag.Int("runs", 1, "run each test this many times")
 	retryMax         = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass          = flag.Bool("log-pass", false, "log test output even if it passes")


### PR DESCRIPTION
## Backport
NO

## Description
Updates the version of go used by CI to 1.15, this also adds in a CI test to ensure we don't drift the bootstrap version

## Impacted Areas in Vitess
- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 
