### PR TITLE
fix common select script to work for both local and operator examples

### DIFF
--- a/examples/common/select_commerce_data.sql
+++ b/examples/common/select_commerce_data.sql
@@ -1,5 +1,5 @@
-\! echo 'Using commerce/0'
-use commerce/0;
+\! echo 'Using commerce'
+use commerce;
 \! echo 'Customer'
 select * from customer;
 \! echo 'Product'

--- a/examples/operator/README.md
+++ b/examples/operator/README.md
@@ -14,7 +14,7 @@ vtctlclient ApplyVSchema -vschema="$(cat vschema_commerce_initial.json)" commerc
 
 # Insert and verify data
 mysql < ../common/insert_commerce_data.sql
-mysql --table < select_commerce_data.sql
+mysql --table < ../common/select_commerce_data.sql
 
 # Bring up customer keyspace
 kubectl apply -f 201_customer_tablets.yaml


### PR DESCRIPTION
Signed-off-by: deepthi <deepthi@planetscale.com>

## Description
In #7245 we removed a file (`select_commerce_data.sql`) from the operator example. However, the README still points to the deleted file.
This PR fixes the README to use the correct path to the file.
In addition, the `use` command in that file only worked for the local example, not the operator example.
That has also been fixed.

## Related Issue(s)
#7245 
A website PR will be created after 9.0 is released and we have archived the 9.0 docs.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
