### PR TITLE
Fix VitessAware system variables of type boolean return NULL when MySQL is not involved

### DIFF
--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -78,9 +78,9 @@ func Int32BindVariable(v int32) *querypb.BindVariable {
 // BoolBindVariable converts an bool to a int32 bind var.
 func BoolBindVariable(v bool) *querypb.BindVariable {
 	if v {
-		return Int32BindVariable(1)
+		return Int64BindVariable(1)
 	}
-	return Int32BindVariable(0)
+	return Int64BindVariable(0)
 }
 
 // Int64BindVariable converts an int64 to a bind var.

--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -75,7 +75,7 @@ func Int32BindVariable(v int32) *querypb.BindVariable {
 	return ValueBindVariable(NewInt32(v))
 }
 
-// BoolBindVariable converts an bool to a int32 bind var.
+// BoolBindVariable converts an bool to a int64 bind var.
 func BoolBindVariable(v bool) *querypb.BindVariable {
 	if v {
 		return Int64BindVariable(1)

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -280,7 +280,7 @@ func (v Value) EncodeSQL(b BinWriter) {
 		encodeBytesSQLBits(v.val, b)
 	default:
 		if v.typ == querypb.Type_INT32 {
-			b.Write([]byte(fmt.Sprintf("CAST(1 as INT) AS autocommit")))
+			b.Write([]byte("CAST(1 as INT) AS autocommit"))
 		} else {
 			b.Write(v.val)
 		}

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -279,11 +279,7 @@ func (v Value) EncodeSQL(b BinWriter) {
 	case v.typ == Bit:
 		encodeBytesSQLBits(v.val, b)
 	default:
-		if v.typ == querypb.Type_INT32 {
-			b.Write([]byte("CAST(1 as INT) AS autocommit"))
-		} else {
-			b.Write(v.val)
-		}
+		b.Write(v.val)
 	}
 }
 

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -279,7 +279,11 @@ func (v Value) EncodeSQL(b BinWriter) {
 	case v.typ == Bit:
 		encodeBytesSQLBits(v.val, b)
 	default:
-		b.Write(v.val)
+		if v.typ == querypb.Type_INT32 {
+			b.Write([]byte(fmt.Sprintf("CAST(1 as INT) AS autocommit")))
+		} else {
+			b.Write(v.val)
+		}
 	}
 }
 

--- a/go/test/endtoend/vtgate/reservedconn/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/main_test.go
@@ -169,3 +169,13 @@ func assertIsEmpty(t *testing.T, conn *mysql.Conn, query string) {
 	qr := checkedExec(t, conn, query)
 	assert.Empty(t, qr.Rows)
 }
+
+func assertResponseMatch(t *testing.T, conn *mysql.Conn, query1, query2 string) {
+	qr1 := checkedExec(t, conn, query1)
+	got1 := fmt.Sprintf("%v", qr1.Rows)
+
+	qr2 := checkedExec(t, conn, query2)
+	got2 := fmt.Sprintf("%v", qr2.Rows)
+
+	assert.Equal(t, got1, got2)
+}

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -367,7 +367,7 @@ func TestSystemVariableType(t *testing.T) {
 
 	checkedExec(t, conn, "set autocommit = false")
 	assertMatches(t, conn, `select @@autocommit`, `[[INT32(0)]]`)
-	assertMatches(t, conn, `select @@autocommit test`, `[[INT32(0)]]`)
+	assertMatches(t, conn, `select @@autocommit from test`, `[[INT32(0)]]`)
 
 	checkedExec(t, conn, "set autocommit = true")
 	assertMatches(t, conn, `select @@autocommit`, `[[INT32(1)]]`)

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
@@ -366,18 +364,12 @@ func TestSystemVariableType(t *testing.T) {
 	checkedExec(t, conn, "insert into test (id, val1, val2, val3) values (1, null, 0, 0)")
 
 	// regardless of the "from", the select @@autocommit should return the same type
+	query1 := "select @@autocommit"
+	query2 := "select @@autocommit from test"
 
 	checkedExec(t, conn, "set autocommit = false")
-	qr1 := checkedExec(t, conn, "select @@autocommit")
-	got1 := fmt.Sprintf("%v", qr1.Rows)
-	qr2 := checkedExec(t, conn, "select @@autocommit from test")
-	got2 := fmt.Sprintf("%v", qr2.Rows)
-	assert.Equal(t, got1, got2)
+	assertResponseMatch(t, conn, query1, query2)
 
 	checkedExec(t, conn, "set autocommit = true")
-	qr1 = checkedExec(t, conn, "select @@autocommit")
-	got1 = fmt.Sprintf("%v", qr1.Rows)
-	qr2 = checkedExec(t, conn, "select @@autocommit from test")
-	got2 = fmt.Sprintf("%v", qr2.Rows)
-	assert.Equal(t, got1, got2)
+	assertResponseMatch(t, conn, query1, query2)
 }

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
@@ -363,13 +365,19 @@ func TestSystemVariableType(t *testing.T) {
 	checkedExec(t, conn, "delete from test")
 	checkedExec(t, conn, "insert into test (id, val1, val2, val3) values (1, null, 0, 0)")
 
-	// regardeless of the "from", the select @@autocommit should always return a INT32 type
+	// regardless of the "from", the select @@autocommit should return the same type
 
 	checkedExec(t, conn, "set autocommit = false")
-	assertMatches(t, conn, `select @@autocommit`, `[[INT32(0)]]`)
-	assertMatches(t, conn, `select @@autocommit from test`, `[[INT32(0)]]`)
+	qr1 := checkedExec(t, conn, "select @@autocommit")
+	got1 := fmt.Sprintf("%v", qr1.Rows)
+	qr2 := checkedExec(t, conn, "select @@autocommit from test")
+	got2 := fmt.Sprintf("%v", qr2.Rows)
+	assert.Equal(t, got1, got2)
 
 	checkedExec(t, conn, "set autocommit = true")
-	assertMatches(t, conn, `select @@autocommit`, `[[INT32(1)]]`)
-	assertMatches(t, conn, `select @@autocommit from test`, `[[INT32(1)]]`)
+	qr1 = checkedExec(t, conn, "select @@autocommit")
+	got1 = fmt.Sprintf("%v", qr1.Rows)
+	qr2 = checkedExec(t, conn, "select @@autocommit from test")
+	got2 = fmt.Sprintf("%v", qr2.Rows)
+	assert.Equal(t, got1, got2)
 }

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -329,16 +329,11 @@ func TestEnableSystemSettings(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Insert a single row to correctly select @@enable_system_settings.
-	// See: https://github.com/vitessio/vitess/issues/7301
-	checkedExec(t, conn, "delete from test")
-	checkedExec(t, conn, "insert into test (id, val1, val2, val3) values (1, null, 0, 0)")
-
 	// test set @@enable_system_settings to false and true
 	checkedExec(t, conn, "set enable_system_settings = false")
-	assertMatches(t, conn, `select @@enable_system_settings from test`, `[[INT64(0)]]`)
+	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT32(0)]]`)
 	checkedExec(t, conn, "set enable_system_settings = true")
-	assertMatches(t, conn, `select @@enable_system_settings from test`, `[[INT64(1)]]`)
+	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT32(1)]]`)
 
 	// prepare the @@sql_mode variable
 	checkedExec(t, conn, "set sql_mode = 'NO_ZERO_DATE'")

--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -331,9 +331,9 @@ func TestEnableSystemSettings(t *testing.T) {
 
 	// test set @@enable_system_settings to false and true
 	checkedExec(t, conn, "set enable_system_settings = false")
-	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT32(0)]]`)
+	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT64(0)]]`)
 	checkedExec(t, conn, "set enable_system_settings = true")
-	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT32(1)]]`)
+	assertMatches(t, conn, `select @@enable_system_settings`, `[[INT64(1)]]`)
 
 	// prepare the @@sql_mode variable
 	checkedExec(t, conn, "set sql_mode = 'NO_ZERO_DATE'")

--- a/go/vt/vtgate/evalengine/evalengine.go
+++ b/go/vt/vtgate/evalengine/evalengine.go
@@ -200,34 +200,34 @@ func (v EvalResult) toSQLValue(resultType querypb.Type) sqltypes.Value {
 	switch {
 	case sqltypes.IsSigned(resultType):
 		switch v.typ {
-		case sqltypes.Int64:
-			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10))
-		case sqltypes.Uint64:
+		case sqltypes.Int64, sqltypes.Int32:
+			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, int64(v.ival), 10))
+		case sqltypes.Uint64, sqltypes.Uint32:
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, int64(v.uval), 10))
-		case sqltypes.Float64:
+		case sqltypes.Float64, sqltypes.Float32:
 			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, int64(v.fval), 10))
 		}
 	case sqltypes.IsUnsigned(resultType):
 		switch v.typ {
-		case sqltypes.Uint64:
-			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, v.uval, 10))
-		case sqltypes.Int64:
+		case sqltypes.Uint64, sqltypes.Uint32:
+			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, uint64(v.uval), 10))
+		case sqltypes.Int64, sqltypes.Int32:
 			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, uint64(v.ival), 10))
-		case sqltypes.Float64:
+		case sqltypes.Float64, sqltypes.Float32:
 			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, uint64(v.fval), 10))
 		}
 	case sqltypes.IsFloat(resultType) || resultType == sqltypes.Decimal:
 		switch v.typ {
-		case sqltypes.Int64:
-			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10))
-		case sqltypes.Uint64:
-			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, v.uval, 10))
-		case sqltypes.Float64:
+		case sqltypes.Int64, sqltypes.Int32:
+			return sqltypes.MakeTrusted(resultType, strconv.AppendInt(nil, int64(v.ival), 10))
+		case sqltypes.Uint64, sqltypes.Uint32:
+			return sqltypes.MakeTrusted(resultType, strconv.AppendUint(nil, uint64(v.uval), 10))
+		case sqltypes.Float64, sqltypes.Float32:
 			format := byte('g')
 			if resultType == sqltypes.Decimal {
 				format = 'f'
 			}
-			return sqltypes.MakeTrusted(resultType, strconv.AppendFloat(nil, v.fval, format, -1, 64))
+			return sqltypes.MakeTrusted(resultType, strconv.AppendFloat(nil, float64(v.fval), format, -1, 64))
 		}
 	default:
 		return sqltypes.MakeTrusted(resultType, v.bytes)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -349,10 +349,10 @@ func TestSelectSystemVariables(t *testing.T) {
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			// the following are the uninitialised session values
-			sqltypes.NULL,
-			sqltypes.NULL,
-			sqltypes.NULL,
-			sqltypes.NULL,
+			sqltypes.NewInt32(0),
+			sqltypes.NewInt32(0),
+			sqltypes.NewInt32(0),
+			sqltypes.NewInt32(0),
 			sqltypes.NewInt64(0),
 			sqltypes.NewVarBinary("UNSPECIFIED"),
 			sqltypes.NewVarBinary(""),
@@ -383,7 +383,7 @@ func TestSelectSingleVitessAwareVariable(t *testing.T) {
 		},
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt32(1),
+			sqltypes.NewInt32(0), // autocommit is by default false in the masterSession, thus 0
 		}},
 	}
 	require.NoError(t, err)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -334,10 +334,10 @@ func TestSelectSystemVariables(t *testing.T) {
 	result, err := executorExec(executor, sql, map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
-			{Name: "@@autocommit", Type: sqltypes.Int32},
-			{Name: "@@client_found_rows", Type: sqltypes.Int32},
-			{Name: "@@skip_query_plan_cache", Type: sqltypes.Int32},
-			{Name: "@@enable_system_settings", Type: sqltypes.Int32},
+			{Name: "@@autocommit", Type: sqltypes.Int64},
+			{Name: "@@client_found_rows", Type: sqltypes.Int64},
+			{Name: "@@skip_query_plan_cache", Type: sqltypes.Int64},
+			{Name: "@@enable_system_settings", Type: sqltypes.Int64},
 			{Name: "@@sql_select_limit", Type: sqltypes.Int64},
 			{Name: "@@transaction_mode", Type: sqltypes.VarBinary},
 			{Name: "@@workload", Type: sqltypes.VarBinary},
@@ -349,10 +349,10 @@ func TestSelectSystemVariables(t *testing.T) {
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			// the following are the uninitialised session values
-			sqltypes.NewInt32(0),
-			sqltypes.NewInt32(0),
-			sqltypes.NewInt32(0),
-			sqltypes.NewInt32(0),
+			sqltypes.NewInt64(0),
+			sqltypes.NewInt64(0),
+			sqltypes.NewInt64(0),
+			sqltypes.NewInt64(0),
 			sqltypes.NewInt64(0),
 			sqltypes.NewVarBinary("UNSPECIFIED"),
 			sqltypes.NewVarBinary(""),
@@ -386,13 +386,13 @@ func TestSelectInitializedVitessAwareVariable(t *testing.T) {
 	result, err := executorExec(executor, sql, nil)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
-			{Name: "@@autocommit", Type: sqltypes.Int32},
-			{Name: "@@enable_system_settings", Type: sqltypes.Int32},
+			{Name: "@@autocommit", Type: sqltypes.Int64},
+			{Name: "@@enable_system_settings", Type: sqltypes.Int64},
 		},
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt32(1),
-			sqltypes.NewInt32(1),
+			sqltypes.NewInt64(1),
+			sqltypes.NewInt64(1),
 		}},
 	}
 	require.NoError(t, err)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -367,6 +367,29 @@ func TestSelectSystemVariables(t *testing.T) {
 	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
+// Must fail until https://github.com/vitessio/vitess/issues/7301 is not fixed.
+func TestSelectSingleVitessAwareVariable(t *testing.T) {
+	executor, _, _, _ := createLegacyExecutorEnv()
+	executor.normalize = true
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
+	sql := "select @@autocommit"
+
+	result, err := executorExec(executor, sql, map[string]*querypb.BindVariable{})
+	wantResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "@@autocommit", Type: sqltypes.Int32},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt32(1),
+		}},
+	}
+	require.NoError(t, err)
+	utils.MustMatch(t, wantResult, result, "Mismatch")
+}
+
 func TestSelectUserDefindVariable(t *testing.T) {
 	executor, _, _, _ := createLegacyExecutorEnv()
 	executor.normalize = true

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -313,7 +313,7 @@ func TestSelectLastInsertId(t *testing.T) {
 		}},
 	}
 	require.NoError(t, err)
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
 func TestSelectSystemVariables(t *testing.T) {
@@ -364,7 +364,7 @@ func TestSelectSystemVariables(t *testing.T) {
 		}},
 	}
 	require.NoError(t, err)
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
 func TestSelectUserDefindVariable(t *testing.T) {
@@ -385,7 +385,7 @@ func TestSelectUserDefindVariable(t *testing.T) {
 			sqltypes.NULL,
 		}},
 	}
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 
 	masterSession = &vtgatepb.Session{UserDefinedVariables: createMap([]string{"foo"}, []interface{}{"bar"})}
 	result, err = executorExec(executor, sql, map[string]*querypb.BindVariable{})
@@ -399,7 +399,7 @@ func TestSelectUserDefindVariable(t *testing.T) {
 			sqltypes.NewVarBinary("bar"),
 		}},
 	}
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
 func TestFoundRows(t *testing.T) {
@@ -424,7 +424,7 @@ func TestFoundRows(t *testing.T) {
 		}},
 	}
 	require.NoError(t, err)
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
 func TestRowCount(t *testing.T) {
@@ -454,7 +454,7 @@ func testRowCount(t *testing.T, executor *Executor, wantRowCount int64) {
 		}},
 	}
 	require.NoError(t, err)
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 }
 
 func TestSelectLastInsertIdInUnion(t *testing.T) {
@@ -558,7 +558,7 @@ func TestSelectDatabase(t *testing.T) {
 		}},
 	}
 	require.NoError(t, err)
-	utils.MustMatch(t, result, wantResult, "Mismatch")
+	utils.MustMatch(t, wantResult, result, "Mismatch")
 
 }
 

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -783,7 +783,7 @@ func TestSelectBooleanSystemVariables(t *testing.T) {
 
 	for _, tc := range tcs {
 		qr, err := client.Execute(
-			fmt.Sprintf("select :%s", tc.Variable),
+			"select @@autocommit",
 			map[string]*querypb.BindVariable{tc.Variable: sqltypes.Int32BindVariable(int32(tc.Value))},
 		)
 		if err != nil {

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -766,25 +766,25 @@ func TestSelectBooleanSystemVariables(t *testing.T) {
 
 	type testCase struct {
 		Variable string
-		Value    int
+		Value    bool
 		Type     querypb.Type
 	}
 
-	newTestCase := func(varname string, vartype querypb.Type, value int) testCase {
+	newTestCase := func(varname string, vartype querypb.Type, value bool) testCase {
 		return testCase{Variable: varname, Value: value, Type: vartype}
 	}
 
 	tcs := []testCase{
-		newTestCase("autocommit", querypb.Type_INT32, 1),
-		newTestCase("autocommit", querypb.Type_INT32, 0),
-		newTestCase("enable_system_settings", querypb.Type_INT32, 1),
-		newTestCase("enable_system_settings", querypb.Type_INT32, 0),
+		newTestCase("autocommit", querypb.Type_INT64, true),
+		newTestCase("autocommit", querypb.Type_INT64, false),
+		newTestCase("enable_system_settings", querypb.Type_INT64, true),
+		newTestCase("enable_system_settings", querypb.Type_INT64, false),
 	}
 
 	for _, tc := range tcs {
 		qr, err := client.Execute(
-			"select @@autocommit",
-			map[string]*querypb.BindVariable{tc.Variable: sqltypes.Int32BindVariable(int32(tc.Value))},
+			fmt.Sprintf("select :%s", tc.Variable),
+			map[string]*querypb.BindVariable{tc.Variable: sqltypes.BoolBindVariable(tc.Value)},
 		)
 		if err != nil {
 			t.Error(err)

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -783,7 +783,7 @@ func TestSelectBooleanSystemVariables(t *testing.T) {
 
 	for _, tc := range tcs {
 		qr, err := client.Execute(
-			fmt.Sprintf("select @@%s", tc.Variable),
+			fmt.Sprintf("select :%s", tc.Variable),
 			map[string]*querypb.BindVariable{tc.Variable: sqltypes.Int32BindVariable(int32(tc.Value))},
 		)
 		if err != nil {

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -760,3 +760,37 @@ func TestBeginExecuteWithFailingPreQueriesAndCheckConnectionState(t *testing.T) 
 	require.NoError(t, err)
 	require.Empty(t, qr.Rows)
 }
+
+func TestSelectBooleanSystemVariables(t *testing.T) {
+	client := framework.NewClient()
+
+	type testCase struct {
+		Variable string
+		Value    int
+		Type     querypb.Type
+	}
+
+	newTestCase := func(varname string, vartype querypb.Type, value int) testCase {
+		return testCase{Variable: varname, Value: value, Type: vartype}
+	}
+
+	tcs := []testCase{
+		newTestCase("autocommit", querypb.Type_INT32, 1),
+		newTestCase("autocommit", querypb.Type_INT32, 0),
+		newTestCase("enable_system_settings", querypb.Type_INT32, 1),
+		newTestCase("enable_system_settings", querypb.Type_INT32, 0),
+	}
+
+	for _, tc := range tcs {
+		qr, err := client.Execute(
+			fmt.Sprintf("select @@%s", tc.Variable),
+			map[string]*querypb.BindVariable{tc.Variable: sqltypes.Int32BindVariable(int32(tc.Value))},
+		)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		require.NotEmpty(t, qr.Fields, "fields should not be empty")
+		require.Equal(t, tc.Type, qr.Fields[0].Type, fmt.Sprintf("invalid type, wants: %+v, but got: %+v\n", tc.Type, qr.Fields[0].Type))
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes https://github.com/vitessio/vitess/issues/7301. As detailed in the issue, selecting a `VitessAware` system variable without involving MySQL/Vttablets might return a nil result.

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/7301

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
