### PR TITLE
[7.0] don't try to compare varchars in vtgate

### DIFF
--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -525,3 +525,15 @@ func TestSelectNullLookup(t *testing.T) {
 
 	exec(t, conn, "delete from t6")
 }
+
+func TestUnicodeLooseMD5CaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "insert into t4(id1, id2) values(1, 'test')")
+	defer exec(t, conn, "delete from t4")
+
+	assertMatches(t, conn, "SELECT id1, id2 from t4 where id2 = 'Test'", `[[INT64(1) VARCHAR("test")]]`)
+}

--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -87,14 +87,14 @@ create table t4(
 	id1 bigint,
 	id2 varchar(10),
 	primary key(id1)
-) Engine=InnoDB;
+) ENGINE=InnoDB DEFAULT charset=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 create table t4_id2_idx(
 	id2 varchar(10),
 	id1 bigint,
 	keyspace_id varbinary(50),
     primary key(id2, id1)
-) Engine=InnoDB;
+) Engine=InnoDB DEFAULT charset=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 create table t5_null_vindex(
 	id bigint not null,

--- a/go/test/utils/diff.go
+++ b/go/test/utils/diff.go
@@ -43,17 +43,17 @@ import (
 // In Test*() function:
 //
 // mustMatch(t, want, got, "something doesn't match")
-func MustMatchFn(allowUnexportedTypes []interface{}, ignoredFields []string, extraOpts ...cmp.Option) func(t *testing.T, want, got interface{}, errMsg string) {
+func MustMatchFn(allowUnexportedTypes []interface{}, ignoredFields []string, extraOpts ...cmp.Option) func(t *testing.T, want, got interface{}, errMsg ...string) {
 	diffOpts := append([]cmp.Option{
 		cmp.AllowUnexported(allowUnexportedTypes...),
 		cmpIgnoreFields(ignoredFields...),
 	}, extraOpts...)
 	// Diffs want/got and fails with errMsg on any failure.
-	return func(t *testing.T, want, got interface{}, errMsg string) {
+	return func(t *testing.T, want, got interface{}, errMsg ...string) {
 		t.Helper()
 		diff := cmp.Diff(want, got, diffOpts...)
 		if diff != "" {
-			t.Fatalf("%s: (-want +got)\n%v", errMsg, diff)
+			t.Fatalf("%v: (-want +got)\n%v", errMsg, diff)
 		}
 	}
 }

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -60,8 +60,8 @@ select count(*) from user where id = 1 /* point aggregate */
 select count(*) from user where name in ('alice','bob') /* scatter aggregate */
 
 1 ks_sharded/40-80: select name, user_id from name_user_map where name in ('alice') limit 10001 /* scatter aggregate */
-1 ks_sharded/c0-: select name, user_id from name_user_map where name in ('bob') limit 10001 /* scatter aggregate */
-2 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
+2 ks_sharded/c0-: select name, user_id from name_user_map where name in ('bob') limit 10001 /* scatter aggregate */
+3 ks_sharded/-40: select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */

--- a/go/vt/vtgate/vcursor_impl_test.go
+++ b/go/vt/vtgate/vcursor_impl_test.go
@@ -3,6 +3,7 @@ package vtgate
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"vitess.io/vitess/go/vt/proto/vschema"
@@ -237,7 +238,7 @@ func TestSetTarget(t *testing.T) {
 	}}
 
 	for i, tc := range tests {
-		t.Run(string(i)+"#"+tc.targetString, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d#%s", i, tc.targetString), func(t *testing.T) {
 			vc, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{InTransaction: true}), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, nil)
 			vc.vschema = tc.vschema
 			err := vc.SetTarget(tc.targetString)
@@ -277,7 +278,7 @@ func TestPlanPrefixKey(t *testing.T) {
 	}}
 
 	for i, tc := range tests {
-		t.Run(string(i)+"#"+tc.targetString, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d#%s", i, tc.targetString), func(t *testing.T) {
 			ss := NewSafeSession(&vtgatepb.Session{InTransaction: false})
 			ss.SetTargetString(tc.targetString)
 			vc, err := newVCursorImpl(context.Background(), ss, sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, srvtopo.NewResolver(&fakeTopoServer{}, nil, ""))

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -76,7 +76,7 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value, co vtga
 	if lkp.Autocommit {
 		co = vtgatepb.CommitOrder_AUTOCOMMIT
 	}
-	if !ids[0].IsIntegral() && !ids[0].IsBinary() {
+	if !ids[0].IsIntegral() {
 		// for non integral and binary type, fallback to send query per id
 		for _, id := range ids {
 			vars, err := sqltypes.BuildBindVariable([]interface{}{id})


### PR DESCRIPTION
we can't group together multiple varchar values into a IN query,
because that forces use to compare varchar values on the vtgate
level which we can't do correctly yet

This is a backport of #7268 that solves #7254