### PR TITLE
[vtadmin] propagate error contexts

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -830,17 +830,14 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	go func(c *cluster.Cluster) {
 		defer wg.Done()
 
-		res, err := c.Vtctld.GetSchema(ctx, &vtctldatapb.GetSchemaRequest{
-			TabletAlias: tablet.Tablet.Alias,
-		})
-
+		res, err := c.GetSchema(ctx, &vtctldatapb.GetSchemaRequest{}, tablet)
 		if err != nil {
 			er.RecordError(fmt.Errorf("GetSchema(%s): %w", topoproto.TabletAliasString(tablet.Tablet.Alias), err))
 			return
 		}
 
-		schemas := make([]string, len(res.Schema.TableDefinitions))
-		for i, td := range res.Schema.TableDefinitions {
+		schemas := make([]string, len(res.TableDefinitions))
+		for i, td := range res.TableDefinitions {
 			schemas[i] = td.Schema
 		}
 

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -254,7 +254,7 @@ func (api *API) GetGates(ctx context.Context, req *vtadminpb.GetGatesRequest) (*
 
 			gs, err := c.Discovery.DiscoverVTGates(ctx, []string{})
 			if err != nil {
-				er.RecordError(err)
+				er.RecordError(fmt.Errorf("DiscoverVTGates(cluster = %s): %w", c.ID, err))
 				return
 			}
 
@@ -315,7 +315,7 @@ func (api *API) GetKeyspaces(ctx context.Context, req *vtadminpb.GetKeyspacesReq
 
 			resp, err := c.Vtctld.GetKeyspaces(ctx, &vtctldatapb.GetKeyspacesRequest{})
 			if err != nil {
-				er.RecordError(err)
+				er.RecordError(fmt.Errorf("GetKeyspaces(cluster = %s): %w", c.ID, err))
 				return
 			}
 
@@ -337,7 +337,7 @@ func (api *API) GetKeyspaces(ctx context.Context, req *vtadminpb.GetKeyspacesReq
 					})
 
 					if err != nil {
-						er.RecordError(err)
+						er.RecordError(fmt.Errorf("FindAllShardsInKeyspace(%s): %w", ks.Name, err))
 						return
 					}
 
@@ -566,7 +566,7 @@ func (api *API) GetTablet(ctx context.Context, req *vtadminpb.GetTabletRequest) 
 
 			ts, err := c.GetTablets(ctx)
 			if err != nil {
-				er.RecordError(err)
+				er.RecordError(fmt.Errorf("GetTablets(cluster = %s): %w", c.ID, err))
 				return
 			}
 
@@ -622,7 +622,7 @@ func (api *API) GetTablets(ctx context.Context, req *vtadminpb.GetTabletsRequest
 
 			ts, err := c.GetTablets(ctx)
 			if err != nil {
-				er.RecordError(err)
+				er.RecordError(fmt.Errorf("GetTablets(cluster = %s): %w", c.ID, err))
 				return
 			}
 
@@ -796,15 +796,14 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 
 	c, ok := api.clusterMap[req.Cluster]
 	if !ok {
-		return nil, errors.ErrUnsupportedCluster
+		return nil, fmt.Errorf("%w: %s", errors.ErrUnsupportedCluster, req.Cluster)
 	}
 
 	tablet, err := c.FindTablet(ctx, func(t *vtadminpb.Tablet) bool {
 		return t.Tablet.Keyspace == req.Keyspace && topo.IsInServingGraph(t.Tablet.Type) && t.Tablet.Type != topodatapb.TabletType_MASTER && t.State == vtadminpb.Tablet_SERVING
 	})
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot find serving, non-MASTER tablet in keyspace=%s: %w", req.Keyspace, err)
 	}
 
 	if err := c.Vtctld.Dial(ctx); err != nil {
@@ -836,7 +835,7 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		})
 
 		if err != nil {
-			er.RecordError(err)
+			er.RecordError(fmt.Errorf("GetSchema(%s): %w", topoproto.TabletAliasString(tablet.Tablet.Alias), err))
 			return
 		}
 
@@ -857,7 +856,7 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		})
 
 		if err != nil {
-			er.RecordError(err)
+			er.RecordError(fmt.Errorf("GetSrvVSchema(%s): %w", tablet.Tablet.Alias.Cell, err))
 			return
 		}
 
@@ -885,7 +884,7 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		})
 
 		if err != nil {
-			er.RecordError(err)
+			er.RecordError(fmt.Errorf("FindAllShardsInKeyspace(%s): %w", req.Keyspace, err))
 			return
 		}
 
@@ -912,12 +911,12 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	opts := &vtexplain.Options{ReplicationMode: "ROW"}
 
 	if err := vtexplain.Init(srvVSchema, schema, shardMap, opts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error initilaizing vtexplain: %w", err)
 	}
 
 	plans, err := vtexplain.Run(req.Sql)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error running vtexplain: %w", err)
 	}
 
 	response := vtexplain.ExplainsAsText(plans)

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -803,7 +803,7 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		return t.Tablet.Keyspace == req.Keyspace && topo.IsInServingGraph(t.Tablet.Type) && t.Tablet.Type != topodatapb.TabletType_MASTER && t.State == vtadminpb.Tablet_SERVING
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot find serving, non-MASTER tablet in keyspace=%s: %w", req.Keyspace, err)
+		return nil, fmt.Errorf("cannot find serving, non-primary tablet in keyspace=%s: %w", req.Keyspace, err)
 	}
 
 	if err := c.Vtctld.Dial(ctx); err != nil {

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -65,7 +65,7 @@ func New(cfg Config) (*Cluster, error) {
 
 	disco, err := discovery.New(cfg.DiscoveryImpl, cluster.ToProto(), discoargs)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating discovery impl (%s): %w", cfg.DiscoveryImpl, err)
+		return nil, fmt.Errorf("error creating discovery impl (%s): %w", cfg.DiscoveryImpl, err)
 	}
 
 	cluster.Discovery = disco
@@ -76,14 +76,14 @@ func New(cfg Config) (*Cluster, error) {
 
 	vtsqlCfg, err := vtsql.Parse(protocluster, disco, vtsqlargs)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating vtsql connection config: %w", err)
+		return nil, fmt.Errorf("error creating vtsql connection config: %w", err)
 	}
 
 	vtctldargs := buildPFlagSlice(cfg.VtctldFlags)
 
 	vtctldCfg, err := vtctldclient.Parse(protocluster, disco, vtctldargs)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating vtctldclient proxy config: %w", err)
+		return nil, fmt.Errorf("error creating vtctldclient proxy config: %w", err)
 	}
 
 	cluster.DB = vtsql.New(vtsqlCfg)
@@ -179,7 +179,7 @@ func (c *Cluster) parseTablet(rows *sql.Rows) (*vtadminpb.Tablet, error) {
 
 	topotablet.Alias, err = topoproto.ParseTabletAlias(aliasStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse tablet_alias %s: %w", aliasStr, err)
 	}
 
 	if topotablet.Alias.Cell != cell {
@@ -190,7 +190,7 @@ func (c *Cluster) parseTablet(rows *sql.Rows) (*vtadminpb.Tablet, error) {
 	if mtstStr != "" {
 		timeTime, err := time.Parse(time.RFC3339, mtstStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed parsing master_term_start_time %s: %w", mtstStr, err)
 		}
 
 		topotablet.MasterTermStartTime = logutil.TimeToProto(timeTime)

--- a/go/vt/vtadmin/cluster/discovery/discovery.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery.go
@@ -109,5 +109,5 @@ func New(impl string, cluster *vtadminpb.Cluster, args []string) (Discovery, err
 
 func init() { // nolint:gochecknoinits
 	Register("consul", NewConsul)
-	Register("staticFile", NewStaticFile)
+	Register("staticfile", NewStaticFile)
 }

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 
@@ -106,7 +107,7 @@ func NewStaticFile(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []stri
 
 func (d *StaticFileDiscovery) parseConfig(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &d.config); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal staticfile config from json: %w", err)
 	}
 
 	d.gates.byName = make(map[string]*vtadminpb.VTGate, len(d.config.VTGates))

--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -18,6 +18,7 @@ package vtctldclient
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
 
@@ -92,13 +93,13 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 
 		// close before reopen. this is safe to call on an already-closed client.
 		if err := vtctld.Close(); err != nil {
-			return err
+			return fmt.Errorf("error closing possibly-stale connection before re-dialing: %w", err)
 		}
 	}
 
 	addr, err := vtctld.discovery.DiscoverVtctldAddr(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("error discovering vtctld to dial: %w", err)
 	}
 
 	opts := []grpc.DialOption{}

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -139,7 +139,7 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 	if vtgate.host == "" {
 		gate, err := vtgate.discovery.DiscoverVTGateAddr(ctx, vtgate.discoveryTags)
 		if err != nil {
-			return err
+			return fmt.Errorf("error discovering vtgate to dial: %w", err)
 		}
 
 		vtgate.host = gate
@@ -163,7 +163,7 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 
 	db, err := vtgate.DialFunc(conf)
 	if err != nil {
-		return err
+		return fmt.Errorf("error dialing vtgate %s: %w", vtgate.host, err)
 	}
 
 	vtgate.conn = db


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR wraps a bunch of places where errors happen with additional context around what failed. Because debugging should be less hard.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Closes #7633 

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **n/a**
- [ ] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
