### PR TITLE
Rowlog: Update rowlog for the API change made for the vstream skew alignment feature

### DIFF
--- a/tools/rowlog/rowlog.go
+++ b/tools/rowlog/rowlog.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -155,7 +156,7 @@ func startStreaming(ctx context.Context, vtgate, vtctld, keyspace, tablet, table
 		log.Fatal(err)
 	}
 	defer conn.Close()
-	reader, err := conn.VStream(ctx, topodatapb.TabletType_MASTER, vgtid, filter)
+	reader, err := conn.VStream(ctx, topodatapb.TabletType_MASTER, vgtid, filter, &vtgatepb.VStreamFlags{})
 	var fields []*query.Field
 	var gtid string
 	var plan *TablePlan


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
The vstream skew alignment feature had a breaking change wrt to the  API: it now takes an additional parameter to hold flags that can be specified. This PR updates rowlog to use the new API.

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
