### PR TITLE
VDiff: Use byte compare if weight_string() returns null for either source or target

### DIFF
--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/vt/topo"
-
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtgate/engine"
 
 	"context"
 
@@ -34,7 +34,6 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
-	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
 func TestVDiffPlanSuccess(t *testing.T) {
@@ -80,10 +79,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -95,10 +95,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -110,10 +111,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -125,10 +127,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c2, c1 from t1 order by c1 asc",
 			targetExpression: "select c2, c1 from t1 order by c1 asc",
-			compareCols:      []int{0, -1},
-			comparePKs:       []int{1},
-			sourcePrimitive:  newMergeSorter(nil, []int{1}),
-			targetPrimitive:  newMergeSorter(nil, []int{1}),
+			compareCols:      []compareColInfo{{0, 0, false}, {1, 0, true}},
+			comparePKs:       []compareColInfo{{1, 0, true}},
+			pkCols:           []int{1},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, 0, true}}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -140,10 +143,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c0 as c1, c2 from t2 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// non-pk text column.
@@ -156,10 +160,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "nonpktext",
 			sourceExpression: "select c1, textcol, weight_string(textcol) from nonpktext order by c1 asc",
 			targetExpression: "select c1, textcol, weight_string(textcol) from nonpktext order by c1 asc",
-			compareCols:      []int{-1, 2},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 2, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// non-pk text column, different order.
@@ -172,10 +177,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "nonpktext",
 			sourceExpression: "select textcol, c1, weight_string(textcol) from nonpktext order by c1 asc",
 			targetExpression: "select textcol, c1, weight_string(textcol) from nonpktext order by c1 asc",
-			compareCols:      []int{2, -1},
-			comparePKs:       []int{1},
-			sourcePrimitive:  newMergeSorter(nil, []int{1}),
-			targetPrimitive:  newMergeSorter(nil, []int{1}),
+			compareCols:      []compareColInfo{{0, 2, false}, {1, 0, true}},
+			comparePKs:       []compareColInfo{{1, 0, true}},
+			pkCols:           []int{1},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, 0, true}}),
 		},
 	}, {
 		// pk text column.
@@ -188,10 +194,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "pktext",
 			sourceExpression: "select textcol, c2, weight_string(textcol) from pktext order by textcol asc",
 			targetExpression: "select textcol, c2, weight_string(textcol) from pktext order by textcol asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter(nil, []int{2}),
-			targetPrimitive:  newMergeSorter(nil, []int{2}),
+			compareCols:      []compareColInfo{{0, 2, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 2, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 2, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 2, true}}),
 		},
 	}, {
 		// pk text column, different order.
@@ -204,10 +211,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "pktext",
 			sourceExpression: "select c2, textcol, weight_string(textcol) from pktext order by textcol asc",
 			targetExpression: "select c2, textcol, weight_string(textcol) from pktext order by textcol asc",
-			compareCols:      []int{0, -1},
-			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter(nil, []int{2}),
-			targetPrimitive:  newMergeSorter(nil, []int{2}),
+			compareCols:      []compareColInfo{{0, 0, false}, {1, 2, true}},
+			comparePKs:       []compareColInfo{{1, 2, true}},
+			pkCols:           []int{1},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, 2, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, 2, true}}),
 		},
 	}, {
 		// text column as expression.
@@ -220,10 +228,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "pktext",
 			sourceExpression: "select c2, a + b as textcol, weight_string(a + b) from pktext order by textcol asc",
 			targetExpression: "select c2, textcol, weight_string(textcol) from pktext order by textcol asc",
-			compareCols:      []int{0, -1},
-			comparePKs:       []int{2},
-			sourcePrimitive:  newMergeSorter(nil, []int{2}),
-			targetPrimitive:  newMergeSorter(nil, []int{2}),
+			compareCols:      []compareColInfo{{0, 0, false}, {1, 2, true}},
+			comparePKs:       []compareColInfo{{1, 2, true}},
+			pkCols:           []int{1},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, 2, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, 2, true}}),
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -234,10 +243,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "multipk",
 			sourceExpression: "select c1, c2 from multipk order by c1 asc, c2 asc",
 			targetExpression: "select c1, c2 from multipk order by c1 asc, c2 asc",
-			compareCols:      []int{-1, -1},
-			comparePKs:       []int{0, 1},
-			sourcePrimitive:  newMergeSorter(nil, []int{0, 1}),
-			targetPrimitive:  newMergeSorter(nil, []int{0, 1}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, true}},
+			comparePKs:       []compareColInfo{{0, 0, true}, {1, 0, true}},
+			pkCols:           []int{0, 1},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}, {1, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}, {1, 0, true}}),
 		},
 	}, {
 		// in_keyrange
@@ -250,10 +260,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// in_keyrange on RHS of AND.
@@ -267,10 +278,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// in_keyrange on LHS of AND.
@@ -284,10 +296,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// in_keyrange on cascaded AND expression
@@ -301,10 +314,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 where c2 = 2 and c1 = 1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// in_keyrange parenthesized
@@ -318,10 +332,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 where c2 = 2 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// group by
@@ -334,10 +349,11 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "t1",
 			sourceExpression: "select c1, c2 from t1 group by c1 order by c1 asc",
 			targetExpression: "select c1, c2 from t1 order by c1 asc",
-			compareCols:      []int{-1, 1},
-			comparePKs:       []int{0},
-			sourcePrimitive:  newMergeSorter(nil, []int{0}),
-			targetPrimitive:  newMergeSorter(nil, []int{0}),
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
+			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
+			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}, {
 		// aggregations
@@ -350,8 +366,9 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			targetTable:      "aggr",
 			sourceExpression: "select c1, c2, count(*) as c3, sum(c4) as c4 from t1 group by c1 order by c1 asc",
 			targetExpression: "select c1, c2, c3, c4 from aggr order by c1 asc",
-			compareCols:      []int{-1, 1, 2, 3},
-			comparePKs:       []int{0},
+			compareCols:      []compareColInfo{{0, 0, true}, {1, 0, false}, {2, 0, false}, {3, 0, false}},
+			comparePKs:       []compareColInfo{{0, 0, true}},
+			pkCols:           []int{0},
 			sourcePrimitive: &engine.OrderedAggregate{
 				Aggregates: []engine.AggregateParams{{
 					Opcode: engine.AggregateCount,
@@ -361,11 +378,12 @@ func TestVDiffPlanSuccess(t *testing.T) {
 					Col:    3,
 				}},
 				Keys:  []int{0},
-				Input: newMergeSorter(nil, []int{0}),
+				Input: newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 			},
-			targetPrimitive: newMergeSorter(nil, []int{0}),
+			targetPrimitive: newMergeSorter(nil, []compareColInfo{{0, 0, true}}),
 		},
 	}}
+
 	for _, tcase := range testcases {
 		t.Run(tcase.input.Filter, func(t *testing.T) {
 			filter := &binlogdatapb.Filter{Rules: []*binlogdatapb.Rule{tcase.input}}
@@ -562,12 +580,14 @@ func TestVDiffUnsharded(t *testing.T) {
 	}}
 
 	for _, tcase := range testcases {
-		env.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, tcase.source)
-		env.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetMasterPosition, tcase.target)
+		t.Run(tcase.id, func(t *testing.T) {
+			env.tablets[101].setResults("select c1, c2 from t1 order by c1 asc", vdiffSourceGtid, tcase.source)
+			env.tablets[201].setResults("select c1, c2 from t1 order by c1 asc", vdiffTargetMasterPosition, tcase.target)
 
-		dr, err := env.wr.VDiff(context.Background(), "target", env.workflow, env.cell, env.cell, "replica", 30*time.Second, "", 100, "")
-		require.NoError(t, err)
-		assert.Equal(t, tcase.dr, dr["t1"], tcase.id)
+			dr, err := env.wr.VDiff(context.Background(), "target", env.workflow, env.cell, env.cell, "replica", 30*time.Second, "", 100, "")
+			require.NoError(t, err)
+			assert.Equal(t, tcase.dr, dr["t1"], tcase.id)
+		})
 	}
 }
 
@@ -942,12 +962,14 @@ func TestVDiffFindPKs(t *testing.T) {
 				},
 			},
 			tdIn: &tableDiffer{
-				compareCols: []int{0, 1},
-				comparePKs:  []int{},
+				compareCols: []compareColInfo{{0, 0, false}, {1, 0, false}},
+				comparePKs:  []compareColInfo{},
+				pkCols:      []int{},
 			},
 			tdOut: &tableDiffer{
-				compareCols: []int{-1, 1},
-				comparePKs:  []int{0},
+				compareCols: []compareColInfo{{0, 0, true}, {1, 0, false}},
+				comparePKs:  []compareColInfo{{0, 0, true}},
+				pkCols:      []int{0},
 			},
 		}, {
 			name: "",
@@ -966,12 +988,14 @@ func TestVDiffFindPKs(t *testing.T) {
 				},
 			},
 			tdIn: &tableDiffer{
-				compareCols: []int{0, 1, 2, 3},
-				comparePKs:  []int{},
+				compareCols: []compareColInfo{{0, 0, false}, {1, 0, false}, {2, 0, false}, {3, 0, false}},
+				comparePKs:  []compareColInfo{},
+				pkCols:      []int{},
 			},
 			tdOut: &tableDiffer{
-				compareCols: []int{-1, 1, 2, -1},
-				comparePKs:  []int{0, 3},
+				compareCols: []compareColInfo{{0, 0, true}, {1, 0, false}, {2, 0, false}, {3, 0, true}},
+				comparePKs:  []compareColInfo{{0, 0, true}, {3, 0, true}},
+				pkCols:      []int{0, 3},
 			},
 		},
 	}
@@ -1097,13 +1121,13 @@ func TestVDiffNullWeightString(t *testing.T) {
 		id:   "2",
 		source: sqltypes.MakeTestStreamingResults(fields,
 			"1|abd|null",
-			"1|abd|abd",
-			"1|abd|null",
+			"2|abd|abd",
+			"3|abd|null",
 		),
 		target: sqltypes.MakeTestStreamingResults(fields,
 			"1|abc|null",
-			"1|abc|abc",
-			"1|abc|null",
+			"2|abc|abc",
+			"3|abc|null",
 		),
 		dr: &DiffReport{
 			ProcessedRows:  3,


### PR DESCRIPTION
## Description

VDiff compares text columns using the weight_string() of the value. However there are times when weight_string() can return a null value. Per the mysql reference
```
String-valued functions return NULL if the length of the result would be greater than the value of the max_allowed_packet system variable.
```
It is possible that just one of the weight_string(), for source or target is null or both are null, depending on the configuration of the source and target servers. Currently if one is null vdiff detects a mismatch and if both are null then it is considered a match. This is incorrect since, in such cases, vdiff needs to compare the actual data.

This PR detects such a condition and uses a byte compare instead.

See related issue for more details and repro.
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)

- #7296 

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
