### PR TITLE
Add VT_BASE_VER to vtexplain/Dockerfile

### DIFF
--- a/docker/k8s/vtexplain/Dockerfile
+++ b/docker/k8s/vtexplain/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM vitess/base AS base
+ARG VT_BASE_VER=latest
+
+FROM vitess/base:${VT_BASE_VER} AS base
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
## Description
Fix vtexplain Dockerfile so that it can be built off a branch instead of always using latest.
We don't really need this change on the main branch, but we will need it on the next release branch, so it needs to go in.

## Related Issue(s)
#7401 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
