### PR TITLE
make sure to add necessary bindvars when preparing queries

### DIFF
--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -38,6 +38,22 @@ func TestSelect(t *testing.T) {
 	selectWhere(t, dbo, "")
 }
 
+func TestSelectDatabase(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	dbo := Connect(t)
+	defer dbo.Close()
+	prepare, err := dbo.Prepare("select database()")
+	require.NoError(t, err)
+	rows, err := prepare.Query()
+	require.NoError(t, err)
+	defer rows.Close()
+	var resultBytes sql.RawBytes
+	require.True(t, rows.Next(), "no rows found")
+	err = rows.Scan(&resultBytes)
+	require.NoError(t, err)
+	assert.Equal(t, string(resultBytes), "test_keyspace")
+}
+
 // TestInsertUpdateDelete validates all insert, update and
 // delete method on prepared statements.
 func TestInsertUpdateDelete(t *testing.T) {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1612,6 +1612,12 @@ func (e *Executor) handlePrepare(ctx context.Context, safeSession *SafeSession, 
 		return nil, err
 	}
 
+	err = e.addNeededBindVars(plan.BindVarNeeds, bindVars, safeSession)
+	if err != nil {
+		logStats.Error = err
+		return nil, err
+	}
+
 	qr, err := plan.Instructions.GetFields(vcursor, bindVars)
 	logStats.ExecuteTime = time.Since(execStart)
 	var errCount uint64

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2178,6 +2178,17 @@ func TestSelectBindvarswithPrepare(t *testing.T) {
 	}
 }
 
+func TestSelectDatabasePrepare(t *testing.T) {
+	executor, _, _, _ := createExecutorEnv()
+	executor.normalize = true
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
+	sql := "select database()"
+	_, err := executorPrepare(executor, sql, map[string]*querypb.BindVariable{})
+	require.NoError(t, err)
+}
+
 func TestSelectWithUnionAll(t *testing.T) {
 	executor, sbc1, sbc2, _ := createLegacyExecutorEnv()
 	executor.normalize = true


### PR DESCRIPTION
Fixes #7379 

Some queries need extra bindvars injected before executing. The error here was that for the field type query during `PREPARE`, we were not setting all the required bindvars.

Signed-off-by: Andres Taylor <andres@planetscale.com>
