### PR TITLE
VReplication: optimize the catchup phases by filtering out rows which not within range of copied pks during inserts

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -88,12 +88,13 @@ type Stats struct {
 
 	State sync2.AtomicString
 
-	PhaseTimings  *stats.Timings
-	QueryTimings  *stats.Timings
-	QueryCount    *stats.CountersWithSingleLabel
-	CopyRowCount  *stats.Counter
-	CopyLoopCount *stats.Counter
-	ErrorCounts   *stats.CountersWithMultiLabels
+	PhaseTimings   *stats.Timings
+	QueryTimings   *stats.Timings
+	QueryCount     *stats.CountersWithSingleLabel
+	CopyRowCount   *stats.Counter
+	CopyLoopCount  *stats.Counter
+	ErrorCounts    *stats.CountersWithMultiLabels
+	NoopQueryCount *stats.CountersWithSingleLabel
 }
 
 // RecordHeartbeat updates the time the last heartbeat from vstreamer was seen
@@ -149,6 +150,7 @@ func NewStats() *Stats {
 	bps.CopyRowCount = stats.NewCounter("", "")
 	bps.CopyLoopCount = stats.NewCounter("", "")
 	bps.ErrorCounts = stats.NewCountersWithMultiLabels("", "", []string{"type"})
+	bps.NoopQueryCount = stats.NewCountersWithSingleLabel("", "", "Statement", "")
 	return bps
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -247,6 +247,9 @@ func (tp *TablePlan) applyBulkInsert(rows *binlogdatapb.VStreamRowsResponse, exe
 // unit test reliably and without flakiness with our current test framework. So as a pragmatic decision we support Insert
 // now and punt on the others.
 func (tp *TablePlan) isOutsidePKRange(bindvars map[string]*querypb.BindVariable, before, after bool, stmtType string) bool {
+	if *vreplicationExperimentalFlags&vreplicationExperimentalOptimizeInserts == 0 {
+		return false
+	}
 	// Ensure there is one and only one value in lastpk and pkrefs.
 	if tp.Lastpk != nil && len(tp.Lastpk.Fields) == 1 && len(tp.Lastpk.Rows) == 1 && len(tp.Lastpk.Rows[0]) == 1 && len(tp.PKReferences) == 1 {
 		// check again that this is an insert

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -22,6 +22,9 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 
@@ -47,6 +50,7 @@ type ReplicatorPlan struct {
 	TargetTables  map[string]*TablePlan
 	TablePlans    map[string]*TablePlan
 	PKInfoMap     map[string][]*PrimaryKeyInfo
+	stats         *binlogplayer.Stats
 }
 
 // buildExecution plan uses the field info as input and the partially built
@@ -89,6 +93,7 @@ func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Res
 		name:    sqlparser.NewTableIdent(tableName),
 		lastpk:  lastpk,
 		pkInfos: rp.PKInfoMap[tableName],
+		stats:   rp.stats,
 	}
 	for _, field := range fields {
 		colName := sqlparser.NewColIdent(field.Name)
@@ -173,6 +178,7 @@ type TablePlan struct {
 	// PKReferences is used to check if an event changed
 	// a primary key column (row move).
 	PKReferences []string
+	Stats        *binlogplayer.Stats
 }
 
 // MarshalJSON performs a custom JSON Marshalling.
@@ -224,6 +230,46 @@ func (tp *TablePlan) applyBulkInsert(rows *binlogdatapb.VStreamRowsResponse, exe
 	return executor(buf.String())
 }
 
+// During the copy phase we run catchup and fastforward, which stream binlogs. During this we should only process
+// rows whose PK has already been copied. Ideally we should compare the PKs before applying the change and never send
+// such rows to the target mysql server. However reliably comparing primary keys in a manner compatible to MySQL will require a lot of
+// coding: consider composite PKs, character sets ... So we send these rows to the mysql server which then does the comparison
+// in sql, through where clauses like "pk_val <= last_seen_pk".
+//
+// But this does generate a lot of unnecessary load of, effectively no-ops, since the where
+// clauses are always false. This can create a significant cpu load on the target for high qps servers resulting in a
+// much lower copy bandwidth (or provisioning more powerful servers).
+// isOutsidePKRange currently checks for rows with single primary keys which are currently comparable in Vitess:
+// (see NullsafeCompare() for types supported)
+//
+// Currently we have decided to only do this optimization for Insert statements. Insert statements form a significant majority of
+// the generated noop load during catchup and are easier to test for. Update and Delete statements are very difficult to
+// unit test reliably and without flakiness with our current test framework. So as a pragmatic decision we support Insert
+// now and punt on the others.
+func (tp *TablePlan) isOutsidePKRange(bindvars map[string]*querypb.BindVariable, before, after bool, stmtType string) bool {
+	// Ensure there is one and only one value in lastpk and pkrefs.
+	if tp.Lastpk != nil && len(tp.Lastpk.Fields) == 1 && len(tp.Lastpk.Rows) == 1 && len(tp.Lastpk.Rows[0]) == 1 && len(tp.PKReferences) == 1 {
+		// check again that this is an insert
+		var bindvar *querypb.BindVariable
+		switch {
+		case !before && after:
+			bindvar = bindvars["a_"+tp.PKReferences[0]]
+		}
+		if bindvar == nil {
+			return false
+		}
+
+		rowVal, _ := sqltypes.BindVariableToValue(bindvar)
+		result, err := evalengine.NullsafeCompare(rowVal, tp.Lastpk.Rows[0][0])
+		// If rowVal is > last pk, transaction will be a noop, so don't apply this statement
+		if err == nil && result > 0 {
+			tp.Stats.NoopQueryCount.Add(stmtType, 1)
+			return true
+		}
+	}
+	return false
+}
+
 func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
 	// MakeRowTrusted is needed here because Proto3ToResult is not convenient.
 	var before, after bool
@@ -244,6 +290,10 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 	}
 	switch {
 	case !before && after:
+		// only apply inserts for rows whose primary keys
+		if tp.isOutsidePKRange(bindvars, before, after, "insert") {
+			return nil, nil
+		}
 		return execParsedQuery(tp.Insert, bindvars, executor)
 	case before && !after:
 		if tp.Delete == nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -247,7 +247,8 @@ func (tp *TablePlan) applyBulkInsert(rows *binlogdatapb.VStreamRowsResponse, exe
 // unit test reliably and without flakiness with our current test framework. So as a pragmatic decision we support Insert
 // now and punt on the others.
 func (tp *TablePlan) isOutsidePKRange(bindvars map[string]*querypb.BindVariable, before, after bool, stmtType string) bool {
-	if *vreplicationExperimentalFlags&vreplicationExperimentalOptimizeInserts == 0 {
+	// added empty comments below, otherwise gofmt removes the spaces between the bitwise & and obfuscates this check!
+	if *vreplicationExperimentalFlags /**/ & /**/ vreplicationExperimentalOptimizeInserts == 0 {
 		return false
 	}
 	// Ensure there is one and only one value in lastpk and pkrefs.

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -682,7 +684,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 	}
 
 	for _, tcase := range testcases {
-		plan, err := buildReplicatorPlan(tcase.input, PrimaryKeyInfos, nil)
+		plan, err := buildReplicatorPlan(tcase.input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 		gotPlan, _ := json.Marshal(plan)
 		wantPlan, _ := json.Marshal(tcase.plan)
 		if string(gotPlan) != string(wantPlan) {
@@ -696,7 +698,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			t.Errorf("Filter err(%v): %s, want %v", tcase.input, gotErr, tcase.err)
 		}
 
-		plan, err = buildReplicatorPlan(tcase.input, PrimaryKeyInfos, copyState)
+		plan, err = buildReplicatorPlan(tcase.input, PrimaryKeyInfos, copyState, binlogplayer.NewStats())
 		if err != nil {
 			continue
 		}
@@ -722,7 +724,7 @@ func TestBuildPlayerPlanNoDup(t *testing.T) {
 			Filter: "select * from t",
 		}},
 	}
-	_, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
+	_, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 	want := "more than one target for source table t"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("buildReplicatorPlan err: %v, must contain: %v", err, want)
@@ -743,7 +745,7 @@ func TestBuildPlayerPlanExclude(t *testing.T) {
 			Filter: "",
 		}},
 	}
-	plan, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil)
+	plan, err := buildReplicatorPlan(input, PrimaryKeyInfos, nil, binlogplayer.NewStats())
 	assert.NoError(t, err)
 
 	want := &TestReplicatorPlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -226,6 +226,39 @@ func (st *vrStats) register() {
 		})
 
 	stats.NewGaugesFuncWithMultiLabels(
+		"VReplicationNoopQueryCount",
+		"vreplication noop query counts per stream",
+		[]string{"source_keyspace", "source_shard", "workflow", "counts", "phase"},
+		func() map[string]int64 {
+			st.mu.Lock()
+			defer st.mu.Unlock()
+			result := make(map[string]int64, len(st.controllers))
+			for _, ct := range st.controllers {
+				for label, count := range ct.blpStats.NoopQueryCount.Counts() {
+					if label == "" {
+						continue
+					}
+					result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)+"."+label] = count
+				}
+			}
+			return result
+		})
+
+	stats.NewCounterFunc(
+		"VReplicationNoopQueryCountTotal",
+		"vreplication query noop counts aggregated across all streams",
+		func() int64 {
+			st.mu.Lock()
+			defer st.mu.Unlock()
+			result := int64(0)
+			for _, ct := range st.controllers {
+				for _, count := range ct.blpStats.NoopQueryCount.Counts() {
+					result += count
+				}
+			}
+			return result
+		})
+	stats.NewGaugesFuncWithMultiLabels(
 		"VReplicationCopyRowCount",
 		"vreplication rows copied in copy phase per stream",
 		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
@@ -353,6 +386,7 @@ func (st *vrStats) status() *EngineStatus {
 			PhaseTimings:        ct.blpStats.PhaseTimings.Counts(),
 			CopyRowCount:        ct.blpStats.CopyRowCount.Get(),
 			CopyLoopCount:       ct.blpStats.CopyLoopCount.Get(),
+			NoopQueryCounts:     ct.blpStats.NoopQueryCount.Counts(),
 		}
 		i++
 	}
@@ -384,6 +418,7 @@ type ControllerStatus struct {
 	PhaseTimings        map[string]int64
 	CopyRowCount        int64
 	CopyLoopCount       int64
+	NoopQueryCounts     map[string]int64
 }
 
 var vreplicationTemplate = `

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -51,6 +53,7 @@ type tablePlanBuilder struct {
 	pkCols     []*colExpr
 	lastpk     *sqltypes.Result
 	pkInfos    []*PrimaryKeyInfo
+	stats      *binlogplayer.Stats
 }
 
 // colExpr describes the processing to be performed to
@@ -120,12 +123,13 @@ const (
 // The TablePlan built is a partial plan. The full plan for a table is built
 // when we receive field information from events or rows sent by the source.
 // buildExecutionPlan is the function that builds the full plan.
-func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*PrimaryKeyInfo, copyState map[string]*sqltypes.Result) (*ReplicatorPlan, error) {
+func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*PrimaryKeyInfo, copyState map[string]*sqltypes.Result, stats *binlogplayer.Stats) (*ReplicatorPlan, error) {
 	plan := &ReplicatorPlan{
 		VStreamFilter: &binlogdatapb.Filter{FieldEventMode: filter.FieldEventMode},
 		TargetTables:  make(map[string]*TablePlan),
 		TablePlans:    make(map[string]*TablePlan),
 		PKInfoMap:     pkInfoMap,
+		stats:         stats,
 	}
 	for tableName := range pkInfoMap {
 		lastpk, ok := copyState[tableName]
@@ -140,7 +144,7 @@ func buildReplicatorPlan(filter *binlogdatapb.Filter, pkInfoMap map[string][]*Pr
 		if rule == nil {
 			continue
 		}
-		tablePlan, err := buildTablePlan(tableName, rule.Filter, pkInfoMap, lastpk)
+		tablePlan, err := buildTablePlan(tableName, rule.Filter, pkInfoMap, lastpk, stats)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +183,7 @@ func MatchTable(tableName string, filter *binlogdatapb.Filter) (*binlogdatapb.Ru
 	return nil, nil
 }
 
-func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKeyInfo, lastpk *sqltypes.Result) (*TablePlan, error) {
+func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKeyInfo, lastpk *sqltypes.Result, stats *binlogplayer.Stats) (*TablePlan, error) {
 	query := filter
 	// generate equivalent select statement if filter is empty or a keyrange.
 	switch {
@@ -216,6 +220,7 @@ func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKey
 			TargetName: tableName,
 			SendRule:   sendRule,
 			Lastpk:     lastpk,
+			Stats:      stats,
 		}
 		return tablePlan, nil
 	}
@@ -229,6 +234,7 @@ func buildTablePlan(tableName, filter string, pkInfoMap map[string][]*PrimaryKey
 		selColumns: make(map[string]bool),
 		lastpk:     lastpk,
 		pkInfos:    pkInfoMap[tableName],
+		stats:      stats,
 	}
 
 	if err := tpb.analyzeExprs(sel.SelectExprs); err != nil {
@@ -299,6 +305,7 @@ func (tpb *tablePlanBuilder) generate() *TablePlan {
 		Update:           tpb.generateUpdateStatement(),
 		Delete:           tpb.generateDeleteStatement(),
 		PKReferences:     pkrefs,
+		Stats:            tpb.stats,
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -56,7 +56,7 @@ func newVCopier(vr *vreplicator) *vcopier {
 func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 	defer vc.vr.dbClient.Rollback()
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil, vc.vr.stats)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 	log.Infof("Copying table %s, lastpk: %v", tableName, copyState[tableName])
 
-	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil)
+	plan, err := buildReplicatorPlan(vc.vr.source.Filter, vc.vr.pkInfoMap, nil, vc.vr.stats)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -997,7 +997,7 @@ func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 		{"4", "new"},
 	})
 	for _, ct := range playerEngine.controllers {
-		require.Equal(t, 1, ct.blpStats.NoopQueryCount.Counts()["insert"])
+		require.Equal(t, int64(1), ct.blpStats.NoopQueryCount.Counts()["insert"])
 		break
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -917,7 +917,7 @@ func TestPlayerCopyTableContinuation(t *testing.T) {
 }
 
 // TestPlayerCopyWildcardTableContinuation tests the copy workflow where tables have been partially copied.
-func TestPlayerCopyWildcardTableContinuationX(t *testing.T) {
+func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{
@@ -998,10 +998,11 @@ func TestPlayerCopyWildcardTableContinuationX(t *testing.T) {
 	})
 }
 
-// TestPlayerCopyWildcardTableContinuation tests the copy workflow where tables have been partially copied.
+// TestPlayerCopyWildcardTableContinuationWithOptimizeInserts tests the copy workflow where tables have been partially copied
+// enabling the optimize inserts functionality
 func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
 	oldVreplicationExperimentalFlags := *vreplicationExperimentalFlags
-	*vreplicationExperimentalFlags = vreplicationExperimentalOptimizeInserts
+	*vreplicationExperimentalFlags = vreplicationExperimentalFlagOptimizeInserts
 	defer func() {
 		*vreplicationExperimentalFlags = oldVreplicationExperimentalFlags
 	}()
@@ -1009,8 +1010,6 @@ func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{
-		// src is initialized as partially copied.
-		// lastpk will be initialized at (6,6) later below.
 		"create table src(id int, val varbinary(128), primary key(id))",
 		"insert into src values(2,'copied'), (3,'uncopied')",
 		fmt.Sprintf("create table %s.dst(id int, val varbinary(128), primary key(id))", vrepldb),
@@ -1044,7 +1043,6 @@ func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// As mentioned above. lastpk cut-off is set at (6,6)
 	lastpk := sqltypes.ResultToProto3(sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 		"id",
 		"int32"),

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -621,7 +621,7 @@ func TestPlayerCopyBigTable(t *testing.T) {
 		"insert into dst(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
 		// The next catchup executes the new row insert, but will be a no-op.
-		//Rohit //"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
+		"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into dst(id,val) values (2,'bbb')",
@@ -738,7 +738,7 @@ func TestPlayerCopyWildcardRule(t *testing.T) {
 		"insert into src(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
 		// The next catchup executes the new row insert, but will be a no-op.
-		//Rohit //"insert into src(id,val) select 3, 'ccc' from dual where (3) <= (1)",
+		"insert into src(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into src(id,val) values (2,'bbb')",
@@ -1072,7 +1072,6 @@ func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
 		"/insert into _vt.vreplication",
 		"/update _vt.vreplication set state = 'Copying'",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		//Rohit //"insert into dst(id,val) select 4, 'new' from dual where (4) <= (2)",
 		// Copy
 		"insert into dst(id,val) values (3,'uncopied'), (4,'new')",
 		`/update _vt.copy_state set lastpk.*`,

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -917,7 +917,95 @@ func TestPlayerCopyTableContinuation(t *testing.T) {
 }
 
 // TestPlayerCopyWildcardTableContinuation tests the copy workflow where tables have been partially copied.
-func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
+func TestPlayerCopyWildcardTableContinuationX(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	execStatements(t, []string{
+		// src is initialized as partially copied.
+		// lastpk will be initialized at (6,6) later below.
+		"create table src(id int, val varbinary(128), primary key(id))",
+		"insert into src values(2,'copied'), (3,'uncopied')",
+		fmt.Sprintf("create table %s.dst(id int, val varbinary(128), primary key(id))", vrepldb),
+		fmt.Sprintf("insert into %s.dst values(2,'copied')", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src",
+		fmt.Sprintf("drop table %s.dst", vrepldb),
+	})
+	env.SchemaEngine.Reload(context.Background())
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst",
+			Filter: "select * from src",
+		}},
+	}
+	pos := masterPosition(t)
+	execStatements(t, []string{
+		"insert into src values(4,'new')",
+	})
+
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogplayer.BlpStopped, playerEngine.dbName)
+	qr, err := playerEngine.Exec(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// As mentioned above. lastpk cut-off is set at (6,6)
+	lastpk := sqltypes.ResultToProto3(sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"id",
+		"int32"),
+		"2",
+	))
+	lastpk.RowsAffected = 0
+	execStatements(t, []string{
+		fmt.Sprintf("insert into _vt.copy_state values(%d, '%s', %s)", qr.InsertID, "dst", encodeString(fmt.Sprintf("%v", lastpk))),
+	})
+	id := qr.InsertID
+	_, err = playerEngine.Exec(fmt.Sprintf("update _vt.vreplication set state='Copying', pos=%s where id=%d", encodeString(pos), id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", id)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+	}()
+
+	expectNontxQueries(t, []string{
+		// Catchup
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set state = 'Copying'",
+		"/update _vt.vreplication set message='Picked source tablet.*",
+		"insert into dst(id,val) select 4, 'new' from dual where (4) <= (2)",
+		// Copy
+		"insert into dst(id,val) values (3,'uncopied'), (4,'new')",
+		`/update _vt.copy_state set lastpk.*`,
+		"/delete from _vt.copy_state.*dst",
+		"/update _vt.vreplication set state='Running'",
+	})
+	expectData(t, "dst", [][]string{
+		{"2", "copied"},
+		{"3", "uncopied"},
+		{"4", "new"},
+	})
+}
+
+// TestPlayerCopyWildcardTableContinuation tests the copy workflow where tables have been partially copied.
+func TestPlayerCopyWildcardTableContinuationWithOptimizeInserts(t *testing.T) {
+	oldVreplicationExperimentalFlags := *vreplicationExperimentalFlags
+	*vreplicationExperimentalFlags = vreplicationExperimentalOptimizeInserts
+	defer func() {
+		*vreplicationExperimentalFlags = oldVreplicationExperimentalFlags
+	}()
+
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{
@@ -1000,7 +1088,6 @@ func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 		require.Equal(t, int64(1), ct.blpStats.NoopQueryCount.Counts()["insert"])
 		break
 	}
-
 }
 
 func TestPlayerCopyTablesNone(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -621,7 +621,7 @@ func TestPlayerCopyBigTable(t *testing.T) {
 		"insert into dst(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
 		// The next catchup executes the new row insert, but will be a no-op.
-		"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
+		//Rohit //"insert into dst(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into dst(id,val) values (2,'bbb')",
@@ -738,7 +738,7 @@ func TestPlayerCopyWildcardRule(t *testing.T) {
 		"insert into src(id,val) values (1,'aaa')",
 		`/update _vt.copy_state set lastpk='fields:<name:\\"id\\" type:INT32 > rows:<lengths:1 values:\\"1\\" > ' where vrepl_id=.*`,
 		// The next catchup executes the new row insert, but will be a no-op.
-		"insert into src(id,val) select 3, 'ccc' from dual where (3) <= (1)",
+		//Rohit //"insert into src(id,val) select 3, 'ccc' from dual where (3) <= (1)",
 		// fastForward has nothing to add. Just saves position.
 		// Second row gets copied.
 		"insert into src(id,val) values (2,'bbb')",
@@ -984,7 +984,7 @@ func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 		"/insert into _vt.vreplication",
 		"/update _vt.vreplication set state = 'Copying'",
 		"/update _vt.vreplication set message='Picked source tablet.*",
-		"insert into dst(id,val) select 4, 'new' from dual where (4) <= (2)",
+		//Rohit //"insert into dst(id,val) select 4, 'new' from dual where (4) <= (2)",
 		// Copy
 		"insert into dst(id,val) values (3,'uncopied'), (4,'new')",
 		`/update _vt.copy_state set lastpk.*`,
@@ -996,6 +996,11 @@ func TestPlayerCopyWildcardTableContinuation(t *testing.T) {
 		{"3", "uncopied"},
 		{"4", "new"},
 	})
+	for _, ct := range playerEngine.controllers {
+		require.Equal(t, 1, ct.blpStats.NoopQueryCount.Counts()["insert"])
+		break
+	}
+
 }
 
 func TestPlayerCopyTablesNone(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -105,7 +105,7 @@ func (vp *vplayer) play(ctx context.Context) error {
 		return nil
 	}
 
-	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.pkInfoMap, vp.copyState)
+	plan, err := buildReplicatorPlan(vp.vr.source.Filter, vp.vr.pkInfoMap, vp.copyState, vp.vr.stats)
 	if err != nil {
 		vp.vr.stats.ErrorCounts.Add([]string{"Plan"}, 1)
 		return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -59,8 +59,9 @@ var (
 	// to ensure that it satisfies liveness criteria implicitly expected by internal processes like Online DDL
 	vreplicationMinimumHeartbeatUpdateInterval = 60
 
-	vreplicationExperimentalFlags                 = flag.Int64("vreplication_experimental_flags", 0, "Experimental features in vreplication to enable")
-	vreplicationExperimentalOptimizeInserts int64 = 1
+	vreplicationExperimentalFlags = flag.Int64("vreplication_experimental_flags", 0, "(Bitmask) of experimental features in vreplication to enable")
+
+	vreplicationExperimentalFlagOptimizeInserts int64 = 1
 )
 
 // vreplicator provides the core logic to start vreplication streams

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -58,6 +58,9 @@ var (
 	// vreplicationMinimumHeartbeatUpdateInterval overrides vreplicationHeartbeatUpdateInterval if the latter is higher than this
 	// to ensure that it satisfies liveness criteria implicitly expected by internal processes like Online DDL
 	vreplicationMinimumHeartbeatUpdateInterval = 60
+
+	vreplicationExperimentalFlags                 = flag.Int64("vreplication_experimental_flags", 0, "Experimental features in vreplication to enable")
+	vreplicationExperimentalOptimizeInserts int64 = 1
 )
 
 // vreplicator provides the core logic to start vreplication streams


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
For high QPS systems the catchup phase of vreplication workflows is unnecessarily slow. Dmls that are out of the range of the primary key range that has already been copied do not need to be applied to the target db.  To avoid this we would have had to do the arithmetic, of comparing PKs, in code. This is a hard problem mainly due to character collations and also needing to support all possible PK data types as well as composite keys. So currently we do the comparison in sql by adding the range check in a where clause. So all out-of-range rows will result in noops. However these are still being executed on the mysql server using up unnecessary cpu cycles. 

Most schemas have a preponderance of tables with a single column (usually an _id_). The catchup phase of such tables can be speeded quite easily, especially if we also use the empirical observation that the  majority of the noop load is caused by insert statements.

This PR adds code to do the PK comparison in code for such tables and discard the row events that don't match before applying them on the db. 

We also add
* a  per stream metric `VReplicationNoopQueryCountTotal` to record these discarded rows for better visibility into actual performance gains
* a generic experimental flag for vreplication intended to be used as a bitmask to enable/disable features that are new and presumed to need field testing before being released as default functionality.


## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
