### PR TITLE
[vtctldclient] Set `SilenceErrors` on the root command, so we don't double-log

### DIFF
--- a/go/cmd/vtctldclient/internal/command/root.go
+++ b/go/cmd/vtctldclient/internal/command/root.go
@@ -64,6 +64,14 @@ var (
 			return err
 		},
 		TraverseChildren: true,
+		// By default, cobra will print any error returned by a child command to
+		// stderr, and then return that error back up the call chain. Since we
+		// use vitess's log package to log any error we get back from
+		// Root.Execute() (in ../../main.go) this actually results in duplicate
+		// stderr lines. So, somewhat counterintuitively, we actually "silence"
+		// all errors in cobra (just from being output, they still get
+		// propagated).
+		SilenceErrors: true,
 	}
 )
 


### PR DESCRIPTION
## Description

What it says in the title. I noticed this while I was doing testing for #7395.

Before (`SilenceErrors: false`):

```
❯ vtctldclient --server "localhost:15999" DeleteKeyspace commerce >/dev/null
Error: DeleteKeyspace(commerce) error: rpc error: code = Unknown desc = keyspace commerce still has 1 shards; use Recursive=true or remove them manually; please check the topo
E0127 20:20:34.651188   89060 main.go:42] DeleteKeyspace(commerce) error: rpc error: code = Unknown desc = keyspace commerce still has 1 shards; use Recursive=true or remove them manually; please check the topo
```

After (`SilenceErrors: true`):

```
❯ vtctldclient --server "localhost:15999" DeleteKeyspace commerce >/dev/null
E0127 20:21:43.410431   89307 main.go:42] DeleteKeyspace(commerce) error: rpc error: code = Unknown desc = keyspace commerce still has 1 shards; use Recursive=true or remove them manually; please check the topo
```

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported? **No**
- [ ] Tests were added or are not required **N/A**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
