### PR TITLE
Update `GetSchema` filtering to exclude shards where `IsMasterServing` but no `MasterAlias`

### DIFF
--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -557,6 +557,10 @@ func TestFindSchema(t *testing.T) {
 										Name:     "-80",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  100,
+											},
 										},
 									},
 									"80-": {
@@ -564,6 +568,10 @@ func TestFindSchema(t *testing.T) {
 										Name:     "80-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  200,
+											},
 										},
 									},
 								},
@@ -577,6 +585,10 @@ func TestFindSchema(t *testing.T) {
 										Name:     "-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  300,
+											},
 										},
 									},
 								},
@@ -668,6 +680,10 @@ func TestFindSchema(t *testing.T) {
 										Name:     "-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c2z1",
+												Uid:  100,
+											},
 										},
 									},
 								},
@@ -1403,6 +1419,10 @@ func TestGetSchema(t *testing.T) {
 										Name:     "-80",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  100,
+											},
 										},
 									},
 									"80-": {
@@ -1410,6 +1430,10 @@ func TestGetSchema(t *testing.T) {
 										Name:     "80-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  200,
+											},
 										},
 									},
 								},
@@ -2073,6 +2097,10 @@ func TestGetSchemas(t *testing.T) {
 										Name:     "-80",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  100,
+											},
 										},
 									},
 									"80-": {
@@ -2080,6 +2108,10 @@ func TestGetSchemas(t *testing.T) {
 										Name:     "80-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone1",
+												Uid:  200,
+											},
 										},
 									},
 								},
@@ -2093,6 +2125,10 @@ func TestGetSchemas(t *testing.T) {
 										Name:     "-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c1zone2",
+												Uid:  100,
+											},
 										},
 									},
 								},
@@ -2184,6 +2220,10 @@ func TestGetSchemas(t *testing.T) {
 										Name:     "-",
 										Shard: &topodatapb.Shard{
 											IsMasterServing: true,
+											MasterAlias: &topodatapb.TabletAlias{
+												Cell: "c2z1",
+												Uid:  100,
+											},
 										},
 									},
 								},

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -633,7 +633,7 @@ func (c *Cluster) getTabletsToQueryForSchemas(ctx context.Context, keyspace stri
 		tabletsToQuery := make([]*vtadminpb.Tablet, 0, len(shards))
 
 		for _, shard := range shards {
-			if !shard.Shard.IsMasterServing {
+			if !(shard.Shard.IsMasterServing && shard.Shard.MasterAlias != nil) {
 				log.Infof("%s/%s is not serving; ignoring ...", keyspace, shard.Name)
 				continue
 			}

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -633,6 +633,11 @@ func (c *Cluster) getTabletsToQueryForSchemas(ctx context.Context, keyspace stri
 		tabletsToQuery := make([]*vtadminpb.Tablet, 0, len(shards))
 
 		for _, shard := range shards {
+			// In certain setups, empty but "serving" shards may required to
+			// provide a contiguous keyspace so that certain keyspace-level
+			// operations will work. In our case, we care about whether the
+			// shard is truly serving, which we define as also having a known
+			// primary (via MasterAlias) in addition to the IsMasterServing bit.
 			if !(shard.Shard.IsMasterServing && shard.Shard.MasterAlias != nil) {
 				log.Infof("%s/%s is not serving; ignoring ...", keyspace, shard.Name)
 				continue

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -632,12 +632,20 @@ func TestGetSchema(t *testing.T) {
 											Name: "-80",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  100,
+												},
 											},
 										},
 										"80-": {
 											Name: "80-",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  200,
+												},
 											},
 										},
 										"-": {
@@ -769,12 +777,20 @@ func TestGetSchema(t *testing.T) {
 											Name: "-80",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  100,
+												},
 											},
 										},
 										"80-": {
 											Name: "80-",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  200,
+												},
 											},
 										},
 										"-": {
@@ -876,12 +892,20 @@ func TestGetSchema(t *testing.T) {
 											Name: "-80",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  100,
+												},
 											},
 										},
 										"80-": {
 											Name: "80-",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  200,
+												},
 											},
 										},
 										"-": {
@@ -1016,12 +1040,20 @@ func TestGetSchema(t *testing.T) {
 											Name: "-80",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  100,
+												},
 											},
 										},
 										"80-": {
 											Name: "80-",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  200,
+												},
 											},
 										},
 										"-": {
@@ -1197,12 +1229,20 @@ func TestGetSchema(t *testing.T) {
 											Name: "-80",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  100,
+												},
 											},
 										},
 										"80-": {
 											Name: "80-",
 											Shard: &topodatapb.Shard{
 												IsMasterServing: true,
+												MasterAlias: &topodatapb.TabletAlias{
+													Cell: "zone1",
+													Uid:  200,
+												},
 											},
 										},
 									},


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

This effectively accounts for corner cases where there is an empty shard which happens to also be marked as serving.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
