### PR TITLE
gen4: fail unsupported queries

### DIFF
--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -433,8 +433,9 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vschemaWrapper, c
 			//       this is shown by not having any info at all after the result for the V3 planner
 			//       with this last expectation, it is an error if the V4 planner
 			//       produces the same plan as the V3 planner does
+			testName := fmt.Sprintf("%d V4: %s", tcase.lineno, tcase.comments)
 			if !empty || checkAllTests {
-				t.Run(fmt.Sprintf("%d V4: %s", tcase.lineno, tcase.comments), func(t *testing.T) {
+				t.Run(testName, func(t *testing.T) {
 					if out != tcase.output2ndPlanner {
 						fail = true
 						t.Errorf("V4 - %s:%d\nDiff:\n%s\n[%s] \n[%s]", filename, tcase.lineno, cmp.Diff(tcase.output2ndPlanner, out), tcase.output, out)
@@ -452,7 +453,7 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vschemaWrapper, c
 				})
 			} else {
 				if out == tcase.output && checkV4equalPlan {
-					t.Run("V4: "+tcase.comments, func(t *testing.T) {
+					t.Run(testName, func(t *testing.T) {
 						t.Errorf("V4 - %s:%d\nplanner produces same output as V3", filename, tcase.lineno)
 					})
 				}

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -78,7 +78,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # distinct and group by together for single route.
 "select distinct col1, id from user group by col1"
@@ -97,7 +96,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # scatter group by a text column
 "select count(*), a, textcol1, b from user group by a, textcol1, b"
@@ -347,7 +345,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a unique vindex and other column should use a simple route
 "select id, col, count(*) from user group by id, col"
@@ -366,7 +363,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a non-vindex column should use an OrderdAggregate primitive
 "select col, count(*) from user group by col"
@@ -445,7 +441,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a unique vindex where alias from select list is used
 "select id as val, 1+count(*) from user group by val"
@@ -464,7 +459,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a unique vindex where expression is qualified (alias should be ignored)
 "select val as id, 1+count(*) from user group by user.id"
@@ -483,7 +477,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a unique vindex where it should skip non-aliased expressions.
 "select *, id, 1+count(*) from user group by id"
@@ -502,7 +495,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # group by a unique vindex should revert to simple route, and having clause should find the correct symbols.
 "select id, count(*) c from user group by id having id=1 and c=10"
@@ -657,7 +649,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # count with distinct unique vindex
 "select col, count(distinct id) from user group by col"

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -15,21 +15,7 @@
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user`",
-    "Table": "`user`"
-  }
-}
+Gen4 plan same as above
 
 # Query that always return empty
 "select id from user where someColumn = null"
@@ -48,21 +34,7 @@
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where someColumn = null",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectNone",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where someColumn = null",
-    "Table": "`user`"
-  }
-}
+Gen4 plan same as above
 
 # Single table unique vindex route
 "select id from user where user.id = 5"
@@ -85,25 +57,7 @@
     "Vindex": "user_index"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.id = 5",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 5",
-    "Table": "`user`",
-    "Values": [
-      5
-    ],
-    "Vindex": "user_index"
-  }
-}
+Gen4 plan same as above
 
 # Single table unique vindex route, but complex expr
 "select id from user where user.id = 5+5"
@@ -122,21 +76,7 @@
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.id = 5+5",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 5 + 5",
-    "Table": "`user`"
-  }
-}
+Gen4 plan same as above
 
 # Single table multiple unique vindex match
 "select id from music where id = 5 and user_id = 4"
@@ -182,25 +122,7 @@ Gen4 plan same as above
     "Vindex": "name_user_map"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where costly = 'aa' and name = 'bb'",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqual",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'",
-    "Table": "`user`",
-    "Values": [
-      "bb"
-    ],
-    "Vindex": "name_user_map"
-  }
-}
+Gen4 plan same as above
 
 # Single table multiple non-unique vindex match for IN clause
 "select id from user where costly in ('aa', 'bb') and name in ('aa', 'bb')"
@@ -372,25 +294,6 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where (col, name) in (('aa', 'bb')) and id = 5",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col, `name`) in (('aa', 'bb')) and id = 5",
-    "Table": "`user`",
-    "Values": [
-      5
-    ],
-    "Vindex": "user_index"
-  }
-}
 
 # Composite IN: multiple vindex matches
 "select id from user where (costly, name) in (('aa', 'bb'), ('cc', 'dd'))"
@@ -484,21 +387,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where ((col1, name), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where ((col1, `name`), col2) in (('aa', 'bb', 'cc'), (('dd', 'ee'), 'ff'))",
-    "Table": "`user`"
-  }
-}
 
 # Composite IN: RHS not tuple
 "select id from user where (col1, name) in (select * from music where music.user_id=user.id)"
@@ -520,21 +408,6 @@ Gen4 plan same as above
 
 # Composite IN: RHS has no simple values
 "select id from user where (col1, name) in (('aa', 1+1))"
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where (col1, name) in (('aa', 1+1))",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where (col1, `name`) in (('aa', 1 + 1))",
-    "Table": "`user`"
-  }
-}
 {
   "QueryType": "SELECT",
   "Original": "select id from user where (col1, name) in (('aa', 1+1))",
@@ -586,21 +459,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where name in (col, 'bb')",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` in (col, 'bb')",
-    "Table": "`user`"
-  }
-}
 
 # Single table equality route with val arg
 "select id from user where name = :a"
@@ -623,25 +481,7 @@ Gen4 plan same as above
     "Vindex": "name_user_map"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where name = :a",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqual",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` = :a",
-    "Table": "`user`",
-    "Values": [
-      ":a"
-    ],
-    "Vindex": "name_user_map"
-  }
-}
+Gen4 plan same as above
 
 # Single table equality route with unsigned value
 "select id from user where name = 18446744073709551615"
@@ -664,25 +504,7 @@ Gen4 plan same as above
     "Vindex": "name_user_map"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where name = 18446744073709551615",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqual",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `name` = 18446744073709551615",
-    "Table": "`user`",
-    "Values": [
-      18446744073709551615
-    ],
-    "Vindex": "name_user_map"
-  }
-}
+Gen4 plan same as above
 
 # Single table in clause list arg
 "select id from user where name in ::list"
@@ -834,44 +656,7 @@ Gen4 plan same as above
     ]
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "Join",
-    "JoinColumnIndexes": "1",
-    "TableName": "`user`_user_extra",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectEqualUnique",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-        "Query": "select `user`.col from `user` where `user`.id = 5",
-        "Table": "`user`",
-        "Values": [
-          5
-        ],
-        "Vindex": "user_index"
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectScatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
-        "Query": "select user_extra.id from user_extra where user_extra.col = :user_col",
-        "Table": "user_extra"
-      }
-    ]
-  }
-}
+Gen4 plan same as above
 
 # Multi-route unique vindex route on both routes
 "select user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5 and user_extra.user_id = 5"
@@ -1067,47 +852,9 @@ Gen4 plan same as above
     "Vindex": "name_user_map"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select (id or col) as val from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa'",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqual",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id or col as val from `user` where 1 != 1",
-    "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
-    "Table": "`user`",
-    "Values": [
-      "aa"
-    ],
-    "Vindex": "name_user_map"
-  }
-}
 
 # Route with multiple route constraints, SelectEqual is the best constraint.
 "select id from user where user.col = false and user.id in (1, 2) and user.name = 'aa'"
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.col = false and user.id in (1, 2) and user.name = 'aa'",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqual",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
-    "Table": "`user`",
-    "Values": [
-      "aa"
-    ],
-    "Vindex": "name_user_map"
-  }
-}
 {
   "QueryType": "SELECT",
   "Original": "select id from user where user.col = false and user.id in (1, 2) and user.name = 'aa'",
@@ -1149,47 +896,9 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa' and user.id = 1",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
-    "Table": "`user`",
-    "Values": [
-      1
-    ],
-    "Vindex": "user_index"
-  }
-}
 
 # Route with multiple route constraints, SelectEqualUnique is the best constraint, order reversed.
 "select id from user where user.id = 1 and user.name = 'aa' and user.id in (1, 2) and user.col = 5"
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.id = 1 and user.name = 'aa' and user.id in (1, 2) and user.col = 5",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
-    "Table": "`user`",
-    "Values": [
-      1
-    ],
-    "Vindex": "user_index"
-  }
-}
 {
   "QueryType": "SELECT",
   "Original": "select id from user where user.id = 1 and user.name = 'aa' and user.id in (1, 2) and user.col = 5",
@@ -1227,21 +936,7 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select id from user where user.id = 1 or user.name = 'aa' and user.id in (1, 2)",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select id from `user` where 1 != 1",
-    "Query": "select id from `user` where `user`.id = 1 or `user`.`name` = 'aa' and `user`.id in (1, 2)",
-    "Table": "`user`"
-  }
-}
+Gen4 plan same as above
 
 # Unsharded route
 "select unsharded.id from user join unsharded where unsharded.id = user.id"
@@ -2037,7 +1732,6 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
-Gen4 plan same as above
 
 # Single table with unique vindex match and NOT IN (null, 1, 2)
 "select id from music where user_id = 4 and id NOT IN (null, 1, 2)"

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -108,21 +108,6 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select m1.col from unsharded as m1 join unsharded as m2",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "FieldQuery": "select m1.col from unsharded as m1, unsharded as m2 where 1 != 1",
-    "Query": "select m1.col from unsharded as m1, unsharded as m2",
-    "Table": "unsharded"
-  }
-}
 
 # Multi-table, multi-chunk
 "select music.col from user join music"
@@ -179,7 +164,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # routing rules where table name matches, and there's an alias.
 "select * from second_user.user as a"
@@ -198,7 +182,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # routing rules where table name does not match, and there's no alias.
 "select * from route1"
@@ -319,7 +302,6 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 plan same as above
 
 # ',' join information_schema
 "select a.id,b.id from information_schema.a as a, information_schema.b as b"
@@ -355,7 +337,6 @@ Gen4 plan same as above
     "Table": "unsharded"
   }
 }
-Gen4 plan same as above
 
 # Left join, single chunk
 "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a=m2.b"
@@ -632,40 +613,6 @@ Gen4 plan same as above
     ]
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select user.col from user join unsharded as m1 join unsharded as m2",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "Join",
-    "JoinColumnIndexes": "-1",
-    "TableName": "`user`_unsharded",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectScatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-        "Query": "select `user`.col from `user`",
-        "Table": "`user`"
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectUnsharded",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select 1 from unsharded as m1, unsharded as m2 where 1 != 1",
-        "Query": "select 1 from unsharded as m1, unsharded as m2",
-        "Table": "unsharded"
-      }
-    ]
-  }
-}
 
 # Parenthesized, single chunk
 "select user.col from user join (unsharded as m1 join unsharded as m2)"
@@ -698,40 +645,6 @@ Gen4 plan same as above
         },
         "FieldQuery": "select 1 from (unsharded as m1 join unsharded as m2) where 1 != 1",
         "Query": "select 1 from (unsharded as m1 join unsharded as m2)",
-        "Table": "unsharded"
-      }
-    ]
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select user.col from user join (unsharded as m1 join unsharded as m2)",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "Join",
-    "JoinColumnIndexes": "-1",
-    "TableName": "`user`_unsharded",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectScatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.col from `user` where 1 != 1",
-        "Query": "select `user`.col from `user`",
-        "Table": "`user`"
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectUnsharded",
-        "Keyspace": {
-          "Name": "main",
-          "Sharded": false
-        },
-        "FieldQuery": "select 1 from unsharded as m1, unsharded as m2 where 1 != 1",
-        "Query": "select 1 from unsharded as m1, unsharded as m2",
         "Table": "unsharded"
       }
     ]
@@ -1020,40 +933,6 @@ Gen4 plan same as above
     ]
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select user.col from user join user_extra on user.id \u003c user_extra.user_id",
-  "Instructions": {
-    "OperatorType": "Join",
-    "Variant": "Join",
-    "JoinColumnIndexes": "-2",
-    "TableName": "`user`_user_extra",
-    "Inputs": [
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectScatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
-        "Query": "select `user`.id, `user`.col from `user`",
-        "Table": "`user`"
-      },
-      {
-        "OperatorType": "Route",
-        "Variant": "SelectScatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "select 1 from user_extra where 1 != 1",
-        "Query": "select 1 from user_extra where :user_id \u003c user_extra.user_id",
-        "Table": "user_extra"
-      }
-    ]
-  }
-}
 
 # sharded join, non-col reference RHS
 "select user.col from user join user_extra on user.id = 5"
@@ -1287,21 +1166,6 @@ Gen4 plan same as above
     },
     "FieldQuery": "select r1.col from ref as r1 join ref where 1 != 1",
     "Query": "select r1.col from ref as r1 join ref",
-    "Table": "ref"
-  }
-}
-{
-  "QueryType": "SELECT",
-  "Original": "select r1.col from ref r1 join ref",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectReference",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select r1.col from ref as r1, ref where 1 != 1",
-    "Query": "select r1.col from ref as r1, ref",
     "Table": "ref"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -314,7 +314,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # ORDER BY after pull-out subquery
 "select col from user where col in (select col2 from user) order by col"
@@ -539,7 +538,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # ORDER BY RAND() for join
 "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by RAND()"
@@ -1019,7 +1017,6 @@ Gen4 plan same as above
     ]
   }
 }
-Gen4 plan same as above
 
 # scatter limit after pullout subquery
 "select col from user where col in (select col1 from user) limit 1"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -34,7 +34,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # unqualified '*' expression for simple route
 "select * from user"
@@ -53,7 +52,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # select with timeout directive sets QueryTimeout in the route
 "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from user"
@@ -72,7 +70,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # select aggregation with timeout directive sets QueryTimeout in the route
 "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from user"
@@ -123,7 +120,6 @@ Gen4 plan same as above
     ]
   }
 }
-Gen4 plan same as above
 
 # select with partial scatter directive
 "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ * from user"
@@ -142,7 +138,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # select aggregation with partial scatter directive
 "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from user"
@@ -219,7 +214,6 @@ Gen4 plan same as above
     ]
   }
 }
-Gen4 plan same as above
 
 # qualified '*' expression for simple route
 "select user.* from user"
@@ -238,7 +232,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # fully qualified '*' expression for simple route
 "select user.user.* from user.user"
@@ -838,7 +831,6 @@ Gen4 plan same as above
     "Table": "`user`"
   }
 }
-Gen4 plan same as above
 
 # sharded limit offset
 "select user_id from music order by user_id limit 10, 20"
@@ -956,7 +948,6 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
-Gen4 plan same as above
 
 # Column Aliasing with Column
 "select user0_.col as col0_ from user user0_ where id = 1 order by col0_ desc limit 3"
@@ -979,7 +970,6 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
-Gen4 plan same as above
 
 # Booleans and parenthesis
 "select * from user where (id = 1) AND name = true limit 5"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -446,14 +446,11 @@ Gen4 plan same as above
 # create view with sql_calc_found_rows with limit
 "create view user.view_a as select sql_calc_found_rows * from music limit 100"
 "Complex select queries are not supported in create or alter view statements"
-Gen4 plan same as above
 
 # create view with sql_calc_found_rows with group by and having
 "create view user.view_a as select sql_calc_found_rows user_id, count(id) from music group by user_id having count(user_id) = 1 order by user_id limit 2"
 "Complex select queries are not supported in create or alter view statements"
-Gen4 plan same as above
 
 # create view with incompatible keyspaces
 "create view main.view_a as select * from user.user_extra"
 "Select query does not belong to the same keyspace as the view statement"
-Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
@@ -633,9 +633,7 @@
 # Invalid value in IN clause from LHS of join
 "select u1.id from user u1 join user u2 where u1.id = 18446744073709551616"
 "strconv.ParseUint: parsing "18446744073709551616": value out of range"
-Gen4 plan same as above
 
 # Invalid value in IN clause from RHS of join
 "select u1.id from user u1 join user u2 where u2.id = 18446744073709551616"
 "strconv.ParseUint: parsing "18446744073709551616": value out of range"
-Gen4 plan same as above

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -53,7 +53,7 @@ func (a *analyzer) analyzeDown(cursor *sqlparser.Cursor) bool {
 			return false
 		}
 	case *sqlparser.DerivedTable:
-		a.err = vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "%T not supported", node)
+		a.err = Gen4NotSupportedF("derived tables")
 	case *sqlparser.TableExprs:
 		// this has already been visited when we encountered the SELECT struct
 		return false
@@ -98,10 +98,13 @@ func (a *analyzer) analyzeTableExprs(tablExprs sqlparser.TableExprs) error {
 func (a *analyzer) analyzeTableExpr(tableExpr sqlparser.TableExpr) error {
 	switch table := tableExpr.(type) {
 	case *sqlparser.AliasedTableExpr:
+		if !table.As.IsEmpty() {
+			return Gen4NotSupportedF("table aliases")
+		}
 		return a.bindTable(table, table.Expr)
 	case *sqlparser.JoinTableExpr:
 		if table.Join != sqlparser.NormalJoinType {
-			return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "Join type not supported: %s", table.Join.ToString())
+			return Gen4NotSupportedF("join type %s", table.Join.ToString())
 		}
 		if err := a.analyzeTableExpr(table.LeftExpr); err != nil {
 			return err
@@ -137,7 +140,7 @@ func (a *analyzer) resolveUnQualifiedColumn(current *scope, expr *sqlparser.ColN
 			return tableExpr, nil
 		}
 	}
-	return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unable to map column to a table: %s", sqlparser.String(expr))
+	return nil, Gen4NotSupportedF("unable to map column to a table: %s", sqlparser.String(expr))
 }
 
 func (a *analyzer) tableSetFor(t table) TableSet {
@@ -205,4 +208,9 @@ func (a *analyzer) currentScope() *scope {
 		return nil
 	}
 	return a.scopes[size-1]
+}
+
+// Gen4NotSupportedF returns a common error for shortcomings in the gen4 planner
+func Gen4NotSupportedF(format string, args ...interface{}) error {
+	return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "gen4 does not yet support: "+format, args...)
 }

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package semantics
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,7 @@ func extract(in *sqlparser.Select, idx int) sqlparser.Expr {
 }
 
 func TestScopeForSubqueries(t *testing.T) {
+	t.Skip("subqueries not yet supported")
 	query := `
 select t.col1, (
 	select t.col2 from z as t) 
@@ -157,6 +159,9 @@ func TestNotUniqueTableName(t *testing.T) {
 
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
+			if strings.Contains(query, "as") {
+				t.Skip("table alias not implemented")
+			}
 			parse, _ := sqlparser.Parse(query)
 			_, err := Analyse(parse)
 			require.Error(t, err)


### PR DESCRIPTION
## Description
Then Gen4 planner is growing, but there is still a lot of query types that are not supported. This PR makes sure to fail the unsupported cases instead of producing bad plans.

## Related Issue(s)
Gen4 tracking #7280

## Impacted Areas in Vitess
Components that this PR will affect:

- [x ]  Query Serving

No docs are needed.