### PR TITLE
Start of making CREATE DATABASE pluggable

### DIFF
--- a/go/vt/vtgate/engine/create_database.go
+++ b/go/vt/vtgate/engine/create_database.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+var _ Primitive = (*CreateDatabase)(nil)
+
+// CreateDatabase is just a container around custom database provisioning plugins
+// the default behaviour is to just return an error
+type CreateDatabase struct {
+	Name string
+	DoIt func(dbName string) error
+	noInputs
+	noTxNeeded
+}
+
+// RouteType implements the Primitive interface
+func (c *CreateDatabase) RouteType() string {
+	return "create database"
+}
+
+// GetKeyspaceName implements the Primitive interface
+func (c *CreateDatabase) GetKeyspaceName() string {
+	return c.Name
+}
+
+// GetTableName implements the Primitive interface
+func (c *CreateDatabase) GetTableName() string {
+	return ""
+}
+
+// Execute implements the Primitive interface
+func (c *CreateDatabase) Execute(VCursor, map[string]*querypb.BindVariable, bool) (*sqltypes.Result, error) {
+	err := c.DoIt(c.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sqltypes.Result{}, nil
+}
+
+// StreamExecute implements the Primitive interface
+func (c *CreateDatabase) StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	res, err := c.Execute(vcursor, bindVars, wantfields)
+	if err != nil {
+		return err
+	}
+	return callback(res)
+}
+
+// GetFields implements the Primitive interface
+func (c *CreateDatabase) GetFields(VCursor, map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	return &sqltypes.Result{}, nil
+}
+
+// description implements the Primitive interface
+func (c *CreateDatabase) description() PrimitiveDescription {
+	return PrimitiveDescription{
+		OperatorType: "CREATE DATABASE",
+		Keyspace:     &vindexes.Keyspace{Name: c.Name},
+	}
+}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -198,7 +198,10 @@ func buildDBDDLPlan(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Pr
 		if !dbDDL.IfNotExists && ksExists {
 			return nil, vterrors.Errorf(vtrpcpb.Code_ALREADY_EXISTS, "cannot create database '%s'; database exists", ksName)
 		}
-		return databaseCreator(dbDDL, vschema)
+		return &engine.CreateDatabase{
+			Name: dbDDL.DBName,
+			DoIt: databaseCreator,
+		}, nil
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unreachable code path: %s", sqlparser.String(dbDDLstmt))
 }

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -198,7 +198,7 @@ func buildDBDDLPlan(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Pr
 		if !dbDDL.IfNotExists && ksExists {
 			return nil, vterrors.Errorf(vtrpcpb.Code_ALREADY_EXISTS, "cannot create database '%s'; database exists", ksName)
 		}
-		return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "create database not allowed")
+		return databaseCreator(dbDDL, vschema)
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unreachable code path: %s", sqlparser.String(dbDDLstmt))
 }

--- a/go/vt/vtgate/planbuilder/create_database_pluggable.go
+++ b/go/vt/vtgate/planbuilder/create_database_pluggable.go
@@ -18,19 +18,15 @@ package planbuilder
 
 import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
-// PlanFunc is the function signature that you need to implement to add a custom CREATE DATABASE handler
-type PlanFunc = func(stmt *sqlparser.CreateDatabase, vschema ContextVSchema) (engine.Primitive, error)
-
-var databaseCreator = defaultCreateDatabase
+// CreateDatabasePlug is the function signature that you need to implement to add a custom CREATE DATABASE handler
+type CreateDatabasePlug = func(name string) error
 
 //goland:noinspection GoVarAndConstTypeMayBeOmitted
-var _ PlanFunc = databaseCreator
+var databaseCreator CreateDatabasePlug = defaultCreateDatabase
 
-func defaultCreateDatabase(_ *sqlparser.CreateDatabase, _ ContextVSchema) (engine.Primitive, error) {
-	return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "create database not allowed")
+func defaultCreateDatabase(_ string) error {
+	return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "create database not allowed")
 }

--- a/go/vt/vtgate/planbuilder/create_database_pluggable.go
+++ b/go/vt/vtgate/planbuilder/create_database_pluggable.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+// PlanFunc is the function signature that you need to implement to add a custom CREATE DATABASE handler
+type PlanFunc = func(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error)
+
+var databaseCreator = defaultCreateDatabase
+
+//goland:noinspection GoVarAndConstTypeMayBeOmitted
+var _ PlanFunc = databaseCreator
+
+func defaultCreateDatabase(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error) {
+	return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "create database not allowed")
+}

--- a/go/vt/vtgate/planbuilder/create_database_pluggable.go
+++ b/go/vt/vtgate/planbuilder/create_database_pluggable.go
@@ -24,13 +24,13 @@ import (
 )
 
 // PlanFunc is the function signature that you need to implement to add a custom CREATE DATABASE handler
-type PlanFunc = func(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error)
+type PlanFunc = func(stmt *sqlparser.CreateDatabase, vschema ContextVSchema) (engine.Primitive, error)
 
 var databaseCreator = defaultCreateDatabase
 
 //goland:noinspection GoVarAndConstTypeMayBeOmitted
 var _ PlanFunc = databaseCreator
 
-func defaultCreateDatabase(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error) {
+func defaultCreateDatabase(_ *sqlparser.CreateDatabase, _ ContextVSchema) (engine.Primitive, error) {
 	return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "create database not allowed")
 }

--- a/go/vt/vtgate/planbuilder/create_database_pluggable_test.go
+++ b/go/vt/vtgate/planbuilder/create_database_pluggable_test.go
@@ -49,7 +49,7 @@ func TestCreateDB(t *testing.T) {
 
 	// setting custom behaviour for CREATE DATABASE
 	s := &engine.SingleRow{}
-	databaseCreator = func(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error) {
+	databaseCreator = func(stmt *sqlparser.CreateDatabase, vschema ContextVSchema) (engine.Primitive, error) {
 		return s, nil
 	}
 

--- a/go/vt/vtgate/planbuilder/create_database_pluggable_test.go
+++ b/go/vt/vtgate/planbuilder/create_database_pluggable_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func TestCreateDB(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "main"}
+	vschema := &vschemaWrapper{
+		v: &vindexes.VSchema{
+			Keyspaces: map[string]*vindexes.KeyspaceSchema{"main": {Keyspace: ks}},
+		},
+		keyspace: ks,
+	}
+
+	// default behaviour
+	_, err := TestBuilder("create database test", vschema)
+	require.EqualError(t, err, "create database not allowed")
+
+	// we make sure to restore the state so we don't destabilize other tests
+	before := databaseCreator
+	defer func() {
+		databaseCreator = before
+	}()
+
+	// setting custom behaviour for CREATE DATABASE
+	s := &engine.SingleRow{}
+	databaseCreator = func(stmt sqlparser.Statement, vschema ContextVSchema) (engine.Primitive, error) {
+		return s, nil
+	}
+
+	output, err := TestBuilder("create database test", vschema)
+	require.NoError(t, err)
+	assert.Same(t, s, output.Instructions)
+}

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
@@ -98,7 +98,17 @@
 
 # create db foo
 "create database foo"
-"create database not allowed"
+{
+  "QueryType": "DDL",
+  "Original": "create database foo",
+  "Instructions": {
+    "OperatorType": "CREATE DATABASE",
+    "Keyspace": {
+      "Name": "foo",
+      "Sharded": false
+    }
+  }
+}
 
 # create db main
 "create database main"


### PR DESCRIPTION
My thinking is that given this, when an user wants custom behaviour around the `CREATE DATABASE` statement type, they just add a `custom_create_db_planner.go` or something in the `planbuilder` folder, containing code that does something like this:

```golang

package planbuilder

import (
	"vitess.io/vitess/go/vt/sqlparser"
	"vitess.io/vitess/go/vt/vtgate/engine"
	"vitess.io/vitess/go/vt/vtgate/evalengine"
)


func init() {
	databaseCreator = myCustomFunc
}

func myCustomFunc(dbName string) error {
	expr := evalengine.NewLiteralString([]byte(stmt.DBName))
	colName := "tried to create database with name"

	return &engine.Projection{
		Exprs: []evalengine.Expr{expr},
		Cols:  []string{colName},
		Input: &engine.SingleRow{},
	}, nil
}

```