### PR TITLE
Optimise AST rewriting

### DIFF
--- a/go/tools/asthelpergen/integration/rewriter.go
+++ b/go/tools/asthelpergen/integration/rewriter.go
@@ -34,16 +34,20 @@ func (a *application) apply(parent, node AST, replacer replacerFunc) {
 	case InterfaceContainer:
 	case InterfaceSlice:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(InterfaceSlice)[x] = newNode.(AST)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(InterfaceSlice)[idx] = newNode.(AST)
+				}
+			}(x))
 		}
 	case *Leaf:
 	case LeafSlice:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(LeafSlice)[x] = newNode.(*Leaf)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(LeafSlice)[idx] = newNode.(*Leaf)
+				}
+			}(x))
 		}
 	case *NoCloneType:
 	case *RefContainer:
@@ -55,14 +59,18 @@ func (a *application) apply(parent, node AST, replacer replacerFunc) {
 		})
 	case *RefSliceContainer:
 		for x, el := range n.ASTElements {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(*RefSliceContainer).ASTElements[x] = newNode.(AST)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(*RefSliceContainer).ASTElements[idx] = newNode.(AST)
+				}
+			}(x))
 		}
 		for x, el := range n.ASTImplementationElements {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(*RefSliceContainer).ASTImplementationElements[x] = newNode.(*Leaf)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(*RefSliceContainer).ASTImplementationElements[idx] = newNode.(*Leaf)
+				}
+			}(x))
 		}
 	case *SubImpl:
 		a.apply(node, n.inner, func(newNode, parent AST) {
@@ -73,14 +81,18 @@ func (a *application) apply(parent, node AST, replacer replacerFunc) {
 		a.apply(node, n.ASTImplementationType, replacePanic("ValueContainer ASTImplementationType"))
 	case ValueSliceContainer:
 		for x, el := range n.ASTElements {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(ValueSliceContainer).ASTElements[x] = newNode.(AST)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(ValueSliceContainer).ASTElements[idx] = newNode.(AST)
+				}
+			}(x))
 		}
 		for x, el := range n.ASTImplementationElements {
-			a.apply(node, el, func(newNode, container AST) {
-				container.(ValueSliceContainer).ASTImplementationElements[x] = newNode.(*Leaf)
-			})
+			a.apply(node, el, func(idx int) func(AST, AST) {
+				return func(newNode, container AST) {
+					container.(ValueSliceContainer).ASTImplementationElements[idx] = newNode.(*Leaf)
+				}
+			}(x))
 		}
 	}
 	if a.post != nil && !a.post(&a.cursor) {

--- a/go/tools/asthelpergen/rewriter_gen.go
+++ b/go/tools/asthelpergen/rewriter_gen.go
@@ -133,13 +133,14 @@ func (r *rewriterGen) createReplacementMethod(container, elem types.Type, x jen.
 			return func(newnode, container AST) {
 				container.(InterfaceSlice)[idx] = newnode.(AST)
 			}
-		}
-
+		}(x)
 	*/
-	return jen.Func().Params(jen.List(jen.Id("newNode"), jen.Id("container")).Id(r.ifaceName)).Block(
-		jen.Id("container").Assert(jen.Id(types.TypeString(container, noQualifier))).Add(x).Index(jen.Id("x")).Op("=").
-			Id("newNode").Assert(jen.Id(types.TypeString(elem, noQualifier))),
-	)
+	return jen.Func().Params(jen.Id("idx").Int()).Func().Params(jen.List(jen.Id(r.ifaceName), jen.Id(r.ifaceName))).Block(
+		jen.Return(jen.Func().Params(jen.List(jen.Id("newNode"), jen.Id("container")).Id(r.ifaceName))).Block(
+			jen.Id("container").Assert(jen.Id(types.TypeString(container, noQualifier))).Add(x).Index(jen.Id("idx")).Op("=").
+				Id("newNode").Assert(jen.Id(types.TypeString(elem, noQualifier))),
+		),
+	).Call(jen.Id("x"))
 }
 
 func (r *rewriterGen) createFile(pkgName string) (string, *jen.File) {

--- a/go/vt/sqlparser/rewriter.go
+++ b/go/vt/sqlparser/rewriter.go
@@ -32,9 +32,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 	switch n := node.(type) {
 	case *AddColumns:
 		for x, el := range n.Columns {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*AddColumns).Columns[x] = newNode.(*ColumnDefinition)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*AddColumns).Columns[idx] = newNode.(*ColumnDefinition)
+				}
+			}(x))
 		}
 		a.apply(node, n.First, func(newNode, parent SQLNode) {
 			parent.(*AddColumns).First = newNode.(*ColName)
@@ -84,9 +86,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*AlterTable).Table = newNode.(TableName)
 		})
 		for x, el := range n.AlterOptions {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*AlterTable).AlterOptions[x] = newNode.(AlterOption)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*AlterTable).AlterOptions[idx] = newNode.(AlterOption)
+				}
+			}(x))
 		}
 		a.apply(node, n.PartitionSpec, func(newNode, parent SQLNode) {
 			parent.(*AlterTable).PartitionSpec = newNode.(*PartitionSpec)
@@ -109,9 +113,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*AlterVschema).VindexSpec = newNode.(*VindexSpec)
 		})
 		for x, el := range n.VindexCols {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*AlterVschema).VindexCols[x] = newNode.(ColIdent)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*AlterVschema).VindexCols[idx] = newNode.(ColIdent)
+				}
+			}(x))
 		}
 		a.apply(node, n.AutoIncSpec, func(newNode, parent SQLNode) {
 			parent.(*AlterVschema).AutoIncSpec = newNode.(*AutoIncSpec)
@@ -151,9 +157,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*CaseExpr).Expr = newNode.(Expr)
 		})
 		for x, el := range n.Whens {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*CaseExpr).Whens[x] = newNode.(*When)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*CaseExpr).Whens[idx] = newNode.(*When)
+				}
+			}(x))
 		}
 		a.apply(node, n.Else, func(newNode, parent SQLNode) {
 			parent.(*CaseExpr).Else = newNode.(Expr)
@@ -200,9 +208,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case Columns:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(Columns)[x] = newNode.(ColIdent)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(Columns)[idx] = newNode.(ColIdent)
+				}
+			}(x))
 		}
 	case Comments:
 	case *Commit:
@@ -321,9 +331,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case Exprs:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(Exprs)[x] = newNode.(Expr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(Exprs)[idx] = newNode.(Expr)
+				}
+			}(x))
 		}
 	case *Flush:
 		a.apply(node, n.TableNames, func(newNode, parent SQLNode) {
@@ -358,9 +370,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case GroupBy:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(GroupBy)[x] = newNode.(Expr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(GroupBy)[idx] = newNode.(Expr)
+				}
+			}(x))
 		}
 	case *GroupConcatExpr:
 		a.apply(node, n.Exprs, func(newNode, parent SQLNode) {
@@ -378,9 +392,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case *IndexHints:
 		for x, el := range n.Indexes {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*IndexHints).Indexes[x] = newNode.(ColIdent)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*IndexHints).Indexes[idx] = newNode.(ColIdent)
+				}
+			}(x))
 		}
 	case *IndexInfo:
 		a.apply(node, n.Name, func(newNode, parent SQLNode) {
@@ -470,9 +486,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 	case *NullVal:
 	case OnDup:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(OnDup)[x] = newNode.(*UpdateExpr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(OnDup)[idx] = newNode.(*UpdateExpr)
+				}
+			}(x))
 		}
 	case *OptLike:
 		a.apply(node, n.LikeTable, func(newNode, parent SQLNode) {
@@ -491,9 +509,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case OrderBy:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(OrderBy)[x] = newNode.(*Order)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(OrderBy)[idx] = newNode.(*Order)
+				}
+			}(x))
 		}
 	case *OrderByOption:
 		a.apply(node, n.Cols, func(newNode, parent SQLNode) {
@@ -527,15 +547,19 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*PartitionSpec).TableName = newNode.(TableName)
 		})
 		for x, el := range n.Definitions {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*PartitionSpec).Definitions[x] = newNode.(*PartitionDefinition)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*PartitionSpec).Definitions[idx] = newNode.(*PartitionDefinition)
+				}
+			}(x))
 		}
 	case Partitions:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(Partitions)[x] = newNode.(ColIdent)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(Partitions)[idx] = newNode.(ColIdent)
+				}
+			}(x))
 		}
 	case *RangeCond:
 		a.apply(node, n.Left, func(newNode, parent SQLNode) {
@@ -596,9 +620,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case SelectExprs:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(SelectExprs)[x] = newNode.(SelectExpr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(SelectExprs)[idx] = newNode.(SelectExpr)
+				}
+			}(x))
 		}
 	case *SelectInto:
 	case *Set:
@@ -617,9 +643,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case SetExprs:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(SetExprs)[x] = newNode.(*SetExpr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(SetExprs)[idx] = newNode.(*SetExpr)
+				}
+			}(x))
 		}
 	case *SetTransaction:
 		a.apply(node, n.SQLNode, func(newNode, parent SQLNode) {
@@ -629,9 +657,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*SetTransaction).Comments = newNode.(Comments)
 		})
 		for x, el := range n.Characteristics {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*SetTransaction).Characteristics[x] = newNode.(Characteristic)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*SetTransaction).Characteristics[idx] = newNode.(Characteristic)
+				}
+			}(x))
 		}
 	case *Show:
 		a.apply(node, n.Internal, func(newNode, parent SQLNode) {
@@ -695,9 +725,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case TableExprs:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(TableExprs)[x] = newNode.(TableExpr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(TableExprs)[idx] = newNode.(TableExpr)
+				}
+			}(x))
 		}
 	case TableIdent:
 	case TableName:
@@ -705,26 +737,34 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		a.apply(node, n.Qualifier, replacePanic("TableName Qualifier"))
 	case TableNames:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(TableNames)[x] = newNode.(TableName)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(TableNames)[idx] = newNode.(TableName)
+				}
+			}(x))
 		}
 	case TableOptions:
 	case *TableSpec:
 		for x, el := range n.Columns {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*TableSpec).Columns[x] = newNode.(*ColumnDefinition)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*TableSpec).Columns[idx] = newNode.(*ColumnDefinition)
+				}
+			}(x))
 		}
 		for x, el := range n.Indexes {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*TableSpec).Indexes[x] = newNode.(*IndexDefinition)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*TableSpec).Indexes[idx] = newNode.(*IndexDefinition)
+				}
+			}(x))
 		}
 		for x, el := range n.Constraints {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*TableSpec).Constraints[x] = newNode.(*ConstraintDefinition)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*TableSpec).Constraints[idx] = newNode.(*ConstraintDefinition)
+				}
+			}(x))
 		}
 		a.apply(node, n.Options, func(newNode, parent SQLNode) {
 			parent.(*TableSpec).Options = newNode.(TableOptions)
@@ -750,9 +790,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*Union).FirstStatement = newNode.(SelectStatement)
 		})
 		for x, el := range n.UnionSelects {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*Union).UnionSelects[x] = newNode.(*UnionSelect)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*Union).UnionSelects[idx] = newNode.(*UnionSelect)
+				}
+			}(x))
 		}
 		a.apply(node, n.OrderBy, func(newNode, parent SQLNode) {
 			parent.(*Union).OrderBy = newNode.(OrderBy)
@@ -793,9 +835,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case UpdateExprs:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(UpdateExprs)[x] = newNode.(*UpdateExpr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(UpdateExprs)[idx] = newNode.(*UpdateExpr)
+				}
+			}(x))
 		}
 	case *Use:
 		a.apply(node, n.DBName, func(newNode, parent SQLNode) {
@@ -819,16 +863,20 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 		})
 	case ValTuple:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(ValTuple)[x] = newNode.(Expr)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(ValTuple)[idx] = newNode.(Expr)
+				}
+			}(x))
 		}
 	case *Validation:
 	case Values:
 		for x, el := range n {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(Values)[x] = newNode.(ValTuple)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(Values)[idx] = newNode.(ValTuple)
+				}
+			}(x))
 		}
 	case *ValuesFuncExpr:
 		a.apply(node, n.Name, func(newNode, parent SQLNode) {
@@ -844,9 +892,11 @@ func (a *application) apply(parent, node SQLNode, replacer replacerFunc) {
 			parent.(*VindexSpec).Type = newNode.(ColIdent)
 		})
 		for x, el := range n.Params {
-			a.apply(node, el, func(newNode, container SQLNode) {
-				container.(*VindexSpec).Params[x] = newNode.(VindexParam)
-			})
+			a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
+				return func(newNode, container SQLNode) {
+					container.(*VindexSpec).Params[idx] = newNode.(VindexParam)
+				}
+			}(x))
 		}
 	case *When:
 		a.apply(node, n.Cond, func(newNode, parent SQLNode) {


### PR DESCRIPTION
When visiting slice elements, we were creating a closure over the index variable, like so:

```go
case *IndexHints:
	for x, el := range n.Indexes {
		a.apply(node, el, func(newNode, container SQLNode) {
			container.(*IndexHints).Indexes[x] = newNode.(ColIdent) // x is closed over
		})
	}
```

this PR changes these code snippets to be explicit about the parameter, like this:

```go
case *IndexHints:
	for x, el := range n.Indexes {
		a.apply(node, el, func(idx int) func(SQLNode, SQLNode) {
			return func(newNode, container SQLNode) {
				container.(*IndexHints).Indexes[idx] = newNode.(ColIdent)
			}
		}(x))
```

Even though the latter looks a little worse, what with the creation of a function for each element, the benchmarks show a small but significant improvement:

```
name                     old time/op  new time/op  delta
Normalize-16             4.64µs ± 1%  4.52µs ± 1%  -2.59%  (p=0.000 n=9+10)
VisitLargeExpression-16  15.7µs ± 1%  14.7µs ± 3%  -6.14%  (p=0.000 n=10+10)
```