### PR TITLE
perf: vttablet/mysql optimizations

### DIFF
--- a/go/bucketpool/bucketpool.go
+++ b/go/bucketpool/bucketpool.go
@@ -17,7 +17,7 @@ limitations under the License.
 package bucketpool
 
 import (
-	"math"
+	"math/bits"
 	"sync"
 )
 
@@ -69,12 +69,10 @@ func (p *Pool) findPool(size int) *sizedPool {
 	if size > p.maxSize {
 		return nil
 	}
-	idx := int(math.Ceil(math.Log2(float64(size) / float64(p.minSize))))
-	if idx < 0 {
-		idx = 0
-	}
-	if idx > len(p.pools)-1 {
-		return nil
+	div, rem := bits.Div64(0, uint64(size), uint64(p.minSize))
+	idx := bits.Len64(div)
+	if rem == 0 && div != 0 && (div&(div-1)) == 0 {
+		idx = idx - 1
 	}
 	return p.pools[idx]
 }

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1472,7 +1472,7 @@ func ParseErrorPacket(data []byte) error {
 	pos++
 
 	// SQL state is 5 bytes
-	sqlState, pos, ok := readBytesCopy(data, pos, 5)
+	sqlState, pos, ok := readBytes(data, pos, 5)
 	if !ok {
 		return NewSQLError(CRUnknownError, SSUnknownSQLState, "invalid error packet sqlState: %v", data)
 	}

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -766,7 +766,7 @@ func parseConnAttrs(data []byte, pos int) (map[string]string, int, error) {
 		attrLenRead += uint64(keyLen) + 1
 
 		var connAttrKey []byte
-		connAttrKey, pos, ok = readBytesCopy(data, pos, int(keyLen))
+		connAttrKey, pos, ok = readBytes(data, pos, int(keyLen))
 		if !ok {
 			return nil, 0, vterrors.Errorf(vtrpc.Code_INTERNAL, "parseClientHandshakePacket: can't read connection attribute key")
 		}
@@ -779,7 +779,7 @@ func parseConnAttrs(data []byte, pos int) (map[string]string, int, error) {
 		attrLenRead += uint64(valLen) + 1
 
 		var connAttrVal []byte
-		connAttrVal, pos, ok = readBytesCopy(data, pos, int(valLen))
+		connAttrVal, pos, ok = readBytes(data, pos, int(valLen))
 		if !ok {
 			return nil, 0, vterrors.Errorf(vtrpc.Code_INTERNAL, "parseClientHandshakePacket: can't read connection attribute value")
 		}

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -133,7 +133,7 @@ func (c *Conn) FetchNext() ([]sqltypes.Value, error) {
 	}
 
 	// Regular row.
-	return c.parseRow(data, c.fields)
+	return c.parseRow(data, c.fields, readLenEncStringAsBytes)
 }
 
 // CloseResult can be used to terminate a streaming query

--- a/go/vt/sqlparser/keywords.go
+++ b/go/vt/sqlparser/keywords.go
@@ -519,6 +519,7 @@ type perfectTable struct {
 	level0Mask int      // len(Level0) - 1
 	level1     []uint32 // power of 2 size >= len(keys)
 	level1Mask int      // len(Level1) - 1
+	min, max   int
 }
 
 const offset64 = uint64(14695981039346656037)
@@ -568,8 +569,17 @@ func buildKeywordTable(keywords []keyword) *perfectTable {
 		level1Mask    = len(level1) - 1
 		sparseBuckets = make([][]int, len(level0))
 		zeroSeed      = offset64
+		min, max      = len(keywords[0].name), len(keywords[0].name)
 	)
 	for i, kw := range keywords {
+		kwlen := len(kw.name)
+		if kwlen > max {
+			max = kwlen
+		}
+		if kwlen < min {
+			min = kwlen
+		}
+
 		n := int(fnv1aIstr(zeroSeed, kw.name)) & level0Mask
 		sparseBuckets[n] = append(sparseBuckets[n], i)
 	}
@@ -611,12 +621,19 @@ func buildKeywordTable(keywords []keyword) *perfectTable {
 		level0Mask: level0Mask,
 		level1:     level1,
 		level1Mask: level1Mask,
+		min:        min,
+		max:        max,
 	}
 }
 
 // Lookup looks up the given keyword on the perfect map for keywords.
 // The provided bytes are not modified and are compared **case insensitively**
 func (t *perfectTable) Lookup(keyword []byte) (int, bool) {
+	kwlen := len(keyword)
+	if kwlen > t.max || kwlen < t.min {
+		return 0, false
+	}
+
 	i0 := int(fnv1aI(offset64, keyword)) & t.level0Mask
 	seed := t.level0[i0]
 	i1 := int(fnv1aI(uint64(seed), keyword)) & t.level1Mask
@@ -630,6 +647,11 @@ func (t *perfectTable) Lookup(keyword []byte) (int, bool) {
 // LookupString looks up the given keyword on the perfect map for keywords.
 // The provided string is compared **case insensitively**
 func (t *perfectTable) LookupString(keyword string) (int, bool) {
+	kwlen := len(keyword)
+	if kwlen > t.max || kwlen < t.min {
+		return 0, false
+	}
+
 	i0 := int(fnv1aIstr(offset64, keyword)) & t.level0Mask
 	seed := t.level0[i0]
 	i1 := int(fnv1aIstr(uint64(seed), keyword)) & t.level1Mask

--- a/go/vt/vttablet/endtoend/stream_test.go
+++ b/go/vt/vttablet/endtoend/stream_test.go
@@ -45,31 +45,56 @@ func TestStreamUnion(t *testing.T) {
 	assert.Equal(t, 1, len(qr.Rows))
 }
 
+func populateStressQuery(client *framework.QueryClient, rowCount int, rowContent string) error {
+	err := client.Begin(false)
+	if err != nil {
+		return err
+	}
+	defer client.Rollback()
+
+	for i := 0; i < rowCount; i++ {
+		query := fmt.Sprintf("insert into vitess_stress values (%d, '%s')", i, strings.Repeat(rowContent, 2048/len(rowContent)))
+		_, err := client.Execute(query, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return client.Commit()
+}
+
+func BenchmarkStreamQuery(b *testing.B) {
+	const RowCount = 1100
+	const RowContent = "abcdefghijklmnopqrstuvwxyz"
+
+	client := framework.NewClient()
+	err := populateStressQuery(client, RowCount, RowContent)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer client.Execute("delete from vitess_stress", nil)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := client.Stream("select * from vitess_stress", nil, func(result *sqltypes.Result) error {
+			return nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestStreamConsolidation(t *testing.T) {
 	const Workers = 50
 	const RowCount = 1100
 	const RowContent = "abcdefghijklmnopqrstuvwxyz"
 
-	populate := func(client *framework.QueryClient) error {
-		err := client.Begin(false)
-		if err != nil {
-			return err
-		}
-		defer client.Rollback()
-
-		for i := 0; i < RowCount; i++ {
-			query := fmt.Sprintf("insert into vitess_stress values (%d, '%s')", i, strings.Repeat(RowContent, 2048/len(RowContent)))
-			_, err := client.Execute(query, nil)
-			if err != nil {
-				return err
-			}
-		}
-		return client.Commit()
-	}
-
 	client := framework.NewClient()
-	err := populate(client)
-	require.NoError(t, err)
+	err := populateStressQuery(client, RowCount, RowContent)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer client.Execute("delete from vitess_stress", nil)
 
 	defaultPoolSize := framework.Server.StreamPoolSize()


### PR DESCRIPTION
## Description

Hi! Here's a small list of optimizations for `vttablet` and it's connection to the MySQL upstream server.

Brief explanation for each follows:

- `sqlparser: do not lookup keywords if they're too long`: this is going to apply to all SQL parsing in Vitess, also to `vtgate`. It's most noticeable on synthetic queries, like the ones we were using for benchmarking the MySQL client, with large keywords. The idea is this: when building the perfect map for SQL keywords in the parser, we keep track of the longest and the shortest of the keywords. That way, when looking up keywords afterwards, we don't have to bother hashing the potential keyword if it's either shorter than the shortest keyword we know, or longer than the longest.

- `mysql: do not copy bytes that are immediately cast to string`: the MySQL client code was calling `readBytesCopy` more than it should. You don't have to copy a slice of bytes before you cast it to `string`: the compiler does that for you automatically (otherwise the cast would be unsafe!), so we were copying twice.

- `bucketpool: do not use floating point math`: this was interestingly hot when profiling the MySQL wire protocol _server_ interface. We can simplify the math required to find the bucket for a given size in our pool by replacing floating point math with bit-level math. In this particular case, we can replace FP `Log2` with a reversed count-leading-zeroes (which is essentially what `Len64` does in the `bits` package). It's not magical but it's as fast as it'll get:

```
name        old time/op  new time/op  delta
Pool-16      281ns ± 1%   244ns ± 2%  -13.15%  (p=0.000 n=10+10)
```

- `mysql: do not copy streaming packets`: this is the :moneybag: prize here. The streaming code is already allocating full packets on each read (as opposed to using ephemeral ones like the normal client), so there is no need to copy them when parsing the rows. We can have all the row structs share the same underlying byte slice from the packet. The benefits are massive, because the vast majority of time spent in a streaming query is just parsing rows:

```
name            old time/op    new time/op    delta
StreamQuery-16    2.82ms ± 1%    2.28ms ± 2%  -19.12%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
StreamQuery-16    4.71MB ± 0%    2.59MB ± 0%  -45.00%  (p=0.000 n=10+9)

name            old allocs/op  new allocs/op  delta
StreamQuery-16     5.68k ± 0%     3.51k ± 0%  -38.19%  (p=0.000 n=10+9)
```

That's 20% increase in throughput with streaming queries, 45% decrease in total memory allocations. This will be very noticeable in large Vitess deployments, particularly ones using OLAP workloads.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- https://github.com/vitessio/vitess/issues/7674

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
