### PR TITLE
fix regression - should be able to plan subquery on top of subquery

### DIFF
--- a/go/vt/vtgate/planbuilder/filtering.go
+++ b/go/vt/vtgate/planbuilder/filtering.go
@@ -63,6 +63,8 @@ func planFilter(pb *primitiveBuilder, input logicalPlan, filter sqlparser.Expr, 
 		}
 		node.UpdatePlan(pb, filter)
 		return node, nil
+	case *pulloutSubquery:
+		return planFilter(pb, node.underlying, filter, whereType, origin)
 	case *vindexFunc:
 		return filterVindexFunc(node, filter)
 	case *subquery:

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1843,3 +1843,46 @@ Gen4 plan same as above
     "SysTableTableSchema": "VARBINARY(\"ks\")"
   }
 }
+
+# pullout sq after pullout sq
+"select id from user where not id in (select user_extra.col from user_extra where user_extra.user_id = 42) and id in (select user_extra.col from user_extra where user_extra.user_id = 411)"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where not id in (select user_extra.col from user_extra where user_extra.user_id = 42) and id in (select user_extra.col from user_extra where user_extra.user_id = 411)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutIn",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
+        "Query": "select user_extra.col from user_extra where user_extra.user_id = 42",
+        "Table": "user_extra",
+        "Values": [
+          42
+        ],
+        "Vindex": "user_index"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectIN",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1",
+        "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals and not (:__sq_has_values2 = 1 and id in ::__sq2)",
+        "Table": "`user`",
+        "Values": [
+          "::__sq1"
+        ],
+        "Vindex": "user_index"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

During a refactoring of the planner code in the V9.0.0 release, this query type was broken. This restored the capability to plan IN sub queries on top of other IN sub queries.

## Checklist
- [x] Should this PR be backported? `Yes, it needs to go into the 9.0 release`
- [x] Tests were added or are not required  `Added`

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
