### PR TITLE
[reparentutil | ERS] Bind status variable to each goroutine in WaitForRelayLogsToApply

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -379,11 +379,11 @@ func (erp *EmergencyReparenter) waitForAllRelayLogsToApply(
 			continue
 		}
 
-		go func(alias string) {
+		go func(alias string, status *replicationdatapb.StopReplicationStatus) {
 			var err error
 			defer func() { errCh <- err }()
 			err = WaitForRelayLogsToApply(groupCtx, erp.tmc, tabletMap[alias], status)
-		}(candidate)
+		}(candidate, status)
 
 		waiterCount++
 	}


### PR DESCRIPTION
Closes #7691.

Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Pretty much what it says in the issue description. We're binding that `status` variable on each iteration to the goroutine we're spawning to prevent potentially telling tablet A to wait for tablet B's StopPosition.

## Related Issue(s)

- Closes #7691.

## Checklist
- [x] Should this PR be backported?
    - This bug was introduced in https://github.com/vitessio/vitess/pull/7523, which is tagged for 10.0, so this either needs to be backported to that release branch, or just simply pulled in as-normal. I'm not sure what the status there is. @askdba can you advise, and I can do the backport if needed?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
