### PR TITLE
Throttler: fix to client usage in vreplication and table GC

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -134,7 +134,7 @@ func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, cell string, mys
 		mysqld:          mysqld,
 		journaler:       make(map[string]*journalEvent),
 		ec:              newExternalConnector(config.ExternalConnections),
-		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckSelf),
+		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckPrimaryWrite),
 	}
 	return vre
 }

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -122,7 +122,7 @@ type GCStatus struct {
 // NewTableGC creates a table collector
 func NewTableGC(env tabletenv.Env, ts *topo.Server, tabletTypeFunc func() topodatapb.TabletType, lagThrottler *throttle.Throttler) *TableGC {
 	collector := &TableGC{
-		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckSelf),
+		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckPrimaryWrite),
 		isPrimary:       0,
 		isOpen:          0,
 


### PR DESCRIPTION
## Description

In https://github.com/vitessio/vitess/pull/7364 we introduced [client.go](https://github.com/vitessio/vitess/pull/7364/files#diff-1e881a210b1fd5f748a4952b1b5cc5ad9d1b60c35f0fe53ab90c071b5174d6c3), a throttler client, which we then used in tabletserver/tablegc, vreplication/engine and vstreamer/engine.

In the first two, I used the wrong check type: `ThrottleCheckSelf`, where in fact I should have used `ThrottleCheckPrimaryWrite` because table GC and vreplication/engine both _write to a primary_ and should therefore consider replication lag on the shard. This must have been a copy+paste mistake.

The reason endtoend tests didn't catch this is that we don't have the capacity to run replicas on our vreplication tests, and so we only have primaries; in that scenario both types of checks converge to the same result.

## Related Issue(s)
Tracking: #7362 


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
