### PR TITLE
Delete select_commerce_data.sql

### DIFF
--- a/examples/operator/select_commerce_data.sql
+++ b/examples/operator/select_commerce_data.sql
@@ -1,8 +1,0 @@
-\! echo 'Using commerce'
-use commerce;
-\! echo 'Customer'
-select * from customer;
-\! echo 'Product'
-select * from product;
-\! echo 'COrder'
-select * from corder;


### PR DESCRIPTION
## Description
Once https://github.com/vitessio/website/pull/656 and https://github.com/vitessio/website/pull/646 have been committed to adjust the Vitess docs this file should be removed as it was confirmed to be redundant to https://github.com/vitessio/vitess/blob/master/examples/common/select_commerce_data.sql.

## Related Issue(s)
https://github.com/vitessio/website/pull/646
https://github.com/vitessio/website/pull/656

## Checklist
- Should this PR be backported? No
- Tests are not required (file deletion only no other changes)
- Documentation was added (the related pull requests)

## Impacted Areas in Vitess
Components that this PR will affect:

- Vitess Docs
- Operator examples
