### PR TITLE
Add hook for statsd integration

### DIFF
--- a/go/stats/histogram.go
+++ b/go/stats/histogram.go
@@ -27,6 +27,7 @@ import (
 // splitting the counts under different buckets
 // using specified cutoffs.
 type Histogram struct {
+	name       string
 	help       string
 	cutoffs    []int64
 	labels     []string
@@ -60,6 +61,7 @@ func NewGenericHistogram(name, help string, cutoffs []int64, labels []string, co
 		panic("mismatched cutoff and label lengths")
 	}
 	h := &Histogram{
+		name:       name,
 		help:       help,
 		cutoffs:    cutoffs,
 		labels:     labels,
@@ -84,6 +86,9 @@ func (h *Histogram) Add(value int64) {
 	}
 	if h.hook != nil {
 		h.hook(value)
+	}
+	if defaultStatsdHook.histogramHook != nil && h.name != "" {
+		defaultStatsdHook.histogramHook(h.name, value)
 	}
 }
 

--- a/go/stats/hooks.go
+++ b/go/stats/hooks.go
@@ -17,14 +17,14 @@ limitations under the License.
 package stats
 
 type statsdHook struct {
-	timerHook     func(string, int64, []string)
+	timerHook     func(string, string, int64, *Timings)
 	histogramHook func(string, int64)
 }
 
 var defaultStatsdHook = statsdHook{}
 
 // RegisterTimerHook registers timer hook
-func RegisterTimerHook(hook func(string, int64, []string)) {
+func RegisterTimerHook(hook func(string, string, int64, *Timings)) {
 	defaultStatsdHook.timerHook = hook
 }
 

--- a/go/stats/hooks.go
+++ b/go/stats/hooks.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+type statsdHook struct {
+	timerHook     func(string, int64, []string)
+	histogramHook func(string, int64)
+}
+
+var defaultStatsdHook = statsdHook{}
+
+// RegisterTimerHook registers timer hook
+func RegisterTimerHook(hook func(string, int64, []string)) {
+	defaultStatsdHook.timerHook = hook
+}
+
+// RegisterHistogramHook registers timer hook
+func RegisterHistogramHook(hook func(string, int64)) {
+	defaultStatsdHook.histogramHook = hook
+}

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -63,16 +63,7 @@ func Init(namespace string) {
 		sb.sampleRate = *statsdSampleRate
 		stats.RegisterPushBackend("statsd", sb)
 		stats.RegisterTimerHook(func(statsName, name string, value int64, timings *stats.Timings) {
-			labels := strings.Split(timings.Label(), ".")
-			names := strings.Split(name, ".")
-			var tags []string
-			if len(labels) != len(names) {
-				log.Errorf("Mismatch labels and names for %s tag: %v, %v", statsName, labels, names)
-				return
-			}
-			for i, label := range labels {
-				tags = append(tags, makeLabel(label, names[i])[0])
-			}
+			tags := makeLabels(strings.Split(timings.Label(), "."), name)
 			if err := statsdC.TimeInMilliseconds(statsName, float64(value), tags, sb.sampleRate); err != nil {
 				log.Errorf("Fail to TimeInMilliseconds %v: %v", statsName, err)
 			}

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -46,25 +46,6 @@ func makeLabels(labelNames []string, labelValsCombined string) []string {
 	return tags
 }
 
-func (sb StatsBackend) addHistogram(name string, h *stats.Histogram, tags []string) {
-	labels := h.Labels()
-	buckets := h.Buckets()
-	for i := range labels {
-		name := fmt.Sprintf("%s.%s", name, labels[i])
-		sb.statsdClient.Gauge(name, float64(buckets[i]), tags, sb.sampleRate)
-	}
-	sb.statsdClient.Gauge(fmt.Sprintf("%s.%s", name, h.CountLabel()),
-		(float64)(h.Count()),
-		tags,
-		sb.sampleRate,
-	)
-	sb.statsdClient.Gauge(fmt.Sprintf("%s.%s", name, h.TotalLabel()),
-		(float64)(h.Total()),
-		tags,
-		sb.sampleRate,
-	)
-}
-
 // Init initializes the statsd with the given namespace.
 func Init(namespace string) {
 	servenv.OnRun(func() {
@@ -81,16 +62,22 @@ func Init(namespace string) {
 		sb.statsdClient = statsdC
 		sb.sampleRate = *statsdSampleRate
 		stats.RegisterPushBackend("statsd", sb)
+		stats.RegisterTimerHook(func(name string, val int64, tags []string) {
+			if err := statsdC.TimeInMilliseconds(name, float64(val), tags, sb.sampleRate); err != nil {
+				log.Errorf("Fail to TimeInMilliseconds %v: %v", name, err)
+			}
+		})
+		stats.RegisterHistogramHook(func(name string, val int64) {
+			if err := statsdC.Histogram(name, float64(val), []string{}, sb.sampleRate); err != nil {
+				log.Errorf("Fail to Histogram for %v: %v", name, err)
+			}
+		})
 	})
 }
 
 func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 	k := kv.Key
 	switch v := kv.Value.(type) {
-	case *stats.String:
-		if err := sb.statsdClient.Set(k, v.Get(), nil, sb.sampleRate); err != nil {
-			log.Errorf("Failed to add String %v for key %v", v, k)
-		}
 	case *stats.Counter:
 		if err := sb.statsdClient.Count(k, v.Get(), nil, sb.sampleRate); err != nil {
 			log.Errorf("Failed to add Counter %v for key %v", v, k)
@@ -159,25 +146,9 @@ func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 				log.Errorf("Failed to add GaugesWithSingleLabel %v for key %v", v, k)
 			}
 		}
-	case *stats.MultiTimings:
-		labels := v.Labels()
-		hists := v.Histograms()
-		for labelValsCombined, histogram := range hists {
-			sb.addHistogram(k, histogram, makeLabels(labels, labelValsCombined))
-		}
-	case *stats.Timings:
-		// TODO: for statsd.timing metrics, there is no good way to transfer the histogram to it
-		// If we store a in memory buffer for stats.Timings and flush it here it's hard to make the stats
-		// thread safe.
-		// Instead, we export the timings stats as histogram here. We won't have the percentile breakdown
-		// for the metrics, but we can still get the average from total and count
-		labels := []string{v.Label()}
-		hists := v.Histograms()
-		for labelValsCombined, histogram := range hists {
-			sb.addHistogram(k, histogram, makeLabels(labels, labelValsCombined))
-		}
-	case *stats.Histogram:
-		sb.addHistogram(k, v, []string{})
+	case *stats.Timings, *stats.MultiTimings, *stats.Histogram:
+		// it does not make sense to export static expvar to statsd,
+		// instead we rely on hooks to integrate with statsd' timing and histogram api directly
 	case expvar.Func:
 		// Export memstats as gauge so that we don't need to call extra ReadMemStats
 		if k == "memstats" {
@@ -209,7 +180,7 @@ func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 				}
 			}
 		}
-	case *stats.StringMapFunc, *stats.Rates, *stats.RatesFunc:
+	case *stats.Rates, *stats.RatesFunc, *stats.String, *stats.StringFunc, *stats.StringMapFunc:
 		// Silently ignore metrics that does not make sense to be exported to statsd
 	default:
 		log.Warningf("Silently ignore metrics with key %v [%T]", k, kv.Value)

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -2,7 +2,6 @@ package statsd
 
 import (
 	"expvar"
-	"fmt"
 	"net"
 	"sort"
 	"strings"
@@ -27,12 +26,7 @@ func getBackend(t *testing.T) (StatsBackend, *net.UDPConn) {
 	sb.sampleRate = 1
 	sb.statsdClient = client
 	stats.RegisterTimerHook(func(stats, name string, value int64, timings *stats.Timings) {
-		labels := strings.Split(timings.Label(), ".")
-		names := strings.Split(name, ".")
-		var tags []string
-		for i, label := range labels {
-			tags = append(tags, fmt.Sprintf("%s:%s", label, names[i]))
-		}
+		tags := makeLabels(strings.Split(timings.Label(), "."), name)
 		client.TimeInMilliseconds(stats, float64(value), tags, sb.sampleRate)
 	})
 	stats.RegisterHistogramHook(func(name string, val int64) {

--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -19,7 +19,6 @@ package stats
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -91,15 +90,7 @@ func (t *Timings) Add(name string, elapsed time.Duration) {
 		t.mu.Unlock()
 	}
 	if defaultStatsdHook.timerHook != nil && t.name != "" {
-		labels := strings.Split(t.label, ".")
-		names := strings.Split(name, ".")
-		var tags []string
-		if len(labels) == len(names) {
-			for i, label := range labels {
-				tags = append(tags, fmt.Sprintf("%s:%s", label, names[i]))
-			}
-		}
-		defaultStatsdHook.timerHook(t.name, elapsed.Milliseconds(), tags)
+		defaultStatsdHook.timerHook(t.name, name, elapsed.Milliseconds(), t)
 	}
 
 	elapsedNs := int64(elapsed)


### PR DESCRIPTION
Signed-off-by: crowu <y.wu4515@gmail.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This PR adds a hook interface for different backend to register timing and histogram metrics.

The main motivation comes from the integration with statsd: 
the statsd API for timing / histogram takes a name and value, and it will aggregate the percentile metrics for us. This makes it really hard to parse the histogram data from vitess as latency in statsd. 
We currently just represent them as a plain gauges with bucket suffix - this is not a very helpful metrics to understand the latency performance.

This PR adds a statsdHook, different stats backend can choose to add different hooks for timing and histogram, and when we add timing / histogram, Vitess will also try to invoke the hook function as well. 

**One caveat**: this setup only applies to stats that published after the register functions in servenv.OnRun being called. For metrics that published *before* vitess server starts, we will just ignore them since we haven't register the hook yet


Although we are plan to integrate with OpenTelemetry , I feel there is still value to add this support to unblock any existing statsd use case. 

## Related Issue(s)
<!-- List related issues and pull requests: -->
- https://github.com/vitessio/vitess/issues/7298

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
NA

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving - mostly for stats reporting
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
