### PR TITLE
servenv: fix var shadowing caused by short variable declaration

### DIFF
--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -51,7 +51,7 @@ func Run(port int) {
 	}
 	go http.Serve(l, nil)
 
-	ExitChan := make(chan os.Signal, 1)
+	ExitChan = make(chan os.Signal, 1)
 	signal.Notify(ExitChan, syscall.SIGTERM, syscall.SIGINT)
 	// Wait for signal
 	<-ExitChan


### PR DESCRIPTION
## Description
In #7563, we fixed the panic reported in #7261. However, there is a bug in that PR, as reported by @yangxuanjia [here](https://github.com/vitessio/vitess/pull/7563#issuecomment-800118897).
This PR fixes that bug.
Tested manually that master vttablet shuts down when tablet record is deleted, using local_example (`examples/local`).

## Related Issue(s)
#7261  

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
