### PR TITLE
[vtadmin] add to local example

### DIFF
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -25,7 +25,6 @@ trap cleanup INT QUIT TERM
 
 echo "vtadmin-api is up! Logs are in ${log_dir}/vtadmin-api.out, and its PID is ${vtadmin_pid}"
 
-
 (
   cd ../../web/vtadmin &&
   npm install &&

--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+source ./env.sh
+
+log_dir="${VTDATAROOT}/tmp"
+vtadmin_api_port=14200
+
+vtadmin \
+  --addr ":${vtadmin_api_port}" \
+  --http-origin "http://localhost:3000" \
+  --logtostderr \
+  --alsologtostderr \
+  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json" \
+  > "${log_dir}/vtadmin-api.out" 2>&1 &
+vtadmin_pid=$!
+
+function cleanup() {
+  kill -9 "${vtadmin_pid}"
+
+  echo
+  echo "Shutdown complete!"
+}
+
+trap cleanup INT QUIT TERM
+
+echo "vtadmin-api is up! Logs are in ${log_dir}/vtadmin-api.out, and its PID is ${vtadmin_pid}"
+
+
+(
+  cd ../../web/vtadmin &&
+  npm install &&
+  REACT_APP_VTADMIN_API_ADDRESS="http://127.0.0.1:${vtadmin_api_port}" \
+    npm run start
+)

--- a/examples/local/vtadmin/discovery.json
+++ b/examples/local/vtadmin/discovery.json
@@ -1,0 +1,16 @@
+{
+    "vtctlds": [
+        {
+            "host": {
+                "hostname": "localhost:15999"
+            }
+        }
+    ],
+    "vtgates": [
+        {
+            "host": {
+                "hostname": "localhost:15991"
+            }
+        }
+    ]
+}

--- a/go/vt/vtadmin/vtsql/vtsql.go
+++ b/go/vt/vtadmin/vtsql/vtsql.go
@@ -154,13 +154,12 @@ func (vtgate *VTGateProxy) Dial(ctx context.Context, target string, opts ...grpc
 		Protocol:        fmt.Sprintf("grpc_%s", vtgate.cluster.Id),
 		Address:         vtgate.host,
 		Target:          target,
-		GRPCDialOptions: opts,
+		GRPCDialOptions: append(opts, grpc.WithInsecure()),
 	}
 
 	if vtgate.creds != nil {
 		conf.GRPCDialOptions = append([]grpc.DialOption{
 			grpc.WithPerRPCCredentials(vtgate.creds),
-			grpc.WithInsecure(),
 		}, conf.GRPCDialOptions...)
 	}
 


### PR DESCRIPTION
## Description

This PR does two things:
* Remove our poorly-and-not-actually-supported TLS based grpc connections, by always specifying `grpc.WithInsecure` when dialing vtctlds and vtgates. We'll come back around to make this more robust and flexible.
* Add scripts to run vtadmin-{api,web}, with the local example.

To run, `cd examples/local; ./101_initial_cluster.sh; ./vtadmin-up.sh`, and ctrl-C at any point to tear down the vtadmin components. `401_teardown.sh` is still used to tear down the other components, as per usual.

Example: 
<img width="1125" alt="Screen Shot 2021-03-16 at 2 24 14 PM" src="https://user-images.githubusercontent.com/4276638/111363923-01824480-8667-11eb-9d8f-f34ccb39f0f6.png">


## Related Issue(s)
<!-- List related issues and pull requests: -->

- Closes #7598 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
