### PR TITLE
Descriptive names for CI checks

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (11)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (12)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (13)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (14)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (15)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (16)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (17)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (18)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (19)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (20)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (21)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (22)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (23)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (24)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (26)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cluster_endtoend_27.yml
+++ b/.github/workflows/cluster_endtoend_27.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on Cluster (27)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 on: [push, pull_request]
 jobs:
   build:
-    name: Build
+    name: Lint using golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.15

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    name: Run endtoend tests on {{.Name}}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Signed-off-by: deepthi <deepthi@planetscale.com>

## Description
Add descriptive names for cluster endtoend tests and golangci-lint checks.
This is needed to manage branch protection rules, otherwise all these checks show up as `build`.
Also, once a PR is merged, this is the name that is visible when you go back and look at the status of checks at the time of merge.

## Related Issue(s)
#7258 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 
- [ ]  VTAdmin
