### PR TITLE
Publish table size on schema 

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -45,6 +45,8 @@ const (
 	// mariaDBVersionString is present in
 	mariaDBVersionString = "MariaDB"
 	// mysql57VersionPrefix is the prefix for 5.7 mysql version, such as 5.7.31-log
+	mysql57VersionPrefix = "5.7."
+	// mysql80VersionPrefix is the prefix for 8.0 mysql version, such as 8.0.19
 	mysql80VersionPrefix = "8.0."
 )
 
@@ -145,10 +147,12 @@ func (c *Conn) fillFlavor(params *ConnParams) {
 		c.flavor = mariadbFlavor{}
 	case strings.Contains(c.ServerVersion, mariaDBVersionString):
 		c.flavor = mariadbFlavor{}
+	case strings.HasPrefix(c.ServerVersion, mysql57VersionPrefix):
+		c.flavor = mysqlFlavor57{}
 	case strings.HasPrefix(c.ServerVersion, mysql80VersionPrefix):
 		c.flavor = mysqlFlavor80{}
 	default:
-		c.flavor = mysqlFlavor57{}
+		c.flavor = mysqlFlavor56{}
 	}
 }
 

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -274,5 +274,5 @@ func (*filePosFlavor) disableBinlogPlaybackCommand() string {
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (*filePosFlavor) baseShowTablesWithSizes() string {
-	return TablesWithSize57
+	return TablesWithSize56
 }

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -271,3 +271,8 @@ func (*filePosFlavor) enableBinlogPlaybackCommand() string {
 func (*filePosFlavor) disableBinlogPlaybackCommand() string {
 	return ""
 }
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (*filePosFlavor) baseShowTablesWithSizes() string {
+	return ""
+}

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -274,5 +274,5 @@ func (*filePosFlavor) disableBinlogPlaybackCommand() string {
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (*filePosFlavor) baseShowTablesWithSizes() string {
-	return ""
+	return TablesWithSize57
 }

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -30,6 +30,15 @@ import (
 
 // mariadbFlavor implements the Flavor interface for MariaDB.
 type mariadbFlavor struct{}
+type mariadbFlavor101 struct {
+	mariadbFlavor
+}
+type mariadbFlavor102 struct {
+	mariadbFlavor
+}
+
+var _ flavor = (*mariadbFlavor101)(nil)
+var _ flavor = (*mariadbFlavor102)(nil)
 
 // masterGTIDSet is part of the Flavor interface.
 func (mariadbFlavor) masterGTIDSet(c *Conn) (GTIDSet, error) {

--- a/go/mysql/flavor_mariadb_binlog_playback.go
+++ b/go/mysql/flavor_mariadb_binlog_playback.go
@@ -29,3 +29,8 @@ func (mariadbFlavor) enableBinlogPlaybackCommand() string {
 func (mariadbFlavor) disableBinlogPlaybackCommand() string {
 	return ""
 }
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mariadbFlavor) baseShowTablesWithSizes() string {
+	return ""
+}

--- a/go/mysql/flavor_mariadb_binlog_playback.go
+++ b/go/mysql/flavor_mariadb_binlog_playback.go
@@ -32,5 +32,5 @@ func (mariadbFlavor) disableBinlogPlaybackCommand() string {
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (mariadbFlavor) baseShowTablesWithSizes() string {
-	return ""
+	return TablesWithSize57
 }

--- a/go/mysql/flavor_mariadb_binlog_playback.go
+++ b/go/mysql/flavor_mariadb_binlog_playback.go
@@ -31,6 +31,11 @@ func (mariadbFlavor) disableBinlogPlaybackCommand() string {
 }
 
 // baseShowTablesWithSizes is part of the Flavor interface.
-func (mariadbFlavor) baseShowTablesWithSizes() string {
+func (mariadbFlavor101) baseShowTablesWithSizes() string {
+	return TablesWithSize56
+}
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mariadbFlavor102) baseShowTablesWithSizes() string {
 	return TablesWithSize57
 }

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -40,7 +40,7 @@ func TestMariadbSetMasterCommands(t *testing.T) {
   MASTER_CONNECT_RETRY = 1234,
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor{}}
+	conn := &Conn{flavor: mariadbFlavor101{}}
 	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mariadbFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
@@ -73,7 +73,7 @@ func TestMariadbSetMasterCommandsSSL(t *testing.T) {
   MASTER_SSL_KEY = 'ssl-key',
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor{}}
+	conn := &Conn{flavor: mariadbFlavor101{}}
 	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mariadbFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -260,7 +260,7 @@ UNION ALL
 	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
 	FROM information_schema.tables t
 	WHERE table_schema = database() AND NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name)) 
-	group by table_name
+	group by table_name, table_type, unix_timestamp(create_time), table_comment
 `
 
 // TablesWithSize80 is a query to select table along with size for mysql 8.0

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -258,8 +258,8 @@ const TablesWithSize57 = `
 	WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)
 UNION ALL
 	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
-	FROM information_schema.tables 
-	WHERE table_schema = database() AND NOT EXISTS(SELECT * FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)) 
+	FROM information_schema.tables t
+	WHERE table_schema = database() AND NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name)) 
 	group by table_name
 `
 

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -252,8 +252,7 @@ const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_t
 // TablesWithSize57 is a query to select table along with size for mysql 5.7.
 // It's a little weird, because the JOIN predicate only works if the table and databases do not contain weird characters.
 // As a fallback, we use the mysql 5.6 query, which is not always up to date, but works for all table/db names.
-const TablesWithSize57 = `
-	SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
 	FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
 	WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)
 UNION ALL

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -247,7 +247,7 @@ func (mysqlFlavor) disableBinlogPlaybackCommand() string {
 
 // TablesWithSize56 is a query to select table along with size for mysql 5.6
 const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length) 
-		FROM information_schema.tables WHERE table_schema = database()`
+		FROM information_schema.tables WHERE table_schema = database() group by table_name`
 
 // TablesWithSize57 is a query to select table along with size for mysql 5.7
 const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -29,6 +29,9 @@ import (
 
 // mysqlFlavor implements the Flavor interface for Mysql.
 type mysqlFlavor struct{}
+type mysqlFlavor56 struct {
+	mysqlFlavor
+}
 type mysqlFlavor57 struct {
 	mysqlFlavor
 }
@@ -36,6 +39,7 @@ type mysqlFlavor80 struct {
 	mysqlFlavor
 }
 
+var _ flavor = (*mysqlFlavor56)(nil)
 var _ flavor = (*mysqlFlavor57)(nil)
 var _ flavor = (*mysqlFlavor80)(nil)
 
@@ -241,6 +245,10 @@ func (mysqlFlavor) disableBinlogPlaybackCommand() string {
 	return ""
 }
 
+// TablesWithSize56 is a query to select table along with size for mysql 5.6
+const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length) 
+		FROM information_schema.tables WHERE table_schema = database()`
+
 // TablesWithSize57 is a query to select table along with size for mysql 5.7
 const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
 		FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
@@ -250,6 +258,11 @@ const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.cr
 const TablesWithSize80 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
 		FROM information_schema.tables t, information_schema.innodb_tablespaces i 
 		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mysqlFlavor56) baseShowTablesWithSizes() string {
+	return TablesWithSize56
+}
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (mysqlFlavor57) baseShowTablesWithSizes() string {

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -29,6 +29,15 @@ import (
 
 // mysqlFlavor implements the Flavor interface for Mysql.
 type mysqlFlavor struct{}
+type mysqlFlavor57 struct {
+	mysqlFlavor
+}
+type mysqlFlavor80 struct {
+	mysqlFlavor
+}
+
+var _ flavor = (*mysqlFlavor57)(nil)
+var _ flavor = (*mysqlFlavor80)(nil)
 
 // masterGTIDSet is part of the Flavor interface.
 func (mysqlFlavor) masterGTIDSet(c *Conn) (GTIDSet, error) {
@@ -230,4 +239,18 @@ func (mysqlFlavor) enableBinlogPlaybackCommand() string {
 // disableBinlogPlaybackCommand is part of the Flavor interface.
 func (mysqlFlavor) disableBinlogPlaybackCommand() string {
 	return ""
+}
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mysqlFlavor57) baseShowTablesWithSizes() string {
+	return `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+		FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
+		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+}
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mysqlFlavor80) baseShowTablesWithSizes() string {
+	return `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+		FROM information_schema.tables t, information_schema.innodb_tablespaces i 
+		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
 }

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -241,16 +241,22 @@ func (mysqlFlavor) disableBinlogPlaybackCommand() string {
 	return ""
 }
 
-// baseShowTablesWithSizes is part of the Flavor interface.
-func (mysqlFlavor57) baseShowTablesWithSizes() string {
-	return `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+// TablesWithSize57 is a query to select table along with size for mysql 5.7
+const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
 		FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
 		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+
+// TablesWithSize80 is a query to select table along with size for mysql 8.0
+const TablesWithSize80 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+		FROM information_schema.tables t, information_schema.innodb_tablespaces i 
+		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+
+// baseShowTablesWithSizes is part of the Flavor interface.
+func (mysqlFlavor57) baseShowTablesWithSizes() string {
+	return TablesWithSize57
 }
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (mysqlFlavor80) baseShowTablesWithSizes() string {
-	return `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
-		FROM information_schema.tables t, information_schema.innodb_tablespaces i 
-		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+	return TablesWithSize80
 }

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -39,7 +39,7 @@ func TestMysql56SetMasterCommands(t *testing.T) {
   MASTER_CONNECT_RETRY = 1234,
   MASTER_AUTO_POSITION = 1`
 
-	conn := &Conn{flavor: mysqlFlavor{}}
+	conn := &Conn{flavor: mysqlFlavor57{}}
 	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mysqlFlavor.SetMasterCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
@@ -72,7 +72,7 @@ func TestMysql56SetMasterCommandsSSL(t *testing.T) {
   MASTER_SSL_KEY = 'ssl-key',
   MASTER_AUTO_POSITION = 1`
 
-	conn := &Conn{flavor: mysqlFlavor{}}
+	conn := &Conn{flavor: mysqlFlavor57{}}
 	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mysqlFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -30,11 +30,6 @@ import (
 // data.
 
 const (
-	// BaseShowTables is the base query used in further methods.
-	BaseShowTables = "SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size " +
-		"FROM information_schema.tables t, information_schema.innodb_tablespaces i " +
-		"WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)"
-
 	// BaseShowPrimary is the base query for fetching primary key info.
 	BaseShowPrimary = "SELECT table_name, column_name FROM information_schema.key_column_usage WHERE table_schema=database() AND constraint_name='PRIMARY' ORDER BY table_name, ordinal_position"
 )
@@ -42,48 +37,55 @@ const (
 // BaseShowTablesFields contains the fields returned by a BaseShowTables or a BaseShowTablesForTable command.
 // They are validated by the
 // testBaseShowTables test.
-var BaseShowTablesFields = []*querypb.Field{
-	{
-		Name:         "table_name",
-		Type:         querypb.Type_VARCHAR,
-		Table:        "tables",
-		OrgTable:     "TABLES",
-		Database:     "information_schema",
-		OrgName:      "TABLE_NAME",
-		ColumnLength: 192,
-		Charset:      CharacterSetUtf8,
-		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
-	},
-	{
-		Name:         "table_type",
-		Type:         querypb.Type_VARCHAR,
-		Table:        "tables",
-		OrgTable:     "TABLES",
-		Database:     "information_schema",
-		OrgName:      "TABLE_TYPE",
-		ColumnLength: 192,
-		Charset:      CharacterSetUtf8,
-		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
-	},
-	{
-		Name:         "unix_timestamp(create_time)",
-		Type:         querypb.Type_INT64,
-		ColumnLength: 11,
-		Charset:      CharacterSetBinary,
-		Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
-	},
-	{
-		Name:         "table_comment",
-		Type:         querypb.Type_VARCHAR,
-		Table:        "tables",
-		OrgTable:     "TABLES",
-		Database:     "information_schema",
-		OrgName:      "TABLE_COMMENT",
-		ColumnLength: 6144,
-		Charset:      CharacterSetUtf8,
-		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
-	},
-}
+var BaseShowTablesFields = []*querypb.Field{{
+	Name:         "t.table_name",
+	Type:         querypb.Type_VARCHAR,
+	Table:        "tables",
+	OrgTable:     "TABLES",
+	Database:     "information_schema",
+	OrgName:      "TABLE_NAME",
+	ColumnLength: 192,
+	Charset:      CharacterSetUtf8,
+	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
+}, {
+	Name:         "t.table_type",
+	Type:         querypb.Type_VARCHAR,
+	Table:        "tables",
+	OrgTable:     "TABLES",
+	Database:     "information_schema",
+	OrgName:      "TABLE_TYPE",
+	ColumnLength: 192,
+	Charset:      CharacterSetUtf8,
+	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
+}, {
+	Name:         "unix_timestamp(t.create_time)",
+	Type:         querypb.Type_INT64,
+	ColumnLength: 11,
+	Charset:      CharacterSetBinary,
+	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
+}, {
+	Name:         "t.table_comment",
+	Type:         querypb.Type_VARCHAR,
+	Table:        "tables",
+	OrgTable:     "TABLES",
+	Database:     "information_schema",
+	OrgName:      "TABLE_COMMENT",
+	ColumnLength: 6144,
+	Charset:      CharacterSetUtf8,
+	Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
+}, {
+	Name:         "i.file_size",
+	Type:         querypb.Type_INT64,
+	ColumnLength: 11,
+	Charset:      CharacterSetBinary,
+	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
+}, {
+	Name:         "i.allocated_size",
+	Type:         querypb.Type_INT64,
+	ColumnLength: 11,
+	Charset:      CharacterSetBinary,
+	Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
+}}
 
 // BaseShowTablesRow returns the fields from a BaseShowTables or
 // BaseShowTablesForTable command.
@@ -97,6 +99,8 @@ func BaseShowTablesRow(tableName string, isView bool, comment string) []sqltypes
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(tableType)),
 		sqltypes.MakeTrusted(sqltypes.Int64, []byte("1427325875")), // unix_timestamp(create_time)
 		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(comment)),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte("100")), // file_size
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte("150")), // allocated_size
 	}
 }
 

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -32,7 +32,7 @@ import (
 const (
 	// BaseShowTables is the base query used in further methods.
 	BaseShowTables = "SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size " +
-		"FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i " +
+		"FROM information_schema.tables t, information_schema.innodb_tablespaces i " +
 		"WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)"
 
 	// BaseShowPrimary is the base query for fetching primary key info.

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -31,7 +31,9 @@ import (
 
 const (
 	// BaseShowTables is the base query used in further methods.
-	BaseShowTables = "SELECT table_name, table_type, unix_timestamp(create_time), table_comment FROM information_schema.tables WHERE table_schema = database()"
+	BaseShowTables = "SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size " +
+		"FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i " +
+		"WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)"
 
 	// BaseShowPrimary is the base query for fetching primary key info.
 	BaseShowPrimary = "SELECT table_name, column_name FROM information_schema.key_column_usage WHERE table_schema=database() AND constraint_name='PRIMARY' ORDER BY table_name, ordinal_position"

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -382,7 +382,7 @@ func initTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) error {
 		}
 		showTableRows = append(showTableRows, mysql.BaseShowTablesRow(table, false, options))
 	}
-	schemaQueries[mysql.BaseShowTables] = &sqltypes.Result{
+	schemaQueries["mysql.BaseShowTables"] = &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
 		Rows:   showTableRows,
 	}

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -382,7 +382,7 @@ func initTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) error {
 		}
 		showTableRows = append(showTableRows, mysql.BaseShowTablesRow(table, false, options))
 	}
-	schemaQueries["mysql.BaseShowTables"] = &sqltypes.Result{
+	schemaQueries[mysql.TablesWithSize57] = &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
 		Rows:   showTableRows,
 	}

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -374,6 +374,11 @@ func (dbc *DBConn) ID() int64 {
 	return dbc.conn.ID()
 }
 
+// BaseShowTables returns a query that shows tables and their sizes
+func (dbc *DBConn) BaseShowTables() string {
+	return dbc.conn.BaseShowTables()
+}
+
 func (dbc *DBConn) reconnect(ctx context.Context) error {
 	dbc.conn.Close()
 	// Reuse MySQLTimings from dbc.conn.

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -32,16 +32,13 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/mysql"
-
-	"context"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/cache"
-	"vitess.io/vitess/go/streamlog"
-
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/tableacl"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -32,6 +32,9 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/mysql"
+
+	"context"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/cache"
@@ -120,6 +123,15 @@ func TestGetMessageStreamPlan(t *testing.T) {
 	for query, result := range schematest.Queries() {
 		db.AddQuery(query, result)
 	}
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
+		Rows: [][]sqltypes.Value{
+			mysql.BaseShowTablesRow("test_table_01", false, ""),
+			mysql.BaseShowTablesRow("test_table_02", false, ""),
+			mysql.BaseShowTablesRow("test_table_03", false, ""),
+			mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
+			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
+		}})
 	qe := newTestQueryEngine(10*time.Second, true, newDBConfigs(db))
 	qe.se.Open()
 	qe.Open()

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -327,11 +327,13 @@ func (se *Engine) reload(ctx context.Context) error {
 			continue
 		}
 		log.V(2).Infof("Reading schema for table: %s", tableName)
-		table, err := LoadTable(conn, tableName, row[1].ToString(), row[3].ToString())
+		table, err := LoadTable(conn, tableName, row[3].ToString())
 		if err != nil {
 			rec.RecordError(err)
 			continue
 		}
+		table.FileSize, _ = evalengine.ToUint64(row[4])
+		table.AllocatedSize, _ = evalengine.ToUint64(row[5])
 		changedTables[tableName] = table
 		if _, ok := se.tables[tableName]; ok {
 			altered = append(altered, tableName)

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -28,7 +28,7 @@ import (
 )
 
 // LoadTable creates a Table from the schema info in the database.
-func LoadTable(conn *connpool.DBConn, tableName string, tableType string, comment string) (*Table, error) {
+func LoadTable(conn *connpool.DBConn, tableName string, comment string) (*Table, error) {
 	ta := NewTable(tableName)
 	sqlTableName := sqlparser.String(ta.Name)
 	if err := fetchColumns(ta, conn, sqlTableName); err != nil {

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -173,7 +173,7 @@ func newTestLoadTable(tableType string, comment string, db *fakesqldb.DB) (*Tabl
 	}
 	defer conn.Recycle()
 
-	return LoadTable(conn, "test_table", tableType, comment)
+	return LoadTable(conn, "test_table", comment)
 }
 
 func getTestLoadTableQueries() map[string]*sqltypes.Result {

--- a/go/vt/vttablet/tabletserver/schema/main_test.go
+++ b/go/vt/vttablet/tabletserver/schema/main_test.go
@@ -34,10 +34,9 @@ func getTestSchemaEngine(t *testing.T) (*Engine, *fakesqldb.DB, func()) {
 		"int64"),
 		"1427325876",
 	))
-	db.AddQuery(mysql.BaseShowTables, &sqltypes.Result{})
-
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{})
 	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{})
-	se := newEngine(10, 10*time.Second, 10*time.Second, true, db)
+	se := newEngine(10, 10*time.Second, 10*time.Second, db)
 	require.NoError(t, se.Open())
 	cancel := func() {
 		defer db.Close()

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -52,6 +52,9 @@ type Table struct {
 
 	// MessageInfo contains info for message tables.
 	MessageInfo *MessageInfo
+
+	FileSize      uint64
+	AllocatedSize uint64
 }
 
 // SequenceInfo contains info specific to sequence tabels.

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -61,16 +61,6 @@ func Queries() map[string]*sqltypes.Result {
 				{sqltypes.NewVarBinary("0")},
 			},
 		},
-		mysql.BaseShowTables: {
-			Fields: mysql.BaseShowTablesFields,
-			Rows: [][]sqltypes.Value{
-				mysql.BaseShowTablesRow("test_table_01", false, ""),
-				mysql.BaseShowTablesRow("test_table_02", false, ""),
-				mysql.BaseShowTablesRow("test_table_03", false, ""),
-				mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
-				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
-			},
-		},
 		mysql.BaseShowPrimary: {
 			Fields: mysql.ShowPrimaryFields,
 			Rows: [][]sqltypes.Value{

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2458,6 +2458,14 @@ func setupFakeDB(t *testing.T) *fakesqldb.DB {
 	for query, result := range getSupportedQueries() {
 		db.AddQuery(query, result)
 	}
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
+		Rows: [][]sqltypes.Value{
+			mysql.BaseShowTablesRow("test_table", false, ""),
+			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
+		},
+	})
+
 	return db
 }
 
@@ -2518,13 +2526,6 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 			}},
 			Rows: [][]sqltypes.Value{
 				{sqltypes.NewVarBinary("0")},
-			},
-		},
-		mysql.BaseShowTables: {
-			Fields: mysql.BaseShowTablesFields,
-			Rows: [][]sqltypes.Value{
-				mysql.BaseShowTablesRow("test_table", false, ""),
-				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 			},
 		},
 		mysql.BaseShowPrimary: {


### PR DESCRIPTION
## Description
Adds more information per table in the exposed tablet metrics. They now include `FileSize` and `AllocatedSize`.

From the [mysql docs](https://dev.mysql.com/doc/refman/5.7/en/information-schema-innodb-sys-tablespaces-table.html):
> FILE_SIZE
> The apparent size of the file, which represents the maximum size of the file, uncompressed. This column pertains to the InnoDB transparent page compression feature.
> 
> ALLOCATED_SIZE
> The actual size of the file, which is the amount of space allocated on disk. This column pertains to the InnoDB transparent page compression feature.

We do this by extending the query we already use to keep track of tables on the server so it returns more data.

## Impacted Areas in Vitess
Components that this PR will affect:

- Query Serving
