### PR TITLE
Mysql Fuzzer: Add requirement for minimum length of input data

### DIFF
--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -167,6 +167,9 @@ var _ net.Addr = (*fuzzmockAddress)(nil)
 
 // Fuzzers begin here:
 func FuzzWritePacket(data []byte) int {
+	if len(data) < 10 {
+		return -1
+	}
 	listener, sConn, cConn := createFuzzingSocketPair()
 	defer func() {
 		listener.Close()
@@ -186,6 +189,9 @@ func FuzzWritePacket(data []byte) int {
 }
 
 func FuzzHandleNextCommand(data []byte) int {
+	if len(data) < 10 {
+		return -1
+	}
 	sConn := newConn(fuzztestConn{
 		writeToPass: []bool{false},
 		pos:         -1,


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This PR adds a requirement to two of the mysql fuzzers that the input length must be greater than 10.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
