### PR TITLE
VReplication: add table for logging stream errors, state changes and key workflow steps

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_plan.go
@@ -222,7 +222,7 @@ func buildDeletePlan(del *sqlparser.Delete) (*controllerPlan, error) {
 
 func buildSelectPlan(sel *sqlparser.Select) (*controllerPlan, error) {
 	switch sqlparser.String(sel.From) {
-	case vreplicationTableName, reshardingJournalTableName, copyStateTableName:
+	case vreplicationTableName, reshardingJournalTableName, copyStateTableName, vreplicationLogTableName:
 		return &controllerPlan{
 			opcode: selectQuery,
 		}, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -405,7 +405,6 @@ func (vre *Engine) exec(query string, runAsAdmin bool) (*sqltypes.Result, error)
 		if err != nil {
 			return nil, err
 		}
-
 		qr, err := withDDL.Exec(vre.ctx, query, dbClient.ExecuteFetch)
 		if err != nil {
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -466,8 +466,7 @@ func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan in
 
 func shouldIgnoreQuery(query string) bool {
 	queriesToIgnore := []string{
-		"insert into _vt.vreplication_log",
-		"select id, type, state, message from _vt.vreplication_log",
+		"_vt.vreplication_log", // ignore all selects, updates and inserts into this table
 	}
 	for _, q := range queriesToIgnore {
 		if strings.Contains(query, q) {

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -570,7 +570,6 @@ func expectNontxQueries(t *testing.T, queries []string) {
 			if shouldIgnoreQuery(got) {
 				continue
 			}
-
 			t.Errorf("unexpected query: %s", got)
 		default:
 			return

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -132,6 +132,11 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
+		if err := env.Mysqld.ExecuteSuperQuery(context.Background(), createVReplicationLog); err != nil {
+			fmt.Fprintf(os.Stderr, "%v", err)
+			return 1
+		}
+
 		return m.Run()
 	}()
 	os.Exit(exitCode)
@@ -459,6 +464,19 @@ func expectLogsAndUnsubscribe(t *testing.T, logs []LogExpectation, logCh chan in
 	}
 }
 
+func shouldIgnoreQuery(query string) bool {
+	queriesToIgnore := []string{
+		"insert into _vt.vreplication_log",
+		"select id, type, state, message from _vt.vreplication_log",
+	}
+	for _, q := range queriesToIgnore {
+		if strings.Contains(query, q) {
+			return true
+		}
+	}
+	return heartbeatRe.MatchString(query)
+}
+
 func expectDBClientQueries(t *testing.T, queries []string) {
 	t.Helper()
 	failed := false
@@ -473,7 +491,7 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 		case got = <-globalDBQueries:
 			// We rule out heartbeat time update queries because otherwise our query list
 			// is indeterminable and varies with each test execution.
-			if heartbeatRe.MatchString(got) {
+			if shouldIgnoreQuery(got) {
 				goto retry
 			}
 
@@ -498,6 +516,9 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 	for {
 		select {
 		case got := <-globalDBQueries:
+			if shouldIgnoreQuery(got) {
+				continue
+			}
 			t.Errorf("unexpected query: %s", got)
 		default:
 			return
@@ -520,7 +541,8 @@ func expectNontxQueries(t *testing.T, queries []string) {
 	retry:
 		select {
 		case got = <-globalDBQueries:
-			if got == "begin" || got == "commit" || got == "rollback" || strings.Contains(got, "update _vt.vreplication set pos") || heartbeatRe.MatchString(got) {
+			if got == "begin" || got == "commit" || got == "rollback" || strings.Contains(got, "update _vt.vreplication set pos") ||
+				shouldIgnoreQuery(got) {
 				goto retry
 			}
 
@@ -546,6 +568,10 @@ func expectNontxQueries(t *testing.T, queries []string) {
 			if got == "begin" || got == "commit" || got == "rollback" || strings.Contains(got, "_vt.vreplication") {
 				continue
 			}
+			if shouldIgnoreQuery(got) {
+				continue
+			}
+
 			t.Errorf("unexpected query: %s", got)
 		default:
 			return

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	createVReplicationLog = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
+	vreplicationLogTableName = "_vt.vreplication_log"
+	createVReplicationLog    = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
 		id BIGINT(20) AUTO_INCREMENT,
 		vrepl_id INT NOT NULL,
 		type VARBINARY(256) NOT NULL,

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -57,9 +57,9 @@ func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, str
 		return 0, "", "", "", nil
 	}
 	id, _ := evalengine.ToInt64(row[0])
-	typ := row[1].String()
-	state := row[2].String()
-	message := row[3].String()
+	typ := row[1].ToString()
+	state := row[2].ToString()
+	message := row[3].ToString()
 	return id, typ, state, message, nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -1,0 +1,95 @@
+package vreplication
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+)
+
+const (
+	createVReplicationLog = `CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
+		id BIGINT(20) AUTO_INCREMENT,
+		vrepl_id INT NOT NULL,
+		type VARBINARY(256) NOT NULL,
+		state VARBINARY(100) NOT NULL,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+		message text NOT NULL,
+		count BIGINT(20) NOT NULL DEFAULT 1,
+		PRIMARY KEY (id))`
+)
+
+const (
+	// Enum values for type column of _vt.vreplication_log
+
+	// LogStreamCreate is used when a row in _vt.vreplication is inserted via VReplicationExec
+	LogStreamCreate = "Stream Created"
+	// LogStreamUpdate is used when a row in _vt.vreplication is updated via VReplicationExec
+	LogStreamUpdate = "Stream Updated"
+	// LogStreamDelete is used when a row in _vt.vreplication is deleted via VReplicationExec
+	LogStreamDelete = "Stream Deleted"
+	// LogMessage is used for generic log messages
+	LogMessage = "Message"
+	// LogCopyStart is used when the copy phase is started
+	LogCopyStart = "Started Copy Phase"
+	// LogCopyEnd is used when the copy phase is done
+	LogCopyEnd = "Ended Copy Phase"
+	// LogStateChange is used when the state of the stream changes
+	LogStateChange = "State Changed"
+	// LogError is used when there is an error from which we cannot recover and the operator needs to fix something
+	LogError = "Error"
+)
+
+func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, string, error) {
+	var qr *sqltypes.Result
+	var err error
+	query := fmt.Sprintf("select id, type, state, message from _vt.vreplication_log where vrepl_id = %d order by id desc limit 1", vreplID)
+	if qr, err = dbClient.ExecuteFetch(query, 1); err != nil {
+		return 0, "", "", "", err
+	}
+	if len(qr.Rows) != 1 {
+		return 0, "", "", "", nil
+	}
+	row := qr.Rows[0]
+	if len(row) != 4 {
+		return 0, "", "", "", nil
+	}
+	id, _ := evalengine.ToInt64(row[0])
+	typ := row[1].String()
+	state := row[2].String()
+	message := row[3].String()
+	return id, typ, state, message, nil
+}
+
+func insertLog(dbClient *vdbClient, typ string, vreplID uint32, state, message string) error {
+	var query string
+
+	id, currentType, currentState, currentMessage, err := getLastLog(dbClient, vreplID)
+	if err != nil {
+		return err
+	}
+	if id > 0 && typ == currentType && state == currentState && message == currentMessage {
+		query = fmt.Sprintf("update _vt.vreplication_log set count = count + 1 where id = %d", id)
+	} else {
+		query = `insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%d, '%s', '%s', %s)`
+		query = fmt.Sprintf(query, vreplID, typ, state, encodeString(message))
+	}
+	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
+		return fmt.Errorf("could not insert into log table: %v: %v", query, err)
+	}
+	return nil
+}
+
+func insertLogWithParams(dbClient *vdbClient, action string, vreplID uint32, params map[string]string) error {
+	var message string
+	if params != nil {
+		obj, _ := json.Marshal(params)
+		message = string(obj)
+	}
+	if err := insertLog(dbClient, action, vreplID, params["state"], message); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -80,6 +80,10 @@ func (vc *vcopier) initTablesForCopy(ctx context.Context) error {
 		if err := vc.vr.setState(binlogplayer.VReplicationCopying, ""); err != nil {
 			return err
 		}
+		if err := vc.vr.insertLog(LogCopyStart, fmt.Sprintf("Copy phase started for %d table(s)",
+			len(plan.TargetTables))); err != nil {
+			return err
+		}
 	} else {
 		if err := vc.vr.setState(binlogplayer.BlpStopped, "There is nothing to replicate"); err != nil {
 			return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -521,21 +521,24 @@ func TestPlayerCopyTables(t *testing.T) {
 	expectData(t, "yes", [][]string{})
 	validateCopyRowCountStat(t, 2)
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Run("Check log for start of copy", func(t *testing.T) {
-		query = "select count(*) from _vt.vreplication_log where type = 'LogCopyStarted'"
-		qr, err := env.Mysqld.FetchSuperQuery(ctx, query)
-		require.NoError(t, err)
-		require.NotNil(t, qr)
-		require.Equal(t, 1, len(qr.Rows))
-	})
 
-	t.Run("Check log for end of copy", func(t *testing.T) {
-		query = "select count(*) from _vt.vreplication_log where type = 'LogCopyEnded'"
-		qr, err := env.Mysqld.FetchSuperQuery(ctx, query)
-		require.NoError(t, err)
-		require.NotNil(t, qr)
-		require.Equal(t, 1, len(qr.Rows))
-	})
+	type logTestCase struct {
+		name string
+		typ  string
+	}
+	testCases := []logTestCase{
+		{name: "Check log for start of copy", typ: "LogCopyStarted"},
+		{name: "Check log for end of copy", typ: "LogCopyEnded"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			query = fmt.Sprintf("select count(*) from _vt.vreplication_log where type = '%s'", testCase.typ)
+			qr, err := env.Mysqld.FetchSuperQuery(ctx, query)
+			require.NoError(t, err)
+			require.NotNil(t, qr)
+			require.Equal(t, 1, len(qr.Rows))
+		})
+	}
 	cancel()
 
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -520,6 +520,24 @@ func TestPlayerCopyTables(t *testing.T) {
 	})
 	expectData(t, "yes", [][]string{})
 	validateCopyRowCountStat(t, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Run("Check log for start of copy", func(t *testing.T) {
+		query = "select count(*) from _vt.vreplication_log where type = 'LogCopyStarted'"
+		qr, err := env.Mysqld.FetchSuperQuery(ctx, query)
+		require.NoError(t, err)
+		require.NotNil(t, qr)
+		require.Equal(t, 1, len(qr.Rows))
+	})
+
+	t.Run("Check log for end of copy", func(t *testing.T) {
+		query = "select count(*) from _vt.vreplication_log where type = 'LogCopyEnded'"
+		qr, err := env.Mysqld.FetchSuperQuery(ctx, query)
+		require.NoError(t, err)
+		require.NotNil(t, qr)
+		require.Equal(t, 1, len(qr.Rows))
+	})
+	cancel()
+
 }
 
 // TestPlayerCopyBigTable ensures the copy-catchup back-and-forth loop works correctly.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2464,17 +2464,22 @@ func TestVReplicationLogs(t *testing.T) {
 	defer dbClient.Close()
 	vdbc := newVDBClient(dbClient, binlogplayer.NewStats())
 	query := "select vrepl_id, state, message, count from _vt.vreplication_log order by id desc limit 1"
-	err = insertLog(vdbc, LogMessage, 1, "Running", "message1")
-	require.NoError(t, err)
-	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), query)
-	require.NoError(t, err)
-	require.Equal(t, "[[INT32(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(1)]]", fmt.Sprintf("%v", qr.Rows))
 
-	err = insertLog(vdbc, LogMessage, 1, "Running", "message1")
-	require.NoError(t, err)
-	qr, err = env.Mysqld.FetchSuperQuery(context.Background(), query)
-	require.NoError(t, err)
-	require.Equal(t, "[[INT32(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(2)]]", fmt.Sprintf("%v", qr.Rows))
+	expected := []string{
+		"[[INT32(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(1)]]",
+		"[[INT32(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(2)]]",
+	}
+
+	for _, want := range expected {
+		t.Run("", func(t *testing.T) {
+			err = insertLog(vdbc, LogMessage, 1, "Running", "message1")
+			require.NoError(t, err)
+			qr, err := env.Mysqld.FetchSuperQuery(context.Background(), query)
+			require.NoError(t, err)
+			require.Equal(t, want, fmt.Sprintf("%v", qr.Rows))
+		})
+
+	}
 }
 
 func expectJSON(t *testing.T, table string, values [][]string, id int, exec func(ctx context.Context, query string) (*sqltypes.Result, error)) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2456,6 +2456,27 @@ func TestPlayerJSONDocs(t *testing.T) {
 	}
 }
 
+func TestVReplicationLogs(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+	dbClient := playerEngine.dbClientFactoryDba()
+	err := dbClient.Connect()
+	require.NoError(t, err)
+	defer dbClient.Close()
+	vdbc := newVDBClient(dbClient, binlogplayer.NewStats())
+
+	err = insertLog(vdbc, LogMessage, 1, "Running", "message1")
+	require.NoError(t, err)
+	qr, err := env.Mysqld.FetchSuperQuery(context.Background(), "select id, state, message, count from _vt.vreplication_log")
+	require.NoError(t, err)
+	require.Equal(t, "[[INT64(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(1)]]", fmt.Sprintf("%v", qr.Rows))
+
+	err = insertLog(vdbc, LogMessage, 1, "Running", "message1")
+	require.NoError(t, err)
+	qr, err = env.Mysqld.FetchSuperQuery(context.Background(), "select id, state, message, count from _vt.vreplication_log")
+	require.NoError(t, err)
+	require.Equal(t, "[[INT64(1) VARBINARY(\"Running\") TEXT(\"message1\") INT64(2)]]", fmt.Sprintf("%v", qr.Rows))
+}
+
 func expectJSON(t *testing.T, table string, values [][]string, id int, exec func(ctx context.Context, query string) (*sqltypes.Result, error)) {
 	t.Helper()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -72,8 +72,8 @@ type vreplicator struct {
 	// source
 	source          *binlogdatapb.BinlogSource
 	sourceVStreamer VStreamerClient
-
-	stats *binlogplayer.Stats
+	state           string
+	stats           *binlogplayer.Stats
 	// mysqld is used to fetch the local schema.
 	mysqld    mysqlctl.MysqlDaemon
 	pkInfoMap map[string][]*PrimaryKeyInfo
@@ -317,7 +317,14 @@ func (vr *vreplicator) setMessage(message string) error {
 	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}
+	if err := insertLog(vr.dbClient, LogMessage, vr.id, vr.state, message); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (vr *vreplicator) insertLog(typ, message string) error {
+	return insertLog(vr.dbClient, typ, vr.id, vr.state, message)
 }
 
 func (vr *vreplicator) setState(state, message string) error {
@@ -332,6 +339,14 @@ func (vr *vreplicator) setState(state, message string) error {
 	if _, err := vr.dbClient.ExecuteFetch(query, 1); err != nil {
 		return fmt.Errorf("could not set state: %v: %v", query, err)
 	}
+	if state == vr.state {
+		return nil
+	}
+	if err := insertLog(vr.dbClient, LogStateChange, vr.id, vr.state, message); err != nil {
+		return err
+	}
+	vr.state = state
+
 	return nil
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -189,6 +189,15 @@ func (vr *vreplicator) replicate(ctx context.Context) error {
 				vr.stats.ErrorCounts.Add([]string{"Copy"}, 1)
 				return err
 			}
+			settings, numTablesToCopy, err = vr.readSettings(ctx)
+			if err != nil {
+				return err
+			}
+			if numTablesToCopy == 0 {
+				if err := vr.insertLog(LogCopyEnd, fmt.Sprintf("Copy phase completed at gtid %s", settings.StartPos)); err != nil {
+					return err
+				}
+			}
 		case settings.StartPos.IsZero():
 			if err := newVCopier(vr).initTablesForCopy(ctx); err != nil {
 				vr.stats.ErrorCounts.Add([]string{"Copy"}, 1)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -342,7 +342,7 @@ func (vr *vreplicator) setState(state, message string) error {
 	if state == vr.state {
 		return nil
 	}
-	if err := insertLog(vr.dbClient, LogStateChange, vr.id, vr.state, message); err != nil {
+	if err := insertLog(vr.dbClient, LogStateChange, vr.id, state, message); err != nil {
 		return err
 	}
 	vr.state = state

--- a/go/vt/wrangler/fake_dbclient_test.go
+++ b/go/vt/wrangler/fake_dbclient_test.go
@@ -75,7 +75,9 @@ func newFakeDBClient() *fakeDBClient {
 		queriesRE: make(map[string]*dbResults),
 		invariants: map[string]*sqltypes.Result{
 			"use _vt": {},
-			"select * from _vt.vreplication where db_name='db'": {},
+			"select * from _vt.vreplication where db_name='db'":         {},
+			"select id, type, state, message from _vt.vreplication_log": {},
+			"insert into _vt.vreplication_log":                          {},
 		},
 	}
 }

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -80,6 +80,6 @@ sleep 3 # TODO: Required for now!
 
 mysql --table < ../common/select_customer-80_data.sql
 mysql --table < ../common/select_customer80-_data.sql
-
+exit
 ./401_teardown.sh
 

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -80,6 +80,6 @@ sleep 3 # TODO: Required for now!
 
 mysql --table < ../common/select_customer-80_data.sql
 mysql --table < ../common/select_customer80-_data.sql
-exit
+
 ./401_teardown.sh
 


### PR DESCRIPTION
## Description

This PR adds a new table to the _vt sidecar database. The `_vt.vreplication_log` table will record certain types of events. To start with we record
* stream creation along with stream parameters
* stream errors 
* state changes
* key workflow steps (currently start and end of the copy phase) (Todo)


```
CREATE TABLE IF NOT EXISTS _vt.vreplication_log (
	id BIGINT(20) AUTO_INCREMENT,
	vrepl_id INT NOT NULL,
	type VARBINARY(256) NOT NULL,
	state VARBINARY(100) NOT NULL,
	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
	message text NOT NULL,
	count BIGINT(20) NOT NULL DEFAULT 1,
	PRIMARY KEY (id))
```

The value of the message will usually be a string. In the case of stream inserts it records all the parameters including the binlogsource field.

Before inserting a new row we check if the latest message matches the state and message of the new message and if it does then it increments the count. This prevents any repeated errors from spamming the table.

### Tests

When I tried adding the queries related to the vreplication_log to expect them during other vreplication tests it lead to a huge number of updates to existing tests and also created race conditions and other flakiness. For now we ignore these queries
during the workflow and test the log insertion code separately.

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  VReplication
- [X]  VTAdmin
