### PR TITLE
make: build vitess as static binaries by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,16 @@ embed_config:
 	go run github.com/GeertJohan/go.rice/rice embed-go
 	go build .
 
+# build the vitess binaries with dynamic dependency on libc (not recommenced)
+build-libc:
+ifndef NOBANNER
+	echo $$(date): Building source tree
+endif
+	bash ./build.env
+	go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
+
+# build the vitess binaries statically
 build:
 ifndef NOBANNER
 	echo $$(date): Building source tree

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/... && \
-		(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
+	# build all the binaries by default with CGO disabled
+	CGO_ENABLED=0 go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	# embed local resources in the vttablet executable
+	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
+	# build vtorc with CGO, because it depends on sqlite
+	CGO_ENABLED=1 go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
 
 debug:
 ifndef NOBANNER

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ embed_config:
 	go build .
 
 # build the vitess binaries with dynamic dependency on libc
-build:
+build-dyn:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
@@ -63,7 +63,7 @@ endif
 	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
 
 # build the vitess binaries statically
-build-static:
+build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ embed_config:
 	go run github.com/GeertJohan/go.rice/rice embed-go
 	go build .
 
-# build the vitess binaries with dynamic dependency on libc (not recommenced)
-build-libc:
+# build the vitess binaries with dynamic dependency on libc
+build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
@@ -63,7 +63,7 @@ endif
 	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
 
 # build the vitess binaries statically
-build:
+build-static:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e h1:4ZrkT/RzpnRO
 github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e/go.mod h1:uw9h2sd4WWHOPdJ13MQpwK5qYWKYDumDqxWWIknEQ+k=
 github.com/DataDog/datadog-go v2.2.0+incompatible h1:V5BKkxACZLjzHjSgBbr2gvLA2Ae49yhc6CSY7MLy5k4=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/jt0CW30vsg=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0 h1:KkI6O9uMaQU3VEKaj01ulavtF7o1fWT7+pk/4voiMLQ=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
@@ -75,6 +76,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f h1:HR5nRmUQgXrwqZOwZ2DAc/aCi3Bu3xENpspW935vxu0=
 github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f/go.mod h1:f3HiCrHjHBdcm6E83vGaXh1KomZMA2P6aeo3hKx/wg0=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
@@ -407,6 +409,7 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -529,6 +532,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
+github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229 h1:E2B8qYyeSgv5MXpmzZXRNp8IAQ4vjxIjhpAf5hv/tAg=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
@@ -694,7 +698,9 @@ github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/go/cmd/vtorc/main.go
+++ b/go/cmd/vtorc/main.go
@@ -19,6 +19,9 @@ package main
 import (
 	"flag"
 
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/mattn/go-sqlite3"
+
 	"vitess.io/vitess/go/vt/orchestrator/app"
 	"vitess.io/vitess/go/vt/orchestrator/config"
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"

--- a/go/vt/orchestrator/db/db.go
+++ b/go/vt/orchestrator/db/db.go
@@ -133,8 +133,10 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 		if err == nil && !fromCache {
 			log.Debugf("Connected to orchestrator backend: sqlite on %v", config.Config.SQLite3DataFile)
 		}
-		db.SetMaxOpenConns(1)
-		db.SetMaxIdleConns(1)
+		if db != nil {
+			db.SetMaxOpenConns(1)
+			db.SetMaxIdleConns(1)
+		}
 	} else {
 		if db, fromCache, err := openOrchestratorMySQLGeneric(); err != nil {
 			return db, log.Errore(err)

--- a/go/vt/orchestrator/external/golib/sqlutils/sqlutils.go
+++ b/go/vt/orchestrator/external/golib/sqlutils/sqlutils.go
@@ -25,9 +25,6 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/mattn/go-sqlite3"
-
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
 )
 

--- a/go/vt/orchestrator/inst/cluster_test.go
+++ b/go/vt/orchestrator/inst/cluster_test.go
@@ -21,6 +21,8 @@ import (
 
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
+
 	"vitess.io/vitess/go/vt/orchestrator/config"
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
 	test "vitess.io/vitess/go/vt/orchestrator/external/golib/tests"


### PR DESCRIPTION
## Description

We're trying to solve two related issues here:

1. Since the introduction of `vtorc`, all the different binaries have ballooned up in size and dependencies, because the CGo dependencies of `orchestrator` (namely, SQLite) were being propagated through the build.
2. Since newer versions of Go have been released, dynamically linked Go binaries depend on newer versions of `libc` that are not available on older OSSes.

Let's try to fix the two issues at once: first, we stop importing the `go-sqlite` package on `orchestrator`'s `sqlutils` package, because it's being used in other parts of the codebase. We can add the dependency at the root of the binary itself. Secondly, we update our `Makefile` so that CGo is disabled by default for all binaries except `vtorc`.

Building Vitess with CGo disabled by default has a major implication: `vitess` will use Go's native DNS resolver always, and this could potentially be a breaking change. Usually, the Go runtime chooses the DNS resolver dynamically at runtime, between its native resolver and the one on `glibc` based on some heuristics. **The native resolver is always selected unless the runtime detects configuration options in `resolv.conf` or `/etc/gai.conf` that it doesn't know how to handle** (you can see the full heuristics [here](https://golang.org/src/net/conf.go)). By disabling CGo, the native resolver will always be used, and particular deployments that customize their DNS resolution in unsupported ways will error out with a helpful message.

How breaking is this change? I'm not sure, that's why I left a target in the Makefile to keep building versions of Vitess that depend dynamically on `libc`. I think that the sensible choice by far would be to ship Vitess as static binaries by default, because it greatly simplifies deployment in a large amount of (older) OS versions that we couldn't support otherwise -- an use case much more frequent than deploying in modern OSses with env-defined local resolver configurations.

## Related Issue(s)

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
