### PR TITLE
docker/vttestserver:  Add MYSQL_BIND_HOST env

### DIFF
--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1}

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1}


### PR DESCRIPTION
## Description
Adds an optional `MYSQL_BIND_HOST` environment variable to the `vttestserver` container; if included, this is passed as `-mysql_bind_host` to `vttestserver`

## Related Issue(s)
- #7203
- #7262

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
Run as follows:
```
$ docker run --rm -d -p33577:33577 -e PORT=33574 -e KEYSPACES=test -e NUM_SHARDS=1 -e MYSQL_BIND_HOST=0.0.0.0 vitess/vttestserver:mysql57
2c04c50156bd9ad7cac4b3f41bb653de37b78a0505c4154f1491e8d2730f5336
$ mysql -h127.0.0.1 -p33577
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.9-Vitess MySQL Community Server (GPL)

Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> SHOW DATABASES;
+----------+
| Database |
+----------+
| test     |
+----------+
1 row in set (0.00 sec)

```

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
