### PR TITLE
keep-heartbeat-reader-running-on-master

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/repltracker.go
+++ b/go/vt/vttablet/tabletserver/repltracker/repltracker.go
@@ -87,7 +87,6 @@ func (rt *ReplTracker) MakeMaster() {
 
 	rt.isMaster = true
 	if rt.mode == tabletenv.Heartbeat {
-		rt.hr.Close()
 		rt.hw.Open()
 	}
 	if rt.forceHeartbeat {


### PR DESCRIPTION
From Slack discussion: https://vitess.slack.com/archives/C0PQY0PTK/p1606781256023700

Signed-off-by: Andrei Sura <andrei.sura@sharpspring.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
"...the issue is, when you stop the ticker under that condition, the lag
metric gets frozen at a value, but continues to be exported.  This leads
to problematic metric values wherein e.g. you have a replica constantly
reporting 10 seconds of lag, and there’s no simple way in prometheus to
determine that this is the lag of the replica that is the master at that
point in time
"


## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
