### PR TITLE
fix hang when local topo was down

### DIFF
--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -47,6 +47,7 @@ var (
 	// setting the watch fails, we will use the last known value until
 	// srv_topo_cache_ttl elapses and we only try to re-establish the watch
 	// once every srv_topo_cache_refresh interval.
+	srvTopoTimeout      = flag.Duration("srv_topo_timeout", 1*time.Second, "topo server timeout")
 	srvTopoCacheTTL     = flag.Duration("srv_topo_cache_ttl", 1*time.Second, "how long to use cached entries for topology")
 	srvTopoCacheRefresh = flag.Duration("srv_topo_cache_refresh", 1*time.Second, "how frequently to refresh the topology for cached entries")
 )
@@ -288,9 +289,9 @@ func (server *ResilientServer) GetSrvKeyspaceNames(ctx context.Context, cell str
 					log.Errorf("GetSrvKeyspaceNames uncaught panic, cell :%v, err :%v)", cell, err)
 				}
 			}()
-
-			result, err := server.topoServer.GetSrvKeyspaceNames(ctx, cell)
-
+			newCtx, cancel := context.WithTimeout(ctx, *srvTopoTimeout)
+			defer cancel()
+			result, err := server.topoServer.GetSrvKeyspaceNames(newCtx, cell)
 			entry.mutex.Lock()
 			defer func() {
 				close(entry.refreshingChan)
@@ -308,7 +309,8 @@ func (server *ResilientServer) GetSrvKeyspaceNames(ctx context.Context, cell str
 				server.counts.Add(errorCategory, 1)
 				if entry.insertionTime.IsZero() {
 					log.Errorf("GetSrvKeyspaceNames(%v, %v) failed: %v (no cached value, caching and returning error)", ctx, cell, err)
-
+				} else if newCtx.Err() == context.DeadlineExceeded {
+					log.Errorf("GetSrvKeyspaceNames(%v, %v) failed: %v (request timeout), (keeping cached value: %v)", ctx, cell, err, entry.value)
 				} else if entry.value != nil && time.Since(entry.insertionTime) < server.cacheTTL {
 					server.counts.Add(cachedCategory, 1)
 					log.Warningf("GetSrvKeyspaceNames(%v, %v) failed: %v (keeping cached value: %v)", ctx, cell, err, entry.value)
@@ -320,7 +322,7 @@ func (server *ResilientServer) GetSrvKeyspaceNames(ctx context.Context, cell str
 			}
 
 			entry.lastError = err
-			entry.lastErrorCtx = ctx
+			entry.lastErrorCtx = newCtx
 		}()
 	}
 


### PR DESCRIPTION
when local cell topo  server is down, all commands related with function GetSrvKeyspaceNames are hanging
Added topo timeout and when local cell topo is broken , will use cache instead , make sure not too much effect on vtgate

Signed-off-by: JohnnyThree <whereshallyoube@gmail.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
