### PR TITLE
WithDDL: enforce apply schema once at first access 

### DIFF
--- a/go/vt/binlog/binlogplayer/fake_dbclient.go
+++ b/go/vt/binlog/binlogplayer/fake_dbclient.go
@@ -77,6 +77,12 @@ func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Re
 		return &sqltypes.Result{}, nil
 	case strings.HasPrefix(query, "use"):
 		return &sqltypes.Result{}, nil
+	case strings.HasPrefix(query, "create"):
+		return &sqltypes.Result{}, nil
+	case strings.HasPrefix(query, "alter"):
+		return &sqltypes.Result{}, nil
+	case strings.HasPrefix(query, "drop"):
+		return &sqltypes.Result{}, nil
 	}
 	return nil, fmt.Errorf("unexpected: %v", query)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -75,6 +75,10 @@ func init() {
 	withDDL = withddl.New(allddls)
 }
 
+func WithDDLs() []string {
+	return withDDL.DDLs()
+}
+
 // this are the default tablet_types that will be used by the tablet picker to find sources for a vreplication stream
 // it can be overridden by passing a different list to the MoveTables or Reshard commands
 var tabletTypesStr = flag.String("vreplication_tablet_type", "MASTER,REPLICA", "comma separated list of tablet types used as a source")

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -154,6 +154,9 @@ func TestEngineExec(t *testing.T) {
 	vre.Open(context.Background())
 	defer vre.Close()
 
+	for _, ddl := range withDDL.DDLs() {
+		dbClient.ExpectRequest(ddl, &sqltypes.Result{}, nil)
+	}
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequest("insert into _vt.vreplication values(null)", &sqltypes.Result{InsertID: 1}, nil)
 	dbClient.ExpectRequest("select * from _vt.vreplication where id = 1", sqltypes.MakeTestResult(

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -49,11 +48,6 @@ func TestCreateSchema(t *testing.T) {
 	db.OrderMatters()
 	upsert := fmt.Sprintf("INSERT INTO %s.heartbeat (ts, tabletUid, keyspaceShard) VALUES (%d, %d, '%s') ON DUPLICATE KEY UPDATE ts=VALUES(ts), tabletUid=VALUES(tabletUid)",
 		"_vt", now.UnixNano(), tw.tabletAlias.Uid, tw.keyspaceShard)
-	failInsert := fakesqldb.ExpectedExecuteFetch{
-		Query: upsert,
-		Error: mysql.NewSQLError(mysql.ERBadDb, "", "bad db error"),
-	}
-	db.AddExpectedExecuteFetch(failInsert)
 	db.AddExpectedQuery(fmt.Sprintf(sqlCreateSidecarDB, "_vt"), nil)
 	db.AddExpectedQuery(fmt.Sprintf(sqlCreateHeartbeatTable, "_vt"), nil)
 	db.AddExpectedQuery(upsert, nil)

--- a/go/vt/withddl/withddl.go
+++ b/go/vt/withddl/withddl.go
@@ -48,6 +48,11 @@ func New(ddls []string) *WithDDL {
 	}
 }
 
+// DDLs returns the ddl statements used by this WithDDL
+func (wd *WithDDL) DDLs() []string {
+	return wd.ddls
+}
+
 // applyDDLs applies DDLs and ignores any schema error
 func (wd *WithDDL) applyDDLs(ctx context.Context, exec func(query string) (*sqltypes.Result, error)) error {
 	log.Infof("Updating schema")

--- a/go/vt/withddl/withddl_test.go
+++ b/go/vt/withddl/withddl_test.go
@@ -144,7 +144,7 @@ func TestExec(t *testing.T) {
 			"invalid sql",
 		},
 		query: "insert into a values(1)",
-		err:   "doesn't exist",
+		err:   "error in your SQL syntax",
 	}}
 
 	withdb := connParams


### PR DESCRIPTION
## Description

With this PR we force `WithDDL` to apply the schema _once_ at first request to execute a query. Up till now, it only deployed schema when query encoutnered a schema problem, like a missing column. But, what happens when we add a new index in `ddls`? No query will fail on that, and as result `WithDDL` does not apply the index change.

Granted, applying the schema _every time_ upon startup is wasteful. But, our tables are small, and on startup there's lower traffic and migrations should be quick.

The change causes multiple tests to fail and I'm trying to track this down.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/7392


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
