### PR TITLE
add planner preprocessor plugin point

### DIFF
--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -103,6 +103,11 @@ var ErrPlanNotSupported = errors.New("plan building not supported")
 
 // BuildFromStmt builds a plan based on the AST provided.
 func BuildFromStmt(query string, stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema, bindVarNeeds *sqlparser.BindVarNeeds) (*engine.Plan, error) {
+	stmt, err := PreProcessor(stmt)
+	if err != nil {
+		return nil, err
+	}
+
 	instruction, err := createInstructionFor(query, stmt, reservedVars, vschema)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -18,7 +18,7 @@ const (
 )
 
 // buildGeneralDDLPlan builds a general DDL plan, which can be either normal DDL or online DDL.
-// The two behave compeltely differently, and have two very different primitives.
+// The two behave completely differently, and have two very different primitives.
 // We want to be able to dynamically choose between normal/online plans according to Session settings.
 // However, due to caching of plans, we're unable to make that choice right now. In this function we don't have
 // a session context. It's only when we Execute() the primitive that we have that context.

--- a/go/vt/vtgate/planbuilder/preprocess.go
+++ b/go/vt/vtgate/planbuilder/preprocess.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import "vitess.io/vitess/go/vt/sqlparser"
+
+// PreProcessor can be used for anyone extending Vitess as a way to rewrite or fail a query
+// before the normal plan building process starts. This default one is empty
+var PreProcessor = func(statement sqlparser.Statement) (sqlparser.Statement, error) {
+	return statement, nil
+}


### PR DESCRIPTION
## Description
Adds a function that is called before planning gets started. The function is used through a global variable, which allows it to be overwritten by a plugin for anyone building their private fork of Vitess.

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
