### PR TITLE
[vtctld] Fix accidentally-broken legacy vtctl output format

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2561,7 +2561,14 @@ func commandFindAllShardsInKeyspace(ctx context.Context, wr *wrangler.Wrangler, 
 		return err
 	}
 
-	return printJSON(wr.Logger(), result.Shards)
+	// reformat data into structure of old interface
+	legacyShardMap := make(map[string]*topodatapb.Shard, len(result.Shards))
+
+	for _, shard := range result.Shards {
+		legacyShardMap[shard.Name] = shard.Shard
+	}
+
+	return printJSON(wr.Logger(), legacyShardMap)
 }
 
 func commandValidate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {


### PR DESCRIPTION
This was a regression introduced in #7128.

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

This restores the original json format of the old vtctl API, which I broke when trying to reimplement the old API in terms of the new. Example (using the local example): first the new, changed output, and then the old, correct output:

```
❯ vtctlclient -server "localhost:15999" FindAllShardsInKeyspace commerce
{
  "0": {
    "keyspace": "commerce",
    "name": "0",
    "shard": {
      "master_alias": {
        "cell": "zone1",
        "uid": 100
      },
      "master_term_start_time": {
        "seconds": 1610412569,
        "nanoseconds": 995650000
      },
      "is_master_serving": true
    }
  }
}
❯ cd -
~/work/vitess
❯ make build
Mon Jan 11 19:50:24 EST 2021: Building source tree
❯ cd -
~/work/vitess/examples/local
❯ ./scripts/vtctld-down.sh
Stopping vtctld...
❯ ./scripts/vtctld-up.sh
Starting vtctld...
❯ vtctlclient -server "localhost:15999" FindAllShardsInKeyspace commerce
{
  "0": {
    "master_alias": {
      "cell": "zone1",
      "uid": 100
    },
    "master_term_start_time": {
      "seconds": 1610412569,
      "nanoseconds": 995650000
    },
    "is_master_serving": true
  }
}
```

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported? **No** (it hasn't been actually released yet)
- [ ] Tests were added or are not required **Probably should?**
- [ ] Documentation was added or is not required **N/A**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
