### PR TITLE
Pull Request template: link to contribution guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
   How to contribute: https://vitess.io/docs/contributing/
-  We’re looking forward to any contribution! Before you start larger contributions, make sure to reach out first and discuss your plans with us.
+  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
+  If this is a new feature, please mark the Issue as "RFC".
  -->
 
 <!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+  How to contribute: https://vitess.io/docs/contributing/
+  We’re looking forward to any contribution! Before you start larger contributions, make sure to reach out first and discuss your plans with us.
+ -->
+
 <!-- if this PR is Work in Progress please create it as a Draft Pull Request -->
 
 ## Description


### PR DESCRIPTION

## Description

As discussed in an internal meeting, we see many contributions that are not linked with an existing issue or a prior discussion.
This PR updated th epull request template to first and foremost ask the submitter to read the Contributing guide on the Vitess docs.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
