### PR TITLE
Refresh replicas and rdonly after MigrateServedTypes except on skipRefreshState.

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1032,7 +1032,7 @@ func commandRefreshStateByShard(ctx context.Context, wr *wrangler.Wrangler, subF
 	if *cellsStr != "" {
 		cells = strings.Split(*cellsStr, ",")
 	}
-	return wr.RefreshTabletsByShard(ctx, si, nil /* tabletTypes */, cells)
+	return wr.RefreshTabletsByShard(ctx, si, cells)
 }
 
 func commandRunHealthCheck(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1129,7 +1129,7 @@ func (ts *trafficSwitcher) changeTableSourceWrites(ctx context.Context, access a
 		}); err != nil {
 			return err
 		}
-		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil, nil)
+		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil)
 	})
 }
 
@@ -1364,7 +1364,7 @@ func (ts *trafficSwitcher) allowTableTargetWrites(ctx context.Context) error {
 		}); err != nil {
 			return err
 		}
-		return ts.wr.RefreshTabletsByShard(ctx, target.si, nil, nil)
+		return ts.wr.RefreshTabletsByShard(ctx, target.si, nil)
 	})
 }
 
@@ -1522,7 +1522,7 @@ func (ts *trafficSwitcher) dropSourceBlacklistedTables(ctx context.Context) erro
 		}); err != nil {
 			return err
 		}
-		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil, nil)
+		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil)
 	})
 }
 


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This PR changes MigrateServedTypes to refresh both Replicas and Rdonly tablets after every migration. Ran into an issue during a migration in which a replica was promoted to primary but hadn't been refreshed since we initially only refreshed tablets with `servedType`. With the primaries migrated and refreshed but not the replicas, when there is a failover before the replicas have had their state refreshed, the replica will still believe it is in a split state causing it not to serve until RefreshState is done on the host. 
## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
