### PR TITLE
actions: set ephemeral port range to include more ports

### DIFF
--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -29,6 +29,10 @@ jobs:
 
         go mod download
 
+    - name: Tune the OS
+      run: |
+        echo 1024 65535 > /proc/sys/net/ipv4/ip_local_port_range
+
     - name: Run make tools
       run: |
         make tools

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Tune the OS
       run: |
-        echo 1024 65535 > /proc/sys/net/ipv4/ip_local_port_range
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
     - name: Run make tools
       run: |


### PR DESCRIPTION
## Description

This change aims to test whether ephemeral port exhaustion plays a role in intermittently failing tests.

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
