### PR TITLE
Online DDL executor databae pool size increase

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -102,6 +102,7 @@ const (
 	maxPasswordLength             = 32 // MySQL's *replication* password may not exceed 32 characters
 	staleMigrationMinutes         = 10
 	progressPctFull       float64 = 100.0
+	databasePoolSize              = 3
 )
 
 var (
@@ -156,8 +157,8 @@ func NewExecutor(env tabletenv.Env, tabletAlias topodatapb.TabletAlias, ts *topo
 		env:         env,
 		tabletAlias: &tabletAlias,
 
-		pool: connpool.NewPool(env, "ExecutorPool", tabletenv.ConnPoolConfig{
-			Size:               1,
+		pool: connpool.NewPool(env, "OnlineDDLExecutorPool", tabletenv.ConnPoolConfig{
+			Size:               databasePoolSize,
 			IdleTimeoutSeconds: env.Config().OltpReadPool.IdleTimeoutSeconds,
 		}),
 		tabletTypeFunc: tabletTypeFunc,


### PR DESCRIPTION
## Backport
NO

## Status
READY

## Description
Fixing an issue raised in chat by @aquarapid, this PR:

- Uses more explicit name for the online DDL executor database pool
- Sets pool size to `3` rather than `1`. Originally I thought all operations would necessarily be sequential, and so set max pool size to `1`. Operations are not all sequential now, and in hindsight it was wrong to set to `1`.  

## Impacted Areas in Vitess

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
