### PR TITLE
VReplication: error out if binlog compression is turned on

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -122,6 +122,9 @@ type BinlogEvent interface {
 
 	// IsPseudo is for custom implementations of GTID.
 	IsPseudo() bool
+
+	// IsCompressed returns true if a compressed event is found (binlog_transaction_compression=ON)
+	IsCompressed() bool
 }
 
 // BinlogFormat contains relevant data from the FORMAT_DESCRIPTION_EVENT.

--- a/go/mysql/binlog_event_common.go
+++ b/go/mysql/binlog_event_common.go
@@ -167,6 +167,11 @@ func (ev binlogEvent) IsPseudo() bool {
 	return false
 }
 
+// IsCompressed returns true if a compressed event is found (binlog_transaction_compression=ON)
+func (ev binlogEvent) IsCompressed() bool {
+	return ev.Type() == eCompressedEvent
+}
+
 // Format implements BinlogEvent.Format().
 //
 // Expected format (L = total length of event data):

--- a/go/mysql/binlog_event_filepos.go
+++ b/go/mysql/binlog_event_filepos.go
@@ -212,6 +212,10 @@ func (ev filePosFakeEvent) IsPseudo() bool {
 	return false
 }
 
+func (ev filePosFakeEvent) IsCompressed() bool {
+	return false
+}
+
 //----------------------------------------------------------------------------
 
 // filePosGTIDEvent is a fake GTID event for filePos.

--- a/go/mysql/replication_constants.go
+++ b/go/mysql/replication_constants.go
@@ -207,6 +207,9 @@ const (
 	//eViewChangeEvent         = 37
 	//eXAPrepareLogEvent       = 38
 
+	// Transaction_payload_event when binlog compression is turned on
+	eCompressedEvent = 40
+
 	// MariaDB specific values. They start at 160.
 	//eMariaAnnotateRowsEvent = 160
 	// Unused

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -567,6 +567,9 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 		if err != nil {
 			return nil, err
 		}
+	case ev.IsCompressed():
+		log.Errorf("VReplication does not handle binlog compression")
+		return nil, fmt.Errorf("VReplication does not handle binlog compression")
 	}
 	for _, vevent := range vevents {
 		vevent.Timestamp = int64(ev.Timestamp())


### PR DESCRIPTION
## Description

The binlog streamer does not handle the `transaction_payload_event`, which is sent when binlog compression is used. Currently these events were being silently dropped by VReplication. The copy phase succeeds, but no events are processed while replicating and no error is reported.

With this PR, the VStreamer will error out if it detects binlog compression so that it is reported back to the user. The output of `Workflow Show` would display something like:

```
                                        "Pos": "MySQL56/963a4ef5-8333-11eb-a12a-04ed332e05c2:1-42",
					"StopPos": "",
					"State": "Error",
					"DBName": "vt_customer",
					"TransactionTimestamp": 1615554393,
					"TimeUpdated": 1615554417,
					"Message": "Error: vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ 963a4ef5-8333-11eb-a12a-04ed332e05c2:1-43: VReplication does not handle binlog compression",
					"CopyState": null
```
See related issue for discussions around this.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/7567

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
