### PR TITLE
MoveTables: Refresh SrvVSchema (for Routing Rules) and source tablets (for Blacklisted Tables) on completion

### DIFF
--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1109,7 +1109,7 @@ func (ts *trafficSwitcher) changeTableSourceWrites(ctx context.Context, access a
 		}); err != nil {
 			return err
 		}
-		return ts.wr.tmc.RefreshState(ctx, source.master.Tablet)
+		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil, nil)
 	})
 }
 
@@ -1344,7 +1344,7 @@ func (ts *trafficSwitcher) allowTableTargetWrites(ctx context.Context) error {
 		}); err != nil {
 			return err
 		}
-		return ts.wr.tmc.RefreshState(ctx, target.master.Tablet)
+		return ts.wr.RefreshTabletsByShard(ctx, target.si, nil, nil)
 	})
 }
 
@@ -1488,7 +1488,7 @@ func (ts *trafficSwitcher) dropSourceBlacklistedTables(ctx context.Context) erro
 		}); err != nil {
 			return err
 		}
-		return ts.wr.tmc.RefreshState(ctx, source.master.Tablet)
+		return ts.wr.RefreshTabletsByShard(ctx, source.si, nil, nil)
 	})
 }
 

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -676,6 +676,9 @@ func (wr *Wrangler) DropTargets(ctx context.Context, targetKeyspace, workflow st
 	if err := wr.dropArtifacts(ctx, sw); err != nil {
 		return nil, err
 	}
+	if err := ts.wr.ts.RebuildSrvVSchema(ctx, nil); err != nil {
+		return nil, err
+	}
 	return sw.logs(), nil
 }
 
@@ -750,6 +753,10 @@ func (wr *Wrangler) DropSources(ctx context.Context, targetKeyspace, workflow st
 	if err := wr.dropArtifacts(ctx, sw); err != nil {
 		return nil, err
 	}
+	if err := ts.wr.ts.RebuildSrvVSchema(ctx, nil); err != nil {
+		return nil, err
+	}
+
 	return sw.logs(), nil
 }
 

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -768,7 +768,7 @@ func TestShardMigrateMainflow(t *testing.T) {
 	verifyQueries(t, tme.allDBClients)
 }
 
-func TestTableMigrateOneToManyX(t *testing.T) {
+func TestTableMigrateOneToMany(t *testing.T) {
 	ctx := context.Background()
 	tme := newTestTableMigraterCustom(ctx, t, []string{"0"}, []string{"-80", "80-"}, "select * %s")
 	defer tme.stopTablets(t)


### PR DESCRIPTION
## Description
This PR fixes two refresh problems during vreplication workflows:

* SrvVSchema was not being rebuilt after DropSources resulting in existing routing rules still being visible to vtgate since vttablets still saw the old rules. This PR updates the SrvVSchema when routing rules are modify.
* When blacklisted tables are updated only the current primary tablet was being refreshed. However this causes a problem if there is a reparenting operation. This PR now refreshes all tablets in the shard.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/7477

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
