### PR TITLE
[vitessdriver|vtadmin] Support Ping in vitessdriver, use in vtadmin to healthcheck connections during Dial

### DIFF
--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -209,6 +209,15 @@ func (c *conn) dial() error {
 	return nil
 }
 
+func (c *conn) Ping(ctx context.Context) error {
+	if c.Streaming {
+		return errors.New("Ping not allowed for streaming connections")
+	}
+
+	_, err := c.ExecContext(ctx, "select 1", nil)
+	return err
+}
+
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	return &stmt{c: c, query: query}, nil
 }

--- a/go/vt/vtadmin/vtsql/config.go
+++ b/go/vt/vtadmin/vtsql/config.go
@@ -18,6 +18,7 @@ package vtsql
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -33,6 +34,8 @@ type Config struct {
 	Discovery     discovery.Discovery
 	DiscoveryTags []string
 	Credentials   Credentials
+
+	DialPingTimeout time.Duration
 
 	// CredentialsPath is used only to power vtadmin debug endpoints; there may
 	// be a better way where we don't need to put this in the config, because
@@ -65,6 +68,8 @@ func Parse(cluster *vtadminpb.Cluster, disco discovery.Discovery, args []string)
 func (c *Config) Parse(args []string) error {
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 
+	fs.DurationVar(&c.DialPingTimeout, "dial-ping-timeout", time.Millisecond*500,
+		"Timeout to use when pinging an existing connection during calls to Dial.")
 	fs.StringSliceVar(&c.DiscoveryTags, "discovery-tags", []string{},
 		"repeated, comma-separated list of tags to use when discovering a vtgate to connect to. "+
 			"the semantics of the tags may depend on the specific discovery implementation used")

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,6 +144,7 @@ func TestConfigParse(t *testing.T) {
 				Id:   "cid",
 				Name: "testcluster",
 			},
+			DialPingTimeout: time.Millisecond * 500,
 			DiscoveryTags:   expectedTags,
 			Credentials:     expectedCreds,
 			CredentialsPath: path,

--- a/go/vt/vtadmin/vtsql/vtsql_test.go
+++ b/go/vt/vtadmin/vtsql/vtsql_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,8 +101,9 @@ func TestDial(t *testing.T) {
 		{
 			name: "existing conn",
 			proxy: &VTGateProxy{
-				cluster: &vtadminpb.Cluster{},
-				conn:    sql.OpenDB(&fakevtsql.Connector{}),
+				cluster:         &vtadminpb.Cluster{},
+				conn:            sql.OpenDB(&fakevtsql.Connector{}),
+				dialPingTimeout: time.Millisecond * 10,
 			},
 			shouldErr: false,
 		},


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR fixes a longstanding issue in vtadmin, where if vtadmin had `Dial`-ed a cluster, obtained a connection to a vtgate, and that vtgate was torn down, that cluster would become unusable without restarting vtadmin, and we would see the following, forever:

```
W0317 12:23:29.496680       7 clientconn.go:1191] grpc: addrConn.createTransport failed to connect to {${somehostname} 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp ${someaddr}: connect: connection refused". Reconnecting...
```

To fix this, I've introduced the following:
* An implementation of the `database/sq/driver.Pinger` interface in `vitessdriver`, which just issues a `select 1` query.
* A call to `Ping` during `VTGateProxy.Dial` in the case where the proxy has a non-nil connection. We set a configurable timeout here, to avoid blocking forever, and if the call fails we attempt to close the connection and then fall through to the "discover new vtgate and dial it" phase of the `Dial` method. If the ping check succeeds, we know we can just keep using that connection.

## Related Issue(s)

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving (maybe?)
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
