### PR TITLE
[vtadmin-web] Add useSyncedURLParam hook to persist filter parameter in the URL

### DIFF
--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 
 import { useSchemas } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
+import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
 import { filterNouns } from '../../util/filterNouns';
 import { formatBytes } from '../../util/formatBytes';
 import { getTableDefinitions } from '../../util/tableDefinitions';
@@ -48,7 +49,7 @@ export const Schemas = () => {
     useDocumentTitle('Schemas');
 
     const { data = [] } = useSchemas();
-    const [filter, setFilter] = React.useState<string>('');
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
     const filteredData = React.useMemo(() => {
         const tableDefinitions = getTableDefinitions(data);
@@ -100,11 +101,11 @@ export const Schemas = () => {
                 <TextInput
                     autoFocus
                     iconLeft={Icons.search}
-                    onChange={(e) => setFilter(e.target.value)}
+                    onChange={(e) => updateFilter(e.target.value)}
                     placeholder="Filter schemas"
-                    value={filter}
+                    value={filter || ''}
                 />
-                <Button disabled={!filter} onClick={() => setFilter('')} secondary>
+                <Button disabled={!filter} onClick={() => updateFilter('')} secondary>
                     Clear filters
                 </Button>
             </div>

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -27,11 +27,12 @@ import style from './Tablets.module.scss';
 import { Button } from '../Button';
 import { DataCell } from '../dataTable/DataCell';
 import { TabletServingPip } from '../pips/TabletServingPip';
+import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
 
-    const [filter, setFilter] = React.useState<string>('');
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
     const { data = [] } = useTablets();
 
     const filteredData = React.useMemo(() => {
@@ -63,11 +64,11 @@ export const Tablets = () => {
                 <TextInput
                     autoFocus
                     iconLeft={Icons.search}
-                    onChange={(e) => setFilter(e.target.value)}
+                    onChange={(e) => updateFilter(e.target.value)}
                     placeholder="Filter tablets"
-                    value={filter}
+                    value={filter || ''}
                 />
-                <Button disabled={!filter} onClick={() => setFilter('')} secondary>
+                <Button disabled={!filter} onClick={() => updateFilter('')} secondary>
                     Clear filters
                 </Button>
             </div>
@@ -106,7 +107,7 @@ const formatDisplayType = (t: pb.Tablet) => {
 
 const formatState = (t: pb.Tablet) => t.state && SERVING_STATES[t.state];
 
-export const formatRows = (tablets: pb.Tablet[] | null, filter: string) => {
+export const formatRows = (tablets: pb.Tablet[] | null | undefined, filter: string | null | undefined) => {
     if (!tablets) return [];
 
     // Properties prefixed with "_" are hidden and included for filtering only.

--- a/web/vtadmin/src/hooks/useSyncedURLParam.test.tsx
+++ b/web/vtadmin/src/hooks/useSyncedURLParam.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { createMemoryHistory, To } from 'history';
+import { Router } from 'react-router-dom';
+
+import { useSyncedURLParam } from './useSyncedURLParam';
+
+describe('useSyncedURLParam', () => {
+    it('should push to history when updating initially empty value', () => {
+        const history = createMemoryHistory();
+
+        jest.spyOn(history, 'push');
+        jest.spyOn(history, 'replace');
+
+        const { result } = renderHook(() => useSyncedURLParam('hello'), {
+            wrapper: ({ children }) => {
+                return <Router history={history}>{children}</Router>;
+            },
+        });
+
+        expect(history.location.search).toEqual('');
+        expect(result.current.value).toEqual('');
+
+        act(() => {
+            result.current.updateValue('world');
+        });
+
+        expect(history.location.search).toEqual('?hello=world');
+        expect(result.current.value).toEqual('world');
+
+        expect(history.push).toHaveBeenCalledTimes(1);
+        expect(history.replace).toHaveBeenCalledTimes(0);
+    });
+
+    it('should replace history when a value is already defined in the URL', () => {
+        const history = createMemoryHistory({ initialEntries: ['/?hello=world'] });
+
+        jest.spyOn(history, 'push');
+        jest.spyOn(history, 'replace');
+
+        const { result } = renderHook(() => useSyncedURLParam('hello'), {
+            wrapper: ({ children }) => {
+                return <Router history={history}>{children}</Router>;
+            },
+        });
+
+        expect(history.location.search).toEqual('?hello=world');
+        expect(result.current.value).toEqual('world');
+
+        act(() => {
+            result.current.updateValue('moon');
+        });
+
+        expect(history.location.search).toEqual('?hello=moon');
+        expect(result.current.value).toEqual('moon');
+
+        expect(history.push).toHaveBeenCalledTimes(0);
+        expect(history.replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear the URL parameter and push to history when given an empty value', () => {
+        const history = createMemoryHistory({ initialEntries: ['/?hello=world'] });
+
+        jest.spyOn(history, 'push');
+        jest.spyOn(history, 'replace');
+
+        const { result } = renderHook(() => useSyncedURLParam('hello'), {
+            wrapper: ({ children }) => {
+                return <Router history={history}>{children}</Router>;
+            },
+        });
+
+        expect(history.location.search).toEqual('?hello=world');
+        expect(result.current.value).toEqual('world');
+
+        act(() => {
+            result.current.updateValue(null);
+        });
+
+        expect(history.location.search).toEqual('?');
+        expect(result.current.value).toEqual('');
+
+        expect(history.push).toHaveBeenCalledTimes(1);
+        expect(history.replace).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not modify unrelated URL parameters', () => {
+        const history = createMemoryHistory({ initialEntries: ['/?goodbye=world'] });
+
+        const { result } = renderHook(() => useSyncedURLParam('hello'), {
+            wrapper: ({ children }) => {
+                return <Router history={history}>{children}</Router>;
+            },
+        });
+
+        expect(history.location.search).toEqual('?goodbye=world');
+        expect(result.current.value).toEqual('');
+
+        act(() => {
+            result.current.updateValue('moon');
+        });
+
+        expect(history.location.search).toEqual('?goodbye=world&hello=moon');
+        expect(result.current.value).toEqual('moon');
+
+        act(() => {
+            result.current.updateValue(null);
+        });
+
+        expect(history.location.search).toEqual('?goodbye=world');
+        expect(result.current.value).toEqual('');
+    });
+
+    // This is a longer, integration-y test that simulates traversing the history stack
+    // with the browser's "back" button.
+    it('should properly manipulate history given a sequence of inputs', () => {
+        const history = createMemoryHistory();
+
+        jest.spyOn(history, 'push');
+        jest.spyOn(history, 'replace');
+
+        const { result } = renderHook(() => useSyncedURLParam('sequence'), {
+            wrapper: ({ children }) => {
+                return <Router history={history}>{children}</Router>;
+            },
+        });
+
+        act(() => {
+            result.current.updateValue('one');
+        });
+
+        expect(history.location.search).toEqual('?sequence=one');
+        expect(result.current.value).toEqual('one');
+
+        act(() => {
+            result.current.updateValue('two');
+        });
+
+        expect(history.location.search).toEqual('?sequence=two');
+        expect(result.current.value).toEqual('two');
+
+        act(() => {
+            result.current.updateValue(null);
+        });
+
+        expect(history.location.search).toEqual('?');
+        expect(result.current.value).toEqual('');
+
+        act(() => {
+            result.current.updateValue('three');
+        });
+
+        expect(history.location.search).toEqual('?sequence=three');
+        expect(result.current.value).toEqual('three');
+
+        act(() => {
+            history.back();
+        });
+
+        expect(history.location.search).toEqual('?');
+        expect(result.current.value).toEqual('');
+
+        act(() => {
+            history.back();
+        });
+
+        expect(history.location.search).toEqual('?sequence=two');
+        expect(result.current.value).toEqual('two');
+
+        act(() => {
+            history.back();
+        });
+
+        // Note that we expect to be missing the "one" value since it was *replaced* by "two"
+        expect(history.location.search).toEqual('');
+        expect(result.current.value).toEqual('');
+    });
+});

--- a/web/vtadmin/src/hooks/useSyncedURLParam.ts
+++ b/web/vtadmin/src/hooks/useSyncedURLParam.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback } from 'react';
+
+import { useURLQuery } from './useURLQuery';
+
+/**
+ * useSyncedURLValue is a hook for synchronizing a string between a component
+ * and the URL. It is optimized for values that change quickly, like user input.
+ *
+ * Note: the value returned is always a string, so any formatting/parsing is
+ * left to the caller.
+ *
+ * @param key - The key for the URL parameter. A key of "search", for example, would
+ * manipulate the `?search=...` value in the URL.
+ */
+export const useSyncedURLParam = (
+    key: string
+): {
+    updateValue: (nextValue: string | null | undefined) => void;
+    // `value` is always a string, since (a) the value in the URL will
+    // be a string in the end :) and (b) primitive values like strings are much,
+    // much easier to memoize and cache. This means all parsing/formatting is
+    // left to the caller.
+    value: string | null | undefined;
+} => {
+    // TODO(doeg): a potentially nice enhancement is to maintain an ephemeral cache
+    // (optionally) mapping routes to the last used set of URL parameters.
+    // So, for example, if you were (1) on the /tablets view, (2) updated the "filter" parameter,
+    // (3) navigated away, and then (4) clicked a nav link back to /tablets, the "filter" parameter
+    // parameter you typed in (2) will be lost, since it's only preserved on the history stack,
+    // which is only traversable with the "back" button.
+    const { query, pushQuery, replaceQuery } = useURLQuery();
+    const value = `${query[key] || ''}`;
+
+    const updateValue = useCallback(
+        (nextValue: string | null | undefined) => {
+            if (!nextValue) {
+                // Push an undefined value to omit the parameter from the URL.
+                // This gives us URLs like `?goodbye=moon` instead of `?hello=&goodbye=moon`.
+                pushQuery({ [key]: undefined });
+            } else if (nextValue && !value) {
+                // Replace the current value with a new value. There's a bit of nuance here, since this
+                // means that clearing the input is the _only_ way to persist discrete values to
+                // the history stack, which is not very intuitive or delightful!
+                //
+                // TODO(doeg): One possible, more nuanced re-implementation is to push entries onto the stack
+                // on a timeout. This means you could type a query, pause and click around a bit,
+                // and then type a new query -- both queries would be persisted to the stack,
+                // without resorting to calling `pushQuery` on _every_ character typed.
+                pushQuery({ [key]: nextValue });
+            } else {
+                // Replace the current value in the URL with a new one. The previous
+                // value (that was replaced) will no longer be available (i.e., it won't
+                // be accessible via the back button).
+                //
+                // We use replaceQuery instead of pushQuery, as pushQuery would push
+                // every single letter onto the history stack, which means every click
+                // of the back button would iterate backwards, one letter at a time.
+                replaceQuery({ [key]: nextValue });
+            }
+        },
+        [key, value, pushQuery, replaceQuery]
+    );
+
+    return { value, updateValue };
+};

--- a/web/vtadmin/src/util/filterNouns.ts
+++ b/web/vtadmin/src/util/filterNouns.ts
@@ -20,7 +20,7 @@ import { KeyValueSearchToken, SearchTokenTypes, tokenizeSearch } from './tokeniz
 /**
  * `filterNouns` filters a list of nouns by a search string.
  */
-export const filterNouns = <T extends { [k: string]: any }>(needle: string | null, haystack: T[]): T[] => {
+export const filterNouns = <T extends { [k: string]: any }>(needle: string | null | undefined, haystack: T[]): T[] => {
     if (!needle) return haystack;
 
     const tokens = tokenizeSearch(needle);


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds `useSyncedURLParam`, a hook for synchronizing values (particularly user input) with the URL. The principle here is that every view of VTAdmin should be encoded in the URL, so it's easy to share what you're seeing with someone else. 😎 

https://user-images.githubusercontent.com/855595/114622966-a864fb00-9c7c-11eb-98c4-05eb3690be74.mov

This is a fairly straightforward implementation to get something out the door. I already have some improvements in mind, based on our internal prototype, so I added a fair amount of commentary + unit tests so it's easy to update down the road. 

## Related Issue(s)

N/A 

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
