### PR TITLE
tests: reset stat at the beginning of test

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1310,7 +1310,7 @@ func TestListenerShutdown(t *testing.T) {
 		Uname: "user1",
 		Pass:  "password1",
 	}
-	initialconnRefuse := connRefuse.Get()
+	connRefuse.Reset()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1326,9 +1326,7 @@ func TestListenerShutdown(t *testing.T) {
 
 	l.Shutdown()
 
-	if connRefuse.Get()-initialconnRefuse != 1 {
-		t.Errorf("Expected connRefuse delta=1, got %d", connRefuse.Get()-initialconnRefuse)
-	}
+	assert.EqualValues(t, 1, connRefuse.Get(), "connRefuse")
 
 	if err := conn.Ping(); err != nil {
 		sqlErr, ok := err.(*SQLError)


### PR DESCRIPTION
Fixes flaky test failure:
```
--- FAIL: TestListenerShutdown (0.00s)
Error:     server_test.go:250: listening on address '::1' port 40883
Error:     server_test.go:1330: Expected connRefuse delta=1, got 1
FAIL
```

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
