### PR TITLE
[vtadmin] GetSchema(s) should always check keyspace field when filtering tablets

### DIFF
--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -634,12 +634,12 @@ func (c *Cluster) getTabletsToQueryForSchemas(ctx context.Context, keyspace stri
 
 		for _, shard := range shards {
 			if !shard.Shard.IsMasterServing {
-				log.Infof("%s/%s is not serving; ignoring because IncludeNonServingShards=false", keyspace, shard.Name)
+				log.Infof("%s/%s is not serving; ignoring ...", keyspace, shard.Name)
 				continue
 			}
 
 			shardTablets := vtadminproto.FilterTablets(func(tablet *vtadminpb.Tablet) bool {
-				return tablet.Tablet.Shard == shard.Name && tablet.State == vtadminpb.Tablet_SERVING
+				return tablet.Tablet.Keyspace == keyspace && tablet.Tablet.Shard == shard.Name && tablet.State == vtadminpb.Tablet_SERVING
 			}, opts.Tablets, len(opts.Tablets))
 
 			if len(shardTablets) == 0 {


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

This fixes a bug in the size aggregation code where, I removed what I thought was a redundant check on `tablet.Tablet.Keyspace`, we could end up picking a tablet in `ks1/-80` when we were looking for `ks2/-80` (because we only compared the shard name).

I also removed a reference to a non-existent variable in a log line while I was here.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported? no
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
