### PR TITLE
tests: disable flaky test until it can be fixed

### DIFF
--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -304,20 +304,25 @@ func TestGetSrvKeyspace(t *testing.T) {
 
 	// Force another error and lock the topo. Then wait for the TTL to
 	// expire and verify that the context timeout unblocks the request.
-	forceErr = fmt.Errorf("force long test error")
-	factory.SetError(forceErr)
-	factory.Lock()
 
-	time.Sleep(*srvTopoCacheTTL)
+	// TODO(deepthi): Commenting out this test until we fix https://github.com/vitessio/vitess/issues/6134
 
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2) //nolint
-	defer cancel()
-	_, err = rs.GetSrvKeyspace(timeoutCtx, "test_cell", "test_ks")
-	wantErr := "timed out waiting for keyspace"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("expected error '%v', got '%v'", wantErr, err)
-	}
-	factory.Unlock()
+	/*
+		forceErr = fmt.Errorf("force long test error")
+		factory.SetError(forceErr)
+		factory.Lock()
+
+		time.Sleep(*srvTopoCacheTTL)
+
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2) //nolint
+		defer cancel()
+		_, err = rs.GetSrvKeyspace(timeoutCtx, "test_cell", "test_ks")
+		wantErr := "timed out waiting for keyspace"
+		if err == nil || err.Error() != wantErr {
+			t.Errorf("expected error '%v', got '%v'", wantErr, err)
+		}
+		factory.Unlock()
+	*/
 }
 
 // TestSrvKeyspaceCachedError will test we properly re-try to query


### PR DESCRIPTION
## Description
This test is failing frequently in CI. We can revert this PR once the test is fixed.

## Related Issue(s)
#6134 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
