### PR TITLE
upgrade tests: test against v9.0.0

### DIFF
--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -13,15 +13,15 @@ jobs:
       with:
         go-version: 1.15
 
-    - name: Check out v8.0.0
+    - name: Check out v9.0.0
       uses: actions/checkout@v2
       with:
-        ref: v8.0.0
+        ref: v9.0.0
 
     - name: Get dependencies
       run: |
         # This prepares general purpose binary dependencies
-        # as well as v8.0.0 specific go modules
+        # as well as v9.0.0 specific go modules
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
@@ -36,28 +36,28 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    - name: Building v8.0.0 binaries
+    - name: Building v9.0.0 binaries
       timeout-minutes: 10
       run: |
-        # We build v8.0.0 binaries and save them in a temporary location
+        # We build v9.0.0 binaries and save them in a temporary location
         source build.env
         make build
-        mkdir -p /tmp/vitess-build-v8.0.0/
-        cp -R bin /tmp/vitess-build-v8.0.0/
+        mkdir -p /tmp/vitess-build-v9.0.0/
+        cp -R bin /tmp/vitess-build-v9.0.0/
 
     - name: Check out HEAD
       uses: actions/checkout@v2
 
-    - name: Run cluster endtoend test v8.0.0 (create cluster)
+    - name: Run cluster endtoend test v9.0.0 (create cluster)
       timeout-minutes: 5
       run: |
-        # By checking out we deleted bin/ directory. We now restore our pre-built v8.0.0 binaries
-        cp -R /tmp/vitess-build-v8.0.0/bin .
+        # By checking out we deleted bin/ directory. We now restore our pre-built v9.0.0 binaries
+        cp -R /tmp/vitess-build-v9.0.0/bin .
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
         source build.env
-        # We pass -skip-build so that we use the v8.0.0 binaries, not HEAD binaries
+        # We pass -skip-build so that we use the v9.0.0 binaries, not HEAD binaries
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
     - name: Check out HEAD
@@ -74,7 +74,7 @@ jobs:
         mkdir -p /tmp/vitess-build-head/
         cp -R bin /tmp/vitess-build-head/
 
-    - name: Run cluster endtoend test HEAD based on v8.0.0 data (upgrade path)
+    - name: Run cluster endtoend test HEAD based on v9.0.0 data (upgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
@@ -95,11 +95,11 @@ jobs:
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
 
-    - name: Run cluster endtoend test v8.0.0 based on HEAD data (downgrade path)
+    - name: Run cluster endtoend test v9.0.0 based on HEAD data (downgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
-        cp -R /tmp/vitess-build-v8.0.0/bin .
+        cp -R /tmp/vitess-build-v9.0.0/bin .
 
         source build.env
         # We again built manually and there's no need for the test to build.


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

## Description

I've missed an update to CI's upgrade tests. Updating now to compare vs `v9.0.0`. Release `v10.0.0` is expected in a couple weeks, and we'll update this tests again in two weeks to reflect that release.


## Checklist
- [x] Should this PR be backported? Yes to release-10.0 branch
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
