### PR TITLE
Fuzzing: Add more fuzzers

### DIFF
--- a/go/test/fuzzing/oss_fuzz_build.sh
+++ b/go/test/fuzzing/oss_fuzz_build.sh
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 compile_go_fuzzer ./go/test/fuzzing Fuzz vtctl_fuzzer
-compile_go_fuzzer ./go/vt/sqlparser Fuzz fuzz
+compile_go_fuzzer ./go/test/fuzzing FuzzIsDML is_dml_fuzzer
+compile_go_fuzzer ./go/test/fuzzing FuzzNormalizer normalizer_fuzzer
+compile_go_fuzzer ./go/test/fuzzing FuzzParser parser_fuzzer
 
 
 # Build dictionaries

--- a/go/test/fuzzing/parser_fuzzer.go
+++ b/go/test/fuzzing/parser_fuzzer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2021 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,11 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+// +build gofuzz
 
-package sqlparser
+package fuzzing
 
-func Fuzz(data []byte) int {
-	_, err := Parse(string(data))
+import (
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func FuzzIsDML(data []byte) int {
+	_ = sqlparser.IsDML(string(data))
+	return 1
+}
+
+func FuzzNormalizer(data []byte) int {
+	stmt, err := sqlparser.Parse(string(data))
+	if err != nil {
+		return -1
+	}
+	prefix := "bv"
+	bv := make(map[string]*querypb.BindVariable)
+	sqlparser.Normalize(stmt, bv, prefix)
+	return 1
+}
+
+func FuzzParser(data []byte) int {
+	_, err := sqlparser.Parse(string(data))
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This PR adds more fuzzers to Vitess. It also renames the existing sqlparser fuzzer and moves that fuzzer into `/go/test/fuzzing` 
Furthermore the oss-fuzz build script is updated to include the added fuzzers.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
