### PR TITLE
[vttest] disable field caching in vttest

### DIFF
--- a/go/vt/vtgate/endtoend/misc_test.go
+++ b/go/vt/vtgate/endtoend/misc_test.go
@@ -19,9 +19,11 @@ package endtoend
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
 	"vitess.io/vitess/go/mysql"
 )
 

--- a/go/vt/vtgate/endtoend/misc_test.go
+++ b/go/vt/vtgate/endtoend/misc_test.go
@@ -19,22 +19,30 @@ package endtoend
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
-
 	"vitess.io/vitess/go/mysql"
 )
 
 func TestDatabaseFunc(t *testing.T) {
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer conn.Close()
 
 	exec(t, conn, "use ks")
 	qr := exec(t, conn, "select database()")
-	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARBINARY("ks")]]`; got != want {
-		t.Errorf("select:\n%v want\n%v", got, want)
-	}
+	require.Equal(t, `[[VARBINARY("ks")]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+func TestSysNumericPrecisionScale(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	qr := exec(t, conn, "select numeric_precision, numeric_scale from information_schema.columns where table_schema = 'ks' and table_name = 't1'")
+	assert.True(t, qr.Fields[0].Type == qr.Rows[0][0].Type())
+	assert.True(t, qr.Fields[1].Type == qr.Rows[0][1].Type())
 }

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -221,6 +221,7 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 		"-mycnf_server_id", "1",
 		"-mycnf_socket_file", socket,
 		"-normalize_queries",
+		"-enable_query_plan_field_caching=false",
 	}...)
 
 	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)


### PR DESCRIPTION
Due to regression in mysql for numeric_precision and numeric_scale for mysql 8.0, we need to disable field caching for the vtcombo server.

https://bugs.mysql.com/bug.php?id=103155