### PR TITLE
VReplication Stats: publish the state of streams 

### DIFF
--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -77,7 +77,6 @@ sleep 3 # TODO: Required for now!
 
 ./304_switch_reads.sh
 ./305_switch_writes.sh
-exit
 
 mysql --table < ../common/select_customer-80_data.sql
 mysql --table < ../common/select_customer80-_data.sql

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -77,6 +77,7 @@ sleep 3 # TODO: Required for now!
 
 ./304_switch_reads.sh
 ./305_switch_writes.sh
+exit
 
 mysql --table < ../common/select_customer-80_data.sql
 mysql --table < ../common/select_customer80-_data.sql


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
Adds a new stat on the `/debug/vars` page to publish state of a stream (Running/Stopped). Looks like:

`"VReplicationStreamState": {"cust2cust_reverse.3": "Running", "cust2cust_reverse.2": "Running"}`


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
