### PR TITLE
[vtadmin-web] Add hooks + skeleton view for workflows

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -181,3 +181,12 @@ export const fetchTablets = async () =>
             return pb.Tablet.create(e);
         },
     });
+
+export const fetchWorkflows = async () => {
+    const { result } = await vtfetch(`/api/workflows`);
+
+    const err = pb.GetWorkflowsResponse.verify(result);
+    if (err) throw Error(err);
+
+    return pb.GetWorkflowsResponse.create(result);
+};

--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -26,6 +26,7 @@ import { Gates } from './routes/Gates';
 import { Keyspaces } from './routes/Keyspaces';
 import { Schemas } from './routes/Schemas';
 import { Schema } from './routes/Schema';
+import { Workflows } from './routes/Workflows';
 
 export const App = () => {
     return (
@@ -59,6 +60,10 @@ export const App = () => {
 
                         <Route path="/tablets">
                             <Tablets />
+                        </Route>
+
+                        <Route path="/workflows">
+                            <Workflows />
                         </Route>
 
                         <Route path="/debug">

--- a/web/vtadmin/src/components/NavRail.tsx
+++ b/web/vtadmin/src/components/NavRail.tsx
@@ -18,7 +18,7 @@ import { Link, NavLink } from 'react-router-dom';
 
 import style from './NavRail.module.scss';
 import logo from '../img/vitess-icon-color.svg';
-import { useClusters, useGates, useKeyspaces, useTableDefinitions, useTablets } from '../hooks/api';
+import { useClusters, useGates, useKeyspaces, useTableDefinitions, useTablets, useWorkflows } from '../hooks/api';
 import { Icon, Icons } from './Icon';
 
 export const NavRail = () => {
@@ -27,6 +27,7 @@ export const NavRail = () => {
     const { data: gates = [] } = useGates();
     const { data: schemas = [] } = useTableDefinitions();
     const { data: tablets = [] } = useTablets();
+    const { data: workflows = [] } = useWorkflows();
 
     return (
         <div className={style.container}>
@@ -40,7 +41,7 @@ export const NavRail = () => {
                         <NavRailLink icon={Icons.chart} text="Dashboard" to="/dashboard" count={0} />
                     </li>
                     <li>
-                        <NavRailLink icon={Icons.wrench} text="Workflows" to="/workflows" count={0} />
+                        <NavRailLink icon={Icons.wrench} text="Workflows" to="/workflows" count={workflows.length} />
                     </li>
                 </ul>
 

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -24,7 +24,10 @@ export const Workflows = () => {
     useDocumentTitle('Workflows');
     const { data } = useWorkflows();
 
-    const sortedData = React.useMemo(() => orderBy(data, ['cluster.name', 'keyspace.name']), [data]);
+    const sortedData = React.useMemo(
+        () => orderBy(data, ['workflow.name', 'cluster.name', 'workflow.source.keyspace', 'workflow.target.keyspace']),
+        [data]
+    );
 
     const renderRows = (rows: typeof sortedData) =>
         rows.map(({ cluster, workflow }, idx) => {

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -35,8 +35,8 @@ export const Workflows = () => {
                 <tr key={idx}>
                     <td>{workflow?.name}</td>
                     <td>{cluster?.name}</td>
-                    <td>{workflow?.source?.keyspace || '-'}</td>
-                    <td>{workflow?.target?.keyspace || '-'}</td>
+                    <td>{workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}</td>
+                    <td>{workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}</td>
                 </tr>
             );
         });

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { orderBy } from 'lodash-es';
+import * as React from 'react';
+
+import { useWorkflows } from '../../hooks/api';
+import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { DataTable } from '../dataTable/DataTable';
+
+export const Workflows = () => {
+    useDocumentTitle('Workflows');
+    const { data } = useWorkflows();
+
+    const sortedData = React.useMemo(() => orderBy(data, ['cluster.name', 'keyspace.name']), [data]);
+
+    const renderRows = (rows: typeof sortedData) =>
+        rows.map(({ cluster, workflow }, idx) => {
+            return (
+                <tr key={idx}>
+                    <td>{workflow?.name}</td>
+                    <td>{cluster?.name}</td>
+                    <td>{workflow?.source?.keyspace || '-'}</td>
+                    <td>{workflow?.target?.keyspace || '-'}</td>
+                </tr>
+            );
+        });
+
+    return (
+        <div className="max-width-content">
+            <h1>Workflows</h1>
+            <DataTable
+                columns={['Workflow', 'Cluster', 'Source', 'Target']}
+                data={sortedData}
+                renderRows={renderRows}
+            />
+        </div>
+    );
+};

--- a/web/vtadmin/src/hooks/api.test.tsx
+++ b/web/vtadmin/src/hooks/api.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import * as api from './api';
+import * as httpAPI from '../api/http';
+import { vtadmin as pb } from '../proto/vtadmin';
+
+jest.mock('../api/http');
+
+describe('useWorkflows', () => {
+    const tests: {
+        name: string;
+        response: pb.GetWorkflowsResponse | undefined;
+        expected: pb.Workflow[] | undefined;
+    }[] = [
+        {
+            name: 'returns a flat list of workflows',
+            response: pb.GetWorkflowsResponse.create({
+                workflows_by_cluster: {
+                    east: {
+                        workflows: [
+                            {
+                                workflow: { name: 'one-goes-east' },
+                            },
+                        ],
+                    },
+                    west: {
+                        workflows: [
+                            {
+                                workflow: { name: 'one-goes-west' },
+                            },
+                        ],
+                    },
+                },
+            }),
+            expected: [
+                pb.Workflow.create({ workflow: { name: 'one-goes-east' } }),
+                pb.Workflow.create({ workflow: { name: 'one-goes-west' } }),
+            ],
+        },
+    ];
+
+    const queryClient = new QueryClient();
+    const wrapper: React.FunctionComponent = ({ children }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    test.each(tests.map(Object.values))(
+        '%s',
+        async (name: string, response: pb.GetWorkflowsResponse | undefined, expected: pb.Workflow[] | undefined) => {
+            (httpAPI.fetchWorkflows as any).mockResolvedValueOnce(response);
+
+            const { result, waitFor } = renderHook(() => api.useWorkflows(), { wrapper });
+
+            // Check that our query helper handles when the query is still in flight
+            expect(result.current.data).toBeUndefined();
+
+            // "Wait" for the underlying fetch request to resolve (scare-quotes because,
+            // in practice, we're not "waiting" for anything since the response is mocked.)
+            await waitFor(() => result.current.isSuccess);
+
+            expect(result.current.data).toEqual(expected);
+        }
+    );
+});


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

- Adds react-query hooks for the `/api/workflows` endpoint
- Updates the NavRail (sidebar) with workflow counts
- Adds a very rudimentary `/workflows` view as a placeholder for later. 

<img width="1680" alt="Screen Shot 2021-03-30 at 1 14 24 PM" src="https://user-images.githubusercontent.com/855595/113028966-e2e97680-9159-11eb-8782-0792e6dacf1a.png">


## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
