### PR TITLE
Add mysqlctl docker image

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -42,6 +42,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Copy binaries
 COPY --from=base /vt/bin/mysqlctld /vt/bin/
+COPY --from=base /vt/bin/mysqlctl /vt/bin/
 COPY --from=base /vt/bin/vtctld /vt/bin/
 COPY --from=base /vt/bin/vtctl /vt/bin/
 COPY --from=base /vt/bin/vtctlclient /vt/bin/

--- a/docker/k8s/mysqlctl/Dockerfile
+++ b/docker/k8s/mysqlctl/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG VT_BASE_VER=latest
+
+FROM vitess/k8s:${VT_BASE_VER} AS k8s
+
+FROM debian:buster-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vtdataroot
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin && \
+   mkdir -p /vt/config && mkdir -p /vtdataroot
+
+# Copy binaries
+COPY --from=k8s /vt/bin/mysqlctl /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# copy vitess config
+COPY --from=k8s /vt/config /vt/config
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -27,6 +27,11 @@ docker tag vitess/mysqlctld:$vt_base_version-buster vitess/mysqlctld:$vt_base_ve
 docker push vitess/mysqlctld:$vt_base_version-buster
 docker push vitess/mysqlctld:$vt_base_version
 
+docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/mysqlctl:$vt_base_version-buster mysqlctl
+docker tag vitess/mysqlctl:$vt_base_version-buster vitess/mysqlctl:$vt_base_version
+docker push vitess/mysqlctl:$vt_base_version-buster
+docker push vitess/mysqlctl:$vt_base_version
+
 docker build --build-arg VT_BASE_VER=$vt_base_version -t vitess/vtctl:$vt_base_version-buster vtctl
 docker tag vitess/vtctl:$vt_base_version-buster vitess/vtctl:$vt_base_version
 docker push vitess/vtctl:$vt_base_version-buster


### PR DESCRIPTION
## Description
The Vitess Connector is using the `vitess/base` docker image as the base image to copy useful binaries, such as `mysqlctl`, `vtctl`, etc. The `vitess/base` docker image is huge (6.56GB). In order to avoid downloading this huge image, this PR creates the `mysqlctl` docker image, so that users can copy `mysqlctl` from this much smaller docker image.

The new docker image `vitess/mysqlctl` should be pushed to DockerHub.

Related Slack discussion: https://vitess.slack.com/archives/C0PQY0PTK/p1612339740175400

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
