### PR TITLE
[reparentutil / ERS] confirm at least one replica succeeded to `SetMaster`, or fail

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -179,7 +179,15 @@ func (erp *EmergencyReparenter) promoteNewPrimary(
 
 		forceStart := false
 		if status, ok := statusMap[alias]; ok {
-			forceStart = ReplicaWasRunning(status)
+			fs, err := ReplicaWasRunning(status)
+			if err != nil {
+				err = vterrors.Wrapf(err, "tablet %v could not determine StopReplicationStatus: %v", alias, err)
+				rec.RecordError(err)
+
+				return
+			}
+
+			forceStart = fs
 		}
 
 		err := erp.tmc.SetMaster(replCtx, ti.Tablet, newPrimaryTabletInfo.Alias, now, "", forceStart)

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -142,6 +142,10 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
+				SetMasterResults: map[string]error{
+					"zone1-0000000100": nil,
+					"zone1-0000000101": nil,
+				},
 				StopReplicationAndGetStatusResults: map[string]struct {
 					Status     *replicationdatapb.Status
 					StopStatus *replicationdatapb.StopReplicationStatus
@@ -239,6 +243,10 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Result: "ok",
 						Error:  nil,
 					},
+				},
+				SetMasterResults: map[string]error{
+					"zone1-0000000100": nil,
+					"zone1-0000000102": nil,
 				},
 				StopReplicationAndGetStatusResults: map[string]struct {
 					Status     *replicationdatapb.Status

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -1003,7 +1003,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 						},
 					},
 				},
-				"zone1-00000000102": {
+				"zone1-0000000102": {
 					Tablet: &topodatapb.Tablet{
 						Alias: &topodatapb.TabletAlias{
 							Cell: "zone1",
@@ -1012,7 +1012,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 						Hostname: "requires force start",
 					},
 				},
-				"zone1-00000000404": {
+				"zone1-0000000404": {
 					Tablet: &topodatapb.Tablet{
 						Alias: &topodatapb.TabletAlias{
 							Cell: "zone1",
@@ -1052,6 +1052,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 				"zone1-0000000100": {},
 				"zone1-0000000101": {},
 			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
 			opts:      EmergencyReparentOptions{},
 			shouldErr: true,
 		},
@@ -1174,7 +1175,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "replicas failing to SetMaster does not fail the promotion",
+			name: "all replicas failing to SetMaster does fail the promotion",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &emergencyReparenterTestTMClient{
 				PopulateReparentJournalResults: map[string]error{
@@ -1189,7 +1190,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 					},
 				},
 				SetMasterResults: map[string]error{
-					// everyone fails, who cares?!
+					// everyone fails, we all fail
 					"zone1-0000000101": assert.AnError,
 					"zone1-0000000102": assert.AnError,
 				},
@@ -1225,6 +1226,121 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			},
 			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
 			opts:      EmergencyReparentOptions{},
+			shouldErr: true,
+		},
+		{
+			name: "all replicas slow to SetMaster does fail the promotion",
+			ts:   memorytopo.NewServer("zone1"),
+			tmc: &emergencyReparenterTestTMClient{
+				PopulateReparentJournalResults: map[string]error{
+					"zone1-0000000100": nil,
+				},
+				PromoteReplicaResults: map[string]struct {
+					Result string
+					Error  error
+				}{
+					"zone1-0000000100": {
+						Error: nil,
+					},
+				},
+				SetMasterDelays: map[string]time.Duration{
+					// nothing is failing, we're just slow
+					"zone1-0000000101": time.Millisecond * 100,
+					"zone1-0000000102": time.Millisecond * 75,
+				},
+				SetMasterResults: map[string]error{
+					"zone1-0000000101": nil,
+					"zone1-0000000102": nil,
+				},
+			},
+			keyspace:              "testkeyspace",
+			shard:                 "-",
+			newPrimaryTabletAlias: "zone1-0000000100",
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+				"zone1-0000000102": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  102,
+						},
+					},
+				},
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
+			opts: EmergencyReparentOptions{
+				WaitReplicasTimeout: time.Millisecond * 10,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "one replica failing to SetMaster does not fail the promotion",
+			ts:   memorytopo.NewServer("zone1"),
+			tmc: &emergencyReparenterTestTMClient{
+				PopulateReparentJournalResults: map[string]error{
+					"zone1-0000000100": nil,
+				},
+				PromoteReplicaResults: map[string]struct {
+					Result string
+					Error  error
+				}{
+					"zone1-0000000100": {
+						Error: nil,
+					},
+				},
+				SetMasterResults: map[string]error{
+					"zone1-0000000101": nil, // this one succeeds, so we're good
+					"zone1-0000000102": assert.AnError,
+				},
+			},
+			keyspace:              "testkeyspace",
+			shard:                 "-",
+			newPrimaryTabletAlias: "zone1-0000000100",
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+				"zone1-0000000102": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  102,
+						},
+					},
+				},
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
+			opts: EmergencyReparentOptions{
+				WaitReplicasTimeout: time.Millisecond * 10,
+			},
 			shouldErr: false,
 		},
 	}
@@ -1234,10 +1350,6 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			if tt.ts == nil {
-				t.Skip("toposerver is nil, assuming we're working on other test cases")
-			}
 
 			ctx := context.Background()
 			logger := logutil.NewMemoryLogger()
@@ -1535,6 +1647,8 @@ type emergencyReparenterTestTMClient struct {
 		Error  error
 	}
 	// keyed by tablet alias.
+	SetMasterDelays map[string]time.Duration
+	// keyed by tablet alias.
 	SetMasterResults map[string]error
 	// keyed by tablet alias.
 	StopReplicationAndGetStatusDelays map[string]time.Duration
@@ -1583,6 +1697,18 @@ func (fake *emergencyReparenterTestTMClient) SetMaster(ctx context.Context, tabl
 	}
 
 	key := topoproto.TabletAliasString(tablet.Alias)
+
+	if fake.SetMasterDelays != nil {
+		if delay, ok := fake.SetMasterDelays[key]; ok {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				// proceed to results
+			}
+		}
+	}
+
 	if result, ok := fake.SetMasterResults[key]; ok {
 		return result
 	}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -1346,9 +1346,6 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 				},
 			},
 			statusMap: map[string]*replicationdatapb.StopReplicationStatus{},
-			opts: EmergencyReparentOptions{
-				WaitReplicasTimeout: time.Millisecond * 10,
-			},
 			shouldErr: false,
 		},
 	}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -153,6 +153,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				}{
 					"zone1-0000000100": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21",
@@ -161,6 +162,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 					},
 					"zone1-0000000101": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21",
@@ -169,6 +171,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 					},
 					"zone1-0000000102": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-26",
@@ -255,6 +258,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				}{
 					"zone1-0000000100": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21",
@@ -263,6 +267,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 					},
 					"zone1-0000000101": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21",
@@ -271,6 +276,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 					},
 					"zone1-0000000102": {
 						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{},
 							After: &replicationdatapb.Status{
 								MasterUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
 								RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21",

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -142,6 +142,10 @@ func FindValidEmergencyReparentCandidates(
 // ReplicaWasRunning returns true if a StopReplicationStatus indicates that the
 // replica had running replication threads before being stopped.
 func ReplicaWasRunning(stopStatus *replicationdatapb.StopReplicationStatus) bool {
+	if stopStatus.Before == nil {
+		return false
+	}
+
 	return stopStatus.Before.IoThreadRunning || stopStatus.Before.SqlThreadRunning
 }
 

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -140,13 +140,14 @@ func FindValidEmergencyReparentCandidates(
 }
 
 // ReplicaWasRunning returns true if a StopReplicationStatus indicates that the
-// replica had running replication threads before being stopped.
-func ReplicaWasRunning(stopStatus *replicationdatapb.StopReplicationStatus) bool {
-	if stopStatus.Before == nil {
-		return false
+// replica had running replication threads before being stopped. It returns an
+// error if the Before state of replication is nil.
+func ReplicaWasRunning(stopStatus *replicationdatapb.StopReplicationStatus) (bool, error) {
+	if stopStatus == nil || stopStatus.Before == nil {
+		return false, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "could not determine Before state of StopReplicationStatus %v", stopStatus)
 	}
 
-	return stopStatus.Before.IoThreadRunning || stopStatus.Before.SqlThreadRunning
+	return stopStatus.Before.IoThreadRunning || stopStatus.Before.SqlThreadRunning, nil
 }
 
 // StopReplicationAndBuildStatusMaps stops replication on all replicas, then

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -760,6 +760,13 @@ func TestReplicaWasRunning(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "status.Before is nil means we were not running",
+			in: &replicationdatapb.StopReplicationStatus{
+				Before: nil,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -716,9 +716,10 @@ func TestReplicaWasRunning(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		in       *replicationdatapb.StopReplicationStatus
-		expected bool
+		name      string
+		in        *replicationdatapb.StopReplicationStatus
+		expected  bool
+		shouldErr bool
 	}{
 		{
 			name: "io thread running",
@@ -728,7 +729,8 @@ func TestReplicaWasRunning(t *testing.T) {
 					SqlThreadRunning: false,
 				},
 			},
-			expected: true,
+			expected:  true,
+			shouldErr: false,
 		},
 		{
 			name: "sql thread running",
@@ -738,7 +740,8 @@ func TestReplicaWasRunning(t *testing.T) {
 					SqlThreadRunning: true,
 				},
 			},
-			expected: true,
+			expected:  true,
+			shouldErr: false,
 		},
 		{
 			name: "io and sql threads running",
@@ -748,7 +751,8 @@ func TestReplicaWasRunning(t *testing.T) {
 					SqlThreadRunning: true,
 				},
 			},
-			expected: true,
+			expected:  true,
+			shouldErr: false,
 		},
 		{
 			name: "no replication threads running",
@@ -758,14 +762,22 @@ func TestReplicaWasRunning(t *testing.T) {
 					SqlThreadRunning: false,
 				},
 			},
-			expected: false,
+			expected:  false,
+			shouldErr: false,
 		},
 		{
-			name: "status.Before is nil means we were not running",
+			name:      "passing nil pointer results in an error",
+			in:        nil,
+			expected:  false,
+			shouldErr: true,
+		},
+		{
+			name: "status.Before is nil results in an error",
 			in: &replicationdatapb.StopReplicationStatus{
 				Before: nil,
 			},
-			expected: false,
+			expected:  false,
+			shouldErr: true,
 		},
 	}
 
@@ -775,7 +787,14 @@ func TestReplicaWasRunning(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := ReplicaWasRunning(tt.in)
+			actual, err := ReplicaWasRunning(tt.in)
+			if tt.shouldErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}


### PR DESCRIPTION
## Description

This introduces two background goroutines and contexts derived from
`context.Background()` to poll and signal for (1) at least one replica
finished successfully and (2) all replicas finished, regardless of
status, respectively.

The overall `promotePrimary` function returns error conditions based on
which of those contexts gets signaled first. We still fail if
`PromoteReplica` fails, which gets checked first, but this covers the
case where we're not running with semi-sync, and none of the replicas
are able to reparent even if the new primary is able to populate its
reparent journal (in the semi-sync case, if 0 replicas succeed to
`SetMaster`, than the primary will fail to `PromoteReplica`, so this was
already covered there).

Fixes #7480 

Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes #7480 

## Checklist
- [ ] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
