### PR TITLE
Increase the timeout for StartActionLoop

### DIFF
--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -223,8 +223,8 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 
 	// And wait for it to serve, so we don't start using it before it's
 	// ready.
-	timeout := 10 * time.Second
-	step := 10 * time.Millisecond
+	timeout := 10 * time.Minute
+	step := 100 * time.Millisecond
 	c := tmclient.NewTabletManagerClient()
 	for timeout >= 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -223,7 +223,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 
 	// And wait for it to serve, so we don't start using it before it's
 	// ready.
-	timeout := 5 * time.Second
+	timeout := 10 * time.Second
 	step := 10 * time.Millisecond
 	c := tmclient.NewTabletManagerClient()
 	for timeout >= 0 {


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Recently this function was added with vreplication test engine and may be due to that it would be taken more time to come up. Increasing the timeout to see if that makes it less flaky.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 


## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Build/CI
