### PR TITLE
Add tools.go + setup k8s codegen in Makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 10m
+  skip-dirs:
+    - go/vt/topo/k8stopo/client
 
 linters-settings:
   goimports:

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,11 @@ client_go_gen: install_k8s-code-generator
 	# Delete and re-generate the deepcopy types
 	find $(VTROOT)/go/vt/topo/k8stopo/apis/topo/v1beta1 -name "zz_generated.deepcopy.go" -delete
 
-	$(DEEPCOPY_GEN) --input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
+	# We output to ./ and then copy over the generated files to the appropriate path
+	# This is done so we don't have rely on the repository being cloned to `$GOPATH/src/vitess.io/vitess`
+
+	$(DEEPCOPY_GEN) -o ./ \
+	--input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
 	-O zz_generated.deepcopy \
 	--bounding-dirs $(GEN_BASE_DIR)/apis \
 	--go-header-file ./go/vt/topo/k8stopo/boilerplate.go.txt
@@ -306,7 +310,8 @@ client_go_gen: install_k8s-code-generator
 	rm -rf go/vt/topo/k8stopo/client
 
 	# Generate clientset
-	$(CLIENT_GEN) --clientset-name versioned \
+	$(CLIENT_GEN) -o ./ \
+	--clientset-name versioned \
 	--input-base $(GEN_BASE_DIR)/apis \
 	--input 'topo/v1beta1' \
 	--output-package $(GEN_BASE_DIR)/client/clientset \
@@ -314,16 +319,22 @@ client_go_gen: install_k8s-code-generator
 	--go-header-file ./go/vt/topo/k8stopo/boilerplate.go.txt
 
 	# Generate listers
-	$(LISTER_GEN) --input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
+	$(LISTER_GEN) -o ./ \
+	--input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
 	--output-package $(GEN_BASE_DIR)/client/listers \
 	--go-header-file ./go/vt/topo/k8stopo/boilerplate.go.txt
 
 	# Generate informers
-	$(INFORMER_GEN) --input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
+	$(INFORMER_GEN) -o ./ \
+	--input-dirs $(GEN_BASE_DIR)/apis/topo/v1beta1 \
 	--output-package $(GEN_BASE_DIR)/client/informers \
 	--versioned-clientset-package $(GEN_BASE_DIR)/client/clientset/versioned \
 	--listers-package $(GEN_BASE_DIR)/client/listers \
 	--go-header-file ./go/vt/topo/k8stopo/boilerplate.go.txt
+
+	mv vitess.io/vitess/go/vt/topo/k8stopo/client go/vt/topo/k8stopo/
+	mv vitess.io/vitess/go/vt/topo/k8stopo/apis/topo/v1beta1/zz_generated.deepcopy.go go/vt/topo/k8stopo/apis/topo/v1beta1/zz_generated.deepcopy.go
+	rm -rf vitess.io/vitess/go/vt/topo/k8stopo/
 
 # Check prerequisites and install dependencies
 web_bootstrap:

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
-	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.3 // indirect
 	github.com/montanaflynn/stats v0.6.3
@@ -117,6 +116,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
+	k8s.io/code-generator v0.17.3
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,6 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
-github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.0 h1:/x0XQ6h+3U3nAyk1yx+bHPURrKa9sVVvYbuqZ7pIAtI=
 github.com/mitchellh/go-testing-interface v1.14.0/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
@@ -966,9 +964,11 @@ k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0
 k8s.io/apiserver v0.17.3/go.mod h1:iJtsPpu1ZpEnHaNawpSV0nYTGBhhX2dUlnn7/QS7QiY=
 k8s.io/client-go v0.17.3 h1:deUna1Ksx05XeESH6XGCyONNFfiQmDdqeqUvicvP6nU=
 k8s.io/client-go v0.17.3/go.mod h1:cLXlTMtWHkuK4tD360KpWz2gG2KtdWEr/OT02i3emRQ=
+k8s.io/code-generator v0.17.3 h1:q/hDMk2cvFzSxol7k/VA1qCssR7VSMXHQHhzuX29VJ8=
 k8s.io/code-generator v0.17.3/go.mod h1:l8BLVwASXQZTo2xamW5mQNFCe1XPiAesVq7Y1t7PiQQ=
 k8s.io/component-base v0.17.3/go.mod h1:GeQf4BrgelWm64PXkIXiPh/XS0hnO42d9gx9BtbZRp8=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190822140433-26a664648505 h1:ZY6yclUKVbZ+SdWnkfY+Je5vrMpKOxmGeKRbsXVmqYM=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/go/vt/topo/k8stopo/client/clientset/versioned/fake/register.go
+++ b/go/vt/topo/k8stopo/client/clientset/versioned/fake/register.go
@@ -30,7 +30,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme) //nolint
+var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	topov1beta1.AddToScheme,
 }

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,14 @@
+//+build tools
+
+package tools
+
+// Package tools is used to import go modules that we use for tooling as dependencies.
+// For more information, please refer to: https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
+
+import (
+	_ "github.com/golang/protobuf/protoc-gen-go"
+	_ "k8s.io/code-generator/cmd/client-gen"
+	_ "k8s.io/code-generator/cmd/deepcopy-gen"
+	_ "k8s.io/code-generator/cmd/informer-gen"
+	_ "k8s.io/code-generator/cmd/lister-gen"
+)


### PR DESCRIPTION
## Description 

- Adding a `tools.go` to import and version codegen tooling. See https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
- Adding a make target to install `k8s.io/code-generator` tools (inline comments follow)

cc @carsonoid (since you last touched these files)