### PR TITLE
mariadb secure user support

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -15,11 +15,37 @@
 # Changes during the init db should not make it to the binlog.
 # They could potentially create errant transactions on replicas.
 SET sql_log_bin = 0;
-# Remove anonymous users.
-DELETE FROM mysql.user WHERE User = '';
 
-# Disable remote root access (only allow UNIX socket).
-DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+# Remove anonymous users and non-localhost root users.
+
+# use standard DROP USER on anon users and the local root TCP based user
+# The default standard install uses @@hostname as the hostname, but only
+# MariaDB(10.2.3+) supports the EXECUTE IMMEDIATE.
+
+DROP USER /*M!100103 IF EXISTS */ ''@localhost;
+/*M!100203 EXECUTE IMMEDIATE CONCAT('DROP USER IF EXISTS ""@', @@hostname) */;
+
+DROP USER /*M!100103 IF EXISTS */ 'root'@'127.0.0.1';
+DROP USER /*M!100103 IF EXISTS */ 'root'@'::1';
+/*M!100203 EXECUTE IMMEDIATE CONCAT('DROP USER IF EXISTS root@', @@hostname) */;
+
+# MariaDB-10.3 can be a bit more thorough with this FOR synax.
+DELIMITER $$
+/*M!100301 CREATE OR REPLACE PROCEDURE mysql.secure_users()
+FOR insecuser IN ( SELECT user,host FROM mysql.user WHERE user='' OR (user='root' AND host!='localhost') )
+DO
+	EXECUTE IMMEDIATE CONCAT('DROP USER `', insecuser.user, '`@`', insecuser.host, '`');
+END FOR */
+$$
+DELIMITER ;
+/*M!100301 call mysql.secure_users() */;
+/*M!100301 DROP PROCEDURE mysql.secure_users */;
+
+# MySQL-5.7 (not MariaDB) can use direct table manipulation. MariaDB-10.4 has mysql.user as a VIEW
+# so the previous cases of MariaDB will work.
+/*!50701 DELETE FROM mysql.user WHERE User= '' OR (User = 'root' AND Host != 'localhost') */;
+/*!50701 FLUSH PRIVILEGES */;
+
 
 # Remove test database.
 DROP DATABASE IF EXISTS test;
@@ -97,8 +123,6 @@ GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
   ON *.* TO 'orc_client_user'@'%';
 GRANT SELECT
   ON _vt.* TO 'orc_client_user'@'%';
-
-FLUSH PRIVILEGES;
 
 RESET SLAVE ALL;
 RESET MASTER;


### PR DESCRIPTION
MariaDB-10.4 uses mysql.user as a VIEW so the old mechanism of securing
won't work.

To replace it a combination DROP USER for the default created users
is used.

Using the MariaDB-10.2, the current minimum upstream supported version,
DROP USER ''@ @@hostname and DROP USER root@ @@hostname are used.

10.3+ uses a more thorough cursor on the mysql.user table to remove users.
A more elaborate use of CURSOR would be able to do the same on 10.2
as this supports EXECUTE IMMEDIATE (please advice if this is desired).

The previous behavior of deleting to mysql.user is limited to MySQL-5.7+
(and not MariaDB). MySQL-5.6 is EOL In February 2021 by all
accounts (https://lefred.be/content/mysql-5-6-eol-is-february-2021/)
so this is a few days pre-emptive.

Signed-off-by: Daniel Black <daniel@mariadb.org>

## Description

This cleans up the user initialization of mysql_secure_install effects in a largely compatible way for MariaDB and MySQL. It allows the installation of this file to extend beyond MariaDB-10.4 where mysql.user becomes a view.

Note I've largely developed and tested this independent of vitess, scripting the install into MariaDB-10.2 and 10.3 as tests.

## Related Issue(s)
 
#6697, #5362

## Checklist

- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin

(unsure)