### PR TITLE
local docker: copy examples/common into /vt/common to match MoveTables user guide

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -34,4 +34,7 @@ ENV PATH="/var/opt/etcd:${PATH}"
 RUN mkdir /vt/local
 COPY examples/local /vt/local
 
+RUN mkdir /vt/common
+COPY examples/common /vt/common
+
 CMD cd /vt/local && ./101_initial_cluster.sh && /bin/bash


### PR DESCRIPTION
## Description

The current MoveTables user guide https://vitess.io/docs/user-guides/migration/move-tables/ doesn't work with the local dockerfile setup as the guide expects SQL files to be available in the relative path `../common`. Because that directory isn't copied into the top-level `/vt` directory they aren't available for the entrypoint working directory. This PR copies `examples/common` into `/vt/common` to make the docker environment match the user guide expectations.

I'd also note that I tested this on the `v8.0.0` tag, as  `make docker_local` was broken for me the latest `master:HEAD` ea65a1cf3429997f3173097f9995d89417df3e10 with `Docker version 1.13.1` (admittedly an older version):

```
$ make docker_local
Building vitess/local
Sending build context to Docker daemon 235.2 MB
Step 1/22 : ARG bootstrap_version=0
Please provide a source image with `from` prior to commit
make: *** [docker_local] Error 1
```

could be related to https://github.com/vitessio/vitess/pull/7182, happy to open a separate issue for it

## Related Issue(s)
<!-- List related issues and pull requests: -->

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 
