### PR TITLE
DropSources: change table rename logic

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test_env.go
+++ b/go/test/endtoend/vreplication/vreplication_test_env.go
@@ -97,8 +97,8 @@ var dryRunResultsSwitchWritesM2m3 = []string{
 var dryRunResultsDropSourcesDropCustomerShard = []string{
 	"Lock keyspace product",
 	"Lock keyspace customer",
-	"Dropping following tables from the database and from the vschema for keyspace product:",
-	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer RemovalType DROP TABLE",
+	"Dropping these tables from the database and removing them from the vschema for keyspace product:",
+	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer",
 	"Blacklisted tables customer will be removed from:",
 	"	Keyspace product Shard 0 Tablet 100",
 	"Delete reverse vreplication streams on source:",
@@ -114,8 +114,8 @@ var dryRunResultsDropSourcesDropCustomerShard = []string{
 var dryRunResultsDropSourcesRenameCustomerShard = []string{
 	"Lock keyspace product",
 	"Lock keyspace customer",
-	"Dropping following tables from the database and from the vschema for keyspace product:",
-	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer RemovalType RENAME TABLE",
+	"Renaming these tables from the database and removing them from the vschema for keyspace product:",
+	"	Keyspace product Shard 0 DbName vt_product Tablet 100 Table customer",
 	"Blacklisted tables customer will be removed from:",
 	"	Keyspace product Shard 0 Tablet 100",
 	"Delete reverse vreplication streams on source:",

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -234,14 +234,17 @@ func (dr *switcherDryRun) removeSourceTables(ctx context.Context, removalType Ta
 	logs := make([]string, 0)
 	for _, source := range dr.ts.sources {
 		for _, tableName := range dr.ts.tables {
-			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s RemovalType %s",
-				source.master.Keyspace, source.master.Shard, source.master.DbName(), source.master.Alias.Uid, tableName,
-				removalType))
+			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s",
+				source.master.Keyspace, source.master.Shard, source.master.DbName(), source.master.Alias.Uid, tableName))
 		}
 	}
+	action := "Dropping"
+	if removalType == RenameTable {
+		action = "Renaming"
+	}
 	if len(logs) > 0 {
-		dr.drLog.Log(fmt.Sprintf("Dropping following tables from the database and from the vschema for keyspace %s:",
-			dr.ts.sourceKeyspace))
+		dr.drLog.Log(fmt.Sprintf("%s these tables from the database and removing them from the vschema for keyspace %s:",
+			action, dr.ts.sourceKeyspace))
 		dr.drLog.LogSlice(logs)
 	}
 	return nil
@@ -335,7 +338,7 @@ func (dr *switcherDryRun) removeTargetTables(ctx context.Context) error {
 		}
 	}
 	if len(logs) > 0 {
-		dr.drLog.Log(fmt.Sprintf("Dropping following tables from the database and from the vschema for keyspace %s:",
+		dr.drLog.Log(fmt.Sprintf("Dropping these tables from the database and removing from the vschema for keyspace %s:",
 			dr.ts.targetKeyspace))
 		dr.drLog.LogSlice(logs)
 	}

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -1485,7 +1486,7 @@ func getRenameFileName(tableName string) string {
 }
 
 func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
-		err := ts.forAllSources(func(source *tsSource) error {
+	err := ts.forAllSources(func(source *tsSource) error {
 		for _, tableName := range ts.tables {
 			query := fmt.Sprintf("drop table %s.%s", source.master.DbName(), tableName)
 			if removalType == DropTable {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -49,6 +49,8 @@ import (
 const (
 	frozenStr      = "FROZEN"
 	errorNoStreams = "no streams found in keyspace %s for: %s"
+	// use pt-osc's naming convention, this format also ensures vstreamer ignores such tables
+	renameTableTemplate = "_%.59s_old" // limit table name to 64 characters
 )
 
 // TrafficSwitchDirection specifies the switching direction.
@@ -1478,14 +1480,18 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 
 }
 
-func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) (err error) {
-	err = ts.forAllSources(func(source *tsSource) error {
+func getRenameFileName(tableName string) string {
+	return fmt.Sprintf(renameTableTemplate, tableName)
+}
+
+func (ts *trafficSwitcher) removeSourceTables(ctx context.Context, removalType TableRemovalType) error {
+		err := ts.forAllSources(func(source *tsSource) error {
 		for _, tableName := range ts.tables {
 			query := fmt.Sprintf("drop table %s.%s", source.master.DbName(), tableName)
 			if removalType == DropTable {
 				ts.wr.Logger().Infof("Dropping table %s.%s\n", source.master.DbName(), tableName)
 			} else {
-				renameName := fmt.Sprintf("_%.63s", tableName)
+				renameName := getRenameFileName(tableName)
 				ts.wr.Logger().Infof("Renaming table %s.%s to %s.%s\n", source.master.DbName(), tableName, source.master.DbName(), renameName)
 				query = fmt.Sprintf("rename table %s.%s TO %s.%s", source.master.DbName(), tableName, source.master.DbName(), renameName)
 			}

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"context"
+
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -884,7 +885,7 @@ func TestTableMigrateOneToMany(t *testing.T) {
 	wantdryRunRenameSources := []string{
 		"Lock keyspace ks1",
 		"Lock keyspace ks2",
-		"Renaming these tables from the database and removing them from the vschema for keyspace ks1:","	" +
+		"Renaming these tables from the database and removing them from the vschema for keyspace ks1:", "	" +
 			"Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t1",
 		"	Keyspace ks1 Shard 0 DbName vt_ks1 Tablet 10 Table t2",
 		"Blacklisted tables t1,t2 will be removed from:",


### PR DESCRIPTION
## Description
DropSources (achieved via the Complete subcommand in the v2 MoveTables command) supports a rename flag for MoveTables workflows. Tables are renamed as _<table_name> (see PR https://github.com/vitessio/vitess/pull/6383) . This change uses a similar logic to that used by pt-osc when it drops tables using the rename template _<table_name>_old. 

Reasons:

    * we now use a more standard convention
    * VReplication already ignores such tables, so they won't show up in vreplication workflows and vstream api events
     
## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required 
https://github.com/vitessio/website/pull/655

## Impacted Areas in Vitess

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
