### PR TITLE
Check error response before attempting to access InitShardPrimary response

### DIFF
--- a/go/cmd/vtctldclient/internal/command/reparents.go
+++ b/go/cmd/vtctldclient/internal/command/reparents.go
@@ -150,6 +150,9 @@ func commandInitShardPrimary(cmd *cobra.Command, args []string) error {
 		WaitReplicasTimeout:     protoutil.DurationToProto(initShardPrimaryOptions.WaitReplicasTimeout),
 		Force:                   initShardPrimaryOptions.Force,
 	})
+	if err != nil {
+		return err
+	}
 
 	for _, event := range resp.Events {
 		log.Infof("%v", event)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
    - @deepthi do you know if this needs to be backported to 9.0?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
