### PR TITLE
VReplication: Speed up the catchup phase by ignoring pks outside range in code rather than in sql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/minio/minio-go v0.0.0-20190131015406-c8a261de75c1
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.3 // indirect
 	github.com/montanaflynn/stats v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.0 h1:/x0XQ6h+3U3nAyk1yx+bHPURrKa9sVVvYbuqZ7pIAtI=
 github.com/mitchellh/go-testing-interface v1.14.0/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=

--- a/go/test/endtoend/datapump/doc.go
+++ b/go/test/endtoend/datapump/doc.go
@@ -1,0 +1,1 @@
+package datapump

--- a/go/test/endtoend/datapump/pump.go
+++ b/go/test/endtoend/datapump/pump.go
@@ -1,0 +1,73 @@
+package datapump
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+type TestDataPump struct {
+	t        *testing.T
+	keyspace string
+	dbConn   *mysql.Conn
+
+	tables []*TestTable
+
+	concurrency int
+}
+
+func NewTestDataPump(t *testing.T, keyspace string, dbConn *mysql.Conn, numTables int) (*TestDataPump, error) {
+	tdp := &TestDataPump{
+		t:           t,
+		dbConn:      dbConn,
+		concurrency: 1,
+		keyspace:    keyspace,
+	}
+	for i := 0; i < numTables; i++ {
+		tableName := fmt.Sprintf("stress_test_%d", i)
+		if _, err := tdp.dbConn.ExecuteFetch(fmt.Sprintf(createStatement, keyspace, tableName), 1, false); err != nil {
+			return nil, err
+		}
+
+		table := NewTestTable(tableName, keyspace, dbConn)
+		if table == nil {
+			return nil, fmt.Errorf("could not create table %s", tableName)
+		}
+		tdp.tables = append(tdp.tables, table)
+	}
+	return tdp, nil
+}
+
+func (tdp *TestDataPump) Start(ctx context.Context) {
+	for _, table := range tdp.tables {
+		for i := 0; i < tdp.concurrency; i++ {
+			go tdp.startPumping(ctx, table)
+		}
+	}
+}
+
+func (tdp *TestDataPump) startPumping(ctx context.Context, table *TestTable) {
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Printf(">>>>>>>>>>>>>>>>>>>>>> Context Done in startPumping\n")
+			return
+		default:
+		}
+
+		r := rand.Intn(6)
+		switch r {
+		case 0, 1, 2:
+			require.NoError(tdp.t, table.Insert())
+		case 3, 4:
+			require.NoError(tdp.t, table.Update())
+		case 5:
+			require.NoError(tdp.t, table.Delete())
+		}
+	}
+}

--- a/go/test/endtoend/datapump/table.go
+++ b/go/test/endtoend/datapump/table.go
@@ -1,0 +1,76 @@
+package datapump
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+var (
+	createStatement = `
+		CREATE TABLE %s.%s (
+			id bigint(20) auto_increment,
+			vc varchar(32) default "default",
+			vb varbinary(32) default '123' ,
+			j json  not null,
+			e enum('individual','soho','enterprise') default 'individual',
+			s set('football','cricket','baseball') default 'cricket',
+			t timestamp not null default current_timestamp,
+			i int unsigned not null default 0,
+			PRIMARY KEY (id)
+		) ENGINE=InnoDB
+`
+	insertStatement = "insert into %s.%s(j) values('{}')"
+	updateStatement = "update %s.%s set i = i + 1, j = '{}' order by rand() limit 1"
+	deleteStatement = "delete from %s.%s order by rand() limit 1"
+)
+
+type StatementType int
+
+const (
+	InsertStatement StatementType = iota
+	UpdateStatement
+	DeleteStatement
+)
+
+// for now just a single table
+
+type TestTable struct {
+	tableName, create, insert, update, delete string
+	dbConn                                    *mysql.Conn
+}
+
+func (tt *TestTable) Insert() error {
+	_, err := tt.dbConn.ExecuteFetch(tt.insert, 1, false)
+	return err
+}
+
+func (tt *TestTable) Update() error {
+	_, err := tt.dbConn.ExecuteFetch(tt.update, 1, false)
+	return err
+}
+
+func (tt *TestTable) Delete() error {
+	_, err := tt.dbConn.ExecuteFetch(tt.delete, 1, false)
+	return err
+}
+
+func NewTestTable(tableName, keyspace string, dbConn *mysql.Conn) *TestTable {
+	tt := &TestTable{
+		tableName: tableName,
+		dbConn:    dbConn,
+		create:    fmt.Sprintf(createStatement, keyspace, tableName),
+		insert:    fmt.Sprintf(insertStatement, keyspace, tableName),
+		update:    fmt.Sprintf(updateStatement, keyspace, tableName),
+		delete:    fmt.Sprintf(deleteStatement, keyspace, tableName),
+	}
+	return tt
+}
+
+type ITestTable interface {
+	Insert() error
+	Update() error
+	Delete() error
+}
+
+var _ ITestTable = (*TestTable)(nil)

--- a/go/test/endtoend/vreplication/vreplication_stress_test.go
+++ b/go/test/endtoend/vreplication/vreplication_stress_test.go
@@ -1,0 +1,67 @@
+package vreplication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/datapump"
+)
+
+func TestVreplicationStress(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defaultCellName := "zone1"
+	allCells := []string{"zone1"}
+	allCellNames = "zone1"
+	mainClusterConfig.packetSize = 1
+	vc = NewVitessCluster(t, "TestVreplicationStress", allCells, mainClusterConfig)
+	require.NotNil(t, vc)
+
+	//defer vc.TearDown()
+
+	sourceKs := "stress"
+	targetKs := "stress2"
+	defaultCell = vc.Cells[defaultCellName]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, sourceKs, "0", "", "", 0, 0, 100)
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", sourceKs, "0"), 1)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+	verifyClusterHealth(t, vc)
+
+	vc.AddKeyspace(t, []*Cell{defaultCell}, targetKs, "0", "", "", 0, 0, 200)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", targetKs, "0"), 1)
+
+	tdp, err := datapump.NewTestDataPump(t, sourceKs, vtgateConn, 1)
+	if output, err := vc.VtctlClient.ExecuteCommandWithOutput("ReloadSchemaKeyspace", "-include_master=true", sourceKs); err != nil {
+		t.Fatalf("ReloadSchemaKeyspace command failed with %s, %+v\n", output, err)
+	}
+
+	tdp.Start(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tdp)
+	// wait for some data for copy phase
+	time.Sleep(1 * time.Second)
+
+	workflow := "stresswf"
+	ksWorkflow := "stress2.stresswf"
+	moveTables(t, defaultCellName, workflow, sourceKs, targetKs, "stress_test_0")
+	stressKs := vc.Cells[defaultCell.Name].Keyspaces["stress"]
+	stressTab := stressKs.Shards["0"].Tablets["zone1-100"].Vttablet
+
+	// wait for some data for replicate phase
+	time.Sleep(3 * time.Second)
+	cancel()
+
+	// let movetables catchup
+	time.Sleep(1 * time.Second)
+	catchup(t, stressTab, workflow, "MoveTables")
+
+	vdiff(t, ksWorkflow, "")
+
+}

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -88,8 +88,8 @@ func TestBasicVreplicationWorkflow(t *testing.T) {
 	allCells := []string{"zone1"}
 	allCellNames = "zone1"
 	vc = NewVitessCluster(t, "TestBasicVreplicationWorkflow", allCells, mainClusterConfig)
-
 	require.NotNil(t, vc)
+
 	defaultReplicas = 0 // because of CI resource constraints we can only run this test with master tablets
 	defer func() { defaultReplicas = 1 }()
 
@@ -103,12 +103,14 @@ func TestBasicVreplicationWorkflow(t *testing.T) {
 
 	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 	defer vtgateConn.Close()
+
+	//getExpVars(t, vc.Cells["zone1"].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet.VerifyURL)
+
 	verifyClusterHealth(t, vc)
 	insertInitialData(t)
 	materializeRollup(t)
 
 	shardCustomer(t, true, []*Cell{defaultCell}, defaultCellName)
-
 	validateRollupReplicates(t)
 	shardOrders(t)
 	shardMerchant(t)

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -88,12 +88,13 @@ type Stats struct {
 
 	State sync2.AtomicString
 
-	PhaseTimings  *stats.Timings
-	QueryTimings  *stats.Timings
-	QueryCount    *stats.CountersWithSingleLabel
-	CopyRowCount  *stats.Counter
-	CopyLoopCount *stats.Counter
-	ErrorCounts   *stats.CountersWithMultiLabels
+	PhaseTimings   *stats.Timings
+	QueryTimings   *stats.Timings
+	QueryCount     *stats.CountersWithSingleLabel
+	CopyRowCount   *stats.Counter
+	CopyLoopCount  *stats.Counter
+	ErrorCounts    *stats.CountersWithMultiLabels
+	NoopQueryCount *stats.CountersWithSingleLabel
 }
 
 // RecordHeartbeat updates the time the last heartbeat from vstreamer was seen
@@ -149,6 +150,7 @@ func NewStats() *Stats {
 	bps.CopyRowCount = stats.NewCounter("", "")
 	bps.CopyLoopCount = stats.NewCounter("", "")
 	bps.ErrorCounts = stats.NewCountersWithMultiLabels("", "", []string{"type"})
+	bps.NoopQueryCount = stats.NewCountersWithSingleLabel("", "", "Statement		", "")
 	return bps
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -682,7 +684,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 	}
 
 	for _, tcase := range testcases {
-		plan, err := buildReplicatorPlan(tcase.input, PrimaryKeyInfos, nil)
+		plan, err := buildReplicatorPlan(tcase.input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 		gotPlan, _ := json.Marshal(plan)
 		wantPlan, _ := json.Marshal(tcase.plan)
 		if string(gotPlan) != string(wantPlan) {
@@ -696,7 +698,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			t.Errorf("Filter err(%v): %s, want %v", tcase.input, gotErr, tcase.err)
 		}
 
-		plan, err = buildReplicatorPlan(tcase.input, PrimaryKeyInfos, copyState)
+		plan, err = buildReplicatorPlan(tcase.input, PrimaryKeyInfos, copyState, binlogplayer.NewStats())
 		if err != nil {
 			continue
 		}
@@ -722,7 +724,7 @@ func TestBuildPlayerPlanNoDup(t *testing.T) {
 			Filter: "select * from t",
 		}},
 	}
-	_, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
+	_, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 	want := "more than one target for source table t"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("buildReplicatorPlan err: %v, must contain: %v", err, want)
@@ -743,7 +745,7 @@ func TestBuildPlayerPlanExclude(t *testing.T) {
 			Filter: "",
 		}},
 	}
-	plan, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
+	plan, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 	assert.NoError(t, err)
 
 	want := &TestReplicatorPlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -51,6 +52,7 @@ type tablePlanBuilder struct {
 	pkCols     []*colExpr
 	lastpk     *sqltypes.Result
 	pkInfos    []*PrimaryKeyInfo
+	stats      *binlogplayer.Stats
 }
 
 // colExpr describes the processing to be performed to
@@ -120,12 +122,13 @@ const (
 // The TablePlan built is a partial plan. The full plan for a table is built
 // when we receive field information from events or rows sent by the source.
 // buildExecutionPlan is the function that builds the full plan.
-func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*PrimaryKeyInfo, copyState map[string]*sqltypes.Result) (*ReplicatorPlan, error) {
+func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*PrimaryKeyInfo, copyState map[string]*sqltypes.Result, stats *binlogplayer.Stats) (*ReplicatorPlan, error) {
 	plan := &ReplicatorPlan{
 		VStreamFilter: &binlogdatapb.Filter{FieldEventMode: filter.FieldEventMode},
 		TargetTables:  make(map[string]*TablePlan),
 		TablePlans:    make(map[string]*TablePlan),
 		PKInfoMap:     pkInfoMap,
+		stats:         stats,
 	}
 	for tableName := range pkInfoMap {
 		lastpk, ok := copyState[tableName]
@@ -140,7 +143,7 @@ func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*Pr
 		if rule == nil {
 			continue
 		}
-		tablePlan, err := buildTablePlan(tableName, rule.Filter, pkInfoMap, lastpk)
+		tablePlan, err := buildTablePlan(tableName, rule.Filter, pkInfoMap, lastpk, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +182,7 @@ func MatchTable(tableName string, filter *binlogdatapb.Filter) (*binlogdatapb.Ru
 	return nil, nil
 }
 
-func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKeyInfo, lastpk *sqltypes.Result) (*TablePlan, error) {
+func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKeyInfo, lastpk *sqltypes.Result, stats *binlogplayer.Stats) (*TablePlan, error) {
 	query := filter
 	// generate equivalent select statement if filter is empty or a keyrange.
 	switch {
@@ -216,6 +219,7 @@ func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKey
 			TargetName: tableName,
 			SendRule:   sendRule,
 			Lastpk:     lastpk,
+			Stats:      stats,
 		}
 		return tablePlan, nil
 	}
@@ -229,6 +233,7 @@ func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKey
 		selColumns: make(map[string]bool),
 		lastpk:     lastpk,
 		pkInfos:    pkInfoMap[tableName],
+		stats:      stats,
 	}
 
 	if err := tpb.analyzeExprs(sel.SelectExprs); err != nil {
@@ -299,6 +304,7 @@ func (tpb *tablePlanBuilder) generate() *TablePlan {
 		Update:           tpb.generateUpdateStatement(),
 		Delete:           tpb.generateDeleteStatement(),
 		PKReferences:     pkrefs,
+		Stats:            tpb.stats,
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -56,7 +56,7 @@ func newVCopier(vr *vreplicator) *vcopier {
 func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 	defer vc.vr.dbClient.Rollback()
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil, vc.vr.stats)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 	log.Infof("Copying table %s, lastpk: %v", tableName, copyState[tableName])
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil, vc.vr.stats)
 	if err != nil {
 		return err
 	}
@@ -307,6 +307,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 		if err := vc.vr.dbClient.Commit(); err != nil {
 			return err
 		}
+
 		return nil
 	})
 	// If there was a timeout, return without an error.

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -620,8 +620,6 @@ func TestPlayerCopyBigTable(t *testing.T) {
 		"/update _vt.vreplication set state='Copying'",
 		"insert into dst(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
-		// The next catchup executes the new row insert, but will be a no-op.
-		"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into dst(id,val) values (2,'bbb')",
@@ -737,8 +735,6 @@ func TestPlayerCopyWildcardRule(t *testing.T) {
 		// The first fast-forward has no starting point. So, it just saves the current position.
 		"insert into src(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
-		// The next catchup executes the new row insert, but will be a no-op.
-		"insert into src(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into src(id,val) values (2,'bbb')",
@@ -984,7 +980,6 @@ func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 		"/insert into _vt.vreplication",
 		"/update _vt.vreplication set state = 'Copying'",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"insert into dst(id,val) select 4, 'new' from dual where (4) <= (2)",
 		// Copy
 		"insert into dst(id,val) values (3,'uncopied'), (4,'new')",
 		`/update _vt.copy_state set lastpk.*`,

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -102,7 +102,7 @@ func (vp *vplayer) play(ctx context.Context) error {
 		return nil
 	}
 
-	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.pkInfoMap, vp.copyState)
+	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.pkInfoMap, vp.copyState, vp.vr.stats)
 	if err != nil {
 		vp.vr.stats.ErrorCounts.Add([]string{"Plan"}, 1)
 		return err


### PR DESCRIPTION


Signed-off-by: Rohit Nayak <rohit@planetscale.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
