### PR TITLE
more resilient rebuild keyspace graph check, tablet controls not in e…

### DIFF
--- a/go/vt/topotools/rebuild_keyspace.go
+++ b/go/vt/topotools/rebuild_keyspace.go
@@ -83,10 +83,11 @@ func RebuildKeyspaceLocked(ctx context.Context, log logutil.Logger, ts *topo.Ser
 		switch {
 		case err == nil:
 			for _, partition := range srvKeyspace.GetPartitions() {
-				if partition.GetShardTabletControls() != nil {
-					return fmt.Errorf("can't rebuild serving keyspace while a migration is on going. TabletControls is set for partition %v", partition)
+				for _, shardTabletControl := range partition.GetShardTabletControls() {
+					if shardTabletControl.QueryServiceDisabled {
+						return fmt.Errorf("can't rebuild serving keyspace while a migration is on going. TabletControls is set for partition %v", partition)
+					}
 				}
-
 			}
 		case topo.IsErrType(err, topo.NoNode):
 			// NOOP


### PR DESCRIPTION
## Description
After some emergency fix post split shard (SwitchWrites), we have some lingering tablet controls left in the partitions.
And those're blocking RebuildKeyspaceGraph due to the rigid check of any tablet controls even if there's no actual disabled service

## Related Issue(s)
Fixes #7503

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [X]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
