### PR TITLE
VReplication: add table for logging stream errors, state changes and key workflow steps

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -528,22 +528,22 @@ func CreateVReplicationTable() []string {
 		"CREATE DATABASE IF NOT EXISTS _vt",
 		"DROP TABLE IF EXISTS _vt.blp_checkpoint",
 		`CREATE TABLE IF NOT EXISTS _vt.vreplication (
-  id INT AUTO_INCREMENT,
-  workflow VARBINARY(1000),
-  source VARBINARY(10000) NOT NULL,
-  pos VARBINARY(10000) NOT NULL,
-  stop_pos VARBINARY(10000) DEFAULT NULL,
-  max_tps BIGINT(20) NOT NULL,
-  max_replication_lag BIGINT(20) NOT NULL,
-  cell VARBINARY(1000) DEFAULT NULL,
-  tablet_types VARBINARY(100) DEFAULT NULL,
-  time_updated BIGINT(20) NOT NULL,
-  transaction_timestamp BIGINT(20) NOT NULL,
-  state VARBINARY(100) NOT NULL,
-  message VARBINARY(1000) DEFAULT NULL,
-  db_name VARBINARY(255) NOT NULL,
-  PRIMARY KEY (id)
-) ENGINE=InnoDB`,
+		  id INT AUTO_INCREMENT,
+		  workflow VARBINARY(1000),
+		  source VARBINARY(10000) NOT NULL,
+		  pos VARBINARY(10000) NOT NULL,
+		  stop_pos VARBINARY(10000) DEFAULT NULL,
+		  max_tps BIGINT(20) NOT NULL,
+		  max_replication_lag BIGINT(20) NOT NULL,
+		  cell VARBINARY(1000) DEFAULT NULL,
+		  tablet_types VARBINARY(100) DEFAULT NULL,
+		  time_updated BIGINT(20) NOT NULL,
+		  transaction_timestamp BIGINT(20) NOT NULL,
+		  state VARBINARY(100) NOT NULL,
+		  message VARBINARY(1000) DEFAULT NULL,
+		  db_name VARBINARY(255) NOT NULL,
+		  PRIMARY KEY (id)
+		) ENGINE=InnoDB`,
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -50,7 +50,7 @@ var (
 )
 
 // controller is created by Engine. Members are initialized upfront.
-// There is no mutex within a controller becaust its members are
+// There is no mutex within a controller because its members are
 // either read-only or self-synchronized.
 type controller struct {
 	vre             *Engine

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -96,7 +96,7 @@ func newController(ctx context.Context, params map[string]string, dbClientFactor
 
 	blpStats.State.Set(params["state"])
 	// Nothing to do if replication is stopped.
-	if params["state"] == binlogplayer.BlpStopped {
+	if params["state"] == binlogplayer.BlpStopped || params["state"] == binlogplayer.BlpError {
 		ct.cancel = func() {}
 		close(ct.done)
 		return ct, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -60,6 +60,17 @@ const (
   table_name varbinary(128),
   lastpk varbinary(2000),
   primary key (vrepl_id, table_name))`
+
+	createVReplicationLog = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
+		id BIGINT(20) AUTO_INCREMENT,
+		vrepl_id INT NOT NULL,
+		state VARBINARY(100) NOT NULL,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		message JSON,
+		UNIQUE KEY vrepl_id_time_entered (vrepl_id, created_at),
+		INDEX vrepl_id_last_updated (vrepl_id, updated_at),
+		PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
 )
 
 var withDDL *withddl.WithDDL
@@ -72,6 +83,7 @@ func init() {
 	allddls := append([]string{}, binlogplayer.CreateVReplicationTable()...)
 	allddls = append(allddls, binlogplayer.AlterVReplicationTable...)
 	allddls = append(allddls, createReshardingJournalTable, createCopyState)
+	allddls = append(allddls, createVReplicationLog)
 	withDDL = withddl.New(allddls)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -409,6 +409,16 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 		if err != nil {
 			return nil, err
 		}
+
+		oldParamMap := make(map[int]map[string]string)
+		for _, id := range ids {
+			params, err := readRow(dbClient, id)
+			if err != nil {
+				return nil, err
+			}
+			oldParamMap[id] = params
+		}
+
 		qr, err := withDDL.Exec(vre.ctx, query, dbClient.ExecuteFetch)
 		if err != nil {
 			return nil, err
@@ -425,8 +435,20 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 				return nil, err
 			}
 			vre.controllers[id] = ct
-			if err := insertLogWithParams(vdbc, LogStreamUpdate, uint32(id), params); err != nil {
-				return nil, err
+
+			oldParams, ok := oldParamMap[id]
+			if ok {
+				if oldParams["source"] != params["source"] || oldParams["cell"] != params["cell"] ||
+					oldParams["tablet_types"] != params["tablet_types"] {
+					if err := insertLogWithParams(vdbc, LogStreamUpdate, uint32(id), params); err != nil {
+						return nil, err
+					}
+				}
+				if oldParams["state"] != params["state"] {
+					if err := insertLog(vdbc, LogStateChange, uint32(id), params["state"], ""); err != nil {
+						return nil, err
+					}
+				}
 			}
 		}
 		return qr, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -500,6 +500,7 @@ func TestCreateDBAndTable(t *testing.T) {
 		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD KEY.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("create table if not exists _vt.resharding_journal.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("create table if not exists _vt.copy_state.*", &sqltypes.Result{}, nil)
+		dbClient.ExpectRequestRE("CREATE TABLE IF NOT EXISTS _vt.vreplication_log.*", &sqltypes.Result{}, nil)
 	}
 	expectDDLs()
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -165,7 +165,7 @@ func TestEngineExec(t *testing.T) {
 			),
 			fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 		), nil)
-		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 		dbClient.ExpectRequest("commit", &sqltypes.Result{}, nil)
 		//select id, type, state, message from _vt.vreplication_log
@@ -264,7 +264,7 @@ func TestEngineExec(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequest("select id from _vt.vreplication where id = 1", testSelectorResponse1, nil)
-		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 		dbClient.ExpectRequest("begin", nil, nil)
 		dbClient.ExpectRequest("delete from _vt.vreplication where id in (1)", testDMLResponse, nil)
@@ -296,9 +296,9 @@ func TestEngineExec(t *testing.T) {
 	t.Run("DeleteMultiple", func(t *testing.T) {
 		dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequest("select id from _vt.vreplication where id > 1", testSelectorResponse2, nil)
-		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
-		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+		dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 		dbClient.ExpectRequest("begin", nil, nil)
 		dbClient.ExpectRequest("delete from _vt.vreplication where id in (1, 2)", testDMLResponse, nil)
@@ -551,7 +551,7 @@ func TestCreateDBAndTable(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
-	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 	dbClient.ExpectRequest("commit", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -155,6 +155,7 @@ func TestEngineExec(t *testing.T) {
 	defer vre.Close()
 
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
+	dbClient.ExpectRequest("begin", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequest("insert into _vt.vreplication values(null)", &sqltypes.Result{InsertID: 1}, nil)
 	dbClient.ExpectRequest("select * from _vt.vreplication where id = 1", sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
@@ -163,6 +164,11 @@ func TestEngineExec(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequest("commit", &sqltypes.Result{}, nil)
+	//select id, type, state, message from _vt.vreplication_log
+
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -205,6 +211,8 @@ func TestEngineExec(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:<end:"\200" > `, env.KeyspaceName),
 	), nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -248,6 +256,8 @@ func TestEngineExec(t *testing.T) {
 
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequest("select id from _vt.vreplication where id = 1", testSelectorResponse1, nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("delete from _vt.vreplication where id in (1)", testDMLResponse, nil)
 	dbClient.ExpectRequest("delete from _vt.copy_state where vrepl_id in (1)", nil, nil)
@@ -277,6 +287,10 @@ func TestEngineExec(t *testing.T) {
 
 	dbClient.ExpectRequest("use _vt", &sqltypes.Result{}, nil)
 	dbClient.ExpectRequest("select id from _vt.vreplication where id > 1", testSelectorResponse2, nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("select id, type, state, message from _vt.vreplication_log", testDMLResponse, nil)
+	dbClient.ExpectRequestRE("insert into _vt.vreplication_log", testDMLResponse, nil)
 	dbClient.ExpectRequest("begin", nil, nil)
 	dbClient.ExpectRequest("delete from _vt.vreplication where id in (1, 2)", testDMLResponse, nil)
 	dbClient.ExpectRequest("delete from _vt.copy_state where vrepl_id in (1, 2)", nil, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
@@ -67,10 +67,12 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
+		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	execStatements(t, []string{"insert into tab1 values(3, 'c')"})
 	expectDBClientQueries(t, []string{
+		"/insert into _vt.vreplication_log",
 		"begin",
 		"insert into tab1(id,val) values (3,'c')",
 		"/update _vt.vreplication set pos=",
@@ -99,6 +101,7 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
+		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	cancel2()
@@ -124,6 +127,7 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
+		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	cancel3()
@@ -179,10 +183,15 @@ func expectDBClientAndVreplicationQueries(t *testing.T, queries []string, pos st
 func getExpectedVreplicationQueries(t *testing.T, pos string) []string {
 	if pos == "" {
 		return []string{
+			"begin",
 			"/insert into _vt.vreplication",
+			"/insert into _vt.vreplication_log",
+			"commit",
 			"begin",
 			"/insert into _vt.copy_state",
 			"/update _vt.vreplication set state='Copying'",
+			"/insert into _vt.vreplication_log",
+			"/insert into _vt.vreplication_log",
 			"commit",
 			"/update _vt.vreplication set pos=",
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
@@ -67,12 +67,10 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
-		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	execStatements(t, []string{"insert into tab1 values(3, 'c')"})
 	expectDBClientQueries(t, []string{
-		"/insert into _vt.vreplication_log",
 		"begin",
 		"insert into tab1(id,val) values (3,'c')",
 		"/update _vt.vreplication set pos=",
@@ -101,7 +99,6 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
-		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	cancel2()
@@ -127,7 +124,6 @@ func TestExternalConnectorCopy(t *testing.T) {
 		"/update _vt.copy_state",
 		"commit",
 		"/delete from _vt.copy_state",
-		"/insert into _vt.vreplication_log",
 		"/update _vt.vreplication set state='Running'",
 	}, "")
 	cancel3()
@@ -185,13 +181,10 @@ func getExpectedVreplicationQueries(t *testing.T, pos string) []string {
 		return []string{
 			"begin",
 			"/insert into _vt.vreplication",
-			"/insert into _vt.vreplication_log",
 			"commit",
 			"begin",
 			"/insert into _vt.copy_state",
 			"/update _vt.vreplication set state='Copying'",
-			"/insert into _vt.vreplication_log",
-			"/insert into _vt.vreplication_log",
 			"commit",
 			"/update _vt.vreplication set pos=",
 		}
@@ -199,10 +192,8 @@ func getExpectedVreplicationQueries(t *testing.T, pos string) []string {
 	return []string{
 		"begin",
 		"/insert into _vt.vreplication",
-		"/insert into _vt.vreplication_log",
 		"commit",
 		"/update _vt.vreplication set state='Running'",
-		"/insert into _vt.vreplication_log",
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector_test.go
@@ -197,8 +197,12 @@ func getExpectedVreplicationQueries(t *testing.T, pos string) []string {
 		}
 	}
 	return []string{
+		"begin",
 		"/insert into _vt.vreplication",
+		"/insert into _vt.vreplication_log",
+		"commit",
 		"/update _vt.vreplication set state='Running'",
+		"/insert into _vt.vreplication_log",
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -505,7 +505,7 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 	for {
 		select {
 		case got := <-globalDBQueries:
-			if heartbeatRe.MatchString(got) {
+			if heartbeatRe.MatchString(got) || strings.Contains(got, "_vt.vreplication_log") {
 				continue
 			}
 			t.Errorf("unexpected query: %s", got)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -506,6 +506,9 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 	for {
 		select {
 		case got := <-globalDBQueries:
+			if heartbeatRe.MatchString(got) {
+				continue
+			}
 			t.Errorf("unexpected query: %s", got)
 		default:
 			return
@@ -560,6 +563,9 @@ func expectNontxQueries(t *testing.T, queries []string) {
 		select {
 		case got := <-globalDBQueries:
 			if got == "begin" || got == "commit" || got == "rollback" || strings.Contains(got, "_vt.vreplication") {
+				continue
+			}
+			if heartbeatRe.MatchString(got) {
 				continue
 			}
 			t.Errorf("unexpected query: %s", got)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -164,6 +164,7 @@ func execStatements(t *testing.T, queries []string) {
 // Topos and tablets
 
 func addTablet(id int) *topodatapb.Tablet {
+	globalDBQueries = make(chan string, 1000)
 	tablet := &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: env.Cells[0],
@@ -461,10 +462,11 @@ func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan in
 	}
 }
 
+var passthrough = false //true // for testing
+
 func expectDBClientQueries(t *testing.T, queries []string) {
 	t.Helper()
 	failed := false
-	passthrough := false //true // for testing
 	for i, query := range queries {
 		if failed {
 			t.Errorf("no query received, expecting %s", query)
@@ -526,6 +528,10 @@ func expectNontxQueries(t *testing.T, queries []string) {
 	retry:
 		select {
 		case got = <-globalDBQueries:
+			if passthrough {
+				fmt.Printf(">>> \"%s\",\n", got)
+			}
+
 			if got == "begin" || got == "commit" || got == "rollback" ||
 				strings.Contains(got, "update _vt.vreplication set pos") || heartbeatRe.MatchString(got) ||
 				strings.Contains(got, "_vt.vreplication_log") {
@@ -542,7 +548,9 @@ func expectNontxQueries(t *testing.T, queries []string) {
 			} else {
 				match = (got == query)
 			}
-			require.True(t, match, "query %d:: got:%s, want:%s", i, got, query)
+			if !passthrough {
+				require.True(t, match, "query %d:: got:%s, want:%s", i, got, query)
+			}
 		case <-time.After(5 * time.Second):
 			t.Fatalf("no query received, expecting %s", query)
 			failed = true

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -477,7 +477,7 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 		case got = <-globalDBQueries:
 			// We rule out heartbeat time update queries because otherwise our query list
 			// is indeterminable and varies with each test execution.
-			if heartbeatRe.MatchString(got) {
+			if heartbeatRe.MatchString(got) || strings.Contains(got, "_vt.vreplication_log") {
 				goto retry
 			}
 			if passthrough {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -68,7 +68,7 @@ type LogExpectation struct {
 	Detail string
 }
 
-var heartbeatRe, logQueryRe *regexp.Regexp
+var heartbeatRe *regexp.Regexp
 
 func init() {
 	tabletconn.RegisterDialer("test", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
@@ -83,7 +83,6 @@ func init() {
 	flag.Set("binlog_player_protocol", "test")
 
 	heartbeatRe = regexp.MustCompile(`update _vt.vreplication set time_updated=\d+ where id=\d+`)
-	logQueryRe = regexp.MustCompile(`_vt.vreplication_log`)
 }
 
 func TestMain(m *testing.M) {

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -91,7 +91,7 @@ func TestJournalOneToMany(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 	defer deleteTablet(addOtherTablet(101, "other_keyspace", "-80"))
 	defer deleteTablet(addOtherTablet(102, "other_keyspace", "80-"))
-
+	globalDBQueries = make(chan string, 1000)
 	execStatements(t, []string{
 		"create table t(id int, val varbinary(128), primary key(id))",
 		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
@@ -331,7 +331,6 @@ func TestJournalTableMixed(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set pos=",
 		"/update _vt.vreplication set state='Error', message='unable to handle journal event: tables were partially matched' where id",
-		"/insert into _vt.vreplication_log",
 	})
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -330,7 +330,8 @@ func TestJournalTableMixed(t *testing.T) {
 
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set pos=",
-		"/update _vt.vreplication set state='Stopped', message='unable to handle journal event: tables were partially matched' where id",
+		"/update _vt.vreplication set state='Error', message='unable to handle journal event: tables were partially matched' where id",
+		"/insert into _vt.vreplication_log",
 	})
 
 	// Delete all vreplication streams. There should be only one, but we don't know its id.

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -1,0 +1,56 @@
+package vreplication
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+)
+
+const (
+	createVReplicationLog = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
+		id BIGINT(20) AUTO_INCREMENT,
+		vrepl_id INT NOT NULL,
+		state VARBINARY(100) NOT NULL,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		message text NOT NULL,
+		count BIGINT(20) NOT NULL DEFAULT 1,
+		PRIMARY KEY (id))`
+)
+
+func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, error) {
+	var qr *sqltypes.Result
+	var err error
+	query := fmt.Sprintf("select id, state, message from _vt.vreplication_log where vrepl_id = %d order by id desc limit 1", vreplID)
+	if qr, err = dbClient.ExecuteFetch(query, 1); err != nil {
+		return 0, "", "", err
+	}
+	if len(qr.Rows) != 1 {
+		return 0, "", "", nil
+	}
+	row := qr.Rows[0]
+	id, _ := evalengine.ToInt64(row[0])
+	state := row[1].String()
+	message := row[2].String()
+	return id, state, message, nil
+}
+
+func insertLog(dbClient *vdbClient, vreplID uint32, state, message string) error {
+	var query string
+
+	id, currentState, currentMessage, err := getLastLog(dbClient, vreplID)
+	if err != nil {
+		return err
+	}
+	if id > 0 && state == currentState && message == currentMessage {
+		query = fmt.Sprintf("update _vt.vreplication_log set count = count + 1 where id = %d", id)
+	} else {
+		query = `insert into _vt.vreplication_log(vrepl_id, state, message) values(%d, '%s', %s)`
+		query = fmt.Sprintf(query, vreplID, state, encodeString(message))
+	}
+	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
+		return fmt.Errorf("could not insert into log table: %v: %v", query, err)
+	}
+	return nil
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -1,6 +1,7 @@
 package vreplication
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -11,6 +12,7 @@ const (
 	createVReplicationLog = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
 		id BIGINT(20) AUTO_INCREMENT,
 		vrepl_id INT NOT NULL,
+		type VARBINARY(256) NOT NULL,
 		state VARBINARY(100) NOT NULL,
 		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -19,38 +21,72 @@ const (
 		PRIMARY KEY (id))`
 )
 
-func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, error) {
+const (
+	// Enum values for type column of _vt.vreplication_log
+
+	// LogStreamCreate is used when a row in _vt.vreplication is inserted via VReplicationExec
+	LogStreamCreate = "Stream Created"
+	// LogStreamUpdate is used when a row in _vt.vreplication is updated via VReplicationExec
+	LogStreamUpdate = "Stream Updated"
+	// LogStreamDelete is used when a row in _vt.vreplication is deleted via VReplicationExec
+	LogStreamDelete = "Stream Deleted"
+	// LogMessage is used for generic log messages
+	LogMessage = "Message"
+	// LogCopyStart is used when the copy phase is started
+	LogCopyStart = "Started Copy Phase"
+	// LogCopyEnd is used when the copy phase is done
+	LogCopyEnd = "Ended Copy Phase"
+	// LogStateChange is used when the state of the stream changes
+	LogStateChange = "State Changed"
+	// LogError is used when there is an error from which we cannot recover and the operator needs to fix something
+	LogError = "Error"
+)
+
+func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, string, error) {
 	var qr *sqltypes.Result
 	var err error
-	query := fmt.Sprintf("select id, state, message from _vt.vreplication_log where vrepl_id = %d order by id desc limit 1", vreplID)
+	query := fmt.Sprintf("select id, type, state, message from _vt.vreplication_log where vrepl_id = %d order by id desc limit 1", vreplID)
 	if qr, err = dbClient.ExecuteFetch(query, 1); err != nil {
-		return 0, "", "", err
+		return 0, "", "", "", err
 	}
 	if len(qr.Rows) != 1 {
-		return 0, "", "", nil
+		return 0, "", "", "", nil
 	}
 	row := qr.Rows[0]
 	id, _ := evalengine.ToInt64(row[0])
-	state := row[1].String()
-	message := row[2].String()
-	return id, state, message, nil
+	typ := row[1].String()
+	state := row[2].String()
+	message := row[3].String()
+	return id, typ, state, message, nil
 }
 
-func insertLog(dbClient *vdbClient, vreplID uint32, state, message string) error {
+func insertLog(dbClient *vdbClient, typ string, vreplID uint32, state, message string) error {
 	var query string
 
-	id, currentState, currentMessage, err := getLastLog(dbClient, vreplID)
+	id, currentType, currentState, currentMessage, err := getLastLog(dbClient, vreplID)
 	if err != nil {
 		return err
 	}
-	if id > 0 && state == currentState && message == currentMessage {
+	if id > 0 && typ != currentType && state == currentState && message == currentMessage {
 		query = fmt.Sprintf("update _vt.vreplication_log set count = count + 1 where id = %d", id)
 	} else {
-		query = `insert into _vt.vreplication_log(vrepl_id, state, message) values(%d, '%s', %s)`
-		query = fmt.Sprintf(query, vreplID, state, encodeString(message))
+		query = `insert into _vt.vreplication_log(vrepl_id, typ, state, message) values(%d, '%s', '%s', %s)`
+		query = fmt.Sprintf(query, vreplID, typ, state, encodeString(message))
 	}
 	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
 		return fmt.Errorf("could not insert into log table: %v: %v", query, err)
+	}
+	return nil
+}
+
+func insertLogWithParams(dbClient *vdbClient, action string, vreplID uint32, params map[string]string) error {
+	var message string
+	if params != nil {
+		obj, _ := json.Marshal(params)
+		message = string(obj)
+	}
+	if err := insertLog(dbClient, action, vreplID, params["state"], message); err != nil {
+		return err
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -67,10 +67,10 @@ func insertLog(dbClient *vdbClient, typ string, vreplID uint32, state, message s
 	if err != nil {
 		return err
 	}
-	if id > 0 && typ != currentType && state == currentState && message == currentMessage {
+	if id > 0 && typ == currentType && state == currentState && message == currentMessage {
 		query = fmt.Sprintf("update _vt.vreplication_log set count = count + 1 where id = %d", id)
 	} else {
-		query = `insert into _vt.vreplication_log(vrepl_id, typ, state, message) values(%d, '%s', '%s', %s)`
+		query = `insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%d, '%s', '%s', %s)`
 		query = fmt.Sprintf(query, vreplID, typ, state, encodeString(message))
 	}
 	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -53,6 +53,9 @@ func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, str
 		return 0, "", "", "", nil
 	}
 	row := qr.Rows[0]
+	if len(row) != 4 {
+		return 0, "", "", "", nil
+	}
 	id, _ := evalengine.ToInt64(row[0])
 	typ := row[1].String()
 	state := row[2].String()

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -78,7 +78,7 @@ func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 		if err := vc.vr.setState(binlogplayer.VReplicationCopying, ""); err != nil {
 			return err
 		}
-		if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d tables", len(plan.TargetTables))); err != nil {
+		if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d table(s)", len(plan.TargetTables))); err != nil {
 			return err
 		}
 	} else {

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -78,8 +78,11 @@ func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 		if err := vc.vr.setState(binlogplayer.VReplicationCopying, ""); err != nil {
 			return err
 		}
+		if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d tables", len(plan.TargetTables))); err != nil {
+			return err
+		}
 	} else {
-		if err := vc.vr.setState(binlogplayer.BlpStopped, "There is nothing to replicate"); err != nil {
+		if err := vc.vr.setState(binlogplayer.BlpError, "Error: no tables were found to copy"); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -43,7 +43,7 @@ var initialQueries = []string{
 	"insert into _vt.copy_state(vrepl_id, table_name) values (1, 'dst1')",
 	"update _vt.vreplication set state='Copying', message='' where id=1",
 	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'State Changed', 'Copying', ''\\)",
-	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'Started Copy Phase', 'Copying', 'Copy phase started for .* tables'\\)",
+	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'Started Copy Phase', 'Copying', 'Copy phase started for .* table(s)'\\)",
 	"commit",
 }
 
@@ -468,7 +468,7 @@ func TestPlayerCopyTablesWithFK(t *testing.T) {
 
 }
 
-func TestPlayerCopyTables2(t *testing.T) {
+func TestPlayerCopyTables(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	execStatements(t, []string{

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -43,7 +43,7 @@ var initialQueries = []string{
 	"insert into _vt.copy_state(vrepl_id, table_name) values (1, 'dst1')",
 	"update _vt.vreplication set state='Copying', message='' where id=1",
 	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'State Changed', 'Copying', ''\\)",
-	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'Started Copy Phase', 'Copying', 'Copy phase started for .* table(s)'\\)",
+	"/insert into _vt.vreplication_log\\(vrepl_id, type, state, message\\) values\\(.*, 'Started Copy Phase', 'Copying', 'Copy phase started for .* table\\(s\\)'\\)",
 	"commit",
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -602,7 +602,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 			switch {
 			case found && notFound:
 				// Some were found and some were not found. We can't handle this.
-				if err := vp.vr.setState(binlogplayer.BlpStopped, "unable to handle journal event: tables were partially matched"); err != nil {
+				if err := vp.vr.setState(binlogplayer.BlpError, "unable to handle journal event: tables were partially matched"); err != nil {
 					return err
 				}
 				return io.EOF
@@ -614,7 +614,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		}
 		log.Infof("Binlog event registering journal event %+v", event.Journal)
 		if err := vp.vr.vre.registerJournal(event.Journal, int(vp.vr.id)); err != nil {
-			if err := vp.vr.setState(binlogplayer.BlpStopped, err.Error()); err != nil {
+			if err := vp.vr.setState(binlogplayer.BlpError, err.Error()); err != nil {
 				return err
 			}
 			return io.EOF

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -406,7 +406,7 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	output := []string{
 		"begin",
 		"rollback",
-		"/update _vt.vreplication set state='Error', message='Error: filter rules are not supported for SBR",
+		"/update _vt.vreplication set message='Error: filter rules are not supported for SBR",
 	}
 
 	execStatements(t, input)
@@ -1570,7 +1570,7 @@ func TestPlayerDDL(t *testing.T) {
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
 		"alter table t1 add column val2 varchar(128)",
-		"/update _vt.vreplication set state='Error', message='Error: Duplicate",
+		"/update _vt.vreplication set message='Error: Duplicate",
 	})
 	cancel()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2502,9 +2502,13 @@ func startVReplication(t *testing.T, bls *binlogdatapb.BinlogSource, pos string)
 		t.Fatal(err)
 	}
 	expectDBClientQueries(t, []string{
+		"begin",
 		"/insert into _vt.vreplication",
+		"/insert into _vt.vreplication_log",
+		"commit",
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update _vt.vreplication set state='Running'",
+		"/insert into _vt.vreplication_log",
 	})
 	var once sync.Once
 	return func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1525,7 +1525,6 @@ func TestPlayerDDL(t *testing.T) {
 		"begin",
 		fmt.Sprintf("/update _vt.vreplication set pos='%s'", pos1),
 		"/update _vt.vreplication set state='Stopped'",
-		"/insert into _vt.vreplication_log",
 		"commit",
 	})
 	pos2b := masterPosition(t)
@@ -1540,15 +1539,12 @@ func TestPlayerDDL(t *testing.T) {
 	// It should stop at the next DDL
 	expectDBClientQueries(t, []string{
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		"begin",
 		fmt.Sprintf("/update.*'%s'", pos2),
 		"/update _vt.vreplication set state='Stopped'",
-		"/insert into _vt.vreplication_log",
 		"commit",
 	})
 	cancel()
@@ -1649,19 +1645,15 @@ func TestPlayerStopPos(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"begin",
 		"/insert into _vt.vreplication",
-		"/insert into _vt.vreplication_log",
 		"commit",
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		"begin",
 		"insert into yes(id,val) values (1,'aaa')",
 		fmt.Sprintf("/update.*'%s'", stopPos),
 		"/update.*'Stopped'",
-		"/insert into _vt.vreplication_log",
 		"commit",
 	})
 
@@ -1680,17 +1672,14 @@ func TestPlayerStopPos(t *testing.T) {
 	}
 	expectDBClientQueries(t, []string{
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		"begin",
 		// Since 'no' generates empty transactions that are skipped by
 		// vplayer, a commit is done only for the stop position event.
 		fmt.Sprintf("/update.*'%s'", stopPos),
 		"/update.*'Stopped'",
-		"/insert into _vt.vreplication_log",
 		"commit",
 	})
 
@@ -1701,13 +1690,10 @@ func TestPlayerStopPos(t *testing.T) {
 	}
 	expectDBClientQueries(t, []string{
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		// Second update is from vreplicator.
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
-		"/insert into _vt.vreplication_log",
 		"/update.*'Stopped'.*already reached",
-		"/insert into _vt.vreplication_log",
 	})
 }
 
@@ -2318,7 +2304,6 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 	streamerEngine.Close()
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set message='Error: vstream ended'",
-		"/insert into _vt.vreplication_log",
 	})
 	streamerEngine.Open()
 	execStatements(t, []string{
@@ -2328,7 +2313,6 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update _vt.vreplication set state='Running'",
-		"/insert into _vt.vreplication_log",
 		"begin",
 		"insert into t1(id,val) values (2,'aaa')",
 		"/update _vt.vreplication set pos=",
@@ -2522,11 +2506,9 @@ func startVReplication(t *testing.T, bls *binlogdatapb.BinlogSource, pos string)
 	expectDBClientQueries(t, []string{
 		"begin",
 		"/insert into _vt.vreplication",
-		"/insert into _vt.vreplication_log",
 		"commit",
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update _vt.vreplication set state='Running'",
-		"/insert into _vt.vreplication_log",
 	})
 	var once sync.Once
 	return func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2275,7 +2275,6 @@ func TestPlayerRelayLogMaxSize(t *testing.T) {
 }
 
 func TestRestartOnVStreamEnd(t *testing.T) {
-	t.Skip()
 	defer deleteTablet(addTablet(100))
 
 	savedDelay := *retryDelay
@@ -2318,13 +2317,14 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 
 	streamerEngine.Close()
 	expectDBClientQueries(t, []string{
-		"/update _vt.vreplication set state='Stopped', message='Error: vstream ended'",
+		"/update _vt.vreplication set message='Error: vstream ended'",
 		"/insert into _vt.vreplication_log",
 	})
 	streamerEngine.Open()
 	execStatements(t, []string{
 		"insert into t1 values(2, 'aaa')",
 	})
+	time.Sleep(1 * time.Second)
 	expectDBClientQueries(t, []string{
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update _vt.vreplication set state='Running'",

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -139,16 +139,8 @@ func (vr *vreplicator) Replicate(ctx context.Context) error {
 	err := vr.replicate(ctx)
 	if err != nil {
 		log.Errorf("Replicate error: %s", err.Error())
-		// a vstreamer connection could break due to a network timeout, reparenting etc which are resumable
-		// so unless we get specific errors we just log the error but keep the stream running
-		if strings.Contains(strings.ToLower(err.Error()), "vstream ended") {
-			if err := vr.setMessage(fmt.Sprintf("Error: %s", err.Error())); err != nil {
-				log.Errorf("Failed to set error state: %v", err)
-			}
-		} else {
-			if err := vr.setState(binlogplayer.BlpError, fmt.Sprintf("Error: %s", err.Error())); err != nil {
-				log.Errorf("Failed to set error state: %v", err)
-			}
+		if err := vr.setMessage(fmt.Sprintf("Error: %s", err.Error())); err != nil {
+			log.Errorf("Failed to set error state: %v", err)
 		}
 	}
 	return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -139,10 +139,8 @@ func (vr *vreplicator) Replicate(ctx context.Context) error {
 	err := vr.replicate(ctx)
 	if err != nil {
 		log.Errorf("Replicate error: %s", err.Error())
-		// note: the error we receive could be due to a temporary network disconnect, so we don't want to set
-		// an error state on the stream. Otherwise we always need an operator to reset such errors
-		// To differentiate between such issues and errors which require user intervention we use a convention
-		// that if the error string contains "error" then we set the state of the stream to BlpError
+		// a vstreamer connection could break due to a network timeout, reparenting etc which are resumable
+		// so unless we get specific errors we just log the error but keep the stream running
 		if strings.Contains(strings.ToLower(err.Error()), "vstream ended") {
 			if err := vr.setMessage(fmt.Sprintf("Error: %s", err.Error())); err != nil {
 				log.Errorf("Failed to set error state: %v", err)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -64,6 +64,7 @@ var (
 type vreplicator struct {
 	vre      *Engine
 	id       uint32
+	state    string
 	dbClient *vdbClient
 	// source
 	source          *binlogdatapb.BinlogSource
@@ -313,6 +314,9 @@ func (vr *vreplicator) setMessage(message string) error {
 	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}
+	if err := insertLog(vr.dbClient, vr.id, vr.state, message); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -323,10 +327,14 @@ func (vr *vreplicator) setState(state, message string) error {
 			Message: message,
 		})
 	}
+	vr.state = state
 	vr.stats.State.Set(state)
 	query := fmt.Sprintf("update _vt.vreplication set state='%v', message=%v where id=%v", state, encodeString(binlogplayer.MessageTruncate(message)), vr.id)
 	if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
 		return fmt.Errorf("could not set state: %v: %v", query, err)
+	}
+	if err := insertLog(vr.dbClient, vr.id, vr.state, message); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

This PR adds a new table to the _vt sidecar database. The `_vt.vreplication_log` table will record certain types of events. To start with we record
* stream creation and updates to the stream parameters
* stream errors 
* state changes
* key workflow steps (currently start and end of the copy phase)


```
CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
	id BIGINT(20) AUTO_INCREMENT,
	vrepl_id INT NOT NULL,
	type VARBINARY(256) NOT NULL,
	state VARBINARY(100) NOT NULL,
	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
	message text NOT NULL,
	count BIGINT(20) NOT NULL DEFAULT 1,
	PRIMARY KEY (id))
```

The value of the message will usually be a string. In the case of stream inserts and updates it records all the parameters including the binlogsource field.

Before inserting a new row we check if the latest message matches the state and message of the new message and if it does then it increments the count. This prevents any repeated errors from spamming the table.

### Tests

The introduction of the new queries to read and write to the log table result in new queries and the change in the order of expected queries in several vreplication tests. So a lot of this PR are to the unit tests ...

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
