### PR TITLE
[vtadmin-web] Add DataCell component

### DIFF
--- a/web/vtadmin/src/components/dataTable/DataCell.tsx
+++ b/web/vtadmin/src/components/dataTable/DataCell.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from 'react';
+import cx from 'classnames';
+
+interface Props
+    extends React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> {}
+
+export const DataCell: React.FunctionComponent<Props> = ({ children, className, ...tdProps }) => {
+    return (
+        <td {...tdProps} className={cx(className, 'font-family-monospace')}>
+            {children}
+        </td>
+    );
+};

--- a/web/vtadmin/src/components/routes/Clusters.tsx
+++ b/web/vtadmin/src/components/routes/Clusters.tsx
@@ -19,6 +19,7 @@ import { useClusters } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { DataTable } from '../dataTable/DataTable';
 import { vtadmin as pb } from '../../proto/vtadmin';
+import { DataCell } from '../dataTable/DataCell';
 
 export const Clusters = () => {
     useDocumentTitle('Clusters');
@@ -31,8 +32,8 @@ export const Clusters = () => {
     const renderRows = (rows: pb.Cluster[]) =>
         rows.map((cluster, idx) => (
             <tr key={idx}>
-                <td>{cluster.name}</td>
-                <td>{cluster.id}</td>
+                <DataCell>{cluster.name}</DataCell>
+                <DataCell>{cluster.id}</DataCell>
             </tr>
         ));
 

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useGates } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { vtadmin as pb } from '../../proto/vtadmin';
+import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
 
 export const Gates = () => {
@@ -31,8 +32,8 @@ export const Gates = () => {
     const renderRows = (gates: pb.VTGate[]) =>
         gates.map((gate, idx) => (
             <tr key={idx}>
-                <td>{gate.cluster?.name}</td>
-                <td>{gate.hostname}</td>
+                <DataCell>{gate.cluster?.name}</DataCell>
+                <DataCell>{gate.hostname}</DataCell>
             </tr>
         ));
 

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useKeyspaces } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { vtadmin as pb } from '../../proto/vtadmin';
+import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
 
 export const Keyspaces = () => {
@@ -31,8 +32,8 @@ export const Keyspaces = () => {
     const renderRows = (rows: pb.Keyspace[]) =>
         rows.map((keyspace, idx) => (
             <tr key={idx}>
-                <td>{keyspace.cluster?.name}</td>
-                <td>{keyspace.keyspace?.name}</td>
+                <DataCell>{keyspace.cluster?.name}</DataCell>
+                <DataCell>{keyspace.keyspace?.name}</DataCell>
             </tr>
         ));
 

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -21,6 +21,7 @@ import { useTableDefinitions } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { filterNouns } from '../../util/filterNouns';
 import { Button } from '../Button';
+import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
 import { Icons } from '../Icon';
 import { TextInput } from '../TextInput';
@@ -53,9 +54,13 @@ export const Schemas = () => {
                     : null;
             return (
                 <tr key={idx}>
-                    <td>{row.cluster}</td>
-                    <td>{row.keyspace}</td>
-                    <td>{href ? <Link to={href}>{row.table}</Link> : row.table}</td>
+                    <DataCell>
+                        <div>{row.keyspace}</div>
+                        <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                    </DataCell>
+                    <DataCell className="font-weight-bold">
+                        {href ? <Link to={href}>{row.table}</Link> : row.table}
+                    </DataCell>
                 </tr>
             );
         });
@@ -76,7 +81,7 @@ export const Schemas = () => {
                 </Button>
             </div>
 
-            <DataTable columns={['Cluster', 'Keyspace', 'Table']} data={filteredData} renderRows={renderRows} />
+            <DataTable columns={['Keyspace', 'Table']} data={filteredData} renderRows={renderRows} />
         </div>
     );
 };

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -25,6 +25,7 @@ import { Icons } from '../Icon';
 import { filterNouns } from '../../util/filterNouns';
 import style from './Tablets.module.scss';
 import { Button } from '../Button';
+import { DataCell } from '../dataTable/DataCell';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -39,13 +40,15 @@ export const Tablets = () => {
     const renderRows = React.useCallback((rows: typeof filteredData) => {
         return rows.map((t, tdx) => (
             <tr key={tdx}>
-                <td>{t.cluster}</td>
-                <td>{t.keyspace}</td>
-                <td>{t.shard}</td>
-                <td>{t.type}</td>
-                <td>{t.state}</td>
-                <td>{t.alias}</td>
-                <td>{t.hostname}</td>
+                <DataCell>
+                    <div>{t.keyspace}</div>
+                    <div className="font-size-small text-color-secondary">{t.cluster}</div>
+                </DataCell>
+                <DataCell>{t.shard}</DataCell>
+                <DataCell>{t.type}</DataCell>
+                <DataCell>{t.state}</DataCell>
+                <DataCell>{t.alias}</DataCell>
+                <DataCell>{t.hostname}</DataCell>
             </tr>
         ));
     }, []);
@@ -66,7 +69,7 @@ export const Tablets = () => {
                 </Button>
             </div>
             <DataTable
-                columns={['Cluster', 'Keyspace', 'Shard', 'Type', 'State', 'Alias', 'Hostname']}
+                columns={['Keyspace', 'Shard', 'Type', 'State', 'Alias', 'Hostname']}
                 data={filteredData}
                 renderRows={renderRows}
             />

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 
 import { useWorkflows } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
 
 export const Workflows = () => {
@@ -39,10 +40,19 @@ export const Workflows = () => {
 
             return (
                 <tr key={idx}>
-                    <td>{href ? <Link to={href}>{workflow?.name}</Link> : workflow?.name}</td>
-                    <td>{cluster?.name}</td>
-                    <td>{workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}</td>
-                    <td>{workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}</td>
+                    <DataCell>
+                        <div className="font-weight-bold">
+                            {href ? <Link to={href}>{workflow?.name}</Link> : workflow?.name}
+                        </div>
+                    </DataCell>
+                    <DataCell>
+                        {workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}
+                        <div className="font-size-small text-color-secondary">{cluster?.name}</div>
+                    </DataCell>
+                    <DataCell>
+                        {workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}
+                        <div className="font-size-small text-color-secondary">{cluster?.name}</div>
+                    </DataCell>
                 </tr>
             );
         });
@@ -50,11 +60,7 @@ export const Workflows = () => {
     return (
         <div className="max-width-content">
             <h1>Workflows</h1>
-            <DataTable
-                columns={['Workflow', 'Cluster', 'Source', 'Target']}
-                data={sortedData}
-                renderRows={renderRows}
-            />
+            <DataTable columns={['Workflow', 'Source', 'Target']} data={sortedData} renderRows={renderRows} />
         </div>
     );
 };

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -44,14 +44,13 @@ export const Workflows = () => {
                         <div className="font-weight-bold">
                             {href ? <Link to={href}>{workflow?.name}</Link> : workflow?.name}
                         </div>
+                        <div className="font-size-small text-color-secondary">{cluster?.name}</div>
                     </DataCell>
                     <DataCell>
                         {workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}
-                        <div className="font-size-small text-color-secondary">{cluster?.name}</div>
                     </DataCell>
                     <DataCell>
                         {workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}
-                        <div className="font-size-small text-color-secondary">{cluster?.name}</div>
                     </DataCell>
                 </tr>
             );

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -185,12 +185,32 @@ table th {
   text-align: left;
 }
 
-table tbody td {
+table tbody tr {
   border: solid 1px var(--tableBorderColor);
+}
+
+table tbody td {
   padding: var(--tableCellPadding);
+  vertical-align: top;
+}
+
+table tbody td[rowSpan] {
+  border-right: solid 1px var(--tableBorderColor);
 }
 
 /* One-liner utilities */
+.font-family-monospace {
+  font-family: var(--fontFamilyMonospace);
+}
+
+.font-size-small {
+  font-size: var(--fontSizeSmall);
+}
+
+.font-weight-bold {
+  font-weight: 700;
+}
+
 .max-width-content {
   max-width: var(--contentWidth);
 }


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

A couple of straightforward styling changes that I keep re-implementing in my bigger branches. 😎  Figured I should just pull them out into their own thing:

- Adds a DataCell component for consistent styling. (A separate component will make more sense when we do rowspan grouping... I admit right now it's kinda overkill, haha. But! Still convenient.) 

- Renders cluster as secondary text where it "makes sense", which is (for now) when the cardinality of clusters is << the cardinality of whatever the table is rendering. Every cluster has many tablets, for example, so a separate "cluster" column is quite redundant when every row on a page is for the same cluster. Some tables, though, only have one or two columns right now, and in those cases I left the "cluster" column as a space filler. :) 

Before:
<img width="2672" alt="Screen Shot 2021-04-10 at 10 50 55 AM" src="https://user-images.githubusercontent.com/855595/114274953-b7367e00-99ee-11eb-9960-1255bcfff339.png">

After: 
<img width="2672" alt="Screen Shot 2021-04-10 at 11 19 52 AM" src="https://user-images.githubusercontent.com/855595/114274958-b998d800-99ee-11eb-8b93-f8c8e921c68b.png">


## Related Issue(s)
<!-- List related issues and pull requests: -->

N/A

## Checklist
- [ ] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
