### PR TITLE
Bump MySQL version for docker builds to 8.0.23

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -92,7 +92,7 @@ mysql57)
     )
     ;;
 mysql80)
-    mysql8_version=8.0.21
+    mysql8_version=8.0.23
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb /tmp/libmysqlclient21_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client-core_${mysql8_version}-1debian10_amd64.deb
     do_fetch https://repo.mysql.com/apt/debian/pool/mysql-8.0/m/mysql-community/mysql-community-client_${mysql8_version}-1debian10_amd64.deb /tmp/mysql-community-client_${mysql8_version}-1debian10_amd64.deb

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -330,8 +330,6 @@ func (throttler *Throttler) createThrottlerUser(ctx context.Context) (password s
 		// any query that writes to the binary log, CREATE USER does not hang.
 		// The simplest such query is FLUSH STATUS. Other options are FLUSH PRIVILEGES or similar.
 		// The bug was found in MySQL 8.0.21, and not found in 5.7.30
-		// at this time, Vitess only supports 5.7 an ddoes not support 8.0,
-		// but please keep this code in anticipation of supporting 8.0
 		// - shlomi
 		simpleBinlogQuery := `FLUSH STATUS`
 		if _, err := conn.ExecuteFetch(simpleBinlogQuery, 0, false); err != nil {


### PR DESCRIPTION
since the xtrabackup issue has been resolved.

* Remove comment implying we do not support 8.0

Signed-off-by: Jacques Grove <aquarapid@gmail.com>
