### PR TITLE
Fix Dockerfiles for vtexplain and vtctlclient

### DIFF
--- a/docker/k8s/vtexplain/Dockerfile
+++ b/docker/k8s/vtexplain/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/base AS base
+ARG VT_BASE_VER=latest
+
+FROM vitess/base:${VT_BASE_VER} AS base
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
## Description
Add `VT_BASE_VER` to vtexplain so that we can build release versions of the docker image.
Use `lite` as base for vtctlclient because `k8s` image ~is no longer being updated.~ has not been updated since 8.0.

## Related Issue(s)
#7399 
#7401 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
