### PR TITLE
CI Tests: Add descriptive names to vrep shards. Update test generator script

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (11)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (11)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (12)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (12)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (13)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (13)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (14)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (14)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (15)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (15)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (16)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (16)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (17)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (18)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (18)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (19)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (19)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (20)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (20)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (21)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (21)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (22)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (22)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (23)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (23)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (24)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (24)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (26)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (26)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_27.yml
+++ b/.github/workflows/cluster_endtoend_27.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (27)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_27.yml
+++ b/.github/workflows/cluster_endtoend_27.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (27)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -1,11 +1,11 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
 
-name: Cluster (17)
+name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Run endtoend tests on Cluster (17)
+    name: Run endtoend tests on Cluster (vreplication_cellalias)
     runs-on: ubuntu-latest
 
     steps:
@@ -37,4 +37,4 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 17
+        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_cellalias

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -1,11 +1,11 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
 
-name: Cluster (17)
+name: Cluster (vreplication_multicell)
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Run endtoend tests on Cluster (17)
+    name: Run endtoend tests on Cluster (vreplication_multicell)
     runs-on: ubuntu-latest
 
     steps:
@@ -37,4 +37,4 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 17
+        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_multicell

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -1,11 +1,11 @@
 # DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
 
-name: Cluster (17)
+name: Cluster (vreplication_v2)
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Run endtoend tests on Cluster (17)
+    name: Run endtoend tests on Cluster (vreplication_v2)
     runs-on: ubuntu-latest
 
     steps:
@@ -37,4 +37,4 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 17
+        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_v2

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (mariadb101)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (mariadb101)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (mariadb102)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (mariadb102)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (mariadb103)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (mariadb103)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (mysql57)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (mysql57)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (mysql80)
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (mysql80)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -1,4 +1,4 @@
-# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
 
 name: Unit Test (percona56)
 on: [push, pull_request]

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -1,3 +1,5 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go
+
 name: Unit Test (percona56)
 on: [push, pull_request]
 jobs:

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -31,8 +31,8 @@ const (
 	unitTestTemplate  = "templates/unit_test.tpl"
 	unitTestDatabases = "percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103"
 
-	clusterTestTemplate         = "templates/cluster_endtoend_test.tpl"
-	clusterList                 = "11,12,13,14,15,16,17,18,19,20,21,22,23,24,26,27,vreplication_basic,vreplication_multicell,vreplication_cellalias,vreplication_v2"
+	clusterTestTemplate = "templates/cluster_endtoend_test.tpl"
+	clusterList         = "11,12,13,14,15,16,17,18,19,20,21,22,23,24,26,27,vreplication_basic,vreplication_multicell,vreplication_cellalias,vreplication_v2"
 	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize
 	// this by only installing them in the required clusters
 	clustersRequiringXtraBackup = clusterList

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -138,7 +138,7 @@ func generateWorkflowFile(templateFile, path string, test interface{}) {
 		log.Println("Error creating file: ", err)
 		return
 	}
-	f.WriteString("# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go\n\n")
+	f.WriteString("# DO NOT MODIFY: THIS FILE IS GENERATED USING \"make generate_ci_workflows\"\n\n")
 	f.WriteString(mergeBlankLines(buf))
 	fmt.Printf("Generated %s\n", path)
 

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -31,17 +31,16 @@ const (
 	unitTestTemplate  = "templates/unit_test.tpl"
 	unitTestDatabases = "percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103"
 
-	clusterTestTemplate        = "templates/cluster_endtoend_test.tpl"
-	clusterList                = "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, vreplication_basic"
-	clustersRequiringMakeTools = "18,24"
-
+	clusterTestTemplate         = "templates/cluster_endtoend_test.tpl"
+	clusterList                 = "11,12,13,14,15,16,17,18,19,20,21,22,23,24,26,27,vreplication_basic,vreplication_multicell,vreplication_cellalias,vreplication_v2"
 	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize
 	// this by only installing them in the required clusters
 	clustersRequiringXtraBackup = clusterList
+	clustersRequiringMakeTools  = "18,24"
 )
 
 type unitTest struct {
-	Name, Database string
+	Name, Platform string
 }
 
 type clusterTest struct {
@@ -113,7 +112,7 @@ func generateUnitTestWorkflows() {
 	for _, platform := range platforms {
 		test := &unitTest{
 			Name:     fmt.Sprintf("Unit Test (%s)", platform),
-			Database: platform,
+			Platform: platform,
 		}
 		path := fmt.Sprintf("%s/unit_test_%s.yml", workflowConfigDir, platform)
 		generateWorkflowFile(unitTestTemplate, path, test)
@@ -139,6 +138,7 @@ func generateWorkflowFile(templateFile, path string, test interface{}) {
 		log.Println("Error creating file: ", err)
 		return
 	}
+	f.WriteString("# DO NOT MODIFY: THIS FILE IS GENERATED USING test/ci_workflow_gen.go\n\n")
 	f.WriteString(mergeBlankLines(buf))
 	fmt.Printf("Generated %s\n", path)
 

--- a/test/config.json
+++ b/test/config.json
@@ -594,8 +594,8 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "MultiCell"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "22",
-			"RetryMax": 3,
+			"Shard": "vreplication_multicell",
+			"RetryMax": 0,
 			"Tags": []
 		},
 		"vreplication_cellalias": {
@@ -603,8 +603,8 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "CellAlias"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "23",
-			"RetryMax": 3,
+			"Shard": "vreplication_cellalias",
+			"RetryMax": 0,
 			"Tags": []
 		},
 		"vreplication_basic": {
@@ -613,7 +613,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "vreplication_basic",
-			"RetryMax": 3,
+			"RetryMax": 0,
 			"Tags": []
 		},
 		"orchestrator": {
@@ -639,8 +639,8 @@
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestBasicV2Workflows"],
 			"Command": [],
 			"Manual": false,
-			"Shard": "21",
-			"RetryMax": 3,
+			"Shard": "vreplication_v2",
+			"RetryMax": 0,
 			"Tags": []
 		}
 	}


### PR DESCRIPTION
* Added descriptive names for vreplication shards
* Moved v2 e2e test to its own shard 
I did this because it was failing often while trying to create a replica, presumably running out of resources. I thought it might be because there were other tests running. However I am still seeing this happening while CI ran for this PR. 