### PR TITLE
[9.0] Reset Session for Reserved Connection when the connection id is not found

### DIFF
--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -266,7 +266,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	return qr, allErrors.GetErrors()
 }
 
-var errRegx = regexp.MustCompile("transaction ([a-z0-9:]+) ended")
+var errRegx = regexp.MustCompile("transaction ([a-z0-9:]+) (?:ended|not found)")
 
 func checkAndResetShardSession(info *shardActionInfo, err error, session *SafeSession) bool {
 	if info.reservedID != 0 && info.transactionID == 0 && wasConnectionClosed(err) {

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -295,12 +295,64 @@ func TestReservedConnFail(t *testing.T) {
 
 	session := NewSafeSession(&vtgatepb.Session{InTransaction: false, InReservedConn: true})
 	destinations := []key.Destination{key.DestinationShard("0")}
+
 	executeOnShards(t, res, keyspace, sc, session, destinations)
 	assert.Equal(t, 1, len(session.ShardSessions))
 	oldRId := session.Session.ShardSessions[0].ReservedId
+
 	sbc0.EphemeralShardErr = mysql.NewSQLError(mysql.CRServerGone, mysql.SSUnknownSQLState, "lost connection")
 	_ = executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations)
 	assert.Equal(t, 3, len(sbc0.Queries), "1 for the successful run, one for the failed attempt, and one for the retry")
 	require.Equal(t, 1, len(session.ShardSessions))
 	assert.NotEqual(t, oldRId, session.Session.ShardSessions[0].ReservedId, "should have recreated a reserved connection since the last connection was lost")
+	oldRId = session.Session.ShardSessions[0].ReservedId
+
+	sbc0.Queries = nil
+	sbc0.EphemeralShardErr = mysql.NewSQLError(mysql.ERQueryInterrupted, mysql.SSUnknownSQLState, "transaction 123 not found")
+	_ = executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations)
+	assert.Equal(t, 2, len(sbc0.Queries), "one for the failed attempt, and one for the retry")
+	require.Equal(t, 1, len(session.ShardSessions))
+	assert.NotEqual(t, oldRId, session.Session.ShardSessions[0].ReservedId, "should have recreated a reserved connection since the last connection was lost")
+	oldRId = session.Session.ShardSessions[0].ReservedId
+
+	sbc0.Queries = nil
+	sbc0.EphemeralShardErr = mysql.NewSQLError(mysql.ERQueryInterrupted, mysql.SSUnknownSQLState, "transaction 123 ended at 2020-01-20")
+	_ = executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations)
+	assert.Equal(t, 2, len(sbc0.Queries), "one for the failed attempt, and one for the retry")
+	require.Equal(t, 1, len(session.ShardSessions))
+	assert.NotEqual(t, oldRId, session.Session.ShardSessions[0].ReservedId, "should have recreated a reserved connection since the last connection was lost")
+}
+
+func TestIsConnClosed(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		err       error
+		conClosed bool
+	}{{
+		"server gone",
+		mysql.NewSQLError(mysql.CRServerGone, mysql.SSServerShutdown, ""),
+		true,
+	}, {
+		"connection lost",
+		mysql.NewSQLError(mysql.CRServerLost, mysql.SSServerShutdown, ""),
+		true,
+	}, {
+		"tx ended",
+		mysql.NewSQLError(mysql.ERQueryInterrupted, mysql.SSUnknownSQLState, "transaction 111 ended at ..."),
+		true,
+	}, {
+		"tx not found",
+		mysql.NewSQLError(mysql.ERQueryInterrupted, mysql.SSUnknownSQLState, "transaction 111 not found ..."),
+		true,
+	}, {
+		"tx not found missing tx id",
+		mysql.NewSQLError(mysql.ERQueryInterrupted, mysql.SSUnknownSQLState, "transaction not found"),
+		false,
+	}}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			assert.Equal(t, tCase.conClosed, wasConnectionClosed(tCase.err))
+		})
+	}
 }


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Backport of #7539 

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
