### PR TITLE
[concurrency] Add guard against potentially blocking forever in ErrorGroup.Wait() when NumGoroutines is 0

### DIFF
--- a/go/vt/concurrency/error_group.go
+++ b/go/vt/concurrency/error_group.go
@@ -75,6 +75,10 @@ func (eg ErrorGroup) Wait(cancel context.CancelFunc, errors chan error) *AllErro
 	responseCounter := 0
 	rec := &AllErrorRecorder{}
 
+	if eg.NumGoroutines < 1 {
+		return rec
+	}
+
 	for err := range errors {
 		responseCounter++
 

--- a/go/vt/concurrency/error_group_test.go
+++ b/go/vt/concurrency/error_group_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorGroup(t *testing.T) {
+	t.Run("Wait() returns immediately when NumGoroutines = 0", func(t *testing.T) {
+		eg := ErrorGroup{
+			NumGoroutines: 0,
+		}
+
+		rec := eg.Wait(nil, nil)
+		assert.NoError(t, rec.Error())
+	})
+}


### PR DESCRIPTION
Closes #7462

Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Closes #7462

## Checklist
- [ ] Should this PR be backported? **No** (error group is in master but not any release branches)
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required **N/A**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
