### PR TITLE
vtctl: Add missing err checks for VReplication v2

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2001,6 +2001,7 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	_, err = wr.TopoServer().GetKeyspace(ctx, target)
 	if err != nil {
 		wr.Logger().Errorf("keyspace %s not found", target)
+		return err
 	}
 
 	vrwp := &wrangler.VReplicationWorkflowParams{
@@ -2056,6 +2057,11 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 		case wrangler.MoveTablesWorkflow:
 			if *sourceKeyspace == "" {
 				return fmt.Errorf("source keyspace is not specified")
+			}
+			_, err := wr.TopoServer().GetKeyspace(ctx, *sourceKeyspace)
+			if err != nil {
+				wr.Logger().Errorf("keyspace %s not found", *sourceKeyspace)
+				return err
 			}
 			if !*allTables && *tables == "" {
 				return fmt.Errorf("no tables specified to move")


### PR DESCRIPTION
Return error immediately if the target keyspace is unknown. Do
the same for the source keyspace. Currently, the code will
attempt to continue with a bad keyspace name.

Signed-off-by: Jordan Moldow <jmoldow@alum.mit.edu>

## Related Issue(s)

- 

## Checklist
- [x] Should this PR be backported? - Though not required, it would be nice to include this in v9.0.0 along with the rest of the v2 VReplication changes.
- [ ] Tests were added or are not required - Looking for feedback on this.
- [x] Documentation was added or is not required - Not required

## Deployment Notes

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication - Only vtctl input validation
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
