### PR TITLE
[9.0] fix regression - should be able to plan subquery on top of subquery

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Check Make Parser
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Check Make Visitor
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         name: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27]

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (upgrade)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: cluster initial sharding multi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/docker_test_1.yml
+++ b/.github/workflows/docker_test_1.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Docker Test 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
 

--- a/.github/workflows/docker_test_2.yml
+++ b/.github/workflows/docker_test_2.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Docker Test 2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
 

--- a/.github/workflows/docker_test_3.yml
+++ b/.github/workflows/docker_test_3.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Docker Test 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
 

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: End-to-End Test (Race)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: End-to-End Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Check Bootstrap Updated
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Set up Go 1.15
         uses: actions/setup-go@v1

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Set up Go

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         name: [percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103]

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Unit Test (Race)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Set up Go

--- a/go/vt/vtgate/planbuilder/filtering.go
+++ b/go/vt/vtgate/planbuilder/filtering.go
@@ -63,6 +63,8 @@ func planFilter(pb *primitiveBuilder, input logicalPlan, filter sqlparser.Expr, 
 		}
 		node.UpdatePlan(pb, filter)
 		return node, nil
+	case *pulloutSubquery:
+		return planFilter(pb, node.underlying, filter, whereType, origin)
 	case *vindexFunc:
 		return filterVindexFunc(node, filter)
 	case *subquery:

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1773,3 +1773,46 @@
     "SysTableTableSchema": "VARBINARY(\"ks\")"
   }
 }
+
+# pullout sq after pullout sq
+"select id from user where not id in (select user_extra.col from user_extra where user_extra.user_id = 42) and id in (select user_extra.col from user_extra where user_extra.user_id = 411)"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where not id in (select user_extra.col from user_extra where user_extra.user_id = 42) and id in (select user_extra.col from user_extra where user_extra.user_id = 411)",
+  "Instructions": {
+    "OperatorType": "Subquery",
+    "Variant": "PulloutIn",
+    "Inputs": [
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectEqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
+        "Query": "select user_extra.col from user_extra where user_extra.user_id = 42",
+        "Table": "user_extra",
+        "Values": [
+          42
+        ],
+        "Vindex": "user_index"
+      },
+      {
+        "OperatorType": "Route",
+        "Variant": "SelectIN",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from user where 1 != 1",
+        "Query": "select id from user where :__sq_has_values1 = 1 and id in ::__vals and not (:__sq_has_values2 = 1 and id in ::__sq2)",
+        "Table": "user",
+        "Values": [
+          "::__sq1"
+        ],
+        "Vindex": "user_index"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

During a refactoring of the planner code in the V9.0.0 release, this query type was broken. This restored the capability to plan IN sub queries on top of other IN sub queries.

## Checklist
- [x] Should this PR be backported? `No, this is the backport`
- [x] Tests were added or are not required  `Added`

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving

(This is a backport of #7682)