### PR TITLE
Expose vtctld gRPC port in local Docker example + update VTAdmin README

### DIFF
--- a/docker/local/run.sh
+++ b/docker/local/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 15000:15000 -p 15001:15001 -p 15991:15991 --rm -it vitess/local
+docker run -p 15000:15000 -p 15001:15001 -p 15991:15991 -p 15999:15999 --rm -it vitess/local

--- a/web/vtadmin/README.md
+++ b/web/vtadmin/README.md
@@ -11,7 +11,7 @@ In this section, we'll get vtadmin-web, vtadmin-api, and Vitess all running loca
 	./docker/local/run.sh
 	```
 
-1. Create an empty vtgate credentials file to avoid the gRPC dialer bug mentioned in https://github.com/vitessio/vitess/pull/7187. Location and filename don't matter since you'll be passing this in as a flag; I put mine at ` /Users/sarabee/id1-grpc_vtgate_credentials.json`:
+1. Create an empty vtgate credentials file to avoid the gRPC dialer bug mentioned in https://github.com/vitessio/vitess/pull/7187. Location and filename don't matter since you'll be passing this in as a flag; I put mine at ` /Users/sarabee/vtadmin-creds.json`:
 
 	```json
 	{
@@ -28,14 +28,14 @@ In this section, we'll get vtadmin-web, vtadmin-api, and Vitess all running loca
 			{
 				"host": {
 					"hostname": "127.0.0.1:15991"
-				},
-				"tags": ["pool:pool1", "cell:zone1", "extra:tag"]
-			},
+				}
+			}
+		],
+		"vtctlds": [
 			{
 				"host": {
-					"hostname": "127.0.0.1:15992"
-				},
-				"tags": ["dead-dove-do-not-eat"]
+					"hostname": "127.0.0.1:15999"
+				}
 			}
 		]
 	}
@@ -47,9 +47,10 @@ In this section, we'll get vtadmin-web, vtadmin-api, and Vitess all running loca
 	make build
 
 	./bin/vtadmin \
-		--addr ":15999" \
-		--cluster-defaults "vtsql-credentials-path-tmpl=/Users/sarabee/id1-grpc_vtgate_credentials.json" \
-		--cluster "name=cluster1,id=id1,discovery=staticFile,discovery-staticFile-path=/Users/sarabee/vtadmin-cluster1.json,vtsql-discovery-tags=cell:zone1" 
+		--addr ":14200" \
+		--cluster-defaults "vtctld-credentials-path-tmpl=/Users/sarabee/vtadmin-creds.json,vtsql-credentials-path-tmpl=/Users/sarabee/vtadmin-creds.json" \
+		--cluster "name=cluster1,id=id1,discovery=staticFile,discovery-staticFile-path=/Users/sarabee/vtadmin-cluster1.json" \
+		--http-origin=http://localhost:3000
 	```
 
 1. Finally! Start up vtadmin-web on [http://localhost:3000](http://localhost:3000), pointed at the vtadmin-api server you started in the last step. 
@@ -57,7 +58,7 @@ In this section, we'll get vtadmin-web, vtadmin-api, and Vitess all running loca
 	```bash
 	cd web/vtadmin
 	npm install
-	REACT_APP_VTADMIN_API_ADDRESS="http://127.0.0.1:15999" npm start
+	REACT_APP_VTADMIN_API_ADDRESS="http://127.0.0.1:14200" npm start
 	```
 
 # Developer guide


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description
A couple tiny changes to get ✨ https://github.com/vitessio/vitess/pull/7266 ✨ working with local Docker! (I promise promise to add a tidy make target in lieu of those ~~four~~ five README steps... soon... 🙈)

<img width="1792" alt="Screen Shot 2021-01-15 at 4 00 44 PM" src="https://user-images.githubusercontent.com/855595/104778224-0603ad00-574b-11eb-9cf5-ee99b03d8dac.png">


## Related Issue(s)

- https://github.com/vitessio/vitess/pull/7266

## Checklist
- [x] Should this PR be backported? **N/A**
- [x] Tests were added or are not required **N/A**
- [x] Documentation was added or is not required

## Deployment Notes
N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [x]  VTAdmin
