### PR TITLE
show columns query on system schema

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/show_cases_no_default_keyspace.txt
+++ b/go/vt/vtgate/planbuilder/testdata/show_cases_no_default_keyspace.txt
@@ -56,3 +56,39 @@
     ]
   }
 }
+
+# show full columns from system schema
+"show full columns from sys.sys_config"
+{
+  "QueryType": "SHOW",
+  "Original": "show full columns from sys.sys_config",
+  "Instructions": {
+    "OperatorType": "Send",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetDestination": "AnyShard()",
+    "IsDML": false,
+    "Query": "show full columns from sys.sys_config",
+    "SingleShardOnly": true
+  }
+}
+
+# show full columns from system schema replacing qualifier
+"show full columns from x.sys_config from sys"
+{
+  "QueryType": "SHOW",
+  "Original": "show full columns from x.sys_config from sys",
+  "Instructions": {
+    "OperatorType": "Send",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetDestination": "AnyShard()",
+    "IsDML": false,
+    "Query": "show full columns from sys.sys_config",
+    "SingleShardOnly": true
+  }
+}


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Earlier the query failed with error
```
"show full columns from sys.sys_config"
keyspace sys not found in vschema
```

Fix is to send this to any shard of any keyspace as system schema does not change.

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
