### PR TITLE
Change @@version and @@version_comment

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"vitess.io/vitess/go/vt/servenv"
+
 	"vitess.io/vitess/go/sqlescape"
 
 	proxyproto "github.com/pires/go-proxyproto"
@@ -42,7 +44,6 @@ import (
 const (
 	// DefaultServerVersion is the default server version we're sending to the client.
 	// Can be changed.
-	DefaultServerVersion = "5.7.9-Vitess"
 
 	// timing metric keys
 	connectTimingKey  = "Connect"
@@ -232,7 +233,7 @@ func NewListenerWithConfig(cfg ListenerConfig) (*Listener, error) {
 		authServer:         cfg.AuthServer,
 		handler:            cfg.Handler,
 		listener:           l,
-		ServerVersion:      DefaultServerVersion,
+		ServerVersion:      servenv.AppVersion.MySQLVersion(),
 		connectionID:       1,
 		connReadTimeout:    cfg.ConnReadTimeout,
 		connWriteTimeout:   cfg.ConnWriteTimeout,

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -496,6 +496,20 @@ func TestCreateView(t *testing.T) {
 	assertMatches(t, conn, "select * from v1", `[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)] [INT64(5) INT64(5)]]`)
 }
 
+func TestVersions(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	qr := exec(t, conn, `select @@version`)
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), "vitess")
+
+	qr = exec(t, conn, `select @@version_comment`)
+	assert.Contains(t, fmt.Sprintf("%v", qr.Rows), "Git revision")
+}
+
 func TestFlush(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionString(t *testing.T) {
+	now, _ := time.Parse(time.RFC1123, "Tue, 15 Sep 2020 12:04:10 UTC")
+
+	v := &versionInfo{
+		buildHost:       "host",
+		buildUser:       "user",
+		buildTime:       now.Unix(),
+		buildTimePretty: "time is now",
+		buildGitRev:     "d54b87c",
+		buildGitBranch:  "gitBranch",
+		goVersion:       "1.15",
+		goOS:            "amiga",
+		goArch:          "amd64",
+		version:         "v1.2.3-SNAPSHOT",
+	}
+
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.15 amiga/amd64", v.String())
+
+	v.jenkinsBuildNumber = 422
+
+	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (Jenkins build 422) (Git revision d54b87c branch 'gitBranch') built on time is now by user@host using 1.15 amiga/amd64", v.String())
+
+	assert.Equal(t, "5.7.9-vitess-v1.2.3-SNAPSHOT", v.MySQLVersion())
+	newVersion := "test!"
+	MySQLServerVersion = &newVersion
+	assert.Equal(t, newVersion, v.MySQLVersion())
+}

--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -1,0 +1,3 @@
+package servenv
+
+const versionName = "10.0.0-SNAPSHOT"

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -238,7 +238,8 @@ func (er *expressionRewriter) sysVarRewrite(cursor *Cursor, node *ColName) {
 		sysvars.SessionEnableSystemSettings.Name,
 		sysvars.ReadAfterWriteGTID.Name,
 		sysvars.ReadAfterWriteTimeOut.Name,
-		sysvars.VitessVersion.Name,
+		sysvars.Version.Name,
+		sysvars.VersionComment.Name,
 		sysvars.SessionTrackGTIDs.Name:
 		cursor.Replace(bindVarExpression("__vt" + lowered))
 		er.bindVars.AddSysVar(lowered)

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -27,12 +27,12 @@ import (
 )
 
 type myTestCase struct {
-	in, expected                                                      string
-	liid, db, foundRows, rowCount, rawGTID, rawTimeout, sessTrackGTID bool
-	ddlStrategy, sessionUUID, sessionEnableSystemSettings             bool
-	udv                                                               int
-	autocommit, clientFoundRows, skipQueryPlanCache                   bool
-	sqlSelectLimit, transactionMode, workload, vitessVersion          bool
+	in, expected                                                       string
+	liid, db, foundRows, rowCount, rawGTID, rawTimeout, sessTrackGTID  bool
+	ddlStrategy, sessionUUID, sessionEnableSystemSettings              bool
+	udv                                                                int
+	autocommit, clientFoundRows, skipQueryPlanCache                    bool
+	sqlSelectLimit, transactionMode, workload, version, versionComment bool
 }
 
 func TestRewrites(in *testing.T) {
@@ -41,9 +41,13 @@ func TestRewrites(in *testing.T) {
 		expected: "SELECT 42",
 		// no bindvar needs
 	}, {
-		in:            "SELECT @@vitess_version",
-		expected:      "SELECT :__vtvitess_version as `@@vitess_version`",
-		vitessVersion: true,
+		in:       "SELECT @@version",
+		expected: "SELECT :__vtversion as `@@version`",
+		version:  true,
+	}, {
+		in:             "SELECT @@version_comment",
+		expected:       "SELECT :__vtversion_comment as `@@version_comment`",
+		versionComment: true,
 	}, {
 		in:                          "SELECT @@enable_system_settings",
 		expected:                    "SELECT :__vtenable_system_settings as `@@enable_system_settings`",
@@ -207,7 +211,8 @@ func TestRewrites(in *testing.T) {
 			assert.Equal(tc.rawGTID, result.NeedsSysVar(sysvars.ReadAfterWriteGTID.Name), "should need rawGTID")
 			assert.Equal(tc.rawTimeout, result.NeedsSysVar(sysvars.ReadAfterWriteTimeOut.Name), "should need rawTimeout")
 			assert.Equal(tc.sessTrackGTID, result.NeedsSysVar(sysvars.SessionTrackGTIDs.Name), "should need sessTrackGTID")
-			assert.Equal(tc.vitessVersion, result.NeedsSysVar(sysvars.VitessVersion.Name), "should need Vitess version")
+			assert.Equal(tc.version, result.NeedsSysVar(sysvars.Version.Name), "should need Vitess version")
+			assert.Equal(tc.versionComment, result.NeedsSysVar(sysvars.VersionComment.Name), "should need Vitess version")
 		})
 	}
 }

--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -56,8 +56,9 @@ var (
 	SessionUUID                 = SystemVariable{Name: "session_uuid", IdentifierAsString: true}
 	SessionEnableSystemSettings = SystemVariable{Name: "enable_system_settings", IsBoolean: true, Default: on}
 	// Online DDL
-	DDLStrategy   = SystemVariable{Name: "ddl_strategy", IdentifierAsString: true}
-	VitessVersion = SystemVariable{Name: "vitess_version", IdentifierAsString: true}
+	DDLStrategy    = SystemVariable{Name: "ddl_strategy", IdentifierAsString: true}
+	Version        = SystemVariable{Name: "version"}
+	VersionComment = SystemVariable{Name: "version_comment"}
 
 	// Read After Write settings
 	ReadAfterWriteGTID    = SystemVariable{Name: "read_after_write_gtid"}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -319,7 +319,9 @@ func (e *Executor) addNeededBindVars(bindVarNeeds *sqlparser.BindVarNeeds, bindV
 				}
 			})
 			bindVars[key] = sqltypes.StringBindVariable(v)
-		case sysvars.VitessVersion.Name:
+		case sysvars.Version.Name:
+			bindVars[key] = sqltypes.StringBindVariable(servenv.AppVersion.MySQLVersion())
+		case sysvars.VersionComment.Name:
 			bindVars[key] = sqltypes.StringBindVariable(servenv.AppVersion.String())
 		}
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -56,7 +56,6 @@ var (
 	mysqlTCPVersion               = flag.String("mysql_tcp_version", "tcp", "Select tcp, tcp4, or tcp6 to control the socket type.")
 	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "static", "Which auth server implementation to use. Options: none, ldap, clientcert, static, vault.")
 	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
-	mysqlServerVersion            = flag.String("mysql_server_version", mysql.DefaultServerVersion, "MySQL server version to advertise.")
 	mysqlProxyProtocol            = flag.Bool("proxy_protocol", false, "Enable HAProxy PROXY protocol on MySQL listener socket")
 
 	mysqlServerRequireSecureTransport = flag.Bool("mysql_server_require_secure_transport", false, "Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided")
@@ -425,8 +424,8 @@ func initMySQLProtocol() {
 		if err != nil {
 			log.Exitf("mysql.NewListener failed: %v", err)
 		}
-		if *mysqlServerVersion != "" {
-			mysqlListener.ServerVersion = *mysqlServerVersion
+		if *servenv.MySQLServerVersion != "" {
+			mysqlListener.ServerVersion = *servenv.MySQLServerVersion
 		}
 		if *mysqlSslCert != "" && *mysqlSslKey != "" {
 			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlServerRequireSecureTransport)


### PR DESCRIPTION
## Description
This PR changes the `@@version` and `@@version_comment` values to include information about the Vitess version.
It also removed the recently added `@@vitess_version`.

The change includes a new file, `version.go` that contains very little. It's kept minimal like this to be easy for our release scripts to update the named version.

```sql
mysql> select @@version;
+------------------------------+
| @@version                    |
+------------------------------+
| 5.7.9-vitess-10.0.0-SNAPSHOT |
+------------------------------+

mysql> select @@version_comment;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| @@version_comment                                                                                                                                                                        |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Version: 10.0.0-SNAPSHOT (Git revision d54b87c83 branch 'release-name-in-version') built on Wed Jan 20 20:42:46 CET 2021 by systay@Andress-MacBook-Pro.local using go1.15.5 darwin/amd64 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


```