### PR TITLE
[vtadmin] tracing refactor

### DIFF
--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"vitess.io/vitess/go/trace"
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
@@ -139,7 +140,14 @@ func (d *StaticFileDiscovery) parseConfig(bytes []byte) error {
 
 // DiscoverVTGate is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
-	gates, err := d.DiscoverVTGates(ctx, tags)
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVTGate")
+	defer span.Finish()
+
+	return d.discoverVTGate(ctx, tags)
+}
+
+func (d *StaticFileDiscovery) discoverVTGate(ctx context.Context, tags []string) (*vtadminpb.VTGate, error) {
+	gates, err := d.discoverVTGates(ctx, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +163,9 @@ func (d *StaticFileDiscovery) DiscoverVTGate(ctx context.Context, tags []string)
 
 // DiscoverVTGateAddr is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []string) (string, error) {
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVTGateAddr")
+	defer span.Finish()
+
 	gate, err := d.DiscoverVTGate(ctx, tags)
 	if err != nil {
 		return "", err
@@ -165,6 +176,13 @@ func (d *StaticFileDiscovery) DiscoverVTGateAddr(ctx context.Context, tags []str
 
 // DiscoverVTGates is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVTGates")
+	defer span.Finish()
+
+	return d.discoverVTGates(ctx, tags)
+}
+
+func (d *StaticFileDiscovery) discoverVTGates(ctx context.Context, tags []string) ([]*vtadminpb.VTGate, error) {
 	if len(tags) == 0 {
 		results := []*vtadminpb.VTGate{}
 		for _, g := range d.gates.byName {
@@ -204,7 +222,14 @@ func (d *StaticFileDiscovery) DiscoverVTGates(ctx context.Context, tags []string
 
 // DiscoverVtctld is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
-	vtctlds, err := d.DiscoverVtctlds(ctx, tags)
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVtctld")
+	defer span.Finish()
+
+	return d.discoverVtctld(ctx, tags)
+}
+
+func (d *StaticFileDiscovery) discoverVtctld(ctx context.Context, tags []string) (*vtadminpb.Vtctld, error) {
+	vtctlds, err := d.discoverVtctlds(ctx, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +245,10 @@ func (d *StaticFileDiscovery) DiscoverVtctld(ctx context.Context, tags []string)
 
 // DiscoverVtctldAddr is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []string) (string, error) {
-	vtctld, err := d.DiscoverVtctld(ctx, tags)
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVtctldAddr")
+	defer span.Finish()
+
+	vtctld, err := d.discoverVtctld(ctx, tags)
 	if err != nil {
 		return "", err
 	}
@@ -230,6 +258,13 @@ func (d *StaticFileDiscovery) DiscoverVtctldAddr(ctx context.Context, tags []str
 
 // DiscoverVtctlds is part of the Discovery interface.
 func (d *StaticFileDiscovery) DiscoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
+	span, ctx := trace.NewSpan(ctx, "StaticFileDiscovery.DiscoverVtctlds")
+	defer span.Finish()
+
+	return d.discoverVtctlds(ctx, tags)
+}
+
+func (d *StaticFileDiscovery) discoverVtctlds(ctx context.Context, tags []string) ([]*vtadminpb.Vtctld, error) {
 	if len(tags) == 0 {
 		results := []*vtadminpb.Vtctld{}
 		for _, v := range d.vtctlds.byName {

--- a/go/vt/vtadmin/vtadminproto/trace.go
+++ b/go/vt/vtadmin/vtadminproto/trace.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package vtadminproto
 
 import (
 	"vitess.io/vitess/go/trace"
-	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
+
+	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"
 )
 
-// AnnotateSpan adds the cluster_id and cluster_name to a span.
-func AnnotateSpan(c *Cluster, span trace.Span) {
-	vtadminproto.AnnotateClusterSpan(c.ToProto(), span)
-	// (TODO:@ajm188) add support for discovery impls to add annotations to a
-	// span, like `discovery_impl` and any parameters that might be relevant.
+// AnnotateClusterSpan adds the cluster_id and cluster_name to a span.
+func AnnotateClusterSpan(c *vtadminpb.Cluster, span trace.Span) {
+	span.Annotate("cluster_id", c.Id)
+	span.Annotate("cluster_name", c.Name)
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

This PR does two things:

1. Refactors to support code reuse without over tracing. This is mostly a process of:
    a. Move code to private function
    b. Do tracing in public function, then call private function.
    c. Other internal code that was calling the public function, now calls the private, and we don't double trace (e.g. it would not make sense for `VTGateProxy.Ping` to create a root span called "VTGateProxy.PingContext", which it would if we tried to add tracing there while also having `Ping` call `PingContext`)

2. Instrument tracing through more vtadmin API endpoints.
3. (okay I lied, three things) Add some helpers for common span annotations.

## Related Issue(s)

## Checklist
- [ ] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
