### PR TITLE
Corrects the comment handling in vitess

### DIFF
--- a/go/vt/sqlparser/parse_next_test.go
+++ b/go/vt/sqlparser/parse_next_test.go
@@ -32,7 +32,7 @@ func TestParseNextValid(t *testing.T) {
 		sql.WriteRune(';')
 	}
 
-	tokens := NewTokenizer(&sql)
+	tokens := NewStringTokenizer(sql.String())
 	for i, tcase := range validSQL {
 		input := tcase.input + ";"
 		want := tcase.output

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -77,7 +77,7 @@ var (
 		input:  "select 1 from t # aa\n",
 		output: "select 1 from t",
 	}, {
-		input:  "select 1 --aa\nfrom t",
+		input:  "select 1 -- aa\nfrom t",
 		output: "select 1 from t",
 	}, {
 		input:  "select 1 #aa\nfrom t",
@@ -840,6 +840,9 @@ var (
 	}, {
 		input:  "set character set 'utf8'",
 		output: "set charset 'utf8'",
+	}, {
+		input:  "set s = 1--4",
+		output: "set s = 1 - -4",
 	}, {
 		input:  "set character set \"utf8\"",
 		output: "set charset 'utf8'",

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -19,7 +19,6 @@ package sqlparser
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"strings"
 
 	"vitess.io/vitess/go/bytes2"
@@ -27,14 +26,12 @@ import (
 )
 
 const (
-	defaultBufSize = 4096
-	eofChar        = 0x100
+	eofChar = 0x100
 )
 
 // Tokenizer is the struct used to generate SQL
 // tokens for the parser.
 type Tokenizer struct {
-	InStream            io.Reader
 	AllowComments       bool
 	SkipSpecialComments bool
 	SkipToEnd           bool
@@ -61,15 +58,6 @@ func NewStringTokenizer(sql string) *Tokenizer {
 	return &Tokenizer{
 		buf:     buf,
 		bufSize: len(buf),
-	}
-}
-
-// NewTokenizer creates a new Tokenizer reading a sql
-// string from the io.Reader.
-func NewTokenizer(r io.Reader) *Tokenizer {
-	return &Tokenizer{
-		InStream: r,
-		buf:      make([]byte, defaultBufSize),
 	}
 }
 
@@ -691,8 +679,11 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 		case '-':
 			switch tkn.lastChar {
 			case '-':
-				tkn.next()
-				return tkn.scanCommentType1("--")
+				nextChar := tkn.peek(0)
+				if nextChar == ' ' || nextChar == '\n' || nextChar == '\t' || nextChar == '\r' || nextChar == eofChar {
+					tkn.next()
+					return tkn.scanCommentType1("--")
+				}
 			case '>':
 				tkn.next()
 				if tkn.lastChar == '>' {
@@ -1052,15 +1043,6 @@ func (tkn *Tokenizer) consumeNext(buffer *bytes2.Buffer) {
 }
 
 func (tkn *Tokenizer) next() {
-	if tkn.bufPos >= tkn.bufSize && tkn.InStream != nil {
-		// Try and refill the buffer
-		var err error
-		tkn.bufPos = 0
-		if tkn.bufSize, err = tkn.InStream.Read(tkn.buf); err != io.EOF && err != nil {
-			tkn.LastError = err
-		}
-	}
-
 	if tkn.bufPos >= tkn.bufSize {
 		if tkn.lastChar != eofChar {
 			tkn.Position++
@@ -1071,6 +1053,13 @@ func (tkn *Tokenizer) next() {
 		tkn.lastChar = uint16(tkn.buf[tkn.bufPos])
 		tkn.bufPos++
 	}
+}
+
+func (tkn *Tokenizer) peek(dist int) uint16 {
+	if tkn.bufPos+dist >= tkn.bufSize {
+		return eofChar
+	}
+	return uint16(tkn.buf[tkn.bufPos+dist])
 }
 
 // reset clears any internal state.


### PR DESCRIPTION
## Description
Vitess treats everything after `-- ` as a comment just like MySQL. This means that the query `SET @S = 1--4` is valid on both MySQL and Vitess. Refer to https://dev.mysql.com/doc/refman/8.0/en/ansi-diff-comments.html for MySQL documentation regarding the same

## Related Issue(s)
<!-- List related issues and pull requests: -->

-  Fixes #7580 

## Checklist
- [ ] Should this PR be backported? No
- [X] Tests were added or are not required Yes
- [X] Documentation was added or is not required Documentation not required.

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
