### PR TITLE
[vtadmin-web] Display (approximate) table sizes + row count on /schemas view

### DIFF
--- a/web/vtadmin/src/components/dataTable/DataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/DataTable.tsx
@@ -22,7 +22,11 @@ import { stringify } from '../../util/queryString';
 import { PaginationNav } from './PaginationNav';
 
 interface Props<T> {
-    columns: string[];
+    // When passing a JSX.Element, note that the column element
+    // will be rendered *inside* a <th> tag. (Note: I don't love this
+    // abstraction + we'll likely want to revisit this when we add
+    // table sorting.)
+    columns: Array<string | JSX.Element>;
     data: T[];
     pageSize?: number;
     renderRows: (rows: T[]) => JSX.Element[];

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 import { useSchemas } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { filterNouns } from '../../util/filterNouns';
+import { formatBytes } from '../../util/formatBytes';
 import { getTableDefinitions } from '../../util/tableDefinitions';
 import { Button } from '../Button';
 import { DataCell } from '../dataTable/DataCell';
@@ -27,6 +28,21 @@ import { DataTable } from '../dataTable/DataTable';
 import { Icons } from '../Icon';
 import { TextInput } from '../TextInput';
 import style from './Schemas.module.scss';
+
+const TABLE_COLUMNS = [
+    'Keyspace',
+    'Table',
+    // TODO: add tooltips to explain that "approx." means something
+    // along the lines of "information_schema is an eventually correct
+    // statistical analysis, past results do not guarantee future performance,
+    // please consult an attorney and we are not a licensed medical professional".
+    // Namely, these numbers come from `information_schema`, which is never precisely
+    // correct for tables that have a high rate of updates. (The only way to get
+    // accurate numbers is to run `ANALYZE TABLE` on the tables periodically, which
+    // is out of scope for VTAdmin.)
+    <div className="text-align-right">Approx. Size</div>,
+    <div className="text-align-right">Approx. Rows</div>,
+];
 
 export const Schemas = () => {
     useDocumentTitle('Schemas');
@@ -64,6 +80,15 @@ export const Schemas = () => {
                     <DataCell className="font-weight-bold">
                         {href ? <Link to={href}>{row.table}</Link> : row.table}
                     </DataCell>
+                    <DataCell className="text-align-right">
+                        <div>{formatBytes(row._raw.tableSize?.data_length)}</div>
+                        <div className="font-size-small text-color-secondary">
+                            {formatBytes(row._raw.tableSize?.data_length, 'B')}
+                        </div>
+                    </DataCell>
+                    <DataCell className="text-align-right">
+                        {(row._raw.tableSize?.row_count || 0).toLocaleString()}
+                    </DataCell>
                 </tr>
             );
         });
@@ -84,7 +109,7 @@ export const Schemas = () => {
                 </Button>
             </div>
 
-            <DataTable columns={['Keyspace', 'Table']} data={filteredData} renderRows={renderRows} />
+            <DataTable columns={TABLE_COLUMNS} data={filteredData} renderRows={renderRows} />
         </div>
     );
 };

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -215,6 +215,10 @@ table tbody td[rowSpan] {
   max-width: var(--contentWidth);
 }
 
+.text-align-right {
+  text-align: right;
+}
+
 .text-color-secondary {
   color: var(--textColorSecondary);
 }

--- a/web/vtadmin/src/util/formatBytes.test.ts
+++ b/web/vtadmin/src/util/formatBytes.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+    const tests: {
+        name: string;
+        params: Parameters<typeof formatBytes>;
+        expected: string | null;
+    }[] = [
+        {
+            name: 'handles numeric inputs',
+            params: [1024],
+            expected: '1 KiB',
+        },
+        {
+            name: 'handles string inputs',
+            params: ['1024'],
+            expected: '1 KiB',
+        },
+        {
+            name: 'handles undefined inputs',
+            params: [undefined],
+            expected: null,
+        },
+        {
+            name: 'handles null inputs',
+            params: [null],
+            expected: null,
+        },
+        {
+            name: 'handles NaN inputs',
+            params: ['not-a-number'],
+            expected: null,
+        },
+        {
+            name: 'uses default precision',
+            params: [1234],
+            expected: '1.21 KiB',
+        },
+        {
+            name: 'uses units parameter if defined',
+            params: [1234567890, 'MiB'],
+            expected: '1,177.38 MiB',
+        },
+    ];
+
+    test.each(tests.map(Object.values))(
+        '%s',
+        (name: string, params: Parameters<typeof formatBytes>, expected: string | null) => {
+            expect(formatBytes(...params)).toEqual(expected);
+        }
+    );
+});

--- a/web/vtadmin/src/util/formatBytes.ts
+++ b/web/vtadmin/src/util/formatBytes.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const BASE = 1024;
+const PRECISION = 2;
+const UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+
+export const formatBytes = (
+    bytes: number | Long | string | null | undefined,
+    units?: string | null | undefined
+): string | null => {
+    if (bytes === null || typeof bytes === 'undefined') return null;
+
+    const num = Number(bytes);
+    if (isNaN(num)) return null;
+
+    const i = units ? UNITS.indexOf(units) : Math.floor(Math.log(num) / Math.log(BASE));
+    if (i < 0) return null;
+
+    return parseFloat((num / Math.pow(BASE, i)).toFixed(PRECISION)).toLocaleString() + ' ' + UNITS[i];
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

Not much to say here beyond what the title + inline comments mention!

<img width="2672" alt="Screen Shot 2021-04-12 at 6 58 43 AM" src="https://user-images.githubusercontent.com/855595/114384393-a572e900-9b5c-11eb-9e89-8d710eb47749.png">


## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
