### PR TITLE
CI: Use ubuntu-18.04 in tests

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (11)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (12)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (13)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (14)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (15)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (16)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (17)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (18)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (19)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (20)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (21)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (22)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (23)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (24)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (26)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_27.yml
+++ b/.github/workflows/cluster_endtoend_27.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (27)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Run endtoend tests on {{.Name}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go


### PR DESCRIPTION
## Description
Some of the CI tests fail on Ubuntu 20.04 which will soon be the default when you specify `ubuntu-latest` in a GitHub action workflow.
https://github.com/actions/virtual-environments/issues/1816

I have changed the workflow files for these tests to explicitly request `ubuntu-18.04`.
Once the failing tests are fixed to work on the `ubuntu-20.04` VM we can switch back to `ubuntu-latest`.
Note that because we use templates to generate workflow files uniformly, the set of changed files in this PR is larger than the set of documented test failures.

## Related Issue(s)
<!-- List related issues and pull requests: -->
#7612 #7613 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
