### PR TITLE
Add Show Status query to vtexplain and make asthelpergen/sizegen quiet

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -32,6 +32,8 @@ import (
 const (
 	// BaseShowPrimary is the base query for fetching primary key info.
 	BaseShowPrimary = "SELECT table_name, column_name FROM information_schema.key_column_usage WHERE table_schema=database() AND constraint_name='PRIMARY' ORDER BY table_name, ordinal_position"
+	// ShowRowsRead is the query used to find the number of rows read.
+	ShowRowsRead = "show status like 'Innodb_rows_read'"
 )
 
 // BaseShowTablesFields contains the fields returned by a BaseShowTables or a BaseShowTablesForTable command.

--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -241,7 +241,6 @@ func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 func GenerateASTHelpers(packagePatterns []string, rootIface, exceptCloneType string) (map[string]*jen.File, error) {
 	loaded, err := packages.Load(&packages.Config{
 		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports | packages.NeedModule,
-		Logf: log.Printf,
 	}, packagePatterns...)
 
 	if err != nil {

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -501,7 +501,6 @@ func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 func GenerateSizeHelpers(packagePatterns []string, typePatterns []string) (map[string]*jen.File, error) {
 	loaded, err := packages.Load(&packages.Config{
 		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports | packages.NeedModule,
-		Logf: log.Printf,
 	}, packagePatterns...)
 
 	if err != nil {

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -366,6 +366,13 @@ func initTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options) error {
 			}},
 			Rows: [][]sqltypes.Value{},
 		},
+		mysql.ShowRowsRead: sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields(
+				"Variable_name|value",
+				"varchar|uint64",
+			),
+			"Innodb_rows|0",
+		),
 	}
 
 	showTableRows := make([][]sqltypes.Value, 0, 4)

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -394,7 +394,7 @@ func (se *Engine) reload(ctx context.Context) error {
 }
 
 func (se *Engine) updateInnoDBRowsRead(ctx context.Context, conn *connpool.DBConn) error {
-	readRowsData, err := conn.Exec(ctx, "show status like 'Innodb_rows_read'", 10, false)
+	readRowsData, err := conn.Exec(ctx, mysql.ShowRowsRead, 10, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## Description
This PR add Show Status query to vtexplain so that it no longer throws warnings in the tests and makes asthelpergen, sizegen quite.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Fixes #7564 

## Checklist
- [ ] Should this PR be backported? No
- [ ] Tests were added or are not required Not Required
- [ ] Documentation was added or is not required Not Required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [X]  Build/CI
- [ ]  VTAdmin
