### PR TITLE
[vtadmin] vtexplain lock

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -55,6 +56,8 @@ type API struct {
 	clusterMap map[string]*cluster.Cluster
 	serv       *grpcserver.Server
 	router     *mux.Router
+
+	vtexplainLock sync.Mutex
 }
 
 // NewAPI returns a new API, configured to service the given set of clusters,
@@ -995,6 +998,16 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 	}
 
 	opts := &vtexplain.Options{ReplicationMode: "ROW"}
+
+	lockWaitStart := time.Now()
+
+	api.vtexplainLock.Lock()
+	defer api.vtexplainLock.Unlock()
+
+	lockWaitTime := time.Since(lockWaitStart)
+	log.Infof("vtexplain lock wait time: %s", lockWaitTime)
+
+	span.Annotate("vtexplain_lock_wait_time", lockWaitTime.String())
 
 	if err := vtexplain.Init(srvVSchema, schema, shardMap, opts); err != nil {
 		return nil, fmt.Errorf("error initilaizing vtexplain: %w", err)

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -57,6 +57,7 @@ type API struct {
 	serv       *grpcserver.Server
 	router     *mux.Router
 
+	// See https://github.com/vitessio/vitess/issues/7723 for why this exists.
 	vtexplainLock sync.Mutex
 }
 

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -1013,6 +1013,8 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		return nil, fmt.Errorf("error initilaizing vtexplain: %w", err)
 	}
 
+	defer vtexplain.Stop()
+
 	plans, err := vtexplain.Run(req.Sql)
 	if err != nil {
 		return nil, fmt.Errorf("error running vtexplain: %w", err)


### PR DESCRIPTION
## Description

(I took the easy way out, because the longer-term fix is much more, uh, involved 😅)

This PR adds a synchronization lock to concurrent vtexplain requests. I also took this opportunity to give us some rudimentary insight into how long we're stuck waiting on that lock, as well as to ensure we clean up the execution environment after each request.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- This is the short-term fix described in #7723. I'll tackle the vtexplain refactor later, at which point we can remove this lock.

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **no**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
