### PR TITLE
docker/vttestserver:  Set max_connections in default-fast.cnf at container build time

### DIFF
--- a/docker/vttestserver/Dockerfile.mysql57
+++ b/docker/vttestserver/Dockerfile.mysql57
@@ -57,5 +57,6 @@ USER vitess
 
 COPY docker/vttestserver/setup_vschema_folder.sh /vt/setup_vschema_folder.sh
 COPY docker/vttestserver/run.sh /vt/run.sh
+RUN bash -c 'echo "max_connections = 1000"' >> /vt/config/mycnf/default-fast.cnf
 
 CMD /vt/run.sh "5.7.9-vitess"

--- a/docker/vttestserver/Dockerfile.mysql80
+++ b/docker/vttestserver/Dockerfile.mysql80
@@ -57,5 +57,6 @@ USER vitess
 
 COPY docker/vttestserver/setup_vschema_folder.sh /vt/setup_vschema_folder.sh
 COPY docker/vttestserver/run.sh /vt/run.sh
+RUN bash -c 'echo "max_connections = 1000"' >> /vt/config/mycnf/default-fast.cnf
 
 CMD /vt/run.sh "8.0.21-vitess"


### PR DESCRIPTION
## Description
In both `vttestserver` container images, this sets `max_connections` to 1000 on the underlying MySQL daemons

## Related Issue(s)
N/A

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
