### PR TITLE
Make vttestserver compatible with persistent data directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,9 @@ docker_local:
 docker_mini:
 	${call build_docker_image,docker/mini/Dockerfile,vitess/mini}
 
+docker_vttestserver:
+	${call build_docker_image,docker/vttestserver/Dockerfile.mysql57,vitess/vttestserver}
+
 # This rule loads the working copy of the code into a bootstrap image,
 # and then runs the tests inside Docker.
 # Example: $ make docker_test flavor=mariadb

--- a/Makefile
+++ b/Makefile
@@ -251,8 +251,12 @@ docker_local:
 docker_mini:
 	${call build_docker_image,docker/mini/Dockerfile,vitess/mini}
 
-docker_vttestserver:
-	${call build_docker_image,docker/vttestserver/Dockerfile.mysql57,vitess/vttestserver}
+DOCKER_VTTESTSERVER_SUFFIX = mysql57 mysql80
+DOCKER_VTTESTSERVER_TARGETS = $(addprefix docker_vttestserver_,$(DOCKER_VTTESTSERVER_SUFFIX))
+$(DOCKER_VTTESTSERVER_TARGETS): docker_vttestserver_%:
+	${call build_docker_image,docker/vttestserver/Dockerfile.$*,vitess/vttestserver:$*}
+
+docker_vttestserver: $(DOCKER_VTTESTSERVER_TARGETS)
 
 # This rule loads the working copy of the code into a bootstrap image,
 # and then runs the tests inside Docker.

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -23,8 +23,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/golang/protobuf/proto"
 
@@ -80,6 +82,16 @@ func init() {
 			" The rest of the vitess components are not started."+
 			" Also, the output specifies the mysql unix socket"+
 			" instead of the vtgate port.")
+
+	flag.BoolVar(&config.PersistentMode, "persistent_mode", false,
+		"If this flag is set, the MySQL data directory is not cleaned up"+
+			" when LocalCluster.TearDown() is called. This is useful for running"+
+			" vttestserver as a database container in local developer environments. Note"+
+			" that db migration files (-schema_dir option) and seeding of"+
+			" random data (-initialize_with_random_data option) will only run during"+
+			" cluster startup if the data directory does not already exist. vschema"+
+			" migrations are run every time the cluster starts, since persistence"+
+			" for the topology server has not been implemented yet")
 
 	flag.BoolVar(&doSeed, "initialize_with_random_data", false,
 		"If this flag is each table-shard will be initialized"+
@@ -229,7 +241,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	select {}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	<-c
 }
 
 func runCluster() (vttest.LocalCluster, error) {

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -74,6 +74,7 @@ func TestMain(m *testing.M) {
 		cfg.Topology = topology
 		cfg.SchemaDir = os.Getenv("VTROOT") + "/test/vttest_schema"
 		cfg.DefaultSchemaDir = os.Getenv("VTROOT") + "/test/vttest_schema/default"
+		cfg.PersistentMode = true
 
 		localCluster = &vttest.LocalCluster{
 			Config: cfg,
@@ -116,27 +117,24 @@ func TestStandalone(t *testing.T) {
 	conn, err := vtgateconn.Dial(ctx, grpcAddress)
 	require.Nil(t, err)
 	defer conn.Close()
-	cur := conn.Session(ks1+":-80@master", nil)
 
 	idStart, rowCount := 1000, 500
-	query := "insert into test_table (id, msg, keyspace_id) values (:id, :msg, :keyspace_id)"
-	_, err = cur.Execute(ctx, "begin", nil)
+	insertManyRows(ctx, t, conn, idStart, rowCount)
+	assertInsertedRowsExist(ctx, t, conn, idStart, rowCount)
+	assertCanInsertRow(ctx, t, conn)
+	assertTablesPresent(t)
+
+	err = localCluster.TearDown()
+	require.Nil(t, err)
+	err = localCluster.Setup()
 	require.Nil(t, err)
 
-	for i := idStart; i < idStart+rowCount; i++ {
-		bindVariables := map[string]*querypb.BindVariable{
-			"id":          {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
-			"msg":         {Type: querypb.Type_VARCHAR, Value: []byte("test" + strconv.FormatInt(int64(i), 10))},
-			"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
-		}
-		_, err = cur.Execute(ctx, query, bindVariables)
-		require.Nil(t, err)
-	}
+	assertInsertedRowsExist(ctx, t, conn, idStart, rowCount)
+	assertTablesPresent(t)
+}
 
-	_, err = cur.Execute(ctx, "commit", nil)
-	require.Nil(t, err)
-
-	cur = conn.Session(ks1+":-80@rdonly", nil)
+func assertInsertedRowsExist(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn, idStart, rowCount int) {
+	cur := conn.Session(ks1+":-80@rdonly", nil)
 	bindVariables := map[string]*querypb.BindVariable{
 		"id_start": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(idStart), 10))},
 	}
@@ -153,23 +151,49 @@ func TestStandalone(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(res.Rows))
 	assert.Equal(t, "VARCHAR(\"test1000\")", res.Rows[0][1].String())
+}
 
-	cur = conn.Session(ks1+":80-@master", nil)
-	_, err = cur.Execute(ctx, "begin", nil)
+func assertCanInsertRow(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn) {
+	cur := conn.Session(ks1+":80-@master", nil)
+	_, err := cur.Execute(ctx, "begin", nil)
 	require.Nil(t, err)
 
 	i := 0x810000000000000
-	bindVariables = map[string]*querypb.BindVariable{
+	bindVariables := map[string]*querypb.BindVariable{
 		"id":          {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
 		"msg":         {Type: querypb.Type_VARCHAR, Value: []byte("test" + strconv.FormatInt(int64(i), 10))},
 		"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
 	}
+	query := "insert into test_table (id, msg, keyspace_id) values (:id, :msg, :keyspace_id)"
 	_, err = cur.Execute(ctx, query, bindVariables)
 	require.Nil(t, err)
 
 	_, err = cur.Execute(ctx, "commit", nil)
 	require.Nil(t, err)
+}
 
+func insertManyRows(ctx context.Context, t *testing.T, conn *vtgateconn.VTGateConn, idStart, rowCount int) {
+	cur := conn.Session(ks1+":-80@master", nil)
+
+	query := "insert into test_table (id, msg, keyspace_id) values (:id, :msg, :keyspace_id)"
+	_, err := cur.Execute(ctx, "begin", nil)
+	require.Nil(t, err)
+
+	for i := idStart; i < idStart+rowCount; i++ {
+		bindVariables := map[string]*querypb.BindVariable{
+			"id":          {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
+			"msg":         {Type: querypb.Type_VARCHAR, Value: []byte("test" + strconv.FormatInt(int64(i), 10))},
+			"keyspace_id": {Type: querypb.Type_UINT64, Value: []byte(strconv.FormatInt(int64(i), 10))},
+		}
+		_, err = cur.Execute(ctx, query, bindVariables)
+		require.Nil(t, err)
+	}
+
+	_, err = cur.Execute(ctx, "commit", nil)
+	require.Nil(t, err)
+}
+
+func assertTablesPresent(t *testing.T) {
 	tmpCmd := exec.Command("vtctlclient", "-vtctl_client_protocol", "grpc", "-server", grpcAddress, "-stderrthreshold", "0", "ListAllTablets", "test")
 
 	log.Infof("Running vtctlclient with command: %v", tmpCmd.Args)

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -92,7 +92,12 @@ func TabletDir(uid uint32) string {
 	if *tabletDir != "" {
 		return fmt.Sprintf("%s/%s", env.VtDataRoot(), *tabletDir)
 	}
-	return fmt.Sprintf("%s/vt_%010d", env.VtDataRoot(), uid)
+	return DefaultTabletDirAtRoot(env.VtDataRoot(), uid)
+}
+
+// DefaultTabletDirAtRoot returns the default directory for a tablet given a UID and a VtDataRoot variable
+func DefaultTabletDirAtRoot(dataRoot string, uid uint32) string {
+	return fmt.Sprintf("%s/vt_%010d", dataRoot, uid)
 }
 
 // MycnfFile returns the default location of the my.cnf file.

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -144,6 +144,7 @@ func (env *LocalTestEnv) MySQLManager(mycnf []string, snapshot string) (MySQLMan
 		Port:      env.PortForProtocol("mysql", ""),
 		MyCnf:     append(env.DefaultMyCnf, mycnf...),
 		Env:       env.EnvVars(),
+		UID:       1,
 	}, nil
 }
 
@@ -241,9 +242,11 @@ func NewLocalTestEnv(flavor string, basePort int) (*LocalTestEnv, error) {
 // NewLocalTestEnvWithDirectory returns a new instance of the default test
 // environment with a directory explicitly specified.
 func NewLocalTestEnvWithDirectory(flavor string, basePort int, directory string) (*LocalTestEnv, error) {
-	err := os.Mkdir(path.Join(directory, "logs"), 0700)
-	if err != nil {
-		return nil, err
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		err := os.Mkdir(path.Join(directory, "logs"), 0700)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	flavor, mycnf, err := GetMySQLOptions(flavor)


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

This is an attempt at making the `vttestserver` container honour a persisted data directory.

There were a few changes required to get here and I'm happy to split into multiple PRs:

* Previously, the `vttestserver` binary did not correctly handle interruption signals. As such, the `defer cluster.TearDown()` was not run in `go/cmd/vttestserver/main.go`. I have added a signal handler to correctly run deferred functions.
* The `mysqlctl` binary was previously always run with the `init` subcommand. We now check if the directory provided in `-data_dir` argument already exists, and if so, we use the `mysqlctl start` command instead!
* I have added a `-keep_data` flag to `vttestserver` binary. This will guard all existing invocations from the new codepath and keeps things backwards compatible.

## Related Issue(s)
<!-- List related issues and pull requests: -->

Fixes https://github.com/vitessio/vitess/issues/7717

## Checklist
- [ ] Should this PR be backported?
    - [x] **I'm not sure!**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
