### PR TITLE
Makefile: add cross-build target for cross-compiling client binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 # xbuild can be used to cross-compile Vitess client binaries
 # Outside of select client binaries (namely vtctlclient & vtexplain), cross-compiled Vitess Binaries are not recommended for production deployments
 # Usage: GOOS=darwin GOARCH=amd64 make xbuild
-xbuild:
+cross-build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,23 @@ endif
 	# build vtorc with CGO, because it depends on sqlite
 	CGO_ENABLED=1 go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
 
+# xbuild can be used to cross-compile Vitess client binaries
+# Outside of select client binaries (namely vtctlclient & vtexplain), cross-compiled Vitess Binaries are not recommended for production deployments
+# Usage: GOOS=darwin GOARCH=amd64 make xbuild
+xbuild:
+ifndef NOBANNER
+	echo $$(date): Building source tree
+endif
+	bash ./build.env
+	# In order to cross-compile, go install requires GOBIN to be unset
+	export GOBIN=""
+	# For the specified GOOS + GOARCH, build all the binaries by default with CGO disabled
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	# unset GOOS and embed local resources in the vttablet executable
+	(cd go/cmd/vttablet && unset GOOS && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
+	# Cross-compiling w/ cgo isn't trivial and we don't need vtorc, so we can skip building it 
+	#CGO_ENABLED=1 GOOS=${GOOS} GOARCH=${GOARCH} go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
+
 debug:
 ifndef NOBANNER
 	echo $$(date): Building source tree

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ endif
 	# unset GOOS and embed local resources in the vttablet executable
 	(cd go/cmd/vttablet && unset GOOS && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
 	# Cross-compiling w/ cgo isn't trivial and we don't need vtorc, so we can skip building it 
-	#CGO_ENABLED=1 GOOS=${GOOS} GOARCH=${GOARCH} go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
 
 debug:
 ifndef NOBANNER


### PR DESCRIPTION
Signed-off-by: Gary Edgar <gary@planetscale.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Adds a `cross-build` target which allows you to cross-compile Vitess binaries.
This makes it easier build a slim client tarball (namely, vtexplain + vtctl{,d}client) for OSX from Linux, which we can start including in PlanetScale's biweekly Vitess release. 

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
