### PR TITLE
added information_schema_stats_expiry to allowed list of set vars

### DIFF
--- a/go/vt/sysvars/sysvars.go
+++ b/go/vt/sysvars/sysvars.go
@@ -160,6 +160,7 @@ var (
 		{Name: "explicit_defaults_for_timestamp"},
 		{Name: "foreign_key_checks", IsBoolean: true},
 		{Name: "group_concat_max_len"},
+		{Name: "information_schema_stats_expiry"},
 		{Name: "max_heap_table_size"},
 		{Name: "max_seeks_for_key"},
 		{Name: "max_tmp_tables"},


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7351

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
