### PR TITLE
Restore CI workflow shard 26, accidentally dropped

### DIFF
--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -32,7 +32,7 @@ const (
 	unitTestDatabases = "percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103"
 
 	clusterTestTemplate = "templates/cluster_endtoend_test.tpl"
-	clusterList         = "11,12,13,14,15,16,17,18,19,20,21,22,23,24,27,vreplication_basic,vreplication_multicell,vreplication_cellalias,vreplication_v2,onlineddl_ghost,onlineddl_vrepl,onlineddl_vrepl_stress"
+	clusterList         = "11,12,13,14,15,16,17,18,19,20,21,22,23,24,26,27,vreplication_basic,vreplication_multicell,vreplication_cellalias,vreplication_v2,onlineddl_ghost,onlineddl_vrepl,onlineddl_vrepl_stress"
 	// TODO: currently some percona tools including xtrabackup are installed on all clusters, we can possibly optimize
 	// this by only installing them in the required clusters
 	clustersRequiringXtraBackup = clusterList


### PR DESCRIPTION
In https://github.com/vitessio/vitess/pull/7419 I accidentally dropped shard `26` from workflow generator. This PR restores it.

I dropped it because I extracted `onlineddl_ghost` test out of `26` and into its own shard. But I missed the fact there was another test, `vitess.io/vitess/go/test/endtoend/recovery/pitrtls`, still using `26`.

Nothing is terribly broken right now: `26` stills runs in CI. It will take someone to re-run `make generate_ci_workflows` to actually remove it. This hasn't happened yet.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
