### PR TITLE
tm init: if srvKeyspace exists but is empty, rebuild it

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+
 	"context"
 
 	"github.com/stretchr/testify/assert"
@@ -564,10 +566,8 @@ func ensureSrvKeyspace(t *testing.T, ts *topo.Server, cell, keyspace string) {
 	found := false
 	for i := 0; i < 10; i++ {
 		ks, err := ts.GetSrvKeyspace(context.Background(), cell, keyspace)
-		if err == nil {
+		if err == nil && !proto.Equal(&topodatapb.SrvKeyspace{}, ks) /* require non-empty SrvKeyspace */ {
 			found = true
-			// require non-empty
-			require.NotEqual(t, &topodatapb.SrvKeyspace{}, ks, "SrvKeyspace is empty")
 			break
 		}
 		require.True(t, topo.IsErrType(err, topo.NoNode), err)


### PR DESCRIPTION
## Description
Sometimes clusters get into a situation where vtgate is unable to serve and only a `RebuildKeyspaceGraph` will fix it.
This PR detects the condition on tablet startup and rebuilds the SrvKeyspace if necessary.

## Related Issue(s)
Fixes #7855 

## Checklist
- [x] Should this PR be backported? (Only for 10.0)
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
