### PR TITLE
Fix dual table query when system schema is selected database

### DIFF
--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -139,6 +139,7 @@ func TestConnectWithSystemSchema(t *testing.T) {
 		connParams.DbName = dbname
 		conn, err := mysql.Connect(ctx, &connParams)
 		require.NoError(t, err)
+		exec(t, conn, `select @@max_allowed_packet from dual`)
 		conn.Close()
 	}
 }
@@ -146,12 +147,12 @@ func TestConnectWithSystemSchema(t *testing.T) {
 func TestUseSystemSchema(t *testing.T) {
 	defer cluster.PanicHandler(t)
 	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
 	for _, dbname := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
-		conn, err := mysql.Connect(ctx, &vtParams)
-		require.NoError(t, err)
-
 		exec(t, conn, fmt.Sprintf("use %s", dbname))
-		conn.Close()
+		exec(t, conn, `select @@max_allowed_packet from dual`)
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -252,6 +252,20 @@ func TestWithDefaultKeyspaceFromFile(t *testing.T) {
 	testFile(t, "call_cases.txt", testOutputTempDir, vschema, false)
 }
 
+func TestWithSystemSchemaAsDefaultKeyspace(t *testing.T) {
+	// We are testing this separately so we can set a default keyspace
+	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(testOutputTempDir)
+	vschema := &vschemaWrapper{
+		v:          loadSchema(t, "schema_test.json"),
+		keyspace:   &vindexes.Keyspace{Name: "mysql"},
+		tabletType: topodatapb.TabletType_MASTER,
+	}
+
+	testFile(t, "sysschema_default.txt", testOutputTempDir, vschema, false)
+}
+
 func TestOtherPlanningFromFile(t *testing.T) {
 	// We are testing this separately so we can set a default keyspace
 	testOutputTempDir, err := ioutil.TempDir("", "plan_test")

--- a/go/vt/vtgate/planbuilder/testdata/sysschema_default.txt
+++ b/go/vt/vtgate/planbuilder/testdata/sysschema_default.txt
@@ -1,0 +1,17 @@
+# max_allowed_packet
+"select @@max_allowed_packet from dual"
+{
+  "QueryType": "SELECT",
+  "Original": "select @@max_allowed_packet from dual",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectReference",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select @@max_allowed_packet from dual where 1 != 1",
+    "Query": "select @@max_allowed_packet from dual",
+    "Table": "dual"
+  }
+}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -282,13 +282,24 @@ func (vc *vcursorImpl) FindTableOrVindex(name sqlparser.TableName) (*vindexes.Ta
 		return nil, nil, "", destTabletType, nil, err
 	}
 	if destKeyspace == "" {
-		destKeyspace = vc.keyspace
+		destKeyspace = vc.getActualKeyspace()
 	}
 	table, vindex, err := vc.vschema.FindTableOrVindex(destKeyspace, name.Name.String(), vc.tabletType)
 	if err != nil {
 		return nil, nil, "", destTabletType, nil, err
 	}
 	return table, vindex, destKeyspace, destTabletType, dest, nil
+}
+
+func (vc *vcursorImpl) getActualKeyspace() string {
+	if !sqlparser.SystemSchema(vc.keyspace) {
+		return vc.keyspace
+	}
+	ks, err := vc.AnyKeyspace()
+	if err != nil {
+		return ""
+	}
+	return ks.Name
 }
 
 // DefaultKeyspace returns the default keyspace of the current request


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

If a system schema is selected as a database the dual query fails

```
use `mysql`;
select @@max_allowed_packet from dual;
ERROR: "keyspace mysql not found in vschema"
```

The fix is to send to any keyspace if default is system schema.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
