### PR TITLE
Use `context` from Go's standard library

### DIFF
--- a/go/cmd/automation_client/automation_client.go
+++ b/go/cmd/automation_client/automation_client.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/cmd"
 	"vitess.io/vitess/go/exit"

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -28,7 +28,7 @@ import (
 
 	"vitess.io/vitess/go/cmd"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtctld/schema.go
+++ b/go/cmd/vtctld/schema.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/cmd/vtgateclienttest/services/callerid.go
+++ b/go/cmd/vtgateclienttest/services/callerid.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"

--- a/go/cmd/vtgateclienttest/services/echo.go
+++ b/go/cmd/vtgateclienttest/services/echo.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"

--- a/go/cmd/vtgateclienttest/services/errors.go
+++ b/go/cmd/vtgateclienttest/services/errors.go
@@ -19,7 +19,7 @@ package services
 import (
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/cmd/vtgateclienttest/services/fallback.go
+++ b/go/cmd/vtgateclienttest/services/fallback.go
@@ -17,7 +17,7 @@ limitations under the License.
 package services
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/vtgateservice"

--- a/go/cmd/vtgateclienttest/services/terminal.go
+++ b/go/cmd/vtgateclienttest/services/terminal.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"io/ioutil"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/log"

--- a/go/cmd/vtworkerclient/vtworkerclient.go
+++ b/go/cmd/vtworkerclient/vtworkerclient.go
@@ -22,7 +22,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/worker/vtworkerclient"

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -32,9 +32,9 @@ import (
 	"syscall"
 	"time"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
 	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttls"

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // assertSQLError makes sure we get the right error.

--- a/go/mysql/endtoend/client_test.go
+++ b/go/mysql/endtoend/client_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/mysql/endtoend/query_benchmark_test.go
+++ b/go/mysql/endtoend/query_benchmark_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	vttestpb "vitess.io/vitess/go/vt/proto/vttest"

--- a/go/mysql/endtoend/query_test.go
+++ b/go/mysql/endtoend/query_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -27,7 +27,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type filePosFlavor struct {

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/tlstest"
 	"vitess.io/vitess/go/vt/vttls"

--- a/go/mysql/query_benchmark_test.go
+++ b/go/mysql/query_benchmark_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var testReadConnBufferSize = connBufferSize

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -29,9 +29,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	vtenv "vitess.io/vitess/go/vt/env"

--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/timer"

--- a/go/pools/resource_pool_flaky_test.go
+++ b/go/pools/resource_pool_flaky_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sync2"
 )
 

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -67,9 +67,9 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"

--- a/go/trace/fake.go
+++ b/go/trace/fake.go
@@ -19,14 +19,16 @@ package trace
 import (
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 )
 
 type noopTracingServer struct{}
 
-func (noopTracingServer) New(Span, string) Span                                     { return NoopSpan{} }
-func (noopTracingServer) NewClientSpan(parent Span, serviceName, label string) Span { return NoopSpan{} }
+func (noopTracingServer) New(Span, string) Span { return NoopSpan{} }
+func (noopTracingServer) NewClientSpan(parent Span, serviceName, label string) Span {
+	return NoopSpan{}
+}
 func (noopTracingServer) FromContext(context.Context) (Span, bool)                  { return nil, false }
 func (noopTracingServer) NewFromString(parent, label string) (Span, error)          { return NoopSpan{}, nil }
 func (noopTracingServer) NewContext(parent context.Context, _ Span) context.Context { return parent }

--- a/go/trace/opentracing.go
+++ b/go/trace/opentracing.go
@@ -20,9 +20,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
+	"context"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )

--- a/go/trace/trace.go
+++ b/go/trace/trace.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/trace/trace_test.go
+++ b/go/trace/trace_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 )
 

--- a/go/vt/automation/copy_schema_shard_task.go
+++ b/go/vt/automation/copy_schema_shard_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 )
 

--- a/go/vt/automation/migrate_served_from_task.go
+++ b/go/vt/automation/migrate_served_from_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/migrate_served_types_task.go
+++ b/go/vt/automation/migrate_served_types_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/rebuild_keyspace_graph_task.go
+++ b/go/vt/automation/rebuild_keyspace_graph_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 )
 

--- a/go/vt/automation/scheduler.go
+++ b/go/vt/automation/scheduler.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/automation/scheduler_test.go
+++ b/go/vt/automation/scheduler_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	context "context"
 	"github.com/golang/protobuf/proto"
-	context "golang.org/x/net/context"
 
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 )

--- a/go/vt/automation/split_clone_task.go
+++ b/go/vt/automation/split_clone_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/split_diff_task.go
+++ b/go/vt/automation/split_diff_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/vertical_split_diff_task.go
+++ b/go/vt/automation/vertical_split_diff_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/automation/vertical_split_task_test.go
+++ b/go/vt/automation/vertical_split_task_test.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/vtctl/fakevtctlclient"

--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"

--- a/go/vt/automation/vtworkerclient_wrapper.go
+++ b/go/vt/automation/vtworkerclient_wrapper.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/worker/vtworkerclient"

--- a/go/vt/automation/wait_for_filtered_replication_task.go
+++ b/go/vt/automation/wait_for_filtered_replication_task.go
@@ -17,7 +17,7 @@ limitations under the License.
 package automation
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	automationpb "vitess.io/vitess/go/vt/proto/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 )

--- a/go/vt/binlog/binlog_connection.go
+++ b/go/vt/binlog/binlog_connection.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/pools"

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"strings"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -29,8 +29,8 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/history"
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/throttler"

--- a/go/vt/binlog/binlogplayer/client.go
+++ b/go/vt/binlog/binlogplayer/client.go
@@ -19,7 +19,7 @@ package binlogplayer
 import (
 	"flag"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"

--- a/go/vt/binlog/binlogplayer/framework_test.go
+++ b/go/vt/binlog/binlogplayer/framework_test.go
@@ -23,8 +23,8 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/binlog/binlogplayertest/player.go
+++ b/go/vt/binlog/binlogplayertest/player.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/binlog/event_streamer.go
+++ b/go/vt/binlog/event_streamer.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -17,7 +17,7 @@ limitations under the License.
 package grpcbinlogplayer
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc"
 

--- a/go/vt/binlog/keyspace_id_resolver.go
+++ b/go/vt/binlog/keyspace_id_resolver.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/binlog/updatestream.go
+++ b/go/vt/binlog/updatestream.go
@@ -17,7 +17,7 @@ limitations under the License.
 package binlog
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/binlog/updatestreamctl.go
+++ b/go/vt/binlog/updatestreamctl.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/callerid/callerid.go
+++ b/go/vt/callerid/callerid.go
@@ -19,7 +19,7 @@ limitations under the License.
 package callerid
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"

--- a/go/vt/callerid/testsuite/testsuite.go
+++ b/go/vt/callerid/testsuite/testsuite.go
@@ -19,8 +19,8 @@ package testsuite
 import (
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/callerid"
 

--- a/go/vt/callinfo/callinfo.go
+++ b/go/vt/callinfo/callinfo.go
@@ -21,7 +21,7 @@ package callinfo
 import (
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // CallInfo is the extra data stored in the Context

--- a/go/vt/callinfo/plugin_grpc.go
+++ b/go/vt/callinfo/plugin_grpc.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 )

--- a/go/vt/callinfo/plugin_mysql.go
+++ b/go/vt/callinfo/plugin_mysql.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 )
 

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -37,7 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/status"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/discovery/legacy_healthcheck.go
+++ b/go/vt/discovery/legacy_healthcheck.go
@@ -48,8 +48,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/discovery/legacy_healthcheck.go
+++ b/go/vt/discovery/legacy_healthcheck.go
@@ -49,6 +49,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
@@ -766,6 +767,7 @@ func (hc *LegacyHealthCheckImpl) AddTablet(tablet *topodatapb.Tablet, name strin
 	if hc.addrToHealth == nil {
 		// already closed.
 		hc.mu.Unlock()
+		cancelFunc()
 		return
 	}
 	if th, ok := hc.addrToHealth[key]; ok {
@@ -774,6 +776,7 @@ func (hc *LegacyHealthCheckImpl) AddTablet(tablet *topodatapb.Tablet, name strin
 		if topoproto.TabletAliasEqual(th.latestTabletStats.Tablet.Alias, tablet.Alias) {
 			hc.mu.Unlock()
 			log.Warningf("refusing to add duplicate tablet %v for %v: %+v", name, tablet.Alias.Cell, tablet)
+			cancelFunc()
 			return
 		}
 		// If it's a different tablet, then we trust this new tablet that claims

--- a/go/vt/discovery/legacy_healthcheck_flaky_test.go
+++ b/go/vt/discovery/legacy_healthcheck_flaky_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/status"

--- a/go/vt/discovery/legacy_tablet_stats_cache.go
+++ b/go/vt/discovery/legacy_tablet_stats_cache.go
@@ -19,7 +19,7 @@ package discovery
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/discovery/legacy_tablet_stats_cache_wait.go
+++ b/go/vt/discovery/legacy_tablet_stats_cache_wait.go
@@ -19,7 +19,7 @@ package discovery
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/discovery/legacy_tablet_stats_cache_wait_test.go
+++ b/go/vt/discovery/legacy_tablet_stats_cache_wait_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/discovery/legacy_topology_watcher.go
+++ b/go/vt/discovery/legacy_topology_watcher.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/trace"
 
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/discovery/legacy_topology_watcher_test.go
+++ b/go/vt/discovery/legacy_topology_watcher_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -31,7 +31,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
-	"golang.org/x/net/context"
+	"context"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -22,10 +22,10 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/vt/key"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/trace"
 

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"io/ioutil"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 )
 

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -30,8 +30,8 @@ import (
 
 	"errors"
 
+	"context"
 	minio "github.com/minio/minio-go"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"

--- a/go/vt/mysqlctl/filebackupstorage/file_test.go
+++ b/go/vt/mysqlctl/filebackupstorage/file_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // This file tests the file BackupStorage engine.

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/storage"
-	"golang.org/x/net/context"
+	"context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlclient"

--- a/go/vt/mysqlctl/grpcmysqlctlserver/server.go
+++ b/go/vt/mysqlctl/grpcmysqlctlserver/server.go
@@ -23,7 +23,7 @@ package grpcmysqlctlserver
 import (
 	"google.golang.org/grpc"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/mysqlctl"
 
 	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"

--- a/go/vt/mysqlctl/metadata_tables.go
+++ b/go/vt/mysqlctl/metadata_tables.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mysqlctl
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/mysqlctl/mysqlctlclient/interface.go
+++ b/go/vt/mysqlctl/mysqlctlclient/interface.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 )
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -43,7 +43,7 @@ import (
 
 	rice "github.com/GeertJohan/go.rice"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/dbconnpool"

--- a/go/vt/mysqlctl/permissions.go
+++ b/go/vt/mysqlctl/permissions.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mysqlctl
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 )

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -29,7 +29,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // CreateReparentJournal returns the commands to execute to create

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/netutil"

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -39,6 +39,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -46,7 +47,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -28,7 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/schemamanager/local_controller.go
+++ b/go/vt/schemamanager/local_controller.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 )
 

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )

--- a/go/vt/schemamanager/plain_controller.go
+++ b/go/vt/schemamanager/plain_controller.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/schemamanager/plain_controller_test.go
+++ b/go/vt/schemamanager/plain_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestPlainController(t *testing.T) {

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/schema"

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"

--- a/go/vt/schemamanager/ui_controller.go
+++ b/go/vt/schemamanager/ui_controller.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 )
 

--- a/go/vt/schemamanager/ui_controller_test.go
+++ b/go/vt/schemamanager/ui_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestUIController(t *testing.T) {

--- a/go/vt/servenv/grpc_auth.go
+++ b/go/vt/servenv/grpc_auth.go
@@ -17,7 +17,7 @@ limitations under the License.
 package servenv
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/grpccommon"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vttls"

--- a/go/vt/servenv/grpc_server_auth_mtls.go
+++ b/go/vt/servenv/grpc_server_auth_mtls.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"

--- a/go/vt/servenv/grpc_server_test.go
+++ b/go/vt/servenv/grpc_server_test.go
@@ -19,7 +19,7 @@ package servenv
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc"
 )

--- a/go/vt/srvtopo/discover.go
+++ b/go/vt/srvtopo/discover.go
@@ -19,7 +19,7 @@ package srvtopo
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/srvtopo/discover_test.go
+++ b/go/vt/srvtopo/discover_test.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 

--- a/go/vt/srvtopo/keyspace_filtering_server.go
+++ b/go/vt/srvtopo/keyspace_filtering_server.go
@@ -19,7 +19,7 @@ package srvtopo
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"

--- a/go/vt/srvtopo/keyspace_filtering_server_test.go
+++ b/go/vt/srvtopo/keyspace_filtering_server_test.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/status"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/status"
 	"vitess.io/vitess/go/vt/topo"
@@ -308,7 +309,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 
 	time.Sleep(*srvTopoCacheTTL)
 
-	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2)
+	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2) //nolint
 	_, err = rs.GetSrvKeyspace(timeoutCtx, "test_cell", "test_ks")
 	wantErr := "timed out waiting for keyspace"
 	if err == nil || err.Error() != wantErr {
@@ -612,7 +613,7 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 
 	time.Sleep(*srvTopoCacheTTL)
 
-	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2)
+	timeoutCtx, _ := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2) //nolint
 	_, err = rs.GetSrvKeyspaceNames(timeoutCtx, "test_cell", false)
 	wantErr := "timed out waiting for keyspace names"
 	if err == nil || err.Error() != wantErr {

--- a/go/vt/srvtopo/resolver.go
+++ b/go/vt/srvtopo/resolver.go
@@ -19,8 +19,8 @@ package srvtopo
 import (
 	"sort"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/srvtopo/resolver_test.go
+++ b/go/vt/srvtopo/resolver_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/srvtopo/server.go
+++ b/go/vt/srvtopo/server.go
@@ -21,7 +21,7 @@ use the topology service in a serving environment.
 package srvtopo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"

--- a/go/vt/srvtopo/srvtopotest/passthrough.go
+++ b/go/vt/srvtopo/srvtopotest/passthrough.go
@@ -17,7 +17,7 @@ limitations under the License.
 package srvtopotest
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"

--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
@@ -20,7 +20,7 @@ package grpcthrottlerclient
 import (
 	"flag"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
+++ b/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
@@ -19,7 +19,7 @@ limitations under the License.
 package grpcthrottlerserver
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/servenv"

--- a/go/vt/throttler/throttlerclient/throttlerclient.go
+++ b/go/vt/throttler/throttlerclient/throttlerclient.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	throttlerdatapb "vitess.io/vitess/go/vt/proto/throttlerdata"
 )

--- a/go/vt/throttler/throttlerclienttest/throttlerclient_testsuite.go
+++ b/go/vt/throttler/throttlerclienttest/throttlerclient_testsuite.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/throttler"
 	"vitess.io/vitess/go/vt/throttler/throttlerclient"

--- a/go/vt/topo/cell_info.go
+++ b/go/vt/topo/cell_info.go
@@ -19,8 +19,8 @@ package topo
 import (
 	"path"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/cells_aliases.go
+++ b/go/vt/topo/cells_aliases.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"path"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -19,7 +19,7 @@ package topo
 import (
 	"sort"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Conn defines the interface that must be implemented by topology

--- a/go/vt/topo/consultopo/directory.go
+++ b/go/vt/topo/consultopo/directory.go
@@ -20,7 +20,7 @@ import (
 	"path"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -19,7 +19,7 @@ package consultopo
 import (
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/hashicorp/consul/api"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topo/consultopo/error.go
+++ b/go/vt/topo/consultopo/error.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"net/url"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -19,7 +19,7 @@ package consultopo
 import (
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/hashicorp/consul/api"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/consultopo/lock.go
+++ b/go/vt/topo/consultopo/lock.go
@@ -19,8 +19,8 @@ package consultopo
 import (
 	"path"
 
+	"context"
 	"github.com/hashicorp/consul/api"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -28,8 +28,8 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"context"
 	"github.com/hashicorp/consul/api"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/testfiles"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/test"

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -90,6 +90,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 				notifications <- &topo.WatchData{
 					Err: convertError(err, nodePath),
 				}
+				cancelGetCtx()
 				return
 			}
 
@@ -98,6 +99,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 				notifications <- &topo.WatchData{
 					Err: topo.NewError(topo.NoNode, nodePath),
 				}
+				cancelGetCtx()
 				return
 			}
 
@@ -115,6 +117,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 				notifications <- &topo.WatchData{
 					Err: convertError(watchCtx.Err(), nodePath),
 				}
+				cancelGetCtx()
 				return
 			default:
 			}

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/hashicorp/consul/api"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/etcd2topo/directory.go
+++ b/go/vt/topo/etcd2topo/directory.go
@@ -20,8 +20,8 @@ import (
 	"path"
 	"strings"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/etcd2topo/election.go
+++ b/go/vt/topo/etcd2topo/election.go
@@ -19,8 +19,8 @@ package etcd2topo
 import (
 	"path"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/etcd2topo/error.go
+++ b/go/vt/topo/etcd2topo/error.go
@@ -19,8 +19,8 @@ package etcd2topo
 import (
 	"errors"
 
+	"context"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/go/vt/topo/etcd2topo/file.go
+++ b/go/vt/topo/etcd2topo/file.go
@@ -19,8 +19,8 @@ package etcd2topo
 import (
 	"path"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"path"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/coreos/etcd/pkg/transport"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/coreos/etcd/clientv3"
 	"vitess.io/vitess/go/testfiles"

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -20,9 +20,9 @@ import (
 	"path"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
@@ -60,6 +61,8 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	// not have that much history.
 	watcher := s.cli.Watch(watchCtx, nodePath, clientv3.WithRev(initial.Header.Revision))
 	if watcher == nil {
+		watchCancel()
+		outerCancel()
 		return &topo.WatchData{Err: vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "Watch failed")}, nil, nil
 	}
 

--- a/go/vt/topo/helpers/compare.go
+++ b/go/vt/topo/helpers/compare.go
@@ -21,8 +21,8 @@ package helpers
 import (
 	"reflect"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/topo/helpers/compare_test.go
+++ b/go/vt/topo/helpers/compare_test.go
@@ -19,7 +19,7 @@ package helpers
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestBasicCompare(t *testing.T) {

--- a/go/vt/topo/helpers/copy.go
+++ b/go/vt/topo/helpers/copy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package helpers
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/topo/helpers/copy_test.go
+++ b/go/vt/topo/helpers/copy_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helpers
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/helpers/tee_test.go
+++ b/go/vt/topo/helpers/tee_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/topo/k8stopo/directory.go
+++ b/go/vt/topo/k8stopo/directory.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/k8stopo/election.go
+++ b/go/vt/topo/k8stopo/election.go
@@ -19,7 +19,7 @@ package k8stopo
 import (
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/k8stopo/file.go
+++ b/go/vt/topo/k8stopo/file.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go/vt/topo/k8stopo/lock.go
+++ b/go/vt/topo/k8stopo/lock.go
@@ -19,7 +19,7 @@ package k8stopo
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/go/vt/topo/k8stopo/watch.go
+++ b/go/vt/topo/k8stopo/watch.go
@@ -18,6 +18,7 @@ package k8stopo
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 
@@ -57,6 +58,7 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 	if err != nil {
 		// Per the topo.Conn interface:
 		// current.Err is set, and 'changes'/'cancel' are nil
+		watchCancel()
 		current.Err = err
 		return current, nil, nil
 	}

--- a/go/vt/topo/k8stopo/watch.go
+++ b/go/vt/topo/k8stopo/watch.go
@@ -17,7 +17,7 @@ limitations under the License.
 package k8stopo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -19,8 +19,8 @@ package topo
 import (
 	"path"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/event"

--- a/go/vt/topo/locks.go
+++ b/go/vt/topo/locks.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -17,7 +17,7 @@ limitations under the License.
 package memorytopo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -19,7 +19,7 @@ package memorytopo
 import (
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -19,7 +19,7 @@ package memorytopo
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/memorytopo/watch.go
+++ b/go/vt/topo/memorytopo/watch.go
@@ -19,7 +19,7 @@ package memorytopo
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/replication.go
+++ b/go/vt/topo/replication.go
@@ -19,8 +19,8 @@ package topo
 import (
 	"path"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/trace"

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -47,7 +47,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topo/shard.go
+++ b/go/vt/topo/shard.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/concurrency"

--- a/go/vt/topo/srv_vschema.go
+++ b/go/vt/topo/srv_vschema.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"sync"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/stats_conn.go
+++ b/go/vt/topo/stats_conn.go
@@ -19,7 +19,7 @@ package topo
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/stats"
 )

--- a/go/vt/topo/stats_conn_test.go
+++ b/go/vt/topo/stats_conn_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // The fakeConn is a wrapper for a Conn that emits stats for every operation

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/test/directory.go
+++ b/go/vt/topo/test/directory.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/test/election.go
+++ b/go/vt/topo/test/election.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/test/keyspace.go
+++ b/go/vt/topo/test/keyspace.go
@@ -19,7 +19,7 @@ package test
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/test/lock.go
+++ b/go/vt/topo/test/lock.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/test/replication.go
+++ b/go/vt/topo/test/replication.go
@@ -19,7 +19,7 @@ package test
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -19,8 +19,8 @@ package test
 import (
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/test/shard.go
+++ b/go/vt/topo/test/shard.go
@@ -19,7 +19,7 @@ package test
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/test/tablet.go
+++ b/go/vt/topo/test/tablet.go
@@ -19,8 +19,8 @@ package test
 import (
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/topo/test/vschema.go
+++ b/go/vt/topo/test/vschema.go
@@ -19,9 +19,9 @@ package test
 import (
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/topo"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/topo/test/watch.go
+++ b/go/vt/topo/test/watch.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/topo/topotests/cell_info_test.go
+++ b/go/vt/topo/topotests/cell_info_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topo/topotests/cells_aliases_test.go
+++ b/go/vt/topo/topotests/cells_aliases_test.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 

--- a/go/vt/topo/topotests/replication_test.go
+++ b/go/vt/topo/topotests/replication_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/topotests/shard_watch_test.go
+++ b/go/vt/topo/topotests/shard_watch_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topo/topotests/srv_keyspace_test.go
+++ b/go/vt/topo/topotests/srv_keyspace_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/json2"

--- a/go/vt/topo/topotests/srv_vschema_test.go
+++ b/go/vt/topo/topotests/srv_vschema_test.go
@@ -18,7 +18,7 @@ package topotests
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topo/topotests/tablet_test.go
+++ b/go/vt/topo/topotests/tablet_test.go
@@ -19,8 +19,8 @@ package topotests
 import (
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 

--- a/go/vt/topo/topotests/wildcards_test.go
+++ b/go/vt/topo/topotests/wildcards_test.go
@@ -19,7 +19,7 @@ package topotests
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -19,7 +19,7 @@ package topo
 import (
 	"path"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -19,8 +19,8 @@ package topo
 import (
 	"path"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	workflowpb "vitess.io/vitess/go/vt/proto/workflow"
 )

--- a/go/vt/topo/zk2topo/directory.go
+++ b/go/vt/topo/zk2topo/directory.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 )
 

--- a/go/vt/topo/zk2topo/election.go
+++ b/go/vt/topo/zk2topo/election.go
@@ -20,8 +20,8 @@ import (
 	"path"
 	"sort"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topo/zk2topo/error.go
+++ b/go/vt/topo/zk2topo/error.go
@@ -17,8 +17,8 @@ limitations under the License.
 package zk2topo
 
 import (
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/zk2topo/file.go
+++ b/go/vt/topo/zk2topo/file.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"path"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/zk2topo/lock.go
+++ b/go/vt/topo/zk2topo/lock.go
@@ -19,8 +19,8 @@ package zk2topo
 import (
 	"path"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topo/zk2topo/server_test.go
+++ b/go/vt/topo/zk2topo/server_test.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/testfiles"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/zk2topo/utils.go
+++ b/go/vt/topo/zk2topo/utils.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"sync"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/topo/zk2topo/watch.go
+++ b/go/vt/topo/zk2topo/watch.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/z-division/go-zookeeper/zk"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topotools/shard_test.go
+++ b/go/vt/topotools/shard_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/topotools/split.go
+++ b/go/vt/topotools/split.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sort"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/key"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -37,8 +37,8 @@ import (
 	"errors"
 	"fmt"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topotools/utils.go
+++ b/go/vt/topotools/utils.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/vtgateservice"

--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/vtctl/cell_info.go
+++ b/go/vt/vtctl/cell_info.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/vtctl/cells_aliases.go
+++ b/go/vt/vtctl/cells_aliases.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/wrangler"
 

--- a/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
+++ b/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
@@ -20,7 +20,7 @@ package fakevtctlclient
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 )

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -24,9 +24,9 @@ import (
 	"io"
 	"strconv"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/olekukonko/tablewriter"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/vtctl/throttler.go
+++ b/go/vt/vtctl/throttler.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/olekukonko/tablewriter"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/throttler"

--- a/go/vt/vtctl/topo.go
+++ b/go/vt/vtctl/topo.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -94,9 +94,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/flagutil"
 	"vitess.io/vitess/go/json2"

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vtctl/vtctlclient/wrapper.go
+++ b/go/vt/vtctl/vtctlclient/wrapper.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 )

--- a/go/vt/vtctl/vtctlclienttest/client.go
+++ b/go/vt/vtctl/vtctlclienttest/client.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vtctl/workflow.go
+++ b/go/vt/vtctl/workflow.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/workflow"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/vtctld/action_repository.go
+++ b/go/vt/vtctld/action_repository.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/netutil"

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/vtctld/debug_health.go
+++ b/go/vt/vtctld/debug_health.go
@@ -21,7 +21,7 @@ package vtctld
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vtctld/explorer.go
+++ b/go/vt/vtctld/explorer.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/vtctld/explorer_test.go
+++ b/go/vt/vtctld/explorer_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/vtctld/realtime_status.go
+++ b/go/vt/vtctld/realtime_status.go
@@ -19,7 +19,7 @@ package vtctld
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vtctld/realtime_status_test.go
+++ b/go/vt/vtctld/realtime_status_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtctld/schema.go
+++ b/go/vt/vtctld/schema.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/timer"

--- a/go/vt/vtctld/tablet_data.go
+++ b/go/vt/vtctld/tablet_data.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vtctld/tablet_data_test.go
+++ b/go/vt/vtctld/tablet_data_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -26,7 +26,7 @@ import (
 
 	rice "github.com/GeertJohan/go.rice"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/acl"

--- a/go/vt/vtctld/workflow.go
+++ b/go/vt/vtctld/workflow.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/trace"
 
 	"vitess.io/vitess/go/flagutil"

--- a/go/vt/vterrors/errors_test.go
+++ b/go/vt/vterrors/errors_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -90,7 +90,7 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 

--- a/go/vt/vtexplain/vtexplain_topo.go
+++ b/go/vt/vtexplain/vtexplain_topo.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -25,7 +25,7 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/json2"

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/vtgate/bench_test.go
+++ b/go/vt/vtgate/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"

--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vtgate/buffer/variables_test.go
+++ b/go/vt/vtgate/buffer/variables_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/stats"
 )

--- a/go/vt/vtgate/discoverygateway.go
+++ b/go/vt/vtgate/discoverygateway.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/discoverygateway_test.go
+++ b/go/vt/vtgate/discoverygateway_test.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/discoverygateway_test.go
+++ b/go/vt/vtgate/discoverygateway_test.go
@@ -179,7 +179,7 @@ func TestDiscoveryGatewayWaitForTablets(t *testing.T) {
 	dg.tsc.ResetForTesting()
 	hc.AddTestTablet(cell, "2.2.2.2", 1001, keyspace, shard, topodatapb.TabletType_REPLICA, true, 10, nil)
 	hc.AddTestTablet(cell, "1.1.1.1", 1001, keyspace, shard, topodatapb.TabletType_MASTER, true, 5, nil)
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second) //nolint
 	err := dg.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_REPLICA, topodatapb.TabletType_MASTER})
 	if err != nil {
 		t.Errorf("want %+v, got %+v", nil, err)
@@ -192,7 +192,7 @@ func TestDiscoveryGatewayWaitForTablets(t *testing.T) {
 	}
 
 	// errors because there is no primary on  ks2
-	ctx, _ = context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, _ = context.WithTimeout(context.Background(), 1*time.Second) //nolint
 	srvTopo.SrvKeyspaceNames = []string{keyspace, "ks2"}
 	err = dg.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_MASTER})
 	if err == nil {
@@ -201,7 +201,7 @@ func TestDiscoveryGatewayWaitForTablets(t *testing.T) {
 
 	discovery.KeyspacesToWatch = []string{keyspace}
 	// does not wait for ks2 if it's not part of the filter
-	ctx, _ = context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, _ = context.WithTimeout(context.Background(), 1*time.Second) //nolint
 	err = dg.WaitForTablets(ctx, []topodatapb.TabletType{topodatapb.TabletType_MASTER})
 	if err != nil {
 		t.Errorf("want %+v, got %+v", nil, err)

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -35,7 +35,7 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"vitess.io/vitess/go/vt/sqlparser"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -31,7 +31,7 @@ import (
 
 	"vitess.io/vitess/go/vt/sysvars"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	_ "vitess.io/vitess/go/vt/vtgate/vindexes"

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/executor_stream_test.go
+++ b/go/vt/vtgate/executor_stream_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vtgate/executor_vstream_test.go
+++ b/go/vt/vtgate/executor_vstream_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -25,7 +25,7 @@ import (
 	"math/rand"
 	"reflect"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/gateway_test_suite.go
+++ b/go/vt/vtgate/gateway_test_suite.go
@@ -28,7 +28,7 @@ package vtgate
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vtgate/grpc_discovery_test.go
+++ b/go/vt/vtgate/grpc_discovery_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/grpc"
 

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -22,7 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -26,7 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/grpcvtgateservice"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"

--- a/go/vt/vtgate/grpcvtgateconn/suite_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/suite_test.go
@@ -28,9 +28,9 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/tb"

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/callinfo"

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/stretchr/testify/require"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"

--- a/go/vt/vtgate/mysql_protocol_test.go
+++ b/go/vt/vtgate/mysql_protocol_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -32,7 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/trace"
 
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"vitess.io/vitess/go/trace"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
 )

--- a/go/vt/vtgate/resolver.go
+++ b/go/vt/vtgate/resolver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -33,7 +33,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/vtgate/tabletgateway_test.go
+++ b/go/vt/vtgate/tabletgateway_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/dtids"

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"vitess.io/vitess/go/test/utils"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -35,7 +35,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/planbuilder"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"sync"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/proto/binlogdata"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 

--- a/go/vt/vtgate/vtgateconn/vtgateconn_test.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn_test.go
@@ -19,7 +19,7 @@ package vtgateconn
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestRegisterDialer(t *testing.T) {

--- a/go/vt/vtgate/vtgateservice/interface.go
+++ b/go/vt/vtgate/vtgateservice/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package vtgateservice
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"

--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver"

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -29,7 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -27,9 +27,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/callerid"

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -24,10 +24,10 @@ import (
 
 	"vitess.io/vitess/go/test/utils"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"

--- a/go/vt/vttablet/faketmclient/fake_client.go
+++ b/go/vt/vttablet/faketmclient/fake_client.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/hook"

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/netutil"

--- a/go/vt/vttablet/grpctmserver/server.go
+++ b/go/vt/vttablet/grpctmserver/server.go
@@ -19,7 +19,7 @@ package grpctmserver
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/callinfo"

--- a/go/vt/vttablet/queryservice/fakes/error_query_service.go
+++ b/go/vt/vttablet/queryservice/fakes/error_query_service.go
@@ -19,7 +19,7 @@ package fakes
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
+++ b/go/vt/vttablet/queryservice/fakes/stream_health_query_service.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fakes
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 

--- a/go/vt/vttablet/queryservice/queryservice.go
+++ b/go/vt/vttablet/queryservice/queryservice.go
@@ -23,7 +23,7 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vttablet/queryservice/wrapped.go
+++ b/go/vt/vttablet/queryservice/wrapped.go
@@ -17,7 +17,7 @@ limitations under the License.
 package queryservice
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vttablet/sysloglogger/sysloglogger_test.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"

--- a/go/vt/vttablet/tabletconntest/fakequeryservice.go
+++ b/go/vt/vttablet/tabletconntest/fakequeryservice.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletconntest/tabletconntest.go
+++ b/go/vt/vttablet/tabletconntest/tabletconntest.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/replmanager_test.go
+++ b/go/vt/vttablet/tabletmanager/replmanager_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -32,7 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/vttablet/tabletmanager/rpc_actions.go
+++ b/go/vt/vttablet/tabletmanager/rpc_actions.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/mysqlctl"

--- a/go/vt/vttablet/tabletmanager/rpc_agent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_agent.go
@@ -19,7 +19,7 @@ package tabletmanager
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/vttablet/tabletmanager/rpc_lock_tables.go
+++ b/go/vt/vttablet/tabletmanager/rpc_lock_tables.go
@@ -27,7 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/log"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var (

--- a/go/vt/vttablet/tabletmanager/rpc_query.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletmanager
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/rpc_schema.go
+++ b/go/vt/vttablet/tabletmanager/rpc_schema.go
@@ -19,7 +19,7 @@ package tabletmanager
 import (
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/rpc_server.go
+++ b/go/vt/vttablet/tabletmanager/rpc_server.go
@@ -21,7 +21,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/vt/callinfo"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/rpc_vexec.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vexec.go
@@ -23,7 +23,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/onlineddl"
 	"vitess.io/vitess/go/vt/vttablet/vexec"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // VExec executes a generic VExec command.

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletmanager
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/vttablet/tabletmanager/shard_watcher.go
+++ b/go/vt/vttablet/tabletmanager/shard_watcher.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletmanager
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -45,7 +45,7 @@ import (
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/dbconnpool"
 
 	"vitess.io/vitess/go/netutil"

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -26,8 +26,8 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/vterrors"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/tb"

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -31,7 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"vitess.io/vitess/go/vt/withddl"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
@@ -19,7 +19,7 @@ package vreplication
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )

--- a/go/vt/vttablet/tabletmanager/vreplication/replica_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replica_connector.go
@@ -21,7 +21,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"

--- a/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vdbclient.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -30,7 +30,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -26,7 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vttablet/tabletserver/binlog_watcher.go
+++ b/go/vt/vttablet/tabletserver/binlog_watcher.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -26,7 +26,7 @@ import (
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -28,7 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestConnPoolGet(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletserver
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"

--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/history"
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vttablet/tabletserver/livequeryz_test.go
+++ b/go/vt/vttablet/tabletserver/livequeryz_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestLiveQueryzHandlerJSON(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -19,7 +19,7 @@ package messager
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -26,7 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -30,8 +30,8 @@ import (
 
 	"vitess.io/vitess/go/test/utils"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/cache"

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/streamlog"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -26,9 +26,9 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callinfo"
 	"vitess.io/vitess/go/vt/sqlparser"

--- a/go/vt/vttablet/tabletserver/query_list_test.go
+++ b/go/vt/vttablet/tabletserver/query_list_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type testConn struct {

--- a/go/vt/vttablet/tabletserver/querylogz_test.go
+++ b/go/vt/vttablet/tabletserver/querylogz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"

--- a/go/vt/vttablet/tabletserver/repltracker/reader.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader.go
@@ -25,7 +25,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/timer"

--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/withddl"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/timer"

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -27,7 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/mysql"

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/schema/tracker_test.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -32,7 +32,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vttablet/tabletserver/stateful_connection_pool.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection_pool.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/vttablet/tabletserver/tabletenv/local_context.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/local_context.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletenv
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 type localContextKey int

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/streamlog"

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -29,7 +29,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -37,8 +37,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"

--- a/go/vt/vttablet/tabletserver/twopc_test.go
+++ b/go/vt/vttablet/tabletserver/twopc_test.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -25,7 +25,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/timer"
 	"vitess.io/vitess/go/trace"

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -35,7 +35,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
-	"golang.org/x/net/context"
+	"context"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 

--- a/go/vt/vttablet/tabletserver/tx_executor.go
+++ b/go/vt/vttablet/tabletserver/tx_executor.go
@@ -21,7 +21,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/tx_executor_test.go
+++ b/go/vt/vttablet/tabletserver/tx_executor_test.go
@@ -25,9 +25,9 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -26,7 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/timer"

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -20,7 +20,7 @@ package tabletservermock
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"time"
 

--- a/go/vt/vttablet/tmclient/rpc_client_api.go
+++ b/go/vt/vttablet/tmclient/rpc_client_api.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/hook"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/worker/block.go
+++ b/go/vt/worker/block.go
@@ -19,7 +19,7 @@ package worker
 import (
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/worker/block_cmd.go
+++ b/go/vt/worker/block_cmd.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/wrangler"
 )
 

--- a/go/vt/worker/chunk.go
+++ b/go/vt/worker/chunk.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/worker/command.go
+++ b/go/vt/worker/command.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -32,7 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 	"vitess.io/vitess/go/vt/wrangler"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/sqlescape"

--- a/go/vt/worker/executor.go
+++ b/go/vt/worker/executor.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/throttler"

--- a/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
+++ b/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
@@ -18,7 +18,7 @@ limitations under the License.
 package fakevtworkerclient
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/vtctl/fakevtctlclient"

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -20,7 +20,7 @@ package grpcvtworkerclient
 import (
 	"flag"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/worker/instance.go
+++ b/go/vt/worker/instance.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/trace"
 
 	"vitess.io/vitess/go/tb"

--- a/go/vt/worker/interactive.go
+++ b/go/vt/worker/interactive.go
@@ -21,7 +21,7 @@ import (
 	"html/template"
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/sqlescape"

--- a/go/vt/worker/legacy_split_clone_cmd.go
+++ b/go/vt/worker/legacy_split_clone_cmd.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"
 )

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -28,7 +28,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/worker/multi_split_diff.go
+++ b/go/vt/worker/multi_split_diff.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"context"
+
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
@@ -496,6 +497,7 @@ func (msdw *MultiSplitDiffWorker) startVreplication(ctx context.Context, shardIn
 	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	_, err := msdw.wr.TabletManagerClient().VReplicationExec(shortCtx, masterInfo.Tablet, binlogplayer.StartVReplication(msdw.sourceUID))
 	if err != nil {
+		cancel()
 		return vterrors.Wrapf(err, "VReplicationExec(start) failed for %v", shardInfo.MasterAlias)
 	}
 	cancel()

--- a/go/vt/worker/multi_split_diff.go
+++ b/go/vt/worker/multi_split_diff.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"

--- a/go/vt/worker/multi_split_diff_cmd.go
+++ b/go/vt/worker/multi_split_diff_cmd.go
@@ -29,7 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/worker/multi_split_diff_test.go
+++ b/go/vt/worker/multi_split_diff_test.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/worker/panic.go
+++ b/go/vt/worker/panic.go
@@ -19,7 +19,7 @@ package worker
 import (
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/wrangler"
 )

--- a/go/vt/worker/panic_cmd.go
+++ b/go/vt/worker/panic_cmd.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/wrangler"
 )
 

--- a/go/vt/worker/ping.go
+++ b/go/vt/worker/ping.go
@@ -19,7 +19,7 @@ package worker
 import (
 	"html/template"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/wrangler"
 )

--- a/go/vt/worker/ping_cmd.go
+++ b/go/vt/worker/ping_cmd.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/wrangler"
 )
 

--- a/go/vt/worker/restartable_result_reader.go
+++ b/go/vt/worker/restartable_result_reader.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/worker/restartable_result_reader_test.go
+++ b/go/vt/worker/restartable_result_reader_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"

--- a/go/vt/worker/result_merger.go
+++ b/go/vt/worker/result_merger.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/worker/result_merger_test.go
+++ b/go/vt/worker/result_merger_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/worker/row_aggregator.go
+++ b/go/vt/worker/row_aggregator.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/sqlescape"

--- a/go/vt/worker/row_differ.go
+++ b/go/vt/worker/row_differ.go
@@ -23,7 +23,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/stats"

--- a/go/vt/worker/split_clone_cmd.go
+++ b/go/vt/worker/split_clone_cmd.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/worker/split_clone_flaky_test.go
+++ b/go/vt/worker/split_clone_flaky_test.go
@@ -30,7 +30,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -264,6 +264,7 @@ func (sdw *SplitDiffWorker) findTargets(ctx context.Context) error {
 	for {
 		select {
 		case <-shortCtx.Done():
+			cancel()
 			return vterrors.Errorf(vtrpc.Code_ABORTED, "could not find healthy table for %v/%v%v: after: %v, aborting", sdw.cell, sdw.keyspace, sdw.sourceShard.Shard, *remoteActionsTimeout)
 		default:
 			sdw.sourceAlias, err = FindWorkerTablet(ctx, sdw.wr, sdw.cleaner, nil /* tsc */, sdw.cell, sdw.keyspace, sdw.sourceShard.Shard, sdw.minHealthyRdonlyTablets, topodatapb.TabletType_RDONLY)

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/worker/split_diff_cmd.go
+++ b/go/vt/worker/split_diff_cmd.go
@@ -28,7 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/worker/tablet_provider.go
+++ b/go/vt/worker/tablet_provider.go
@@ -21,7 +21,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/worker/utils_test.go
+++ b/go/vt/worker/utils_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/worker/vertical_split_clone_cmd.go
+++ b/go/vt/worker/vertical_split_clone_cmd.go
@@ -28,7 +28,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/worker/vertical_split_diff.go
+++ b/go/vt/worker/vertical_split_diff.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/worker/vertical_split_diff_cmd.go
+++ b/go/vt/worker/vertical_split_diff_cmd.go
@@ -26,7 +26,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vterrors"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/worker/vtworkerclient/interface.go
+++ b/go/vt/worker/vtworkerclient/interface.go
@@ -20,7 +20,7 @@ package vtworkerclient
 import (
 	"flag"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/proto/vtrpc"

--- a/go/vt/worker/vtworkerclient/wrapper.go
+++ b/go/vt/worker/vtworkerclient/wrapper.go
@@ -19,7 +19,7 @@ package vtworkerclient
 import (
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/vterrors"
 

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -25,7 +25,7 @@ import (
 	"html/template"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/stats"
 )

--- a/go/vt/workflow/checkpoint.go
+++ b/go/vt/workflow/checkpoint.go
@@ -19,7 +19,7 @@ package workflow
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/timer"

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	gouuid "github.com/pborman/uuid"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/workflow/manager_test.go
+++ b/go/vt/workflow/manager_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 

--- a/go/vt/workflow/node.go
+++ b/go/vt/workflow/node.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	workflowpb "vitess.io/vitess/go/vt/proto/workflow"

--- a/go/vt/workflow/node_test.go
+++ b/go/vt/workflow/node_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/workflow/parallel_runner.go
+++ b/go/vt/workflow/parallel_runner.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 

--- a/go/vt/workflow/parallel_runner_test.go
+++ b/go/vt/workflow/parallel_runner_test.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
+++ b/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
@@ -8,8 +8,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	context "context"
 	gomock "github.com/golang/mock/gomock"
-	context "golang.org/x/net/context"
 	topodata "vitess.io/vitess/go/vt/proto/topodata"
 )
 

--- a/go/vt/workflow/resharding/resharding_wrangler.go
+++ b/go/vt/workflow/resharding/resharding_wrangler.go
@@ -22,7 +22,7 @@ package resharding
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )

--- a/go/vt/workflow/resharding/tasks.go
+++ b/go/vt/workflow/resharding/tasks.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/automation"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/workflow/resharding/workflow.go
+++ b/go/vt/workflow/resharding/workflow.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 	"strings"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/workflow/resharding/workflow_test.go
+++ b/go/vt/workflow/resharding/workflow_test.go
@@ -20,8 +20,8 @@ import (
 	"flag"
 	"testing"
 
+	"context"
 	"github.com/golang/mock/gomock"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/workflow/reshardingworkflowgen/workflow.go
+++ b/go/vt/workflow/reshardingworkflowgen/workflow.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 	"strings"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/workflow/reshardingworkflowgen/workflow_test.go
+++ b/go/vt/workflow/reshardingworkflowgen/workflow_test.go
@@ -19,7 +19,7 @@ package reshardingworkflowgen
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/workflow/sleep_workflow.go
+++ b/go/vt/workflow/sleep_workflow.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/workflow/topovalidator/keyspace.go
+++ b/go/vt/workflow/topovalidator/keyspace.go
@@ -19,7 +19,7 @@ package topovalidator
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 

--- a/go/vt/workflow/topovalidator/keyspace_test.go
+++ b/go/vt/workflow/topovalidator/keyspace_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/workflow/topovalidator/shard.go
+++ b/go/vt/workflow/topovalidator/shard.go
@@ -19,7 +19,7 @@ package topovalidator
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/workflow/topovalidator/shard_test.go
+++ b/go/vt/workflow/topovalidator/shard_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/workflow/topovalidator/ui.go
+++ b/go/vt/workflow/topovalidator/ui.go
@@ -19,7 +19,7 @@ package topovalidator
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/workflow/topovalidator/validator.go
+++ b/go/vt/workflow/topovalidator/validator.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/log"
 
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/workflow/websocket.go
+++ b/go/vt/workflow/websocket.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"context"
 	"github.com/gorilla/websocket"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/workflow/workflow_test.go
+++ b/go/vt/workflow/workflow_test.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/wrangler/cleaner.go
+++ b/go/vt/wrangler/cleaner.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/wrangler/fake_tablet_test.go
+++ b/go/vt/wrangler/fake_tablet_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/netutil"

--- a/go/vt/wrangler/hook.go
+++ b/go/vt/wrangler/hook.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 	hk "vitess.io/vitess/go/vt/hook"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/event"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -30,8 +30,8 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/wrangler/materializer_env_test.go
+++ b/go/vt/wrangler/materializer_env_test.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/wrangler/permissions.go
+++ b/go/vt/wrangler/permissions.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"

--- a/go/vt/wrangler/rebuild.go
+++ b/go/vt/wrangler/rebuild.go
@@ -17,7 +17,7 @@ limitations under the License.
 package wrangler
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topotools"
 )
 

--- a/go/vt/wrangler/resharder.go
+++ b/go/vt/wrangler/resharder.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"

--- a/go/vt/wrangler/resharder_env_test.go
+++ b/go/vt/wrangler/resharder_env_test.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"
 	querypb "vitess.io/vitess/go/vt/proto/query"

--- a/go/vt/wrangler/resharder_test.go
+++ b/go/vt/wrangler/resharder_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"

--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -19,7 +19,7 @@ package wrangler
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 

--- a/go/vt/wrangler/split.go
+++ b/go/vt/wrangler/split.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/stream_migrater.go
+++ b/go/vt/wrangler/stream_migrater.go
@@ -25,8 +25,8 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/wrangler/stream_migrater_test.go
+++ b/go/vt/wrangler/stream_migrater_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/wrangler/switcher.go
+++ b/go/vt/wrangler/switcher.go
@@ -21,7 +21,7 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var _ iswitcher = (*switcher)(nil)

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -27,7 +27,7 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var _ iswitcher = (*switcherDryRun)(nil)

--- a/go/vt/wrangler/switcher_interface.go
+++ b/go/vt/wrangler/switcher_interface.go
@@ -21,7 +21,7 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type iswitcher interface {

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/testlib/apply_schema_flaky_test.go
+++ b/go/vt/wrangler/testlib/apply_schema_flaky_test.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -29,7 +29,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -23,8 +23,8 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
+	"context"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"

--- a/go/vt/wrangler/testlib/find_tablet_test.go
+++ b/go/vt/wrangler/testlib/find_tablet_test.go
@@ -19,7 +19,7 @@ package testlib
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -24,7 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -22,7 +22,7 @@ import (
 
 	"vitess.io/vitess/go/vt/discovery"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/wrangler/testlib/shard_test.go
+++ b/go/vt/wrangler/testlib/shard_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -28,7 +28,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/wrangler/testlib/vtctl_topo_test.go
+++ b/go/vt/wrangler/testlib/vtctl_topo_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/golang/protobuf/proto"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/wrangler/testlib/wait_for_drain_test.go
+++ b/go/vt/wrangler/testlib/wait_for_drain_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -30,8 +30,8 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -23,7 +23,7 @@ import (
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"

--- a/go/vt/wrangler/validator.go
+++ b/go/vt/wrangler/validator.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -28,8 +28,8 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
+	"context"
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/logutil"

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -26,9 +26,9 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
+	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"

--- a/go/vt/wrangler/version.go
+++ b/go/vt/wrangler/version.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/log"


### PR DESCRIPTION
## Description

Use `context` from Go's standard library instead of `golang.org/x/net/context`


- https://pkg.go.dev/golang.org/x/net/context
> As of Go 1.7 this package is available in the standard library under the name context. 

## How
`go fix ./...`


## Impacted Areas in Vitess

This should realistically be a no-op

