### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@ bootstrap.sh @deepthi
 /examples/local @rohit-nayak-ps
 /examples/operator @askdba
 /examples/region_sharding @deepthi
+/java/ @harshit-gangal
 /go/cache @vmg
 /go/cmd/vtadmin @ajm188 @doeg
 /go/cmd/vtctldclient @ajm188 @doeg
@@ -22,7 +23,8 @@ bootstrap.sh @deepthi
 /go/vt/schema @shlomi-noach
 /go/vt/servenv @deepthi
 /go/vt/sqlparser @harshit-gangal @systay @GuptaManan100
-/go/vt/topo @deepthi
+/go/vt/srvtopo @rafael
+/go/vt/topo @deepthi @rafael
 /go/vt/vtadmin @ajm188 @doeg @rohit-nayak-ps
 /go/vt/vtctl @deepthi
 /go/vt/vtctl/vtctl.go @ajm188 @doeg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
-* @sougou
-
+bootstrap.sh @deepthi
 /config/mycnf/ @askdba @shlomi-noach
 /docker/ @derekperkins @dkhenry
 /examples/compose @shlomi-noach
+/examples/demo @sougou
+/examples/legacy_local @deepthi
 /examples/local @rohit-nayak-ps
+/examples/operator @askdba
+/examples/region_sharding @deepthi
 /go/cache @vmg
 /go/cmd/vtadmin @ajm188 @doeg
 /go/cmd/vtctldclient @ajm188 @doeg
@@ -17,19 +20,23 @@
 /go/vt/orchestrator @deepthi @shlomi-noach
 /go/vt/proto/vtadmin @ajm188 @doeg
 /go/vt/schema @shlomi-noach
+/go/vt/servenv @deepthi
 /go/vt/sqlparser @harshit-gangal @systay @GuptaManan100
-/go/vt/vtadmin @ajm188 @doeg
+/go/vt/topo @deepthi
+/go/vt/vtadmin @ajm188 @doeg @rohit-nayak-ps
 /go/vt/vtctl @deepthi
 /go/vt/vtctl/vtctl.go @ajm188 @doeg
 /go/vt/vtctl/grpcvtctldclient @ajm188 @doeg
 /go/vt/vtctl/grpcvtctldserver @ajm188 @doeg
 /go/vt/vtctl/vtctldclient @ajm188 @doeg
+/go/vt/vtctld @ajm188 @doeg @rohit-nayak-ps @deepthi
 /go/vt/vtgate @harshit-gangal @systay
 /go/vt/vttablet/tabletmanager @deepthi @shlomi-noach
 /go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps
 /go/vt/vttablet/tabletmanager/vstreamer @rohit-nayak-ps
 /go/vt/vttablet/tabletserver @harshit-gangal @systay @shlomi-noach
 /go/vt/wrangler @deepthi @rohit-nayak-ps
+/go/vt/workflow @rohit-nayak-ps
 /helm/ @derekperkins @dkhenry
 /proto/vtadmin.proto @ajm188 @doeg
 /proto/vtctldata.proto @ajm188 @doeg


### PR DESCRIPTION
Per request from @sougou I have removed the `*` line from CODEOWNERS and added a few more explicit rules.

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
