### PR TITLE
Add vtgate stats for RowsAffected similar to RowsReturned

### DIFF
--- a/go/mysql/endtoend/client_test.go
+++ b/go/mysql/endtoend/client_test.go
@@ -242,11 +242,6 @@ func expectNoError(t *testing.T, err error) {
 	}
 }
 
-//func expectRows(t *testing.T, msg string, result *sqltypes.Result, want int) {
-//	t.Helper()
-//	assert.EqualValuesf(t, want, len(result.Rows), msg+": %v", result.Rows)
-//}
-
 func expectFlag(t *testing.T, msg string, flag, want bool) {
 	t.Helper()
 	if flag != want {

--- a/go/mysql/endtoend/query_test.go
+++ b/go/mysql/endtoend/query_test.go
@@ -100,7 +100,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
 			},
 		},
-		RowsAffected: 1,
 	}
 	if !result.Equal(expectedResult) {
 		// MySQL 5.7 is adding the NO_DEFAULT_VALUE_FLAG to Flags.

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -425,7 +425,6 @@ func (c *Conn) ReadQueryResult(maxrows int, wantfields bool) (*sqltypes.Result, 
 			if !wantfields {
 				result.Fields = nil
 			}
-			result.RowsAffected = uint64(len(result.Rows))
 
 			// The deprecated EOF packets change means that this is either an
 			// EOF packet or an OK packet with the EOF type code.

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -415,7 +415,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
-		RowsAffected: 2,
+		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_AND_NAME.
@@ -518,7 +518,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
-		RowsAffected: 2,
+		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_AND_NAME.
@@ -538,7 +538,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
 			},
 		},
-		RowsAffected: 2,
+		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_ONLY.
@@ -556,7 +556,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("20")),
 			},
 		},
-		RowsAffected: 2,
+		RowsAffected: 0,
 	})
 
 	// Typical Select with ALL.
@@ -589,7 +589,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("30")),
 			},
 		},
-		RowsAffected: 3,
+		RowsAffected: 0,
 	})
 }
 
@@ -649,7 +649,6 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 	go func() {
 		defer wg.Done()
 
-		// Test ExecuteFetch.
 		maxrows := 10000
 		if !allRows {
 			// Asking for just one row max. The results that have more will fail.
@@ -687,6 +686,7 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 
 		if gotWarnings != warningCount {
 			t.Errorf("ExecuteFetch(%v) expected %v warnings got %v", query, warningCount, gotWarnings)
+			return
 		}
 
 		// Test ExecuteStreamFetch, build a Result.
@@ -732,6 +732,10 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 					t.Logf("========== Got      row(%v) = %v", i, RowString(row))
 					t.Logf("========== Expected row(%v) = %v", i, RowString(expected.Rows[i]))
 				}
+			}
+			if expected.RowsAffected != got.RowsAffected {
+				t.Logf("========== Got      RowsAffected = %v", got.RowsAffected)
+				t.Logf("========== Expected RowsAffected = %v", expected.RowsAffected)
 			}
 			t.Errorf("\nExecuteStreamFetch(%v) returned:\n%+v\nBut was expecting:\n%+v\n", query, got, &expected)
 		}

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -415,7 +415,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
-		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_AND_NAME.
@@ -518,7 +517,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
-		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_AND_NAME.
@@ -538,7 +536,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
 			},
 		},
-		RowsAffected: 0,
 	})
 
 	// Typical Select with TYPE_ONLY.
@@ -556,7 +553,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("20")),
 			},
 		},
-		RowsAffected: 0,
 	})
 
 	// Typical Select with ALL.
@@ -589,7 +585,6 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("30")),
 			},
 		},
-		RowsAffected: 0,
 	})
 }
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -65,7 +65,7 @@ var selectRowsResult = &sqltypes.Result{
 			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nicer name")),
 		},
 	},
-	RowsAffected: 2,
+	RowsAffected: 0,
 }
 
 type testHandler struct {

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -65,7 +65,6 @@ var selectRowsResult = &sqltypes.Result{
 			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nicer name")),
 		},
 	},
-	RowsAffected: 0,
 }
 
 type testHandler struct {

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -227,7 +227,7 @@ func (result *Result) StripMetadata(incl querypb.ExecuteOptions_IncludedFields) 
 // to another result.Note currently it doesn't handle cases like
 // if two results have different fields.We will enhance this function.
 func (result *Result) AppendResult(src *Result) {
-	if src.RowsAffected == 0 && len(src.Fields) == 0 {
+	if src.RowsAffected == 0 && len(src.Rows) == 0 && len(src.Fields) == 0 {
 		return
 	}
 	if result.Fields == nil {

--- a/go/sqltypes/testing.go
+++ b/go/sqltypes/testing.go
@@ -73,7 +73,6 @@ func MakeTestResult(fields []*querypb.Field, rows ...string) *Result {
 			result.Rows[i][j] = MakeTrusted(fields[j].Type, []byte(col))
 		}
 	}
-	result.RowsAffected = uint64(len(result.Rows))
 	return result
 }
 

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -152,7 +152,7 @@ func TestWarnings(t *testing.T) {
 
 	qr, err = conn.ExecuteFetch("SHOW WARNINGS;", 1, false)
 	require.Nilf(t, err, "SHOW WARNINGS; execution failed: %v", err)
-	assert.Equal(t, uint64(1), len(qr.Rows), "number of rows")
+	assert.EqualValues(t, 1, len(qr.Rows), "number of rows")
 	assert.Contains(t, qr.Rows[0][0].String(), "VARCHAR(\"Warning\")", qr.Rows)
 	assert.Contains(t, qr.Rows[0][1].String(), "UINT16(1054)", qr.Rows)
 	assert.Contains(t, qr.Rows[0][2].String(), "Unknown column", qr.Rows)
@@ -164,7 +164,7 @@ func TestWarnings(t *testing.T) {
 
 	qr, err = conn.ExecuteFetch("SHOW WARNINGS;", 1, false)
 	require.Nilf(t, err, "SHOW WARNINGS; execution failed: %v", err)
-	assert.Equal(t, uint64(1), len(qr.Rows), "number of rows")
+	assert.EqualValues(t, 1, len(qr.Rows), "number of rows")
 	assert.Contains(t, qr.Rows[0][0].String(), "VARCHAR(\"Warning\")", qr.Rows)
 	assert.Contains(t, qr.Rows[0][1].String(), "UINT16(1317)", qr.Rows)
 	assert.Contains(t, qr.Rows[0][2].String(), "context deadline exceeded", qr.Rows)

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -80,7 +80,7 @@ func TestLargeComment(t *testing.T) {
 
 	qr, err := conn.ExecuteFetch("select * from vt_insert_test where id = 1", 1, false)
 	require.Nilf(t, err, "select error: %v", err)
-	assert.Equal(t, uint64(1), qr.RowsAffected)
+	assert.Equal(t, 1, len(qr.Rows))
 	assert.Equal(t, "BLOB(\"LLL\")", qr.Rows[0][3].String())
 }
 
@@ -148,11 +148,11 @@ func TestWarnings(t *testing.T) {
 	// validate warning with invalid_field error as warning
 	qr, err := conn.ExecuteFetch("SELECT /*vt+ SCATTER_ERRORS_AS_WARNINGS */ invalid_field from vt_insert_test;", 1, false)
 	require.Nilf(t, err, "select error : %v", err)
-	assert.Equalf(t, uint64(0), qr.RowsAffected, "query should return 0 rows, got %v", qr.RowsAffected)
+	assert.Empty(t, qr.Rows, "number of rows")
 
 	qr, err = conn.ExecuteFetch("SHOW WARNINGS;", 1, false)
 	require.Nilf(t, err, "SHOW WARNINGS; execution failed: %v", err)
-	assert.Equalf(t, uint64(1), qr.RowsAffected, "1 warning expected, got %v ", qr.RowsAffected)
+	assert.Equal(t, uint64(1), len(qr.Rows), "number of rows")
 	assert.Contains(t, qr.Rows[0][0].String(), "VARCHAR(\"Warning\")", qr.Rows)
 	assert.Contains(t, qr.Rows[0][1].String(), "UINT16(1054)", qr.Rows)
 	assert.Contains(t, qr.Rows[0][2].String(), "Unknown column", qr.Rows)
@@ -160,11 +160,11 @@ func TestWarnings(t *testing.T) {
 	// validate warning with query_timeout error as warning
 	qr, err = conn.ExecuteFetch("SELECT /*vt+ SCATTER_ERRORS_AS_WARNINGS QUERY_TIMEOUT_MS=1 */ sleep(1) from vt_insert_test;", 1, false)
 	require.Nilf(t, err, "insertion error : %v", err)
-	assert.Equalf(t, uint64(0), qr.RowsAffected, "should return 0 rows, got %v", qr.RowsAffected)
+	assert.Empty(t, qr.Rows, "number of rows")
 
 	qr, err = conn.ExecuteFetch("SHOW WARNINGS;", 1, false)
 	require.Nilf(t, err, "SHOW WARNINGS; execution failed: %v", err)
-	assert.Equalf(t, uint64(1), qr.RowsAffected, "1 warning expected, got %v ", qr.RowsAffected)
+	assert.Equal(t, uint64(1), len(qr.Rows), "number of rows")
 	assert.Contains(t, qr.Rows[0][0].String(), "VARCHAR(\"Warning\")", qr.Rows)
 	assert.Contains(t, qr.Rows[0][1].String(), "UINT16(1317)", qr.Rows)
 	assert.Contains(t, qr.Rows[0][2].String(), "context deadline exceeded", qr.Rows)
@@ -175,7 +175,7 @@ func TestWarnings(t *testing.T) {
 
 	qr, err = conn.ExecuteFetch("SHOW WARNINGS;", 1, false)
 	require.Nilf(t, err, "SHOW WARNINGS; execution failed: %v", err)
-	assert.Equalf(t, uint64(0), qr.RowsAffected, "0 warning expected, got %v ", qr.RowsAffected)
+	assert.Empty(t, len(qr.Rows), "number of rows")
 }
 
 // TestSelectWithUnauthorizedUser verifies that an unauthorized user

--- a/go/test/endtoend/tabletmanager/commands_test.go
+++ b/go/test/endtoend/tabletmanager/commands_test.go
@@ -120,9 +120,8 @@ func assertExcludeFields(t *testing.T, qr string) {
 	err := json.Unmarshal([]byte(qr), &resultMap)
 	require.Nil(t, err)
 
-	rowsAffected := resultMap["rows_affected"]
-	want := float64(2)
-	assert.Equal(t, want, rowsAffected)
+	rows := resultMap["rows"].([]interface{})
+	assert.Equal(t, 2, len(rows))
 
 	fields := resultMap["fields"]
 	assert.NotContainsf(t, fields, "name", "name should not be in field list")

--- a/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
+++ b/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
@@ -83,9 +83,8 @@ func TestTopoCustomRule(t *testing.T) {
 	err = json.Unmarshal([]byte(result), &resultMap)
 	require.NoError(t, err)
 
-	rowsAffected := resultMap["rows_affected"]
-	want := float64(2)
-	assert.Equal(t, want, rowsAffected)
+	rowsAffected := resultMap["rows"].([]interface{})
+	assert.EqualValues(t, 2, len(rowsAffected))
 
 	// Now update the topocustomrule file.
 	data = []byte(`[{

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -112,8 +112,6 @@ func (d *Distinct) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVar
 		}
 	}
 
-	result.RowsAffected = uint64(len(result.Rows))
-
 	return result, err
 }
 

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -136,9 +136,6 @@ func wrapStreamExecute(prim Primitive, vcursor VCursor, bindVars map[string]*que
 		}
 		return nil
 	})
-	if result != nil {
-		result.RowsAffected = uint64(len(result.Rows))
-	}
 	return result, err
 }
 

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -84,9 +84,6 @@ func (jn *Join) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariab
 		}
 		if jn.Opcode == LeftJoin && len(rresult.Rows) == 0 {
 			result.Rows = append(result.Rows, joinRows(lrow, nil, jn.Cols))
-			result.RowsAffected++
-		} else {
-			result.RowsAffected += uint64(len(rresult.Rows))
 		}
 		if vcursor.ExceedsMaxMemoryRows(len(result.Rows)) {
 			return nil, fmt.Errorf("in-memory row count exceeded allowed limit of %d", vcursor.MaxMemoryRows())
@@ -244,6 +241,7 @@ func (jn *Join) GetTableName() string {
 	return jn.Left.GetTableName() + "_" + jn.Right.GetTableName()
 }
 
+// NeedsTransaction implements the Primitive interface
 func (jn *Join) NeedsTransaction() bool {
 	return jn.Right.NeedsTransaction() || jn.Left.NeedsTransaction()
 }

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -73,18 +73,15 @@ func (l *Limit) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariab
 	// There are more rows in the response than limit + offset
 	if count+offset <= len(result.Rows) {
 		result.Rows = result.Rows[offset : count+offset]
-		result.RowsAffected = uint64(count)
 		return result, nil
 	}
 	// Remove extra rows from response
 	if offset <= len(result.Rows) {
 		result.Rows = result.Rows[offset:]
-		result.RowsAffected = uint64(len(result.Rows))
 		return result, nil
 	}
 	// offset is beyond the result set
 	result.Rows = nil
-	result.RowsAffected = 0
 	return result, nil
 }
 

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -86,7 +86,6 @@ func (ms *MemorySort) Execute(vcursor VCursor, bindVars map[string]*querypb.Bind
 	result.Rows = sh.rows
 	if len(result.Rows) > count {
 		result.Rows = result.Rows[:count]
-		result.RowsAffected = uint64(count)
 	}
 	return result.Truncate(ms.TruncateColumnCount), nil
 }
@@ -151,6 +150,7 @@ func (ms *MemorySort) Inputs() []Primitive {
 	return []Primitive{ms.Input}
 }
 
+// NeedsTransaction implements the Primitive interface
 func (ms *MemorySort) NeedsTransaction() bool {
 	return ms.Input.NeedsTransaction()
 }

--- a/go/vt/vtgate/engine/online_ddl.go
+++ b/go/vt/vtgate/engine/online_ddl.go
@@ -96,8 +96,7 @@ func (v *OnlineDDL) Execute(vcursor VCursor, bindVars map[string]*query.BindVari
 				Type: sqltypes.VarChar,
 			},
 		},
-		Rows:         rows,
-		RowsAffected: uint64(len(rows)),
+		Rows: rows,
 	}
 	return result, err
 }

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -206,7 +206,6 @@ func (oa *OrderedAggregate) execute(vcursor VCursor, bindVars map[string]*queryp
 	if current != nil {
 		out.Rows = append(out.Rows, current)
 	}
-	out.RowsAffected = uint64(len(out.Rows))
 	return out, nil
 }
 
@@ -324,6 +323,7 @@ func (oa *OrderedAggregate) Inputs() []Primitive {
 	return []Primitive{oa.Input}
 }
 
+// NeedsTransaction implements the Primitive interface
 func (oa *OrderedAggregate) NeedsTransaction() bool {
 	return oa.Input.NeedsTransaction()
 }

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -613,7 +613,6 @@ func TestOrderedAggregateMergeFail(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("1")),
 			},
 		},
-		RowsAffected: 1,
 	}
 
 	res, err := oa.Execute(nil, nil, false)

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -158,7 +158,8 @@ type (
 		ExecCount    uint64        // Count of times this plan was executed
 		ExecTime     time.Duration // Total execution time
 		ShardQueries uint64        // Total number of shard queries
-		Rows         uint64        // Total number of rows
+		RowsReturned uint64        // Total number of rows
+		RowsAffected uint64        // Total number of rows
 		Errors       uint64        // Total number of errors
 	}
 
@@ -197,23 +198,25 @@ type (
 )
 
 // AddStats updates the plan execution statistics
-func (p *Plan) AddStats(execCount uint64, execTime time.Duration, shardQueries, rows, errors uint64) {
+func (p *Plan) AddStats(execCount uint64, execTime time.Duration, shardQueries, rowsAffected, rowsReturned, errors uint64) {
 	p.mu.Lock()
 	p.ExecCount += execCount
 	p.ExecTime += execTime
 	p.ShardQueries += shardQueries
-	p.Rows += rows
+	p.RowsAffected += rowsAffected
+	p.RowsReturned += rowsReturned
 	p.Errors += errors
 	p.mu.Unlock()
 }
 
 // Stats returns a copy of the plan execution statistics
-func (p *Plan) Stats() (execCount uint64, execTime time.Duration, shardQueries, rows, errors uint64) {
+func (p *Plan) Stats() (execCount uint64, execTime time.Duration, shardQueries, rowsAffected, rowsReturned, errors uint64) {
 	p.mu.Lock()
 	execCount = p.ExecCount
 	execTime = p.ExecTime
 	shardQueries = p.ShardQueries
-	rows = p.Rows
+	rowsAffected = p.RowsAffected
+	rowsReturned = p.RowsReturned
 	errors = p.Errors
 	p.mu.Unlock()
 	return
@@ -260,7 +263,8 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 		ExecCount    uint64                `json:",omitempty"`
 		ExecTime     time.Duration         `json:",omitempty"`
 		ShardQueries uint64                `json:",omitempty"`
-		Rows         uint64                `json:",omitempty"`
+		RowsAffected uint64                `json:",omitempty"`
+		RowsReturned uint64                `json:",omitempty"`
 		Errors       uint64                `json:",omitempty"`
 	}{
 		QueryType:    p.Type.String(),
@@ -269,7 +273,8 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 		ExecCount:    p.ExecCount,
 		ExecTime:     p.ExecTime,
 		ShardQueries: p.ShardQueries,
-		Rows:         p.Rows,
+		RowsAffected: p.RowsAffected,
+		RowsReturned: p.RowsReturned,
 		Errors:       p.Errors,
 	}
 	return json.Marshal(marshalPlan)

--- a/go/vt/vtgate/engine/rows.go
+++ b/go/vt/vtgate/engine/rows.go
@@ -55,10 +55,9 @@ func (r *Rows) GetTableName() string {
 //Execute implements the Primitive interface
 func (r *Rows) Execute(VCursor, map[string]*querypb.BindVariable, bool) (*sqltypes.Result, error) {
 	return &sqltypes.Result{
-		Fields:       r.fields,
-		RowsAffected: uint64(len(r.rows)),
-		InsertID:     0,
-		Rows:         r.rows,
+		Fields:   r.fields,
+		InsertID: 0,
+		Rows:     r.rows,
 	}, nil
 }
 
@@ -74,10 +73,9 @@ func (r *Rows) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindV
 //GetFields implements the Primitive interface
 func (r *Rows) GetFields(VCursor, map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	return &sqltypes.Result{
-		Fields:       r.fields,
-		RowsAffected: uint64(len(r.rows)),
-		InsertID:     0,
-		Rows:         nil,
+		Fields:   r.fields,
+		InsertID: 0,
+		Rows:     nil,
 	}, nil
 }
 

--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -249,7 +249,7 @@ func (svci *SysVarCheckAndIgnore) Execute(vcursor VCursor, env evalengine.Expres
 	if err != nil {
 		return err
 	}
-	if result.RowsAffected == 0 {
+	if len(result.Rows) == 0 {
 		log.Infof("Ignored inapplicable SET %v = %v", svci.Name, svci.Expr)
 	}
 	return nil

--- a/go/vt/vtgate/engine/singlerow.go
+++ b/go/vt/vtgate/engine/singlerow.go
@@ -47,7 +47,6 @@ func (s *SingleRow) GetTableName() string {
 // Execute performs a non-streaming exec.
 func (s *SingleRow) Execute(vcursor VCursor, bindVars map[string]*query.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	result := sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{},
 		},
@@ -58,7 +57,6 @@ func (s *SingleRow) Execute(vcursor VCursor, bindVars map[string]*query.BindVari
 // StreamExecute performs a streaming exec.
 func (s *SingleRow) StreamExecute(vcursor VCursor, bindVars map[string]*query.BindVariable, wantields bool, callback func(*sqltypes.Result) error) error {
 	result := sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{},
 		},

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -128,7 +128,6 @@ func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars map[string]*querypb.Bi
 	case key.DestinationKeyRange:
 		if d.KeyRange != nil {
 			result.Rows = append(result.Rows, vf.buildRow(vkey, nil, d.KeyRange))
-			result.RowsAffected = 1
 		}
 	case key.DestinationKeyspaceID:
 		if len(d) > 0 {
@@ -144,19 +143,16 @@ func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars map[string]*querypb.Bi
 				result.Rows = [][]sqltypes.Value{
 					vf.buildRow(vkey, d, kr[0]),
 				}
-				result.RowsAffected = 1
 			} else {
 				result.Rows = [][]sqltypes.Value{
 					vf.buildRow(vkey, d, nil),
 				}
-				result.RowsAffected = 1
 			}
 		}
 	case key.DestinationKeyspaceIDs:
 		for _, ksid := range d {
 			result.Rows = append(result.Rows, vf.buildRow(vkey, ksid, nil))
 		}
-		result.RowsAffected = uint64(len(d))
 	case key.DestinationNone:
 		// Nothing to do.
 	default:

--- a/go/vt/vtgate/engine/vindex_func_test.go
+++ b/go/vt/vtgate/engine/vindex_func_test.go
@@ -137,7 +137,7 @@ func TestVindexFuncMap(t *testing.T) {
 			sqltypes.MakeTrusted(sqltypes.VarBinary, []byte{0x60}),
 			sqltypes.NULL,
 		}},
-		RowsAffected: 1,
+		RowsAffected: 0,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
@@ -191,7 +191,7 @@ func TestVindexFuncMap(t *testing.T) {
 			sqltypes.MakeTrusted(sqltypes.VarBinary, []byte{0x60}),
 			sqltypes.NULL,
 		}},
-		RowsAffected: 1,
+		RowsAffected: 0,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -586,9 +586,8 @@ func (e *Executor) handleShowVitessMetadata(ctx context.Context, opt *sqlparser.
 	}
 
 	return &sqltypes.Result{
-		Fields:       buildVarCharFields("Key", "Value"),
-		Rows:         rows,
-		RowsAffected: uint64(len(rows)),
+		Fields: buildVarCharFields("Key", "Value"),
+		Rows:   rows,
 	}, nil
 }
 
@@ -626,9 +625,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 			"YES")
 		rows = append(rows, row)
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Engine", "Support", "Comment", "Transactions", "XA", "Savepoints"),
-			Rows:         rows,
-			RowsAffected: 1,
+			Fields: buildVarCharFields("Engine", "Support", "Comment", "Transactions", "XA", "Savepoints"),
+			Rows:   rows,
 		}, nil
 	// for PLUGINS, return InnoDb + mysql_native_password
 	case sqlparser.KeywordString(sqlparser.PLUGINS):
@@ -641,9 +639,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 			"GPL")
 		rows = append(rows, row)
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Name", "Status", "Type", "Library", "License"),
-			Rows:         rows,
-			RowsAffected: 1,
+			Fields: buildVarCharFields("Name", "Status", "Type", "Library", "License"),
+			Rows:   rows,
 		}, nil
 	case "create table":
 		if !show.Table.Qualifier.IsEmpty() {
@@ -769,9 +766,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		}
 
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Shards"),
-			Rows:         rows,
-			RowsAffected: uint64(len(rows)),
+			Fields: buildVarCharFields("Shards"),
+			Rows:   rows,
 		}, nil
 	case sqlparser.KeywordString(sqlparser.VITESS_TABLETS):
 		return e.showTablets(show)
@@ -779,9 +775,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		var rows [][]sqltypes.Value
 		rows = append(rows, buildVarCharRow(safeSession.TargetString))
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Target"),
-			Rows:         rows,
-			RowsAffected: uint64(len(rows)),
+			Fields: buildVarCharFields("Target"),
+			Rows:   rows,
 		}, nil
 	case "vschema tables":
 		if destKeyspace == "" {
@@ -804,9 +799,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		}
 
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Tables"),
-			Rows:         rows,
-			RowsAffected: uint64(len(rows)),
+			Fields: buildVarCharFields("Tables"),
+			Rows:   rows,
 		}, nil
 	case "vschema vindexes":
 		vschema := e.vm.GetCurrentSrvVschema()
@@ -856,9 +850,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 			}
 
 			return &sqltypes.Result{
-				Fields:       buildVarCharFields("Columns", "Name", "Type", "Params", "Owner"),
-				Rows:         rows,
-				RowsAffected: uint64(len(rows)),
+				Fields: buildVarCharFields("Columns", "Name", "Type", "Params", "Owner"),
+				Rows:   rows,
 			}, nil
 		}
 
@@ -889,9 +882,8 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 			}
 		}
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Keyspace", "Name", "Type", "Params", "Owner"),
-			Rows:         rows,
-			RowsAffected: uint64(len(rows)),
+			Fields: buildVarCharFields("Keyspace", "Name", "Type", "Params", "Owner"),
+			Rows:   rows,
 		}, nil
 	case sqlparser.KeywordString(sqlparser.WARNINGS):
 		fields := []*querypb.Field{
@@ -1034,9 +1026,8 @@ func (e *Executor) showTablets(show *sqlparser.ShowLegacy) (*sqltypes.Result, er
 		}
 	}
 	return &sqltypes.Result{
-		Fields:       buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname", "MasterTermStartTime"),
-		Rows:         rows,
-		RowsAffected: uint64(len(rows)),
+		Fields: buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname", "MasterTermStartTime"),
+		Rows:   rows,
 	}, nil
 }
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1614,7 +1614,7 @@ func (e *Executor) handlePrepare(ctx context.Context, safeSession *SafeSession, 
 	}
 	logStats.RowsAffected = qr.RowsAffected
 
-	plan.AddStats(1, time.Since(logStats.StartTime), uint64(logStats.ShardQueries), logStats.RowsAffected, errCount)
+	plan.AddStats(1, time.Since(logStats.StartTime), uint64(logStats.ShardQueries), qr.RowsAffected, uint64(len(qr.Rows)), errCount)
 
 	return qr.Fields, err
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -171,7 +171,7 @@ func saveSessionStats(safeSession *SafeSession, stmtType sqlparser.StatementType
 		return
 	}
 	if !safeSession.foundRowsHandled {
-		safeSession.FoundRows = result.RowsAffected
+		safeSession.FoundRows = uint64(len(result.Rows))
 	}
 	if result.InsertID > 0 {
 		safeSession.LastInsertId = result.InsertID
@@ -557,7 +557,7 @@ func (e *Executor) handleSetVitessMetadata(ctx context.Context, name, value stri
 		return nil, err
 	}
 
-	return &sqltypes.Result{RowsAffected: 1}, nil
+	return &sqltypes.Result{}, nil
 }
 
 func (e *Executor) handleShowVitessMetadata(ctx context.Context, opt *sqlparser.ShowTablesOpt) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1012,11 +1012,11 @@ func TestInsertGeneratorSharded(t *testing.T) {
 		},
 	}}
 	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
-	wantResult := *sandboxconn.SingleRowResult
-	wantResult.InsertID = 1
-	if !result.Equal(&wantResult) {
-		t.Errorf("result: %+v, want %+v", result, &wantResult)
+	wantResult := &sqltypes.Result{
+		InsertID:     1,
+		RowsAffected: 1,
 	}
+	utils.MustMatch(t, wantResult, result)
 }
 
 func TestInsertAutoincSharded(t *testing.T) {
@@ -1064,11 +1064,11 @@ func TestInsertGeneratorUnsharded(t *testing.T) {
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
 	}
-	wantResult := *sandboxconn.SingleRowResult
-	wantResult.InsertID = 1
-	if !result.Equal(&wantResult) {
-		t.Errorf("result: %+v, want %+v", result, &wantResult)
+	wantResult := &sqltypes.Result{
+		InsertID:     1,
+		RowsAffected: 1,
 	}
+	utils.MustMatch(t, wantResult, result)
 }
 
 func TestInsertAutoincUnsharded(t *testing.T) {
@@ -1161,11 +1161,11 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
 	}
-	wantResult := *sandboxconn.SingleRowResult
-	wantResult.InsertID = 4
-	if !result.Equal(&wantResult) {
-		t.Errorf("result:\n%+v, want\n%+v", result, &wantResult)
+	wantResult := &sqltypes.Result{
+		InsertID:     4,
+		RowsAffected: 1,
 	}
+	utils.MustMatch(t, wantResult, result)
 }
 
 func TestInsertLookupUnowned(t *testing.T) {
@@ -1430,11 +1430,11 @@ func TestMultiInsertGenerator(t *testing.T) {
 		},
 	}}
 	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
-	wantResult := *sandboxconn.SingleRowResult
-	wantResult.InsertID = 1
-	if !result.Equal(&wantResult) {
-		t.Errorf("result: %+v, want %+v", result, &wantResult)
+	wantResult := &sqltypes.Result{
+		InsertID:     1,
+		RowsAffected: 1,
 	}
+	utils.MustMatch(t, wantResult, result)
 }
 
 func TestMultiInsertGeneratorSparse(t *testing.T) {
@@ -1482,11 +1482,11 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 		},
 	}}
 	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
-	wantResult := *sandboxconn.SingleRowResult
-	wantResult.InsertID = 1
-	if !result.Equal(&wantResult) {
-		t.Errorf("result: %+v, want %+v", result, &wantResult)
+	wantResult := &sqltypes.Result{
+		InsertID:     1,
+		RowsAffected: 1,
 	}
+	utils.MustMatch(t, wantResult, result)
 }
 
 func TestInsertBadAutoInc(t *testing.T) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -466,7 +466,6 @@ func TestRowCount(t *testing.T) {
 func testRowCount(t *testing.T, executor *Executor, wantRowCount int64) {
 	result, err := executorExec(executor, "select row_count()", map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "row_count()", Type: sqltypes.Int64},
 		},
@@ -1441,8 +1440,7 @@ func TestSelectScatterAggregate(t *testing.T) {
 			{Name: "col", Type: sqltypes.Int32},
 			{Name: "sum(foo)", Type: sqltypes.Int32},
 		},
-		RowsAffected: 4,
-		InsertID:     0,
+		InsertID: 0,
 	}
 	for i := 0; i < 4; i++ {
 		row := []sqltypes.Value{
@@ -1559,8 +1557,7 @@ func TestSelectScatterLimit(t *testing.T) {
 			{Name: "col1", Type: sqltypes.Int32},
 			{Name: "col2", Type: sqltypes.Int32},
 		},
-		RowsAffected: 3,
-		InsertID:     0,
+		InsertID: 0,
 	}
 	wantResult.Rows = append(wantResult.Rows,
 		[]sqltypes.Value{
@@ -1676,7 +1673,6 @@ func TestSimpleJoin(t *testing.T) {
 				sandboxconn.SingleRowResult.Rows[0][0],
 			},
 		},
-		RowsAffected: 1,
 	}
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
@@ -1854,14 +1850,11 @@ func TestLeftJoin(t *testing.T) {
 				{},
 			},
 		},
-		RowsAffected: 1,
 	}
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
-
 	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
-
 }
 
 func TestLeftJoinStream(t *testing.T) {
@@ -1871,8 +1864,7 @@ func TestLeftJoinStream(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -2098,7 +2090,6 @@ func TestCrossShardSubquery(t *testing.T) {
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 		}},
@@ -2115,8 +2106,7 @@ func TestCrossShardSubqueryStream(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -293,7 +293,6 @@ func TestSelectLastInsertId(t *testing.T) {
 	sql := "select last_insert_id()"
 	result, err := executorExec(executor, sql, map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "last_insert_id()", Type: sqltypes.Uint64},
 		},
@@ -335,7 +334,6 @@ func TestSelectSystemVariables(t *testing.T) {
 			{Name: "@@session_track_gtids", Type: sqltypes.VarBinary},
 			{Name: "@@ddl_strategy", Type: sqltypes.VarBinary},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			// the following are the uninitialised session values
 			sqltypes.NewInt64(0),
@@ -378,7 +376,6 @@ func TestSelectInitializedVitessAwareVariable(t *testing.T) {
 			{Name: "@@autocommit", Type: sqltypes.Int64},
 			{Name: "@@enable_system_settings", Type: sqltypes.Int64},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(1),
 			sqltypes.NewInt64(1),
@@ -398,7 +395,6 @@ func TestSelectUserDefindVariable(t *testing.T) {
 	result, err := executorExec(executor, sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "@foo", Type: sqltypes.Null},
 		},
@@ -412,7 +408,6 @@ func TestSelectUserDefindVariable(t *testing.T) {
 	result, err = executorExec(executor, sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 	wantResult = &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "@foo", Type: sqltypes.VarBinary},
 		},
@@ -436,7 +431,6 @@ func TestFoundRows(t *testing.T) {
 	sql := "select found_rows()"
 	result, err := executorExec(executor, sql, map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "found_rows()", Type: sqltypes.Uint64},
 		},
@@ -512,8 +506,7 @@ func TestLastInsertIDInVirtualTable(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -541,7 +534,6 @@ func TestLastInsertIDInSubQueryExpression(t *testing.T) {
 	rs, err := executorExec(executor, "select (select last_insert_id()) as x", nil)
 	require.NoError(t, err)
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "x", Type: sqltypes.Uint64},
 		},
@@ -570,7 +562,6 @@ func TestSelectDatabase(t *testing.T) {
 		sql,
 		map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
-		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{Name: "database()", Type: sqltypes.VarBinary},
 		},
@@ -1165,8 +1156,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 				{Name: "col1", Type: sqltypes.Int32},
 				{Name: "col2", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				// i%4 ensures that there are duplicates across shards.
@@ -1196,8 +1186,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 			{Name: "col1", Type: sqltypes.Int32},
 			{Name: "col2", Type: sqltypes.Int32},
 		},
-		RowsAffected: 8,
-		InsertID:     0,
+		InsertID: 0,
 	}
 	for i := 0; i < 4; i++ {
 		// There should be a duplicate for each row returned.
@@ -1231,8 +1220,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 				{Name: "col1", Type: sqltypes.Int32},
 				{Name: "textcol", Type: sqltypes.VarChar},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				// i%4 ensures that there are duplicates across shards.
@@ -1263,8 +1251,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 			{Name: "col1", Type: sqltypes.Int32},
 			{Name: "textcol", Type: sqltypes.VarChar},
 		},
-		RowsAffected: 8,
-		InsertID:     0,
+		InsertID: 0,
 	}
 	for i := 0; i < 4; i++ {
 		// There should be a duplicate for each row returned.
@@ -1297,8 +1284,7 @@ func TestStreamSelectScatterOrderBy(t *testing.T) {
 				{Name: "id", Type: sqltypes.Int32},
 				{Name: "col", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				sqltypes.NewInt32(int32(i % 4)),
@@ -1354,8 +1340,7 @@ func TestStreamSelectScatterOrderByVarChar(t *testing.T) {
 				{Name: "id", Type: sqltypes.Int32},
 				{Name: "textcol", Type: sqltypes.VarChar},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				sqltypes.NewVarChar(fmt.Sprintf("%d", i%4)),
@@ -1413,8 +1398,7 @@ func TestSelectScatterAggregate(t *testing.T) {
 				{Name: "col", Type: sqltypes.Int32},
 				{Name: "sum(foo)", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(int32(i % 4)),
 				sqltypes.NewInt32(int32(i)),
@@ -1471,8 +1455,7 @@ func TestStreamSelectScatterAggregate(t *testing.T) {
 				{Name: "col", Type: sqltypes.Int32},
 				{Name: "sum(foo)", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(int32(i % 4)),
 				sqltypes.NewInt32(int32(i)),
@@ -1530,8 +1513,7 @@ func TestSelectScatterLimit(t *testing.T) {
 				{Name: "col1", Type: sqltypes.Int32},
 				{Name: "col2", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				sqltypes.NewInt32(int32(i % 4)),
@@ -1597,8 +1579,7 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 				{Name: "col1", Type: sqltypes.Int32},
 				{Name: "col2", Type: sqltypes.Int32},
 			},
-			RowsAffected: 1,
-			InsertID:     0,
+			InsertID: 0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt32(1),
 				sqltypes.NewInt32(int32(i % 4)),
@@ -1752,8 +1733,7 @@ func TestVarJoin(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -1788,8 +1768,7 @@ func TestVarJoinStream(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -1823,8 +1802,7 @@ func TestLeftJoin(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -2065,8 +2043,7 @@ func TestCrossShardSubquery(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32},
 			{Name: "col", Type: sqltypes.Int32},
 		},
-		RowsAffected: 1,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewInt32(3),
@@ -2282,7 +2259,6 @@ func TestSelectLock(t *testing.T) {
 			TabletAlias:   sbc1.Tablet().Alias,
 		}},
 		LockSession: &vtgatepb.Session_ShardSession{
-
 			Target:      &querypb.Target{Keyspace: "TestExecutor", Shard: "-20", TabletType: topodatapb.TabletType_MASTER},
 			TabletAlias: sbc1.Tablet().Alias,
 			ReservedId:  1,

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -464,6 +464,7 @@ func TestRowCount(t *testing.T) {
 }
 
 func testRowCount(t *testing.T, executor *Executor, wantRowCount int64) {
+	t.Helper()
 	result, err := executorExec(executor, "select row_count()", map[string]*querypb.BindVariable{})
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -440,14 +440,14 @@ func TestExecutorShow(t *testing.T) {
 	for _, query := range []string{"show vitess_keyspaces", "show keyspaces"} {
 		qr, err := executor.Execute(ctx, "TestExecute", session, query, nil)
 		require.NoError(t, err)
-		require.EqualValues(t, 5, qr.RowsAffected, fmt.Sprintf("unexpected results running query: %s", query))
+		require.EqualValues(t, 5, len(qr.Rows), fmt.Sprintf("unexpected results running query: %s", query))
 	}
 
 	for _, query := range []string{"show databases", "show DATABASES", "show schemas", "show SCHEMAS"} {
 		qr, err := executor.Execute(ctx, "TestExecute", session, query, nil)
 		require.NoError(t, err)
 		// Showing default tables (5+4[default])
-		require.EqualValues(t, 9, qr.RowsAffected, fmt.Sprintf("unexpected results running query: %s", query))
+		require.EqualValues(t, 9, len(qr.Rows), fmt.Sprintf("unexpected results running query: %s", query))
 	}
 
 	_, err := executor.Execute(ctx, "TestExecute", session, "show variables", nil)
@@ -590,7 +590,6 @@ func TestExecutorShow(t *testing.T) {
 					"utf8mb4_general_ci"),
 					sqltypes.NewInt32(4)),
 			},
-			RowsAffected: 2,
 		}
 
 		utils.MustMatch(t, wantqr, qr, query)
@@ -619,7 +618,6 @@ func TestExecutorShow(t *testing.T) {
 					"UTF-8 Unicode",
 					"utf8_general_ci"), sqltypes.NewInt32(3)),
 			},
-			RowsAffected: 1,
 		}
 
 		utils.MustMatch(t, wantqr, qr, query)
@@ -637,9 +635,7 @@ func TestExecutorShow(t *testing.T) {
 					"utf8mb4_general_ci"),
 					sqltypes.NewInt32(4)),
 			},
-			RowsAffected: 1,
 		}
-
 		utils.MustMatch(t, wantqr, qr, query)
 	}
 
@@ -657,7 +653,6 @@ func TestExecutorShow(t *testing.T) {
 				"YES",
 				"YES"),
 		},
-		RowsAffected: 1,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -674,7 +669,6 @@ func TestExecutorShow(t *testing.T) {
 				"NULL",
 				"GPL"),
 		},
-		RowsAffected: 1,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -682,9 +676,8 @@ func TestExecutorShow(t *testing.T) {
 		qr, err = executor.Execute(ctx, "TestExecute", session, "show session status", nil)
 		require.NoError(t, err)
 		wantqr = &sqltypes.Result{
-			Fields:       buildVarCharFields("Variable_name", "Value"),
-			Rows:         make([][]sqltypes.Value, 0, 2),
-			RowsAffected: 0,
+			Fields: buildVarCharFields("Variable_name", "Value"),
+			Rows:   make([][]sqltypes.Value, 0, 2),
 		}
 
 		utils.MustMatch(t, wantqr, qr, query)
@@ -706,7 +699,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestExecutor/-20"),
 			buildVarCharRow("TestXBadVSchema/e0-"),
 		},
-		RowsAffected: 33,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -721,7 +713,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("FakeCell", "TestExecutor", "-20", "MASTER", "SERVING", "aa-0000000000", "-20", "1970-01-01T00:00:01Z"),
 			buildVarCharRow("FakeCell", "TestUnsharded", "0", "MASTER", "SERVING", "aa-0000000000", "0", "1970-01-01T00:00:01Z"),
 		},
-		RowsAffected: 9,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -729,9 +720,8 @@ func TestExecutorShow(t *testing.T) {
 	qr, err = executor.Execute(ctx, "TestExecute", session, query, nil)
 	require.NoError(t, err)
 	wantqr = &sqltypes.Result{
-		Fields:       buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname", "MasterTermStartTime"),
-		Rows:         [][]sqltypes.Value{},
-		RowsAffected: 0,
+		Fields: buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname", "MasterTermStartTime"),
+		Rows:   [][]sqltypes.Value{},
 	}
 	utils.MustMatch(t, wantqr, qr, fmt.Sprintf("%q should be empty", query))
 
@@ -743,7 +733,6 @@ func TestExecutorShow(t *testing.T) {
 		Rows: [][]sqltypes.Value{
 			buildVarCharRow("FakeCell", "TestExecutor", "-20", "MASTER", "SERVING", "aa-0000000000", "-20", "1970-01-01T00:00:01Z"),
 		},
-		RowsAffected: 1,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -765,7 +754,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestExecutor", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),
 			buildVarCharRow("TestExecutor", "t1_lkp_vdx", "consistent_lookup_unique", "from=unq_col; table=t1_lkp_idx; to=keyspace_id", "t1"),
 		},
-		RowsAffected: 11,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -778,7 +766,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("Id", "hash_index", "hash", "", ""),
 			buildVarCharRow("name", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),
 		},
-		RowsAffected: 2,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -802,7 +789,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("Id", "hash_index", "hash", "", ""),
 			buildVarCharRow("name", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),
 		},
-		RowsAffected: 2,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -816,7 +802,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("id", "hash_index", "hash", "", ""),
 			buildVarCharRow("name, lastname", "name_lastname_keyspace_id_map", "lookup", "from=name,lastname; table=name_lastname_keyspace_id_map; to=keyspace_id", "user2"),
 		},
-		RowsAffected: 2,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -834,8 +819,7 @@ func TestExecutorShow(t *testing.T) {
 			{Name: "Code", Type: sqltypes.Uint16},
 			{Name: "Message", Type: sqltypes.VarChar},
 		},
-		Rows:         [][]sqltypes.Value{},
-		RowsAffected: 0,
+		Rows: [][]sqltypes.Value{},
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -849,8 +833,7 @@ func TestExecutorShow(t *testing.T) {
 			{Name: "Code", Type: sqltypes.Uint16},
 			{Name: "Message", Type: sqltypes.VarChar},
 		},
-		Rows:         [][]sqltypes.Value{},
-		RowsAffected: 0,
+		Rows: [][]sqltypes.Value{},
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -872,7 +855,6 @@ func TestExecutorShow(t *testing.T) {
 			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(mysql.ERBadTable), sqltypes.NewVarChar("bad table")},
 			{sqltypes.NewVarChar("Warning"), sqltypes.NewUint32(mysql.EROutOfResources), sqltypes.NewVarChar("ks/-40: query timed out")},
 		},
-		RowsAffected: 0,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
@@ -889,7 +871,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestSharded/-20"),
 			buildVarCharRow("TestXBadVSchema/e0-"),
 		},
-		RowsAffected: 25,
 	}
 	utils.MustMatch(t, wantqr, qr, fmt.Sprintf("%s, with a bad keyspace", query))
 
@@ -910,7 +891,6 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("user_msgs"),
 			buildVarCharRow("user_seq"),
 		},
-		RowsAffected: 9,
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -331,7 +331,7 @@ func TestExecutorAutocommit(t *testing.T) {
 
 	_, err = executor.Execute(ctx, "TestExecute", session, "update main1 set id=1", nil)
 	require.NoError(t, err)
-	wantSession = &vtgatepb.Session{Autocommit: true, TargetString: "@master", FoundRows: 1, RowCount: 1}
+	wantSession = &vtgatepb.Session{Autocommit: true, TargetString: "@master", FoundRows: 0, RowCount: 1}
 	utils.MustMatch(t, wantSession, session.Session, "session does not match for autocommit=1")
 
 	logStats = testQueryLog(t, logChan, "TestExecute", "UPDATE", "update main1 set id=1", 1)
@@ -347,7 +347,7 @@ func TestExecutorAutocommit(t *testing.T) {
 
 	_, err = executor.Execute(ctx, "TestExecute", session, "update main1 set id=1", nil)
 	require.NoError(t, err)
-	wantSession = &vtgatepb.Session{InTransaction: true, Autocommit: true, TargetString: "@master", FoundRows: 1, RowCount: 1}
+	wantSession = &vtgatepb.Session{InTransaction: true, Autocommit: true, TargetString: "@master", FoundRows: 0, RowCount: 1}
 	testSession = *session.Session
 	testSession.ShardSessions = nil
 	utils.MustMatch(t, wantSession, &testSession, "session does not match for autocommit=1")

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -315,8 +315,8 @@ func TestExecutorAutocommit(t *testing.T) {
 	if logStats.CommitTime != 0 {
 		t.Errorf("logstats: expected zero CommitTime")
 	}
-	if logStats.RowsAffected == 0 {
-		t.Errorf("logstats: expected non-zero RowsAffected")
+	if logStats.RowsReturned == 0 {
+		t.Errorf("logstats: expected non-zero RowsReturned")
 	}
 
 	// autocommit = 1

--- a/go/vt/vtgate/executor_vstream.go
+++ b/go/vt/vtgate/executor_vstream.go
@@ -150,9 +150,8 @@ func (e *Executor) startVStream(ctx context.Context, keyspace string, shard stri
 	}
 	send := func(evs []*binlogdata.VEvent) error {
 		result := &sqltypes.Result{
-			Fields:       nil,
-			RowsAffected: 0,
-			Rows:         [][]sqltypes.Value{},
+			Fields: nil,
+			Rows:   [][]sqltypes.Value{},
 		}
 		for _, ev := range evs {
 			if totalRows+numRows >= limit {
@@ -188,7 +187,6 @@ func (e *Executor) startVStream(ctx context.Context, keyspace string, shard stri
 						break
 					}
 				}
-				result.RowsAffected = uint64(numRows)
 			default:
 			}
 		}

--- a/go/vt/vtgate/executor_vstream_test.go
+++ b/go/vt/vtgate/executor_vstream_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/test/utils"
+
 	"context"
 
 	"github.com/stretchr/testify/require"
@@ -93,8 +95,7 @@ func TestVStreamFrom(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int64},
 			{Name: "val", Type: sqltypes.VarChar},
 		},
-		RowsAffected: 3,
-		InsertID:     0,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewVarChar("+"),
 			sqltypes.NewInt64(1),
@@ -109,9 +110,7 @@ func TestVStreamFrom(t *testing.T) {
 			sqltypes.NewVarChar("xyz"),
 		}},
 	}
-	if !result.Equal(want) {
-		t.Errorf("result: %+v, want %+v", result, want)
-	}
+	utils.MustMatch(t, want, result)
 }
 
 func vstreamEvents(executor *Executor, sql string) (qr *sqltypes.Result, err error) {

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -269,8 +269,8 @@ func testScatterConnGeneric(t *testing.T, name string, f func(sc *ScatterConn, s
 	if execCount := sbc1.ExecCount.Get(); execCount != 1 {
 		t.Errorf("want 1, got %v", execCount)
 	}
-	if qr.RowsAffected != 2 {
-		t.Errorf("want 2, got %v", qr.RowsAffected)
+	if qr.RowsAffected != 0 {
+		t.Errorf("want 0, got %v", qr.RowsAffected)
 	}
 	if len(qr.Rows) != 2 {
 		t.Errorf("want 2, got %v", len(qr.Rows))

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -49,6 +49,7 @@ type LogStats struct {
 	EndTime       time.Time
 	ShardQueries  uint32
 	RowsAffected  uint64
+	RowsReturned  uint64
 	PlanTime      time.Duration
 	ExecuteTime   time.Duration
 	CommitTime    time.Duration

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -200,7 +200,11 @@ func (e *Executor) logExecutionEnd(logStats *LogStats, execStart time.Time, plan
 		logStats.Error = err
 		errCount = 1
 	} else {
-		logStats.RowsAffected = qr.RowsAffected
+		if qr.RowsAffected > 0 {
+			logStats.RowsAffected = qr.RowsAffected
+		} else {
+			logStats.RowsAffected = uint64(len(qr.Rows))
+		}
 	}
 	return errCount
 }

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -200,11 +200,7 @@ func (e *Executor) logExecutionEnd(logStats *LogStats, execStart time.Time, plan
 		logStats.Error = err
 		errCount = 1
 	} else {
-		if qr.RowsAffected > 0 {
-			logStats.RowsAffected = qr.RowsAffected
-		} else {
-			logStats.RowsAffected = uint64(len(qr.Rows))
-		}
+		logStats.RowsAffected = qr.RowsAffected
 	}
 	return errCount
 }

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -179,7 +179,7 @@ func (e *Executor) executePlan(ctx context.Context, plan *engine.Plan, vcursor *
 		logStats.Table = plan.Instructions.GetTableName()
 		logStats.TabletType = vcursor.TabletType().String()
 		errCount := e.logExecutionEnd(logStats, execStart, plan, err, qr)
-		plan.AddStats(1, time.Since(logStats.StartTime), uint64(logStats.ShardQueries), logStats.RowsAffected, errCount)
+		plan.AddStats(1, time.Since(logStats.StartTime), uint64(logStats.ShardQueries), logStats.RowsAffected, logStats.RowsReturned, errCount)
 
 		// Check if there was partial DML execution. If so, rollback the transaction.
 		if err != nil && safeSession.InTransaction() && vcursor.rollbackOnPartialExec {
@@ -201,6 +201,7 @@ func (e *Executor) logExecutionEnd(logStats *LogStats, execStart time.Time, plan
 		errCount = 1
 	} else {
 		logStats.RowsAffected = qr.RowsAffected
+		logStats.RowsReturned = uint64(len(qr.Rows))
 	}
 	return errCount
 }

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -48,7 +48,7 @@ func TestQueryzHandler(t *testing.T) {
 		t.Fatalf("couldn't get plan from cache")
 	}
 	plan1 := result.(*engine.Plan)
-	plan1.ExecTime = time.Duration(1 * time.Millisecond)
+	plan1.ExecTime = 1 * time.Millisecond
 
 	// scatter
 	sql = "select id from user"
@@ -59,7 +59,7 @@ func TestQueryzHandler(t *testing.T) {
 		t.Fatalf("couldn't get plan from cache")
 	}
 	plan2 := result.(*engine.Plan)
-	plan2.ExecTime = time.Duration(1 * time.Second)
+	plan2.ExecTime = 1 * time.Second
 
 	sql = "insert into user (id, name) values (:id, :name)"
 	_, err = executorExec(executor, sql, map[string]*querypb.BindVariable{
@@ -88,8 +88,8 @@ func TestQueryzHandler(t *testing.T) {
 
 	require.NoError(t, err)
 
-	plan3.ExecTime = time.Duration(100 * time.Millisecond)
-	plan4.ExecTime = time.Duration(200 * time.Millisecond)
+	plan3.ExecTime = 100 * time.Millisecond
+	plan4.ExecTime = 200 * time.Millisecond
 
 	queryzHandler(executor, resp, req)
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -99,10 +99,12 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>1</td>`,
 		`<td>0.001000</td>`,
 		`<td>1</td>`,
+		`<td>0</td>`,
 		`<td>1</td>`,
 		`<td>0</td>`,
 		`<td>0.001000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>1.000000</td>`,
 		`<td>0.000000</td>`,
 		`</tr>`,
@@ -114,10 +116,12 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>1</td>`,
 		`<td>1.000000</td>`,
 		`<td>8</td>`,
+		`<td>0</td>`,
 		`<td>8</td>`,
 		`<td>0</td>`,
 		`<td>1.000000</td>`,
 		`<td>8.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>8.000000</td>`,
 		`<td>0.000000</td>`,
 		`</tr>`,
@@ -131,9 +135,11 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>2</td>`,
 		`<td>2</td>`,
 		`<td>0</td>`,
+		`<td>0</td>`,
 		`<td>0.050000</td>`,
 		`<td>1.000000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>0.000000</td>`,
 		`</tr>`,
 	}
@@ -146,9 +152,11 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>2</td>`,
 		`<td>2</td>`,
 		`<td>0</td>`,
+		`<td>0</td>`,
 		`<td>0.100000</td>`,
 		`<td>1.000000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>0.000000</td>`,
 		`</tr>`,
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -125,6 +125,7 @@ type VTGate struct {
 	// are global vars that depend on this member var.
 	timings      *stats.MultiTimings
 	rowsReturned *stats.CountersWithMultiLabels
+	rowsAffected *stats.CountersWithMultiLabels
 
 	// the throttled loggers for all errors, one per API entry
 	logExecute       *logutil.ThrottledLogger
@@ -191,6 +192,10 @@ func Init(ctx context.Context, serv srvtopo.Server, cell string, tabletTypesToWa
 		rowsReturned: stats.NewCountersWithMultiLabels(
 			"VtgateApiRowsReturned",
 			"Rows returned through the VTgate API",
+			[]string{"Operation", "Keyspace", "DbType"}),
+		rowsAffected: stats.NewCountersWithMultiLabels(
+			"VtgateApiRowsAffected",
+			"Rows affected by a write (DML) operation through the VTgate API",
 			[]string{"Operation", "Keyspace", "DbType"}),
 
 		logExecute:       logutil.NewThrottledLogger("Execute", 5*time.Second),
@@ -267,6 +272,7 @@ func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql s
 	qr, err = vtg.executor.Execute(ctx, "Execute", NewSafeSession(session), sql, bindVariables)
 	if err == nil {
 		vtg.rowsReturned.Add(statsKey, int64(len(qr.Rows)))
+		vtg.rowsAffected.Add(statsKey, int64(qr.RowsAffected))
 		return session, qr, nil
 	}
 
@@ -302,6 +308,7 @@ func (vtg *VTGate) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, 
 		session, qrl[i].QueryResult, qrl[i].QueryError = vtg.Execute(ctx, session, sql, bv)
 		if qr := qrl[i].QueryResult; qr != nil {
 			vtg.rowsReturned.Add(statsKey, int64(len(qr.Rows)))
+			vtg.rowsAffected.Add(statsKey, int64(qr.RowsAffected))
 		}
 	}
 	return session, qrl, nil
@@ -333,6 +340,7 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 			},
 			func(reply *sqltypes.Result) error {
 				vtg.rowsReturned.Add(statsKey, int64(len(reply.Rows)))
+				vtg.rowsAffected.Add(statsKey, int64(reply.RowsAffected))
 				return callback(reply)
 			})
 	}
@@ -373,7 +381,6 @@ func (vtg *VTGate) Prepare(ctx context.Context, session *vtgatepb.Session, sql s
 
 	fld, err = vtg.executor.Prepare(ctx, "Prepare", NewSafeSession(session), sql, bindVariables)
 	if err == nil {
-		vtg.rowsReturned.Add(statsKey, int64(len(fld)))
 		return session, fld, nil
 	}
 
@@ -510,6 +517,10 @@ func LegacyInit(ctx context.Context, hc discovery.LegacyHealthCheck, serv srvtop
 		rowsReturned: stats.NewCountersWithMultiLabels(
 			"VtgateApiRowsReturned",
 			"Rows returned through the VTgate API",
+			[]string{"Operation", "Keyspace", "DbType"}),
+		rowsAffected: stats.NewCountersWithMultiLabels(
+			"VtgateApiRowsAffected",
+			"Rows affected by a write (DML) operation through the VTgate API",
 			[]string{"Operation", "Keyspace", "DbType"}),
 
 		logExecute:       logutil.NewThrottledLogger("Execute", 5*time.Second),

--- a/go/vt/vttablet/endtoend/batch_test.go
+++ b/go/vt/vttablet/endtoend/batch_test.go
@@ -86,7 +86,6 @@ func TestBatchRead(t *testing.T) {
 			Charset:      63,
 			Flags:        128,
 		}},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.NewInt64(1),
@@ -119,7 +118,6 @@ func TestBatchRead(t *testing.T) {
 			Charset:      63,
 			Flags:        49155,
 		}},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.NewInt64(1),

--- a/go/vt/vttablet/endtoend/compatibility_test.go
+++ b/go/vt/vttablet/endtoend/compatibility_test.go
@@ -77,7 +77,6 @@ func TestCharaterSet(t *testing.T) {
 				Flags:        128,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Int32, "1"),
@@ -232,7 +231,6 @@ func TestInts(t *testing.T) {
 				Flags:        32864,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Int8, "-128"),
@@ -268,7 +266,6 @@ func TestInts(t *testing.T) {
 				Flags:        32928,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Uint64, "18446744073709551615"),
@@ -358,7 +355,6 @@ func TestFractionals(t *testing.T) {
 				Flags:        32768,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Int32, "1"),
@@ -501,7 +497,6 @@ func TestStrings(t *testing.T) {
 				Flags:        2048,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.VarBinary, "a"),
@@ -605,7 +600,6 @@ func TestMiscTypes(t *testing.T) {
 				Flags:        144,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Int32, "1"),
@@ -635,7 +629,6 @@ func TestNull(t *testing.T) {
 				Flags:   32896,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				{},
@@ -689,7 +682,6 @@ func TestJSONType(t *testing.T) {
 				Flags:        144,
 			},
 		},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.TestValue(sqltypes.Int32, "1"),

--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -245,7 +245,6 @@ func (client *QueryClient) StreamExecuteWithOptions(query string, bindvars map[s
 				result.Fields = res.Fields
 			}
 			result.Rows = append(result.Rows, res.Rows...)
-			result.RowsAffected += uint64(len(res.Rows))
 			return nil
 		},
 	)

--- a/go/vt/vttablet/endtoend/framework/querystats.go
+++ b/go/vt/vttablet/endtoend/framework/querystats.go
@@ -24,8 +24,8 @@ import (
 
 // QueryStat contains the stats for one query.
 type QueryStat struct {
-	Query, Table, Plan                                string
-	QueryCount, Time, MysqlTime, RowCount, ErrorCount int
+	Query, Table, Plan                                                  string
+	QueryCount, Time, MysqlTime, RowsAffected, RowsReturned, ErrorCount int
 }
 
 // QueryStats parses /debug/query_stats and returns

--- a/go/vt/vttablet/endtoend/framework/testcase.go
+++ b/go/vt/vttablet/endtoend/framework/testcase.go
@@ -77,8 +77,11 @@ type TestCase struct {
 	// query. The check is skipped if Result is nil.
 	Result [][]string
 
-	// Rows affected can be nil or an int.
+	// RowsAffected affected can be nil or an int.
 	RowsAffected interface{}
+
+	// 	RowsReturned affected can be nil or an int.
+	RowsReturned interface{}
 
 	// Rewritten specifies how the query should have be rewritten.
 	Rewritten []string
@@ -124,6 +127,13 @@ func (tc *TestCase) Test(name string, client *QueryClient) error {
 		want := tc.RowsAffected.(int)
 		if int(qr.RowsAffected) != want {
 			errs = append(errs, fmt.Sprintf("RowsAffected mismatch: %d, want %d", int(qr.RowsAffected), want))
+		}
+	}
+
+	if tc.RowsReturned != nil {
+		want := tc.RowsReturned.(int)
+		if len(qr.Rows) != want {
+			errs = append(errs, fmt.Sprintf("RowsReturned mismatch: %d, want %d", len(qr.Rows), want))
 		}
 	}
 

--- a/go/vt/vttablet/endtoend/metadata_test.go
+++ b/go/vt/vttablet/endtoend/metadata_test.go
@@ -66,37 +66,31 @@ func TestMetadataSpecificExecOptions(t *testing.T) {
 	}
 
 	want := &sqltypes.Result{
-		Fields: []*querypb.Field{
-			{
-				Name:         "eid",
-				Type:         sqltypes.Int64,
-				Table:        "vitess_b",
-				OrgTable:     "vitess_b",
-				Database:     "vttest",
-				OrgName:      "eid",
-				ColumnLength: 20,
-				Charset:      63,
-				Flags:        49155,
-			},
-			{
-				Name:         "id",
-				Type:         sqltypes.Int32,
-				Table:        "vitess_b",
-				OrgTable:     "vitess_b",
-				Database:     "vttest",
-				OrgName:      "id",
-				ColumnLength: 11,
-				Charset:      63,
-				Flags:        49155,
-			},
-		},
-		RowsAffected: 1,
-		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.NewInt64(-9223372036854775808),
-				sqltypes.NewInt32(-2147483648),
-			},
-		},
+		Fields: []*querypb.Field{{
+			Name:         "eid",
+			Type:         sqltypes.Int64,
+			Table:        "vitess_b",
+			OrgTable:     "vitess_b",
+			Database:     "vttest",
+			OrgName:      "eid",
+			ColumnLength: 20,
+			Charset:      63,
+			Flags:        49155,
+		}, {
+			Name:         "id",
+			Type:         sqltypes.Int32,
+			Table:        "vitess_b",
+			OrgTable:     "vitess_b",
+			Database:     "vttest",
+			OrgName:      "id",
+			ColumnLength: 11,
+			Charset:      63,
+			Flags:        49155,
+		}},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(-9223372036854775808),
+			sqltypes.NewInt32(-2147483648),
+		}},
 		StatusFlags: sqltypes.ServerStatusAutocommit,
 	}
 	mustMatch(t, want, qr)
@@ -118,23 +112,17 @@ func TestMetadataDefaultExecOptions(t *testing.T) {
 	}
 
 	want := &sqltypes.Result{
-		Fields: []*querypb.Field{
-			{
-				Name: "eid",
-				Type: sqltypes.Int64,
-			},
-			{
-				Name: "id",
-				Type: sqltypes.Int32,
-			},
-		},
-		RowsAffected: 1,
-		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.NewInt64(-9223372036854775808),
-				sqltypes.NewInt32(-2147483648),
-			},
-		},
+		Fields: []*querypb.Field{{
+			Name: "eid",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "id",
+			Type: sqltypes.Int32,
+		}},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(-9223372036854775808),
+			sqltypes.NewInt32(-2147483648),
+		}},
 		StatusFlags: sqltypes.ServerStatusAutocommit,
 	}
 	mustMatch(t, want, qr)
@@ -156,23 +144,17 @@ func TestMetadataNoExecOptions(t *testing.T) {
 	}
 
 	want := &sqltypes.Result{
-		Fields: []*querypb.Field{
-			{
-				Name: "eid",
-				Type: sqltypes.Int64,
-			},
-			{
-				Name: "id",
-				Type: sqltypes.Int32,
-			},
-		},
-		RowsAffected: 1,
-		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.NewInt64(-9223372036854775808),
-				sqltypes.NewInt32(-2147483648),
-			},
-		},
+		Fields: []*querypb.Field{{
+			Name: "eid",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "id",
+			Type: sqltypes.Int32,
+		}},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(-9223372036854775808),
+			sqltypes.NewInt32(-2147483648),
+		}},
 		StatusFlags: sqltypes.ServerStatusAutocommit,
 	}
 	mustMatch(t, want, qr)

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/test/utils"
+
 	"context"
 
 	"github.com/golang/protobuf/proto"
@@ -440,16 +442,16 @@ func TestQueryStats(t *testing.T) {
 	stat.Time = 0
 	stat.MysqlTime = 0
 	want := framework.QueryStat{
-		Query:      query,
-		Table:      "vitess_a",
-		Plan:       "Select",
-		QueryCount: 1,
-		RowCount:   2,
-		ErrorCount: 0,
+		Query:        query,
+		Table:        "vitess_a",
+		Plan:         "Select",
+		QueryCount:   1,
+		RowsAffected: 0,
+		RowsReturned: 2,
+		ErrorCount:   0,
 	}
-	if stat != want {
-		t.Errorf("stat: %+v, want %+v", stat, want)
-	}
+
+	utils.MustMatch(t, want, stat)
 
 	// Query cache should be updated for errors that happen at MySQL level also.
 	query = "select /* query_stats */ eid from vitess_a where dontexist(eid) = :eid"
@@ -458,12 +460,13 @@ func TestQueryStats(t *testing.T) {
 	stat.Time = 0
 	stat.MysqlTime = 0
 	want = framework.QueryStat{
-		Query:      query,
-		Table:      "vitess_a",
-		Plan:       "Select",
-		QueryCount: 1,
-		RowCount:   0,
-		ErrorCount: 1,
+		Query:        query,
+		Table:        "vitess_a",
+		Plan:         "Select",
+		QueryCount:   1,
+		RowsAffected: 0,
+		RowsReturned: 0,
+		ErrorCount:   1,
 	}
 	if stat != want {
 		t.Errorf("stat: %+v, want %+v", stat, want)

--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -19,6 +19,10 @@ package endtoend
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/utils"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
 
@@ -29,7 +33,7 @@ var frameworkErrors = `fail failed:
 Result mismatch:
 '[[1 1] [1 2]]' does not match
 '[[2 1] [1 2]]'
-RowsAffected mismatch: 2, want 1
+RowsReturned mismatch: 2, want 1
 Rewritten mismatch:
 '["select eid, id from vitess_a where 1 != 1 union select eid, id from vitess_b where 1 != 1" "select /* fail */ eid, id from vitess_a union select eid, id from vitess_b limit 10001"]' does not match
 '["select eid id from vitess_a where 1 != 1 union select eid, id from vitess_b where 1 != 1" "select /* fail */ eid, id from vitess_a union select eid, id from vitess_b"]'
@@ -45,7 +49,7 @@ func TestTheFramework(t *testing.T) {
 			{"2", "1"},
 			{"1", "2"},
 		},
-		RowsAffected: 1,
+		RowsReturned: 1,
 		Rewritten: []string{
 			"select eid id from vitess_a where 1 != 1 union select eid, id from vitess_b where 1 != 1",
 			"select /* fail */ eid, id from vitess_a union select eid, id from vitess_b",
@@ -54,9 +58,8 @@ func TestTheFramework(t *testing.T) {
 		Table: "bb",
 	}
 	err := expectFail.Test("", client)
-	if err == nil || err.Error() != frameworkErrors {
-		t.Errorf("Framework result: \n%q\nexpecting\n%q", err.Error(), frameworkErrors)
-	}
+	require.Error(t, err)
+	utils.MustMatch(t, frameworkErrors, err.Error())
 }
 
 // Most of these tests are not really needed because the queries are mostly pass-through.
@@ -76,7 +79,7 @@ func TestQueries(t *testing.T) {
 				"select eid, id from vitess_a where 1 != 1 union select eid, id from vitess_b where 1 != 1",
 				"select /* union */ eid, id from vitess_a union select eid, id from vitess_b limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "double union",
@@ -89,7 +92,7 @@ func TestQueries(t *testing.T) {
 				"select eid, id from vitess_a where 1 != 1 union select eid, id from vitess_b where 1 != 1 union select eid, id from vitess_d where 1 != 1",
 				"select /* double union */ eid, id from vitess_a union select eid, id from vitess_b union select eid, id from vitess_d limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "distinct",
@@ -113,7 +116,7 @@ func TestQueries(t *testing.T) {
 				"select eid, sum(id) from vitess_a where 1 != 1 group by eid",
 				"select /* group by */ eid, sum(id) from vitess_a group by eid limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "having",
@@ -125,7 +128,7 @@ func TestQueries(t *testing.T) {
 				"select sum(id) from vitess_a where 1 != 1",
 				"select /* having */ sum(id) from vitess_a having sum(id) = 3 limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "limit",
@@ -140,7 +143,7 @@ func TestQueries(t *testing.T) {
 				"select eid, id from vitess_a where 1 != 1",
 				"select /* limit */ eid, id from vitess_a limit 1",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "multi-table",
@@ -155,7 +158,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a, vitess_b as b where 1 != 1",
 				"select /* multi-table */ a.eid, a.id, b.eid, b.id from vitess_a as a, vitess_b as b order by a.eid asc, a.id asc, b.eid asc, b.id asc limit 10001",
 			},
-			RowsAffected: 4,
+			RowsReturned: 4,
 		},
 		&framework.TestCase{
 			Name:  "join",
@@ -168,7 +171,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* join */ a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "straight_join",
@@ -181,7 +184,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a straight_join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* straight_join */ a.eid, a.id, b.eid, b.id from vitess_a as a straight_join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "cross join",
@@ -194,7 +197,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* cross join */ a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "natural join",
@@ -207,7 +210,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a natural join vitess_b as b where 1 != 1",
 				"select /* natural join */ a.eid, a.id, b.eid, b.id from vitess_a as a natural join vitess_b as b limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "left join",
@@ -220,7 +223,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a left join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* left join */ a.eid, a.id, b.eid, b.id from vitess_a as a left join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "right join",
@@ -233,7 +236,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid, a.id, b.eid, b.id from vitess_a as a right join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* right join */ a.eid, a.id, b.eid, b.id from vitess_a as a right join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "complex select list",
@@ -246,7 +249,7 @@ func TestQueries(t *testing.T) {
 				"select eid + 1, id from vitess_a where 1 != 1",
 				"select /* complex select list */ eid + 1, id from vitess_a limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "*",
@@ -259,7 +262,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* * */ * from vitess_a limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "table alias",
@@ -272,7 +275,7 @@ func TestQueries(t *testing.T) {
 				"select a.eid from vitess_a as a where 1 != 1",
 				"select /* table alias */ a.eid from vitess_a as a where a.eid = 1 limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "parenthesised col",
@@ -284,7 +287,7 @@ func TestQueries(t *testing.T) {
 				"select eid from vitess_a where 1 != 1",
 				"select /* parenthesised col */ eid from vitess_a where eid = 1 and id = 1 limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.MultiCase{
 			Name: "for update",
@@ -299,7 +302,7 @@ func TestQueries(t *testing.T) {
 						"select eid from vitess_a where 1 != 1",
 						"select /* for update */ eid from vitess_a where eid = 1 and id = 1 limit 10001 for update",
 					},
-					RowsAffected: 1,
+					RowsReturned: 1,
 				},
 				framework.TestQuery("commit"),
 			},
@@ -317,7 +320,7 @@ func TestQueries(t *testing.T) {
 						"select eid from vitess_a where 1 != 1",
 						"select /* for update */ eid from vitess_a where eid = 1 and id = 1 limit 10001 lock in share mode",
 					},
-					RowsAffected: 1,
+					RowsReturned: 1,
 				},
 				framework.TestQuery("commit"),
 			},
@@ -332,7 +335,7 @@ func TestQueries(t *testing.T) {
 				"select id from vitess_a where 1 != 1",
 				"select /* complex where */ id from vitess_a where id + 1 = 2 limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "complex where (non-value operand)",
@@ -344,7 +347,7 @@ func TestQueries(t *testing.T) {
 				"select eid, id from vitess_a where 1 != 1",
 				"select /* complex where (non-value operand) */ eid, id from vitess_a where eid = id limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "(condition)",
@@ -357,7 +360,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* (condition) */ * from vitess_a where eid = 1 limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "inequality",
@@ -369,7 +372,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* inequality */ * from vitess_a where id > 1 limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "in",
@@ -382,7 +385,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* in */ * from vitess_a where id in (1, 2) limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "between",
@@ -395,7 +398,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* between */ * from vitess_a where id between 1 and 2 limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "order",
@@ -408,7 +411,7 @@ func TestQueries(t *testing.T) {
 				"select * from vitess_a where 1 != 1",
 				"select /* order */ * from vitess_a order by id desc limit 10001",
 			},
-			RowsAffected: 2,
+			RowsReturned: 2,
 		},
 		&framework.TestCase{
 			Name:  "select in select list",
@@ -420,7 +423,7 @@ func TestQueries(t *testing.T) {
 				"select (select eid from vitess_a where 1 != 1), eid from vitess_a where 1 != 1",
 				"select (select eid from vitess_a where id = 1), eid from vitess_a where id = 2 limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.TestCase{
 			Name:  "select in from clause",
@@ -432,7 +435,7 @@ func TestQueries(t *testing.T) {
 				"select eid from (select eid from vitess_a where 1 != 1) as a where 1 != 1",
 				"select eid from (select eid from vitess_a where id = 2) as a limit 10001",
 			},
-			RowsAffected: 1,
+			RowsReturned: 1,
 		},
 		&framework.MultiCase{
 			Name: "select in transaction",

--- a/go/vt/vttablet/endtoend/sequence_test.go
+++ b/go/vt/vttablet/endtoend/sequence_test.go
@@ -36,7 +36,6 @@ func TestSequence(t *testing.T) {
 			Name: "nextval",
 			Type: sqltypes.Int64,
 		}},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(0),
 		}},
@@ -54,7 +53,6 @@ func TestSequence(t *testing.T) {
 	qr.Fields = nil
 
 	want = &sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(13),
 			sqltypes.NewInt64(3),
@@ -72,7 +70,6 @@ func TestSequence(t *testing.T) {
 
 	// Next value generated should be based on the LastVal
 	want = &sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(13),
 		}},
@@ -85,7 +82,6 @@ func TestSequence(t *testing.T) {
 	qr.Fields = nil
 
 	want = &sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(16),
 			sqltypes.NewInt64(3),
@@ -103,7 +99,6 @@ func TestSequence(t *testing.T) {
 
 	// Next value should jump to the high value
 	want = &sqltypes.Result{
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(100),
 		}},
@@ -118,7 +113,6 @@ func TestResetSequence(t *testing.T) {
 			Name: "nextval",
 			Type: sqltypes.Int64,
 		}},
-		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(1),
 		}},

--- a/go/vt/vttablet/endtoend/sequence_test.go
+++ b/go/vt/vttablet/endtoend/sequence_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"vitess.io/vitess/go/test/utils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,6 +46,7 @@ func TestSequence(t *testing.T) {
 		want.Rows[0][0] = sqltypes.NewInt64(wantval)
 		qr, err := framework.NewClient().Execute("select next 2 values from vitess_seq", nil)
 		require.NoError(t, err)
+		utils.MustMatch(t, want, qr)
 		assert.Equal(t, want, qr)
 	}
 
@@ -59,7 +62,7 @@ func TestSequence(t *testing.T) {
 		}},
 		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit,
 	}
-	assert.Equal(t, want, qr)
+	utils.MustMatch(t, want, qr)
 
 	// Mess up the sequence by reducing next_id
 	_, err = framework.NewClient().Execute("update vitess_seq set next_id=1", nil)
@@ -74,7 +77,7 @@ func TestSequence(t *testing.T) {
 			sqltypes.NewInt64(13),
 		}},
 	}
-	assert.Equal(t, want, qr)
+	utils.MustMatch(t, want, qr)
 
 	// next_id should be reset to LastVal+cache
 	qr, err = framework.NewClient().Execute("select next_id, cache from vitess_seq", nil)
@@ -88,7 +91,7 @@ func TestSequence(t *testing.T) {
 		}},
 		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit,
 	}
-	assert.Equal(t, want, qr)
+	utils.MustMatch(t, want, qr)
 
 	// Change next_id to a very high value
 	_, err = framework.NewClient().Execute("update vitess_seq set next_id=100", nil)
@@ -103,7 +106,7 @@ func TestSequence(t *testing.T) {
 			sqltypes.NewInt64(100),
 		}},
 	}
-	assert.Equal(t, want, qr)
+	utils.MustMatch(t, want, qr)
 }
 
 func TestResetSequence(t *testing.T) {

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -36,9 +38,7 @@ func TestStreamUnion(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if qr.RowsAffected != 1 {
-		t.Errorf("RowsAffected: %d, want 1", qr.RowsAffected)
-	}
+	assert.Equal(t, 1, len(qr.Rows))
 }
 
 func TestStreamBigData(t *testing.T) {

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -57,14 +57,14 @@ func TestCommit(t *testing.T) {
 
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	require.Equal(t, uint64(4), len(qr.Rows), "rows affected")
+	require.Equal(t, 4, len(qr.Rows), "rows affected")
 
 	_, err = client.Execute("delete from vitess_test where intval=4", nil)
 	require.NoError(t, err)
 
 	qr, err = client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), qr.RowsAffected, "rows affected")
+	require.EqualValues(t, 3, qr.RowsAffected, "rows affected")
 
 	expectedDiffs := []struct {
 		tag  string

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -64,7 +64,7 @@ func TestCommit(t *testing.T) {
 
 	qr, err = client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	require.EqualValues(t, 3, qr.RowsAffected, "rows affected")
+	require.Equal(t, 3, len(qr.Rows), "rows affected")
 
 	expectedDiffs := []struct {
 		tag  string

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -57,7 +57,7 @@ func TestCommit(t *testing.T) {
 
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	require.Equal(t, uint64(4), qr.RowsAffected, "rows affected")
+	require.Equal(t, uint64(4), len(qr.Rows), "rows affected")
 
 	_, err = client.Execute("delete from vitess_test where intval=4", nil)
 	require.NoError(t, err)

--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -115,9 +115,7 @@ func TestRollback(t *testing.T) {
 
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 3 {
-		t.Errorf("rows affected: %d, want 3", qr.RowsAffected)
-	}
+	assert.Equal(t, 3, len(qr.Rows))
 
 	expectedDiffs := []struct {
 		tag  string
@@ -156,18 +154,14 @@ func TestAutoCommit(t *testing.T) {
 
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 4 {
-		t.Errorf("rows affected: %d, want 4", qr.RowsAffected)
-	}
+	assert.Equal(t, 4, len(qr.Rows))
 
 	_, err = client.Execute("delete from vitess_test where intval=4", nil)
 	require.NoError(t, err)
 
 	qr, err = client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 3 {
-		t.Errorf("rows affected: %d, want 4", qr.RowsAffected)
-	}
+	assert.Equal(t, 3, len(qr.Rows))
 
 	expectedDiffs := []struct {
 		tag  string
@@ -270,9 +264,7 @@ func TestPrepareRollback(t *testing.T) {
 	require.NoError(t, err)
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 3 {
-		t.Errorf("rows affected: %d, want 3", qr.RowsAffected)
-	}
+	assert.Equal(t, 3, len(qr.Rows))
 }
 
 func TestPrepareCommit(t *testing.T) {
@@ -294,9 +286,7 @@ func TestPrepareCommit(t *testing.T) {
 	require.NoError(t, err)
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 4 {
-		t.Errorf("rows affected: %d, want 4", qr.RowsAffected)
-	}
+	assert.Equal(t, 4, len(qr.Rows))
 }
 
 func TestPrepareReparentCommit(t *testing.T) {
@@ -324,9 +314,7 @@ func TestPrepareReparentCommit(t *testing.T) {
 	require.NoError(t, err)
 	qr, err := client.Execute("select * from vitess_test", nil)
 	require.NoError(t, err)
-	if qr.RowsAffected != 4 {
-		t.Errorf("rows affected: %d, want 4", qr.RowsAffected)
-	}
+	assert.Equal(t, 4, len(qr.Rows))
 }
 
 func TestShutdownGracePeriod(t *testing.T) {

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -93,9 +93,7 @@ var vexecInsertTemplates = []string{
 	)`,
 }
 
-var emptyResult = &sqltypes.Result{
-	RowsAffected: 0,
-}
+var emptyResult = &sqltypes.Result{}
 
 var ghostOverridePath = flag.String("gh-ost-path", "", "override default gh-ost binary full path")
 var ptOSCOverridePath = flag.String("pt-osc-path", "", "override default pt-online-schema-change binary full path")

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -515,8 +515,7 @@ var SingleRowResult = &sqltypes.Result{
 		{Name: "id", Type: sqltypes.Int32},
 		{Name: "value", Type: sqltypes.VarChar},
 	},
-	RowsAffected: 1,
-	InsertID:     0,
+	InsertID: 0,
 	Rows: [][]sqltypes.Value{{
 		sqltypes.NewInt32(1),
 		sqltypes.NewVarChar("foo"),

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -508,9 +508,25 @@ func (sbc *SandboxConn) getNextResult(stmt sqlparser.Statement) *sqltypes.Result
 		return SingleRowResult
 	}
 	switch stmt.(type) {
-	case *sqlparser.Select, *sqlparser.Union:
+	case *sqlparser.Select,
+		*sqlparser.Union,
+		*sqlparser.Show,
+		*sqlparser.Explain,
+		*sqlparser.OtherRead:
 		return SingleRowResult
+	case *sqlparser.Set,
+		sqlparser.DDLStatement,
+		*sqlparser.AlterVschema,
+		*sqlparser.Use,
+		*sqlparser.OtherAdmin,
+		*sqlparser.SetTransaction,
+		*sqlparser.Savepoint,
+		*sqlparser.SRollback,
+		*sqlparser.Release:
+		return &sqltypes.Result{}
 	}
+
+	// for everything else we fake a single row being affected
 	return &sqltypes.Result{RowsAffected: 1}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -36,9 +36,8 @@ import (
 
 var (
 	testSettingsResponse = &sqltypes.Result{
-		Fields:       nil,
-		RowsAffected: 1,
-		InsertID:     0,
+		Fields:   nil,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.NewVarBinary("MariaDB/0-1-1083"), // pos
@@ -299,9 +298,8 @@ func TestControllerStopPosition(t *testing.T) {
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	withStop := &sqltypes.Result{
-		Fields:       nil,
-		RowsAffected: 1,
-		InsertID:     0,
+		Fields:   nil,
+		InsertID: 0,
 		Rows: [][]sqltypes.Value{
 			{
 				sqltypes.NewVarBinary("MariaDB/0-1-1083"),    // pos

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -273,7 +273,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			}
 			vc.vr.stats.QueryTimings.Record("copy", start)
 
-			vc.vr.stats.CopyRowCount.Add(int64(len(qr.Rows)))
+			vc.vr.stats.CopyRowCount.Add(int64(qr.RowsAffected))
 			vc.vr.stats.QueryCount.Add("copy", 1)
 
 			return qr, err

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -273,7 +273,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			}
 			vc.vr.stats.QueryTimings.Record("copy", start)
 
-			vc.vr.stats.CopyRowCount.Add(int64(qr.RowsAffected))
+			vc.vr.stats.CopyRowCount.Add(int64(len(qr.Rows)))
 			vc.vr.stats.QueryCount.Add("copy", 1)
 
 			return qr, err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -327,7 +327,7 @@ func (vr *vreplicator) getSettingFKCheck() error {
 	if err != nil {
 		return err
 	}
-	if qr.RowsAffected != 1 || len(qr.Fields) != 1 {
+	if len(qr.Rows) != 1 || len(qr.Fields) != 1 {
 		return fmt.Errorf("unable to select @@foreign_key_checks")
 	}
 	vr.originalFKCheckSetting, err = evalengine.ToInt64(qr.Rows[0][0])

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -54,7 +54,7 @@ func TestDBConnExec(t *testing.T) {
 		Fields: []*querypb.Field{
 			{Type: sqltypes.VarChar},
 		},
-		RowsAffected: 1,
+		RowsAffected: 0,
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewVarChar("123")},
 		},
@@ -126,7 +126,7 @@ func TestDBConnDeadline(t *testing.T) {
 		Fields: []*querypb.Field{
 			{Type: sqltypes.VarChar},
 		},
-		RowsAffected: 1,
+		RowsAffected: 0,
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewVarChar("123")},
 		},

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -59,12 +59,13 @@ type TabletPlan struct {
 	Rules      *rules.Rules
 	Authorized []*tableacl.ACLResult
 
-	mu         sync.Mutex
-	QueryCount int64
-	Time       time.Duration
-	MysqlTime  time.Duration
-	RowCount   int64
-	ErrorCount int64
+	mu           sync.Mutex
+	QueryCount   int64
+	Time         time.Duration
+	MysqlTime    time.Duration
+	RowsAffected int64
+	RowsReturned int64
+	ErrorCount   int64
 }
 
 // Size allows TabletPlan to be in cache.LRUCache.
@@ -73,23 +74,25 @@ func (*TabletPlan) Size() int {
 }
 
 // AddStats updates the stats for the current TabletPlan.
-func (ep *TabletPlan) AddStats(queryCount int64, duration, mysqlTime time.Duration, rowCount, errorCount int64) {
+func (ep *TabletPlan) AddStats(queryCount int64, duration, mysqlTime time.Duration, rowsAffected, rowsReturned, errorCount int64) {
 	ep.mu.Lock()
 	ep.QueryCount += queryCount
 	ep.Time += duration
 	ep.MysqlTime += mysqlTime
-	ep.RowCount += rowCount
+	ep.RowsAffected += rowsAffected
+	ep.RowsReturned += rowsReturned
 	ep.ErrorCount += errorCount
 	ep.mu.Unlock()
 }
 
 // Stats returns the current stats of TabletPlan.
-func (ep *TabletPlan) Stats() (queryCount int64, duration, mysqlTime time.Duration, rowCount, errorCount int64) {
+func (ep *TabletPlan) Stats() (queryCount int64, duration, mysqlTime time.Duration, rowsAffected, rowsReturned, errorCount int64) {
 	ep.mu.Lock()
 	queryCount = ep.QueryCount
 	duration = ep.Time
 	mysqlTime = ep.MysqlTime
-	rowCount = ep.RowCount
+	rowsAffected = ep.RowsAffected
+	rowsReturned = ep.RowsReturned
 	errorCount = ep.ErrorCount
 	ep.mu.Unlock()
 	return
@@ -431,14 +434,15 @@ func (qe *QueryEngine) AddStats(planName, tableName string, queryCount int64, du
 }
 
 type perQueryStats struct {
-	Query      string
-	Table      string
-	Plan       planbuilder.PlanType
-	QueryCount int64
-	Time       time.Duration
-	MysqlTime  time.Duration
-	RowCount   int64
-	ErrorCount int64
+	Query        string
+	Table        string
+	Plan         planbuilder.PlanType
+	QueryCount   int64
+	Time         time.Duration
+	MysqlTime    time.Duration
+	RowsAffected int64
+	RowsReturned int64
+	ErrorCount   int64
 }
 
 func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, request *http.Request) {
@@ -476,7 +480,7 @@ func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, reques
 			pqstats.Query = unicoded(sqlparser.TruncateForUI(v))
 			pqstats.Table = plan.TableName().String()
 			pqstats.Plan = plan.PlanID
-			pqstats.QueryCount, pqstats.Time, pqstats.MysqlTime, pqstats.RowCount, pqstats.ErrorCount = plan.Stats()
+			pqstats.QueryCount, pqstats.Time, pqstats.MysqlTime, pqstats.RowsAffected, pqstats.RowsReturned, pqstats.ErrorCount = plan.Stats()
 
 			qstats = append(qstats, pqstats)
 		}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -506,7 +506,6 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(ret),
 		}},
-		RowsAffected: 1,
 	}, nil
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -83,11 +83,11 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 
 		if reply == nil {
 			qre.tsv.qe.AddStats(planName, tableName, 1, duration, mysqlTime, 0, 1)
-			qre.plan.AddStats(1, duration, mysqlTime, 0, 1)
+			qre.plan.AddStats(1, duration, mysqlTime, 0, 0, 1)
 			return
 		}
 		qre.tsv.qe.AddStats(planName, tableName, 1, duration, mysqlTime, int64(reply.RowsAffected), 0)
-		qre.plan.AddStats(1, duration, mysqlTime, int64(reply.RowsAffected), 0)
+		qre.plan.AddStats(1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0)
 		qre.logStats.RowsAffected = int(reply.RowsAffected)
 		qre.logStats.Rows = reply.Rows
 		qre.tsv.Stats().ResultHistogram.Add(int64(len(reply.Rows)))

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -517,7 +517,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 			sqltypes.NewInt64(1),
 			sqltypes.NewInt64(3),
 		}},
-		RowsAffected: 1,
 	})
 	updateQuery := "update seq set next_id = 4 where id = 0"
 	db.AddQuery(updateQuery, &sqltypes.Result{})
@@ -538,7 +537,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(1),
 		}},
-		RowsAffected: 1,
 	}
 	assert.Equal(t, want, got)
 
@@ -558,7 +556,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(2),
 		}},
-		RowsAffected: 1,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("qre.Execute() =\n%#v, want:\n%#v", got, want)
@@ -575,7 +572,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 			sqltypes.NewInt64(4),
 			sqltypes.NewInt64(3),
 		}},
-		RowsAffected: 1,
 	})
 	updateQuery = "update seq set next_id = 7 where id = 0"
 	db.AddQuery(updateQuery, &sqltypes.Result{})
@@ -592,7 +588,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(3),
 		}},
-		RowsAffected: 1,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("qre.Execute() =\n%#v, want:\n%#v", got, want)
@@ -626,7 +621,6 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt64(5),
 		}},
-		RowsAffected: 1,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("qre.Execute() =\n%#v, want:\n%#v", got, want)
@@ -1202,7 +1196,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewInt32(1427325875)},
 			},
-			RowsAffected: 1,
 		},
 		"select @@global.sql_mode": {
 			Fields: []*querypb.Field{{
@@ -1211,7 +1204,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewVarBinary("STRICT_TRANS_TABLES")},
 			},
-			RowsAffected: 1,
 		},
 		"select @@autocommit": {
 			Fields: []*querypb.Field{{
@@ -1220,7 +1212,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewVarBinary("1")},
 			},
-			RowsAffected: 1,
 		},
 		"select @@sql_auto_is_null": {
 			Fields: []*querypb.Field{{
@@ -1229,7 +1220,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewVarBinary("0")},
 			},
-			RowsAffected: 1,
 		},
 		"select @@version_comment from dual where 1 != 1": {
 			Fields: []*querypb.Field{{
@@ -1243,7 +1233,6 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewVarBinary("fakedb server")},
 			},
-			RowsAffected: 1,
 		},
 		"(select 0 as x from dual where 1 != 1) union (select 1 as y from dual where 1 != 1)": {
 			Fields: []*querypb.Field{{

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -39,11 +39,13 @@ var (
 			<th>Count</th>
 			<th>Time</th>
 			<th>MySQL Time</th>
-			<th>Rows</th>
+			<th>Rows affected</th>
+			<th>Rows returned</th>
 			<th>Errors</th>
 			<th>Time per query</th>
 			<th>MySQL Time per query</th>
-			<th>Rows per query</th>
+			<th>Rows affected per query</th>
+			<th>Rows returned per query</th>
 			<th>Errors per query</th>
 		</tr>
         </thead>
@@ -56,11 +58,13 @@ var (
 			<td>{{.Count}}</td>
 			<td>{{.Time}}</td>
 			<td>{{.MysqlTime}}</td>
-			<td>{{.Rows}}</td>
+			<td>{{.RowsAffected}}</td>
+			<td>{{.RowsReturned}}</td>
 			<td>{{.Errors}}</td>
 			<td>{{.TimePQ}}</td>
 			<td>{{.MysqlTimePQ}}</td>
-			<td>{{.RowsPQ}}</td>
+			<td>{{.RowsAffectedPQ}}</td>
+			<td>{{.RowsReturnedPQ}}</td>
 			<td>{{.ErrorsPQ}}</td>
 		</tr>
 	`))
@@ -69,15 +73,16 @@ var (
 // queryzRow is used for rendering query stats
 // using go's template.
 type queryzRow struct {
-	Query     string
-	Table     string
-	Plan      planbuilder.PlanType
-	Count     int64
-	tm        time.Duration
-	mysqlTime time.Duration
-	Rows      int64
-	Errors    int64
-	Color     string
+	Query        string
+	Table        string
+	Plan         planbuilder.PlanType
+	Count        int64
+	tm           time.Duration
+	mysqlTime    time.Duration
+	RowsAffected int64
+	RowsReturned int64
+	Errors       int64
+	Color        string
 }
 
 // Time returns the total time as a string.
@@ -105,9 +110,15 @@ func (qzs *queryzRow) MysqlTimePQ() string {
 	return fmt.Sprintf("%.6f", val)
 }
 
-// RowsPQ returns the row count per query as a string.
-func (qzs *queryzRow) RowsPQ() string {
-	val := float64(qzs.Rows) / float64(qzs.Count)
+// RowsReturnedPQ returns the row count per query as a string.
+func (qzs *queryzRow) RowsReturnedPQ() string {
+	val := float64(qzs.RowsReturned) / float64(qzs.Count)
+	return fmt.Sprintf("%.6f", val)
+}
+
+// RowsAffectedPQ returns the row count per query as a string.
+func (qzs *queryzRow) RowsAffectedPQ() string {
+	val := float64(qzs.RowsAffected) / float64(qzs.Count)
 	return fmt.Sprintf("%.6f", val)
 }
 
@@ -151,7 +162,7 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 			Table: plan.TableName().String(),
 			Plan:  plan.PlanID,
 		}
-		Value.Count, Value.tm, Value.mysqlTime, Value.Rows, Value.Errors = plan.Stats()
+		Value.Count, Value.tm, Value.mysqlTime, Value.RowsAffected, Value.RowsReturned, Value.Errors = plan.Stats()
 		var timepq time.Duration
 		if Value.Count != 0 {
 			timepq = time.Duration(int64(Value.tm) / Value.Count)

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -43,7 +43,7 @@ func TestQueryzHandler(t *testing.T) {
 			PlanID: planbuilder.PlanSelect,
 		},
 	}
-	plan1.AddStats(10, 2*time.Second, 1*time.Second, 2, 0)
+	plan1.AddStats(10, 2*time.Second, 1*time.Second, 0, 2, 0)
 	qe.plans.Set("select name from test_table", plan1)
 
 	plan2 := &TabletPlan{
@@ -52,7 +52,7 @@ func TestQueryzHandler(t *testing.T) {
 			PlanID: planbuilder.PlanDDL,
 		},
 	}
-	plan2.AddStats(1, 2*time.Millisecond, 1*time.Millisecond, 1, 0)
+	plan2.AddStats(1, 2*time.Millisecond, 1*time.Millisecond, 1, 0, 0)
 	qe.plans.Set("insert into test_table values 1", plan2)
 
 	plan3 := &TabletPlan{
@@ -61,7 +61,7 @@ func TestQueryzHandler(t *testing.T) {
 			PlanID: planbuilder.PlanOtherRead,
 		},
 	}
-	plan3.AddStats(1, 75*time.Millisecond, 50*time.Millisecond, 1, 0)
+	plan3.AddStats(1, 75*time.Millisecond, 50*time.Millisecond, 0, 1, 0)
 	qe.plans.Set("show tables", plan3)
 	qe.plans.Set("", (*TabletPlan)(nil))
 
@@ -71,7 +71,7 @@ func TestQueryzHandler(t *testing.T) {
 			PlanID: planbuilder.PlanOtherRead,
 		},
 	}
-	plan4.AddStats(1, 1*time.Millisecond, 1*time.Millisecond, 1, 0)
+	plan4.AddStats(1, 1*time.Millisecond, 1*time.Millisecond, 1, 0, 0)
 	hugeInsert := "insert into test_table values 0"
 	for i := 1; i < 1000; i++ {
 		hugeInsert = hugeInsert + fmt.Sprintf(", %d", i)
@@ -89,10 +89,12 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>10</td>`,
 		`<td>2.000000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0</td>`,
 		`<td>2</td>`,
 		`<td>0</td>`,
 		`<td>0.200000</td>`,
 		`<td>0.100000</td>`,
+		`<td>0.000000</td>`,
 		`<td>0.200000</td>`,
 		`<td>0.000000</td>`,
 	}
@@ -107,9 +109,11 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>0.001000</td>`,
 		`<td>1</td>`,
 		`<td>0</td>`,
+		`<td>0</td>`,
 		`<td>0.002000</td>`,
 		`<td>0.001000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>0.000000</td>`,
 	}
 	checkQueryzHasPlan(t, planPattern2, plan2, body)
@@ -121,10 +125,12 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>1</td>`,
 		`<td>0.075000</td>`,
 		`<td>0.050000</td>`,
+		`<td>0</td>`,
 		`<td>1</td>`,
 		`<td>0</td>`,
 		`<td>0.075000</td>`,
 		`<td>0.050000</td>`,
+		`<td>0.000000</td>`,
 		`<td>1.000000</td>`,
 		`<td>0.000000</td>`,
 	}
@@ -139,9 +145,11 @@ func TestQueryzHandler(t *testing.T) {
 		`<td>0.001000</td>`,
 		`<td>1</td>`,
 		`<td>0</td>`,
+		`<td>0</td>`,
 		`<td>0.001000</td>`,
 		`<td>0.001000</td>`,
 		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
 		`<td>0.000000</td>`,
 	}
 	checkQueryzHasPlan(t, planPattern4, plan4, body)

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn_test.go
@@ -53,8 +53,7 @@ func TestStartSnapshot(t *testing.T) {
 		Rows: [][]sqltypes.Value{
 			{sqltypes.NewInt32(1), sqltypes.NewVarBinary("aaa")},
 		},
-		RowsAffected: 1,
-		StatusFlags:  sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit | sqltypes.ServerStatusInTrans,
+		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit | sqltypes.ServerStatusInTrans,
 	}
 	qr, err := conn.ExecuteFetch("select * from t1", 10, false)
 	require.NoError(t, err)

--- a/go/vt/worker/result_merger.go
+++ b/go/vt/worker/result_merger.go
@@ -173,9 +173,8 @@ func (rm *ResultMerger) Next() (*sqltypes.Result, error) {
 	}
 
 	result := &sqltypes.Result{
-		Fields:       rm.fields,
-		RowsAffected: uint64(len(rm.output)),
-		Rows:         rm.output,
+		Fields: rm.fields,
+		Rows:   rm.output,
 	}
 	rm.reset()
 

--- a/go/vt/worker/result_merger_test.go
+++ b/go/vt/worker/result_merger_test.go
@@ -191,9 +191,8 @@ func mergedResults(fields []*querypb.Field, rowsTotal, rowsPerResult int) []*sql
 		// Last row in the Result or last row in total.
 		if id%rowsPerResult == (rowsPerResult-1) || id == (rowsTotal-1) {
 			results = append(results, &sqltypes.Result{
-				Fields:       fields,
-				RowsAffected: uint64(len(rows)),
-				Rows:         rows,
+				Fields: fields,
+				Rows:   rows,
 			})
 			rows = make([][]sqltypes.Value, 0)
 		}
@@ -284,7 +283,6 @@ func TestResultMerger(t *testing.T) {
 				results := mergedResults(singlePk, 3, ResultSizeRows)
 				// Duplicate Row 1. New Rows: 0, 1, 1, 2
 				results[0].Rows = append(results[0].Rows[:2], results[0].Rows[1:]...)
-				results[0].RowsAffected = 4
 				return results
 			}(),
 		},
@@ -299,7 +297,6 @@ func TestResultMerger(t *testing.T) {
 				results := mergedResults(singlePk, 3, ResultSizeRows)
 				// Remove row 1. New Rows: 0, 2
 				results[0].Rows = append(results[0].Rows[:1], results[0].Rows[2:]...)
-				results[0].RowsAffected = 2
 				return results
 			}(),
 		},

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -81,7 +81,6 @@ func newVExec(ctx context.Context, workflow, keyspace, query string, wr *Wrangle
 // QueryResultForRowsAffected aggregates results into row-type results (fields + values)
 func (wr *Wrangler) QueryResultForRowsAffected(results map[*topo.TabletInfo]*sqltypes.Result) *sqltypes.Result {
 	var qr = &sqltypes.Result{}
-	qr.RowsAffected = uint64(len(results))
 	qr.Fields = []*querypb.Field{{
 		Name: "Tablet",
 		Type: sqltypes.VarBinary,
@@ -102,7 +101,6 @@ func (wr *Wrangler) QueryResultForRowsAffected(results map[*topo.TabletInfo]*sql
 // QueryResultForTabletResults aggregates given results into a "rows-affected" type result (no row data)
 func (wr *Wrangler) QueryResultForTabletResults(results map[*topo.TabletInfo]*sqltypes.Result) *sqltypes.Result {
 	var qr = &sqltypes.Result{}
-	qr.RowsAffected = uint64(len(results))
 	defaultFields := []*querypb.Field{{
 		Name: "Tablet",
 		Type: sqltypes.VarBinary,

--- a/go/vtbench/vtbench.go
+++ b/go/vtbench/vtbench.go
@@ -231,7 +231,7 @@ func (bt *benchThread) clientLoop(ctx context.Context) {
 			log.Errorf("query error: %v", err)
 			break
 		} else {
-			b.Rows.Add(int64(result.RowsAffected))
+			b.Rows.Add(int64(len(result.Rows)))
 		}
 
 	}


### PR DESCRIPTION
## Description
Add a Gauge called VtgateApiRowsAffected similar to VtgateApiRowsReturned. This will record the number of rows that were inserted/updated/deleted.
While adding this, I discovered that the computation of RowsAffected is incorrect. This PR also attempts to fix that.

## Related Issue(s)
#7372 
Fixes #7415 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build 
- [ ]  VTAdmin
