### PR TITLE
Workflow Show: use timeUpdated to calculate vreplication lag

### DIFF
--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -378,8 +378,6 @@ type ReplicationStatus struct {
 	StopPos string
 	// State represents the state column from the _vt.vreplication table.
 	State string
-	// MaxReplicationLag represents the max_replication_lag column from the _vt.vreplication table.
-	MaxReplicationLag int64
 	// DbName represents the db_name column from the _vt.vreplication table.
 	DBName string
 	// TransactionTimestamp represents the transaction_timestamp column from the _vt.vreplication table.
@@ -395,7 +393,7 @@ type ReplicationStatus struct {
 
 func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqltypes.Value, master *topo.TabletInfo) (*ReplicationStatus, string, error) {
 	var err error
-	var id, maxReplicationLag, timeUpdated, transactionTimestamp int64
+	var id, timeUpdated, transactionTimestamp int64
 	var state, dbName, pos, stopPos, message string
 	var bls binlogdatapb.BinlogSource
 	id, err = evalengine.ToInt64(row[0])
@@ -407,10 +405,6 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqlty
 	}
 	pos = row[2].ToString()
 	stopPos = row[3].ToString()
-	maxReplicationLag, err = evalengine.ToInt64(row[4])
-	if err != nil {
-		return nil, "", err
-	}
 	state = row[5].ToString()
 	dbName = row[6].ToString()
 	timeUpdated, err = evalengine.ToInt64(row[7])
@@ -431,7 +425,6 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqlty
 		StopPos:              stopPos,
 		State:                state,
 		DBName:               dbName,
-		MaxReplicationLag:    maxReplicationLag,
 		TransactionTimestamp: transactionTimestamp,
 		TimeUpdated:          timeUpdated,
 		Message:              message,
@@ -477,8 +470,8 @@ func (wr *Wrangler) getStreams(ctx context.Context, workflow, keyspace string) (
 			sourceShards.Insert(status.Bls.Shard)
 			rsrStatus = append(rsrStatus, status)
 
-			transactionTimestamp := time.Unix(status.TransactionTimestamp, 0)
-			replicationLag := time.Since(transactionTimestamp)
+			timeUpdated := time.Unix(status.TimeUpdated, 0)
+			replicationLag := time.Since(timeUpdated)
 			if replicationLag.Seconds() > float64(rsr.MaxVReplicationLag) {
 				rsr.MaxVReplicationLag = int64(replicationLag.Seconds())
 			}

--- a/go/vt/wrangler/vexec_plan.go
+++ b/go/vt/wrangler/vexec_plan.go
@@ -92,11 +92,11 @@ func (p vreplicationPlanner) dryRun(ctx context.Context) error {
 		p.vx.plannedQuery, p.vx.keyspace, p.vx.workflow)
 	tableString := &strings.Builder{}
 	table := tablewriter.NewWriter(tableString)
-	table.SetHeader([]string{"Tablet", "ID", "BinLogSource", "State", "DBName", "Current GTID", "MaxReplicationLag"})
+	table.SetHeader([]string{"Tablet", "ID", "BinLogSource", "State", "DBName", "Current GTID"})
 	for _, master := range p.vx.masters {
 		key := fmt.Sprintf("%s/%s", master.Shard, master.AliasString())
 		for _, stream := range rsr.ShardStatuses[key].MasterReplicationStatuses {
-			table.Append([]string{key, fmt.Sprintf("%d", stream.ID), stream.Bls.String(), stream.State, stream.DBName, stream.Pos, fmt.Sprintf("%d", stream.MaxReplicationLag)})
+			table.Append([]string{key, fmt.Sprintf("%d", stream.ID), stream.Bls.String(), stream.State, stream.DBName, stream.Pos})
 		}
 	}
 	table.SetAutoMergeCellsByColumnIndex([]int{0})

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -37,7 +37,7 @@ func TestVExec(t *testing.T) {
 	workflow := "wrWorkflow"
 	keyspace := "target"
 	query := "update _vt.vreplication set state = 'Running'"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil)
+	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, time.Now().Unix())
 	defer env.close()
 	var logger = logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -73,6 +73,10 @@ func TestVExec(t *testing.T) {
 
 	vx.plannedQuery = plan.parsedQuery.Query
 	vx.exec()
+
+	res, err := wr.getStreams(ctx, workflow, keyspace)
+	require.NoError(t, err)
+	require.Less(t, res.MaxVReplicationLag, int64(3 /*seconds*/)) // lag should be very small
 
 	type TestCase struct {
 		name        string
@@ -174,7 +178,7 @@ func TestWorkflowListStreams(t *testing.T) {
 	ctx := context.Background()
 	workflow := "wrWorkflow"
 	keyspace := "target"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil)
+	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 1234)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -329,7 +333,7 @@ func TestWorkflowListAll(t *testing.T) {
 	ctx := context.Background()
 	keyspace := "target"
 	workflow := "wrWorkflow"
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil)
+	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 	logger := logutil.NewMemoryLogger()
 	wr := New(logger, env.topoServ, env.tmc)
@@ -348,7 +352,7 @@ func TestVExecValidations(t *testing.T) {
 	workflow := "wf"
 	keyspace := "ks"
 	query := ""
-	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil)
+	env := newWranglerTestEnv([]string{"0"}, []string{"-80", "80-"}, "", nil, 0)
 	defer env.close()
 
 	wr := New(logutil.NewConsoleLogger(), env.topoServ, env.tmc)

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -149,15 +149,15 @@ func TestVExec(t *testing.T) {
 	dryRunResults := []string{
 		"Query: delete from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'",
 		"will be run on the following streams in keyspace target for workflow wrWorkflow:\n\n",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+",
-		"|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID | MAXREPLICATIONLAG |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+",
-		"| -80/zone1-0000000200 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |                 0 |",
-		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |                   |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+",
-		"| 80-/zone1-0000000210 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |                 0 |",
-		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |                   |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+",
+		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
+		"|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID |",
+		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
+		"| -80/zone1-0000000200 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |",
+		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |",
+		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
+		"| 80-/zone1-0000000210 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |",
+		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |",
+		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
 	}
 	require.Equal(t, strings.Join(dryRunResults, "\n")+"\n\n\n\n\n", logger.String())
 }
@@ -227,7 +227,6 @@ func TestWorkflowListStreams(t *testing.T) {
 					"Pos": "pos",
 					"StopPos": "",
 					"State": "Copying",
-					"MaxReplicationLag": 0,
 					"DBName": "vt_target",
 					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
@@ -263,7 +262,6 @@ func TestWorkflowListStreams(t *testing.T) {
 					"Pos": "pos",
 					"StopPos": "",
 					"State": "Copying",
-					"MaxReplicationLag": 0,
 					"DBName": "vt_target",
 					"TransactionTimestamp": 0,
 					"TimeUpdated": 1234,
@@ -310,15 +308,15 @@ func TestWorkflowListStreams(t *testing.T) {
 will be run on the following streams in keyspace target for workflow wrWorkflow:
 
 
-+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+
-|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID | MAXREPLICATIONLAG |
-+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+
-| -80/zone1-0000000200 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |                 0 |
-|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |                   |
-+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+
-| 80-/zone1-0000000210 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |                 0 |
-|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |                   |
-+----------------------+----+--------------------------------+---------+-----------+--------------+-------------------+
++----------------------+----+--------------------------------+---------+-----------+--------------+
+|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID |
++----------------------+----+--------------------------------+---------+-----------+--------------+
+| -80/zone1-0000000200 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |
++----------------------+----+--------------------------------+---------+-----------+--------------+
+| 80-/zone1-0000000210 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |
++----------------------+----+--------------------------------+---------+-----------+--------------+
 
 
 

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
-
-	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -76,7 +75,7 @@ func init() {
 //----------------------------------------------
 // testWranglerEnv
 
-func newWranglerTestEnv(sourceShards, targetShards []string, query string, positions map[string]string) *testWranglerEnv {
+func newWranglerTestEnv(sourceShards, targetShards []string, query string, positions map[string]string, timeUpdated int64) *testWranglerEnv {
 	flag.Set("tablet_protocol", "WranglerTest")
 	env := &testWranglerEnv{
 		workflow:   "wrWorkflow",
@@ -147,7 +146,7 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|message",
 			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|int64|varchar"),
-			fmt.Sprintf("1|%v|pos||0|Running|vt_target|1234|0|", bls),
+			fmt.Sprintf("1|%v|pos||0|Running|vt_target|%d|0|", bls, timeUpdated),
 		)
 		env.tmc.setVRResults(master.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
 		env.tmc.setVRResults(


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
1. There was a problem in the initial implementation of determining MaxVReplicationLag, which was the seconds since `transaction_timestamp`. MaxVReplicationLag is used, in a Reshard workflow, by the operator to determine when resharding is completed. See https://github.com/vitessio/vitess/issues/6946, which logs the problem and fixes it. However this fix was problematic for two reasons:

    * `transaction_timestamp` is 0 as long as the stream is in the copy phase. If there are no new writes on the source once the copy phase is completed then the value does not get updated
    * there are cases when there are no writes on the source relevant to a target. In this case the `transaction_timestamp` column for that stream does not get updated as there are no new events seen by the target. <br/><br/>
    
    In both cases the operator decides that the stream is lagging and doesn't perform the cutover. This PR changes the logic to use the `time_updated` column instead of `transaction_timestamp`. `time_updated` is updated both when there is a binlog event from the source and also when the source sends a heartbeat (every idle second). 

1. Don't display unused column `max_replication_lag` from `_vt.vreplication`
 
    This column was used several versions earlier for throttling SplitClone streams. Vreplication workflows do not use it and it should not be displayed since it always displays MaxInt and is confusing to users.
## Related Issue(s)

<!-- List related issues and pull requests: -->
#6946 

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
