### PR TITLE
Add vtadmin-web build flag for configuring fetch credentials

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -58,13 +58,27 @@ class HttpResponseNotOkError extends Error {
 // Note that this only validates the HttpResponse envelope; it does not
 // do any type checking or validation on the result.
 export const vtfetch = async (endpoint: string): Promise<HttpResponse> => {
-    const url = `${process.env.REACT_APP_VTADMIN_API_ADDRESS}${endpoint}`;
-    const response = await fetch(url);
+    const { REACT_APP_VTADMIN_API_ADDRESS } = process.env;
+
+    const url = `${REACT_APP_VTADMIN_API_ADDRESS}${endpoint}`;
+    const opts = vtfetchOpts();
+
+    const response = await global.fetch(url, opts);
 
     const json = await response.json();
     if (!('ok' in json)) throw new MalformedHttpResponseError('invalid http envelope', json);
 
     return json as HttpResponse;
+};
+
+export const vtfetchOpts = (): RequestInit => {
+    const credentials = process.env.REACT_APP_FETCH_CREDENTIALS;
+    if (credentials && credentials !== 'omit' && credentials !== 'same-origin' && credentials !== 'include') {
+        throw Error(
+            `Invalid fetch credentials property: ${credentials}. Must be undefined or one of omit, same-origin, include`
+        );
+    }
+    return { credentials };
 };
 
 export const fetchTablets = async () => {

--- a/web/vtadmin/src/react-app-env.d.ts
+++ b/web/vtadmin/src/react-app-env.d.ts
@@ -7,6 +7,11 @@ declare namespace NodeJS {
         // Required. The full address of vtadmin-api's HTTP interface.
         // Example: "http://127.0.0.1:12345"
         REACT_APP_VTADMIN_API_ADDRESS: string;
+
+        // Optional. Configures the `credentials` property for fetch requests.
+        // made against vtadmin-api. If unspecified, uses fetch defaults.
+        // See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included
+        REACT_APP_FETCH_CREDENTIALS?: RequestCredentials;
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description
As the title says, this adds a build flag for vtadmin-web to configure the [fetch `credentials` property](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included) when making requests against vtadmin-api. This is useful for VTAdmin deployments that use cookie-based authentication.

I tested this out by deploying it internally. 🎉 Exciting! 

(This PR is identical to https://github.com/vitessio/vitess/pull/7413 modulo a small comment change. 🤔 I can't seem to re-open that PR against this same (downstream) branch, hence a new PR. Sorry about that!) 

## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
