### PR TITLE
[vtadmin] Add static file service discovery implementation

### DIFF
--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 15000:15000 -p 15001:15001 --rm -it vitess/local
+docker run -p 15000:15000 -p 15001:15001 -p 15991:15991 --rm -it vitess/local

--- a/go/vt/vtadmin/cluster/discovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery.go
@@ -91,4 +91,5 @@ func New(impl string, cluster *vtadminpb.Cluster, args []string) (Discovery, err
 
 func init() { // nolint:gochecknoinits
 	Register("consul", NewConsul)
+	Register("staticFile", NewStaticFile)
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
@@ -28,7 +28,22 @@ import (
 )
 
 // StaticFileDiscovery implements the Discovery interface for "discovering"
-// Vitess components hardcoded in a static .json file.
+// Vitess components hardcoded in a static JSON file.
+//
+// As an example, here's a minimal JSON file for a single Vitess cluster running locally
+// (such as the one described in https://vitess.io/docs/get-started/local-docker):
+//
+// 		{
+// 			"vtgates": [
+// 				{
+// 					"host": {
+// 						"hostname": "127.0.0.1:15991"
+// 					}
+// 				}
+// 			]
+// 		}
+//
+// For more examples of various static file configurations, see the unit tests.
 type StaticFileDiscovery struct {
 	cluster *vtadminpb.Cluster
 	config  *StaticFileClusterConfig

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"math/rand"
+
+	"github.com/spf13/pflag"
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
+)
+
+// StaticFileDiscovery implements the Discovery interface for "discovering"
+// Vitess components hardcoded in a static .json file.
+type StaticFileDiscovery struct {
+	cluster *vtadminpb.Cluster
+	config  *StaticFileClusterConfig
+	gates   struct {
+		byName map[string]*vtadminpb.VTGate
+		byTag  map[string][]*vtadminpb.VTGate
+	}
+}
+
+// StaticFileClusterConfig configures Vitess components for a single cluster.
+type StaticFileClusterConfig struct {
+	VTGates []*StaticFileVTGateConfig `json:"vtgates,omitempty"`
+}
+
+// StaticFileVTGateConfig contains host and tag information for a single VTGate in a cluster.
+type StaticFileVTGateConfig struct {
+	Host *vtadminpb.VTGate `json:"host"`
+	Tags []string          `json:"tags"`
+}
+
+// NewStaticFile returns a StaticFileDiscovery for the given cluster.
+func NewStaticFile(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []string) (Discovery, error) {
+	disco := &StaticFileDiscovery{
+		cluster: cluster,
+	}
+
+	filePath := flags.String("path", "", "path to the service discovery JSON config file")
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if filePath == nil || *filePath == "" {
+		return nil, errors.New("must specify path to the service discovery JSON config file")
+	}
+
+	b, err := ioutil.ReadFile(*filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := disco.parseConfig(b); err != nil {
+		return nil, err
+	}
+
+	return disco, nil
+}
+
+func (d *StaticFileDiscovery) parseConfig(bytes []byte) error {
+	if err := json.Unmarshal(bytes, &d.config); err != nil {
+		return err
+	}
+
+	d.gates.byName = make(map[string]*vtadminpb.VTGate, len(d.config.VTGates))
+	d.gates.byTag = make(map[string][]*vtadminpb.VTGate)
+
+	// Index the gates by name and by tag for easier lookups
+	for _, gate := range d.config.VTGates {
+		d.gates.byName[gate.Host.Hostname] = gate.Host
+
+		for _, tag := range gate.Tags {
+			d.gates.byTag[tag] = append(d.gates.byTag[tag], gate.Host)
+		}
+	}
+	return nil
+}
+
+// DiscoverVTGate is part of the Discovery interface.
+func (d *StaticFileDiscovery) DiscoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
+	gates, err := d.DiscoverVTGates(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	count := len(gates)
+	if count == 0 {
+		return nil, ErrNoVTGates
+	}
+
+	gate := gates[rand.Intn(len(gates))]
+	return gate, nil
+}
+
+// DiscoverVTGateAddr is part of the Discovery interface.
+func (d *StaticFileDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string) (string, error) {
+	gate, err := d.DiscoverVTGate(ctx, tags)
+	if err != nil {
+		return "", err
+	}
+
+	return gate.Hostname, nil
+}
+
+// DiscoverVTGates is part of the Discovery interface.
+func (d *StaticFileDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
+	if len(tags) == 0 {
+		results := []*vtadminpb.VTGate{}
+		for _, g := range d.gates.byName {
+			results = append(results, g)
+		}
+
+		return results, nil
+	}
+
+	set := d.gates.byName
+
+	for _, tag := range tags {
+		intermediate := map[string]*vtadminpb.VTGate{}
+
+		gates, ok := d.gates.byTag[tag]
+		if !ok {
+			return []*vtadminpb.VTGate{}, nil
+		}
+
+		for _, g := range gates {
+			if _, ok := set[g.Hostname]; ok {
+				intermediate[g.Hostname] = g
+			}
+		}
+
+		set = intermediate
+	}
+
+	results := make([]*vtadminpb.VTGate, 0, len(set))
+
+	for _, gate := range set {
+		results = append(results, gate)
+	}
+
+	return results, nil
+}

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
@@ -225,7 +225,7 @@ func TestDiscoverVTGates(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, gates)
+			assert.ElementsMatch(t, tt.expected, gates)
 		})
 	}
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/vt/proto/vtadmin"
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
+)
+
+func TestDiscoverVTGate(t *testing.T) {
+	tests := []struct {
+		name      string
+		contents  []byte
+		expected  *vtadminpb.VTGate
+		tags      []string
+		shouldErr bool
+	}{
+		{
+			name:      "empty config",
+			contents:  []byte(`{}`),
+			expected:  nil,
+			shouldErr: true,
+		},
+		{
+			name: "one gate",
+			contents: []byte(`
+				{
+					"vtgates": [{
+						"host": {
+							"hostname": "127.0.0.1:12345"
+						}
+					}]
+				}
+			`),
+			expected: &vtadmin.VTGate{
+				Hostname: "127.0.0.1:12345",
+			},
+		},
+		{
+			name: "filtered by tags (one match)",
+			contents: []byte(`
+				{
+					"vtgates": [
+						{
+							"host": {
+								"hostname": "127.0.0.1:11111"
+							},
+							"tags": ["cell:cellA"]
+						}, 
+						{
+							"host": {
+								"hostname": "127.0.0.1:22222"
+							},
+							"tags": ["cell:cellB"]
+						},
+						{
+							"host": {
+								"hostname": "127.0.0.1:33333"
+							},
+							"tags": ["cell:cellA"]
+						}
+					]
+				}
+			`),
+			expected: &vtadminpb.VTGate{
+				Hostname: "127.0.0.1:22222",
+			},
+			tags: []string{"cell:cellB"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disco := &StaticFileDiscovery{}
+			err := disco.parseConfig(tt.contents)
+			require.NoError(t, err)
+
+			gate, err := disco.DiscoverVTGate(context.Background(), tt.tags)
+			if tt.shouldErr {
+				assert.Error(t, err, assert.AnError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, gate)
+		})
+	}
+}
+
+func TestDiscoverVTGates(t *testing.T) {
+	tests := []struct {
+		name      string
+		contents  []byte
+		tags      []string
+		expected  []*vtadminpb.VTGate
+		shouldErr bool
+	}{
+		{
+			name:      "empty config",
+			contents:  []byte(`{}`),
+			expected:  []*vtadminpb.VTGate{},
+			shouldErr: false,
+		},
+		{
+			name: "no tags",
+			contents: []byte(`
+				{
+					"vtgates": [
+						{
+							"host": {
+								"hostname": "127.0.0.1:12345"
+							}
+						},
+						{
+							"host": {
+								"hostname": "127.0.0.1:67890"
+							}
+						}
+					]
+				}
+			`),
+			expected: []*vtadminpb.VTGate{
+				{Hostname: "127.0.0.1:12345"},
+				{Hostname: "127.0.0.1:67890"},
+			},
+			shouldErr: false,
+		},
+		{
+			name: "filtered by tags",
+			contents: []byte(`
+				{
+					"vtgates": [
+						{
+							"host": {
+								"hostname": "127.0.0.1:11111"
+							},
+							"tags": ["cell:cellA"]
+						}, 
+						{
+							"host": {
+								"hostname": "127.0.0.1:22222"
+							},
+							"tags": ["cell:cellB"]
+						},
+						{
+							"host": {
+								"hostname": "127.0.0.1:33333"
+							},
+							"tags": ["cell:cellA"]
+						}
+					]
+				}
+			`),
+			tags: []string{"cell:cellA"},
+			expected: []*vtadminpb.VTGate{
+				{Hostname: "127.0.0.1:11111"},
+				{Hostname: "127.0.0.1:33333"},
+			},
+			shouldErr: false,
+		},
+		{
+			name: "filtered by multiple tags",
+			contents: []byte(`
+				{
+					"vtgates": [
+						{
+							"host": {
+								"hostname": "127.0.0.1:11111"
+							},
+							"tags": ["cell:cellA"]
+						}, 
+						{
+							"host": {
+								"hostname": "127.0.0.1:22222"
+							},
+							"tags": ["cell:cellA", "pool:poolZ"]
+						},
+						{
+							"host": {
+								"hostname": "127.0.0.1:33333"
+							},
+							"tags": ["pool:poolZ"]
+						}
+					]
+				}
+			`),
+			tags: []string{"cell:cellA", "pool:poolZ"},
+			expected: []*vtadminpb.VTGate{
+				{Hostname: "127.0.0.1:22222"},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disco := &StaticFileDiscovery{}
+
+			err := disco.parseConfig(tt.contents)
+			require.NoError(t, err)
+
+			gates, err := disco.DiscoverVTGates(context.Background(), tt.tags)
+			if tt.shouldErr {
+				assert.Error(t, err, assert.AnError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, gates)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>


## Description

Two changes in this PR:
- Adds a service discovery implementation using static files
- Exposes the vtgate gRPC port `:15991` in `./docker/local/run.sh` so that vtadmin (running outside of Docker) can issue requests

The best part is that now we can run vtadmin-api _and_ vtadmin-web locally, using a local Vitess ([in Docker](https://vitess.io/docs/get-started/local-docker/) or otherwise). 🎉 So we can add data fetching (and real data) to vtadmin-web 😈 finally the fun begins. 

We can enhance this later on by watching the cluster config file(s) for changes so updates don't require a restart of vtadmin-api. 

Many thanks as always to @ajm188 for answering my eight million golang questions! 💛 

### Running it locally

First, you'll want to run Vitess itself locally. 😸 I always run Vitess [using Docker](https://vitess.io/docs/get-started/local-docker/) but this works fine with [uncontainerized local Vitess too](https://vitess.io/docs/get-started/local/). 

(@shlomi-noach, thank you again for the fix in #7213!) 

```bash
# Note that you'll want to use Shlomi's fix in PR #7213 for this step...
make docker_local

# ... and then switch back to this branch to run it, so that we expose the gRPC port 15991
./docker/local/run.sh
```

Second, you'll need to create an empty vtgate credentials file to avoid the gRPC dialer bug mentioned in https://github.com/vitessio/vitess/pull/7187. Location and filename don't matter since you'll be passing this in as a flag; I put mine at ` /Users/sarabee/id1-grpc_vtgate_credentials.json`:

```json
{
	"Username": "",
	"Password": ""
}
```

Third, you'll want to create a cluster configuration file. This is the "static file" part of "static file service discovery". Assuming you're using the standard local Vitess set-up, you can steal this file as-is. (It comes with an entry for a bogus vtgate host to demonstrate that tagging works.) Again, filename and location don't matter since we'll be passing in the path as a flag; I put mine at `/Users/sarabee/vtadmin-cluster1.json`. 

```json
{
	"vtgates": [
		{
			"host": {
				"hostname": "127.0.0.1:15991"
			},
			"tags": ["pool:pool1", "cell:zone1", "extra:tag"]
		},
		{
			"host": {
				"hostname": "127.0.0.1:15992"
			},
			"tags": ["dead-dove-do-not-eat"]
		}
	]
}
```

Fourth, build this branch if you haven't already:

```
make build
```

Fifth, start up vtadmin-api but **make sure to update the filepaths** for the vtgate creds file and static service discovery file you created above!

```bash
./bin/vtadmin \
    --addr ":15999" \
    --cluster-defaults "vtsql-credentials-path-tmpl=/Users/sarabee/id1-grpc_vtgate_credentials.json" \
    --cluster "name=cluster1,id=id1,discovery=staticFile,discovery-staticFile-path=/Users/sarabee/vtadmin-cluster1.json,vtsql-discovery-tags=cell:zone1" 
```

Sixth and finally, we can curl vtadmin-api and get a valid response! 🎉 

```bash
$ curl 127.0.0.1:15999/api/tablets

{"result":{"tablets":[{"cluster":{"id":"id1","name":"cluster1"},"tablet":{"alias":{"cell":"zone1","uid":100},"hostname":"2780467e90c9","keyspace":"commerce","shard":"0","type":1,"master_term_start_time":{"seconds":1609176750}},"state":1},{"cluster":{"id":"id1","name":"cluster1"},"tablet":{"alias":{"cell":"zone1","uid":101},"hostname":"2780467e90c9","keyspace":"commerce","shard":"0","type":2},"state":1},{"cluster":{"id":"id1","name":"cluster1"},"tablet":{"alias":{"cell":"zone1","uid":102},"hostname":"2780467e90c9","keyspace":"commerce","shard":"0","type":3},"state":1}]},"ok":true}
```

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/7187 Initial vtadmin-api PR which contains the Consul service discovery implementation.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
N/A since vtadmin isn't in the deployment path :D 

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
