### PR TITLE
healthcheck: update healthy tablets correctly when a stream returns an error or times out

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -404,17 +404,17 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	}
 }
 
-func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealthResponse, currentTarget *query.Target, trivialNonMasterUpdate bool, isMasterUpdate bool, isMasterChange bool) {
+func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, currentTarget *query.Target, trivialNonMasterUpdate bool, isMasterUpdate bool, isMasterChange bool) {
 	// hc.healthByAlias is authoritative, it should be updated
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := tabletAliasString(topoproto.TabletAliasString(shr.TabletAlias))
-
-	hcErrorCounters.Add([]string{shr.Target.Keyspace, shr.Target.Shard, topoproto.TabletTypeLString(shr.Target.TabletType)}, 0)
-	targetKey := hc.keyFromTarget(shr.Target)
-	targetChanged := currentTarget.TabletType != shr.Target.TabletType || currentTarget.Keyspace != shr.Target.Keyspace || currentTarget.Shard != shr.Target.Shard
+	tabletAlias := tabletAliasString(topoproto.TabletAliasString(th.Tablet.Alias))
+	targetKey := hc.keyFromTarget(th.Target)
+	targetChanged := currentTarget.TabletType != th.Target.TabletType || currentTarget.Keyspace != th.Target.Keyspace || currentTarget.Shard != th.Target.Shard
 	if targetChanged {
+		// Error counter has to be set here in case we get a new tablet type for the first time in a stream response
+		hcErrorCounters.Add([]string{th.Target.Keyspace, th.Target.Shard, topoproto.TabletTypeLString(th.Target.TabletType)}, 0)
 		// keyspace and shard are not expected to change, but just in case ...
 		// move this tabletHealthCheck to the correct map
 		oldTargetKey := hc.keyFromTarget(currentTarget)
@@ -433,12 +433,12 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 		} else {
 			// We already have one up server, see if we
 			// need to replace it.
-			if shr.TabletExternallyReparentedTimestamp < hc.healthy[targetKey][0].MasterTermStartTime {
+			if th.MasterTermStartTime < hc.healthy[targetKey][0].MasterTermStartTime {
 				log.Warningf("not marking healthy master %s as Up for %s because its MasterTermStartTime is smaller than the highest known timestamp from previous MASTERs %s: %d < %d ",
-					topoproto.TabletAliasString(shr.TabletAlias),
-					topoproto.KeyspaceShardString(shr.Target.Keyspace, shr.Target.Shard),
+					topoproto.TabletAliasString(th.Tablet.Alias),
+					topoproto.KeyspaceShardString(th.Target.Keyspace, th.Target.Shard),
 					topoproto.TabletAliasString(hc.healthy[targetKey][0].Tablet.Alias),
-					shr.TabletExternallyReparentedTimestamp,
+					th.MasterTermStartTime,
 					hc.healthy[targetKey][0].MasterTermStartTime)
 			} else {
 				// Just replace it.
@@ -450,21 +450,20 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, shr *query.StreamHealt
 		// We re-sort the healthy tablet list whenever we get a health update for tablets we can route to.
 		// Tablets from other cells for non-master targets should not trigger a re-sort;
 		// they should also be excluded from healthy list.
-		if shr.Target.TabletType != topodata.TabletType_MASTER && hc.isIncluded(shr.Target.TabletType, shr.TabletAlias) {
+		if th.Target.TabletType != topodata.TabletType_MASTER && hc.isIncluded(th.Target.TabletType, th.Tablet.Alias) {
 			hc.recomputeHealthy(targetKey)
 		}
-		if targetChanged && currentTarget.TabletType != topodata.TabletType_MASTER && hc.isIncluded(shr.Target.TabletType, shr.TabletAlias) { // also recompute old target's healthy list
+		if targetChanged && currentTarget.TabletType != topodata.TabletType_MASTER && hc.isIncluded(th.Target.TabletType, th.Tablet.Alias) { // also recompute old target's healthy list
 			oldTargetKey := hc.keyFromTarget(currentTarget)
 			hc.recomputeHealthy(oldTargetKey)
 		}
 	}
 	if isMasterChange {
-		log.Errorf("Adding 1 to MasterPromoted counter for tablet: %v, shr.Tablet: %v, shr.TabletType: %v", currentTarget, topoproto.TabletAliasString(shr.TabletAlias), shr.Target.TabletType)
-		hcMasterPromotedCounters.Add([]string{shr.Target.Keyspace, shr.Target.Shard}, 1)
+		log.Errorf("Adding 1 to MasterPromoted counter for target: %v, tablet: %v, tabletType: %v", currentTarget, topoproto.TabletAliasString(th.Tablet.Alias), th.Target.TabletType)
+		hcMasterPromotedCounters.Add([]string{th.Target.Keyspace, th.Target.Shard}, 1)
 	}
 	// broadcast to subscribers
 	hc.broadcast(th)
-
 }
 
 func (hc *HealthCheckImpl) recomputeHealthy(key keyspaceShardTabletType) {

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -404,7 +404,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	}
 }
 
-func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, currentTarget *query.Target, trivialNonMasterUpdate bool, isMasterUpdate bool, isMasterChange bool) {
+func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, currentTarget *query.Target, trivialUpdate bool, isPrimaryUp bool) {
 	// hc.healthByAlias is authoritative, it should be updated
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
@@ -427,26 +427,31 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, currentTarget *query.T
 	// add it to the map by target
 	hc.healthData[targetKey][tabletAlias] = th
 
-	if isMasterUpdate {
-		if len(hc.healthy[targetKey]) == 0 {
-			hc.healthy[targetKey] = append(hc.healthy[targetKey], th)
-		} else {
-			// We already have one up server, see if we
-			// need to replace it.
-			if th.MasterTermStartTime < hc.healthy[targetKey][0].MasterTermStartTime {
-				log.Warningf("not marking healthy master %s as Up for %s because its MasterTermStartTime is smaller than the highest known timestamp from previous MASTERs %s: %d < %d ",
-					topoproto.TabletAliasString(th.Tablet.Alias),
-					topoproto.KeyspaceShardString(th.Target.Keyspace, th.Target.Shard),
-					topoproto.TabletAliasString(hc.healthy[targetKey][0].Tablet.Alias),
-					th.MasterTermStartTime,
-					hc.healthy[targetKey][0].MasterTermStartTime)
+	if th.Target.TabletType == topodata.TabletType_MASTER {
+		if isPrimaryUp {
+			if len(hc.healthy[targetKey]) == 0 {
+				hc.healthy[targetKey] = append(hc.healthy[targetKey], th)
 			} else {
-				// Just replace it.
-				hc.healthy[targetKey][0] = th
+				// We already have one up server, see if we
+				// need to replace it.
+				if th.MasterTermStartTime < hc.healthy[targetKey][0].MasterTermStartTime {
+					log.Warningf("not marking healthy master %s as Up for %s because its MasterTermStartTime is smaller than the highest known timestamp from previous MASTERs %s: %d < %d ",
+						topoproto.TabletAliasString(th.Tablet.Alias),
+						topoproto.KeyspaceShardString(th.Target.Keyspace, th.Target.Shard),
+						topoproto.TabletAliasString(hc.healthy[targetKey][0].Tablet.Alias),
+						th.MasterTermStartTime,
+						hc.healthy[targetKey][0].MasterTermStartTime)
+				} else {
+					// Just replace it.
+					hc.healthy[targetKey][0] = th
+				}
 			}
+		} else {
+			// No healthy master tablet
+			hc.healthy[targetKey] = []*TabletHealth{}
 		}
 	}
-	if !trivialNonMasterUpdate {
+	if !trivialUpdate {
 		// We re-sort the healthy tablet list whenever we get a health update for tablets we can route to.
 		// Tablets from other cells for non-master targets should not trigger a re-sort;
 		// they should also be excluded from healthy list.
@@ -458,7 +463,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, currentTarget *query.T
 			hc.recomputeHealthy(oldTargetKey)
 		}
 	}
-	if isMasterChange {
+	if currentTarget.TabletType != topodata.TabletType_MASTER && th.Target.TabletType == topodata.TabletType_MASTER {
 		log.Errorf("Adding 1 to MasterPromoted counter for target: %v, tablet: %v, tabletType: %v", currentTarget, topoproto.TabletAliasString(th.Tablet.Alias), th.Target.TabletType)
 		hcMasterPromotedCounters.Add([]string{th.Target.Keyspace, th.Target.Shard}, 1)
 	}

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -869,7 +869,7 @@ func TestMasterInOtherCell(t *testing.T) {
 
 	// check that MASTER tablet from other cell IS in healthy tablet list
 	a := hc.GetHealthyTabletStats(&querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_MASTER})
-	assert.Len(t, a, 1, "")
+	require.Len(t, a, 1, "")
 	mustMatch(t, want, a[0], "Expecting healthy master")
 }
 

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -184,10 +184,10 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 		return vterrors.New(vtrpc.Code_FAILED_PRECONDITION, fmt.Sprintf("health stats mismatch, tablet %+v alias does not match response alias %v", thc.Tablet, shr.TabletAlias))
 	}
 
-	currentTarget := thc.Target
+	prevTarget := thc.Target
 	// check whether this is a trivial update so as to update healthy map
 	trivialUpdate := thc.LastError == nil && thc.Serving && shr.RealtimeStats.HealthError == "" && shr.Serving &&
-		currentTarget.TabletType != topodata.TabletType_MASTER && currentTarget.TabletType == shr.Target.TabletType && thc.isTrivialReplagChange(shr.RealtimeStats)
+		prevTarget.TabletType != topodata.TabletType_MASTER && prevTarget.TabletType == shr.Target.TabletType && thc.isTrivialReplagChange(shr.RealtimeStats)
 	thc.lastResponseTimestamp = time.Now()
 	thc.Target = shr.Target
 	thc.MasterTermStartTime = shr.TabletExternallyReparentedTimestamp
@@ -200,7 +200,7 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 	thc.setServingState(serving, reason)
 
 	// notify downstream for master change
-	hc.updateHealth(thc.SimpleCopy(), currentTarget, trivialUpdate, true)
+	hc.updateHealth(thc.SimpleCopy(), prevTarget, trivialUpdate, true)
 	return nil
 }
 


### PR DESCRIPTION
## Description
There are error conditions from a tablet health check that require the healthy tablet list to be updated.
* Tablet host/port is taken over by a different tablet (Fixed in #7176)
* Healthcheck stream returns an error (this can be for any reason including tablet being down) #7472 
* Healthcheck times out #7177 
* These conditions need to be handled for all tablet types (primary/non-primary)

## Related Issue(s)
Fixes #7472 
Fixes #7177 

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:
- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin

## Testing
Unit tests were added for each case. For #7472 I also followed the provided testing procedure to reproduce the problem and confirmed that the fix works.
```
mysql> show vitess_tablets;
+-------+----------+-------+------------+---------+------------------+------------------+----------------------+
| Cell  | Keyspace | Shard | TabletType | State   | Alias            | Hostname         | MasterTermStartTime  |
+-------+----------+-------+------------+---------+------------------+------------------+----------------------+
| zone1 | commerce | 0     | MASTER     | SERVING | zone1-0000000100 | localhost        | 2021-03-10T01:24:33Z |
| zone1 | commerce | 0     | REPLICA    | SERVING | zone1-0000000101 | localhost        |                      |
| zone1 | commerce | 0     | RDONLY     | SERVING | zone1-0000000102 | localhost        |                      |
+-------+----------+-------+------------+---------+------------------+------------------+----------------------+
3 rows in set (0.00 sec)
----
kill rdonly vttablet
----
mysql> show vitess_tablets;
+-------+----------+-------+------------+-------------+------------------+------------------+----------------------+
| Cell  | Keyspace | Shard | TabletType | State       | Alias            | Hostname         | MasterTermStartTime  |
+-------+----------+-------+------------+-------------+------------------+------------------+----------------------+
| zone1 | commerce | 0     | MASTER     | SERVING     | zone1-0000000100 | localhost        | 2021-03-10T01:24:33Z |
| zone1 | commerce | 0     | REPLICA    | SERVING     | zone1-0000000101 | localhost        |                      |
| zone1 | commerce | 0     | RDONLY     | NOT_SERVING | zone1-0000000102 | localhost        |                      |
+-------+----------+-------+------------+-------------+------------------+------------------+----------------------+
3 rows in set (0.00 sec)

mysql> use @rdonly;
Database changed
mysql> select * from product;
ERROR 1105 (HY000): target: commerce.0.rdonly: no healthy tablet available for 'keyspace:"commerce" shard:"0" tablet_type:RDONLY '
```