### PR TITLE
[vtadmin-web] Add Pip + TabletServingPip components

### DIFF
--- a/web/vtadmin/src/components/pips/Pip.module.scss
+++ b/web/vtadmin/src/components/pips/Pip.module.scss
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.pip {
+  background: var(--colorDisabled);
+  border-radius: 100rem;
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+
+  &.success {
+    background: var(--colorSuccess50);
+  }
+
+  &.primary {
+    background: var(--colorPrimary50);
+  }
+
+  &.warning {
+    background: var(--colorInfo50);
+  }
+
+  &.danger {
+    background: var(--colorError50);
+  }
+}

--- a/web/vtadmin/src/components/pips/Pip.tsx
+++ b/web/vtadmin/src/components/pips/Pip.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import cx from 'classnames';
+
+import style from './Pip.module.scss';
+
+interface Props {
+    className?: string;
+    state?: PipState;
+}
+
+export type PipState = 'primary' | 'success' | 'warning' | 'danger' | null | undefined;
+
+export const Pip = ({ className, state }: Props) => {
+    return <div className={cx(className, style.pip, state && style[state])} />;
+};

--- a/web/vtadmin/src/components/pips/TabletServingPip.tsx
+++ b/web/vtadmin/src/components/pips/TabletServingPip.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pip, PipState } from './Pip';
+import { vtadmin as pb } from '../../proto/vtadmin';
+
+interface Props {
+    state?: pb.Tablet.ServingState | string | null | undefined;
+}
+
+const SERVING_STATES: { [ss in pb.Tablet.ServingState]: PipState } = {
+    [pb.Tablet.ServingState.NOT_SERVING]: 'danger',
+    [pb.Tablet.ServingState.SERVING]: 'success',
+    [pb.Tablet.ServingState.UNKNOWN]: null,
+};
+
+export const TabletServingPip = ({ state }: Props) => {
+    const ss = state && typeof state === 'number' ? SERVING_STATES[state] : null;
+    return <Pip state={ss} />;
+};

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -26,6 +26,7 @@ import { filterNouns } from '../../util/filterNouns';
 import style from './Tablets.module.scss';
 import { Button } from '../Button';
 import { DataCell } from '../dataTable/DataCell';
+import { TabletServingPip } from '../pips/TabletServingPip';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -45,7 +46,9 @@ export const Tablets = () => {
                     <div className="font-size-small text-color-secondary">{t.cluster}</div>
                 </DataCell>
                 <DataCell>{t.shard}</DataCell>
-                <DataCell>{t.type}</DataCell>
+                <DataCell className="white-space-nowrap">
+                    <TabletServingPip state={t._raw.state} /> {t.type}
+                </DataCell>
                 <DataCell>{t.state}</DataCell>
                 <DataCell>{t.alias}</DataCell>
                 <DataCell>{t.hostname}</DataCell>
@@ -118,6 +121,7 @@ export const formatRows = (tablets: pb.Tablet[] | null, filter: string) => {
         hostname: t.tablet?.hostname,
         type: formatDisplayType(t),
         state: formatState(t),
+        _raw: t,
         _keyspaceShard: `${t.tablet?.keyspace}/${t.tablet?.shard}`,
         // Include the unformatted type so (string) filtering by "master" works
         // even if "primary" is what we display, and what we use for key:value searches.

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -218,3 +218,7 @@ table tbody td[rowSpan] {
 .text-color-secondary {
   color: var(--textColorSecondary);
 }
+
+.white-space-nowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

Adds a multi-use `Pip` component, and a tablet-specific `TabletServingPip` component. 

Here's a before/after:

<img width="2672" alt="Screen Shot 2021-04-12 at 8 15 32 AM" src="https://user-images.githubusercontent.com/855595/114392823-4d8daf80-9b67-11eb-8aa1-93a527cd66cf.png">
<img width="2672" alt="Screen Shot 2021-04-12 at 8 18 33 AM" src="https://user-images.githubusercontent.com/855595/114393137-b117dd00-9b67-11eb-9966-f738faedf79f.png">


## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
