### PR TITLE
Fixes bug that prevents creation of logs directory

### DIFF
--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -242,7 +242,7 @@ func NewLocalTestEnv(flavor string, basePort int) (*LocalTestEnv, error) {
 // NewLocalTestEnvWithDirectory returns a new instance of the default test
 // environment with a directory explicitly specified.
 func NewLocalTestEnvWithDirectory(flavor string, basePort int, directory string) (*LocalTestEnv, error) {
-	if _, err := os.Stat(directory); os.IsNotExist(err) {
+	if _, err := os.Stat(path.Join(directory, "logs")); os.IsNotExist(err) {
 		err := os.Mkdir(path.Join(directory, "logs"), 0700)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

https://github.com/vitessio/vitess/pull/7718 created a regression wherein the logs directory was not created if its parent directory already existed. The problematic line is at https://github.com/vitessio/vitess/pull/7718/files#diff-7be49867c740adb69b3abbb3d0bbbe92e1d34fcb944d2c5a3efa99f6a1439006R245. This PR fixes that issue.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
