### PR TITLE
Removes printing of ENFORCED word so that statements remain compatible with mysql 5.7

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2369,9 +2369,7 @@ func (f *ForeignKeyDefinition) Format(buf *TrackedBuffer) {
 // Format formats the node.
 func (c *CheckConstraintDefinition) Format(buf *TrackedBuffer) {
 	buf.astPrintf(c, "check (%v)", c.Expr)
-	if c.Enforced {
-		buf.astPrintf(c, " enforced")
-	} else {
+	if !c.Enforced {
 		buf.astPrintf(c, " not enforced")
 	}
 }

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1021,7 +1021,7 @@ var (
 		output: "alter table a add constraint b unique key c (id)",
 	}, {
 		input:  "alter table a add constraint check (id)",
-		output: "alter table a add check (id) enforced",
+		output: "alter table a add check (id)",
 	}, {
 		input:  "alter table a add id int",
 		output: "alter table a add column id int",
@@ -1801,12 +1801,12 @@ var (
 			"\tc1 int,\n" +
 			"\tc2 int,\n" +
 			"\tc3 int,\n" +
-			"\tcheck (c1 != c2) enforced,\n" +
-			"\tcheck (c1 > 10) enforced,\n" +
-			"\tconstraint c2_positive check (c2 > 0) enforced,\n" +
-			"\tcheck (c3 < 100) enforced,\n" +
-			"\tconstraint c1_nonzero check (c1 != 0) enforced,\n" +
-			"\tcheck (c1 > c3) enforced\n)",
+			"\tcheck (c1 != c2),\n" +
+			"\tcheck (c1 > 10),\n" +
+			"\tconstraint c2_positive check (c2 > 0),\n" +
+			"\tcheck (c3 < 100),\n" +
+			"\tconstraint c1_nonzero check (c1 != 0),\n" +
+			"\tcheck (c1 > c3)\n)",
 	}, {
 		input:  "SHOW INDEXES FROM `AO_E8B6CC_ISSUE_MAPPING` FROM `jiradb`",
 		output: "show indexes from AO_E8B6CC_ISSUE_MAPPING from jiradb",

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1052,6 +1052,9 @@ var (
 		input:  "alter table a drop id",
 		output: "alter table a drop column id",
 	}, {
+		input:  "ALTER TABLE distributors ADD CONSTRAINT zipchk CHECK (char_length(zipcode) = 5)",
+		output: "alter table distributors add constraint zipchk check (char_length(zipcode) = 5)",
+	}, {
 		input: "alter database character set geostd8",
 	}, {
 		input: "alter database d character set geostd8",


### PR DESCRIPTION
Removes printing of ENFORCED word so that statements remain compatible with mysql 5.7

Fixes #7456 