### PR TITLE
[vtadmin-web] Add hooks + skeleton view for workflow details

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -190,3 +190,12 @@ export const fetchWorkflows = async () => {
 
     return pb.GetWorkflowsResponse.create(result);
 };
+
+export const fetchWorkflow = async (params: { clusterID: string; keyspace: string; name: string }) => {
+    const { result } = await vtfetch(`/api/workflow/${params.clusterID}/${params.keyspace}/${params.name}`);
+
+    const err = pb.Workflow.verify(result);
+    if (err) throw Error(err);
+
+    return pb.Workflow.create(result);
+};

--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -27,6 +27,7 @@ import { Keyspaces } from './routes/Keyspaces';
 import { Schemas } from './routes/Schemas';
 import { Schema } from './routes/Schema';
 import { Workflows } from './routes/Workflows';
+import { Workflow } from './routes/Workflow';
 
 export const App = () => {
     return (
@@ -64,6 +65,10 @@ export const App = () => {
 
                         <Route path="/workflows">
                             <Workflows />
+                        </Route>
+
+                        <Route path="/workflow/:clusterID/:keyspace/:name">
+                            <Workflow />
                         </Route>
 
                         <Route path="/debug">

--- a/web/vtadmin/src/components/routes/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/Workflow.tsx
@@ -27,6 +27,7 @@ export const Workflow = () => {
     const { clusterID, keyspace, name } = useParams<RouteParams>();
     const { data } = useWorkflow({ clusterID, keyspace, name });
 
+    // Placeholder
     return (
         <div>
             <h1>{name}</h1>

--- a/web/vtadmin/src/components/routes/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/Workflow.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useParams } from 'react-router-dom';
+import { useWorkflow } from '../../hooks/api';
+import { Code } from '../Code';
+
+interface RouteParams {
+    clusterID: string;
+    keyspace: string;
+    name: string;
+}
+
+export const Workflow = () => {
+    const { clusterID, keyspace, name } = useParams<RouteParams>();
+    const { data } = useWorkflow({ clusterID, keyspace, name });
+
+    return (
+        <div>
+            <h1>{name}</h1>
+            <Code code={JSON.stringify(data, null, 2)} />
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -15,6 +15,7 @@
  */
 import { orderBy } from 'lodash-es';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import { useWorkflows } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
@@ -30,10 +31,15 @@ export const Workflows = () => {
     );
 
     const renderRows = (rows: typeof sortedData) =>
-        rows.map(({ cluster, workflow }, idx) => {
+        rows.map(({ cluster, keyspace, workflow }, idx) => {
+            const href =
+                cluster?.id && keyspace && workflow?.name
+                    ? `/workflow/${cluster.id}/${keyspace}/${workflow.name}`
+                    : null;
+
             return (
                 <tr key={idx}>
-                    <td>{workflow?.name}</td>
+                    <td>{href ? <Link to={href}>{workflow?.name}</Link> : workflow?.name}</td>
                     <td>{cluster?.name}</td>
                     <td>{workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}</td>
                     <td>{workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}</td>

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -22,6 +22,7 @@ import {
     FetchSchemaParams,
     fetchSchemas,
     fetchTablets,
+    fetchWorkflow,
     fetchWorkflows,
 } from '../api/http';
 import { vtadmin as pb } from '../proto/vtadmin';
@@ -138,6 +139,19 @@ export const useSchema = (params: FetchSchemaParams, options?: UseQueryOptions<p
                     s.table_definitions.find((td) => td.name === params.table)
             );
         },
+        ...options,
+    });
+};
+
+/**
+ * useSchema is a query hook that fetches a single schema for the given parameters.
+ */
+export const useWorkflow = (
+    params: Parameters<typeof fetchWorkflow>[0],
+    options?: UseQueryOptions<pb.Workflow, Error> | undefined
+) => {
+    return useQuery(['workflow', params], () => fetchWorkflow(params), {
+        // TODO: initialData
         ...options,
     });
 };

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -144,14 +144,41 @@ export const useSchema = (params: FetchSchemaParams, options?: UseQueryOptions<p
 };
 
 /**
- * useSchema is a query hook that fetches a single schema for the given parameters.
+ * useWorkflow is a query hook that fetches a single workflow for the given parameters.
  */
 export const useWorkflow = (
     params: Parameters<typeof fetchWorkflow>[0],
     options?: UseQueryOptions<pb.Workflow, Error> | undefined
 ) => {
+    const queryClient = useQueryClient();
     return useQuery(['workflow', params], () => fetchWorkflow(params), {
-        // TODO: initialData
+        // If the workflow already exists in the cache from a previous fetchWorkflows call,
+        // then use that for the initial data.
+        //
+        // Important note: `initialData` is persisted to the query cache. If the shapes of the GetWorkflowsResponse
+        // and Workflow protobuf types ever change such that Workflow is not a subset of GetWorkflowsResponse
+        // (e.g., the /api/workflow/... route provides different information than the /api/workflows route)
+        // then instead we will want to use `placeholderData`. (Unfortunately, the HTTP request boundary
+        // is one area where we have to assume typesafety... until we can, perhaps, one day switch to using
+        // gRPC on the client. Or, we could investigate code generating a TypeScript HTTP client. Possibilities!)
+        //
+        // See https://react-query.tanstack.com/guides/initial-query-data for more context on how initialData works.
+        initialData: () => {
+            const workflows = queryClient.getQueryData<pb.GetWorkflowsResponse>('workflows');
+            const cw = workflows?.workflows_by_cluster[params.clusterID];
+            if (!cw) return undefined;
+
+            const workflow = (cw.workflows || []).find(
+                (w) =>
+                    w.cluster?.id === params.clusterID &&
+                    w.keyspace === params.keyspace &&
+                    w.workflow?.name === params.name
+            );
+
+            if (!workflow) return undefined;
+
+            return pb.Workflow.create(workflow);
+        },
         ...options,
     });
 };


### PR DESCRIPTION
## Description

I am once again asking you to ignore this terrible placeholder UI, as the goal of this PR is to add query and caching behaviour for the `/workflow/...` view. 

Here's screenshots anyway:

<img width="2672" alt="Screen Shot 2021-03-31 at 11 27 11 AM" src="https://user-images.githubusercontent.com/855595/113170598-b21a4780-9214-11eb-89c7-63558802fe0a.png">

<img width="2672" alt="Screen Shot 2021-03-31 at 11 27 00 AM" src="https://user-images.githubusercontent.com/855595/113170633-bd6d7300-9214-11eb-8914-fca97e4d7af8.png">


## Related Issue(s)

- https://github.com/vitessio/vitess/pull/7762

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
