### PR TITLE
Introduce Concatenated Fixed-width Composite or CFC vindex

### DIFF
--- a/go/test/endtoend/vtgate/prefixfanout/main_test.go
+++ b/go/test/endtoend/vtgate/prefixfanout/main_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package prefixfanout
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	cell            = "zone1"
+	hostname        = "localhost"
+
+	sKs     = "cfc_testing"
+	sSchema = `
+CREATE TABLE t1 (
+c1 VARCHAR(20) NOT NULL,
+c2 varchar(40) NOT NULL,
+PRIMARY KEY (c1)
+) ENGINE=Innodb;
+`
+	sVSchema = `
+{
+    "sharded": true,
+    "vindexes": {
+        "cfc": {
+          "type": "cfc"
+		}
+	},
+    "tables": {
+        "t1": {
+            "column_vindexes": [
+                {
+                    "column": "c1",
+                    "name": "cfc"
+                }
+			],
+			"columns": [
+				{
+					"name": "c2",
+					"type": "VARCHAR"
+				}
+			]
+		}
+    }
+}`
+
+	sKsMD5     = `cfc_testing_md5`
+	sSchemaMD5 = `
+CREATE TABLE t2 (
+c1 VARCHAR(20) NOT NULL,
+c2 varchar(40) NOT NULL,
+PRIMARY KEY (c1)
+) ENGINE=Innodb;`
+
+	sVSchemaMD5 = `
+{
+    "sharded": true,
+    "vindexes": {
+   	"cfc_md5": {
+		  "type": "cfc",
+		  "params": {
+			  "hash": "md5",
+			  "offsets": "[2]"
+		  }
+		}
+	},
+    "tables": {
+      	"t2": {
+            "column_vindexes": [
+                {
+                    "column": "c1",
+                    "name": "cfc_md5"
+                }
+			],
+			"columns": [
+				{
+					"name": "c2",
+					"type": "VARCHAR"
+				}
+			]
+        }
+    }
+}`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		sKeyspace := &cluster.Keyspace{
+			Name:      sKs,
+			SchemaSQL: sSchema,
+			VSchema:   sVSchema,
+		}
+		// cfc_testing
+		if err := clusterInstance.StartKeyspace(*sKeyspace, []string{"-41", "41-4180", "4180-42", "42-"}, 0, false); err != nil {
+			return 1
+		}
+		// cfc_testing_md5
+		if err := clusterInstance.StartKeyspace(
+			cluster.Keyspace{
+				Name:      sKsMD5,
+				SchemaSQL: sSchemaMD5,
+				VSchema:   sVSchemaMD5,
+			}, []string{"-c2", "c2-c20a80", "c20a80-d0", "d0-"}, 0, false); err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestCFCPrefixQueryNoHash(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "delete from t1")
+	defer exec(t, conn, "delete from t1")
+	// prepare the sentinel rows, i.e. every shard stores a row begins with letter A.
+	// hex ascii code of 'A' is 41. For a given primary key, e.g. 'AA' here, it should
+	// only legally belong to a single shard. We insert into all shards with different
+	// `c2` value so that we can test if a query fans out to all or not. Based on the
+	// following shard layout only "41-4180", "4180-42" should serve the rows staring with 'A'.
+	shards := []string{"-41", "41-4180", "4180-42", "42-"}
+	for i, s := range shards {
+		exec(t, conn, fmt.Sprintf("use `%s:%s`", sKs, s))
+		exec(t, conn, fmt.Sprintf("insert into t1 values('AA', 'shard-%d')", i))
+	}
+	exec(t, conn, "use cfc_testing")
+	qr := exec(t, conn, "select c2 from t1 where c1 like 'A%' order by c2")
+	assert.Equal(t, 2, len(qr.Rows))
+	// should only target a subset of shards serving rows starting with 'A'.
+	assert.EqualValues(t, []string{"shard-1", "shard-2"}, []string{qr.Rows[0][0].ToString(), qr.Rows[1][0].ToString()})
+	// should only target a subset of shards serving rows starting with 'AA',
+	// the shards to which 'AA' maps to.
+	qr = exec(t, conn, "select c2 from t1 where c1 like 'AA'")
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.EqualValues(t, "shard-1", qr.Rows[0][0].ToString())
+	// fan out to all when there is no prefix
+	qr = exec(t, conn, "select c2 from t1 where c1 like '%A' order by c2")
+	assert.Equal(t, 4, len(qr.Rows))
+	for i, r := range qr.Rows {
+		assert.Equal(t, fmt.Sprintf("shard-%d", i), r[0].ToString())
+	}
+}
+
+func TestCFCPrefixQueryWithHash(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "delete from t2")
+	defer exec(t, conn, "delete from t2")
+
+	shards := []string{"-c2", "c2-c20a80", "c20a80-d0", "d0-"}
+	// same idea of sentinel rows as above. Even though each row legally belongs to
+	// only one shard, we insert into all shards with different info to test our fan out.
+	for i, s := range shards {
+		exec(t, conn, fmt.Sprintf("use `%s:%s`", sKsMD5, s))
+		exec(t, conn, fmt.Sprintf("insert into t2 values('12AX', 'shard-%d')", i))
+		exec(t, conn, fmt.Sprintf("insert into t2 values('12BX', 'shard-%d')", i))
+		exec(t, conn, fmt.Sprintf("insert into t2 values('27CX', 'shard-%d')", i))
+	}
+
+	exec(t, conn, fmt.Sprintf("use `%s`", sKsMD5))
+	// The prefix is ('12', 'A')
+	// md5('12') -> c20ad4d76fe97759aa27a0c99bff6710
+	// md5('A') -> 7fc56270e7a70fa81a5935b72eacbe29
+	// so keyspace id is c20a7f, which means shards "c2-c20a80"
+	qr := exec(t, conn, "select c2 from t2 where c1 like '12A%' order by c2")
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.Equal(t, "shard-1", qr.Rows[0][0].ToString())
+	// The prefix is ('12')
+	// md5('12') -> c20ad4d76fe97759aa27a0c99bff6710 so the corresponding
+	// so keyspace id is c20a, which means shards "c2-c20a80", "c20a80-d0"
+	qr = exec(t, conn, "select c2 from t2 where c1 like '12%' order by c2")
+	assert.Equal(t, 4, len(qr.Rows))
+	assert.Equal(t, "shard-1", qr.Rows[0][0].ToString())
+	assert.Equal(t, "shard-1", qr.Rows[1][0].ToString())
+	assert.Equal(t, "shard-2", qr.Rows[2][0].ToString())
+	assert.Equal(t, "shard-2", qr.Rows[3][0].ToString())
+	// in vschema the prefix length is defined as 2 bytes however only 1 byte
+	// is provided here so the query fans out to all.
+	qr = exec(t, conn, "select c2 from t2 where c1 like '2%' order by c2")
+	assert.Equal(t, 4, len(qr.Rows))
+	assert.Equal(t, "shard-0", qr.Rows[0][0].ToString())
+	assert.Equal(t, "shard-1", qr.Rows[1][0].ToString())
+	assert.Equal(t, "shard-2", qr.Rows[2][0].ToString())
+	assert.Equal(t, "shard-3", qr.Rows[3][0].ToString())
+}
+
+func TestCFCInsert(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "delete from t1")
+	defer exec(t, conn, "delete from t1")
+
+	exec(t, conn, "insert into t1 (c1, c2) values ('AAA', 'BBB')")
+	qr := exec(t, conn, "select c2 from t1 where c1 like 'A%'")
+	assert.Equal(t, 1, len(qr.Rows))
+	shards := []string{"-41", "4180-42", "42-"}
+	for _, s := range shards {
+		exec(t, conn, fmt.Sprintf("use `cfc_testing:%s`", s))
+		qr = exec(t, conn, "select * from t1")
+		assert.Equal(t, 0, len(qr.Rows))
+	}
+	// 'AAA' belongs to 41-4180
+	exec(t, conn, "use `cfc_testing:41-4180`")
+	qr = exec(t, conn, "select c2 from t1")
+	assert.Equal(t, 1, len(qr.Rows))
+	assert.Equal(t, "BBB", qr.Rows[0][0].ToString())
+}
+
+func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
+	t.Helper()
+	qr, err := conn.ExecuteFetch(query, 1000, true)
+	require.NoError(t, err)
+	return qr
+}

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -420,7 +420,7 @@ func (f *loggingVCursor) ResolveDestinations(keyspace string, ids []*querypb.Val
 		case key.DestinationAllShards:
 			shards = f.shards
 		case key.DestinationKeyRange:
-			shards = []string{"-20", "20-"}
+			shards = f.shardForKsid
 		case key.DestinationKeyspaceID:
 			if f.shardForKsid == nil || f.curShardForKsid >= len(f.shardForKsid) {
 				shards = []string{"-20"}

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -65,6 +65,26 @@ func (cached *BinaryMD5) CachedSize(alloc bool) int64 {
 	size += int64(len(cached.name))
 	return size
 }
+func (cached *CFC) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field name string
+	size += int64(len(cached.name))
+	// field offsets []int
+	{
+		size += int64(cap(cached.offsets)) * int64(8)
+	}
+	// field prefixVindex vitess.io/vitess/go/vt/vtgate/vindexes.SingleColumn
+	if cc, ok := cached.prefixVindex.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
 func (cached *Column) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)
@@ -477,5 +497,19 @@ func (cached *lookupInternal) CachedSize(alloc bool) int64 {
 	size += int64(len(cached.ver))
 	// field del string
 	size += int64(len(cached.del))
+	return size
+}
+func (cached *prefixCFC) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(24)
+	}
+	// field name string
+	size += int64(len(cached.name))
+	// field cfc *vitess.io/vitess/go/vt/vtgate/vindexes.CFC
+	size += cached.cfc.CachedSize(true)
 	return size
 }

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -505,11 +505,9 @@ func (cached *prefixCFC) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(24)
+		size += int64(8)
 	}
-	// field name string
-	size += int64(len(cached.name))
-	// field cfc *vitess.io/vitess/go/vt/vtgate/vindexes.CFC
-	size += cached.cfc.CachedSize(true)
+	// field CFC *vitess.io/vitess/go/vt/vtgate/vindexes.CFC
+	size += cached.CFC.CachedSize(true)
 	return size
 }

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -145,7 +145,8 @@ func (vind *CFC) String() string {
 	return vind.name
 }
 
-// Cost returns the cost as 1.
+// Cost returns the cost as 1. In regular mode, i.e. not in a LIKE op, CFC has
+// pretty much the same cost as other unique vindexes like 'binary', 'md5' etc.
 func (vind *CFC) Cost() int {
 	return 1
 }
@@ -272,8 +273,11 @@ func (vind *prefixCFC) String() string {
 	return vind.name
 }
 
+// In prefix mode, i.e. within a LIKE op, the cost is higher than regular mode.
+// Ideally the cost should be the number of shards we resolved to but the current
+// framework doesn't do dynamic cost evaluation.
 func (vind *prefixCFC) Cost() int {
-	return 1
+	return 2
 }
 
 func (vind *prefixCFC) IsUnique() bool {
@@ -362,7 +366,7 @@ func md5hash(in []byte) []byte {
 func xxhash64(in []byte) []byte {
 	out := vXXHash(in)
 	n := len(in)
-	if n < 8 {
+	if n < len(out) {
 		return out[:n]
 	}
 	return out

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -1,0 +1,373 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vindexes
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+// CFC is Concatenated Fixed-width Composite Vindex.
+//
+// The purpose of this vindex is to shard the rows based on the prefix of
+// sharding key. Imagine the sharding key is defined as (s1, s2, ... sN), a
+// prefix of this key is (s1, s2, ... sj) (j <= N). This vindex puts the rows
+// with the same prefix among a same group of shards instead of scatter them
+// around all the shards. The benefit of doing so is that prefix queries will
+// only fanout to a subset of shards instead of all the shards. Specifically
+// this vindex maps the full key, i.e. (s1, s2, ... sN) to a
+// `key.DestinationKeyspaceID` and the prefix of it, i.e. (s1, s2, ... sj)(j<N)
+// to a `key.DestinationKeyRange`. Note that the prefix to key range mapping is
+// only active in 'LIKE' expression. When a column with CFC defined appears in
+// other expressions, e.g. =, !=, IN etc, it behaves exactly as other
+// functional unique vindexes.
+//
+// This provides the capability to model hierarchical data models. If we
+// consider the prefix as the 'parent' key and the full key as the 'child' key,
+// all the child data is clustered within the same group of shards identified
+// by the 'parent' key.
+//
+// Due to the prevalance of using `vindexes.SingleColumn` in vindexes, it's way
+// more complex to implement a true multi-column composite index (see github
+// issue) than to implement it using a single column vindex where the
+// components of the composite keys are concatenated together to form a single
+// key. The user can use this single key directly as the keyspace id; one can
+// also define a hash function so that the keyspace id is the concatenation of
+// hash(s1), hash(s2), ... hash(sN). Using the concatenated key directly makes
+// it easier to reason the fanout but the data distribution depends on the key
+// itself; while using the hash on components takes care of the randomness of
+// the data distribution.
+//
+// Since the vindex is on a concatenated key, the offsets into the key are the
+// only way to mark its components. Thus it implicitly requires each component
+// to have a fixed width, except the last one. It's especially true when hash
+// is defined. Because the hash is calculated component by component, only the
+// prefix that aligns with the component boundary can be used to compute the
+// key range. Although the misaligned part doesn't participate the key range
+// calculation, the SQL executed on each shard uses the unchanged prefix; thus
+// the behavior is exactly same as other vindex's but just more efficient in
+// controlling the fanout.
+//
+// The expected format of the vindex definition is
+//
+// "vindexes": {
+//   "cfc_md5": {
+//     "type": "cfc",
+//     "params": {
+//       "hash": "md5",
+//       "offsets": "[2,4]"
+//     }
+//   }
+// }
+//
+// 'offsets' only makes sense when hash is used. Offsets should be a sorted
+// list of positive ints, each of which denotes the byte offset (from the
+// beginning of key) of each component's boundary in the concatenated key.
+// Specifically, offsets[0] is the byte offset of the first component,
+// offsets[1] is the byte offset of the second component, etc.
+type CFC struct {
+	name         string
+	hash         func([]byte) []byte
+	offsets      []int
+	prefixVindex SingleColumn
+}
+
+// NewCFC creates a new CFC vindex
+func NewCFC(name string, params map[string]string) (Vindex, error) {
+	// CFC is used in all compare expressions other than 'LIKE'.
+	ss := &CFC{
+		name: name,
+	}
+	// prefixCFC is only used in 'LIKE' compare expressions.
+	ss.prefixVindex = &prefixCFC{name: name, cfc: ss}
+
+	if params == nil {
+		return ss, nil
+	}
+
+	switch h := params["hash"]; h {
+	case "":
+		return ss, nil
+	case "md5":
+		ss.hash = md5hash
+	case "xxhash64":
+		ss.hash = xxhash64
+	default:
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid hash %s to CFC vindex %s", h, name)
+	}
+
+	var offsets []int
+	if p := params["offsets"]; p == "" {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "CFC vindex requires offsets when hash is defined")
+	} else if err := json.Unmarshal([]byte(p), &offsets); err != nil || !validOffsets(offsets) {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets %s to CFC vindex %s. expected sorted positive ints in brackets", p, name)
+	}
+	// remove duplicates
+	prev := -1
+	for _, off := range offsets {
+		if off != prev {
+			ss.offsets = append(ss.offsets, off)
+		}
+		prev = off
+	}
+
+	return ss, nil
+}
+
+func validOffsets(offsets []int) bool {
+	if len(offsets) == 0 || !sort.IntsAreSorted(offsets) {
+		return false
+	}
+	if offsets[0] <= 0 {
+		return false
+	}
+	return true
+}
+
+func (vind *CFC) String() string {
+	return vind.name
+}
+
+// Cost returns the cost as 1.
+func (vind *CFC) Cost() int {
+	return 1
+}
+
+// IsUnique returns true since the Vindex is unique.
+func (vind *CFC) IsUnique() bool {
+	return true
+}
+
+// NeedsVCursor satisfies the Vindex interface.
+func (vind *CFC) NeedsVCursor() bool {
+	return false
+}
+
+// computeKsid returns the corresponding keyspace id of a key.
+func (vind *CFC) computeKsid(v []byte, prefix bool) ([]byte, error) {
+
+	if vind.hash == nil {
+		return v, nil
+	}
+	n := len(v)
+	m := len(vind.offsets)
+	// if we are not working on a prefix, the key has to have all the components,
+	// that is, it has to be longer than the largest offset.
+	if !prefix && n < vind.offsets[m-1] {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex %s. need %d, got %d", vind.name, vind.offsets[m-1], n)
+	}
+	prev := 0
+	offset := 0
+	buf := new(bytes.Buffer)
+	for _, offset = range vind.offsets {
+		if n < offset {
+			// the given prefix doesn't align with the component boundaries,
+			// return the hashed prefix that's currently available
+			return buf.Bytes(), nil
+		}
+
+		if _, err := buf.Write(vind.hash(v[prev:offset])); err != nil {
+			return nil, err
+		}
+		prev = offset
+	}
+	if offset < n {
+		if _, err := buf.Write(vind.hash(v[offset:n])); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// Verify returns true if ids maps to ksids.
+func (vind *CFC) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	out := make([]bool, len(ids))
+	for i := range ids {
+		v, err := vind.computeKsid(ids[i].ToBytes(), false)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = bytes.Equal(v, ksids[i])
+	}
+	return out, nil
+}
+
+// Map can map ids to key.Destination objects.
+func (vind *CFC) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+	out := make([]key.Destination, len(ids))
+	for i, id := range ids {
+		v, err := vind.computeKsid(id.ToBytes(), false)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = key.DestinationKeyspaceID(v)
+	}
+	return out, nil
+}
+
+// PrefixVindex switches the vindex to prefix mode
+func (vind *CFC) PrefixVindex() SingleColumn {
+	return vind.prefixVindex
+}
+
+// NewKeyRangeFromPrefix creates a keyspace range from a prefix of keyspace id.
+func NewKeyRangeFromPrefix(begin []byte) key.Destination {
+	if len(begin) == 0 {
+		return key.DestinationAllShards{}
+	}
+	// the prefix maps to a keyspace range corresponding to its value and plus one.
+	// that is [ keyspace_id, keyspace_id + 1 ).
+	end := make([]byte, len(begin))
+	copy(end, begin)
+	end = addOne(end)
+	return key.DestinationKeyRange{
+		KeyRange: &topodatapb.KeyRange{
+			Start: begin,
+			End:   end,
+		},
+	}
+}
+
+func addOne(value []byte) []byte {
+	n := len(value)
+	overflow := true
+	for i := n - 1; i >= 0; i-- {
+		if value[i] < 255 {
+			value[i]++
+			overflow = false
+			break
+		} else {
+			value[i] = 0
+		}
+	}
+	if overflow {
+		return nil
+	}
+	return value
+}
+
+type prefixCFC struct {
+	name string
+	cfc  *CFC
+}
+
+func (vind *prefixCFC) String() string {
+	return vind.name
+}
+
+func (vind *prefixCFC) Cost() int {
+	return 1
+}
+
+func (vind *prefixCFC) IsUnique() bool {
+	return false
+}
+
+func (vind *prefixCFC) NeedsVCursor() bool {
+	return false
+}
+
+// Verify returns true if ids maps to ksids.
+func (vind *prefixCFC) Verify(vc VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	// prefixCFC is only active for 'LIKE' expr. Verify is used by 'INSERT' so we re-use CFC.Verify()
+	return vind.cfc.Verify(vc, ids, ksids)
+}
+
+// Map can map ids to key.Destination objects.
+func (vind *prefixCFC) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+	out := make([]key.Destination, len(ids))
+	for i, id := range ids {
+		value := id.ToBytes()
+		prefix := findPrefix(value)
+		begin, err := vind.cfc.computeKsid(prefix, true)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = NewKeyRangeFromPrefix(begin)
+	}
+	return out, nil
+}
+
+// findPrefix returns the 'prefix' of the string literal in LIKE expression.
+// The prefix is the prefix of the string literal up until the first unescaped
+// meta character (% and _). Other escape sequences are escaped according to
+// https://dev.mysql.com/doc/refman/8.0/en/string-literals.html.
+func findPrefix(str []byte) []byte {
+	buf := new(bytes.Buffer)
+L:
+	for len(str) > 0 {
+		n := len(str)
+		p := bytes.IndexAny(str, `%_\`)
+		if p < 0 {
+			buf.Write(str)
+			break
+		}
+		buf.Write(str[:p])
+		switch str[p] {
+		case '%', '_':
+			// prefix found
+			break L
+		// The following is not very efficient in dealing with too many
+		// continuous backslash characters, e.g. '\\\\\\\\\\\\\%', but
+		// hopefully it's the less common case.
+		case '\\':
+			if p == n-1 {
+				// backslash is the very last character of a string, typically
+				// this is an invalid string argument. We write the backslash
+				// anyway because Mysql can deal with it.
+				buf.WriteByte(str[p])
+				break L
+			} else if decoded := sqltypes.SQLDecodeMap[str[p+1]]; decoded != sqltypes.DontEscape {
+				buf.WriteByte(decoded)
+			} else {
+				buf.WriteByte(str[p+1])
+			}
+			str = str[(p + 2):n]
+		}
+	}
+	return buf.Bytes()
+}
+
+// we don't use the full hashed value because it's very long.
+// keyrange resolution is done via comparing []byte so longer
+// keyspace ids have performance impact.
+func md5hash(in []byte) []byte {
+	n := len(in)
+	out := vMD5Hash(in)
+	if n < len(out) {
+		return out[:n]
+	}
+	return out
+
+}
+
+// same here
+func xxhash64(in []byte) []byte {
+	out := vXXHash(in)
+	n := len(in)
+	if n < 8 {
+		return out[:n]
+	}
+	return out
+}
+
+func init() {
+	Register("cfc", NewCFC)
+}

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -15,7 +15,6 @@ package vindexes
 import (
 	"bytes"
 	"encoding/json"
-	"sort"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
@@ -132,11 +131,18 @@ func NewCFC(name string, params map[string]string) (Vindex, error) {
 }
 
 func validOffsets(offsets []int) bool {
-	if len(offsets) == 0 || !sort.IntsAreSorted(offsets) {
+	n := len(offsets)
+	if n == 0 {
 		return false
 	}
 	if offsets[0] <= 0 {
 		return false
+	}
+
+	for i := 1; i < n; i++ {
+		if offsets[i] <= offsets[i-1] {
+			return false
+		}
 	}
 	return true
 }

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -1,0 +1,598 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vindexes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+func assertEqualVtError(t *testing.T, expected, actual error) {
+	// vterrors.Errorf returns a struct containing a stacktrace, which fails
+	// assert.EqualError since the stacktrace would be guaranteed to be different.
+	// so just check the error message
+	if expected == nil {
+		assert.NoError(t, actual)
+	} else {
+		assert.EqualError(t, actual, expected.Error())
+	}
+}
+func TestCFC(t *testing.T) {
+	t.Run("build cfc", func(t *testing.T) {
+		cases := []struct {
+			testName string
+			params   map[string]string
+			err      error
+			offsets  []int
+		}{
+			{
+				testName: "no params",
+			},
+			{
+				testName: "no hash",
+				params:   map[string]string{},
+			},
+			{
+				testName: "no hash",
+				params:   map[string]string{"offsets": "[1,2]"},
+			},
+			{
+				testName: "no offsets",
+				params:   map[string]string{"hash": "md5"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "CFC vindex requires offsets when hash is defined"),
+			},
+			{
+				testName: "invalid offset",
+				params:   map[string]string{"hash": "md5", "offsets": "10,12"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets 10,12 to CFC vindex cfc. expected sorted positive ints in brackets"),
+			},
+			{
+				testName: "invalid offset",
+				params:   map[string]string{"hash": "md5", "offsets": "xxx"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets xxx to CFC vindex cfc. expected sorted positive ints in brackets"),
+			},
+			{
+				testName: "empty offsets",
+				params:   map[string]string{"hash": "md5", "offsets": "[]"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [] to CFC vindex cfc. expected sorted positive ints in brackets"),
+			},
+			{
+				testName: "unsorted offsets",
+				params:   map[string]string{"hash": "md5", "offsets": "[10,3]"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [10,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
+			},
+			{
+				testName: "negative offsets",
+				params:   map[string]string{"hash": "md5", "offsets": "[-1,3]"},
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [-1,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
+			},
+			{
+				testName: "normal",
+				params:   map[string]string{"hash": "md5", "offsets": "[3, 7]"},
+				offsets:  []int{3, 7},
+			},
+			{
+				testName: "duplicated offsets",
+				params:   map[string]string{"hash": "md5", "offsets": "[4,4,6]"},
+				offsets:  []int{4, 6},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.testName, func(t *testing.T) {
+				cfc, err := NewCFC("cfc", tc.params)
+				assertEqualVtError(t, tc.err, err)
+				if cfc != nil {
+					assert.EqualValues(t, tc.offsets, cfc.(*CFC).offsets)
+					assert.Equal(t, "cfc", cfc.String())
+					assert.Equal(t, 1, cfc.Cost())
+					assert.Equal(t, true, cfc.IsUnique())
+					assert.Equal(t, false, cfc.NeedsVCursor())
+				}
+			})
+		}
+	})
+
+	makeCFC := func(params map[string]string) *CFC {
+		vind, err := NewCFC("cfc", params)
+		require.NoError(t, err)
+		cfc, ok := vind.(*CFC)
+		require.True(t, ok)
+		return cfc
+	}
+
+	t.Run("compute ksid no hash", func(t *testing.T) {
+		cfc := makeCFC(nil)
+		id := []byte{3, 6, 20, 7, 60, 1}
+		ksid, err := cfc.computeKsid(id, true)
+		assert.NoError(t, err)
+		assert.EqualValues(t, id, ksid)
+	})
+
+	expectedHash := func(id [][]byte) (res []byte) {
+		for _, c := range id {
+			res = append(res, md5hash(c)...)
+		}
+		return res
+	}
+	flattenKey := func(id [][]byte) (res []byte) {
+		for _, c := range id {
+			res = append(res, c...)
+		}
+		return res
+	}
+
+	t.Run("compute ksid", func(t *testing.T) {
+		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
+
+		cases := []struct {
+			testName string
+			id       [][]byte
+			prefix   bool
+			expected []byte
+			err      error
+		}{
+			{
+				testName: "nonprefix too short",
+				id:       [][]byte{{3, 4, 5}},
+				prefix:   false,
+				expected: nil,
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
+			},
+			{
+				testName: "prefix ok",
+				id:       [][]byte{{3, 4, 5}},
+				prefix:   true,
+				expected: expectedHash([][]byte{{3, 4, 5}}),
+				err:      nil,
+			},
+			{
+				testName: "misaligned prefix",
+				id:       [][]byte{{3, 4, 5}, {1}},
+				prefix:   true,
+				// use the first component that's availabe
+				expected: expectedHash([][]byte{{3, 4, 5}}),
+				err:      nil,
+			},
+			{
+				testName: "misaligned prefix",
+				id:       [][]byte{{3, 4}},
+				prefix:   true,
+				// use the first component that's availabe
+				expected: nil,
+				err:      nil,
+			},
+			{
+				testName: "normal",
+				id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
+				prefix:   false,
+				expected: expectedHash([][]byte{{12, 234, 2}, {7, 1}, {6}}),
+				err:      nil,
+			},
+			{
+				testName: "normal",
+				id:       [][]byte{{5, 21, 124}, {75, 5}},
+				prefix:   true,
+				expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}}),
+				err:      nil,
+			},
+			{
+				testName: "long key",
+				id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}},
+				prefix:   true,
+				expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}),
+				err:      nil,
+			},
+			{
+				testName: "empty key",
+				id:       [][]byte{},
+				prefix:   true,
+				expected: nil,
+				err:      nil,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.testName, func(t *testing.T) {
+				fid := flattenKey(tc.id)
+				ksid, err := cfc.computeKsid(fid, tc.prefix)
+				assertEqualVtError(t, tc.err, err)
+				if err == nil {
+					assert.EqualValues(t, tc.expected, ksid)
+				}
+			})
+		}
+
+	})
+
+	t.Run("compute ksid xxhash", func(t *testing.T) {
+		cfc := makeCFC(map[string]string{"hash": "xxhash64", "offsets": "[3,5]"})
+
+		expectedHashXX := func(ids [][]byte) (res []byte) {
+			for _, c := range ids {
+				res = append(res, xxhash64(c)...)
+			}
+			return res
+		}
+		cases := []struct {
+			testName string
+			id       [][]byte
+			prefix   bool
+			expected []byte
+			err      error
+		}{
+			{
+				testName: "nonprefix too short",
+				id:       [][]byte{{3, 4, 5}},
+				prefix:   false,
+				expected: nil,
+				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
+			},
+			{
+				testName: "prefix ok",
+				id:       [][]byte{{3, 4, 5}},
+				prefix:   true,
+				expected: expectedHashXX([][]byte{{3, 4, 5}}),
+				err:      nil,
+			},
+			{
+				testName: "misaligned prefix",
+				id:       [][]byte{{3, 4, 5}, {1}},
+				prefix:   true,
+				// use the first component that's availabe
+				expected: expectedHashXX([][]byte{{3, 4, 5}}),
+				err:      nil,
+			},
+			{
+				testName: "misaligned prefix",
+				id:       [][]byte{{3, 4}},
+				prefix:   true,
+				// use the first component that's availabe
+				expected: nil,
+				err:      nil,
+			},
+			{
+				testName: "normal",
+				id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
+				prefix:   false,
+				expected: expectedHashXX([][]byte{{12, 234, 2}, {7, 1}, {6}}),
+				err:      nil,
+			},
+			{
+				testName: "long key",
+				id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}},
+				prefix:   true,
+				expected: expectedHashXX([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}}),
+				err:      nil,
+			},
+			{
+				testName: "long key",
+				id:       [][]byte{},
+				prefix:   true,
+				expected: nil,
+				err:      nil,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.testName, func(t *testing.T) {
+				fid := flattenKey(tc.id)
+				ksid, err := cfc.computeKsid(fid, tc.prefix)
+				assertEqualVtError(t, tc.err, err)
+				if err == nil {
+					assert.EqualValues(t, tc.expected, ksid)
+				}
+			})
+		}
+
+	})
+
+	t.Run("CFC verify no hash", func(t *testing.T) {
+		cfc := makeCFC(nil)
+		id := []byte{3, 10, 7, 200}
+		out, err := cfc.Verify(
+			nil,
+			[]sqltypes.Value{sqltypes.NewVarBinary(string(id))},
+			[][]byte{id})
+		assert.NoError(t, err)
+		assert.EqualValues(t, []bool{true}, out)
+
+		out, err = cfc.Verify(
+			nil,
+			[]sqltypes.Value{sqltypes.NewVarBinary("foobar")},
+			[][]byte{id})
+		assert.NoError(t, err)
+		assert.EqualValues(t, []bool{false}, out)
+	})
+
+	t.Run("CFC verify with hash", func(t *testing.T) {
+		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
+		id := [][]byte{
+			{1, 234, 3}, {12, 32}, {7, 9},
+		}
+		out, err := cfc.Verify(
+			nil,
+			[]sqltypes.Value{sqltypes.NewVarBinary(string(flattenKey(id)))},
+			[][]byte{expectedHash(id)})
+		assert.NoError(t, err)
+		assert.EqualValues(t, []bool{true}, out)
+
+		_, err = cfc.Verify(
+			nil,
+			[]sqltypes.Value{sqltypes.NewVarBinary("foo")},
+			[][]byte{expectedHash(id)})
+		assert.Error(t, err)
+	})
+
+	t.Run("CFC map", func(t *testing.T) {
+		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
+		_, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("abc")})
+		assert.EqualError(t, err, "insufficient size for cfc vindex cfc. need 5, got 3")
+
+		dests, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")})
+		require.NoError(t, err)
+		ksid, ok := dests[0].(key.DestinationKeyspaceID)
+		require.True(t, ok)
+		out, err := cfc.Verify(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")}, [][]byte{ksid})
+		assert.NoError(t, err)
+		assert.EqualValues(t, []bool{true}, out)
+	})
+
+	t.Run("CFC build prefix", func(t *testing.T) {
+		cfc := makeCFC(nil)
+		prefixcfc := cfc.PrefixVindex()
+		assert.Equal(t, "cfc", prefixcfc.String())
+		assert.False(t, prefixcfc.IsUnique())
+		assert.False(t, prefixcfc.NeedsVCursor())
+		assert.Equal(t, 1, prefixcfc.Cost())
+	})
+
+	t.Run("CFC prefix map", func(t *testing.T) {
+		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
+		prefixcfc := cfc.PrefixVindex()
+
+		cases := []struct {
+			testName string
+			id       string
+			dest     key.Destination
+		}{
+			{
+				testName: "literal regular",
+				id:       "abcdef",
+				dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}, {'d', 'e'}, {'f'}})),
+			},
+			{
+				testName: "literal use first component",
+				id:       "abcd",
+				dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}})),
+			},
+			{
+				testName: "literal prefix too short",
+				id:       "ab",
+				dest:     key.DestinationAllShards{},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.testName, func(t *testing.T) {
+				dests, err := prefixcfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary(tc.id)})
+				require.NoError(t, err)
+				assert.EqualValues(t, tc.dest, dests[0])
+			})
+		}
+
+	})
+
+	t.Run("CFC prefix query map no hash", func(t *testing.T) {
+		cfc := makeCFC(nil)
+		prefixcfc := cfc.PrefixVindex()
+
+		expected := []struct {
+			start, end []byte
+		}{
+			{[]byte{3, 123, 255}, []byte{3, 124, 0}},
+			{[]byte{3, 123, 255, 6, 7}, []byte{3, 123, 255, 6, 8}},
+			{[]byte{255, 255, 255}, nil},
+		}
+		var ids []sqltypes.Value
+		for _, exp := range expected {
+			ids = append(ids, sqltypes.NewVarBinary(string(exp.start)+"%"))
+		}
+		dests, err := prefixcfc.Map(nil, ids)
+		require.NoError(t, err)
+
+		for i, dest := range dests {
+			kr, ok := dest.(key.DestinationKeyRange)
+			require.True(t, ok)
+			assert.EqualValues(t, expected[i].start, kr.KeyRange.Start)
+			assert.EqualValues(t, expected[i].end, kr.KeyRange.End)
+		}
+	})
+
+	t.Run("find prefix escape", func(t *testing.T) {
+		cases := []struct {
+			str, prefix string
+		}{
+			{
+				str:    "ab%",
+				prefix: "ab",
+			},
+			{
+				str:    "abc",
+				prefix: "abc",
+			},
+			{
+				str:    "a%%",
+				prefix: "a",
+			},
+			{
+				str:    "%ab",
+				prefix: "",
+			},
+			{
+				str:    `\%a%`,
+				prefix: `%a`,
+			},
+			{
+				str:    `\%%`,
+				prefix: `%`,
+			},
+			{
+				str:    `\%`,
+				prefix: `%`,
+			},
+			{
+				str:    `\\%a`,
+				prefix: `\`,
+			},
+			{
+				str:    `a\\%a`,
+				prefix: `a\`,
+			},
+			{
+				str:    `\\\%`,
+				prefix: `\%`,
+			},
+			{
+				str:    `\\\%a%`,
+				prefix: `\%a`,
+			},
+			{
+				str:    `\_\\\%a_`,
+				prefix: `_\%a`,
+			},
+			{
+				str:    `_%a%`,
+				prefix: ``,
+			},
+			{
+				str:    `\i\j\k`,
+				prefix: `ijk`,
+			},
+			{
+				str:    `\0\'\"\b\n\r\t\Z\\`,
+				prefix: "\x00'\"\b\n\r\t\x1A\\",
+			},
+			{
+				str:    `\\0\\'\\"\\b\\n\\r\\t\\Z`,
+				prefix: `\0\'\"\b\n\r\t\Z`,
+			},
+			{
+				str:    `\`,
+				prefix: `\`,
+			},
+		}
+
+		for _, tc := range cases {
+			assert.EqualValues(t, tc.prefix, string(findPrefix([]byte(tc.str))))
+		}
+
+	})
+}
+
+func TestDestinationKeyRangeFromPrefix(t *testing.T) {
+	testCases := []struct {
+		start []byte
+		dest  key.Destination
+	}{
+		{
+			start: []byte{3, 123, 255},
+			dest: key.DestinationKeyRange{
+				KeyRange: &topodatapb.KeyRange{
+					Start: []byte{3, 123, 255},
+					End:   []byte{3, 124, 0},
+				},
+			},
+		},
+		{
+			start: []byte{3, 123, 255, 6, 7},
+			dest: key.DestinationKeyRange{
+				KeyRange: &topodatapb.KeyRange{
+					Start: []byte{3, 123, 255, 6, 7},
+					End:   []byte{3, 123, 255, 6, 8},
+				},
+			},
+		},
+		{
+			start: []byte{255, 255, 255},
+			dest: key.DestinationKeyRange{
+				KeyRange: &topodatapb.KeyRange{
+					Start: []byte{255, 255, 255},
+					End:   nil,
+				},
+			},
+		},
+		{
+			start: nil,
+			dest:  key.DestinationAllShards{},
+		},
+		{
+			start: []byte{},
+			dest:  key.DestinationAllShards{},
+		},
+	}
+
+	for _, tc := range testCases {
+		dest := NewKeyRangeFromPrefix(tc.start)
+		assert.EqualValues(t, tc.dest, dest)
+	}
+
+	t.Run("add one to bytes", func(t *testing.T) {
+		cases := []struct {
+			testName        string
+			input, expected []byte
+		}{
+			{
+				testName: "regular one byte",
+				input:    []byte{213},
+				expected: []byte{214},
+			},
+			{
+				testName: "regular two byte",
+				input:    []byte{213, 7},
+				expected: []byte{213, 8},
+			},
+			{
+				testName: "carry one",
+				input:    []byte{213, 255},
+				expected: []byte{214, 0},
+			},
+			{
+				testName: "carry multi",
+				input:    []byte{1, 255, 255},
+				expected: []byte{2, 0, 0},
+			},
+			{
+				testName: "overflow one byte",
+				input:    []byte{255},
+				expected: nil,
+			},
+			{
+				testName: "overflow multi",
+				input:    []byte{255, 255},
+				expected: nil,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.testName, func(t *testing.T) {
+				assert.EqualValues(t, tc.expected, addOne(tc.input))
+			})
+		}
+	})
+}

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -35,490 +35,490 @@ func assertEqualVtError(t *testing.T, expected, actual error) {
 		assert.EqualError(t, actual, expected.Error())
 	}
 }
-func TestCFC(t *testing.T) {
-	t.Run("build cfc", func(t *testing.T) {
-		cases := []struct {
-			testName string
-			params   map[string]string
-			err      error
-			offsets  []int
-		}{
-			{
-				testName: "no params",
-			},
-			{
-				testName: "no hash",
-				params:   map[string]string{},
-			},
-			{
-				testName: "no hash",
-				params:   map[string]string{"offsets": "[1,2]"},
-			},
-			{
-				testName: "no offsets",
-				params:   map[string]string{"hash": "md5"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "CFC vindex requires offsets when hash is defined"),
-			},
-			{
-				testName: "invalid offset",
-				params:   map[string]string{"hash": "md5", "offsets": "10,12"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets 10,12 to CFC vindex cfc. expected sorted positive ints in brackets"),
-			},
-			{
-				testName: "invalid offset",
-				params:   map[string]string{"hash": "md5", "offsets": "xxx"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets xxx to CFC vindex cfc. expected sorted positive ints in brackets"),
-			},
-			{
-				testName: "empty offsets",
-				params:   map[string]string{"hash": "md5", "offsets": "[]"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [] to CFC vindex cfc. expected sorted positive ints in brackets"),
-			},
-			{
-				testName: "unsorted offsets",
-				params:   map[string]string{"hash": "md5", "offsets": "[10,3]"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [10,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
-			},
-			{
-				testName: "negative offsets",
-				params:   map[string]string{"hash": "md5", "offsets": "[-1,3]"},
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [-1,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
-			},
-			{
-				testName: "normal",
-				params:   map[string]string{"hash": "md5", "offsets": "[3, 7]"},
-				offsets:  []int{3, 7},
-			},
-			{
-				testName: "duplicated offsets",
-				params:   map[string]string{"hash": "md5", "offsets": "[4,4,6]"},
-				offsets:  []int{4, 6},
-			},
-		}
 
-		for _, tc := range cases {
-			t.Run(tc.testName, func(t *testing.T) {
-				cfc, err := NewCFC("cfc", tc.params)
-				assertEqualVtError(t, tc.err, err)
-				if cfc != nil {
-					assert.EqualValues(t, tc.offsets, cfc.(*CFC).offsets)
-					assert.Equal(t, "cfc", cfc.String())
-					assert.Equal(t, 1, cfc.Cost())
-					assert.Equal(t, true, cfc.IsUnique())
-					assert.Equal(t, false, cfc.NeedsVCursor())
-				}
-			})
-		}
-	})
-
-	makeCFC := func(params map[string]string) *CFC {
-		vind, err := NewCFC("cfc", params)
-		require.NoError(t, err)
-		cfc, ok := vind.(*CFC)
-		require.True(t, ok)
-		return cfc
+func TestCFCBuildCFC(t *testing.T) {
+	cases := []struct {
+		testName string
+		params   map[string]string
+		err      error
+		offsets  []int
+	}{
+		{
+			testName: "no params",
+		},
+		{
+			testName: "no hash",
+			params:   map[string]string{},
+		},
+		{
+			testName: "no hash",
+			params:   map[string]string{"offsets": "[1,2]"},
+		},
+		{
+			testName: "no offsets",
+			params:   map[string]string{"hash": "md5"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "CFC vindex requires offsets when hash is defined"),
+		},
+		{
+			testName: "invalid offset",
+			params:   map[string]string{"hash": "md5", "offsets": "10,12"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets 10,12 to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
+		{
+			testName: "invalid offset",
+			params:   map[string]string{"hash": "md5", "offsets": "xxx"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets xxx to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
+		{
+			testName: "empty offsets",
+			params:   map[string]string{"hash": "md5", "offsets": "[]"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [] to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
+		{
+			testName: "unsorted offsets",
+			params:   map[string]string{"hash": "md5", "offsets": "[10,3]"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [10,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
+		{
+			testName: "negative offsets",
+			params:   map[string]string{"hash": "md5", "offsets": "[-1,3]"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [-1,3] to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
+		{
+			testName: "normal",
+			params:   map[string]string{"hash": "md5", "offsets": "[3, 7]"},
+			offsets:  []int{3, 7},
+		},
+		{
+			testName: "duplicated offsets",
+			params:   map[string]string{"hash": "md5", "offsets": "[4,4,6]"},
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid offsets [4,4,6] to CFC vindex cfc. expected sorted positive ints in brackets"),
+		},
 	}
 
-	t.Run("compute ksid no hash", func(t *testing.T) {
-		cfc := makeCFC(nil)
-		id := []byte{3, 6, 20, 7, 60, 1}
-		ksid, err := cfc.computeKsid(id, true)
-		assert.NoError(t, err)
-		assert.EqualValues(t, id, ksid)
-	})
-
-	expectedHash := func(id [][]byte) (res []byte) {
-		for _, c := range id {
-			res = append(res, md5hash(c)...)
-		}
-		return res
-	}
-	flattenKey := func(id [][]byte) (res []byte) {
-		for _, c := range id {
-			res = append(res, c...)
-		}
-		return res
-	}
-
-	t.Run("compute ksid", func(t *testing.T) {
-		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
-
-		cases := []struct {
-			testName string
-			id       [][]byte
-			prefix   bool
-			expected []byte
-			err      error
-		}{
-			{
-				testName: "nonprefix too short",
-				id:       [][]byte{{3, 4, 5}},
-				prefix:   false,
-				expected: nil,
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
-			},
-			{
-				testName: "prefix ok",
-				id:       [][]byte{{3, 4, 5}},
-				prefix:   true,
-				expected: expectedHash([][]byte{{3, 4, 5}}),
-				err:      nil,
-			},
-			{
-				testName: "misaligned prefix",
-				id:       [][]byte{{3, 4, 5}, {1}},
-				prefix:   true,
-				// use the first component that's availabe
-				expected: expectedHash([][]byte{{3, 4, 5}}),
-				err:      nil,
-			},
-			{
-				testName: "misaligned prefix",
-				id:       [][]byte{{3, 4}},
-				prefix:   true,
-				// use the first component that's availabe
-				expected: nil,
-				err:      nil,
-			},
-			{
-				testName: "normal",
-				id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
-				prefix:   false,
-				expected: expectedHash([][]byte{{12, 234, 2}, {7, 1}, {6}}),
-				err:      nil,
-			},
-			{
-				testName: "normal",
-				id:       [][]byte{{5, 21, 124}, {75, 5}},
-				prefix:   true,
-				expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}}),
-				err:      nil,
-			},
-			{
-				testName: "long key",
-				id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}},
-				prefix:   true,
-				expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}),
-				err:      nil,
-			},
-			{
-				testName: "empty key",
-				id:       [][]byte{},
-				prefix:   true,
-				expected: nil,
-				err:      nil,
-			},
-		}
-		for _, tc := range cases {
-			t.Run(tc.testName, func(t *testing.T) {
-				fid := flattenKey(tc.id)
-				ksid, err := cfc.computeKsid(fid, tc.prefix)
-				assertEqualVtError(t, tc.err, err)
-				if err == nil {
-					assert.EqualValues(t, tc.expected, ksid)
-				}
-			})
-		}
-
-	})
-
-	t.Run("compute ksid xxhash", func(t *testing.T) {
-		cfc := makeCFC(map[string]string{"hash": "xxhash64", "offsets": "[3,5]"})
-
-		expectedHashXX := func(ids [][]byte) (res []byte) {
-			for _, c := range ids {
-				res = append(res, xxhash64(c)...)
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			cfc, err := NewCFC("cfc", tc.params)
+			assertEqualVtError(t, tc.err, err)
+			if cfc != nil {
+				assert.EqualValues(t, tc.offsets, cfc.(*CFC).offsets)
+				assert.Equal(t, "cfc", cfc.String())
+				assert.Equal(t, 1, cfc.Cost())
+				assert.Equal(t, true, cfc.IsUnique())
+				assert.Equal(t, false, cfc.NeedsVCursor())
 			}
-			return res
+		})
+	}
+}
+
+func makeCFC(t *testing.T, params map[string]string) *CFC {
+	vind, err := NewCFC("cfc", params)
+	require.NoError(t, err)
+	cfc, ok := vind.(*CFC)
+	require.True(t, ok)
+	return cfc
+}
+
+func expectedHash(id [][]byte) (res []byte) {
+	for _, c := range id {
+		res = append(res, md5hash(c)...)
+	}
+	return res
+}
+
+func flattenKey(id [][]byte) (res []byte) {
+	for _, c := range id {
+		res = append(res, c...)
+	}
+	return res
+}
+
+func TestCFCComputeKsidNoHash(t *testing.T) {
+	cfc := makeCFC(t, nil)
+	id := []byte{3, 6, 20, 7, 60, 1}
+	ksid, err := cfc.computeKsid(id, true)
+	assert.NoError(t, err)
+	assert.EqualValues(t, id, ksid)
+}
+
+func TestCFCComputeKsid(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "md5", "offsets": "[3,5]"})
+
+	cases := []struct {
+		testName string
+		id       [][]byte
+		prefix   bool
+		expected []byte
+		err      error
+	}{
+		{
+			testName: "nonprefix too short",
+			id:       [][]byte{{3, 4, 5}},
+			prefix:   false,
+			expected: nil,
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
+		},
+		{
+			testName: "prefix ok",
+			id:       [][]byte{{3, 4, 5}},
+			prefix:   true,
+			expected: expectedHash([][]byte{{3, 4, 5}}),
+			err:      nil,
+		},
+		{
+			testName: "misaligned prefix",
+			id:       [][]byte{{3, 4, 5}, {1}},
+			prefix:   true,
+			// use the first component that's availabe
+			expected: expectedHash([][]byte{{3, 4, 5}}),
+			err:      nil,
+		},
+		{
+			testName: "misaligned prefix",
+			id:       [][]byte{{3, 4}},
+			prefix:   true,
+			// use the first component that's availabe
+			expected: nil,
+			err:      nil,
+		},
+		{
+			testName: "normal",
+			id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
+			prefix:   false,
+			expected: expectedHash([][]byte{{12, 234, 2}, {7, 1}, {6}}),
+			err:      nil,
+		},
+		{
+			testName: "normal",
+			id:       [][]byte{{5, 21, 124}, {75, 5}},
+			prefix:   true,
+			expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}}),
+			err:      nil,
+		},
+		{
+			testName: "long key",
+			id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}},
+			prefix:   true,
+			expected: expectedHash([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}),
+			err:      nil,
+		},
+		{
+			testName: "empty key",
+			id:       [][]byte{},
+			prefix:   true,
+			expected: nil,
+			err:      nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			fid := flattenKey(tc.id)
+			ksid, err := cfc.computeKsid(fid, tc.prefix)
+			assertEqualVtError(t, tc.err, err)
+			if err == nil {
+				assert.EqualValues(t, tc.expected, ksid)
+			}
+		})
+	}
+
+}
+
+func TestCFCComputeKsidXxhash(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "xxhash64", "offsets": "[3,5]"})
+
+	expectedHashXX := func(ids [][]byte) (res []byte) {
+		for _, c := range ids {
+			res = append(res, xxhash64(c)...)
 		}
-		cases := []struct {
-			testName string
-			id       [][]byte
-			prefix   bool
-			expected []byte
-			err      error
-		}{
-			{
-				testName: "nonprefix too short",
-				id:       [][]byte{{3, 4, 5}},
-				prefix:   false,
-				expected: nil,
-				err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
-			},
-			{
-				testName: "prefix ok",
-				id:       [][]byte{{3, 4, 5}},
-				prefix:   true,
-				expected: expectedHashXX([][]byte{{3, 4, 5}}),
-				err:      nil,
-			},
-			{
-				testName: "misaligned prefix",
-				id:       [][]byte{{3, 4, 5}, {1}},
-				prefix:   true,
-				// use the first component that's availabe
-				expected: expectedHashXX([][]byte{{3, 4, 5}}),
-				err:      nil,
-			},
-			{
-				testName: "misaligned prefix",
-				id:       [][]byte{{3, 4}},
-				prefix:   true,
-				// use the first component that's availabe
-				expected: nil,
-				err:      nil,
-			},
-			{
-				testName: "normal",
-				id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
-				prefix:   false,
-				expected: expectedHashXX([][]byte{{12, 234, 2}, {7, 1}, {6}}),
-				err:      nil,
-			},
-			{
-				testName: "long key",
-				id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}},
-				prefix:   true,
-				expected: expectedHashXX([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}}),
-				err:      nil,
-			},
-			{
-				testName: "long key",
-				id:       [][]byte{},
-				prefix:   true,
-				expected: nil,
-				err:      nil,
-			},
-		}
-		for _, tc := range cases {
-			t.Run(tc.testName, func(t *testing.T) {
-				fid := flattenKey(tc.id)
-				ksid, err := cfc.computeKsid(fid, tc.prefix)
-				assertEqualVtError(t, tc.err, err)
-				if err == nil {
-					assert.EqualValues(t, tc.expected, ksid)
-				}
-			})
-		}
+		return res
+	}
+	cases := []struct {
+		testName string
+		id       [][]byte
+		prefix   bool
+		expected []byte
+		err      error
+	}{
+		{
+			testName: "nonprefix too short",
+			id:       [][]byte{{3, 4, 5}},
+			prefix:   false,
+			expected: nil,
+			err:      vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "insufficient size for cfc vindex cfc. need 5, got 3"),
+		},
+		{
+			testName: "prefix ok",
+			id:       [][]byte{{3, 4, 5}},
+			prefix:   true,
+			expected: expectedHashXX([][]byte{{3, 4, 5}}),
+			err:      nil,
+		},
+		{
+			testName: "misaligned prefix",
+			id:       [][]byte{{3, 4, 5}, {1}},
+			prefix:   true,
+			// use the first component that's availabe
+			expected: expectedHashXX([][]byte{{3, 4, 5}}),
+			err:      nil,
+		},
+		{
+			testName: "misaligned prefix",
+			id:       [][]byte{{3, 4}},
+			prefix:   true,
+			// use the first component that's availabe
+			expected: nil,
+			err:      nil,
+		},
+		{
+			testName: "normal",
+			id:       [][]byte{{12, 234, 2}, {7, 1}, {6}},
+			prefix:   false,
+			expected: expectedHashXX([][]byte{{12, 234, 2}, {7, 1}, {6}}),
+			err:      nil,
+		},
+		{
+			testName: "long key",
+			id:       [][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}},
+			prefix:   true,
+			expected: expectedHashXX([][]byte{{5, 21, 124}, {75, 5}, {1, 2, 3, 4, 5, 6}}),
+			err:      nil,
+		},
+		{
+			testName: "long key",
+			id:       [][]byte{},
+			prefix:   true,
+			expected: nil,
+			err:      nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			fid := flattenKey(tc.id)
+			ksid, err := cfc.computeKsid(fid, tc.prefix)
+			assertEqualVtError(t, tc.err, err)
+			if err == nil {
+				assert.EqualValues(t, tc.expected, ksid)
+			}
+		})
+	}
 
-	})
+}
 
-	t.Run("CFC verify no hash", func(t *testing.T) {
-		cfc := makeCFC(nil)
-		id := []byte{3, 10, 7, 200}
-		out, err := cfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary(string(id))},
-			[][]byte{id})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{true}, out)
+func TestCFCVerifyNoHash(t *testing.T) {
+	cfc := makeCFC(t, nil)
+	id := []byte{3, 10, 7, 200}
+	out, err := cfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary(string(id))},
+		[][]byte{id})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{true}, out)
 
-		out, err = cfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary("foobar")},
-			[][]byte{id})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{false}, out)
-		pcfc := cfc.PrefixVindex()
-		out, err = pcfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary("foobar")},
-			[][]byte{id})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{false}, out)
-	})
+	out, err = cfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary("foobar")},
+		[][]byte{id})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{false}, out)
+	pcfc := cfc.PrefixVindex()
+	out, err = pcfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary("foobar")},
+		[][]byte{id})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{false}, out)
+}
 
-	t.Run("CFC verify with hash", func(t *testing.T) {
-		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
-		id := [][]byte{
-			{1, 234, 3}, {12, 32}, {7, 9},
-		}
-		out, err := cfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary(string(flattenKey(id)))},
-			[][]byte{expectedHash(id)})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{true}, out)
+func TestCFCVerifyWithHash(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "md5", "offsets": "[3,5]"})
+	id := [][]byte{
+		{1, 234, 3}, {12, 32}, {7, 9},
+	}
+	out, err := cfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary(string(flattenKey(id)))},
+		[][]byte{expectedHash(id)})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{true}, out)
 
-		_, err = cfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary("foo")},
-			[][]byte{expectedHash(id)})
-		assert.Error(t, err)
+	_, err = cfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary("foo")},
+		[][]byte{expectedHash(id)})
+	assert.Error(t, err)
 
-		pcfc := cfc.PrefixVindex()
-		out, err = pcfc.Verify(
-			nil,
-			[]sqltypes.Value{sqltypes.NewVarBinary(string(flattenKey(id)))},
-			[][]byte{expectedHash(id)})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{true}, out)
+	pcfc := cfc.PrefixVindex()
+	out, err = pcfc.Verify(
+		nil,
+		[]sqltypes.Value{sqltypes.NewVarBinary(string(flattenKey(id)))},
+		[][]byte{expectedHash(id)})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{true}, out)
 
-	})
+}
 
-	t.Run("CFC map", func(t *testing.T) {
-		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
-		_, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("abc")})
-		assert.EqualError(t, err, "insufficient size for cfc vindex cfc. need 5, got 3")
+func TestCFCMap(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "md5", "offsets": "[3,5]"})
+	_, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("abc")})
+	assert.EqualError(t, err, "insufficient size for cfc vindex cfc. need 5, got 3")
 
-		dests, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")})
-		require.NoError(t, err)
-		ksid, ok := dests[0].(key.DestinationKeyspaceID)
+	dests, err := cfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")})
+	require.NoError(t, err)
+	ksid, ok := dests[0].(key.DestinationKeyspaceID)
+	require.True(t, ok)
+	out, err := cfc.Verify(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")}, [][]byte{ksid})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []bool{true}, out)
+}
+
+func TestCFCBuildPrefix(t *testing.T) {
+	cfc := makeCFC(t, nil)
+	prefixcfc := cfc.PrefixVindex()
+	assert.Equal(t, "cfc", prefixcfc.String())
+	assert.False(t, prefixcfc.IsUnique())
+	assert.False(t, prefixcfc.NeedsVCursor())
+	assert.Equal(t, 2, prefixcfc.Cost())
+}
+
+func TestCFCPrefixMap(t *testing.T) {
+	cfc := makeCFC(t, map[string]string{"hash": "md5", "offsets": "[3,5]"})
+	prefixcfc := cfc.PrefixVindex()
+
+	cases := []struct {
+		testName string
+		id       string
+		dest     key.Destination
+	}{
+		{
+			testName: "literal regular",
+			id:       "abcdef",
+			dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}, {'d', 'e'}, {'f'}})),
+		},
+		{
+			testName: "literal use first component",
+			id:       "abcd",
+			dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}})),
+		},
+		{
+			testName: "literal prefix too short",
+			id:       "ab",
+			dest:     key.DestinationAllShards{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			dests, err := prefixcfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary(tc.id)})
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.dest, dests[0])
+		})
+	}
+
+}
+
+func TestCFCPrefixQueryMapNoHash(t *testing.T) {
+	cfc := makeCFC(t, nil)
+	prefixcfc := cfc.PrefixVindex()
+
+	expected := []struct {
+		start, end []byte
+	}{
+		{[]byte{3, 123, 255}, []byte{3, 124, 0}},
+		{[]byte{3, 123, 255, 6, 7}, []byte{3, 123, 255, 6, 8}},
+		{[]byte{255, 255, 255}, nil},
+	}
+	var ids []sqltypes.Value
+	for _, exp := range expected {
+		ids = append(ids, sqltypes.NewVarBinary(string(exp.start)+"%"))
+	}
+	dests, err := prefixcfc.Map(nil, ids)
+	require.NoError(t, err)
+
+	for i, dest := range dests {
+		kr, ok := dest.(key.DestinationKeyRange)
 		require.True(t, ok)
-		out, err := cfc.Verify(nil, []sqltypes.Value{sqltypes.NewVarBinary("12345567")}, [][]byte{ksid})
-		assert.NoError(t, err)
-		assert.EqualValues(t, []bool{true}, out)
-	})
+		assert.EqualValues(t, expected[i].start, kr.KeyRange.Start)
+		assert.EqualValues(t, expected[i].end, kr.KeyRange.End)
+	}
+}
 
-	t.Run("CFC build prefix", func(t *testing.T) {
-		cfc := makeCFC(nil)
-		prefixcfc := cfc.PrefixVindex()
-		assert.Equal(t, "cfc", prefixcfc.String())
-		assert.False(t, prefixcfc.IsUnique())
-		assert.False(t, prefixcfc.NeedsVCursor())
-		assert.Equal(t, 2, prefixcfc.Cost())
-	})
+func TestCFCFindPrefixEscape(t *testing.T) {
+	cases := []struct {
+		str, prefix string
+	}{
+		{
+			str:    "ab%",
+			prefix: "ab",
+		},
+		{
+			str:    "abc",
+			prefix: "abc",
+		},
+		{
+			str:    "a%%",
+			prefix: "a",
+		},
+		{
+			str:    "%ab",
+			prefix: "",
+		},
+		{
+			str:    `\%a%`,
+			prefix: `%a`,
+		},
+		{
+			str:    `\%%`,
+			prefix: `%`,
+		},
+		{
+			str:    `\%`,
+			prefix: `%`,
+		},
+		{
+			str:    `\\%a`,
+			prefix: `\`,
+		},
+		{
+			str:    `a\\%a`,
+			prefix: `a\`,
+		},
+		{
+			str:    `\\\%`,
+			prefix: `\%`,
+		},
+		{
+			str:    `\\\%a%`,
+			prefix: `\%a`,
+		},
+		{
+			str:    `\_\\\%a_`,
+			prefix: `_\%a`,
+		},
+		{
+			str:    `_%a%`,
+			prefix: ``,
+		},
+		{
+			str:    `\i\j\k`,
+			prefix: `ijk`,
+		},
+		{
+			str:    `\0\'\"\b\n\r\t\Z\\`,
+			prefix: "\x00'\"\b\n\r\t\x1A\\",
+		},
+		{
+			str:    `\\0\\'\\"\\b\\n\\r\\t\\Z`,
+			prefix: `\0\'\"\b\n\r\t\Z`,
+		},
+		{
+			str:    `\`,
+			prefix: `\`,
+		},
+	}
 
-	t.Run("CFC prefix map", func(t *testing.T) {
-		cfc := makeCFC(map[string]string{"hash": "md5", "offsets": "[3,5]"})
-		prefixcfc := cfc.PrefixVindex()
+	for _, tc := range cases {
+		assert.EqualValues(t, tc.prefix, string(findPrefix([]byte(tc.str))))
+	}
 
-		cases := []struct {
-			testName string
-			id       string
-			dest     key.Destination
-		}{
-			{
-				testName: "literal regular",
-				id:       "abcdef",
-				dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}, {'d', 'e'}, {'f'}})),
-			},
-			{
-				testName: "literal use first component",
-				id:       "abcd",
-				dest:     NewKeyRangeFromPrefix(expectedHash([][]byte{{'a', 'b', 'c'}})),
-			},
-			{
-				testName: "literal prefix too short",
-				id:       "ab",
-				dest:     key.DestinationAllShards{},
-			},
-		}
-		for _, tc := range cases {
-			t.Run(tc.testName, func(t *testing.T) {
-				dests, err := prefixcfc.Map(nil, []sqltypes.Value{sqltypes.NewVarBinary(tc.id)})
-				require.NoError(t, err)
-				assert.EqualValues(t, tc.dest, dests[0])
-			})
-		}
-
-	})
-
-	t.Run("CFC prefix query map no hash", func(t *testing.T) {
-		cfc := makeCFC(nil)
-		prefixcfc := cfc.PrefixVindex()
-
-		expected := []struct {
-			start, end []byte
-		}{
-			{[]byte{3, 123, 255}, []byte{3, 124, 0}},
-			{[]byte{3, 123, 255, 6, 7}, []byte{3, 123, 255, 6, 8}},
-			{[]byte{255, 255, 255}, nil},
-		}
-		var ids []sqltypes.Value
-		for _, exp := range expected {
-			ids = append(ids, sqltypes.NewVarBinary(string(exp.start)+"%"))
-		}
-		dests, err := prefixcfc.Map(nil, ids)
-		require.NoError(t, err)
-
-		for i, dest := range dests {
-			kr, ok := dest.(key.DestinationKeyRange)
-			require.True(t, ok)
-			assert.EqualValues(t, expected[i].start, kr.KeyRange.Start)
-			assert.EqualValues(t, expected[i].end, kr.KeyRange.End)
-		}
-	})
-
-	t.Run("find prefix escape", func(t *testing.T) {
-		cases := []struct {
-			str, prefix string
-		}{
-			{
-				str:    "ab%",
-				prefix: "ab",
-			},
-			{
-				str:    "abc",
-				prefix: "abc",
-			},
-			{
-				str:    "a%%",
-				prefix: "a",
-			},
-			{
-				str:    "%ab",
-				prefix: "",
-			},
-			{
-				str:    `\%a%`,
-				prefix: `%a`,
-			},
-			{
-				str:    `\%%`,
-				prefix: `%`,
-			},
-			{
-				str:    `\%`,
-				prefix: `%`,
-			},
-			{
-				str:    `\\%a`,
-				prefix: `\`,
-			},
-			{
-				str:    `a\\%a`,
-				prefix: `a\`,
-			},
-			{
-				str:    `\\\%`,
-				prefix: `\%`,
-			},
-			{
-				str:    `\\\%a%`,
-				prefix: `\%a`,
-			},
-			{
-				str:    `\_\\\%a_`,
-				prefix: `_\%a`,
-			},
-			{
-				str:    `_%a%`,
-				prefix: ``,
-			},
-			{
-				str:    `\i\j\k`,
-				prefix: `ijk`,
-			},
-			{
-				str:    `\0\'\"\b\n\r\t\Z\\`,
-				prefix: "\x00'\"\b\n\r\t\x1A\\",
-			},
-			{
-				str:    `\\0\\'\\"\\b\\n\\r\\t\\Z`,
-				prefix: `\0\'\"\b\n\r\t\Z`,
-			},
-			{
-				str:    `\`,
-				prefix: `\`,
-			},
-		}
-
-		for _, tc := range cases {
-			assert.EqualValues(t, tc.prefix, string(findPrefix([]byte(tc.str))))
-		}
-
-	})
 }
 
 func TestDestinationKeyRangeFromPrefix(t *testing.T) {

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -378,6 +378,13 @@ func TestCFCBuildPrefix(t *testing.T) {
 	assert.False(t, prefixcfc.IsUnique())
 	assert.False(t, prefixcfc.NeedsVCursor())
 	assert.Equal(t, 2, prefixcfc.Cost())
+
+	cfc = makeCFC(t, map[string]string{"offsets": "[1,2,3]", "hash": "xxhash64"})
+	prefixcfc = cfc.PrefixVindex()
+	assert.Equal(t, "cfc", prefixcfc.String())
+	assert.False(t, prefixcfc.IsUnique())
+	assert.False(t, prefixcfc.NeedsVCursor())
+	assert.Equal(t, 3, prefixcfc.Cost())
 }
 
 func TestCFCPrefixMap(t *testing.T) {

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -101,6 +101,14 @@ type Reversible interface {
 	ReverseMap(vcursor VCursor, ks [][]byte) ([]sqltypes.Value, error)
 }
 
+// A Prefixable vindex is one that maps the prefix of a id to a keyspace range
+// instead of a single keyspace id. It's being used to reduced the fan out for
+// 'LIKE' expressions.
+type Prefixable interface {
+	SingleColumn
+	PrefixVindex() SingleColumn
+}
+
 // A Lookup vindex is one that needs to lookup
 // a previously stored map to compute the keyspace
 // id from an id. This means that the creation of


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
The purpose of this vindex is to shard the rows based on the prefix of
sharding key. Imagine the sharding key is defined as (s1, s2, ... sN), a
prefix of this key is (s1, s2, ... sj) (j <= N). This vindex puts the rows
with the same prefix among a same group of shards instead of scatter them
around all the shards. The benefit of doing so is that prefix queries will
only fanout to a subset of shards instead of all the shards. Specifically
this vindex maps the full key, i.e. (s1, s2, ... sN) to a
`key.DestinationKeyspaceID` and the prefix of it, i.e. (s1, s2, ... sj)(j<N)
to a `key.DestinationKeyRange`. Note that the prefix to key range mapping is
only active in 'LIKE' expression. When a column with CFC defined appears in
other expressions, e.g. =, !=, IN etc, it behaves exactly as other
functional unique vindexes.



## Related Issue(s)
<!-- List related issues and pull requests: -->
- https://github.com/vitessio/vitess/issues/7529

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
