### PR TITLE
CI: skip some tests on forked repos

### DIFF
--- a/.github/workflows/check_runs_analysis.yaml
+++ b/.github/workflows/check_runs_analysis.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'vitessio/vitess'
     name: analyze_check_runs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
+    if: github.repository == 'vitessio/vitess'
     name: Run endtoend tests on Cluster (upgrade)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Description
Two CI tests don't make sense on repositories forked from https://github.com/vitessio/vitess:

- CI upgrade, because the tags `v8.0.0` or `v9.0.0` etc. only exist on `vitessio/vitess`
- check runs analysis, because the `metrics` branch only exists on `vitessio/vitess`

This PR only runs these tests on `vitessio/vitess`.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
