### PR TITLE
8.0 backport: Correctly initialize the TabletType stats

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -631,6 +631,7 @@ func (tm *TabletManager) exportStats() {
 	tablet := tm.Tablet()
 	statsKeyspace.Set(tablet.Keyspace)
 	statsShard.Set(tablet.Shard)
+	statsTabletType.Set(topoproto.TabletTypeLString(tm.tmState.tablet.Type))
 	if key.KeyRangeIsPartial(tablet.KeyRange) {
 		statsKeyRangeStart.Set(hex.EncodeToString(tablet.KeyRange.Start))
 		statsKeyRangeEnd.Set(hex.EncodeToString(tablet.KeyRange.End))

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -124,6 +124,8 @@ func TestStartCreateKeyspaceShard(t *testing.T) {
 	tm := newTestTM(t, ts, 1, "ks", "0")
 	defer tm.Stop()
 
+	assert.Equal(t, "replica", statsTabletType.Get())
+
 	_, err := ts.GetShard(ctx, "ks", "0")
 	require.NoError(t, err)
 
@@ -235,6 +237,7 @@ func TestCheckMastership(t *testing.T) {
 	assert.Equal(t, topodatapb.TabletType_MASTER, ti.Type)
 	ter0 := ti.GetMasterTermStartTime()
 	assert.Equal(t, now, ter0)
+	assert.Equal(t, "master", statsTabletType.Get())
 	tm.Stop()
 
 	// 3. Delete the tablet record. The shard record still says that we are the

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -182,6 +182,7 @@ func TestStateChangeTabletType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, topodatapb.TabletType_MASTER, ti.Type)
 	assert.NotNil(t, ti.MasterTermStartTime)
+	assert.Equal(t, "master", statsTabletType.Get())
 
 	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_REPLICA, DBActionNone)
 	require.NoError(t, err)
@@ -189,6 +190,7 @@ func TestStateChangeTabletType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, topodatapb.TabletType_REPLICA, ti.Type)
 	assert.Nil(t, ti.MasterTermStartTime)
+	assert.Equal(t, "replica", statsTabletType.Get())
 }
 
 func TestPublishStateNew(t *testing.T) {


### PR DESCRIPTION
## Description
Backport of #6989 

## Related Issue(s)
#6988 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
