### PR TITLE
Do Not Merge: VReplication Copy Phase: Parallelize bulk insert to check for performance improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
 	k8s.io/code-generator v0.17.3
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -88,13 +88,17 @@ type Stats struct {
 
 	State sync2.AtomicString
 
-	PhaseTimings   *stats.Timings
-	QueryTimings   *stats.Timings
-	QueryCount     *stats.CountersWithSingleLabel
-	CopyRowCount   *stats.Counter
-	CopyLoopCount  *stats.Counter
-	ErrorCounts    *stats.CountersWithMultiLabels
-	NoopQueryCount *stats.CountersWithSingleLabel
+	PhaseTimings       *stats.Timings
+	QueryTimings       *stats.Timings
+	QueryCount         *stats.CountersWithSingleLabel
+	CopyRowCount       *stats.Counter
+	CopyLoopCount      *stats.Counter
+	TableCopyTimings   *stats.Timings
+	ErrorCounts        *stats.CountersWithMultiLabels
+	NoopQueryCount     *stats.CountersWithSingleLabel
+	CopyBandwidth      sync2.AtomicInt64
+	BatchCopyBandwidth sync2.AtomicInt64
+	BatchCopyLoopCount *stats.Counter
 }
 
 // RecordHeartbeat updates the time the last heartbeat from vstreamer was seen
@@ -149,8 +153,10 @@ func NewStats() *Stats {
 	bps.QueryCount = stats.NewCountersWithSingleLabel("", "", "Phase", "")
 	bps.CopyRowCount = stats.NewCounter("", "")
 	bps.CopyLoopCount = stats.NewCounter("", "")
+	bps.TableCopyTimings = stats.NewTimings("", "", "Table")
 	bps.ErrorCounts = stats.NewCountersWithMultiLabels("", "", []string{"type"})
 	bps.NoopQueryCount = stats.NewCountersWithSingleLabel("", "", "Statement", "")
+	bps.BatchCopyLoopCount = stats.NewCounter("", "")
 	return bps
 }
 

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/utils/strings"
+
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -105,7 +107,8 @@ func (dc *dbClientImpl) Close() {
 func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	mqr, err := dc.dbConn.ExecuteFetch(query, maxrows, true)
 	if err != nil {
-		log.Errorf("ExecuteFetch failed w/ error %v", err)
+
+		log.Errorf("ExecuteFetch failed w/ error %s", strings.ShortenString(err.Error(), 200))
 		dc.handleError(err)
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	strings2 "k8s.io/utils/strings"
+
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -159,7 +161,7 @@ func (ct *controller) run(ctx context.Context) {
 			return
 		default:
 		}
-		log.Errorf("stream %v: %v, retrying after %v", ct.id, err, *retryDelay)
+		log.Errorf("stream %v: %s, retrying after %v", ct.id, strings2.ShortenString(err.Error(), 200), *retryDelay)
 		ct.blpStats.ErrorCounts.Add([]string{"Stream Error"}, 1)
 		timer := time.NewTimer(*retryDelay)
 		select {

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -422,7 +422,7 @@ func (st *vrStats) register() {
 			result := make(map[string]int64)
 			for _, ct := range st.controllers {
 				for key, val := range ct.blpStats.ErrorCounts.Counts() {
-					result[fmt.Sprintf("%d.%s", ct.id, key)] = val
+					result[fmt.Sprintf("%s.%d.%s", ct.workflow, ct.id, key)] = val
 				}
 			}
 			return result

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -306,6 +306,7 @@ func (tpb *tablePlanBuilder) generate() *TablePlan {
 		Delete:           tpb.generateDeleteStatement(),
 		PKReferences:     pkrefs,
 		Stats:            tpb.stats,
+		ColExprs:         tpb.colExprs,
 	}
 }
 
@@ -744,6 +745,7 @@ func (tpb *tablePlanBuilder) generatePKConstraint(buf *sqlparser.TrackedBuffer, 
 		buf.Myprintf("%s%s%v%s", separator, charSet, &sqlparser.ColName{Name: sqlparser.NewColIdent(pkname.Name)}, collation)
 		separator = ","
 	}
+
 	separator = ") <= ("
 	for i, val := range tpb.lastpk.Rows[0] {
 		buf.WriteString(separator)


### PR DESCRIPTION
## POC

Batches multiple bulk inserts in the copy phase to test if concurrent bulk inserts improve copy phase performance.

## Description
During the copy phase we stream rows and for every `PacketSize` of rows (default 250K bytes) we do a bulk insert. This PR batches multiple of these sets. 

We add a `VReplicationTableCopyTimings` stat to monitor when a table copy starts and when it ends for benchmarking purposes. This metric is per vreplication stream. 

This feature is behind an experimental vttablet flag. To enable it use `-vreplication_experimental_flags 2` on the target.

You can specify the number of bulk inserts using `-vreplication_parallel_bulk_inserts 16` Default is 4

## Approach
Instead of inserting one batch at a time we collect N batches and insert them in parallel. Commits are done in order.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
