### PR TITLE
Fix all occurrences of `fmt.Sprint(x)` where x is `int`

### DIFF
--- a/go/test/endtoend/mysqlserver/main_test.go
+++ b/go/test/endtoend/mysqlserver/main_test.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"vitess.io/vitess/go/mysql"
@@ -49,7 +50,7 @@ func TestMain(m *testing.M) {
 
 	// setting grpc max size
 	if os.Getenv("grpc_max_massage_size") == "" {
-		os.Setenv("grpc_max_message_size", fmt.Sprint(16*1024*1024))
+		os.Setenv("grpc_max_message_size", strconv.FormatInt(16*1024*1024, 10))
 	}
 
 	exitcode, err := func() (int, error) {

--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -19,6 +19,7 @@ package preparestmt
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -55,7 +56,7 @@ func TestInsertUpdateDelete(t *testing.T) {
 	for i := 1; i <= 100; i++ {
 		// preparing value for the insert testing
 		insertValue := []interface{}{
-			i, fmt.Sprint(i) + "21", i * 100,
+			i, strconv.FormatInt(int64(i), 10) + "21", i * 100,
 			127, 1, 32767, 8388607, 2147483647, 2.55, 64.9, 55.5,
 			time.Date(2009, 5, 5, 0, 0, 0, 50000, time.UTC),
 			time.Date(2009, 5, 5, 0, 0, 0, 50000, location),

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -25,17 +25,18 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 
-	"vitess.io/vitess/go/vt/log"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 	"vitess.io/vitess/go/vt/vttest"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vttestpb "vitess.io/vitess/go/vt/proto/vttest"
 )
 
 var (
@@ -123,9 +124,9 @@ func TestStandalone(t *testing.T) {
 
 	for i := idStart; i < idStart+rowCount; i++ {
 		bindVariables := map[string]*querypb.BindVariable{
-			"id":          {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(i))},
-			"msg":         {Type: querypb.Type_VARCHAR, Value: []byte(fmt.Sprint("test", i))},
-			"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(i))},
+			"id":          {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
+			"msg":         {Type: querypb.Type_VARCHAR, Value: []byte("test" + strconv.FormatInt(int64(i), 10))},
+			"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
 		}
 		_, err = cur.Execute(ctx, query, bindVariables)
 		require.Nil(t, err)
@@ -136,7 +137,7 @@ func TestStandalone(t *testing.T) {
 
 	cur = conn.Session(ks1+":-80@rdonly", nil)
 	bindVariables := map[string]*querypb.BindVariable{
-		"id_start": {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(idStart))},
+		"id_start": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(idStart), 10))},
 	}
 	res, err := cur.Execute(ctx, "select * from test_table where id >= :id_start", bindVariables)
 	require.Nil(t, err)
@@ -145,7 +146,7 @@ func TestStandalone(t *testing.T) {
 
 	cur = conn.Session(redirected+":-80@replica", nil)
 	bindVariables = map[string]*querypb.BindVariable{
-		"id_start": {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(idStart))},
+		"id_start": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(idStart), 10))},
 	}
 	res, err = cur.Execute(ctx, "select * from test_table where id = :id_start", bindVariables)
 	require.Nil(t, err)
@@ -158,9 +159,9 @@ func TestStandalone(t *testing.T) {
 
 	i := 0x810000000000000
 	bindVariables = map[string]*querypb.BindVariable{
-		"id":          {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(i))},
-		"msg":         {Type: querypb.Type_VARCHAR, Value: []byte(fmt.Sprint("test", i))},
-		"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(fmt.Sprint(i))},
+		"id":          {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
+		"msg":         {Type: querypb.Type_VARCHAR, Value: []byte("test" + strconv.FormatInt(int64(i), 10))},
+		"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
 	}
 	_, err = cur.Execute(ctx, query, bindVariables)
 	require.Nil(t, err)

--- a/go/vt/vtctld/redirection.go
+++ b/go/vt/vtctld/redirection.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
 	"strings"
 
 	"vitess.io/vitess/go/netutil"
@@ -70,7 +71,7 @@ func initVTTabletRedirection(ts *topo.Server) {
 			b = bytes.ReplaceAll(b, []byte(`href="/`), []byte(fmt.Sprintf(`href="%s`, prefixPath)))
 			b = bytes.ReplaceAll(b, []byte(`href=/`), []byte(fmt.Sprintf(`href=%s`, prefixPath)))
 			r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-			r.Header["Content-Length"] = []string{fmt.Sprint(len(b))}
+			r.Header["Content-Length"] = []string{strconv.FormatInt(int64(len(b)), 10)}
 
 			// Don't forget redirects
 			loc := r.Header["Location"]

--- a/go/vt/worker/executor.go
+++ b/go/vt/worker/executor.go
@@ -17,16 +17,16 @@ limitations under the License.
 package worker
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"time"
 
-	"vitess.io/vitess/go/vt/vterrors"
-
-	"context"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/throttler"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/wrangler"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -59,7 +59,7 @@ func newExecutor(wr *wrangler.Wrangler, tsc *discovery.LegacyTabletStatsCache, t
 		keyspace:  keyspace,
 		shard:     shard,
 		threadID:  threadID,
-		statsKey:  []string{keyspace, shard, fmt.Sprint(threadID)},
+		statsKey:  []string{keyspace, shard, strconv.FormatInt(int64(threadID), 10)},
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

What it says in the title. Also reorder some imports to follow the "stdlib/3rdparty+vitess/proto" pattern.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- From [this discussion](https://github.com/vitessio/vitess/pull/7240#discussion_r551208289)

## Checklist
- [ ] Should this PR be backported? **No**
- [ ] Tests were added or are not required **N/A**
- [ ] Documentation was added or is not required **N/A**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
