### PR TITLE
Fix information_schema query with system schema in table_schema filter

### DIFF
--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -71,9 +71,11 @@ func TestInformationSchemaQuery(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	assertSingleRowIsReturned(t, conn, "table_schema = 'ks'")
-	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'ks'", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks'", "vt_ks")
 	assertResultIsEmpty(t, conn, "table_schema = 'NONE'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema'", "performance_schema")
+	assertResultIsEmpty(t, conn, "table_schema = 'PERFORMANCE_SCHEMA'")
 }
 
 func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {
@@ -84,12 +86,12 @@ func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {
 	})
 }
 
-func assertSingleRowIsReturned(t *testing.T, conn *mysql.Conn, predicate string) {
+func assertSingleRowIsReturned(t *testing.T, conn *mysql.Conn, predicate string, expectedKs string) {
 	t.Run(predicate, func(t *testing.T) {
 		qr, err := conn.ExecuteFetch("SELECT distinct table_schema FROM information_schema.tables WHERE "+predicate, 1000, true)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(qr.Rows), "did not get enough rows back")
-		assert.Equal(t, "vt_ks", qr.Rows[0][0].ToString())
+		assert.Equal(t, expectedKs, qr.Rows[0][0].ToString())
 	})
 }
 

--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -76,6 +76,8 @@ func TestInformationSchemaQuery(t *testing.T) {
 	assertResultIsEmpty(t, conn, "table_schema = 'NONE'")
 	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema'", "performance_schema")
 	assertResultIsEmpty(t, conn, "table_schema = 'PERFORMANCE_SCHEMA'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema' and table_name = 'users'", "performance_schema")
+	assertResultIsEmpty(t, conn, "table_schema = 'performance_schema' and table_name = 'foo'")
 }
 
 func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -424,24 +424,38 @@ func (route *Route) routeInfoSchemaQuery(vcursor VCursor, bindVars map[string]*q
 			return nil, err
 		}
 		specifiedKS = result.Value().ToString()
-		if sqlparser.SystemSchema(specifiedKS) {
-			return defaultRoute()
-		}
+		bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(specifiedKS)
 	}
 
+	var tableName string
 	if route.SysTableTableName != nil {
-		// the use has specified a table_name - let's check if it's a routed table
-		rss, err := route.paramsRoutedTable(vcursor, env, bindVars)
+		val, err := route.SysTableTableName.Evaluate(env)
+		if err != nil {
+			return nil, err
+		}
+		tableName = val.Value().ToString()
+		bindVars[BvTableName] = sqltypes.StringBindVariable(tableName)
+	}
+
+	// if the table_schema is system system, route to default keyspace.
+	if sqlparser.SystemSchema(specifiedKS) {
+		return defaultRoute()
+	}
+
+	// the use has specified a table_name - let's check if it's a routed table
+	if tableName != "" {
+		rss, err := route.paramsRoutedTable(vcursor, bindVars, specifiedKS, tableName)
 		if err != nil {
 			return nil, err
 		}
 		if rss != nil {
 			return rss, nil
 		}
-		// it was not a routed table, and we dont have a schema name to look up. give up
-		if route.SysTableTableSchema == nil {
-			return defaultRoute()
-		}
+	}
+
+	// it was not a routed table, and we dont have a schema name to look up. give up
+	if specifiedKS == "" {
+		return defaultRoute()
 	}
 
 	// we only have table_schema to work with
@@ -451,26 +465,11 @@ func (route *Route) routeInfoSchemaQuery(vcursor VCursor, bindVars map[string]*q
 		bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(specifiedKS)
 		return defaultRoute()
 	}
-	bindVars[sqltypes.BvReplaceSchemaName] = sqltypes.Int64BindVariable(1)
+	setReplaceSchemaName(bindVars)
 	return destinations, nil
 }
 
-func (route *Route) paramsRoutedTable(vcursor VCursor, env evalengine.ExpressionEnv, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, error) {
-	val, err := route.SysTableTableName.Evaluate(env)
-	if err != nil {
-		return nil, err
-	}
-	tableName := val.Value().ToString()
-
-	var tableSchema string
-	if route.SysTableTableSchema != nil {
-		val, err := route.SysTableTableSchema.Evaluate(env)
-		if err != nil {
-			return nil, err
-		}
-		tableSchema = val.Value().ToString()
-	}
-
+func (route *Route) paramsRoutedTable(vcursor VCursor, bindVars map[string]*querypb.BindVariable, tableSchema string, tableName string) ([]*srvtopo.ResolvedShard, error) {
 	tbl := sqlparser.TableName{
 		Name:      sqlparser.NewTableIdent(tableName),
 		Qualifier: sqlparser.NewTableIdent(tableSchema),
@@ -485,7 +484,7 @@ func (route *Route) paramsRoutedTable(vcursor VCursor, env evalengine.Expression
 		shards, _, err := vcursor.ResolveDestinations(destination.Keyspace.Name, nil, []key.Destination{key.DestinationAnyShard{}})
 		bindVars[BvTableName] = sqltypes.StringBindVariable(destination.Name.String())
 		if tableSchema != "" {
-			bindVars[sqltypes.BvReplaceSchemaName] = sqltypes.Int64BindVariable(1)
+			setReplaceSchemaName(bindVars)
 		}
 		return shards, err
 	}
@@ -493,6 +492,11 @@ func (route *Route) paramsRoutedTable(vcursor VCursor, env evalengine.Expression
 	// no routed table info found. we'll return nil and check on the outside if we can find the table_schema
 	bindVars[BvTableName] = sqltypes.StringBindVariable(tableName)
 	return nil, nil
+}
+
+func setReplaceSchemaName(bindVars map[string]*querypb.BindVariable) {
+	delete(bindVars, sqltypes.BvSchemaName)
+	bindVars[sqltypes.BvReplaceSchemaName] = sqltypes.Int64BindVariable(1)
 }
 
 func (route *Route) paramsAnyShard(vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -69,13 +69,17 @@ func TestSelectDBA(t *testing.T) {
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	sbc1.Queries = nil
 
-	query = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'PERFORMANCE_SCHEMA' AND table_name = 'foo'"
+	query = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'"
 	_, err = executor.Execute(context.Background(), "TestSelectDBA",
 		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
 		query, map[string]*querypb.BindVariable{},
 	)
 	require.NoError(t, err)
-	wantQueries = []*querypb.BoundQuery{{Sql: "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname and table_name = :__vttablename", BindVariables: map[string]*querypb.BindVariable{}}}
+	wantQueries = []*querypb.BoundQuery{{Sql: "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname and table_name = :__vttablename",
+		BindVariables: map[string]*querypb.BindVariable{
+			"__vtschemaname": sqltypes.StringBindVariable("performance_schema"),
+			"__vttablename":  sqltypes.StringBindVariable("foo"),
+		}}}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
 
 }

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -2766,3 +2766,22 @@ Gen4 plan same as above
     "SysTableTableSchema": "VARBINARY(\"a\")"
   }
 }
+
+# system schema in where clause of information_schema query
+"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname and table_name = :__vttablename",
+    "SysTableTableName": "VARBINARY(\"foo\")",
+    "SysTableTableSchema": "VARBINARY(\"performance_schema\")"
+  }
+}


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7408

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
