### PR TITLE
Enable -mysql_server_version in vttestserver, and utilize it in vttestserver container images

### DIFF
--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version 5.7.9-vitess
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version ${MYSQL_SERVER_VERSION:-5.7.9-vitess}

--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1}
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version 5.7.9-vitess

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1}
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version 8.0.0-vitess

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -55,4 +55,4 @@ COPY --from=builder --chown=vitess:vitess /vt/install /vt
 VOLUME /vt/vtdataroot
 USER vitess
 
-CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version 8.0.0-vitess
+CMD /vt/bin/vttestserver -port $PORT -keyspaces $KEYSPACES -num_shards $NUM_SHARDS -mysql_bind_host ${MYSQL_BIND_HOST:-127.0.0.1} -mysql_server_version ${MYSQL_SERVER_VERSION:-8.0.21-vitess}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -247,6 +247,9 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	if args.VSchemaDDLAuthorizedUsers != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-vschema_ddl_authorized_users", args.VSchemaDDLAuthorizedUsers}...)
 	}
+	if *servenv.MySQLServerVersion != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, "-mysql_server_version", *servenv.MySQLServerVersion)
+	}
 
 	if socket != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{


### PR DESCRIPTION
## Description
Exposes the `-mysql_server_version` parameter in `vttestserver`, and changes the `vitess/vttestserver` container images to set it appropriately.

## Related Issue(s)
- Fixes #7470 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
N/A - only impacts new `vttestserver` runs

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
