### PR TITLE
docker images for vttestserver

### DIFF
--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -1,0 +1,58 @@
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We have to build the Vitess binaries from scratch instead of sharing
+#       a base image because Docker Hub dropped the feature we relied upon to
+#       ensure images contain the right binaries.
+
+# Use a temporary layer for the build stage.
+ARG bootstrap_version=0
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
+
+FROM "${image}" AS builder
+
+# Allows docker builds to set the BUILD_NUMBER
+ARG BUILD_NUMBER
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+# Build and install Vitess in a temporary output directory.
+USER vitess
+RUN make install-testing PREFIX=/vt/install
+
+# Start over and build the final image.
+FROM debian:buster-slim
+
+# Install dependencies
+COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql57
+
+# Set up Vitess user and directory tree.
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+
+# Copy artifacts from builder layer.
+COPY --from=builder --chown=vitess:vitess /vt/install /vt
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot
+USER vitess
+
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS

--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -1,4 +1,4 @@
-# Copyright 2019 The Vitess Authors.
+# Copyright 2021 The Vitess Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
 
 FROM "${image}" AS builder

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -1,0 +1,58 @@
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: We have to build the Vitess binaries from scratch instead of sharing
+#       a base image because Docker Hub dropped the feature we relied upon to
+#       ensure images contain the right binaries.
+
+# Use a temporary layer for the build stage.
+ARG bootstrap_version=0
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
+
+FROM "${image}" AS builder
+
+# Allows docker builds to set the BUILD_NUMBER
+ARG BUILD_NUMBER
+
+# Re-copy sources from working tree.
+COPY --chown=vitess:vitess . /vt/src/vitess.io/vitess
+
+# Build and install Vitess in a temporary output directory.
+USER vitess
+RUN make install-testing PREFIX=/vt/install
+
+# Start over and build the final image.
+FROM debian:buster-slim
+
+# Install dependencies
+COPY docker/lite/install_dependencies.sh /vt/dist/install_dependencies.sh
+RUN /vt/dist/install_dependencies.sh mysql80
+
+# Set up Vitess user and directory tree.
+RUN groupadd -r vitess && useradd -r -g vitess vitess
+RUN mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vt/vtdataroot
+ENV PATH $VTROOT/bin:$PATH
+
+# Copy artifacts from builder layer.
+COPY --from=builder --chown=vitess:vitess /vt/install /vt
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot
+USER vitess
+
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -1,4 +1,4 @@
-# Copyright 2019 The Vitess Authors.
+# Copyright 2021 The Vitess Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 #       ensure images contain the right binaries.
 
 # Use a temporary layer for the build stage.
-ARG bootstrap_version=0
+ARG bootstrap_version=1
 ARG image="vitess/bootstrap:${bootstrap_version}-mysql80"
 
 FROM "${image}" AS builder


### PR DESCRIPTION
Signed-off-by: deepthi <deepthi@planetscale.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
There has been a request for a vttestserver docker image for testing purposes.
We already have a [Dockerfile](https://github.com/vitessio/vitess/blob/master/docker/lite/Dockerfile.testing) that does this for mysql57.
The files in this PR are just a little bit different.
- mysql57 and mysql80 flavors
- startup command that runs vttestserver using provided arguments
- removed orchestrator/web because I don't think that is required

## Related Issue(s)
<!-- List related issues and pull requests: -->
Fixes #7203

## Checklist
- [ ] Should this PR be backported? (NO)
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
Run as follows
```
$ docker run -e PORT=9997 -e NUM_SHARDS="1,1" -e KEYSPACES="hello,bye" --network host -d vitess/vttestserver:mysql57
1c64f5b029b198eee678ab9defa78419b11e8c8332c5326b996763404bfeb2e0
$ docker exec -it 1c64f5b029b198eee678ab9defa78419b11e8c8332c5326b996763404bfeb2e0 /bin/bash
vitess@1c64f5b029b1:/$ ps -aef | grep vt
vitess       1     0  0 01:48 ?        00:00:00 /bin/sh -c /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS
vitess       7     1  0 01:48 ?        00:00:00 /vt/bin/vttestserver -port 3303 -keyspaces hello,bye -num_shards 1,1
vitess      55     1  0 01:48 ?        00:00:00 /bin/sh /usr/bin/mysqld_safe --defaults-file=/vt/vtdataroot/vttest883037074/vt_0000000001/my.cnf --basedir=/usr
vitess     678    55  3 01:48 ?        00:00:00 /usr/sbin/mysqld --defaults-file=/vt/vtdataroot/vttest883037074/vt_0000000001/my.cnf --basedir=/usr --datadir=/vt/vtdataroot/vttest883037074/vt_0000000001/data --plugin-dir=/usr/lib/mysql/plugin --log-error=/vt/vtdataroot/vttest883037074/vt_0000000001/error.log --pid-file=/vt/vtdataroot/vttest883037074/vt_0000000001/mysql.pid --socket=/vt/vtdataroot/vttest883037074/vt_0000000001/mysql.sock --port=3305
vitess     709     7  6 01:48 ?        00:00:01 /vt/bin/vtcombo -port 3303 -log_dir /vt/vtdataroot/vttest883037074/logs -alsologtostderr -grpc_port 3304 -db_charset utf8 -db_app_user vt_dba -db_app_password  -db_dba_user vt_dba -db_dba_password  -proto_topo keyspaces:<name:"hello" shards:<name:"0" > replica_count:2 rdonly_count:1 > keyspaces:<name:"bye" shards:<name:"0" > replica_count:2 rdonly_count:1 > cells:"test"  -mycnf_server_id 1 -mycnf_socket_file /vt/vtdataroot/vttest883037074/vt_0000000001/mysql.sock -normalize_queries -queryserver-config-pool-size 4 -queryserver-config-query-timeout 300 -queryserver-config-schema-reload-time 60 -queryserver-config-stream-pool-size 4 -queryserver-config-transaction-cap 4 -queryserver-config-transaction-timeout 300 -queryserver-config-txpool-timeout 300 -service_map grpc-vtgateservice,grpc-vtctl -enable_queries -transaction_mode MULTI -tablet_hostname localhost -db_socket /vt/vtdataroot/vttest883037074/vt_0000000001/mysql.sock -mysql_auth_server_impl none -mysql_server_port 3306 -mysql_server_bind_address localhost
vitess     775   768  0 01:48 pts/0    00:00:00 grep vt
vitess@1c64f5b029b1:/$ exit
$ mysql --host 127.0.0.1 --port 10000
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.9-Vitess MySQL Community Server (GPL)

Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show databases;
+----------+
| Database |
+----------+
| bye      |
| hello    |
+----------+
2 rows in set (0.00 sec)

mysql> exit
Bye
```

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
