### PR TITLE
make docker_local: fix missing mysql_server package

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -4,7 +4,11 @@ ARG image="vitess/bootstrap:${bootstrap_version}-common"
 FROM "${image}"
 
 RUN apt-get update
-RUN apt-get install -y sudo curl vim jq mysql-server
+RUN apt-get install -y sudo curl vim jq
+
+# Install dependencies
+COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql57
 
 COPY docker/local/install_local_dependencies.sh /vt/dist/install_local_dependencies.sh
 RUN /vt/dist/install_local_dependencies.sh


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
We use `docker/lite/install_dependencies.sh` to install mysql57 server and client

## Related Issue(s)
An internal discussion leading to the finding that `make docker_local` is broken:

```
$ make docker_local
Building vitess/local
Sending build context to Docker daemon  245.5MB
Step 1/20 : ARG bootstrap_version=0
Step 2/20 : ARG image="vitess/bootstrap:${bootstrap_version}-common"
Step 3/20 : FROM "${image}"
0-common: Pulling from vitess/bootstrap
b5fccd3d6845: Pull complete 
c25b21fd76f9: Pull complete 
ae6bd386dfb5: Pull complete 
66273862a1f5: Pull complete 
8dd00d46b611: Pull complete 
3a2640662882: Pull complete 
c7af44a17df4: Pull complete 
20e3098c40d6: Pull complete 
e5b9ee5cef7e: Pull complete 
45a16634d019: Pull complete 
341a945a6f03: Pull complete 
c2ee08fcd4ea: Pull complete 
241f187361b4: Pull complete 
1584544faa4a: Pull complete 
Digest: sha256:6351632555d1452e42fe683bc138e1c2234b99bfb4991d758dd74358d0bed8bd
Status: Downloaded newer image for vitess/bootstrap:0-common
 ---> 719ddf079ea4
Step 4/20 : RUN apt-get update
 ---> Running in 5862f956adc6
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [121 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Get:4 http://security.debian.org/debian-security buster/updates/main amd64 Packages [256 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7907 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [7856 B]
Fetched 8410 kB in 4s (2395 kB/s)
Reading package lists...
Removing intermediate container 5862f956adc6
 ---> cea4dd0a127c
Step 5/20 : RUN apt-get install -y sudo curl vim jq mysql-server
 ---> Running in 17b19a8e0597
Reading package lists...
Building dependency tree...
Reading state information...
Package mysql-server is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'mysql-server' has no installation candidate
The command '/bin/sh -c apt-get install -y sudo curl vim jq mysql-server' returned a non-zero code: 100
make: *** [Makefile:240: docker_local] Error 100
```

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 

cc @askdba 