### PR TITLE
Disallow foreign key constraint on ddl

### DIFF
--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1195,12 +1195,12 @@ func TestExecutorDDLFk(t *testing.T) {
 	}
 
 	for _, stmt := range stmts {
-		for _, fk := range []string{"allow", "disallow"} {
-			t.Run(stmt+fk, func(t *testing.T) {
+		for _, fkMode := range []string{"allow", "disallow"} {
+			t.Run(stmt+fkMode, func(t *testing.T) {
 				sbc.ExecCount.Set(0)
-				*foreignKey = fk
+				*foreignKeyMode = fkMode
 				_, err := executor.Execute(ctx, mName, NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded}), stmt, nil)
-				if fk == "allow" {
+				if fkMode == "allow" {
 					require.NoError(t, err)
 					require.EqualValues(t, 1, sbc.ExecCount.Get())
 				} else {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1186,7 +1186,7 @@ func TestExecutorDDL(t *testing.T) {
 }
 
 func TestExecutorDDLFk(t *testing.T) {
-	executor, _, _, sbc := createLegacyExecutorEnv()
+	executor, _, _, sbc := createExecutorEnv()
 
 	mName := "TestExecutorDDLFk"
 	stmts := []string{
@@ -1204,7 +1204,7 @@ func TestExecutorDDLFk(t *testing.T) {
 					require.NoError(t, err)
 					require.EqualValues(t, 1, sbc.ExecCount.Get())
 				} else {
-					require.EqualError(t, err, "foreign key constraint is blocked")
+					require.EqualError(t, err, "foreign key constraint is not allowed")
 				}
 			})
 		}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -62,8 +62,8 @@ type ContextVSchema interface {
 	// that could become a problem if they move to a sharded keyspace
 	WarnUnshardedOnly(format string, params ...interface{})
 
-	// ForeignKey returns the foreign_key flag value
-	ForeignKey() string
+	// ForeignKeyMode returns the foreign_key flag value
+	ForeignKeyMode() string
 }
 
 // PlannerVersion is an alias here to make the code more readable

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -61,6 +61,9 @@ type ContextVSchema interface {
 	// This will let the user know that they are using something
 	// that could become a problem if they move to a sharded keyspace
 	WarnUnshardedOnly(format string, params ...interface{})
+
+	// ForeignKey returns the foreign_key flag value
+	ForeignKey() string
 }
 
 // PlannerVersion is an alias here to make the code more readable

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -1,8 +1,6 @@
 package planbuilder
 
 import (
-	"strings"
-
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -22,13 +20,13 @@ const (
 type fkStrategy int
 
 const (
-	allow fkStrategy = iota
-	disallow
+	fkAllow fkStrategy = iota
+	fkDisallow
 )
 
 var fkStrategyMap = map[string]fkStrategy{
-	"allow":    allow,
-	"disallow": disallow,
+	"allow":    fkAllow,
+	"disallow": fkDisallow,
 }
 
 type fkContraint struct {
@@ -142,7 +140,7 @@ func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars
 }
 
 func checkFKError(vschema ContextVSchema, ddlStatement sqlparser.DDLStatement) error {
-	if fkStrategyMap[strings.ToLower(vschema.ForeignKeyMode())] == disallow {
+	if fkStrategyMap[vschema.ForeignKeyMode()] == fkDisallow {
 		fk := &fkContraint{}
 		_ = sqlparser.Walk(fk.FkWalk, ddlStatement)
 		if fk.found {

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -1,13 +1,15 @@
 package planbuilder
 
 import (
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
+	"strings"
 
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 // Error messages for CreateView queries
@@ -16,6 +18,33 @@ const (
 	ViewComplex           string = "Complex select queries are not supported in create or alter view statements"
 	DifferentDestinations string = "Tables or Views specified in the query do not belong to the same destination"
 )
+
+type fkStrategy int
+
+const (
+	allow fkStrategy = iota
+	disallow
+)
+
+var fkStrategyMap = map[string]fkStrategy{
+	"allow":    allow,
+	"disallow": disallow,
+}
+
+type fkContraint struct {
+	found bool
+}
+
+func (fk *fkContraint) FkWalk(node sqlparser.SQLNode) (kontinue bool, err error) {
+	switch node.(type) {
+	case *sqlparser.CreateTable, *sqlparser.AlterTable,
+		*sqlparser.TableSpec, *sqlparser.AddConstraintDefinition, *sqlparser.ConstraintDefinition:
+		return true, nil
+	case *sqlparser.ForeignKeyDefinition:
+		fk.found = true
+	}
+	return false, nil
+}
 
 // buildGeneralDDLPlan builds a general DDL plan, which can be either normal DDL or online DDL.
 // The two behave compeltely differently, and have two very different primitives.
@@ -55,42 +84,38 @@ func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars
 
 	switch ddl := ddlStatement.(type) {
 	case *sqlparser.AlterTable, *sqlparser.TruncateTable:
+		err = checkFKError(vschema, ddlStatement)
+		if err != nil {
+			return nil, nil, err
+		}
 		// For Alter Table and other statements, the table must already exist
 		// We should find the target of the query from this tables location
 		destination, keyspace, err = findTableDestinationAndKeyspace(vschema, ddlStatement)
-		if err != nil {
-			return nil, nil, err
-		}
 	case *sqlparser.CreateView:
 		destination, keyspace, err = buildCreateView(vschema, ddl, reservedVars)
-		if err != nil {
-			return nil, nil, err
-		}
 	case *sqlparser.AlterView:
 		destination, keyspace, err = buildAlterView(vschema, ddl, reservedVars)
+	case *sqlparser.CreateTable:
+		err = checkFKError(vschema, ddlStatement)
 		if err != nil {
 			return nil, nil, err
 		}
-	case *sqlparser.CreateTable:
 		destination, keyspace, _, err = vschema.TargetDestination(ddlStatement.GetTable().Qualifier.String())
+		if err != nil {
+			return nil, nil, err
+		}
 		// Remove the keyspace name as the database name might be different.
 		ddlStatement.SetTable("", ddlStatement.GetTable().Name.String())
-		if err != nil {
-			return nil, nil, err
-		}
 	case *sqlparser.DropView, *sqlparser.DropTable:
 		destination, keyspace, err = buildDropViewOrTable(vschema, ddlStatement)
-		if err != nil {
-			return nil, nil, err
-		}
 	case *sqlparser.RenameTable:
 		destination, keyspace, err = buildRenameTable(vschema, ddl)
-		if err != nil {
-			return nil, nil, err
-		}
-
 	default:
 		return nil, nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unexpected ddl statement type: %T", ddlStatement)
+	}
+
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if destination == nil {
@@ -114,6 +139,17 @@ func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars
 			DDL:      ddlStatement,
 			SQL:      query,
 		}, nil
+}
+
+func checkFKError(vschema ContextVSchema, ddlStatement sqlparser.DDLStatement) error {
+	if fkStrategyMap[strings.ToLower(vschema.ForeignKey())] == disallow {
+		fk := &fkContraint{}
+		_ = sqlparser.Walk(fk.FkWalk, ddlStatement)
+		if fk.found {
+			return vterrors.Errorf(vtrpcpb.Code_ABORTED, "foreign key constraint is not allowed")
+		}
+	}
+	return nil
 }
 
 func findTableDestinationAndKeyspace(vschema ContextVSchema, ddlStatement sqlparser.DDLStatement) (key.Destination, *vindexes.Keyspace, error) {

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -142,7 +142,7 @@ func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars
 }
 
 func checkFKError(vschema ContextVSchema, ddlStatement sqlparser.DDLStatement) error {
-	if fkStrategyMap[strings.ToLower(vschema.ForeignKey())] == disallow {
+	if fkStrategyMap[strings.ToLower(vschema.ForeignKeyMode())] == disallow {
 		fk := &fkContraint{}
 		_ = sqlparser.Walk(fk.FkWalk, ddlStatement)
 		if fk.found {

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -312,7 +312,7 @@ type vschemaWrapper struct {
 	version       PlannerVersion
 }
 
-func (vw *vschemaWrapper) ForeignKey() string {
+func (vw *vschemaWrapper) ForeignKeyMode() string {
 	return "allow"
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -312,6 +312,10 @@ type vschemaWrapper struct {
 	version       PlannerVersion
 }
 
+func (vw *vschemaWrapper) ForeignKey() string {
+	return "allow"
+}
+
 func (vw *vschemaWrapper) AllKeyspace() ([]*vindexes.Keyspace, error) {
 	if vw.keyspace == nil {
 		return nil, errors.New("keyspace not available")

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -755,7 +755,10 @@ func (vc *vcursorImpl) WarnUnshardedOnly(format string, params ...interface{}) {
 
 // ForeignKey implements the VCursor interface
 func (vc *vcursorImpl) ForeignKeyMode() string {
-	return *foreignKeyMode
+	if foreignKeyMode == nil {
+		return ""
+	}
+	return strings.ToLower(*foreignKeyMode)
 }
 
 // ParseDestinationTarget parses destination target string and sets default keyspace if possible.

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -753,6 +753,11 @@ func (vc *vcursorImpl) WarnUnshardedOnly(format string, params ...interface{}) {
 	}
 }
 
+// ForeignKey implements the VCursor interface
+func (vc *vcursorImpl) ForeignKey() string {
+	return *foreignKey
+}
+
 // ParseDestinationTarget parses destination target string and sets default keyspace if possible.
 func parseDestinationTarget(targetString string, vschema *vindexes.VSchema) (string, topodatapb.TabletType, key.Destination, error) {
 	destKeyspace, destTabletType, dest, err := topoprotopb.ParseDestination(targetString, defaultTabletType)

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -754,8 +754,8 @@ func (vc *vcursorImpl) WarnUnshardedOnly(format string, params ...interface{}) {
 }
 
 // ForeignKey implements the VCursor interface
-func (vc *vcursorImpl) ForeignKey() string {
-	return *foreignKey
+func (vc *vcursorImpl) ForeignKeyMode() string {
+	return *foreignKeyMode
 }
 
 // ParseDestinationTarget parses destination target string and sets default keyspace if possible.

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -83,7 +83,7 @@ var (
 	lockHeartbeatTime = flag.Duration("lock_heartbeat_time", 5*time.Second, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 	warnShardedOnly   = flag.Bool("warn_sharded_only", false, "If any features that are only available in unsharded mode are used, query execution warnings will be added to the session")
 
-	foreignKey = flag.String("foreign_key", "allow", "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
+	foreignKeyMode = flag.String("foreign_key_mode", "allow", "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
 )
 
 func getTxMode() vtgatepb.TransactionMode {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -82,6 +82,8 @@ var (
 	// lockHeartbeatTime is used to set the next heartbeat time.
 	lockHeartbeatTime = flag.Duration("lock_heartbeat_time", 5*time.Second, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 	warnShardedOnly   = flag.Bool("warn_sharded_only", false, "If any features that are only available in unsharded mode are used, query execution warnings will be added to the session")
+
+	foreignKey = flag.String("foreign_key", "allow", "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
 )
 
 func getTxMode() vtgatepb.TransactionMode {


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Vitess today allowed foreign keys constraint to be sent down to the mysql to be applied on the table. 

In a sharded keyspace, they might not be correctly set and would fail user queries. 

This change is to provide a `-foreign_key` flag on VTGate with default "allow" but with an option to change it to "disallow" 

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
