### PR TITLE
fix when execute insert on duplicate key, seems ok but acutally not e…

### DIFF
--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -489,6 +489,9 @@ func (ins *Insert) processPrimary(vcursor VCursor, vindexColumnsKeys [][]sqltype
 			if ins.Opcode != InsertShardedIgnore {
 				return nil, fmt.Errorf("could not map %v to a keyspace id", vindexColumnsKeys[i])
 			}
+			if ins.Opcode == InsertShardedIgnore && vindexColumnsKeys[i][0].Type() == querypb.Type_NULL_TYPE {
+				return nil, fmt.Errorf("could not map %v to a keyspace id", vindexColumnsKeys[i])
+			}
 		default:
 			return nil, fmt.Errorf("could not map %v to a unique keyspace id: %v", vindexColumnsKeys[i], destination)
 		}


### PR DESCRIPTION
fix  Bug : 
when execute query like " insert on duplicate key " , reports executed ok 
but acutally not sending query to backend mysql . 

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

#7627


## Checklist
- [ ] Should this PR be backported? 
 not sure
- [ ] Tests were added or are not required
 not required 
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
