### PR TITLE
removed resolver usage from StreamExecute

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -425,7 +425,7 @@ func TestUseStmtInOLAP(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	queries := []string{"set workload='olap'", "use `ks:80-`"}
+	queries := []string{"set workload='olap'", "use `ks:80-`", "use `ks:-80`"}
 	for i, q := range queries {
 		t.Run(fmt.Sprintf("%d-%s", i, q), func(t *testing.T) {
 			exec(t, conn, q)

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -33,7 +33,6 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/tb"
 	"vitess.io/vitess/go/vt/discovery"
-	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/schema"
@@ -311,7 +310,7 @@ func (vtg *VTGate) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, 
 // by multiple go routines.
 func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error {
 	// In this context, we don't care if we can't fully parse destination
-	destKeyspace, destTabletType, dest, _ := vtg.executor.ParseDestinationTarget(session.TargetString)
+	destKeyspace, destTabletType, _, _ := vtg.executor.ParseDestinationTarget(session.TargetString)
 	statsKey := []string{"StreamExecute", destKeyspace, topoproto.TabletTypeLString(destTabletType)}
 
 	defer vtg.timings.Record(statsKey, time.Now())
@@ -319,26 +318,7 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 	var err error
 	if bvErr := sqltypes.ValidateBindVariables(bindVariables); bvErr != nil {
 		err = vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", bvErr)
-		goto handleError
-	}
-
-	// TODO: This could be simplified to have a StreamExecute that takes
-	// a destTarget without explicit destination.
-	switch dest.(type) {
-	case key.DestinationShard:
-		err = vtg.resolver.StreamExecute(
-			ctx,
-			sql,
-			bindVariables,
-			destKeyspace,
-			destTabletType,
-			dest,
-			session.Options,
-			func(reply *sqltypes.Result) error {
-				vtg.rowsReturned.Add(statsKey, int64(len(reply.Rows)))
-				return callback(reply)
-			})
-	default:
+	} else {
 		err = vtg.executor.StreamExecute(
 			ctx,
 			"StreamExecute",
@@ -354,7 +334,6 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 				return callback(reply)
 			})
 	}
-handleError:
 	if err != nil {
 		query := map[string]interface{}{
 			"Sql":           sql,


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Removed the resolver logic when shard targeting. This enabled planing to be done for all queries. Planner knows how to work with shard targeting.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7259

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
