### PR TITLE
COM_PREPARE - Single TCP response packet with all MySQL Packets

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1071,7 +1071,15 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 	return true
 }
 
-func (c *Conn) handleComPrepare(handler Handler, data []byte) bool {
+func (c *Conn) handleComPrepare(handler Handler, data []byte) (kontinue bool) {
+	c.startWriterBuffering()
+	defer func() {
+		if err := c.endWriterBuffering(); err != nil {
+			log.Errorf("conn %v: flush() failed: %v", c.ID(), err)
+			kontinue = false
+		}
+	}()
+
 	query := c.parseComPrepare(data)
 	c.recycleReadPacket()
 


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

For each column defination we send a seperate TCP packet containing the MySQL Packet.
This change is to send single TCP packet containing all the MySQL Packets for COM_PREPARE.
This is similar to what MySQL does.

![image](https://user-images.githubusercontent.com/11834506/111683461-87f77b80-884b-11eb-8755-7afa525c4ff7.png)


## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving