### PR TITLE
Add missing return in `vtctld-*` DSN case, and log any flag that gets ignored

### DIFF
--- a/go/vt/vtadmin/cluster/flags.go
+++ b/go/vt/vtadmin/cluster/flags.go
@@ -19,6 +19,8 @@ package cluster
 import (
 	"regexp"
 	"strings"
+
+	"vitess.io/vitess/go/vt/log"
 )
 
 // FlagsByImpl groups a set of flags by discovery implementation. Its mapping is
@@ -156,11 +158,14 @@ func parseOne(cfg *Config, name string, val string) error {
 			}
 
 			cfg.VtctldFlags[strings.TrimPrefix(name, "vtctld-")] = val
+
+			return nil
 		}
 
 		match := discoveryFlagRegexp.FindStringSubmatch(name)
 		if match == nil {
 			// not a discovery flag
+			log.Warningf("Attempted to parse %q as a discovery flag, ignoring ...", name)
 			return nil
 		}
 


### PR DESCRIPTION
## Description

A short-and-sweet one! I noticed we were missing a `return nil` in the case where a flag in the cluster DSN began with `vtctld-`, which meant that we were both correctly sending that flag off to the `VtctldClientProxy` for later parsing, _but also_ falling through and attempting to match it against the discovery regexp (which, thankfully, would promptly fail to match). (Compare this block against the block just above where the flag begins with `vtsql-` to see the difference).

This PR adds in that missing return, and also logs any flag that falls through to the discovery case that does not match the regexp, so we can more easily catch (relatively harmless) issues like this if they happen in the future.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **n/a**
- [ ] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
