### PR TITLE
perf: optimize bind var generation

### DIFF
--- a/go/cmd/query_analyzer/query_analyzer.go
+++ b/go/cmd/query_analyzer/query_analyzer.go
@@ -120,7 +120,7 @@ func formatWithBind(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
 	}
 	switch v.Type {
 	case sqlparser.StrVal, sqlparser.HexVal, sqlparser.IntVal:
-		buf.WriteArg(fmt.Sprintf(":v%d", bindIndex))
+		buf.WriteArg(":", fmt.Sprintf("v%d", bindIndex))
 		bindIndex++
 	default:
 		node.Format(buf)

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1118,7 +1118,7 @@ func (c *Conn) handleComPrepare(handler Handler, data []byte) (kontinue bool) {
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
 		switch node := node.(type) {
 		case sqlparser.Argument:
-			if strings.HasPrefix(string(node), ":v") {
+			if strings.HasPrefix(string(node), "v") {
 				paramsCount++
 			}
 		}

--- a/go/test/fuzzing/parser_fuzzer.go
+++ b/go/test/fuzzing/parser_fuzzer.go
@@ -32,9 +32,8 @@ func FuzzNormalizer(data []byte) int {
 	if err != nil {
 		return -1
 	}
-	prefix := "bv"
 	bv := make(map[string]*querypb.BindVariable)
-	sqlparser.Normalize(stmt, reservedVars, bv, prefix)
+	sqlparser.Normalize(stmt, sqlparser.NewReservedVars("bv", reservedVars), bv)
 	return 1
 }
 

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -406,7 +406,7 @@ func IsSimpleTuple(node Expr) bool {
 func NewPlanValue(node Expr) (sqltypes.PlanValue, error) {
 	switch node := node.(type) {
 	case Argument:
-		return sqltypes.PlanValue{Key: string(node[1:])}, nil
+		return sqltypes.PlanValue{Key: string(node)}, nil
 	case *Literal:
 		switch node.Type {
 		case IntVal:
@@ -427,7 +427,7 @@ func NewPlanValue(node Expr) (sqltypes.PlanValue, error) {
 			return sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, v)}, nil
 		}
 	case ListArg:
-		return sqltypes.PlanValue{ListKey: string(node[2:])}, nil
+		return sqltypes.PlanValue{ListKey: string(node)}, nil
 	case ValTuple:
 		pv := sqltypes.PlanValue{
 			Values: make([]sqltypes.PlanValue, 0, len(node)),

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -269,7 +269,7 @@ func TestIsValue(t *testing.T) {
 		in:  NewIntLiteral("1"),
 		out: true,
 	}, {
-		in:  NewArgument(":a"),
+		in:  NewArgument("a"),
 		out: true,
 	}, {
 		in:  &NullVal{},
@@ -320,7 +320,7 @@ func TestIsSimpleTuple(t *testing.T) {
 	}, {
 		in: ValTuple{&ColName{}},
 	}, {
-		in:  ListArg("::a"),
+		in:  ListArg("a"),
 		out: true,
 	}, {
 		in: &ColName{},
@@ -345,7 +345,7 @@ func TestNewPlanValue(t *testing.T) {
 		out sqltypes.PlanValue
 		err string
 	}{{
-		in:  Argument(":valarg"),
+		in:  Argument("valarg"),
 		out: sqltypes.PlanValue{Key: "valarg"},
 	}, {
 		in: &Literal{
@@ -384,11 +384,11 @@ func TestNewPlanValue(t *testing.T) {
 		},
 		err: "odd length hex string",
 	}, {
-		in:  ListArg("::list"),
+		in:  ListArg("list"),
 		out: sqltypes.PlanValue{ListKey: "list"},
 	}, {
 		in: ValTuple{
-			Argument(":valarg"),
+			Argument("valarg"),
 			&Literal{
 				Type: StrVal,
 				Val:  "strval",
@@ -403,7 +403,7 @@ func TestNewPlanValue(t *testing.T) {
 		},
 	}, {
 		in: ValTuple{
-			ListArg("::list"),
+			ListArg("list"),
 		},
 		err: "unsupported: nested lists",
 	}, {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1688,7 +1688,7 @@ type (
 	}
 
 	// ListArg represents a named list argument.
-	ListArg []byte
+	ListArg string
 
 	// ValTuple represents a tuple of actual values.
 	ValTuple Exprs

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -164,7 +164,7 @@ func CloneSQLNode(in SQLNode) SQLNode {
 	case *Limit:
 		return CloneRefOfLimit(in)
 	case ListArg:
-		return CloneListArg(in)
+		return in
 	case *Literal:
 		return CloneRefOfLiteral(in)
 	case *Load:
@@ -1008,13 +1008,6 @@ func CloneRefOfLimit(n *Limit) *Limit {
 	return &out
 }
 
-// CloneListArg creates a deep clone of the input.
-func CloneListArg(n ListArg) ListArg {
-	res := make(ListArg, 0, len(n))
-	copy(res, n)
-	return res
-}
-
 // CloneRefOfLiteral creates a deep clone of the input.
 func CloneRefOfLiteral(n *Literal) *Literal {
 	if n == nil {
@@ -1845,7 +1838,7 @@ func CloneColTuple(in ColTuple) ColTuple {
 	}
 	switch in := in.(type) {
 	case ListArg:
-		return CloneListArg(in)
+		return in
 	case *Subquery:
 		return CloneRefOfSubquery(in)
 	case ValTuple:
@@ -1975,7 +1968,7 @@ func CloneExpr(in Expr) Expr {
 	case *IsExpr:
 		return CloneRefOfIsExpr(in)
 	case ListArg:
-		return CloneListArg(in)
+		return in
 	case *Literal:
 		return CloneRefOfLiteral(in)
 	case *MatchExpr:

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -451,7 +451,7 @@ func EqualsSQLNode(inA, inB SQLNode) bool {
 		if !ok {
 			return false
 		}
-		return EqualsListArg(a, b)
+		return a == b
 	case *Literal:
 		b, ok := inB.(*Literal)
 		if !ok {
@@ -1749,19 +1749,6 @@ func EqualsRefOfLimit(a, b *Limit) bool {
 		EqualsExpr(a.Rowcount, b.Rowcount)
 }
 
-// EqualsListArg does deep equals between the two objects.
-func EqualsListArg(a, b ListArg) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // EqualsRefOfLiteral does deep equals between the two objects.
 func EqualsRefOfLiteral(a, b *Literal) bool {
 	if a == b {
@@ -2841,7 +2828,7 @@ func EqualsColTuple(inA, inB ColTuple) bool {
 		if !ok {
 			return false
 		}
-		return EqualsListArg(a, b)
+		return a == b
 	case *Subquery:
 		b, ok := inB.(*Subquery)
 		if !ok {
@@ -3126,7 +3113,7 @@ func EqualsExpr(inA, inB Expr) bool {
 		if !ok {
 			return false
 		}
-		return EqualsListArg(a, b)
+		return a == b
 	case *Literal:
 		b, ok := inB.(*Literal)
 		if !ok {

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -962,7 +962,7 @@ func (node *Literal) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node Argument) Format(buf *TrackedBuffer) {
-	buf.WriteArg(string(node))
+	buf.WriteArg(":", string(node))
 }
 
 // Format formats the node.
@@ -1004,7 +1004,7 @@ func (node *DerivedTable) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node ListArg) Format(buf *TrackedBuffer) {
-	buf.WriteArg(string(node))
+	buf.WriteArg("::", string(node))
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1293,7 +1293,7 @@ func (node *Literal) formatFast(buf *TrackedBuffer) {
 
 // formatFast formats the node.
 func (node Argument) formatFast(buf *TrackedBuffer) {
-	buf.WriteArg(string(node))
+	buf.WriteArg(":", string(node))
 }
 
 // formatFast formats the node.
@@ -1342,7 +1342,7 @@ func (node *DerivedTable) formatFast(buf *TrackedBuffer) {
 
 // formatFast formats the node.
 func (node ListArg) formatFast(buf *TrackedBuffer) {
-	buf.WriteArg(string(node))
+	buf.WriteArg("::", string(node))
 }
 
 // formatFast formats the node.

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1296,11 +1296,11 @@ func (lock LockOptionType) ToString() string {
 }
 
 // CompliantName is used to get the name of the bind variable to use for this column name
-func (node *ColName) CompliantName(suffix string) string {
+func (node *ColName) CompliantName() string {
 	if !node.Qualifier.IsEmpty() {
-		return node.Qualifier.Name.CompliantName() + "_" + node.Name.CompliantName() + suffix
+		return node.Qualifier.Name.CompliantName() + "_" + node.Name.CompliantName()
 	}
-	return node.Name.CompliantName() + suffix
+	return node.Name.CompliantName()
 }
 
 // AtCount represents the '@' count in ColIdent

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -2378,30 +2378,6 @@ func (a *application) rewriteRefOfLimit(parent SQLNode, node *Limit, replacer re
 	}
 	return true
 }
-func (a *application) rewriteListArg(parent SQLNode, node ListArg, replacer replacerFunc) bool {
-	if node == nil {
-		return true
-	}
-	if a.pre != nil {
-		a.cur.replacer = replacer
-		a.cur.parent = parent
-		a.cur.node = node
-		if !a.pre(&a.cur) {
-			return true
-		}
-	}
-	if a.post != nil {
-		if a.pre == nil {
-			a.cur.replacer = replacer
-			a.cur.parent = parent
-			a.cur.node = node
-		}
-		if !a.post(&a.cur) {
-			return false
-		}
-	}
-	return true
-}
 func (a *application) rewriteRefOfLiteral(parent SQLNode, node *Literal, replacer replacerFunc) bool {
 	if node == nil {
 		return true
@@ -5174,6 +5150,27 @@ func (a *application) rewriteBoolVal(parent SQLNode, node BoolVal, replacer repl
 	return true
 }
 func (a *application) rewriteIsolationLevel(parent SQLNode, node IsolationLevel, replacer replacerFunc) bool {
+	if a.pre != nil {
+		a.cur.replacer = replacer
+		a.cur.parent = parent
+		a.cur.node = node
+		if !a.pre(&a.cur) {
+			return true
+		}
+	}
+	if a.post != nil {
+		if a.pre == nil {
+			a.cur.replacer = replacer
+			a.cur.parent = parent
+			a.cur.node = node
+		}
+		if !a.post(&a.cur) {
+			return false
+		}
+	}
+	return true
+}
+func (a *application) rewriteListArg(parent SQLNode, node ListArg, replacer replacerFunc) bool {
 	if a.pre != nil {
 		a.cur.replacer = replacer
 		a.cur.parent = parent

--- a/go/vt/sqlparser/ast_rewriting.go
+++ b/go/vt/sqlparser/ast_rewriting.go
@@ -34,6 +34,8 @@ type RewriteASTResult struct {
 	AST Statement // The rewritten AST
 }
 
+// ReservedVars keeps track of the bind variable names that have already been used
+// in a parsed query.
 type ReservedVars struct {
 	prefix       string
 	reserved     BindVars
@@ -42,19 +44,24 @@ type ReservedVars struct {
 	fast, static bool
 }
 
-func (r *ReservedVars) ContainsAny(names ...string) bool {
+// ReserveAll tries to reserve all the given variable names. If they're all available,
+// they are reserved and the function returns true. Otherwise the function returns false.
+func (r *ReservedVars) ReserveAll(names ...string) bool {
 	for _, name := range names {
 		if _, ok := r.reserved[name]; ok {
-			return true
+			return false
 		}
 	}
 	for _, name := range names {
 		r.reserved[name] = struct{}{}
 	}
-	return false
+	return true
 }
 
-func (r *ReservedVars) NextColumnName(col *ColName) string {
+// ReserveColName reserves a variable name for the given column; if a variable
+// with the same name already exists, it'll be suffixed with a numberic identifier
+// to make it unique.
+func (r *ReservedVars) ReserveColName(col *ColName) string {
 	compliantName := col.CompliantName()
 	if r.fast && strings.HasPrefix(compliantName, r.prefix) {
 		compliantName = "_" + compliantName
@@ -76,7 +83,7 @@ func (r *ReservedVars) NextColumnName(col *ColName) string {
 const staticBvar10 = "vtg0vtg1vtg2vtg3vtg4vtg5vtg6vtg7vtg8vtg9"
 const staticBvar100 = "vtg10vtg11vtg12vtg13vtg14vtg15vtg16vtg17vtg18vtg19vtg20vtg21vtg22vtg23vtg24vtg25vtg26vtg27vtg28vtg29vtg30vtg31vtg32vtg33vtg34vtg35vtg36vtg37vtg38vtg39vtg40vtg41vtg42vtg43vtg44vtg45vtg46vtg47vtg48vtg49vtg50vtg51vtg52vtg53vtg54vtg55vtg56vtg57vtg58vtg59vtg60vtg61vtg62vtg63vtg64vtg65vtg66vtg67vtg68vtg69vtg70vtg71vtg72vtg73vtg74vtg75vtg76vtg77vtg78vtg79vtg80vtg81vtg82vtg83vtg84vtg85vtg86vtg87vtg88vtg89vtg90vtg91vtg92vtg93vtg94vtg95vtg96vtg97vtg98vtg99"
 
-func (r *ReservedVars) Next() string {
+func (r *ReservedVars) nextUnusedVar() string {
 	if r.fast {
 		r.counter++
 
@@ -107,6 +114,9 @@ func (r *ReservedVars) Next() string {
 	}
 }
 
+// NewReservedVars allocates a ReservedVar instance that will generate unique
+// variable names starting with the given `prefix` and making sure that they
+// don't conflict with the given set of `known` variables.
 func NewReservedVars(prefix string, known BindVars) *ReservedVars {
 	rv := &ReservedVars{
 		prefix:   prefix,

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sqlparser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -403,6 +404,17 @@ func TestFixedPointRewriteToCNF(in *testing.T) {
 			expr := stmt.(*Select).Where.Expr
 			output := RewriteToCNF(expr)
 			assert.Equal(t, tc.expected, String(output))
+		})
+	}
+}
+
+func TestReservedVars(t *testing.T) {
+	for _, prefix := range []string{"vtg", "bv"} {
+		t.Run("prefix_"+prefix, func(t *testing.T) {
+			reserved := NewReservedVars(prefix, make(BindVars))
+			for i := 1; i < 1000; i++ {
+				require.Equal(t, fmt.Sprintf("%s%d", prefix, i), reserved.Next())
+			}
 		})
 	}
 }

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -413,7 +413,7 @@ func TestReservedVars(t *testing.T) {
 		t.Run("prefix_"+prefix, func(t *testing.T) {
 			reserved := NewReservedVars(prefix, make(BindVars))
 			for i := 1; i < 1000; i++ {
-				require.Equal(t, fmt.Sprintf("%s%d", prefix, i), reserved.Next())
+				require.Equal(t, fmt.Sprintf("%s%d", prefix, i), reserved.nextUnusedVar())
 			}
 		})
 	}

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -556,7 +556,7 @@ func TestReplaceExpr(t *testing.T) {
 		in:  "select * from t where case a when b then c when d then c else (select a from b) end",
 		out: "case a when b then c when d then c else :a end",
 	}}
-	to := NewArgument(":a")
+	to := NewArgument("a")
 	for _, tcase := range tcases {
 		tree, err := Parse(tcase.in)
 		if err != nil {

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -770,6 +770,12 @@ func TestSplitStatementToPieces(t *testing.T) {
 	}, {
 		input: "select * from table",
 	}, {
+		input:  "select * from table;",
+		output: "select * from table",
+	}, {
+		input:  "select * from table;   ",
+		output: "select * from table",
+	}, {
 		input:  "select * from table1; select * from table2;",
 		output: "select * from table1; select * from table2",
 	}, {

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -1260,10 +1260,6 @@ func VisitRefOfLimit(in *Limit, f Visit) error {
 	}
 	return nil
 }
-func VisitListArg(in ListArg, f Visit) error {
-	_, err := f(in)
-	return err
-}
 func VisitRefOfLiteral(in *Literal, f Visit) error {
 	if in == nil {
 		return nil
@@ -2711,6 +2707,10 @@ func VisitBoolVal(in BoolVal, f Visit) error {
 	return err
 }
 func VisitIsolationLevel(in IsolationLevel, f Visit) error {
+	_, err := f(in)
+	return err
+}
+func VisitListArg(in ListArg, f Visit) error {
 	_, err := f(in)
 	return err
 }

--- a/go/vt/sqlparser/expression_converter.go
+++ b/go/vt/sqlparser/expression_converter.go
@@ -29,7 +29,7 @@ var ErrExprNotSupported = fmt.Errorf("Expr Not Supported")
 func Convert(e Expr) (evalengine.Expr, error) {
 	switch node := e.(type) {
 	case Argument:
-		return evalengine.NewBindVar(string(node[1:])), nil
+		return evalengine.NewBindVar(string(node)), nil
 	case *Literal:
 		switch node.Type {
 		case IntVal:

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -135,7 +135,7 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 	}
 
 	// Modify the AST node to a bindvar.
-	cursor.Replace(NewArgument(":" + bvname))
+	cursor.Replace(NewArgument(bvname))
 }
 
 // convertLiteral converts an Literal without the dedup.
@@ -148,7 +148,7 @@ func (nz *normalizer) convertLiteral(node *Literal, cursor *Cursor) {
 	bvname := nz.reserved.Next()
 	nz.bindVars[bvname] = bval
 
-	cursor.Replace(NewArgument(":" + bvname))
+	cursor.Replace(NewArgument(bvname))
 }
 
 // convertComparison attempts to convert IN clauses to
@@ -182,7 +182,7 @@ func (nz *normalizer) convertComparison(node *ComparisonExpr) {
 	bvname := nz.reserved.Next()
 	nz.bindVars[bvname] = bvals
 	// Modify RHS to be a list bindvar.
-	node.Right = ListArg(append([]byte("::"), bvname...))
+	node.Right = ListArg(bvname)
 }
 
 func (nz *normalizer) sqlToBindvar(node SQLNode) *querypb.BindVariable {
@@ -217,9 +217,9 @@ func GetBindvars(stmt Statement) map[string]struct{} {
 			// allocations.
 			return false, nil
 		case Argument:
-			bindvars[string(node[1:])] = struct{}{}
+			bindvars[string(node)] = struct{}{}
 		case ListArg:
-			bindvars[string(node[2:])] = struct{}{}
+			bindvars[string(node)] = struct{}{}
 		}
 		return true, nil
 	}, stmt)

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -17,8 +17,6 @@ limitations under the License.
 package sqlparser
 
 import (
-	"strconv"
-
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -34,27 +32,23 @@ type BindVars map[string]struct{}
 // Within Select constructs, bind vars are deduped. This allows
 // us to identify vindex equality. Otherwise, every value is
 // treated as distinct.
-func Normalize(stmt Statement, known BindVars, bindVars map[string]*querypb.BindVariable, prefix string) error {
-	nz := newNormalizer(known, bindVars, prefix)
+func Normalize(stmt Statement, reserved *ReservedVars, bindVars map[string]*querypb.BindVariable) error {
+	nz := newNormalizer(reserved, bindVars)
 	_ = Rewrite(stmt, nz.WalkStatement, nil)
 	return nz.err
 }
 
 type normalizer struct {
 	bindVars map[string]*querypb.BindVariable
-	prefix   string
-	reserved map[string]struct{}
-	counter  int
+	reserved *ReservedVars
 	vals     map[string]string
 	err      error
 }
 
-func newNormalizer(reserved map[string]struct{}, bindVars map[string]*querypb.BindVariable, prefix string) *normalizer {
+func newNormalizer(reserved *ReservedVars, bindVars map[string]*querypb.BindVariable) *normalizer {
 	return &normalizer{
 		bindVars: bindVars,
-		prefix:   prefix,
 		reserved: reserved,
-		counter:  1,
 		vals:     make(map[string]string),
 	}
 }
@@ -135,7 +129,7 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 	bvname, ok := nz.vals[key]
 	if !ok {
 		// If there's no such bindvar, make a new one.
-		bvname = nz.newName()
+		bvname = nz.reserved.Next()
 		nz.vals[key] = bvname
 		nz.bindVars[bvname] = bval
 	}
@@ -151,7 +145,7 @@ func (nz *normalizer) convertLiteral(node *Literal, cursor *Cursor) {
 		return
 	}
 
-	bvname := nz.newName()
+	bvname := nz.reserved.Next()
 	nz.bindVars[bvname] = bval
 
 	cursor.Replace(NewArgument(":" + bvname))
@@ -185,7 +179,7 @@ func (nz *normalizer) convertComparison(node *ComparisonExpr) {
 			Value: bval.Value,
 		})
 	}
-	bvname := nz.newName()
+	bvname := nz.reserved.Next()
 	nz.bindVars[bvname] = bvals
 	// Modify RHS to be a list bindvar.
 	node.Right = ListArg(append([]byte("::"), bvname...))
@@ -211,17 +205,6 @@ func (nz *normalizer) sqlToBindvar(node SQLNode) *querypb.BindVariable {
 		return sqltypes.ValueBindVariable(v)
 	}
 	return nil
-}
-
-func (nz *normalizer) newName() string {
-	for {
-		newName := nz.prefix + strconv.Itoa(nz.counter)
-		if _, ok := nz.reserved[newName]; !ok {
-			nz.reserved[newName] = struct{}{}
-			return newName
-		}
-		nz.counter++
-	}
 }
 
 // GetBindvars returns a map of the bind vars referenced in the statement.

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -129,7 +129,7 @@ func (nz *normalizer) convertLiteralDedup(node *Literal, cursor *Cursor) {
 	bvname, ok := nz.vals[key]
 	if !ok {
 		// If there's no such bindvar, make a new one.
-		bvname = nz.reserved.Next()
+		bvname = nz.reserved.nextUnusedVar()
 		nz.vals[key] = bvname
 		nz.bindVars[bvname] = bval
 	}
@@ -145,7 +145,7 @@ func (nz *normalizer) convertLiteral(node *Literal, cursor *Cursor) {
 		return
 	}
 
-	bvname := nz.reserved.Next()
+	bvname := nz.reserved.nextUnusedVar()
 	nz.bindVars[bvname] = bval
 
 	cursor.Replace(NewArgument(bvname))
@@ -179,7 +179,7 @@ func (nz *normalizer) convertComparison(node *ComparisonExpr) {
 			Value: bval.Value,
 		})
 	}
-	bvname := nz.reserved.Next()
+	bvname := nz.reserved.nextUnusedVar()
 	nz.bindVars[bvname] = bvals
 	// Modify RHS to be a list bindvar.
 	node.Right = ListArg(bvname)

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package sqlparser
 
 import (
+	"bytes"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -349,6 +353,279 @@ func BenchmarkNormalizeVTGate(b *testing.B) {
 			_ = query
 			_ = statement
 			_ = bindVarNeeds
+		}
+	}
+}
+
+var randtmplre = regexp.MustCompile("[#@]")
+
+func randtmpl(template string) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const numberBytes = "0123456789"
+
+	result := []byte(template)
+	for i, c := range result {
+		switch c {
+		case '#':
+			result[i] = numberBytes[rand.Intn(len(numberBytes))]
+		case '@':
+			result[i] = letterBytes[rand.Intn(len(letterBytes))]
+		}
+	}
+	return string(result)
+}
+
+func randString(n int) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func BenchmarkNormalizeTPCCBinds(b *testing.B) {
+	query := `INSERT IGNORE INTO customer0
+(c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data)
+values
+(:c_id, :c_d_id, :c_w_id, :c_first, :c_middle, :c_last, :c_street_1, :c_street_2, :c_city, :c_state, :c_zip, :c_phone, :c_since, :c_credit, :c_credit_lim, :c_discount, :c_balance, :c_ytd_payment, :c_payment_cnt, :c_delivery_cnt, :c_data)`
+	benchmarkNormalization(b, []string{query})
+}
+
+func BenchmarkNormalizeTPCCInsert(b *testing.B) {
+	generateInsert := func(rows int) string {
+		var query bytes.Buffer
+		query.WriteString("INSERT IGNORE INTO customer0 (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) values ")
+		for i := 0; i < rows; i++ {
+			fmt.Fprintf(&query, "(%d, %d, %d, '%s','OE','%s','%s', '%s', '%s', '%s', '%s','%s',NOW(),'%s',50000,%f,-10,10,1,0,'%s' )",
+				rand.Int(), rand.Int(), rand.Int(),
+				"first-"+randString(rand.Intn(10)),
+				randtmpl("last-@@@@"),
+				randtmpl("street1-@@@@@@@@@@@@"),
+				randtmpl("street2-@@@@@@@@@@@@"),
+				randtmpl("city-@@@@@@@@@@@@"),
+				randtmpl("@@"), randtmpl("zip-#####"),
+				randtmpl("################"),
+				"GC", rand.Float64(), randString(300+rand.Intn(200)),
+			)
+			if i < rows-1 {
+				query.WriteString(", ")
+			}
+		}
+		return query.String()
+	}
+
+	var queries []string
+
+	for i := 0; i < 1024; i++ {
+		queries = append(queries, generateInsert(4))
+	}
+
+	benchmarkNormalization(b, queries)
+}
+
+func BenchmarkNormalizeTPCC(b *testing.B) {
+	templates := []string{
+		`SELECT c_discount, c_last, c_credit, w_tax
+FROM customer%d AS c
+JOIN warehouse%d AS w ON c_w_id=w_id
+WHERE w_id = %d
+AND c_d_id = %d
+AND c_id = %d`,
+		`SELECT d_next_o_id, d_tax 
+FROM district%d 
+WHERE d_w_id = %d 
+AND d_id = %d FOR UPDATE`,
+		`UPDATE district%d
+SET d_next_o_id = %d
+WHERE d_id = %d AND d_w_id= %d`,
+		`INSERT INTO orders%d
+(o_id, o_d_id, o_w_id, o_c_id,  o_entry_d, o_ol_cnt, o_all_local)
+VALUES (%d,%d,%d,%d,NOW(),%d,%d)`,
+		`INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id)
+VALUES (%d,%d,%d)`,
+		`SELECT i_price, i_name, i_data 
+FROM item%d
+WHERE i_id = %d`,
+		`SELECT s_quantity, s_data, s_dist_%s s_dist 
+FROM stock%d  
+WHERE s_i_id = %d AND s_w_id= %d FOR UPDATE`,
+		`UPDATE stock%d
+SET s_quantity = %d
+WHERE s_i_id = %d 
+AND s_w_id= %d`,
+		`INSERT INTO order_line%d
+(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+VALUES (%d,%d,%d,%d,%d,%d,%d,%d,'%s')`,
+		`UPDATE warehouse%d
+SET w_ytd = w_ytd + %d 
+WHERE w_id = %d`,
+		`SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name
+FROM warehouse%d
+WHERE w_id = %d`,
+		`UPDATE district%d 
+SET d_ytd = d_ytd + %d 
+WHERE d_w_id = %d 
+AND d_id= %d`,
+		`SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name 
+FROM district%d
+WHERE d_w_id = %d 
+AND d_id = %d`,
+		`SELECT count(c_id) namecnt
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id= %d
+AND c_last='%s'`,
+		`SELECT c_first, c_middle, c_last, c_street_1,
+c_street_2, c_city, c_state, c_zip, c_phone,
+c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id= %d
+AND c_id=%d FOR UPDATE`,
+		`SELECT c_data
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id=%d
+AND c_id= %d`,
+		`UPDATE customer%d
+SET c_balance=%f, c_ytd_payment=%f, c_data='%s'
+WHERE c_w_id = %d 
+AND c_d_id=%d
+AND c_id=%d`,
+		`UPDATE customer%d
+SET c_balance=%f, c_ytd_payment=%f
+WHERE c_w_id = %d 
+AND c_d_id=%d
+AND c_id=%d`,
+		`INSERT INTO history%d
+(h_c_d_id, h_c_w_id, h_c_id, h_d_id,  h_w_id, h_date, h_amount, h_data)
+VALUES (%d,%d,%d,%d,%d,NOW(),%d,'%s')`,
+		`SELECT count(c_id) namecnt
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id= %d
+AND c_last='%s'`,
+		`SELECT c_balance, c_first, c_middle, c_id
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id= %d
+AND c_last='%s' ORDER BY c_first`,
+		`SELECT c_balance, c_first, c_middle, c_last
+FROM customer%d
+WHERE c_w_id = %d 
+AND c_d_id=%d
+AND c_id=%d`,
+		`SELECT o_id, o_carrier_id, o_entry_d
+FROM orders%d 
+WHERE o_w_id = %d 
+AND o_d_id = %d 
+AND o_c_id = %d 
+ORDER BY o_id DESC`,
+		`SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+FROM order_line%d WHERE ol_w_id = %d AND ol_d_id = %d  AND ol_o_id = %d`,
+		`SELECT no_o_id
+FROM new_orders%d 
+WHERE no_d_id = %d 
+AND no_w_id = %d 
+ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE`,
+		`DELETE FROM new_orders%d
+WHERE no_o_id = %d 
+AND no_d_id = %d  
+AND no_w_id = %d`,
+		`SELECT o_c_id
+FROM orders%d 
+WHERE o_id = %d 
+AND o_d_id = %d 
+AND o_w_id = %d`,
+		`UPDATE orders%d 
+SET o_carrier_id = %d
+WHERE o_id = %d 
+AND o_d_id = %d 
+AND o_w_id = %d`,
+		`UPDATE order_line%d 
+SET ol_delivery_d = NOW()
+WHERE ol_o_id = %d 
+AND ol_d_id = %d 
+AND ol_w_id = %d`,
+		`SELECT SUM(ol_amount) sm
+FROM order_line%d 
+WHERE ol_o_id = %d 
+AND ol_d_id = %d 
+AND ol_w_id = %d`,
+		`UPDATE customer%d 
+SET c_balance = c_balance + %f,
+c_delivery_cnt = c_delivery_cnt + 1
+WHERE c_id = %d 
+AND c_d_id = %d 
+AND c_w_id = %d`,
+		`SELECT d_next_o_id 
+FROM district%d
+WHERE d_id = %d AND d_w_id= %d`,
+		`SELECT COUNT(DISTINCT(s.s_i_id))
+FROM stock%d AS s
+JOIN order_line%d AS ol ON ol.ol_w_id=s.s_w_id AND ol.ol_i_id=s.s_i_id			
+WHERE ol.ol_w_id = %d 
+AND ol.ol_d_id = %d
+AND ol.ol_o_id < %d 
+AND ol.ol_o_id >= %d
+AND s.s_w_id= %d
+AND s.s_quantity < %d `,
+		`SELECT DISTINCT ol_i_id FROM order_line%d
+WHERE ol_w_id = %d AND ol_d_id = %d
+AND ol_o_id < %d AND ol_o_id >= %d`,
+		`SELECT count(*) FROM stock%d
+WHERE s_w_id = %d AND s_i_id = %d
+AND s_quantity < %d`,
+		`SELECT min(no_o_id) mo
+FROM new_orders%d 
+WHERE no_w_id = %d AND no_d_id = %d`,
+		`SELECT o_id FROM orders%d o, (SELECT o_c_id,o_w_id,o_d_id,count(distinct o_id) FROM orders%d WHERE o_w_id=%d AND o_d_id=%d AND o_id > 2100 AND o_id < %d GROUP BY o_c_id,o_d_id,o_w_id having count( distinct o_id) > 1 limit 1) t WHERE t.o_w_id=o.o_w_id and t.o_d_id=o.o_d_id and t.o_c_id=o.o_c_id limit 1 `,
+		`DELETE FROM order_line%d where ol_w_id=%d AND ol_d_id=%d AND ol_o_id=%d`,
+		`DELETE FROM orders%d where o_w_id=%d AND o_d_id=%d and o_id=%d`,
+		`DELETE FROM history%d where h_w_id=%d AND h_d_id=%d LIMIT 10`,
+	}
+
+	re := regexp.MustCompile(`%\w`)
+	repl := func(m string) string {
+		switch m {
+		case "%s":
+			return "RANDOM_STRING"
+		case "%d":
+			return strconv.Itoa(rand.Int())
+		case "%f":
+			return strconv.FormatFloat(rand.Float64(), 'f', 8, 64)
+		default:
+			panic(m)
+		}
+	}
+
+	var queries []string
+
+	for _, tmpl := range templates {
+		for i := 0; i < 128; i++ {
+			queries = append(queries, re.ReplaceAllStringFunc(tmpl, repl))
+		}
+	}
+
+	benchmarkNormalization(b, queries)
+}
+
+func benchmarkNormalization(b *testing.B, sqls []string) {
+	b.Helper()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sql := range sqls {
+			stmt, reserved, err := Parse2(sql)
+			if err != nil {
+				b.Fatalf("%v: %q", err, sql)
+			}
+
+			_, err = PrepareAST(stmt, reserved, make(map[string]*querypb.BindVariable), "vtg", true, "keyspace0")
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 }

--- a/go/vt/sqlparser/redact_query.go
+++ b/go/vt/sqlparser/redact_query.go
@@ -28,8 +28,7 @@ func RedactSQLQuery(sql string) (string, error) {
 		return "", err
 	}
 
-	prefix := "redacted"
-	err = Normalize(stmt, reservedVars, bv, prefix)
+	err = Normalize(stmt, NewReservedVars("redacted", reservedVars), bv)
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -10710,7 +10710,7 @@ yydefault:
 		var yyLOCAL ColTuple
 //line sql.y:3555
 		{
-			yyLOCAL = ListArg(yyDollar[1].str)
+			yyLOCAL = ListArg(yyDollar[1].str[2:])
 			bindVariable(yylex, yyDollar[1].str[2:])
 		}
 		yyVAL.union = yyLOCAL
@@ -11625,7 +11625,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:4089
 		{
-			yyLOCAL = NewArgument(yyDollar[1].str)
+			yyLOCAL = NewArgument(yyDollar[1].str[1:])
 			bindVariable(yylex, yyDollar[1].str[1:])
 		}
 		yyVAL.union = yyLOCAL
@@ -11663,7 +11663,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:4113
 		{
-			yyLOCAL = NewArgument(yyDollar[1].str)
+			yyLOCAL = NewArgument(yyDollar[1].str[1:])
 			bindVariable(yylex, yyDollar[1].str[1:])
 		}
 		yyVAL.union = yyLOCAL

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -3553,7 +3553,7 @@ col_tuple:
   }
 | LIST_ARG
   {
-    $$ = ListArg($1)
+    $$ = ListArg($1[2:])
     bindVariable(yylex, $1[2:])
   }
 
@@ -4087,7 +4087,7 @@ value:
   }
 | VALUE_ARG
   {
-    $$ = NewArgument($1)
+    $$ = NewArgument($1[1:])
     bindVariable(yylex, $1[1:])
   }
 | NULL
@@ -4111,7 +4111,7 @@ num_val:
   }
 | VALUE_ARG VALUES
   {
-    $$ = NewArgument($1)
+    $$ = NewArgument($1[1:])
     bindVariable(yylex, $1[1:])
   }
 

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -142,7 +142,16 @@ func (buf *TrackedBuffer) astPrintf(currentNode SQLNode, format string, values .
 				}
 			}
 		case 'a':
-			buf.WriteArg(values[fieldnum].(string))
+			arg := values[fieldnum].(string)
+			if arg[0] == ':' {
+				if arg[1] == ':' {
+					buf.WriteArg("::", arg[2:])
+				} else {
+					buf.WriteArg(":", arg[1:])
+				}
+			} else {
+				buf.WriteArg("", arg)
+			}
 		default:
 			panic("unexpected")
 		}
@@ -212,13 +221,13 @@ func areBothISExpr(op Expr, val Expr) bool {
 }
 
 // WriteArg writes a value argument into the buffer along with
-// tracking information for future substitutions. arg must contain
-// the ":" or "::" prefix.
-func (buf *TrackedBuffer) WriteArg(arg string) {
+// tracking information for future substitutions.
+func (buf *TrackedBuffer) WriteArg(prefix, arg string) {
 	buf.bindLocations = append(buf.bindLocations, bindLocation{
 		offset: buf.Len(),
-		length: len(arg),
+		length: len(prefix) + len(arg),
 	})
+	buf.WriteString(prefix)
 	buf.WriteString(arg)
 }
 

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -142,16 +142,7 @@ func (buf *TrackedBuffer) astPrintf(currentNode SQLNode, format string, values .
 				}
 			}
 		case 'a':
-			arg := values[fieldnum].(string)
-			if arg[0] == ':' {
-				if arg[1] == ':' {
-					buf.WriteArg("::", arg[2:])
-				} else {
-					buf.WriteArg(":", arg[1:])
-				}
-			} else {
-				buf.WriteArg("", arg)
-			}
+			buf.WriteArg("", values[fieldnum].(string))
 		default:
 			panic("unexpected")
 		}

--- a/go/vt/sqlparser/utils.go
+++ b/go/vt/sqlparser/utils.go
@@ -40,7 +40,7 @@ func QueryMatchesTemplates(query string, queryTemplates []string) (match bool, e
 		if err != nil {
 			return "", err
 		}
-		err = Normalize(stmt, reservedVars, bv, "")
+		err = Normalize(stmt, NewReservedVars("", reservedVars), bv)
 		if err != nil {
 			return "", err
 		}

--- a/go/vt/vtgate/engine/memory_sort_test.go
+++ b/go/vt/vtgate/engine/memory_sort_test.go
@@ -66,7 +66,7 @@ func TestMemorySortExecute(t *testing.T) {
 	utils.MustMatch(t, wantResult, result)
 
 	fp.rewind()
-	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument(":__upper_limit"))
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument("__upper_limit"))
 	require.NoError(t, err)
 	ms.UpperLimit = upperlimit
 	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
@@ -129,7 +129,7 @@ func TestMemorySortStreamExecuteWeightString(t *testing.T) {
 
 	t.Run("Limit test", func(t *testing.T) {
 		fp.rewind()
-		upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument(":__upper_limit"))
+		upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument("__upper_limit"))
 		require.NoError(t, err)
 		ms.UpperLimit = upperlimit
 		bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
@@ -189,7 +189,7 @@ func TestMemorySortExecuteWeightString(t *testing.T) {
 	utils.MustMatch(t, wantResult, result)
 
 	fp.rewind()
-	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument(":__upper_limit"))
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument("__upper_limit"))
 	require.NoError(t, err)
 	ms.UpperLimit = upperlimit
 	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
@@ -248,7 +248,7 @@ func TestMemorySortStreamExecute(t *testing.T) {
 	utils.MustMatch(t, wantResults, results)
 
 	fp.rewind()
-	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument(":__upper_limit"))
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument("__upper_limit"))
 	require.NoError(t, err)
 	ms.UpperLimit = upperlimit
 	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}
@@ -409,7 +409,7 @@ func TestMemorySortMultiColumn(t *testing.T) {
 	utils.MustMatch(t, wantResult, result)
 
 	fp.rewind()
-	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument(":__upper_limit"))
+	upperlimit, err := sqlparser.NewPlanValue(sqlparser.NewArgument("__upper_limit"))
 	require.NoError(t, err)
 	ms.UpperLimit = upperlimit
 	bv := map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -448,11 +448,12 @@ func (e *Executor) CloseSession(ctx context.Context, safeSession *SafeSession) e
 }
 
 func (e *Executor) handleSet(ctx context.Context, sql string, logStats *LogStats) (*sqltypes.Result, error) {
-	stmt, reservedVars, err := sqlparser.Parse2(sql)
+	stmt, reserved, err := sqlparser.Parse2(sql)
 	if err != nil {
 		return nil, err
 	}
-	rewrittenAST, err := sqlparser.PrepareAST(stmt, reservedVars, nil, "vtg", false, "")
+	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
+	rewrittenAST, err := sqlparser.PrepareAST(stmt, reservedVars, nil, false, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1237,12 +1238,13 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments sqlparser.
 		return nil, errors.New("vschema not initialized")
 	}
 
-	stmt, reservedVars, err := sqlparser.Parse2(sql)
+	stmt, reserved, err := sqlparser.Parse2(sql)
 	if err != nil {
 		return nil, err
 	}
 	query := sql
 	statement := stmt
+	reservedVars := sqlparser.NewReservedVars("vtg", reserved)
 	bindVarNeeds := &sqlparser.BindVarNeeds{}
 	if !sqlparser.IgnoreMaxPayloadSizeDirective(statement) && !isValidPayloadSize(query) {
 		return nil, vterrors.NewErrorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, vterrors.NetPacketTooLarge, "query payload size above threshold")
@@ -1253,7 +1255,7 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments sqlparser.
 	// Normalize if possible and retry.
 	if (e.normalize && sqlparser.CanNormalize(stmt)) || sqlparser.MustRewriteAST(stmt) {
 		parameterize := e.normalize // the public flag is called normalize
-		result, err := sqlparser.PrepareAST(stmt, reservedVars, bindVars, "vtg", parameterize, vcursor.keyspace)
+		result, err := sqlparser.PrepareAST(stmt, reservedVars, bindVars, parameterize, vcursor.keyspace)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/planbuilder/bypass.go
+++ b/go/vt/vtgate/planbuilder/bypass.go
@@ -24,7 +24,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
-func buildPlanForBypass(stmt sqlparser.Statement, _ sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildPlanForBypass(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	switch vschema.Destination().(type) {
 	case key.DestinationExactKeyRange:
 		if _, ok := stmt.(*sqlparser.Insert); ok {

--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -51,7 +51,7 @@ func (fk *fkContraint) FkWalk(node sqlparser.SQLNode) (kontinue bool, err error)
 // a session context. It's only when we Execute() the primitive that we have that context.
 // This is why we return a compound primitive (DDL) which contains fully populated primitives (Send & OnlineDDL),
 // and which chooses which of the two to invoke at runtime.
-func buildGeneralDDLPlan(sql string, ddlStatement sqlparser.DDLStatement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildGeneralDDLPlan(sql string, ddlStatement sqlparser.DDLStatement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	normalDDLPlan, onlineDDLPlan, err := buildDDLPlans(sql, ddlStatement, reservedVars, vschema)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func buildGeneralDDLPlan(sql string, ddlStatement sqlparser.DDLStatement, reserv
 	}, nil
 }
 
-func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (*engine.Send, *engine.OnlineDDL, error) {
+func buildDDLPlans(sql string, ddlStatement sqlparser.DDLStatement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (*engine.Send, *engine.OnlineDDL, error) {
 	var destination key.Destination
 	var keyspace *vindexes.Keyspace
 	var err error
@@ -177,7 +177,7 @@ func findTableDestinationAndKeyspace(vschema ContextVSchema, ddlStatement sqlpar
 	return destination, keyspace, nil
 }
 
-func buildAlterView(vschema ContextVSchema, ddl *sqlparser.AlterView, reservedVars sqlparser.BindVars) (key.Destination, *vindexes.Keyspace, error) {
+func buildAlterView(vschema ContextVSchema, ddl *sqlparser.AlterView, reservedVars *sqlparser.ReservedVars) (key.Destination, *vindexes.Keyspace, error) {
 	// For Alter View, we require that the view exist and the select query can be satisfied within the keyspace itself
 	// We should remove the keyspace name from the table name, as the database name in MySQL might be different than the keyspace name
 	destination, keyspace, err := findTableDestinationAndKeyspace(vschema, ddl)
@@ -212,7 +212,7 @@ func buildAlterView(vschema ContextVSchema, ddl *sqlparser.AlterView, reservedVa
 	return destination, keyspace, nil
 }
 
-func buildCreateView(vschema ContextVSchema, ddl *sqlparser.CreateView, reservedVars sqlparser.BindVars) (key.Destination, *vindexes.Keyspace, error) {
+func buildCreateView(vschema ContextVSchema, ddl *sqlparser.CreateView, reservedVars *sqlparser.ReservedVars) (key.Destination, *vindexes.Keyspace, error) {
 	// For Create View, we require that the keyspace exist and the select query can be satisfied within the keyspace itself
 	// We should remove the keyspace name from the table name, as the database name in MySQL might be different than the keyspace name
 	destination, keyspace, _, err := vschema.TargetDestination(ddl.ViewName.Qualifier.String())

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -24,7 +24,7 @@ import (
 )
 
 // buildDeletePlan builds the instructions for a DELETE statement.
-func buildDeletePlan(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	del := stmt.(*sqlparser.Delete)
 	dml, ksidVindex, ksidCol, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
 	if err != nil {

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -100,7 +100,7 @@ func nameMatch(node sqlparser.Expr, col sqlparser.ColIdent) bool {
 	return ok && colname.Name.Equal(col)
 }
 
-func buildDMLPlan(vschema ContextVSchema, dmlType string, stmt sqlparser.Statement, reservedVars sqlparser.BindVars, tableExprs sqlparser.TableExprs, where *sqlparser.Where, orderBy sqlparser.OrderBy, limit *sqlparser.Limit, comments sqlparser.Comments, nodes ...sqlparser.SQLNode) (*engine.DML, vindexes.SingleColumn, string, error) {
+func buildDMLPlan(vschema ContextVSchema, dmlType string, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, tableExprs sqlparser.TableExprs, where *sqlparser.Where, orderBy sqlparser.OrderBy, limit *sqlparser.Limit, comments sqlparser.Comments, nodes ...sqlparser.SQLNode) (*engine.DML, vindexes.SingleColumn, string, error) {
 	edml := &engine.DML{}
 	pb := newPrimitiveBuilder(vschema, newJointab(reservedVars))
 	rb, err := pb.processDMLTable(tableExprs, reservedVars, nil)

--- a/go/vt/vtgate/planbuilder/explain.go
+++ b/go/vt/vtgate/planbuilder/explain.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Builds an explain-plan for the given Primitive
-func buildExplainPlan(stmt sqlparser.Explain, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildExplainPlan(stmt sqlparser.Explain, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	switch explain := stmt.(type) {
 	case *sqlparser.ExplainTab:
 		return explainTabPlan(explain, vschema)
@@ -61,7 +61,7 @@ func explainTabPlan(explain *sqlparser.ExplainTab, vschema ContextVSchema) (engi
 	}, nil
 }
 
-func buildVitessTypePlan(explain *sqlparser.ExplainStmt, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildVitessTypePlan(explain *sqlparser.ExplainStmt, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	innerInstruction, err := createInstructionFor(sqlparser.String(explain.Statement), explain.Statement, reservedVars, vschema)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -69,7 +69,7 @@ type subqueryInfo struct {
 //
 // If an expression has no references to the current query, then the left-most
 // origin is chosen as the default.
-func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars sqlparser.BindVars) (pullouts []*pulloutSubquery, origin logicalPlan, pushExpr sqlparser.Expr, err error) {
+func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlparser.ReservedVars) (pullouts []*pulloutSubquery, origin logicalPlan, pushExpr sqlparser.Expr, err error) {
 	// highestOrigin tracks the highest origin referenced by the expression.
 	// Default is the First.
 	highestOrigin := First(pb.plan)
@@ -221,7 +221,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 	return has
 }
 
-func (pb *primitiveBuilder) finalizeUnshardedDMLSubqueries(reservedVars sqlparser.BindVars, nodes ...sqlparser.SQLNode) bool {
+func (pb *primitiveBuilder) finalizeUnshardedDMLSubqueries(reservedVars *sqlparser.ReservedVars, nodes ...sqlparser.SQLNode) bool {
 	var keyspace string
 	if rb, ok := pb.plan.(*route); ok {
 		keyspace = rb.eroute.Keyspace.Name

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -156,7 +156,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 		construct, ok := constructsMap[sqi.ast]
 		if !ok {
 			// (subquery) -> :_sq
-			expr = sqlparser.ReplaceExpr(expr, sqi.ast, sqlparser.NewArgument(":"+sqName))
+			expr = sqlparser.ReplaceExpr(expr, sqi.ast, sqlparser.NewArgument(sqName))
 			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutValue, sqName, hasValues, sqi.plan))
 			continue
 		}
@@ -167,10 +167,10 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 				right := &sqlparser.ComparisonExpr{
 					Operator: construct.Operator,
 					Left:     construct.Left,
-					Right:    sqlparser.ListArg("::" + sqName),
+					Right:    sqlparser.ListArg(sqName),
 				}
 				left := &sqlparser.ComparisonExpr{
-					Left:     sqlparser.NewArgument(":" + hasValues),
+					Left:     sqlparser.NewArgument(hasValues),
 					Operator: sqlparser.EqualOp,
 					Right:    sqlparser.NewIntLiteral("1"),
 				}
@@ -183,14 +183,14 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 			} else {
 				// a not in (subquery) -> (:__sq_has_values = 0 or (a not in ::__sq))
 				left := &sqlparser.ComparisonExpr{
-					Left:     sqlparser.NewArgument(":" + hasValues),
+					Left:     sqlparser.NewArgument(hasValues),
 					Operator: sqlparser.EqualOp,
 					Right:    sqlparser.NewIntLiteral("0"),
 				}
 				right := &sqlparser.ComparisonExpr{
 					Operator: construct.Operator,
 					Left:     construct.Left,
-					Right:    sqlparser.ListArg("::" + sqName),
+					Right:    sqlparser.ListArg(sqName),
 				}
 				newExpr := &sqlparser.OrExpr{
 					Left:  left,
@@ -201,7 +201,7 @@ func (pb *primitiveBuilder) findOrigin(expr sqlparser.Expr, reservedVars *sqlpar
 			}
 		case *sqlparser.ExistsExpr:
 			// exists (subquery) -> :__sq_has_values
-			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewArgument(":"+hasValues))
+			expr = sqlparser.ReplaceExpr(expr, construct, sqlparser.NewArgument(hasValues))
 			pullouts = append(pullouts, newPulloutSubquery(engine.PulloutExists, sqName, hasValues, sqi.plan))
 		}
 	}

--- a/go/vt/vtgate/planbuilder/expr_test.go
+++ b/go/vt/vtgate/planbuilder/expr_test.go
@@ -40,16 +40,16 @@ func TestValEqual(t *testing.T) {
 		in2: &sqlparser.ColName{Metadata: c2, Name: sqlparser.NewColIdent("c1")},
 		out: false,
 	}, {
-		in1: sqlparser.NewArgument(":aa"),
+		in1: sqlparser.NewArgument("aa"),
 		in2: &sqlparser.ColName{Metadata: c1, Name: sqlparser.NewColIdent("c1")},
 		out: false,
 	}, {
-		in1: sqlparser.NewArgument(":aa"),
-		in2: sqlparser.NewArgument(":aa"),
+		in1: sqlparser.NewArgument("aa"),
+		in2: sqlparser.NewArgument("aa"),
 		out: true,
 	}, {
-		in1: sqlparser.NewArgument(":aa"),
-		in2: sqlparser.NewArgument(":bb"),
+		in1: sqlparser.NewArgument("aa"),
+		in2: sqlparser.NewArgument("bb"),
 	}, {
 		in1: sqlparser.NewStrLiteral("aa"),
 		in2: sqlparser.NewStrLiteral("aa"),

--- a/go/vt/vtgate/planbuilder/fallback_planner_test.go
+++ b/go/vt/vtgate/planbuilder/fallback_planner_test.go
@@ -36,8 +36,8 @@ type testPlanner struct {
 
 var _ selectPlanner = (*testPlanner)(nil).plan
 
-func (tp *testPlanner) plan(_ string) func(sqlparser.Statement, sqlparser.BindVars, ContextVSchema) (engine.Primitive, error) {
-	return func(statement sqlparser.Statement, vars sqlparser.BindVars, schema ContextVSchema) (engine.Primitive, error) {
+func (tp *testPlanner) plan(_ string) func(sqlparser.Statement, *sqlparser.ReservedVars, ContextVSchema) (engine.Primitive, error) {
+	return func(statement sqlparser.Statement, vars *sqlparser.ReservedVars, schema ContextVSchema) (engine.Primitive, error) {
 		tp.called = true
 		if tp.panic != nil {
 			panic(tp.panic)

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -32,7 +32,7 @@ import (
 // This file has functions to analyze the FROM clause.
 
 // processDMLTable analyzes the FROM clause for DMLs and returns a route.
-func (pb *primitiveBuilder) processDMLTable(tableExprs sqlparser.TableExprs, reservedVars sqlparser.BindVars, where sqlparser.Expr) (*route, error) {
+func (pb *primitiveBuilder) processDMLTable(tableExprs sqlparser.TableExprs, reservedVars *sqlparser.ReservedVars, where sqlparser.Expr) (*route, error) {
 	if err := pb.processTableExprs(tableExprs, reservedVars, where); err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (pb *primitiveBuilder) processDMLTable(tableExprs sqlparser.TableExprs, res
 
 // processTableExprs analyzes the FROM clause. It produces a logicalPlan
 // with all the routes identified.
-func (pb *primitiveBuilder) processTableExprs(tableExprs sqlparser.TableExprs, reservedVars sqlparser.BindVars, where sqlparser.Expr) error {
+func (pb *primitiveBuilder) processTableExprs(tableExprs sqlparser.TableExprs, reservedVars *sqlparser.ReservedVars, where sqlparser.Expr) error {
 	if len(tableExprs) == 1 {
 		return pb.processTableExpr(tableExprs[0], reservedVars, where)
 	}
@@ -64,7 +64,7 @@ func (pb *primitiveBuilder) processTableExprs(tableExprs sqlparser.TableExprs, r
 }
 
 // processTableExpr produces a logicalPlan subtree for the given TableExpr.
-func (pb *primitiveBuilder) processTableExpr(tableExpr sqlparser.TableExpr, reservedVars sqlparser.BindVars, where sqlparser.Expr) error {
+func (pb *primitiveBuilder) processTableExpr(tableExpr sqlparser.TableExpr, reservedVars *sqlparser.ReservedVars, where sqlparser.Expr) error {
 	switch tableExpr := tableExpr.(type) {
 	case *sqlparser.AliasedTableExpr:
 		return pb.processAliasedTable(tableExpr, reservedVars)
@@ -95,7 +95,7 @@ func (pb *primitiveBuilder) processTableExpr(tableExpr sqlparser.TableExpr, rese
 // versatile than a subquery. If a subquery becomes a route, then any result
 // columns that represent underlying vindex columns are also exposed as
 // vindex columns.
-func (pb *primitiveBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, reservedVars sqlparser.BindVars) error {
+func (pb *primitiveBuilder) processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, reservedVars *sqlparser.ReservedVars) error {
 	switch expr := tableExpr.Expr.(type) {
 	case sqlparser.TableName:
 		return pb.buildTablePrimitive(tableExpr, expr)
@@ -268,7 +268,7 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 // processJoin produces a logicalPlan subtree for the given Join.
 // If the left and right nodes can be part of the same route,
 // then it's a route. Otherwise, it's a join.
-func (pb *primitiveBuilder) processJoin(ajoin *sqlparser.JoinTableExpr, reservedVars sqlparser.BindVars, where sqlparser.Expr) error {
+func (pb *primitiveBuilder) processJoin(ajoin *sqlparser.JoinTableExpr, reservedVars *sqlparser.ReservedVars, where sqlparser.Expr) error {
 	switch ajoin.Join {
 	case sqlparser.NormalJoinType, sqlparser.StraightJoinType, sqlparser.LeftJoinType:
 	case sqlparser.RightJoinType:
@@ -300,7 +300,7 @@ func convertToLeftJoin(ajoin *sqlparser.JoinTableExpr) {
 	ajoin.Join = sqlparser.LeftJoinType
 }
 
-func (pb *primitiveBuilder) join(rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr, reservedVars sqlparser.BindVars, where sqlparser.Expr) error {
+func (pb *primitiveBuilder) join(rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr, reservedVars *sqlparser.ReservedVars, where sqlparser.Expr) error {
 	// Merge the symbol tables. In the case of a left join, we have to
 	// ideally create new symbols that originate from the join primitive.
 	// However, this is not worth it for now, because the Push functions

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -183,7 +183,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (engin
 		for _, col := range colVindex.Columns {
 			colNum := findOrAddColumn(ins, col)
 			for rowNum, row := range rows {
-				name := ":" + engine.InsertVarName(col, rowNum)
+				name := engine.InsertVarName(col, rowNum)
 				row[colNum] = sqlparser.NewArgument(name)
 			}
 		}
@@ -236,7 +236,7 @@ func modifyForAutoinc(ins *sqlparser.Insert, eins *engine.Insert) error {
 			return fmt.Errorf("could not compute value for vindex or auto-inc column: %v", err)
 		}
 		autoIncValues.Values = append(autoIncValues.Values, pv)
-		row[colNum] = sqlparser.NewArgument(":" + engine.SeqVarName + strconv.Itoa(rowNum))
+		row[colNum] = sqlparser.NewArgument(engine.SeqVarName + strconv.Itoa(rowNum))
 	}
 
 	eins.Generate = &engine.Generate{

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -30,7 +30,7 @@ import (
 )
 
 // buildInsertPlan builds the route for an INSERT statement.
-func buildInsertPlan(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildInsertPlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	ins := stmt.(*sqlparser.Insert)
 	pb := newPrimitiveBuilder(vschema, newJointab(reservedVars))
 	exprs := sqlparser.TableExprs{&sqlparser.AliasedTableExpr{Expr: ins.Table}}

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -74,7 +74,7 @@ type join struct {
 // newJoin makes a new join using the two planBuilder. ajoin can be nil
 // if the join is on a ',' operator. lpb will contain the resulting join.
 // rpb will be discarded.
-func newJoin(lpb, rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr, reservedVars sqlparser.BindVars) error {
+func newJoin(lpb, rpb *primitiveBuilder, ajoin *sqlparser.JoinTableExpr, reservedVars *sqlparser.ReservedVars) error {
 	// This function converts ON clauses to WHERE clauses. The WHERE clause
 	// scope can see all tables, whereas the ON clause can only see the
 	// participants of the JOIN. However, since the ON clause doesn't allow

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -17,7 +17,7 @@ limitations under the License.
 package planbuilder
 
 import (
-	"strconv"
+	"fmt"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -26,7 +26,7 @@ import (
 // variables across primitives.
 type jointab struct {
 	refs     map[*column]string
-	vars     map[string]struct{}
+	reserved *sqlparser.ReservedVars
 	varIndex int
 }
 
@@ -34,10 +34,10 @@ type jointab struct {
 // being built. It also needs the current list of bind vars
 // used in the original query to make sure that the names
 // it generates don't collide with those already in use.
-func newJointab(bindvars map[string]struct{}) *jointab {
+func newJointab(reserved *sqlparser.ReservedVars) *jointab {
 	return &jointab{
-		refs: make(map[*column]string),
-		vars: bindvars,
+		refs:     make(map[*column]string),
+		reserved: reserved,
 	}
 }
 
@@ -47,17 +47,7 @@ func (jt *jointab) Procure(plan logicalPlan, col *sqlparser.ColName, to int) str
 	from, joinVar := jt.Lookup(col)
 	// If joinVar is empty, generate a unique name.
 	if joinVar == "" {
-		suffix := ""
-		i := 0
-		for {
-			joinVar = col.CompliantName(suffix)
-			if _, ok := jt.vars[joinVar]; !ok {
-				break
-			}
-			i++
-			suffix = strconv.Itoa(i)
-		}
-		jt.vars[joinVar] = struct{}{}
+		joinVar = jt.reserved.NextColumnName(col)
 		jt.refs[col.Metadata.(*column)] = joinVar
 	}
 	plan.SupplyVar(from, to, col, joinVar)
@@ -71,24 +61,13 @@ func (jt *jointab) Procure(plan logicalPlan, col *sqlparser.ColName, to int) str
 func (jt *jointab) GenerateSubqueryVars() (sq, hasValues string) {
 	for {
 		jt.varIndex++
-		suffix := strconv.Itoa(jt.varIndex)
-		var1 := "__sq" + suffix
-		var2 := "__sq_has_values" + suffix
-		if jt.containsAny(var1, var2) {
+		var1 := fmt.Sprintf("__sq%d", jt.varIndex)
+		var2 := fmt.Sprintf("__sq_has_values%d", jt.varIndex)
+		if jt.reserved.ContainsAny(var1, var2) {
 			continue
 		}
 		return var1, var2
 	}
-}
-
-func (jt *jointab) containsAny(names ...string) bool {
-	for _, name := range names {
-		if _, ok := jt.vars[name]; ok {
-			return true
-		}
-		jt.vars[name] = struct{}{}
-	}
-	return false
 }
 
 // Lookup returns the order of the route that supplies the column and

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -47,7 +47,7 @@ func (jt *jointab) Procure(plan logicalPlan, col *sqlparser.ColName, to int) str
 	from, joinVar := jt.Lookup(col)
 	// If joinVar is empty, generate a unique name.
 	if joinVar == "" {
-		joinVar = jt.reserved.NextColumnName(col)
+		joinVar = jt.reserved.ReserveColName(col)
 		jt.refs[col.Metadata.(*column)] = joinVar
 	}
 	plan.SupplyVar(from, to, col, joinVar)
@@ -63,7 +63,7 @@ func (jt *jointab) GenerateSubqueryVars() (sq, hasValues string) {
 		jt.varIndex++
 		var1 := fmt.Sprintf("__sq%d", jt.varIndex)
 		var2 := fmt.Sprintf("__sq_has_values%d", jt.varIndex)
-		if jt.reserved.ContainsAny(var1, var2) {
+		if !jt.reserved.ReserveAll(var1, var2) {
 			continue
 		}
 		return var1, var2

--- a/go/vt/vtgate/planbuilder/jointab_test.go
+++ b/go/vt/vtgate/planbuilder/jointab_test.go
@@ -19,13 +19,16 @@ package planbuilder
 import (
 	"reflect"
 	"testing"
+
+	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 func TestGenerateSubqueryVars(t *testing.T) {
-	jt := newJointab(map[string]struct{}{
+	reserved := sqlparser.NewReservedVars("vtg", map[string]struct{}{
 		"__sq1":            {},
 		"__sq_has_values3": {},
 	})
+	jt := newJointab(reserved)
 
 	v1, v2 := jt.GenerateSubqueryVars()
 	combined := []string{v1, v2}

--- a/go/vt/vtgate/planbuilder/locktables.go
+++ b/go/vt/vtgate/planbuilder/locktables.go
@@ -25,13 +25,13 @@ import (
 )
 
 // buildLockPlan plans lock tables statement.
-func buildLockPlan(stmt sqlparser.Statement, _ sqlparser.BindVars, _ ContextVSchema) (engine.Primitive, error) {
+func buildLockPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, _ ContextVSchema) (engine.Primitive, error) {
 	log.Warningf("Lock Tables statement is ignored: %v", stmt)
 	return engine.NewRowsPrimitive(make([][]sqltypes.Value, 0), make([]*querypb.Field, 0)), nil
 }
 
 // buildUnlockPlan plans lock tables statement.
-func buildUnlockPlan(stmt sqlparser.Statement, _ sqlparser.BindVars, _ ContextVSchema) (engine.Primitive, error) {
+func buildUnlockPlan(stmt sqlparser.Statement, _ *sqlparser.ReservedVars, _ ContextVSchema) (engine.Primitive, error) {
 	log.Warningf("Unlock Tables statement is ignored: %v", stmt)
 	return engine.NewRowsPrimitive(make([][]sqltypes.Value, 0), make([]*querypb.Field, 0)), nil
 }

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -95,7 +95,7 @@ var _ planVisitor = setUpperLimit
 // that it does not need to return more than the specified number of rows.
 // A primitive that cannot perform this can ignore the request.
 func setUpperLimit(plan logicalPlan) (bool, logicalPlan, error) {
-	arg := sqlparser.NewArgument(":__upper_limit")
+	arg := sqlparser.NewArgument("__upper_limit")
 	switch node := plan.(type) {
 	case *join:
 		return false, node, nil

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -161,7 +161,7 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 				return err
 			}
 			rb.eroute.Values = []sqltypes.PlanValue{pv}
-			vals.Right = sqlparser.ListArg("::" + engine.ListVarName)
+			vals.Right = sqlparser.ListArg(engine.ListVarName)
 		case nil:
 			// no-op.
 		default:
@@ -205,7 +205,7 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 		case *sqlparser.ColName:
 			if !rb.isLocal(node) {
 				joinVar := jt.Procure(plan, node, rb.Order())
-				buf.Myprintf("%a", ":"+joinVar)
+				buf.WriteArg(":", joinVar)
 				return
 			}
 		case sqlparser.TableName:
@@ -287,7 +287,7 @@ func (rb *route) generateFieldQuery(sel sqlparser.SelectStatement, jt *jointab) 
 		case *sqlparser.ColName:
 			if !rb.isLocal(node) {
 				_, joinVar := jt.Lookup(node)
-				buf.Myprintf("%a", ":"+joinVar)
+				buf.WriteArg(":", joinVar)
 				return
 			}
 		case sqlparser.TableName:

--- a/go/vt/vtgate/planbuilder/route_planning.go
+++ b/go/vt/vtgate/planbuilder/route_planning.go
@@ -478,7 +478,7 @@ func breakPredicateInLHSandRHS(expr sqlparser.Expr, semTable *semantics.SemTable
 			}
 			if deps.IsSolvedBy(lhs) {
 				columns = append(columns, node)
-				arg := sqlparser.NewArgument(":" + node.CompliantName(""))
+				arg := sqlparser.NewArgument(node.CompliantName())
 				cursor.Replace(arg)
 			}
 		}

--- a/go/vt/vtgate/planbuilder/route_planning.go
+++ b/go/vt/vtgate/planbuilder/route_planning.go
@@ -35,8 +35,8 @@ import (
 
 var _ selectPlanner = gen4Planner
 
-func gen4Planner(_ string) func(sqlparser.Statement, sqlparser.BindVars, ContextVSchema) (engine.Primitive, error) {
-	return func(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func gen4Planner(_ string) func(sqlparser.Statement, *sqlparser.ReservedVars, ContextVSchema) (engine.Primitive, error) {
+	return func(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 		sel, ok := stmt.(*sqlparser.Select)
 		if !ok {
 			return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "%T not yet supported", stmt)

--- a/go/vt/vtgate/planbuilder/system_tables.go
+++ b/go/vt/vtgate/planbuilder/system_tables.go
@@ -96,11 +96,11 @@ func extractInfoSchemaRoutingPredicate(in sqlparser.Expr) (bool, evalengine.Expr
 					}
 					return false, nil, err
 				}
-				name := ":"
+				var name string
 				if isSchemaName {
-					name += sqltypes.BvSchemaName
+					name = sqltypes.BvSchemaName
 				} else {
-					name += engine.BvTableName
+					name = engine.BvTableName
 				}
 				replaceOther(sqlparser.NewArgument(name))
 				return isSchemaName, evalExpr, nil

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -29,7 +29,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
-func buildUnionPlan(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildUnionPlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	union := stmt.(*sqlparser.Union)
 	// For unions, create a pb with anonymous scope.
 	pb := newPrimitiveBuilder(vschema, newJointab(reservedVars))
@@ -42,7 +42,7 @@ func buildUnionPlan(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, v
 	return pb.plan.Primitive(), nil
 }
 
-func (pb *primitiveBuilder) processUnion(union *sqlparser.Union, reservedVars sqlparser.BindVars, outer *symtab) error {
+func (pb *primitiveBuilder) processUnion(union *sqlparser.Union, reservedVars *sqlparser.ReservedVars, outer *symtab) error {
 	if err := pb.processPart(union.FirstStatement, reservedVars, outer, false); err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (pb *primitiveBuilder) processUnion(union *sqlparser.Union, reservedVars sq
 	return pb.pushLimit(union.Limit)
 }
 
-func (pb *primitiveBuilder) processPart(part sqlparser.SelectStatement, reservedVars sqlparser.BindVars, outer *symtab, hasParens bool) error {
+func (pb *primitiveBuilder) processPart(part sqlparser.SelectStatement, reservedVars *sqlparser.ReservedVars, outer *symtab, hasParens bool) error {
 	switch part := part.(type) {
 	case *sqlparser.Union:
 		return pb.processUnion(part, reservedVars, outer)

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -27,7 +27,7 @@ import (
 )
 
 // buildUpdatePlan builds the instructions for an UPDATE statement.
-func buildUpdatePlan(stmt sqlparser.Statement, reservedVars sqlparser.BindVars, vschema ContextVSchema) (engine.Primitive, error) {
+func buildUpdatePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	upd := stmt.(*sqlparser.Update)
 	dml, ksidVindex, ksidCol, err := buildDMLPlan(vschema, "update", stmt, reservedVars, upd.TableExprs, upd.Where, upd.OrderBy, upd.Limit, upd.Comments, upd.Exprs)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
@@ -152,7 +152,7 @@ func buildUpdatePlan(upd *sqlparser.Update) (*controllerPlan, error) {
 		Expr: &sqlparser.ComparisonExpr{
 			Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("id")},
 			Operator: sqlparser.InOp,
-			Right:    sqlparser.ListArg("::ids"),
+			Right:    sqlparser.ListArg("ids"),
 		},
 	}
 
@@ -194,7 +194,7 @@ func buildDeletePlan(del *sqlparser.Delete) (*controllerPlan, error) {
 		Expr: &sqlparser.ComparisonExpr{
 			Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("id")},
 			Operator: sqlparser.InOp,
-			Right:    sqlparser.ListArg("::ids"),
+			Right:    sqlparser.ListArg("ids"),
 		},
 	}
 
@@ -206,7 +206,7 @@ func buildDeletePlan(del *sqlparser.Delete) (*controllerPlan, error) {
 		Expr: &sqlparser.ComparisonExpr{
 			Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("vrepl_id")},
 			Operator: sqlparser.InOp,
-			Right:    sqlparser.ListArg("::ids"),
+			Right:    sqlparser.ListArg("ids"),
 		},
 	}
 	buf3 := sqlparser.NewTrackedBuffer(nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -777,10 +777,10 @@ func (bvf *bindvarFormatter) formatter(buf *sqlparser.TrackedBuffer, node sqlpar
 	if node, ok := node.(*sqlparser.ColName); ok {
 		switch bvf.mode {
 		case bvBefore:
-			buf.WriteArg(fmt.Sprintf(":b_%s", node.Name.String()))
+			buf.WriteArg(":", "b_"+node.Name.String())
 			return
 		case bvAfter:
-			buf.WriteArg(fmt.Sprintf(":a_%s", node.Name.String()))
+			buf.WriteArg(":", "a_"+node.Name.String())
 			return
 		}
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	execLimit = &sqlparser.Limit{Rowcount: sqlparser.NewArgument(":#maxLimit")}
+	execLimit = &sqlparser.Limit{Rowcount: sqlparser.NewArgument("#maxLimit")}
 
 	// PassthroughDMLs will return plans that pass-through the DMLs without changing them.
 	PassthroughDMLs = false


### PR DESCRIPTION
## Description

This is 3 optimizations in one:

1. `sqlparser: do not split statements that don't contain a semicolon`: the insight is simple: the MySQL server implementation tries to split all incoming query packets into their individual statements, but the vast majority of queries do not contain more than one statement. If a query doesn't contain a `;`, we don't bother to do a full tokenization phase to split it.

2. Optimize reserved variable generation: the normalization/rewriting code uses a map to keep track of the bind variable names that are already in use, as to ensure we don't insert duplicated variables. This becomes very slow in queries with many binds, such as bulk inserts. This optimization implements a new `ReservedVars` type that can detect duplicate variables and generate unique variable names more efficiently.
    - The var generator has a "fast" mode: when creating a new `ReservedVars` instance, we check whether any of the existing variable names has the same prefix as the Vitess-specific variables we're going to generate. If that's not the case, we can generate unique variables incrementally, ensuring that they'll never collide. We don't need to check the existing variables map when generating.
    - Furthermore, the most common use case for query normalization uses the `"vtg"` prefix for all variable names (this is the normalization that is performed for all incoming queries in VTGate), so we don't need to allocate new variable names dynamically. This PR introduces a static array of variable names that can be reused between all the incoming queries to a VTGate, drastically reducing memory allocations, particularly in bulk insert queries.

3. Remove memory allocations in `Argument` and `ListArg`: this is the larger refactoring in this PR. These two SQL AST nodes hold an invariant: that the name of the argument or list argument must always begin with `:` or `::`, respectively. However, the vast majority of places in Vitess where we're using bind variables as arguments, they're **not** prefixed with a colon. This leads to a pattern that repeats dozens of times in the codebase, where we allocate `Argument` instances by creating superfluous string allocations, e.g. `NewArgument(":" + bindVar)`. If we simply store the name of the argument _without_ the colon, we never have to prepend colons -- an operation that happens hundreds of times during a normal `vtgate` request. **This refactoring reduces the individual memory allocations by 5%**, and this is a _global_ reduction. Very significant.

A synthetic benchmark also shows very impressive results. Note that this synthetic benchmark includes parsing (which is required before normalization), and roughly 50% of the runtime of the benchmark is spent on _parsing_, while this is a perf improvement for _normalization_. The point improvement, if it could be measured in isolation, would be closer to `40%`.

```
name                    old time/op    new time/op    delta
NormalizeTPCCInsert-16     255ms ± 1%     203ms ± 1%  -20.29%  (p=0.000 n=9+10)

name                    old alloc/op   new alloc/op   delta
NormalizeTPCCInsert-16    68.5MB ± 0%    61.7MB ± 0%   -9.91%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
NormalizeTPCCInsert-16     1.31M ± 0%     1.06M ± 0%  -19.21%  (p=0.000 n=10+10)
``` 



## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [x]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
