### PR TITLE
docker vitess/vtctlclient: Install curl

### DIFF
--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -20,7 +20,7 @@ FROM debian:buster-slim
 
 RUN apt-get update && \
    apt-get upgrade -qq && \
-   apt-get install jq -qq --no-install-recommends && \
+   apt-get install jq curl -qq --no-install-recommends && \
    apt-get autoremove && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

Backport of pull request #7466 for release-9.0.

Install curl into the docker image vitess/vtctlclient. That way,
for clients using this container, not only can they interact
with vtctld via vtctlclient, but they can also interact with
vtctld and other Vitess components via their HTTP APIs, and can
also interact with the Kubernetes API server over HTTP.

Signed-off-by: Jordan Moldow <jmoldow@alum.mit.edu>

## Checklist
- [x] Should this PR be backported? - Ideally, yes, so that the change can be included in any v9.0.1 images. Backport of pull request #7466.
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

When tested with Docker Desktop for Mac, Docker version 20.10.2,
using the command

        docker build --compress -f Dockerfile -t "vitess/vtctlclient:latest" .

the original Dockerfile generates an artifact that is 94.4MB
(according to docker image ls), whereas the new Dockerfile
generates a 102MB image, about an 8% increase in the image's
size.

Before this merged to HEAD, https://hub.docker.com/r/vitess/vtctlclient/tags?page=1&ordering=last_updated&name=latest showed Compressed Size as 36.24 MB.

After this merged, it showed Compressed Size as 37.85 MB.

A 4.4% / 1.61 MB increase in Compressed Size.

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI - Docker image `vitess/vtctlclient`
- [ ]  VTAdmin
