### PR TITLE
add combine TLS certs feature

### DIFF
--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -61,7 +61,8 @@ func TestValidCert(t *testing.T) {
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
-		path.Join(root, "ca-cert.pem"))
+		path.Join(root, "ca-cert.pem"),
+		"")
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
@@ -143,7 +144,8 @@ func TestNoCert(t *testing.T) {
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
-		path.Join(root, "ca-cert.pem"))
+		path.Join(root, "ca-cert.pem"),
+		"")
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -125,7 +125,8 @@ func TestSSLConnection(t *testing.T) {
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
-		path.Join(root, "ca-cert.pem"))
+		path.Join(root, "ca-cert.pem"),
+		"")
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -839,7 +839,8 @@ func TestTLSServer(t *testing.T) {
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
-		path.Join(root, "ca-cert.pem"))
+		path.Join(root, "ca-cert.pem"),
+		"")
 	require.NoError(t, err)
 	l.TLSConfig.Store(serverConfig)
 	go l.Accept()
@@ -927,7 +928,8 @@ func TestTLSRequired(t *testing.T) {
 	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
-		path.Join(root, "ca-cert.pem"))
+		path.Join(root, "ca-cert.pem"),
+		"")
 	require.NoError(t, err)
 	l.TLSConfig.Store(serverConfig)
 	l.RequireSecureTransport = true

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -64,6 +64,9 @@ var (
 	// GRPCCA is the CA to use if TLS is enabled
 	GRPCCA = flag.String("grpc_ca", "", "server CA to use for gRPC connections, requires TLS, and enforces client certificate check")
 
+	// GRPCServerCA if specified will combine server cert and server CA
+	GRPCServerCA = flag.String("grpc_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
+
 	// GRPCAuth which auth plugin to use (at the moment now only static is supported)
 	GRPCAuth = flag.String("grpc_auth_mode", "", "Which auth plugin implementation to use (eg: static)")
 
@@ -125,7 +128,7 @@ func createGRPCServer() {
 
 	var opts []grpc.ServerOption
 	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
-		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA)
+		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCServerCA)
 		if err != nil {
 			log.Exitf("Failed to log gRPC cert/key/ca: %v", err)
 		}

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -34,12 +34,20 @@ import (
 	"vitess.io/vitess/go/vt/vttls"
 )
 
-// TestClientServer generates:
+func TestClientServerWithoutCombineCerts(t *testing.T) {
+	testClientServer(t, false)
+}
+
+func TestClientServerWithCombineCerts(t *testing.T) {
+	testClientServer(t, true)
+}
+
+// testClientServer generates:
 // - a root CA
 // - a server intermediate CA, with a server.
 // - a client intermediate CA, with a client.
 // And then performs a few tests on them.
-func TestClientServer(t *testing.T) {
+func testClientServer(t *testing.T, combineCerts bool) {
 	// Our test root.
 	root, err := ioutil.TempDir("", "tlstest")
 	if err != nil {
@@ -48,11 +56,17 @@ func TestClientServer(t *testing.T) {
 	defer os.RemoveAll(root)
 
 	clientServerKeyPairs := CreateClientServerCertPairs(root)
+	serverCA := ""
+
+	if combineCerts {
+		serverCA = clientServerKeyPairs.ServerCA
+	}
 
 	serverConfig, err := vttls.ServerConfig(
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
-		clientServerKeyPairs.ClientCA)
+		clientServerKeyPairs.ClientCA,
+		serverCA)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
@@ -165,10 +179,19 @@ func TestClientServer(t *testing.T) {
 	}
 }
 
-func getServerConfig(keypairs ClientServerKeyPairs) (*tls.Config, error) {
+func getServerConfigWithoutCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Config, error) {
 	return vttls.ServerConfig(
-		keypairs.ClientCert,
-		keypairs.ClientKey,
+		keypairs.ServerCert,
+		keypairs.ServerKey,
+		keypairs.ClientCA,
+		"")
+}
+
+func getServerConfigWithCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Config, error) {
+	return vttls.ServerConfig(
+		keypairs.ServerCert,
+		keypairs.ServerKey,
+		keypairs.ClientCA,
 		keypairs.ServerCA)
 }
 
@@ -180,10 +203,18 @@ func getClientConfig(keypairs ClientServerKeyPairs) (*tls.Config, error) {
 		keypairs.ServerName)
 }
 
-func TestServerTLSConfigCaching(t *testing.T) {
+func testServerTLSConfigCaching(t *testing.T, getServerConfig func(ClientServerKeyPairs) (*tls.Config, error)) {
 	testConfigGeneration(t, "servertlstest", getServerConfig, func(config *tls.Config) *x509.CertPool {
 		return config.ClientCAs
 	})
+}
+
+func TestServerTLSConfigCachingWithoutCombinedCerts(t *testing.T) {
+	testServerTLSConfigCaching(t, getServerConfigWithoutCombinedCerts)
+}
+
+func TestServerTLSConfigCachingWithCombinedCerts(t *testing.T) {
+	testServerTLSConfigCaching(t, getServerConfigWithCombinedCerts)
 }
 
 func TestClientTLSConfigCaching(t *testing.T) {
@@ -237,4 +268,38 @@ func testConfigGeneration(t *testing.T, rootPrefix string, generateConfig func(C
 		}
 	}
 
+}
+
+func testNumberOfCertsWithOrWithoutCombining(t *testing.T, numCertsExpected int, combine bool) {
+	// Our test root.
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	clientServerKeyPairs := CreateClientServerCertPairs(root)
+	serverCA := ""
+	if combine {
+		serverCA = clientServerKeyPairs.ServerCA
+	}
+
+	serverConfig, err := vttls.ServerConfig(
+		clientServerKeyPairs.ServerCert,
+		clientServerKeyPairs.ServerKey,
+		clientServerKeyPairs.ClientCA,
+		serverCA)
+
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	assert.Equal(t, numCertsExpected, len(serverConfig.Certificates[0].Certificate))
+}
+
+func TestNumberOfCertsWithoutCombining(t *testing.T) {
+	testNumberOfCertsWithOrWithoutCombining(t, 1, false)
+}
+
+func TestNumberOfCertsWithCombining(t *testing.T) {
+	testNumberOfCertsWithOrWithoutCombining(t, 2, true)
 }

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -64,6 +64,8 @@ var (
 	mysqlSslKey  = flag.String("mysql_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
 	mysqlSslCa   = flag.String("mysql_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
 
+	mysqlSslServerCA = flag.String("mysql_server_ssl_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
+
 	mysqlSlowConnectWarnThreshold = flag.Duration("mysql_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
 
 	mysqlConnReadTimeout  = flag.Duration("mysql_server_read_timeout", 0, "connection read timeout")
@@ -360,8 +362,8 @@ var sigChan chan os.Signal
 var vtgateHandle *vtgateHandler
 
 // initTLSConfig inits tls config for the given mysql listener
-func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mysqlSslCa string, mysqlServerRequireSecureTransport bool) error {
-	serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa)
+func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA string, mysqlServerRequireSecureTransport bool) error {
+	serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA)
 	if err != nil {
 		log.Exitf("grpcutils.TLSServerConfig failed: %v", err)
 		return err
@@ -372,7 +374,7 @@ func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mys
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
 		for range sigChan {
-			serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa)
+			serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA)
 			if err != nil {
 				log.Errorf("grpcutils.TLSServerConfig failed: %v", err)
 			} else {
@@ -428,7 +430,7 @@ func initMySQLProtocol() {
 			mysqlListener.ServerVersion = *servenv.MySQLServerVersion
 		}
 		if *mysqlSslCert != "" && *mysqlSslKey != "" {
-			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlServerRequireSecureTransport)
+			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslServerCA, *mysqlServerRequireSecureTransport)
 		}
 		mysqlListener.AllowClearTextWithoutTLS.Set(*mysqlAllowClearTextWithoutTLS)
 		// Check for the connection threshold

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -248,7 +248,15 @@ func TestDefaultWorkloadOLAP(t *testing.T) {
 	}
 }
 
-func TestInitTLSConfig(t *testing.T) {
+func TestInitTLSConfigWithoutServerCA(t *testing.T) {
+	testInitTLSConfig(t, false)
+}
+
+func TestInitTLSConfigWithServerCA(t *testing.T) {
+	testInitTLSConfig(t, true)
+}
+
+func testInitTLSConfig(t *testing.T, serverCA bool) {
 	// Create the certs.
 	root, err := ioutil.TempDir("", "TestInitTLSConfig")
 	if err != nil {
@@ -258,8 +266,13 @@ func TestInitTLSConfig(t *testing.T) {
 	tlstest.CreateCA(root)
 	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
 
+	serverCACert := ""
+	if serverCA {
+		serverCACert = path.Join(root, "ca-cert.pem")
+	}
+
 	listener := &mysql.Listener{}
-	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), true); err != nil {
+	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), serverCACert, true); err != nil {
 		t.Fatalf("init tls config failure due to: +%v", err)
 	}
 


### PR DESCRIPTION
## Description
Certificate chain (or Chain of Trust) is made up of a list of certificates that start from a server's certificate and terminate with the root certificate. If your server's certificate is to be trusted, its signature has to be traceable back to its root CA. However in case of Vitess we cannot see the full list of certificates. The change is to pass the full list of certs.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/7608

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
Tested in my local env.

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
