### PR TITLE
Add @ajm188 + @doeg as vtadmin codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /go/test/endtoend/vtgate @harshit-gangal @systay
 /go/vt/discovery @deepthi
 /go/vt/mysqlctl @deepthi
+/go/vt/proto/vtadmin @ajm188 @doeg
 /go/vt/orchestrator @deepthi @shlomi-noach
 /go/vt/schema @shlomi-noach
 /go/vt/sqlparser @harshit-gangal @systay
@@ -28,7 +29,8 @@
 /go/vt/vttablet/tabletserver @harshit-gangal @systay @shlomi-noach
 /go/vt/wrangler @deepthi @rohit-nayak-ps
 /helm/ @derekperkins @dkhenry
+/proto/vtadmin.proto @ajm188 @doeg
 /proto/vtctldata.proto @ajm188 @doeg
 /proto/vtctlservice.proto @ajm188 @doeg
-/web/vtctld2 @rohit-nayak-ps
 /web/vtadmin @ajm188 @doeg
+/web/vtctld2 @rohit-nayak-ps


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description
We forgot to add ourselves as codeowners to a couple of vtadmin-related files 😸 

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/7202
- https://github.com/vitessio/vitess/pull/7187

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
