### PR TITLE
[vtadmin-web] Add common max-width to infrastructure table views

### DIFF
--- a/web/vtadmin/src/components/routes/Clusters.tsx
+++ b/web/vtadmin/src/components/routes/Clusters.tsx
@@ -37,7 +37,7 @@ export const Clusters = () => {
         ));
 
     return (
-        <div>
+        <div className="max-width-content">
             <h1>Clusters</h1>
             <DataTable columns={['Name', 'Id']} data={rows} renderRows={renderRows} />
         </div>

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -37,7 +37,7 @@ export const Gates = () => {
         ));
 
     return (
-        <div>
+        <div className="max-width-content">
             <h1>Gates</h1>
             <DataTable columns={['Cluster', 'Hostname']} data={rows} renderRows={renderRows} />
         </div>

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -37,7 +37,7 @@ export const Keyspaces = () => {
         ));
 
     return (
-        <div>
+        <div className="max-width-content">
             <h1>Keyspaces</h1>
             <DataTable columns={['Cluster', 'Keyspace']} data={rows} renderRows={renderRows} />
         </div>

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -44,7 +44,7 @@ export const Schemas = () => {
         });
 
     return (
-        <div>
+        <div className="max-width-content">
             <h1>Schemas</h1>
             <DataTable columns={['Cluster', 'Keyspace', 'Table']} data={rows} renderRows={renderRows} />
         </div>

--- a/web/vtadmin/src/components/routes/Tablets.module.scss
+++ b/web/vtadmin/src/components/routes/Tablets.module.scss
@@ -3,5 +3,4 @@
   grid-gap: 8px;
   grid-template-columns: 1fr min-content;
   margin-bottom: 24px;
-  max-width: 1200px;
 }

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -51,7 +51,7 @@ export const Tablets = () => {
     }, []);
 
     return (
-        <div>
+        <div className="max-width-content">
             <h1>Tablets</h1>
             <div className={style.controls}>
                 <TextInput

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -88,6 +88,9 @@
   --textColorInverted: #fff;
   --textColorSecondary: #718096;
   --textColorDisabled: #cbd5e0;
+
+  /* A common bounding width for views that don't require the full viewport. */
+  --contentWidth: 1200px;
 }
 
 /* Dark theme */
@@ -187,7 +190,11 @@ table tbody td {
   padding: var(--tableCellPadding);
 }
 
-/* Utilities */
+/* One-liner utilities */
+.max-width-content {
+  max-width: var(--contentWidth);
+}
+
 .text-color-secondary {
   color: var(--textColorSecondary);
 }


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

Continuing the theme of "tiny janitorial PRs pulled out of the demo branch", this one adds a common `max-width` class so our infrastructure tables don't look so goofy on wide screens. (Mobile-friendly layout to come... someday... 😊)

I realize this seems like a fair amount of repetition _but_ I don't want to put the max-width in the top-level App component as that ends up being really inflexible when we do want the full width. (Like super long names on detail pages, for example.) 

## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
