### PR TITLE
Add innodb_read_rows as vttablet metric

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1175,6 +1175,11 @@ func initQueryExecutorTestDB(db *fakesqldb.DB) {
 			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 		},
 	})
+	db.AddQuery("show status like 'Innodb_rows_read'", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"Variable_name|Value",
+		"varchar|int64"),
+		"Innodb_rows_read|0",
+	))
 }
 
 func getTestTableFields() []*querypb.Field {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -80,7 +80,7 @@ type Engine struct {
 
 	tableFileSizeGauge      *stats.GaugesWithSingleLabel
 	tableAllocatedSizeGauge *stats.GaugesWithSingleLabel
-	innoDbReadRowsGauge     *stats.GaugesWithSingleLabel
+	innoDbReadRowsGauge     *stats.Gauge
 }
 
 // NewEngine creates a new Engine.
@@ -100,7 +100,7 @@ func NewEngine(env tabletenv.Env) *Engine {
 	_ = env.Exporter().NewGaugeDurationFunc("SchemaReloadTime", "vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.", se.ticks.Interval)
 	se.tableFileSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableFileSize", "tracks table file size", "Table")
 	se.tableAllocatedSizeGauge = env.Exporter().NewGaugesWithSingleLabel("TableAllocatedSize", "tracks table allocated size", "Table")
-	se.innoDbReadRowsGauge = env.Exporter().NewGaugesWithSingleLabel("InnodbRowsRead", "number of rows read by mysql", "Database")
+	se.innoDbReadRowsGauge = env.Exporter().NewGauge("InnodbRowsRead", "number of rows read by mysql")
 
 	env.Exporter().HandleFunc("/debug/schema", se.handleDebugSchema)
 	env.Exporter().HandleFunc("/schemaz", func(w http.ResponseWriter, r *http.Request) {
@@ -405,7 +405,9 @@ func (se *Engine) updateInnoDBRowsRead(ctx context.Context, conn *connpool.DBCon
 			return err
 		}
 
-		se.innoDbReadRowsGauge.Set("read_rows", value)
+		se.innoDbReadRowsGauge.Set(value)
+	} else {
+		log.Warningf("got strange results from 'show status': %v", readRowsData.Rows)
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -399,16 +399,14 @@ func (se *Engine) updateInnoDBRowsRead(ctx context.Context, conn *connpool.DBCon
 		return err
 	}
 
-	if !(len(readRowsData.Rows) == 1 && len(readRowsData.Rows[0]) == 2) {
-		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "got bad output from query, expected one row, two columns")
-	}
+	if len(readRowsData.Rows) == 1 && len(readRowsData.Rows[0]) == 2 {
+		value, err := evalengine.ToInt64(readRowsData.Rows[0][1])
+		if err != nil {
+			return err
+		}
 
-	value, err := evalengine.ToInt64(readRowsData.Rows[0][1])
-	if err != nil {
-		return err
+		se.innoDbReadRowsGauge.Set("read_rows", value)
 	}
-
-	se.innoDbReadRowsGauge.Set("read_rows", value)
 	return nil
 }
 

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -96,8 +96,7 @@ func TestOpenAndReload(t *testing.T) {
 		"int64"),
 		"1427325877",
 	))
-	assert.Contains(t, se.innoDbReadRowsGauge.Counts(), "read_rows")
-	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Counts()["read_rows"])
+	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Get())
 	// Modify test_table_03
 	// Add test_table_04
 	// Drop msg
@@ -171,8 +170,7 @@ func TestOpenAndReload(t *testing.T) {
 	err := se.Reload(context.Background())
 	require.NoError(t, err)
 
-	assert.Contains(t, se.innoDbReadRowsGauge.Counts(), "read_rows")
-	assert.EqualValues(t, secondReadRowsValue, se.innoDbReadRowsGauge.Counts()["read_rows"])
+	assert.EqualValues(t, secondReadRowsValue, se.innoDbReadRowsGauge.Get())
 
 	want["test_table_03"] = &Table{
 		Name: sqlparser.NewTableIdent("test_table_03"),

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"expvar"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -80,6 +81,8 @@ func TestOpenAndReload(t *testing.T) {
 		"int64"),
 		"1427325876",
 	))
+	firstReadRowsValue := 12
+	AddFakeInnoDBReadRowsResult(db, firstReadRowsValue)
 	se := newEngine(10, 10*time.Second, 10*time.Second, db)
 	se.Open()
 	defer se.Close()
@@ -93,6 +96,8 @@ func TestOpenAndReload(t *testing.T) {
 		"int64"),
 		"1427325877",
 	))
+	assert.Contains(t, se.innoDbReadRowsGauge.Counts(), "read_rows")
+	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Counts()["read_rows"])
 	// Modify test_table_03
 	// Add test_table_04
 	// Drop msg
@@ -144,6 +149,8 @@ func TestOpenAndReload(t *testing.T) {
 			mysql.ShowPrimaryRow("seq", "id"),
 		},
 	})
+	secondReadRowsValue := 123
+	AddFakeInnoDBReadRowsResult(db, secondReadRowsValue)
 
 	firstTime := true
 	notifier := func(full map[string]*Table, created, altered, dropped []string) {
@@ -163,6 +170,9 @@ func TestOpenAndReload(t *testing.T) {
 	se.RegisterNotifier("test", notifier)
 	err := se.Reload(context.Background())
 	require.NoError(t, err)
+
+	assert.Contains(t, se.innoDbReadRowsGauge.Counts(), "read_rows")
+	assert.EqualValues(t, secondReadRowsValue, se.innoDbReadRowsGauge.Counts()["read_rows"])
 
 	want["test_table_03"] = &Table{
 		Name: sqlparser.NewTableIdent("test_table_03"),
@@ -338,6 +348,7 @@ func TestOpenFailedDueToTableErr(t *testing.T) {
 			{sqltypes.NewVarBinary("")},
 		},
 	})
+	AddFakeInnoDBReadRowsResult(db, 0)
 	se := newEngine(10, 1*time.Second, 1*time.Second, db)
 	err := se.Open()
 	want := "Row count exceeded"
@@ -491,4 +502,12 @@ func initialSchema() map[string]*Table {
 			},
 		},
 	}
+}
+
+func AddFakeInnoDBReadRowsResult(db *fakesqldb.DB, value int) *fakesqldb.ExpectedResult {
+	return db.AddQuery("show status like 'Innodb_rows_read'", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"Variable_name|Value",
+		"varchar|int64"),
+		fmt.Sprintf("Innodb_rows_read|%d", value),
+	))
 }

--- a/go/vt/vttablet/tabletserver/schema/main_test.go
+++ b/go/vt/vttablet/tabletserver/schema/main_test.go
@@ -36,6 +36,7 @@ func getTestSchemaEngine(t *testing.T) (*Engine, *fakesqldb.DB, func()) {
 	))
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{})
 	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{})
+	AddFakeInnoDBReadRowsResult(db, 1)
 	se := newEngine(10, 10*time.Second, 10*time.Second, db)
 	require.NoError(t, se.Open())
 	cancel := func() {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2465,6 +2465,11 @@ func setupFakeDB(t *testing.T) *fakesqldb.DB {
 			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 		},
 	})
+	db.AddQuery("show status like 'Innodb_rows_read'", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"Variable_name|Value",
+		"varchar|int64"),
+		"Innodb_rows_read|0",
+	))
 
 	return db
 }


### PR DESCRIPTION
We want to be able to track how much work the underlying storage has had to do, not just see how much output there's been.

Related Issue: #7372 