### PR TITLE
tabletserver: more resilient wait for schema changes

### DIFF
--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -191,7 +191,7 @@ func testQueryPlanCache(t *testing.T, cachedPlanSize, cachePlanSize2 int) {
 	t.Helper()
 
 	//sleep to avoid race between SchemaChanged event clearing out the plans cache which breaks this test
-	time.Sleep(1 * time.Second)
+	framework.Server.WaitForSchemaReset(2 * time.Second)
 
 	defer framework.Server.SetQueryPlanCacheCap(framework.Server.QueryPlanCacheCap())
 	framework.Server.SetQueryPlanCacheCap(cachedPlanSize)


### PR DESCRIPTION
## Description

@shlomi-noach has detected a flaky test (e.g. https://github.com/vitessio/vitess/pull/7663/checks?check_run_id=2109940790) which I suspect is related to `SchemaChanged` events flushing our cache in the middle of a test. The current version of the test just sleeps for a small while to prevent this, but in practice this may not be enough. A new helper method has been introduced that waits for `T` seconds without any `SchemaChanged` events, because at the start of these tests we can see more than one of these events, which may lag between each other.

## Related Issue(s)

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
