### PR TITLE
Vreplication V2 Workflows: rename Abort to Cancel

### DIFF
--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -47,7 +47,7 @@ const (
 	workflowActionSwitchTraffic  = "SwitchTraffic"
 	workflowActionReverseTraffic = "ReverseTraffic"
 	workflowActionComplete       = "Complete"
-	workflowActionAbort          = "Abort"
+	workflowActionCancel         = "Cancel"
 )
 
 var (
@@ -154,8 +154,8 @@ func tstWorkflowComplete(t *testing.T) error {
 	return tstWorkflowAction(t, workflowActionComplete, "", "")
 }
 
-func tstWorkflowAbort(t *testing.T) error {
-	return tstWorkflowAction(t, workflowActionAbort, "", "")
+func tstWorkflowCancel(t *testing.T) error {
+	return tstWorkflowAction(t, workflowActionCancel, "", "")
 }
 
 func validateReadsRoute(t *testing.T, tabletTypes string, tablet *cluster.VttabletProcess) {
@@ -276,7 +276,7 @@ func testMoveTablesV2Workflow(t *testing.T) {
 	output, _ = vc.VtctlClient.ExecuteCommandWithOutput(listAllArgs...)
 	require.Contains(t, output, "Following workflow(s) found in keyspace customer: wf1")
 
-	err := tstWorkflowAbort(t)
+	err := tstWorkflowCancel(t)
 	require.NoError(t, err)
 
 	output, _ = vc.VtctlClient.ExecuteCommandWithOutput(listAllArgs...)

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -180,7 +180,7 @@ func (m *Manager) Run(ctx context.Context) {
 	m.workflows = make(map[string]*runningWorkflow)
 	m.mu.Unlock()
 
-	// Abort the running jobs. They won't save their state as
+	// Cancel the running jobs. They won't save their state as
 	// m.ctx is nil and they know it means we're shutting down.
 	for _, rw := range runningWorkflows {
 		rw.cancel()

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -570,7 +570,7 @@ func (wr *Wrangler) SwitchWrites(ctx context.Context, targetKeyspace, workflow s
 	return ts.id, sw.logs(), nil
 }
 
-// DropTargets cleans up target tables, shards and blacklisted tables if a MoveTables/Reshard is aborted
+// DropTargets cleans up target tables, shards and blacklisted tables if a MoveTables/Reshard is cancelled
 func (wr *Wrangler) DropTargets(ctx context.Context, targetKeyspace, workflow string, keepData, dryRun bool) (*[]string, error) {
 	ts, err := wr.buildTrafficSwitcher(ctx, targetKeyspace, workflow)
 	if err != nil {

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -258,7 +258,7 @@ func (vrw *VReplicationWorkflow) ReverseTraffic() error {
 // Workflow errors
 const (
 	ErrWorkflowNotFullySwitched  = "cannot complete workflow because you have not yet switched all read and write traffic"
-	ErrWorkflowPartiallySwitched = "cannot abort workflow because you have already switched some or all read and write traffic"
+	ErrWorkflowPartiallySwitched = "cannot cancel workflow because you have already switched some or all read and write traffic"
 )
 
 // Complete cleans up a successful workflow
@@ -280,8 +280,8 @@ func (vrw *VReplicationWorkflow) Complete() error {
 	return nil
 }
 
-// Abort deletes all artifacts from a workflow which has not yet been switched
-func (vrw *VReplicationWorkflow) Abort() error {
+// Cancel deletes all artifacts from a workflow which has not yet been switched
+func (vrw *VReplicationWorkflow) Cancel() error {
 	ws := vrw.ws
 	if ws.WritesSwitched || len(ws.ReplicaCellsSwitched) > 0 || len(ws.RdonlyCellsSwitched) > 0 {
 		return fmt.Errorf(ErrWorkflowPartiallySwitched)

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -57,7 +57,7 @@ func TestReshardingWorkflowErrorsAndMisc(t *testing.T) {
 	require.True(t, mtwf.Exists())
 	require.Errorf(t, mtwf.Complete(), ErrWorkflowNotFullySwitched)
 	mtwf.ws.WritesSwitched = true
-	require.Errorf(t, mtwf.Abort(), ErrWorkflowPartiallySwitched)
+	require.Errorf(t, mtwf.Cancel(), ErrWorkflowPartiallySwitched)
 
 	require.ElementsMatch(t, mtwf.getCellsAsArray(), []string{"cell1", "cell2"})
 	require.ElementsMatch(t, mtwf.getTabletTypes(), []topodata.TabletType{topodata.TabletType_REPLICA, topodata.TabletType_RDONLY})
@@ -286,7 +286,7 @@ func TestMoveTablesV2Partial(t *testing.T) {
 
 }
 
-func TestMoveTablesV2Abort(t *testing.T) {
+func TestMoveTablesV2Cancel(t *testing.T) {
 	ctx := context.Background()
 	p := &VReplicationWorkflowParams{
 		Workflow:       "test",
@@ -312,7 +312,7 @@ func TestMoveTablesV2Abort(t *testing.T) {
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t1"))
 	require.True(t, checkIfTableExistInVSchema(ctx, t, wf.wr.ts, "ks2", "t2"))
 
-	require.NoError(t, wf.Abort())
+	require.NoError(t, wf.Cancel())
 
 	validateRoutingRuleCount(ctx, t, wf.wr.ts, 0)
 
@@ -356,7 +356,7 @@ func TestReshardV2(t *testing.T) {
 	require.NotNil(t, si)
 }
 
-func TestReshardV2Abort(t *testing.T) {
+func TestReshardV2Cancel(t *testing.T) {
 	ctx := context.Background()
 	sourceShards := []string{"-40", "40-"}
 	targetShards := []string{"-80", "80-"}
@@ -378,7 +378,7 @@ func TestReshardV2Abort(t *testing.T) {
 	require.Equal(t, WorkflowStateNotSwitched, wf.CurrentState())
 	tme.expectNoPreviousJournals()
 	expectReshardQueries(t, tme)
-	require.NoError(t, wf.Abort())
+	require.NoError(t, wf.Cancel())
 }
 
 func expectReshardQueries(t *testing.T, tme *testShardMigraterEnv) {


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
For neutral naming, all references to workflow.Abort renamed to workflow.Cancel.

## Checklist
- [X] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
