### PR TITLE
WIP: CI: partial upgrade tests

### DIFF
--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -48,6 +48,16 @@ jobs:
     - name: Check out HEAD
       uses: actions/checkout@v2
 
+    - name: Building HEAD binaries
+      timeout-minutes: 10
+      run: |
+        go mod download
+
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-head/
+        cp -R bin /tmp/vitess-build-head/
+
     # Test 1: ful upgrade
     # - create a cluster with v8.0.0 binaries,
     # - then try to reuse the data with HEAD binaries
@@ -63,23 +73,11 @@ jobs:
         # We pass -skip-build so that we use the v8.0.0 binaries, not HEAD binaries
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
-    - name: Check out HEAD
-      uses: actions/checkout@v2
-
-    - name: Building HEAD binaries
-      timeout-minutes: 10
-      run: |
-        go mod download
-
-        source build.env
-        make build
-        mkdir -p /tmp/vitess-build-head/
-        cp -R bin /tmp/vitess-build-head/
-
     - name: Run cluster endtoend test HEAD based on v8.0.0 data (upgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
+        cp -R /tmp/vitess-build-head/bin .
 
         source build.env
         # We built HEAD binaries manually in previous step and there's no need for the test to build.
@@ -94,6 +92,7 @@ jobs:
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-head/bin .
 
         source build.env
         # We still have the binaries from previous step. No need to build

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         ref: v8.0.0
 
+    # We begin by installing dependencies, by building v8.0.0 binaries and HEAD binaries.
     - name: Get dependencies
       run: |
         # This prepares general purpose binary dependencies
@@ -47,6 +48,9 @@ jobs:
     - name: Check out HEAD
       uses: actions/checkout@v2
 
+    # Test 1: ful upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with HEAD binaries
     - name: Run cluster endtoend test v8.0.0 (create cluster)
       timeout-minutes: 5
       run: |
@@ -61,7 +65,6 @@ jobs:
 
     - name: Check out HEAD
       uses: actions/checkout@v2
-
 
     - name: Building HEAD binaries
       timeout-minutes: 10
@@ -82,6 +85,9 @@ jobs:
         # We built HEAD binaries manually in previous step and there's no need for the test to build.
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
+    # Test 2: full downgrade
+    # - create a cluster with HEAD binaries,
+    # - then try to reuse the data with v8.0.0 binaries
     - name: Run cluster endtoend test HEAD (create cluster)
       timeout-minutes: 5
       run: |
@@ -93,7 +99,6 @@ jobs:
         # We still have the binaries from previous step. No need to build
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
-
     - name: Run cluster endtoend test v8.0.0 based on HEAD data (downgrade path)
       timeout-minutes: 5
       run: |
@@ -102,4 +107,121 @@ jobs:
 
         source build.env
         # We again built manually and there's no need for the test to build.
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    # Test 3: vtgate upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with vtgate(HEAD) binary; the rest of binaries are v8.0.0
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    - name: Run cluster endtoend test HEAD (vtgate only) based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp /tmp/vitess-build-head/bin/vtgate bin/
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    # Test 4: vtctld upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with vtctl/vtctld(HEAD) binary; the rest of binaries are v8.0.0
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    - name: Run cluster endtoend test HEAD (vtgate only) based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp /tmp/vitess-build-head/bin/vtctl* bin/
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    # Test 5: vttablet upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with vttablet(HEAD) binary on all tablets; the rest of binaries are v8.0.0
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    - name: Run cluster endtoend test HEAD (vtgate only) based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp /tmp/vitess-build-head/bin/vttablet bin/
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    # Test 6: vtgate & vttablet upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with vtgate(HEAD) vttablet(HEAD) binary on all tablets; the rest of binaries are v8.0.0
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    - name: Run cluster endtoend test HEAD (vtgate only) based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp /tmp/vitess-build-head/bin/vtgate bin/
+        cp /tmp/vitess-build-head/bin/vttablet bin/
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    # Test 7: vtctld & vttablet upgrade
+    # - create a cluster with v8.0.0 binaries,
+    # - then try to reuse the data with vtctl/vtctld(HEAD) vttablet(HEAD) binary on all tablets; the rest of binaries are v8.0.0
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+
+    - name: Run cluster endtoend test HEAD (vtgate only) based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp /tmp/vitess-build-head/bin/vtctl* bin/
+        cp /tmp/vitess-build-head/bin/vttablet bin/
+
+        source build.env
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28


### PR DESCRIPTION

## Description

This PR extends the upgrade/downgrade tests in CI by adding partial upgrade tests.

Initial commit tests for partial upgrade paths from `v8.0.0` to `HEAD`:

- only `vtgate` is upgraded
- only `vtctl*` binaries are upgraded
- only `vttablet` binaries are upgraded
- `vtgate` and `vttablet` binaries are upgraded
- `vtctl*` and vttablet` binaries are upgraded

The `vttablet` upgrade tests apply to all tablets. I don't have a good plan for upgrading _some tablets_ yet.

## Related Issue(s)

Context: https://github.com/vitessio/vitess/issues/7344
Followup to https://github.com/vitessio/vitess/pull/7294

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build 
- [ ]  VTAdmin
