### PR TITLE
fix meta data related operation hang when zk down

### DIFF
--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -341,6 +341,8 @@ func (c *ZkConn) handleSessionEvents(conn *zk.Conn, session <-chan zk.Event) {
 func dialZk(ctx context.Context, addr string) (*zk.Conn, <-chan zk.Event, error) {
 	servers := strings.Split(addr, ",")
 	dialer := zk.WithDialer(net.DialTimeout)
+	ctx, cancel := context.WithTimeout(ctx, *baseTimeout)
+	defer cancel()
 	// If TLS is enabled use a TLS enabled dialer option
 	if *certPath != "" && *keyPath != "" {
 		if strings.Contains(addr, ",") {


### PR DESCRIPTION
Signed-off-by: JohnnyThree <whereshallyoube@gmail.com>

## How we reproduce the problem:
### 1.Bring up a normal vitess cluster with zk2 topo implementation
### 2.Execute zk-down.sh, Destroy zk cluster.
### 3.Execute an cmd related with meta data & cmd hang there
![image](https://user-images.githubusercontent.com/2297199/103217485-a8eab780-4953-11eb-86a6-56b70f82d1d5.png)
### 4. After Pr Modified:
![image](https://user-images.githubusercontent.com/2297199/103217595-ea7b6280-4953-11eb-870b-3e239671923f.png)

### Conclusion:
DialZK timeout seems does not take effect under such situation .
So here set context with timeout to make sure that dialZk will perform as expected



<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
