### PR TITLE
Add vtorc binary for rpm,deb builds

### DIFF
--- a/tools/make-release-packages.sh
+++ b/tools/make-release-packages.sh
@@ -35,7 +35,7 @@ mkdir -p releases
 
 # Copy a subset of binaries from issue #5421
 mkdir -p "${RELEASE_DIR}/bin"
-for binary in vttestserver mysqlctl mysqlctld query_analyzer topo2topo vtaclcheck vtbackup vtbench vtclient vtcombo vtctl vtctlclient vtctld vtexplain vtgate vttablet vtworker vtworkerclient zk zkctl zkctld; do 
+for binary in vttestserver mysqlctl mysqlctld query_analyzer topo2topo vtaclcheck vtbackup vtbench vtclient vtcombo vtctl vtctlclient vtctld vtexplain vtgate vttablet vtorc vtworker vtworkerclient zk zkctl zkctld; do 
  cp "bin/$binary" "${RELEASE_DIR}/bin/"
 done;
 


### PR DESCRIPTION
Signed-off-by: Alkin Tezuysal <alkin.tezuysal@gmail.com>

## Description
Adding vtorc binary for build packages. 

## Related Issue(s)
https://github.com/vitessio/vitess/issues/7733
- 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
