### PR TITLE
VReplicationErrors metric: use . as delimiter instead of _ to behave well with Prometheus

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -288,7 +288,7 @@ func (st *vrStats) register() {
 			result := make(map[string]int64)
 			for _, ct := range st.controllers {
 				for key, val := range ct.blpStats.ErrorCounts.Counts() {
-					result[fmt.Sprintf("%d_%s", ct.id, key)] = val
+					result[fmt.Sprintf("%d.%s", ct.id, key)] = val
 				}
 			}
 			return result


### PR DESCRIPTION

## Description

Prometheus requires the . (period) separator between dimensions and was dropping the VReplicationErrors metrics due to the use of _ as a delimiter at one place.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>


## Related Issue(s)
- #7804 


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
