### PR TITLE
[vtadmin] bound inflight `GetSchema` calls

### DIFF
--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
@@ -57,7 +58,7 @@ type Cluster struct {
 
 	// These fields are used to provide an upper bound on the number of
 	// concurrent RPCs a cluster makes across all requests.
-	GetSchemaPool RPCPool
+	GetSchemaPool pools.RPCPool
 
 	// These fields are kept to power debug endpoints.
 	// (TODO|@amason): Figure out if these are needed or if there's a way to
@@ -111,7 +112,7 @@ func New(cfg Config) (*Cluster, error) {
 		getSchemaRPCPoolWaitTimeout = *cfg.GetSchemaRPCPoolWaitTimeout
 	}
 
-	cluster.GetSchemaPool = NewRPCPool(getSchemaRPCPoolSize, getSchemaRPCPoolWaitTimeout)
+	cluster.GetSchemaPool = pools.NewRPCPool(getSchemaRPCPoolSize, getSchemaRPCPoolWaitTimeout)
 
 	return cluster, nil
 }

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
@@ -54,6 +55,10 @@ type Cluster struct {
 
 	DB     vtsql.DB
 	Vtctld vtctldclient.Proxy
+
+	// These fields are used to provide an upper bound on the number of
+	// concurrent RPCs a cluster makes across all requests.
+	getSchemaPool *pools.ResourcePool
 
 	// These fields are kept to power debug endpoints.
 	// (TODO|@amason): Figure out if these are needed or if there's a way to
@@ -95,6 +100,17 @@ func New(cfg Config) (*Cluster, error) {
 
 	cluster.DB = vtsql.New(vtsqlCfg)
 	cluster.Vtctld = vtctldclient.New(vtctldCfg)
+
+	// (TODO:@ajm188) define an interface type that provides the rp.Do(...) func
+	// we need so we can implement an "UnboundedPool" type for when
+	// "max-concurrency" is explicitly set to 0 rather than this "idk pick an
+	// arbitrary default value" thing we're currently doing.
+	maxGetSchemaRPCs := 10
+	if cfg.GetSchemaRPCPoolSize != nil {
+		maxGetSchemaRPCs = *cfg.GetSchemaRPCPoolSize
+	}
+
+	cluster.getSchemaPool = pools.NewResourcePool(pools.NewEmptyResource, maxGetSchemaRPCs, maxGetSchemaRPCs, 0, maxGetSchemaRPCs, nil)
 
 	return cluster, nil
 }
@@ -567,7 +583,23 @@ func (c *Cluster) getSchemaFromTablets(ctx context.Context, keyspace string, tab
 			span.Annotate("keyspace", keyspace)
 			span.Annotate("shard", tablet.Tablet.Shard)
 
-			resp, err := c.Vtctld.GetSchema(ctx, &req)
+			var (
+				resp *vtctldatapb.GetSchemaResponse
+				err  error
+			)
+
+			switch c.getSchemaPool {
+			case nil:
+				resp, err = c.Vtctld.GetSchema(ctx, &req)
+			default:
+				err = c.getSchemaPool.Do(ctx, func(resource pools.Resource) (pools.Resource, error) {
+					var err2 error
+
+					resp, err2 = c.Vtctld.GetSchema(ctx, &req)
+					return resource, err2
+				})
+			}
+
 			if err != nil {
 				err = fmt.Errorf("GetSchema(cluster = %s, keyspace = %s, tablet = %s) failed: %w", c.ID, keyspace, tablet.Tablet.Alias, err)
 				rec.RecordError(err)

--- a/go/vt/vtadmin/cluster/flags.go
+++ b/go/vt/vtadmin/cluster/flags.go
@@ -17,8 +17,11 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"vitess.io/vitess/go/vt/log"
 )
@@ -143,6 +146,20 @@ func parseOne(cfg *Config, name string, val string) error {
 		cfg.Name = val
 	case "discovery":
 		cfg.DiscoveryImpl = val
+	case "getschema-rpcpool-size":
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("parsing `getschema-rpcpool-size`: %w", err)
+		}
+
+		cfg.GetSchemaRPCPoolSize = &i
+	case "getschema-rpcpool-wait-timeout":
+		timeout, err := time.ParseDuration(val)
+		if err != nil {
+			return fmt.Errorf("parsing `getschema-rpcpool-wait-timeout`: %w", err)
+		}
+
+		cfg.GetSchemaRPCPoolWaitTimeout = &timeout
 	default:
 		if strings.HasPrefix(name, "vtsql-") {
 			if cfg.VtSQLFlags == nil {

--- a/go/vt/vtadmin/cluster/rpc_pool.go
+++ b/go/vt/vtadmin/cluster/rpc_pool.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"time"
+
+	"vitess.io/vitess/go/pools"
+)
+
+// RPCPool defines the interface used by Cluster's to pool concurrent outbound
+// RPCs.
+type RPCPool interface {
+	Do(ctx context.Context, f func() error) error
+}
+
+// NewRPCPool returns a new RPCPool. If maxConcurrentRPCs is non-positive, the
+// RPCPool is unbounded, and waitTimeout is irrelevant.
+func NewRPCPool(maxConcurrentRPCs int, waitTimeout time.Duration) RPCPool {
+	if maxConcurrentRPCs <= 0 {
+		return &unboundedPool{}
+	}
+
+	return &boundedPool{
+		rp:          pools.NewResourcePool(pools.NewEmptyResource, maxConcurrentRPCs, maxConcurrentRPCs, 0, maxConcurrentRPCs, nil),
+		waitTimeout: waitTimeout,
+	}
+}
+
+type unboundedPool struct{}
+
+func (pool *unboundedPool) Do(ctx context.Context, f func() error) error { return f() }
+
+type boundedPool struct {
+	rp          *pools.ResourcePool
+	waitTimeout time.Duration
+}
+
+func (pool *boundedPool) Do(ctx context.Context, f func() error) error {
+	ctx, cancel := context.WithTimeout(ctx, pool.waitTimeout)
+	defer cancel()
+
+	return pool.rp.Do(ctx, func(resource pools.Resource) (pools.Resource, error) {
+		return resource, f()
+	})
+}

--- a/go/vt/vtadmin/cluster/rpc_pool.go
+++ b/go/vt/vtadmin/cluster/rpc_pool.go
@@ -52,8 +52,12 @@ type boundedPool struct {
 }
 
 func (pool *boundedPool) Do(ctx context.Context, f func() error) error {
-	ctx, cancel := context.WithTimeout(ctx, pool.waitTimeout)
-	defer cancel()
+	if pool.waitTimeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, pool.waitTimeout)
+		defer cancel()
+	}
 
 	return pool.rp.Do(ctx, func(resource pools.Resource) (pools.Resource, error) {
 		return resource, f()

--- a/go/vt/vtadmin/testutil/cluster.go
+++ b/go/vt/vtadmin/testutil/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vitessdriver"
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
@@ -101,7 +102,7 @@ func BuildCluster(cfg TestClusterConfig) *cluster.Cluster {
 		Discovery:     disco,
 		DB:            db,
 		Vtctld:        vtctld,
-		GetSchemaPool: cluster.NewRPCPool(0, 0),
+		GetSchemaPool: pools.NewRPCPool(0, 0),
 	}
 }
 

--- a/go/vt/vtadmin/testutil/cluster.go
+++ b/go/vt/vtadmin/testutil/cluster.go
@@ -96,11 +96,12 @@ func BuildCluster(cfg TestClusterConfig) *cluster.Cluster {
 	}
 
 	return &cluster.Cluster{
-		ID:        cfg.Cluster.Id,
-		Name:      cfg.Cluster.Name,
-		Discovery: disco,
-		DB:        db,
-		Vtctld:    vtctld,
+		ID:            cfg.Cluster.Id,
+		Name:          cfg.Cluster.Name,
+		Discovery:     disco,
+		DB:            db,
+		Vtctld:        vtctld,
+		GetSchemaPool: cluster.NewRPCPool(0, 0),
 	}
 }
 


### PR DESCRIPTION
## Description

This PR does the following:
* Add a `Do` function to the existing `pools.ResourcePool`, for use when you want to Get a resource, then do something with it, and then optionally Put it back, to manage the Get/Put lifecycle for you.
* Add an `EmptyResource` type to `package pools`, which allows a caller to get the behavior of a ResourcePool (including all the tracing and stats) without having to actually create or use "real resources".
    * In the case of using `EmptyResource` you _probably_ never want to `Put(nil)` or use an `idleTimeout` (because the actual `Resource` values don't matter), but we don't enforce that.
* Add an `RPCPool` interface to vtadmin/cluster, which is a further abstraction on top of the `(pools/*ResourcePool).Do(...)` method, and provide both bounded and unbounded pool implementations for it.
* Add `getschema-rpcpool-{size,wait-timeout}` options to the cluster config DSN. Use these to create either an unbounded or bounded pool, depending on the size, and gate `GetSchema` calls via that pool.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Closes #7866 

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
