### PR TITLE
Fix table parsing on VSchema generation

### DIFF
--- a/go/vt/sqlparser/parse_table.go
+++ b/go/vt/sqlparser/parse_table.go
@@ -32,7 +32,10 @@ func ParseTable(input string) (keyspace, table string, err error) {
 	case ID:
 		table = string(value)
 	default:
-		return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid table name: %s", input)
+		table = KeywordString(token)
+		if table == "" {
+			return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid table name: %s", input)
+		}
 	}
 
 	// Seen first ID, want '.' or 0
@@ -52,7 +55,10 @@ func ParseTable(input string) (keyspace, table string, err error) {
 	case ID:
 		table = string(value)
 	default:
-		return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid table name: %s", input)
+		table = KeywordString(token)
+		if table == "" {
+			return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid table name: %s", input)
+		}
 	}
 
 	// Seen second ID, want 0

--- a/go/vt/sqlparser/parse_table_test.go
+++ b/go/vt/sqlparser/parse_table_test.go
@@ -19,6 +19,8 @@ package sqlparser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,15 +57,37 @@ func TestParseTable(t *testing.T) {
 	}, {
 		input: "k.t.",
 		err:   true,
+	}, {
+		input:    "k.language",
+		keyspace: "k",
+		table:    "language",
+	}, {
+		input:    "language",
+		keyspace: "",
+		table:    "language",
+	}, {
+		input:    "language.tables",
+		keyspace: "language",
+		table:    "tables",
+	}, {
+		input:    "language.t",
+		keyspace: "language",
+		table:    "t",
+	}, {
+		input:    "`from`.`table`",
+		keyspace: "from",
+		table:    "table",
 	}}
 	for _, tcase := range testcases {
-		keyspace, table, err := ParseTable(tcase.input)
-		assert.Equal(t, tcase.keyspace, keyspace)
-		assert.Equal(t, tcase.table, table)
-		if tcase.err {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+		t.Run(tcase.input, func(t *testing.T) {
+			keyspace, table, err := ParseTable(tcase.input)
+			if tcase.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tcase.keyspace, keyspace)
+			assert.Equal(t, tcase.table, table)
+		})
 	}
 }


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
On Vschema Generation we parse the table and it did not handled reserved and non-reserved keywords.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7371

## Checklist
- [X] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
