### PR TITLE
Add common tags for stats backends that support it

### DIFF
--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -322,6 +322,8 @@ func isVarDropped(name string) bool {
 }
 
 // ParseCommonTags parses a comma-separated string into map of tags
+// If you want to global service values like host, service name, git revision, etc,
+// this is the place to do it.
 func ParseCommonTags(s string) map[string]string {
 	inputs := strings.Split(s, ",")
 	tags := make(map[string]string)

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -46,6 +46,9 @@ var statsBackend = flag.String("stats_backend", "", "The name of the registered 
 var combineDimensions = flag.String("stats_combine_dimensions", "", `List of dimensions to be combined into a single "all" value in exported stats vars`)
 var dropVariables = flag.String("stats_drop_variables", "", `Variables to be dropped from the list of exported variables.`)
 
+// CommonTags is a comma-separated list of common tags for stats backends
+var CommonTags = flag.String("stats_common_tags", "", `Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2`)
+
 // StatsAllStr is the consolidated name if a dimension gets combined.
 const StatsAllStr = "all"
 
@@ -316,4 +319,17 @@ func isVarDropped(name string) bool {
 		}
 	}
 	return droppedVars[name]
+}
+
+// ParseCommonTags parses a comma-separated string into map of tags
+func ParseCommonTags(s string) map[string]string {
+	inputs := strings.Split(s, ",")
+	tags := make(map[string]string)
+	for _, input := range inputs {
+		if strings.Contains(input, ":") {
+			tag := strings.Split(input, ":")
+			tags[tag[0]] = tag[1]
+		}
+	}
+	return tags
 }

--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -330,7 +330,7 @@ func ParseCommonTags(s string) map[string]string {
 	for _, input := range inputs {
 		if strings.Contains(input, ":") {
 			tag := strings.Split(input, ":")
-			tags[tag[0]] = tag[1]
+			tags[strings.TrimSpace(tag[0])] = strings.TrimSpace(tag[1])
 		}
 	}
 	return tags

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"expvar"
+	"reflect"
 	"testing"
 )
 
@@ -137,5 +138,22 @@ func TestStringMapToString(t *testing.T) {
 
 	if got != expected1 && got != expected2 {
 		t.Errorf("expected %v or %v, got  %v", expected1, expected2, got)
+	}
+}
+
+func TestParseCommonTags(t *testing.T) {
+	res := ParseCommonTags("")
+	if len(res) != 0 {
+		t.Errorf("expected empty result, got %v", res)
+	}
+	res = ParseCommonTags("s,a:b")
+	expected1 := map[string]string{"a": "b"}
+	if !reflect.DeepEqual(expected1, res) {
+		t.Errorf("expected %v, got %v", expected1, res)
+	}
+	res = ParseCommonTags("a:b,c:d")
+	expected2 := map[string]string{"a": "b", "c": "d"}
+	if !reflect.DeepEqual(expected2, res) {
+		t.Errorf("expected %v, got %v", expected2, res)
 	}
 }

--- a/go/stats/export_test.go
+++ b/go/stats/export_test.go
@@ -146,12 +146,12 @@ func TestParseCommonTags(t *testing.T) {
 	if len(res) != 0 {
 		t.Errorf("expected empty result, got %v", res)
 	}
-	res = ParseCommonTags("s,a:b")
+	res = ParseCommonTags("s,a:b ")
 	expected1 := map[string]string{"a": "b"}
 	if !reflect.DeepEqual(expected1, res) {
 		t.Errorf("expected %v, got %v", expected1, res)
 	}
-	res = ParseCommonTags("a:b,c:d")
+	res = ParseCommonTags("a:b,  c:d")
 	expected2 := map[string]string{"a": "b", "c": "d"}
 	if !reflect.DeepEqual(expected2, res) {
 		t.Errorf("expected %v, got %v", expected2, res)

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -98,10 +98,8 @@ func InitWithoutServenv(prefix string) {
 	}
 
 	backend := &openTSDBBackend{
-		prefix: prefix,
-		// If you want to global service values like host, service name, git revision, etc,
-		// this is the place to do it.
-		commonTags: map[string]string{},
+		prefix:     prefix,
+		commonTags: stats.ParseCommonTags(*stats.CommonTags),
 	}
 
 	stats.RegisterPushBackend("opentsdb", backend)

--- a/go/stats/opentsdb/opentsdb.go
+++ b/go/stats/opentsdb/opentsdb.go
@@ -87,30 +87,35 @@ type dataCollector struct {
 func Init(prefix string) {
 	// Needs to happen in servenv.OnRun() instead of init because it requires flag parsing and logging
 	servenv.OnRun(func() {
-		if *openTsdbURI == "" {
-			return
+		InitWithoutServenv(prefix)
+	})
+}
+
+// InitWithoutServenv initializes the opentsdb without servenv
+func InitWithoutServenv(prefix string) {
+	if *openTsdbURI == "" {
+		return
+	}
+
+	backend := &openTSDBBackend{
+		prefix: prefix,
+		// If you want to global service values like host, service name, git revision, etc,
+		// this is the place to do it.
+		commonTags: map[string]string{},
+	}
+
+	stats.RegisterPushBackend("opentsdb", backend)
+
+	http.HandleFunc("/debug/opentsdb", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		dataPoints := (*backend).getDataPoints()
+		sort.Sort(byMetric(dataPoints))
+
+		if b, err := json.MarshalIndent(dataPoints, "", "  "); err != nil {
+			w.Write([]byte(err.Error()))
+		} else {
+			w.Write(b)
 		}
-
-		backend := &openTSDBBackend{
-			prefix: prefix,
-			// If you want to global service values like host, service name, git revision, etc,
-			// this is the place to do it.
-			commonTags: map[string]string{},
-		}
-
-		stats.RegisterPushBackend("opentsdb", backend)
-
-		http.HandleFunc("/debug/opentsdb", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json; charset=utf-8")
-			dataPoints := (*backend).getDataPoints()
-			sort.Sort(byMetric(dataPoints))
-
-			if b, err := json.MarshalIndent(dataPoints, "", "  "); err != nil {
-				w.Write([]byte(err.Error()))
-			} else {
-				w.Write(b)
-			}
-		})
 	})
 }
 

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -201,8 +201,6 @@ func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 		}
 	case *stats.Rates, *stats.RatesFunc, *stats.String, *stats.StringFunc, *stats.StringMapFunc:
 		// Silently ignore metrics that does not make sense to be exported to statsd
-	default:
-		log.Warningf("Silently ignore metrics with key %v [%T]", k, kv.Value)
 	}
 }
 

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -199,8 +199,11 @@ func (sb StatsBackend) addExpVar(kv expvar.KeyValue) {
 				}
 			}
 		}
-	case *stats.Rates, *stats.RatesFunc, *stats.String, *stats.StringFunc, *stats.StringMapFunc:
+	case *stats.Rates, *stats.RatesFunc, *stats.String, *stats.StringFunc, *stats.StringMapFunc,
+		stats.StringFunc, stats.StringMapFunc:
 		// Silently ignore metrics that does not make sense to be exported to statsd
+	default:
+		log.Warningf("Silently ignore metrics with key %v [%T]", k, kv.Value)
 	}
 }
 

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -65,6 +65,14 @@ func InitWithoutServenv(namespace string) {
 		return
 	}
 	statsdC.Namespace = namespace + "."
+	if tags := stats.ParseCommonTags(*stats.CommonTags); len(tags) > 0 {
+		var commonTags []string
+		for k, v := range tags {
+			commonTag := fmt.Sprintf("%s:%s", k, v)
+			commonTags = append(commonTags, commonTag)
+		}
+		statsdC.Tags = commonTags
+	}
 	sb.namespace = namespace
 	sb.statsdClient = statsdC
 	sb.sampleRate = *statsdSampleRate

--- a/go/stats/statsd/statsd.go
+++ b/go/stats/statsd/statsd.go
@@ -46,6 +46,15 @@ func makeLabels(labelNames []string, labelValsCombined string) []string {
 	return tags
 }
 
+func makeCommonTags(tags map[string]string) []string {
+	var commonTags []string
+	for k, v := range tags {
+		commonTag := fmt.Sprintf("%s:%s", k, v)
+		commonTags = append(commonTags, commonTag)
+	}
+	return commonTags
+}
+
 // Init initializes the statsd with the given namespace.
 func Init(namespace string) {
 	servenv.OnRun(func() {
@@ -66,12 +75,7 @@ func InitWithoutServenv(namespace string) {
 	}
 	statsdC.Namespace = namespace + "."
 	if tags := stats.ParseCommonTags(*stats.CommonTags); len(tags) > 0 {
-		var commonTags []string
-		for k, v := range tags {
-			commonTag := fmt.Sprintf("%s:%s", k, v)
-			commonTags = append(commonTags, commonTag)
-		}
-		statsdC.Tags = commonTags
+		statsdC.Tags = makeCommonTags(tags)
 	}
 	sb.namespace = namespace
 	sb.statsdClient = statsdC

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -3,6 +3,7 @@ package statsd
 import (
 	"expvar"
 	"net"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -445,4 +446,12 @@ func TestStatsdHistogram(t *testing.T) {
 	if !found {
 		t.Errorf("Stat %s not found...", name)
 	}
+}
+
+func TestMakeCommonTags(t *testing.T) {
+	res1 := makeCommonTags(map[string]string{})
+	assert.Equal(t, 0, len(res1))
+	expected2 := []string{"a:b", "c:d"}
+	res2 := makeCommonTags(map[string]string{"a": "b", "c": "d"})
+	assert.Assert(t, reflect.DeepEqual(expected2, res2))
 }

--- a/go/stats/statsd/statsd_test.go
+++ b/go/stats/statsd/statsd_test.go
@@ -3,14 +3,13 @@ package statsd
 import (
 	"expvar"
 	"net"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/stats"
 )
@@ -453,5 +452,5 @@ func TestMakeCommonTags(t *testing.T) {
 	assert.Equal(t, 0, len(res1))
 	expected2 := []string{"a:b", "c:d"}
 	res2 := makeCommonTags(map[string]string{"a": "b", "c": "d"})
-	assert.Assert(t, reflect.DeepEqual(expected2, res2))
+	assert.EqualValues(t, expected2, res2)
 }


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Opentsdb and statsd both support common tags that can be attached to all the metrics we emitted. They are useful to identify the latency at keyspace or shard level. However there is no easy way to integrate with that. 

This PR does 2 things:
1. passes the common tags from a comma-separated string and we can tag the stats client directly
2. minor change on opentsdb and statsd init process by adding `InitWithoutServenv` so that we can init them without servenv. This can be useful to reuse the stats backend on other binaries that does not use servenv (e.g., vtorc, vtbench)

## Related Issue(s)
<!-- List related issues and pull requests: -->

- https://github.com/vitessio/vitess/issues/7647

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
