### PR TITLE
CI upgrade tests: separate paths for upgrade v8.0.0 and v9.0.0

### DIFF
--- a/.github/workflows/cluster_endtoend_upgrade8.yml
+++ b/.github/workflows/cluster_endtoend_upgrade8.yml
@@ -1,0 +1,105 @@
+name: Cluster (upgrade8)
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Run endtoend tests on Cluster (upgrade8)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+
+    - name: Check out v8.0.0
+      uses: actions/checkout@v2
+      with:
+        ref: v8.0.0
+
+    - name: Get dependencies
+      run: |
+        # This prepares general purpose binary dependencies
+        # as well as v8.0.0 specific go modules
+        sudo apt-get update
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
+        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        go mod download
+
+        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get install -y gnupg2
+        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+        sudo apt-get update
+        sudo apt-get install percona-xtrabackup-24
+
+    - name: Building v8.0.0 binaries
+      timeout-minutes: 10
+      run: |
+        # We build v8.0.0 binaries and save them in a temporary location
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-v8.0.0/
+        cp -R bin /tmp/vitess-build-v8.0.0/
+
+    - name: Check out HEAD
+      uses: actions/checkout@v2
+
+    - name: Run cluster endtoend test v8.0.0 (create cluster)
+      timeout-minutes: 5
+      run: |
+        # By checking out we deleted bin/ directory. We now restore our pre-built v8.0.0 binaries
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+        source build.env
+        # We pass -skip-build so that we use the v8.0.0 binaries, not HEAD binaries
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade8
+
+    - name: Check out HEAD
+      uses: actions/checkout@v2
+
+
+    - name: Building HEAD binaries
+      timeout-minutes: 10
+      run: |
+        go mod download
+
+        source build.env
+        make build
+        mkdir -p /tmp/vitess-build-head/
+        cp -R bin /tmp/vitess-build-head/
+
+    - name: Run cluster endtoend test HEAD based on v8.0.0 data (upgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+
+        source build.env
+        # We built HEAD binaries manually in previous step and there's no need for the test to build.
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade8
+
+    - name: Run cluster endtoend test HEAD (create cluster)
+      timeout-minutes: 5
+      run: |
+        # create the directory where we store test data; ensure it is empty:
+        rm -rf /tmp/vtdataroot
+        mkdir -p /tmp/vtdataroot
+
+        source build.env
+        # We still have the binaries from previous step. No need to build
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade8
+
+
+    - name: Run cluster endtoend test v8.0.0 based on HEAD data (downgrade path)
+      timeout-minutes: 5
+      run: |
+        # /tmp/vtdataroot exists from previous test
+        cp -R /tmp/vitess-build-v8.0.0/bin .
+
+        source build.env
+        # We again built manually and there's no need for the test to build.
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade8

--- a/.github/workflows/cluster_endtoend_upgrade9.yml
+++ b/.github/workflows/cluster_endtoend_upgrade9.yml
@@ -1,9 +1,9 @@
-name: Cluster (upgrade)
+name: Cluster (upgrade9)
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Run endtoend tests on Cluster (upgrade)
+    name: Run endtoend tests on Cluster (upgrade9)
     runs-on: ubuntu-latest
 
     steps:
@@ -12,15 +12,15 @@ jobs:
       with:
         go-version: 1.15
 
-    - name: Check out v8.0.0
+    - name: Check out v9.0.0
       uses: actions/checkout@v2
       with:
-        ref: v8.0.0
+        ref: v9.0.0
 
     - name: Get dependencies
       run: |
         # This prepares general purpose binary dependencies
-        # as well as v8.0.0 specific go modules
+        # as well as v9.0.0 specific go modules
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
@@ -35,29 +35,29 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    - name: Building v8.0.0 binaries
+    - name: Building v9.0.0 binaries
       timeout-minutes: 10
       run: |
-        # We build v8.0.0 binaries and save them in a temporary location
+        # We build v9.0.0 binaries and save them in a temporary location
         source build.env
         make build
-        mkdir -p /tmp/vitess-build-v8.0.0/
-        cp -R bin /tmp/vitess-build-v8.0.0/
+        mkdir -p /tmp/vitess-build-v9.0.0/
+        cp -R bin /tmp/vitess-build-v9.0.0/
 
     - name: Check out HEAD
       uses: actions/checkout@v2
 
-    - name: Run cluster endtoend test v8.0.0 (create cluster)
+    - name: Run cluster endtoend test v9.0.0 (create cluster)
       timeout-minutes: 5
       run: |
-        # By checking out we deleted bin/ directory. We now restore our pre-built v8.0.0 binaries
-        cp -R /tmp/vitess-build-v8.0.0/bin .
+        # By checking out we deleted bin/ directory. We now restore our pre-built v9.0.0 binaries
+        cp -R /tmp/vitess-build-v9.0.0/bin .
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
         source build.env
-        # We pass -skip-build so that we use the v8.0.0 binaries, not HEAD binaries
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+        # We pass -skip-build so that we use the v9.0.0 binaries, not HEAD binaries
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade9
 
     - name: Check out HEAD
       uses: actions/checkout@v2
@@ -73,14 +73,14 @@ jobs:
         mkdir -p /tmp/vitess-build-head/
         cp -R bin /tmp/vitess-build-head/
 
-    - name: Run cluster endtoend test HEAD based on v8.0.0 data (upgrade path)
+    - name: Run cluster endtoend test HEAD based on v9.0.0 data (upgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
 
         source build.env
         # We built HEAD binaries manually in previous step and there's no need for the test to build.
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade9
 
     - name: Run cluster endtoend test HEAD (create cluster)
       timeout-minutes: 5
@@ -91,15 +91,15 @@ jobs:
 
         source build.env
         # We still have the binaries from previous step. No need to build
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade9
 
 
-    - name: Run cluster endtoend test v8.0.0 based on HEAD data (downgrade path)
+    - name: Run cluster endtoend test v9.0.0 based on HEAD data (downgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
-        cp -R /tmp/vitess-build-v8.0.0/bin .
+        cp -R /tmp/vitess-build-v9.0.0/bin .
 
         source build.env
         # We again built manually and there's no need for the test to build.
-        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
+        eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard upgrade9

--- a/test/config.json
+++ b/test/config.json
@@ -441,12 +441,21 @@
 				"site_test"
 			]
 		},
-		"upgrade": {
+		"upgrade8": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/versionupgrade", "-keep-data", "-force-vtdataroot", "/tmp/vtdataroot/vtroot_10901", "-force-port-start", "11900", "-force-base-tablet-uid", "1190"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "28",
+			"Shard": "upgrade8",
+			"RetryMax": 0,
+			"Tags": []
+		},
+		"upgrade9": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/versionupgrade", "-keep-data", "-force-vtdataroot", "/tmp/vtdataroot/vtroot_10901", "-force-port-start", "11900", "-force-base-tablet-uid", "1190"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "upgrade9",
 			"RetryMax": 0,
 			"Tags": []
 		},


### PR DESCRIPTION

## Description

Yesterday we released https://github.com/vitessio/vitess/releases/tag/v9.0.0. From now on, we want to have CI verify that our PRs have valid upgrade path from `v9.0.0`.

I'm still keeping upgrade tests for `v8.0.0` although I think we may not need to run them anymore? Any code we contribute from now on goes to > `v9.0.0` version, and therefore should not necessarily be compatible with `v8.0.0`? cc @deepthi 

So now there's two distinct CI tests, one called `upgrade8` and one called `upgrade9`.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
