### PR TITLE
[vtadmin-web] Display more data on /gates view and add filtering

### DIFF
--- a/web/vtadmin/src/components/routes/Gates.module.scss
+++ b/web/vtadmin/src/components/routes/Gates.module.scss
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.controls {
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: 1fr min-content;
+  margin-bottom: 24px;
+}

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -17,7 +17,6 @@ import { orderBy } from 'lodash-es';
 import * as React from 'react';
 import { useGates } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
-import { vtadmin as pb } from '../../proto/vtadmin';
 import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
 
@@ -26,21 +25,33 @@ export const Gates = () => {
     const { data } = useGates();
 
     const rows = React.useMemo(() => {
-        return orderBy(data, ['cluster.name', 'hostname']);
+        const mapped = (data || []).map((g) => ({
+            cell: g.cell,
+            cluster: g.cluster?.name,
+            hostname: g.hostname,
+            keyspaces: g.keyspaces,
+            pool: g.pool,
+        }));
+        return orderBy(mapped, ['cluster', 'pool', 'hostname', 'cell']);
     }, [data]);
 
-    const renderRows = (gates: pb.VTGate[]) =>
+    const renderRows = (gates: typeof rows) =>
         gates.map((gate, idx) => (
             <tr key={idx}>
-                <DataCell>{gate.cluster?.name}</DataCell>
-                <DataCell>{gate.hostname}</DataCell>
+                <DataCell className="white-space-nowrap">
+                    <div>{gate.pool}</div>
+                    <div className="font-size-small text-color-secondary">{gate.cluster}</div>
+                </DataCell>
+                <DataCell className="white-space-nowrap">{gate.hostname}</DataCell>
+                <DataCell className="white-space-nowrap">{gate.cell}</DataCell>
+                <DataCell>{(gate.keyspaces || []).join(', ')}</DataCell>
             </tr>
         ));
 
     return (
         <div className="max-width-content">
             <h1>Gates</h1>
-            <DataTable columns={['Cluster', 'Hostname']} data={rows} renderRows={renderRows} />
+            <DataTable columns={['Pool', 'Hostname', 'Cell', 'Keyspaces']} data={rows} renderRows={renderRows} />
         </div>
     );
 };


### PR DESCRIPTION
## Description

A small PR to restructure the /gates view + add a filter input. (If... you hadn't noticed, I'm still favoring repetition over (bad) abstraction for these list views on purpose, since they'll diverge in significant ways when we add the dropdown filters and ... I've already made the mistake of poor abstraction in our internal prototype.) 😎 

Before:

<img width="2672" alt="Screen Shot 2021-04-15 at 3 27 36 PM" src="https://user-images.githubusercontent.com/855595/114927114-205b2e80-9dff-11eb-9e99-ed70f8ec3649.png">

After:

<img width="2672" alt="Screen Shot 2021-04-15 at 3 26 05 PM" src="https://user-images.githubusercontent.com/855595/114926992-fbff5200-9dfe-11eb-950a-84bdd35a531f.png">
<img width="2672" alt="Screen Shot 2021-04-15 at 3 26 09 PM" src="https://user-images.githubusercontent.com/855595/114926980-f6a20780-9dfe-11eb-9a88-ae718063bb0c.png">

## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **Nope**
- [x] Tests were added or are not required **N/A**
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
