### PR TITLE
Fix Set Statement in Tablet when executed with bindvars

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -294,11 +294,7 @@ func checkForPoolingUnsafeConstructs(expr sqlparser.SQLNode) error {
 	return sqlparser.Walk(func(in sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := in.(type) {
 		case *sqlparser.Set:
-			for _, setExpr := range node.Exprs {
-				if setExpr.Name.AtCount() > 0 {
-					return false, genError(node)
-				}
-			}
+			return false, genError(node)
 		case *sqlparser.FuncExpr:
 			if sqlparser.IsLockingFunc(node) {
 				return false, genError(node)

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -595,38 +595,6 @@ options:PassthroughDMLs
   "FullQuery": "delete from a limit 10"
 }
 
-# int
-"set  a=1"
-{
-  "PlanID": "Set",
-  "TableName": "",
-  "FullQuery": "set a = 1"
-}
-
-# float
-"set  a=1.2"
-{
-  "PlanID": "Set",
-  "TableName": "",
-  "FullQuery": "set a = 1.2"
-}
-
-# string
-"set a='b'"
-{
-  "PlanID": "Set",
-  "TableName": "",
-  "FullQuery": "set a = 'b'"
-}
-
-# multi
-"set a=1, b=2"
-{
-  "PlanID": "Set",
-  "TableName": "",
-  "FullQuery": "set a = 1, b = 2"
-}
-
 # create
 "create table a(a int, b varchar(8))"
 {

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/pool_unsafe_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/pool_unsafe_cases.txt
@@ -19,5 +19,13 @@
 "release_lock('foo') not allowed without a reserved connections"
 
 # setting system variables must happen inside reserved connections
-"set @sql_safe_updates = false"
-"set @sql_safe_updates = false not allowed without a reserved connections"
+"set sql_safe_updates = false"
+"set sql_safe_updates = false not allowed without a reserved connections"
+
+# setting system variables must happen inside reserved connections
+"set @@sql_safe_updates = false"
+"set @@sql_safe_updates = false not allowed without a reserved connections"
+
+# setting system variables must happen inside reserved connections
+"set @udv = false"
+"set @udv = false not allowed without a reserved connections"

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -197,14 +197,14 @@ func (qre *QueryExecutor) execAsTransaction(f func(conn *StatefulConnection) (*s
 
 func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result, error) {
 	switch qre.plan.PlanID {
-	case p.PlanInsert, p.PlanUpdate, p.PlanDelete:
+	case p.PlanInsert, p.PlanUpdate, p.PlanDelete, p.PlanSet:
 		return qre.txFetch(conn, true)
 	case p.PlanInsertMessage:
 		qre.bindVars["#time_now"] = sqltypes.Int64BindVariable(time.Now().UnixNano())
 		return qre.txFetch(conn, true)
 	case p.PlanUpdateLimit, p.PlanDeleteLimit:
 		return qre.execDMLLimit(conn)
-	case p.PlanSet, p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush:
+	case p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush:
 		return qre.execStatefulConn(conn, qre.query, true)
 	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
 		return qre.execStatefulConn(conn, qre.query, true)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -137,7 +137,7 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		return qr, nil
 	case p.PlanSelectLock:
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "%s disallowed outside transaction", qre.plan.PlanID.String())
-	case p.PlanSet, p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush:
+	case p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush:
 		return qre.execOther()
 	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
 		return qre.execOther()

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -113,15 +113,6 @@ func TestQueryExecutorPlans(t *testing.T) {
 		// not get re-executed.
 		inTxWant: "select * from t limit 1",
 	}, {
-		input: "set a=1",
-		dbResponses: []dbResponse{{
-			query:  "set a=1",
-			result: dmlResult,
-		}},
-		resultWant: dmlResult,
-		planWant:   "Set",
-		logWant:    "set a=1",
-	}, {
 		input: "show engines",
 		dbResponses: []dbResponse{{
 			query:  "show engines",
@@ -262,7 +253,7 @@ func TestQueryExecutorPlans(t *testing.T) {
 		inTxWant:   "RELEASE savepoint a",
 	}}
 	for _, tcase := range testcases {
-		func() {
+		t.Run(tcase.input, func(t *testing.T) {
 			db := setUpQueryExecutorTest(t)
 			defer db.Close()
 			for _, dbr := range tcase.dbResponses {
@@ -300,7 +291,7 @@ func TestQueryExecutorPlans(t *testing.T) {
 				want = tcase.inTxWant
 			}
 			assert.Equal(t, want, qre.logStats.RewrittenSQL(), "in tx: %v", tcase.input)
-		}()
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Fixed the Set statements to build the query using bind vars passed.
Also, disable the use of set statements outside of reserved connections.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7375

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
