### PR TITLE
Do vschema_customer_sharded.json before create_customer_sharded.sql.

### DIFF
--- a/examples/local/301_customer_sharded.sh
+++ b/examples/local/301_customer_sharded.sh
@@ -24,5 +24,5 @@ source ./env.sh
 
 vtctlclient ApplySchema -sql-file create_commerce_seq.sql commerce
 vtctlclient ApplyVSchema -vschema_file vschema_commerce_seq.json commerce
-vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer
 vtctlclient ApplyVSchema -vschema_file vschema_customer_sharded.json customer
+vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer


### PR DESCRIPTION
When doing create_customer_sharded.sql (removing auto-increments) before vschema_customer_sharded.json (applying VIndex), there is a short period of time where INSERTs in the customer and corder tables would fail if the customer_id or order_id is not set.  Doing vschema_customer_sharded.json before create_customer_sharded.sql remove this failure possibility.