### PR TITLE
Allow Select with lock to pass through in vttablet

### DIFF
--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -18,7 +18,6 @@ package endtoend
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -230,10 +229,7 @@ func TestForUpdate(t *testing.T) {
 		client := framework.NewClient()
 		query := fmt.Sprintf("select * from vitess_test where intval=2 %s", mode)
 		_, err := client.Execute(query, nil)
-		want := "SelectLock disallowed outside transaction"
-		if err == nil || !strings.HasPrefix(err.Error(), want) {
-			t.Errorf("%v, must have prefix %s", err, want)
-		}
+		require.NoError(t, err)
 
 		// We should not get errors here
 		err = client.Begin(false)

--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -33,9 +33,6 @@ func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table) (plan
 		FieldQuery: GenerateFieldQuery(sel),
 		FullQuery:  GenerateLimitQuery(sel),
 	}
-	if sel.Lock != sqlparser.NoLock {
-		plan.PlanID = PlanSelectLock
-	}
 
 	if sel.Where != nil {
 		comp, ok := sel.Where.Expr.(*sqlparser.ComparisonExpr)

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -43,7 +43,6 @@ type PlanType int
 // The following are PlanType values.
 const (
 	PlanSelect PlanType = iota
-	PlanSelectLock
 	PlanNextval
 	PlanSelectImpossible
 	PlanInsert
@@ -78,7 +77,6 @@ const (
 // Must exactly match order of plan constants.
 var planName = []string{
 	"Select",
-	"SelectLock",
 	"Nextval",
 	"SelectImpossible",
 	"Insert",
@@ -123,7 +121,7 @@ func PlanByName(s string) (pt PlanType, ok bool) {
 
 // IsSelect returns true if PlanType is about a select query.
 func (pt PlanType) IsSelect() bool {
-	return pt == PlanSelect || pt == PlanSelectLock || pt == PlanSelectImpossible
+	return pt == PlanSelect || pt == PlanSelectImpossible
 }
 
 // MarshalJSON returns a json string for PlanType.

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -197,7 +197,7 @@
 # for update
 "select eid from a for update"
 {
-  "PlanID": "SelectLock",
+  "PlanID": "Select",
   "TableName": "a",
   "Permissions": [
     {
@@ -212,7 +212,7 @@
 # lock in share mode
 "select eid from a lock in share mode"
 {
-  "PlanID": "SelectLock",
+  "PlanID": "Select",
   "TableName": "a",
   "Permissions": [
     {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -135,8 +135,6 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 			return nil, err
 		}
 		return qr, nil
-	case p.PlanSelectLock:
-		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "%s disallowed outside transaction", qre.plan.PlanID.String())
 	case p.PlanOtherRead, p.PlanOtherAdmin, p.PlanFlush:
 		return qre.execOther()
 	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
@@ -208,7 +206,7 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 		return qre.execStatefulConn(conn, qre.query, true)
 	case p.PlanSavepoint, p.PlanRelease, p.PlanSRollback:
 		return qre.execStatefulConn(conn, qre.query, true)
-	case p.PlanSelect, p.PlanSelectLock, p.PlanSelectImpossible, p.PlanShow:
+	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow:
 		maxrows := qre.getSelectLimit()
 		qre.bindVars["#maxLimit"] = sqltypes.Int64BindVariable(maxrows + 1)
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -527,12 +527,9 @@ func TestQueryExecutorPlanPassSelectWithLockOutsideATransaction(t *testing.T) {
 	tsv := newTestTabletServer(ctx, noFlags, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
-	assert.Equal(t, planbuilder.PlanSelectLock, qre.plan.PlanID)
+	assert.Equal(t, planbuilder.PlanSelect, qre.plan.PlanID)
 	_, err := qre.Execute()
-	if code := vterrors.Code(err); code != vtrpcpb.Code_FAILED_PRECONDITION {
-		assert.NoError(t, err)
-		t.Fatalf("qre.Execute: %v, want %v", code, vtrpcpb.Code_FAILED_PRECONDITION)
-	}
+	assert.NoError(t, err)
 }
 
 func TestQueryExecutorPlanNextval(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/rules/rules_test.go
+++ b/go/vt/vttablet/tabletserver/rules/rules_test.go
@@ -112,7 +112,7 @@ func TestFilterByPlan(t *testing.T) {
 
 	qr2 := NewQueryRule("rule 2", "r2", QRFail)
 	qr2.AddPlanCond(planbuilder.PlanSelect)
-	qr2.AddPlanCond(planbuilder.PlanSelectLock)
+	qr2.AddPlanCond(planbuilder.PlanSelect)
 	qr2.AddBindVarCond("a", true, false, QRNoOp, nil)
 
 	qr3 := NewQueryRule("rule 3", "r3", QRFail)
@@ -179,7 +179,7 @@ func TestFilterByPlan(t *testing.T) {
 		t.Errorf("qrs1:\n%s, want\n%s", got, want)
 	}
 
-	qrs1 = qrs.FilterByPlan("insert", planbuilder.PlanSelectLock, "a")
+	qrs1 = qrs.FilterByPlan("insert", planbuilder.PlanSelect, "a")
 	got = marshalled(qrs1)
 	if got != want {
 		t.Errorf("qrs1:\n%s, want\n%s", got, want)


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Currently, we do not allow select query with a lock to be executed on mysql outside of a transaction. In MySQL, this is a lock no-op.
Therefore this change is to no handle this case and treat it like a select query and allow it to be executed outside of transaction. For Vitess also it will be a lock no-op.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes https://github.com/vitessio/vitess/issues/7571

## Checklist
- [ ] Should this PR be backported? NO
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
