### PR TITLE
vttablet: fix flaky tests

### DIFF
--- a/go/cache/ristretto/cache.go
+++ b/go/cache/ristretto/cache.go
@@ -337,6 +337,10 @@ loop:
 	for {
 		select {
 		case i := <-c.setBuf:
+			if i.wg != nil {
+				i.wg.Done()
+				continue
+			}
 			if i.flag != itemUpdate {
 				// In itemUpdate, the value is already set in the store.  So, no need to call
 				// onEvict here.

--- a/go/vt/vttablet/endtoend/framework/testcase.go
+++ b/go/vt/vttablet/endtoend/framework/testcase.go
@@ -108,6 +108,9 @@ func (tc *TestCase) Test(name string, client *QueryClient) error {
 		name = tc.Name
 	}
 
+	// wait for all previous test cases to have been settled in cache
+	client.server.QueryPlanCacheWait()
+
 	catcher := NewQueryCatcher()
 	defer catcher.Close()
 

--- a/go/vt/vttablet/endtoend/queries_test.go
+++ b/go/vt/vttablet/endtoend/queries_test.go
@@ -18,7 +18,6 @@ package endtoend
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -1784,9 +1783,6 @@ func TestQueries(t *testing.T) {
 			},
 		},
 	}
-
-	// Wait for the vtgate caches to flush
-	time.Sleep(1 * time.Second)
 
 	for _, tcase := range testCases {
 		if err := tcase.Test("", client); err != nil {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -301,6 +301,9 @@ func TestQueryExecutorPlans(t *testing.T) {
 			assert.Equal(t, tcase.planWant, qre.logStats.PlanType, tcase.input)
 			assert.Equal(t, tcase.logWant, qre.logStats.RewrittenSQL(), tcase.input)
 
+			// Wait for the existing query to be processed by the cache
+			tsv.QueryPlanCacheWait()
+
 			// Test inside a transaction.
 			target := tsv.sm.Target()
 			txid, alias, err := tsv.Begin(ctx, &target, nil)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1742,6 +1742,11 @@ func (tsv *TabletServer) QueryPlanCacheLen() int {
 	return tsv.qe.QueryPlanCacheLen()
 }
 
+// QueryPlanCacheWait waits until the query plan cache has processed all recent queries
+func (tsv *TabletServer) QueryPlanCacheWait() {
+	tsv.qe.plans.Wait()
+}
+
 // SetMaxResultSize changes the max result size to the specified value.
 func (tsv *TabletServer) SetMaxResultSize(val int) {
 	tsv.qe.maxResultSize.Set(int64(val))


### PR DESCRIPTION
## Description

`TestQueryExecutorPlans` and `TestQueries` have been intermittently flaky since I introduced the new cache implementation. MY BAD. It's not clear from reading the code, but these tests are run sequentially and expect the results of the previous execution to be in cache, so we need to ensure that the cache has settled before we attempt the next test.

Took me a while to figure out!

## Related Issue(s)

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
