### PR TITLE
Use actions/setup-go@v2 and go 1.15.11 or newer

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ~1.15.11
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_27.yml
+++ b/.github/workflows/cluster_endtoend_27.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -6,13 +6,13 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -6,13 +6,13 @@ jobs:
 
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out v8.0.0
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/cluster_initial_sharding_multi.yml
+++ b/.github/workflows/cluster_initial_sharding_multi.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/docker_test_1.yml
+++ b/.github/workflows/docker_test_1.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/docker_test_2.yml
+++ b/.github/workflows/docker_test_2.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/docker_test_3.yml
+++ b/.github/workflows/docker_test_3.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/ensure_bootstrap_updated.yml
+++ b/.github/workflows/ensure_bootstrap_updated.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/golangci-linter.yml
+++ b/.github/workflows/golangci-linter.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.15
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ~1.15.11
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/gomod-tidy.yml
+++ b/.github/workflows/gomod-tidy.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.15
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ~1.15.11
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/sonar_analysis.yml
+++ b/.github/workflows/sonar_analysis.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: ~1.15.11
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -7,9 +7,9 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ~1.15.11
 
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: John Watson <johnw@planetscale.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
actions/setup-go v2 contains fixes for version matching and logging of go env

Also, rather than relying on whatever latest Go version is cached on the runner, explicitly ask for Go 1.15.11 or newer patch release

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
