### PR TITLE
CI: check run analysis to post JSON from file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,5 +28,5 @@ Components that this PR will affect:
 - [ ]  Query Serving
 - [ ]  VReplication
 - [ ]  Cluster Management
-- [ ]  Build 
+- [ ]  Build/CI
 - [ ]  VTAdmin

--- a/.github/workflows/check_runs_analysis.yaml
+++ b/.github/workflows/check_runs_analysis.yaml
@@ -46,6 +46,8 @@ jobs:
             \"content\": \"$(cat $tmpfile)\"
           }
         "
+        json_tmpfile="$(mktemp)"
+        echo "$json" > $json_tmpfile
 
         curl \
           -X PUT \
@@ -53,4 +55,4 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-type: application/json" \
           "https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${WORKFLOW_FAILURES_FILE}" \
-          -d "$json"
+          -d "@${json_tmpfile}"


### PR DESCRIPTION
## Description

The check runs analysis CI job sends the contents of the analysis, encoded as `base64`, with a `curl` command. Currently as an argument, but that content grew to be too long.

With this PR, we write the content to file, and ask `curl` to attach it. With this approach the size limitation is lifted.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/7382
- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

CI

cc @deepthi 