### PR TITLE
[vtadmin] test refactors

### DIFF
--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -528,6 +528,8 @@ func TestFindSchema(t *testing.T) {
 }
 
 func TestGetClusters(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		clusters []*cluster.Cluster
@@ -566,7 +568,11 @@ func TestGetClusters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			api := NewAPI(tt.clusters, grpcserver.Options{}, http.Options{})
 			ctx := context.Background()
 
@@ -578,6 +584,8 @@ func TestGetClusters(t *testing.T) {
 }
 
 func TestGetGates(t *testing.T) {
+	t.Parallel()
+
 	fakedisco1 := fakediscovery.New()
 	cluster1 := &cluster.Cluster{
 		ID:        "c1",
@@ -663,6 +671,8 @@ func TestGetGates(t *testing.T) {
 }
 
 func TestGetKeyspaces(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name             string
 		clusterKeyspaces [][]*vtctldatapb.Keyspace
@@ -849,53 +859,59 @@ func TestGetKeyspaces(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		// Note that these test cases were written prior to the existence of
-		// WithTestServers, so they are all written with the assumption that
-		// there are exactly 2 clusters.
-		topos := []*topo.Server{
-			memorytopo.NewServer("c0_cell1"),
-			memorytopo.NewServer("c1_cell1"),
-		}
+		tt := tt
 
-		for cdx, cks := range tt.clusterKeyspaces {
-			for _, ks := range cks {
-				testutil.AddKeyspace(ctx, t, topos[cdx], ks)
-			}
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		for cdx, css := range tt.clusterShards {
-			testutil.AddShards(ctx, t, topos[cdx], css...)
-		}
-
-		servers := []vtctlservicepb.VtctldServer{
-			grpcvtctldserver.NewVtctldServer(topos[0]),
-			grpcvtctldserver.NewVtctldServer(topos[1]),
-		}
-
-		testutil.WithTestServers(t, func(t *testing.T, clients ...vtctldclient.VtctldClient) {
-			clusters := []*cluster.Cluster{
-				vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
-					Cluster: &vtadminpb.Cluster{
-						Id:   "c0",
-						Name: "cluster0",
-					},
-					VtctldClient: clients[0],
-				}),
-				vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
-					Cluster: &vtadminpb.Cluster{
-						Id:   "c1",
-						Name: "cluster1",
-					},
-					VtctldClient: clients[1],
-				}),
+			// Note that these test cases were written prior to the existence of
+			// WithTestServers, so they are all written with the assumption that
+			// there are exactly 2 clusters.
+			topos := []*topo.Server{
+				memorytopo.NewServer("c0_cell1"),
+				memorytopo.NewServer("c1_cell1"),
 			}
 
-			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
-			resp, err := api.GetKeyspaces(ctx, tt.req)
-			require.NoError(t, err)
+			for cdx, cks := range tt.clusterKeyspaces {
+				for _, ks := range cks {
+					testutil.AddKeyspace(ctx, t, topos[cdx], ks)
+				}
+			}
 
-			vtadmintestutil.AssertKeyspaceSlicesEqual(t, tt.expected.Keyspaces, resp.Keyspaces)
-		}, servers...)
+			for cdx, css := range tt.clusterShards {
+				testutil.AddShards(ctx, t, topos[cdx], css...)
+			}
+
+			servers := []vtctlservicepb.VtctldServer{
+				grpcvtctldserver.NewVtctldServer(topos[0]),
+				grpcvtctldserver.NewVtctldServer(topos[1]),
+			}
+
+			testutil.WithTestServers(t, func(t *testing.T, clients ...vtctldclient.VtctldClient) {
+				clusters := []*cluster.Cluster{
+					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+						Cluster: &vtadminpb.Cluster{
+							Id:   "c0",
+							Name: "cluster0",
+						},
+						VtctldClient: clients[0],
+					}),
+					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+						Cluster: &vtadminpb.Cluster{
+							Id:   "c1",
+							Name: "cluster1",
+						},
+						VtctldClient: clients[1],
+					}),
+				}
+
+				api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
+				resp, err := api.GetKeyspaces(ctx, tt.req)
+				require.NoError(t, err)
+
+				vtadmintestutil.AssertKeyspaceSlicesEqual(t, tt.expected.Keyspaces, resp.Keyspaces)
+			}, servers...)
+		})
 	}
 }
 
@@ -1635,6 +1651,8 @@ func TestGetSchemas(t *testing.T) {
 }
 
 func TestGetTablet(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		clusterTablets [][]*vtadminpb.Tablet
@@ -1850,7 +1868,11 @@ func TestGetTablet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			clusters := make([]*cluster.Cluster, len(tt.clusterTablets))
 
 			for i, tablets := range tt.clusterTablets {
@@ -1881,6 +1903,8 @@ func TestGetTablet(t *testing.T) {
 }
 
 func TestGetTablets(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		clusterTablets [][]*vtadminpb.Tablet
@@ -2037,7 +2061,11 @@ func TestGetTablets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			clusters := make([]*cluster.Cluster, len(tt.clusterTablets))
 
 			for i, tablets := range tt.clusterTablets {
@@ -2531,6 +2559,8 @@ func TestGetVSchemas(t *testing.T) {
 }
 
 func TestVTExplain(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		keyspaces     []*vtctldatapb.Keyspace
@@ -2748,8 +2778,14 @@ func TestVTExplain(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			toposerver := memorytopo.NewServer("c0_cell1")
 
 			tmc := testutil.TabletManagerClient{
@@ -2765,14 +2801,14 @@ func TestVTExplain(t *testing.T) {
 
 			testutil.WithTestServer(t, vtctldserver, func(t *testing.T, vtctldClient vtctldclient.VtctldClient) {
 				if tt.srvVSchema != nil {
-					err := toposerver.UpdateSrvVSchema(context.Background(), "c0_cell1", tt.srvVSchema)
+					err := toposerver.UpdateSrvVSchema(ctx, "c0_cell1", tt.srvVSchema)
 					require.NoError(t, err)
 				}
-				testutil.AddKeyspaces(context.Background(), t, toposerver, tt.keyspaces...)
-				testutil.AddShards(context.Background(), t, toposerver, tt.shards...)
+				testutil.AddKeyspaces(ctx, t, toposerver, tt.keyspaces...)
+				testutil.AddShards(ctx, t, toposerver, tt.shards...)
 
 				for _, tablet := range tt.tablets {
-					testutil.AddTablet(context.Background(), t, toposerver, tablet.Tablet, nil)
+					testutil.AddTablet(ctx, t, toposerver, tablet.Tablet, nil)
 
 					// Adds each SchemaDefinition to the fake TabletManagerClient, or nil
 					// if there are no schemas for that tablet. (All tablet aliases must
@@ -2800,7 +2836,7 @@ func TestVTExplain(t *testing.T) {
 				}
 
 				api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
-				resp, err := api.VTExplain(context.Background(), tt.req)
+				resp, err := api.VTExplain(ctx, tt.req)
 
 				if tt.expectedError != nil {
 					assert.True(t, errors.Is(err, tt.expectedError), "expected error type %w does not match actual error type %w", err, tt.expectedError)

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -567,6 +567,8 @@ func TestGetClusters(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -574,7 +576,6 @@ func TestGetClusters(t *testing.T) {
 			t.Parallel()
 
 			api := NewAPI(tt.clusters, grpcserver.Options{}, http.Options{})
-			ctx := context.Background()
 
 			resp, err := api.GetClusters(ctx, &vtadminpb.GetClustersRequest{})
 			assert.NoError(t, err)
@@ -1105,13 +1106,14 @@ func TestGetSchema(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
 			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, tt.tmc, func(ts *topo.Server) vtctlservicepb.VtctldServer {
 				return grpcvtctldserver.NewVtctldServer(ts)
 			})
@@ -1867,6 +1869,8 @@ func TestGetTablet(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -1890,7 +1894,7 @@ func TestGetTablet(t *testing.T) {
 			}
 
 			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
-			resp, err := api.GetTablet(context.Background(), tt.req)
+			resp, err := api.GetTablet(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -2060,6 +2064,8 @@ func TestGetTablets(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -2083,7 +2089,7 @@ func TestGetTablets(t *testing.T) {
 			}
 
 			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
-			resp, err := api.GetTablets(context.Background(), tt.req)
+			resp, err := api.GetTablets(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -41,284 +41,97 @@ import (
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
-// This test only validates the error handling on dialing database connections.
-// Other cases are covered by one or both of TestFindTablets and TestFindTablet.
-func TestGetTablets(t *testing.T) {
-	t.Parallel()
-
-	disco := fakediscovery.New()
-	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
-
-	db := vtsql.New(&vtsql.Config{
-		Cluster: &vtadminpb.Cluster{
-			Id:   "c1",
-			Name: "one",
-		},
-		Discovery: disco,
-	})
-	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
-		return nil, assert.AnError
-	}
-
-	c := &cluster.Cluster{DB: db}
-	_, err := c.GetTablets(context.Background())
-	assert.Error(t, err)
-}
-
-func TestGetSchema(t *testing.T) {
+func TestFindTablet(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		vtctld    vtctldclient.VtctldClient
-		req       *vtctldatapb.GetSchemaRequest
-		tablet    *vtadminpb.Tablet
-		expected  *vtadminpb.Schema
-		shouldErr bool
+		name          string
+		tablets       []*vtadminpb.Tablet
+		filter        func(*vtadminpb.Tablet) bool
+		expected      *vtadminpb.Tablet
+		expectedError error
 	}{
 		{
-			name: "success",
-			vtctld: &testutil.VtctldClient{
-				GetSchemaResults: map[string]struct {
-					Response *vtctldatapb.GetSchemaResponse
-					Error    error
-				}{
-					"zone1-0000000100": {
-						Response: &vtctldatapb.GetSchemaResponse{
-							Schema: &tabletmanagerdatapb.SchemaDefinition{
-								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-									{
-										Name: "some_table",
-									},
-								},
-							},
+			name: "returns the first matching tablet",
+			tablets: []*vtadminpb.Tablet{
+				{
+					State: vtadminpb.Tablet_NOT_SERVING,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c0_cell1",
+							Uid:  100,
 						},
+						Keyspace: "commerce",
+					},
+				},
+				{
+					State: vtadminpb.Tablet_SERVING,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c0_cell1",
+							Uid:  101,
+						},
+						Keyspace: "commerce",
+					},
+				},
+				{
+					State: vtadminpb.Tablet_SERVING,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c0_cell1",
+							Uid:  102,
+						},
+						Keyspace: "commerce",
 					},
 				},
 			},
-			req: &vtctldatapb.GetSchemaRequest{},
-			tablet: &vtadminpb.Tablet{
+
+			filter: func(t *vtadminpb.Tablet) bool {
+				return t.State == vtadminpb.Tablet_SERVING
+			},
+			expected: &vtadminpb.Tablet{
+				Cluster: &vtadminpb.Cluster{
+					Id:   "c0",
+					Name: "cluster0",
+				},
+				State: vtadminpb.Tablet_SERVING,
 				Tablet: &topodatapb.Tablet{
 					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
+						Cell: "c0_cell1",
+						Uid:  101,
 					},
-					Keyspace: "testkeyspace",
+					Keyspace: "commerce",
 				},
 			},
-			expected: &vtadminpb.Schema{
-				Cluster: &vtadminpb.Cluster{
-					Name: "cluster0",
-					Id:   "c0",
-				},
-				Keyspace: "testkeyspace",
-				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-					{
-						Name: "some_table",
-					},
-				},
-			},
-			shouldErr: false,
 		},
 		{
-			name: "error getting schema",
-			vtctld: &testutil.VtctldClient{
-				GetSchemaResults: map[string]struct {
-					Response *vtctldatapb.GetSchemaResponse
-					Error    error
-				}{
-					"zone1-0000000100": {
-						Error: assert.AnError,
-					},
-				},
-			},
-			req: &vtctldatapb.GetSchemaRequest{},
-			tablet: &vtadminpb.Tablet{
-				Tablet: &topodatapb.Tablet{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Keyspace: "testkeyspace",
-				},
-			},
-			expected:  nil,
-			shouldErr: true,
-		},
-		{
-			name: "underlying schema is nil",
-			vtctld: &testutil.VtctldClient{
-				GetSchemaResults: map[string]struct {
-					Response *vtctldatapb.GetSchemaResponse
-					Error    error
-				}{
-					"zone1-0000000100": {
-						Response: &vtctldatapb.GetSchemaResponse{
-							Schema: nil,
+			name: "returns an error if no match found",
+			tablets: []*vtadminpb.Tablet{
+				{
+					State: vtadminpb.Tablet_NOT_SERVING,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c0_cell1",
+							Uid:  100,
 						},
-						Error: nil,
+						Keyspace: "commerce",
 					},
 				},
-			},
-			req: &vtctldatapb.GetSchemaRequest{},
-			tablet: &vtadminpb.Tablet{
-				Tablet: &topodatapb.Tablet{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Keyspace: "testkeyspace",
-				},
-			},
-			expected:  nil,
-			shouldErr: false,
-		},
-	}
-
-	for i, tt := range tests {
-		i := i
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
-				Cluster: &vtadminpb.Cluster{
-					Id:   fmt.Sprintf("c%d", i),
-					Name: fmt.Sprintf("cluster%d", i),
-				},
-				VtctldClient: tt.vtctld,
-				Tablets:      nil,
-				DBConfig:     testutil.Dbcfg{},
-			})
-
-			ctx := context.Background()
-			err := cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
-
-			schema, err := cluster.GetSchema(ctx, tt.req, tt.tablet)
-			if tt.shouldErr {
-				assert.Error(t, err)
-
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, schema)
-		})
-	}
-
-	t.Run("does not modify passed-in request", func(t *testing.T) {
-		t.Parallel()
-
-		vtctld := &testutil.VtctldClient{
-			GetSchemaResults: map[string]struct {
-				Response *vtctldatapb.GetSchemaResponse
-				Error    error
-			}{
-				"zone1-0000000100": {
-					Response: &vtctldatapb.GetSchemaResponse{},
-				},
-			},
-		}
-
-		ctx := context.Background()
-		req := &vtctldatapb.GetSchemaRequest{
-			TabletAlias: &topodatapb.TabletAlias{
-				Cell: "otherzone",
-				Uid:  500,
-			},
-		}
-		tablet := &vtadminpb.Tablet{
-			Tablet: &topodatapb.Tablet{
-				Alias: &topodatapb.TabletAlias{
-					Cell: "zone1",
-					Uid:  100,
-				},
-			},
-		}
-
-		cluster := testutil.BuildCluster(testutil.TestClusterConfig{
-			Cluster: &vtadminpb.Cluster{
-				Id:   "c0",
-				Name: "cluster0",
-			},
-			VtctldClient: vtctld,
-		})
-
-		err := cluster.Vtctld.Dial(ctx)
-		require.NoError(t, err, "could not dial test vtctld")
-
-		cluster.GetSchema(ctx, req, tablet)
-
-		assert.NotEqual(t, req.TabletAlias, tablet.Tablet.Alias, "expected GetSchema to not modify original request object")
-	})
-}
-
-func TestGetVSchema(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		cfg       testutil.TestClusterConfig
-		keyspace  string
-		expected  *vtadminpb.VSchema
-		shouldErr bool
-	}{
-		{
-			name: "success",
-			cfg: testutil.TestClusterConfig{
-				Cluster: &vtadminpb.Cluster{
-					Id:   "c0",
-					Name: "cluster0",
-				},
-				VtctldClient: &testutil.VtctldClient{
-					GetVSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetVSchemaResponse
-						Error    error
-					}{
-						"testkeyspace": {
-							Response: &vtctldatapb.GetVSchemaResponse{
-								VSchema: &vschemapb.Keyspace{Sharded: true},
-							},
+				{
+					State: vtadminpb.Tablet_NOT_SERVING,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c0_cell1",
+							Uid:  101,
 						},
+						Keyspace: "commerce",
 					},
 				},
 			},
-			keyspace: "testkeyspace",
-			expected: &vtadminpb.VSchema{
-				Cluster: &vtadminpb.Cluster{
-					Id:   "c0",
-					Name: "cluster0",
-				},
-				Name:    "testkeyspace",
-				VSchema: &vschemapb.Keyspace{Sharded: true},
+			filter: func(t *vtadminpb.Tablet) bool {
+				return t.State == vtadminpb.Tablet_SERVING
 			},
-			shouldErr: false,
-		},
-		{
-			name: "error",
-			cfg: testutil.TestClusterConfig{
-				Cluster: &vtadminpb.Cluster{
-					Id:   "c0",
-					Name: "cluster0",
-				},
-				VtctldClient: &testutil.VtctldClient{
-					GetVSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetVSchemaResponse
-						Error    error
-					}{
-						"testkeyspace": {
-							Response: &vtctldatapb.GetVSchemaResponse{
-								VSchema: &vschemapb.Keyspace{Sharded: true},
-							},
-						},
-					},
-				},
-			},
-			keyspace:  "notfound",
-			expected:  nil,
-			shouldErr: true,
+			expectedError: vtadminerrors.ErrNoTablet,
 		},
 	}
 
@@ -330,19 +143,21 @@ func TestGetVSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cluster := testutil.BuildCluster(tt.cfg)
-			err := cluster.Vtctld.Dial(ctx)
-			require.NoError(t, err, "could not dial test vtctld")
+			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
+				Cluster: &vtadminpb.Cluster{
+					Id:   "c0",
+					Name: "cluster0",
+				},
+				Tablets: tt.tablets,
+			})
+			tablet, err := cluster.FindTablet(ctx, tt.filter)
 
-			vschema, err := cluster.GetVSchema(ctx, tt.keyspace)
-			if tt.shouldErr {
-				assert.Error(t, err)
-
-				return
+			if tt.expectedError != nil {
+				assert.True(t, errors.Is(err, tt.expectedError), "expected error type %w does not match actual error type %w", err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				testutil.AssertTabletsEqual(t, tt.expected, tablet)
 			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, vschema)
 		})
 	}
 }
@@ -554,97 +369,284 @@ func TestFindTablets(t *testing.T) {
 	}
 }
 
-func TestFindTablet(t *testing.T) {
+func TestGetSchema(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		tablets       []*vtadminpb.Tablet
-		filter        func(*vtadminpb.Tablet) bool
-		expected      *vtadminpb.Tablet
-		expectedError error
+		name      string
+		vtctld    vtctldclient.VtctldClient
+		req       *vtctldatapb.GetSchemaRequest
+		tablet    *vtadminpb.Tablet
+		expected  *vtadminpb.Schema
+		shouldErr bool
 	}{
 		{
-			name: "returns the first matching tablet",
-			tablets: []*vtadminpb.Tablet{
-				{
-					State: vtadminpb.Tablet_NOT_SERVING,
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "c0_cell1",
-							Uid:  100,
+			name: "success",
+			vtctld: &testutil.VtctldClient{
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name: "some_table",
+									},
+								},
+							},
 						},
-						Keyspace: "commerce",
-					},
-				},
-				{
-					State: vtadminpb.Tablet_SERVING,
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "c0_cell1",
-							Uid:  101,
-						},
-						Keyspace: "commerce",
-					},
-				},
-				{
-					State: vtadminpb.Tablet_SERVING,
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "c0_cell1",
-							Uid:  102,
-						},
-						Keyspace: "commerce",
 					},
 				},
 			},
+			req: &vtctldatapb.GetSchemaRequest{},
+			tablet: &vtadminpb.Tablet{
+				Tablet: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  100,
+					},
+					Keyspace: "testkeyspace",
+				},
+			},
+			expected: &vtadminpb.Schema{
+				Cluster: &vtadminpb.Cluster{
+					Name: "cluster0",
+					Id:   "c0",
+				},
+				Keyspace: "testkeyspace",
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					{
+						Name: "some_table",
+					},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			name: "error getting schema",
+			vtctld: &testutil.VtctldClient{
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Error: assert.AnError,
+					},
+				},
+			},
+			req: &vtctldatapb.GetSchemaRequest{},
+			tablet: &vtadminpb.Tablet{
+				Tablet: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  100,
+					},
+					Keyspace: "testkeyspace",
+				},
+			},
+			expected:  nil,
+			shouldErr: true,
+		},
+		{
+			name: "underlying schema is nil",
+			vtctld: &testutil.VtctldClient{
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: nil,
+						},
+						Error: nil,
+					},
+				},
+			},
+			req: &vtctldatapb.GetSchemaRequest{},
+			tablet: &vtadminpb.Tablet{
+				Tablet: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  100,
+					},
+					Keyspace: "testkeyspace",
+				},
+			},
+			expected:  nil,
+			shouldErr: false,
+		},
+	}
 
-			filter: func(t *vtadminpb.Tablet) bool {
-				return t.State == vtadminpb.Tablet_SERVING
+	for i, tt := range tests {
+		i := i
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
+				Cluster: &vtadminpb.Cluster{
+					Id:   fmt.Sprintf("c%d", i),
+					Name: fmt.Sprintf("cluster%d", i),
+				},
+				VtctldClient: tt.vtctld,
+				Tablets:      nil,
+				DBConfig:     testutil.Dbcfg{},
+			})
+
+			ctx := context.Background()
+			err := cluster.Vtctld.Dial(ctx)
+			require.NoError(t, err, "could not dial test vtctld")
+
+			schema, err := cluster.GetSchema(ctx, tt.req, tt.tablet)
+			if tt.shouldErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, schema)
+		})
+	}
+
+	t.Run("does not modify passed-in request", func(t *testing.T) {
+		t.Parallel()
+
+		vtctld := &testutil.VtctldClient{
+			GetSchemaResults: map[string]struct {
+				Response *vtctldatapb.GetSchemaResponse
+				Error    error
+			}{
+				"zone1-0000000100": {
+					Response: &vtctldatapb.GetSchemaResponse{},
+				},
 			},
-			expected: &vtadminpb.Tablet{
+		}
+
+		ctx := context.Background()
+		req := &vtctldatapb.GetSchemaRequest{
+			TabletAlias: &topodatapb.TabletAlias{
+				Cell: "otherzone",
+				Uid:  500,
+			},
+		}
+		tablet := &vtadminpb.Tablet{
+			Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			},
+		}
+
+		cluster := testutil.BuildCluster(testutil.TestClusterConfig{
+			Cluster: &vtadminpb.Cluster{
+				Id:   "c0",
+				Name: "cluster0",
+			},
+			VtctldClient: vtctld,
+		})
+
+		err := cluster.Vtctld.Dial(ctx)
+		require.NoError(t, err, "could not dial test vtctld")
+
+		cluster.GetSchema(ctx, req, tablet)
+
+		assert.NotEqual(t, req.TabletAlias, tablet.Tablet.Alias, "expected GetSchema to not modify original request object")
+	})
+}
+
+// This test only validates the error handling on dialing database connections.
+// Other cases are covered by one or both of TestFindTablets and TestFindTablet.
+func TestGetTablets(t *testing.T) {
+	t.Parallel()
+
+	disco := fakediscovery.New()
+	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
+
+	db := vtsql.New(&vtsql.Config{
+		Cluster: &vtadminpb.Cluster{
+			Id:   "c1",
+			Name: "one",
+		},
+		Discovery: disco,
+	})
+	db.DialFunc = func(cfg vitessdriver.Configuration) (*sql.DB, error) {
+		return nil, assert.AnError
+	}
+
+	c := &cluster.Cluster{DB: db}
+	_, err := c.GetTablets(context.Background())
+	assert.Error(t, err)
+}
+
+func TestGetVSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       testutil.TestClusterConfig
+		keyspace  string
+		expected  *vtadminpb.VSchema
+		shouldErr bool
+	}{
+		{
+			name: "success",
+			cfg: testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   "c0",
 					Name: "cluster0",
 				},
-				State: vtadminpb.Tablet_SERVING,
-				Tablet: &topodatapb.Tablet{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "c0_cell1",
-						Uid:  101,
+				VtctldClient: &testutil.VtctldClient{
+					GetVSchemaResults: map[string]struct {
+						Response *vtctldatapb.GetVSchemaResponse
+						Error    error
+					}{
+						"testkeyspace": {
+							Response: &vtctldatapb.GetVSchemaResponse{
+								VSchema: &vschemapb.Keyspace{Sharded: true},
+							},
+						},
 					},
-					Keyspace: "commerce",
 				},
 			},
+			keyspace: "testkeyspace",
+			expected: &vtadminpb.VSchema{
+				Cluster: &vtadminpb.Cluster{
+					Id:   "c0",
+					Name: "cluster0",
+				},
+				Name:    "testkeyspace",
+				VSchema: &vschemapb.Keyspace{Sharded: true},
+			},
+			shouldErr: false,
 		},
 		{
-			name: "returns an error if no match found",
-			tablets: []*vtadminpb.Tablet{
-				{
-					State: vtadminpb.Tablet_NOT_SERVING,
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "c0_cell1",
-							Uid:  100,
-						},
-						Keyspace: "commerce",
-					},
+			name: "error",
+			cfg: testutil.TestClusterConfig{
+				Cluster: &vtadminpb.Cluster{
+					Id:   "c0",
+					Name: "cluster0",
 				},
-				{
-					State: vtadminpb.Tablet_NOT_SERVING,
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "c0_cell1",
-							Uid:  101,
+				VtctldClient: &testutil.VtctldClient{
+					GetVSchemaResults: map[string]struct {
+						Response *vtctldatapb.GetVSchemaResponse
+						Error    error
+					}{
+						"testkeyspace": {
+							Response: &vtctldatapb.GetVSchemaResponse{
+								VSchema: &vschemapb.Keyspace{Sharded: true},
+							},
 						},
-						Keyspace: "commerce",
 					},
 				},
 			},
-			filter: func(t *vtadminpb.Tablet) bool {
-				return t.State == vtadminpb.Tablet_SERVING
-			},
-			expectedError: vtadminerrors.ErrNoTablet,
+			keyspace:  "notfound",
+			expected:  nil,
+			shouldErr: true,
 		},
 	}
 
@@ -656,21 +658,19 @@ func TestFindTablet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
-				Cluster: &vtadminpb.Cluster{
-					Id:   "c0",
-					Name: "cluster0",
-				},
-				Tablets: tt.tablets,
-			})
-			tablet, err := cluster.FindTablet(ctx, tt.filter)
+			cluster := testutil.BuildCluster(tt.cfg)
+			err := cluster.Vtctld.Dial(ctx)
+			require.NoError(t, err, "could not dial test vtctld")
 
-			if tt.expectedError != nil {
-				assert.True(t, errors.Is(err, tt.expectedError), "expected error type %w does not match actual error type %w", err, tt.expectedError)
-			} else {
-				assert.NoError(t, err)
-				testutil.AssertTabletsEqual(t, tt.expected, tablet)
+			vschema, err := cluster.GetVSchema(ctx, tt.keyspace)
+			if tt.shouldErr {
+				assert.Error(t, err)
+
+				return
 			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, vschema)
 		})
 	}
 }

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -479,6 +479,8 @@ func TestGetSchema(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for i, tt := range tests {
 		i := i
 		tt := tt
@@ -496,7 +498,6 @@ func TestGetSchema(t *testing.T) {
 				DBConfig:     testutil.Dbcfg{},
 			})
 
-			ctx := context.Background()
 			err := cluster.Vtctld.Dial(ctx)
 			require.NoError(t, err, "could not dial test vtctld")
 
@@ -526,7 +527,6 @@ func TestGetSchema(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
 		req := &vtctldatapb.GetSchemaRequest{
 			TabletAlias: &topodatapb.TabletAlias{
 				Cell: "otherzone",

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -44,6 +44,8 @@ import (
 // This test only validates the error handling on dialing database connections.
 // Other cases are covered by one or both of TestFindTablets and TestFindTablet.
 func TestGetTablets(t *testing.T) {
+	t.Parallel()
+
 	disco := fakediscovery.New()
 	disco.AddTaggedGates(nil, &vtadminpb.VTGate{Hostname: "gate"})
 
@@ -346,6 +348,8 @@ func TestGetVSchema(t *testing.T) {
 }
 
 func TestFindTablets(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		tablets  []*vtadminpb.Tablet
@@ -533,6 +537,8 @@ func TestFindTablets(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   "c0",
@@ -549,6 +555,8 @@ func TestFindTablets(t *testing.T) {
 }
 
 func TestFindTablet(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		tablets       []*vtadminpb.Tablet
@@ -646,6 +654,8 @@ func TestFindTablet(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   "c0",

--- a/go/vt/vtadmin/cluster/config_test.go
+++ b/go/vt/vtadmin/cluster/config_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestMergeConfig(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		base     Config
@@ -131,7 +133,11 @@ func TestMergeConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := tt.base.Merge(tt.override)
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -139,6 +145,8 @@ func TestMergeConfig(t *testing.T) {
 }
 
 func TestConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		yaml   string
@@ -187,7 +195,11 @@ discovery-zk-whatever: 5
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := Config{
 				DiscoveryFlagsByImpl: map[string]map[string]string{},
 			}

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
@@ -230,6 +230,8 @@ func TestConsulDiscoverVTGates(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -242,7 +244,7 @@ func TestConsulDiscoverVTGates(t *testing.T) {
 				},
 			}
 
-			gates, err := tt.disco.DiscoverVTGates(context.Background(), tt.tags)
+			gates, err := tt.disco.DiscoverVTGates(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err, assert.AnError)
 				return
@@ -339,6 +341,8 @@ func TestConsulDiscoverVTGate(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -351,7 +355,7 @@ func TestConsulDiscoverVTGate(t *testing.T) {
 				},
 			}
 
-			gate, err := tt.disco.DiscoverVTGate(context.Background(), tt.tags)
+			gate, err := tt.disco.DiscoverVTGate(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err, assert.AnError)
 				return
@@ -435,6 +439,8 @@ func TestConsulDiscoverVTGateAddr(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -447,7 +453,7 @@ func TestConsulDiscoverVTGateAddr(t *testing.T) {
 				},
 			}
 
-			addr, err := tt.disco.DiscoverVTGateAddr(context.Background(), tt.tags)
+			addr, err := tt.disco.DiscoverVTGateAddr(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err, assert.AnError)
 				return

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
@@ -87,6 +87,8 @@ func consulServiceEntry(name string, tags []string, meta map[string]string) *con
 }
 
 func TestConsulDiscoverVTGates(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		disco     *ConsulDiscovery
@@ -229,7 +231,11 @@ func TestConsulDiscoverVTGates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tt.disco.client = &fakeConsulClient{
 				health: &fakeConsulHealth{
 					entries: tt.entries,
@@ -249,6 +255,8 @@ func TestConsulDiscoverVTGates(t *testing.T) {
 }
 
 func TestConsulDiscoverVTGate(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		disco     *ConsulDiscovery
@@ -332,7 +340,11 @@ func TestConsulDiscoverVTGate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tt.disco.client = &fakeConsulClient{
 				health: &fakeConsulHealth{
 					entries: tt.entries,
@@ -352,6 +364,8 @@ func TestConsulDiscoverVTGate(t *testing.T) {
 }
 
 func TestConsulDiscoverVTGateAddr(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		disco     *ConsulDiscovery
@@ -422,7 +436,11 @@ func TestConsulDiscoverVTGateAddr(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tt.disco.client = &fakeConsulClient{
 				health: &fakeConsulHealth{
 					entries: tt.entries,

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
@@ -91,6 +91,8 @@ func TestDiscoverVTGate(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -101,7 +103,7 @@ func TestDiscoverVTGate(t *testing.T) {
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
 
-			gate, err := disco.DiscoverVTGate(context.Background(), tt.tags)
+			gate, err := disco.DiscoverVTGate(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -234,6 +236,8 @@ func TestDiscoverVTGates(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -249,7 +253,7 @@ func TestDiscoverVTGates(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			gates, err := disco.DiscoverVTGates(context.Background(), tt.tags)
+			gates, err := disco.DiscoverVTGates(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -325,6 +329,8 @@ func TestDiscoverVtctld(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -335,7 +341,7 @@ func TestDiscoverVtctld(t *testing.T) {
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
 
-			vtctld, err := disco.DiscoverVtctld(context.Background(), tt.tags)
+			vtctld, err := disco.DiscoverVtctld(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return
@@ -468,6 +474,8 @@ func TestDiscoverVtctlds(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -483,7 +491,7 @@ func TestDiscoverVtctlds(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			vtctlds, err := disco.DiscoverVtctlds(context.Background(), tt.tags)
+			vtctlds, err := disco.DiscoverVtctlds(ctx, tt.tags)
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestDiscoverVTGate(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		contents  []byte
@@ -90,7 +92,11 @@ func TestDiscoverVTGate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			disco := &StaticFileDiscovery{}
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
@@ -108,6 +114,8 @@ func TestDiscoverVTGate(t *testing.T) {
 }
 
 func TestDiscoverVTGates(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		contents []byte
@@ -227,7 +235,11 @@ func TestDiscoverVTGates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			disco := &StaticFileDiscovery{}
 
 			err := disco.parseConfig(tt.contents)
@@ -250,6 +262,8 @@ func TestDiscoverVTGates(t *testing.T) {
 }
 
 func TestDiscoverVtctld(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		contents  []byte
@@ -312,7 +326,11 @@ func TestDiscoverVtctld(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			disco := &StaticFileDiscovery{}
 			err := disco.parseConfig(tt.contents)
 			require.NoError(t, err)
@@ -330,6 +348,8 @@ func TestDiscoverVtctld(t *testing.T) {
 }
 
 func TestDiscoverVtctlds(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		contents []byte
@@ -449,7 +469,11 @@ func TestDiscoverVtctlds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			disco := &StaticFileDiscovery{}
 
 			err := disco.parseConfig(tt.contents)

--- a/go/vt/vtadmin/cluster/discovery/discovery_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		impl string
@@ -48,7 +50,11 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			disco, err := New(tt.impl, &vtadminpb.Cluster{Id: "testid", Name: "testcluster"}, []string{})
 			if tt.err != nil {
 				assert.Error(t, err, tt.err.Error())
@@ -62,8 +68,10 @@ func TestNew(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
+	t.Parallel()
+
 	// Use a timestamp to allow running tests with `-count=N`.
-	ts := time.Now().Unix()
+	ts := time.Now().UnixNano()
 	factoryName := fmt.Sprintf("testfactory-%d", ts)
 
 	Register(factoryName, nil)

--- a/go/vt/vtadmin/cluster/discovery/discovery_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package discovery
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -60,7 +62,11 @@ func TestNew(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	Register("testfactory", nil)
+	// Use a timestamp to allow running tests with `-count=N`.
+	ts := time.Now().Unix()
+	factoryName := fmt.Sprintf("testfactory-%d", ts)
+
+	Register(factoryName, nil)
 
 	defer func() {
 		err := recover()
@@ -70,6 +76,6 @@ func TestRegister(t *testing.T) {
 	}()
 
 	// this one panics
-	Register("testfactory", nil)
+	Register(factoryName, nil)
 	assert.Equal(t, 1, 2, "double register should have panicked")
 }

--- a/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery_test.go
+++ b/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestDiscoverVTGates(t *testing.T) {
+	t.Parallel()
+
 	fake := New()
 	gates := []*vtadminpb.VTGate{
 		{

--- a/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery_test.go
+++ b/go/vt/vtadmin/cluster/discovery/fakediscovery/discovery_test.go
@@ -41,33 +41,35 @@ func TestDiscoverVTGates(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	fake.AddTaggedGates(nil, gates...)
 	fake.AddTaggedGates([]string{"tag1:val1"}, gates[0], gates[1])
 	fake.AddTaggedGates([]string{"tag2:val2"}, gates[0], gates[2])
 
-	actual, err := fake.DiscoverVTGates(context.Background(), nil)
+	actual, err := fake.DiscoverVTGates(ctx, nil)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, gates, actual)
 
-	actual, err = fake.DiscoverVTGates(context.Background(), []string{"tag1:val1"})
+	actual, err = fake.DiscoverVTGates(ctx, []string{"tag1:val1"})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []*vtadminpb.VTGate{gates[0], gates[1]}, actual)
 
-	actual, err = fake.DiscoverVTGates(context.Background(), []string{"tag2:val2"})
+	actual, err = fake.DiscoverVTGates(ctx, []string{"tag2:val2"})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []*vtadminpb.VTGate{gates[0], gates[2]}, actual)
 
-	actual, err = fake.DiscoverVTGates(context.Background(), []string{"tag1:val1", "tag2:val2"})
+	actual, err = fake.DiscoverVTGates(ctx, []string{"tag1:val1", "tag2:val2"})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []*vtadminpb.VTGate{gates[0]}, actual)
 
-	actual, err = fake.DiscoverVTGates(context.Background(), []string{"differentTag:val"})
+	actual, err = fake.DiscoverVTGates(ctx, []string{"differentTag:val"})
 	assert.NoError(t, err)
 	assert.Equal(t, []*vtadminpb.VTGate{}, actual)
 
 	fake.SetGatesError(true)
 
-	actual, err = fake.DiscoverVTGates(context.Background(), nil)
+	actual, err = fake.DiscoverVTGates(ctx, nil)
 	assert.Error(t, err)
 	assert.Nil(t, actual)
 }

--- a/go/vt/vtadmin/cluster/file_config_test.go
+++ b/go/vt/vtadmin/cluster/file_config_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestFileConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		yaml   string
@@ -92,7 +94,11 @@ clusters:
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := FileConfig{
 				Defaults: Config{
 					DiscoveryFlagsByImpl: map[string]map[string]string{},
@@ -113,6 +119,8 @@ clusters:
 }
 
 func TestCombine(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		fc       FileConfig
@@ -254,7 +262,11 @@ func TestCombine(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := tt.fc.Combine(tt.defaults, tt.configs)
 			assert.ElementsMatch(t, tt.expected, actual)
 		})

--- a/go/vt/vtadmin/cluster/flags_test.go
+++ b/go/vt/vtadmin/cluster/flags_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMergeFlagsByImpl(t *testing.T) {
+	t.Parallel()
+
 	var NilMap map[string]map[string]string
 
 	tests := []struct {
@@ -95,11 +97,15 @@ func TestMergeFlagsByImpl(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			flags := FlagsByImpl(test.base)
-			flags.Merge(test.in)
-			assert.Equal(t, FlagsByImpl(test.expected), flags)
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags := FlagsByImpl(tt.base)
+			flags.Merge(tt.in)
+			assert.Equal(t, FlagsByImpl(tt.expected), flags)
 		})
 	}
 }

--- a/go/vt/vtadmin/credentials/credentials_test.go
+++ b/go/vt/vtadmin/credentials/credentials_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func Test_loadCredentials(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		contents  []byte
@@ -55,7 +57,11 @@ func Test_loadCredentials(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			path := ""
 
 			if len(tt.contents) > 0 {

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -42,7 +42,11 @@ func withTempFile(t *testing.T, tmpdir string, name string, f func(*testing.T, *
 }
 
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no credentials provided", func(t *testing.T) {
+		t.Parallel()
+
 		cfg, err := Parse(nil, nil, []string{})
 		require.NoError(t, err)
 
@@ -56,6 +60,8 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("credential loading", func(t *testing.T) {
+		t.Parallel()
+
 		withTempFile(t, "", "vtctldclient.config_test.testcluster.*", func(t *testing.T, credsfile *os.File) {
 			creds := &grpcclient.StaticAuthClientCreds{
 				Username: "admin",

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestConfigParse(t *testing.T) {
+	t.Parallel()
+
 	cfg := Config{}
 
 	// This asserts we do not attempt to load a credentialsFlag via its Set func
@@ -41,6 +43,8 @@ func TestConfigParse(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("", func(t *testing.T) {
+		t.Parallel()
+
 		f, err := ioutil.TempFile("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
 		require.NoError(t, err)
 
@@ -93,6 +97,8 @@ func TestConfigParse(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
+		t.Parallel()
+
 		f, err := ioutil.TempFile("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
 		require.NoError(t, err)
 

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -36,11 +36,15 @@ import (
 )
 
 func assertImmediateCaller(t *testing.T, im *querypb.VTGateCallerID, expected string) {
+	t.Helper()
+
 	require.NotNil(t, im, "immediate caller cannot be nil")
 	assert.Equal(t, im.Username, expected, "immediate caller username mismatch")
 }
 
 func assertEffectiveCaller(t *testing.T, ef *vtrpcpb.CallerID, principal string, component string, subcomponent string) {
+	t.Helper()
+
 	require.NotNil(t, ef, "effective caller cannot be nil")
 	assert.Equal(t, ef.Principal, principal, "effective caller principal mismatch")
 	assert.Equal(t, ef.Component, component, "effective caller component mismatch")
@@ -48,6 +52,8 @@ func assertEffectiveCaller(t *testing.T, ef *vtrpcpb.CallerID, principal string,
 }
 
 func Test_getQueryContext(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	creds := &StaticAuthCredentials{
@@ -81,6 +87,8 @@ func Test_getQueryContext(t *testing.T) {
 }
 
 func TestDial(t *testing.T) {
+	t.Helper()
+
 	tests := []struct {
 		name      string
 		disco     *fakediscovery.Fake
@@ -145,7 +153,11 @@ func TestDial(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if tt.disco != nil {
 				if len(tt.gates) > 0 {
 					tt.disco.AddTaggedGates(nil, tt.gates...)

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -152,6 +152,8 @@ func TestDial(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		tt := tt
 
@@ -166,7 +168,7 @@ func TestDial(t *testing.T) {
 				tt.proxy.discovery = tt.disco
 			}
 
-			err := tt.proxy.Dial(context.Background(), "")
+			err := tt.proxy.Dial(ctx, "")
 			if tt.shouldErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR contains a bunch of miscellaneous refactors to vtadmin tests, namely:
* use of subtests (`t.Run(...)`) in places where it was previously missing
* use of `t.Parallel()` in most places
* fixing a test in `package discovery` that would panic if you tried running it twice, allowing us to run tests now with `-count=N` for N > 1.
* bulk replacement of inlined `context.Background()` calls with a single, shared context per test function

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported? **no**
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [x]  VTAdmin
