### PR TITLE
VReplication: ability to compress gtid when stored in _vt.vreplication's pos column

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	debug = false // set to true to always use local env vtdataroot for local debugging
+	debug = false // set to true for local debugging: this uses the local env vtdataroot and does not teardown clusters
 
 	originalVtdataroot    string
 	vtdataroot            string
@@ -391,6 +391,9 @@ func (vc *VitessCluster) AddCell(t testing.TB, name string) (*Cell, error) {
 
 // TearDown brings down a cluster, deleting processes, removing topo keys
 func (vc *VitessCluster) TearDown(t testing.TB) {
+	if debug {
+		return
+	}
 	for _, cell := range vc.Cells {
 		for _, vtgate := range cell.Vtgates {
 			if err := vtgate.TearDown(); err != nil {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -162,7 +162,10 @@ func TestMultiCellVreplicationWorkflow(t *testing.T) {
 
 func TestCellAliasVreplicationWorkflow(t *testing.T) {
 	cells := []string{"zone1", "zone2"}
-
+	mainClusterConfig.vreplicationCompressGTID = true
+	defer func() {
+		mainClusterConfig.vreplicationCompressGTID = false
+	}()
 	vc = NewVitessCluster(t, "TestBasicVreplicationWorkflow", cells, mainClusterConfig)
 	require.NotNil(t, vc)
 	allCellNames = "zone1,zone2"

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -21,8 +21,11 @@ package binlogplayer
 
 import (
 	"bytes"
+	"compress/zlib"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"math"
 	"sync"
 	"time"
@@ -470,13 +473,13 @@ func (blp *BinlogPlayer) exec(sql string) (*sqltypes.Result, error) {
 //   transaction_timestamp alone (keeping the old value), and we don't
 //   change SecondsBehindMaster
 func (blp *BinlogPlayer) writeRecoveryPosition(tx *binlogdatapb.BinlogTransaction) error {
-	position, err := mysql.DecodePosition(tx.EventToken.Position)
+	position, err := DecodePosition(tx.EventToken.Position)
 	if err != nil {
 		return err
 	}
 
 	now := time.Now().Unix()
-	updateRecovery := GenerateUpdatePos(blp.uid, position, now, tx.EventToken.Timestamp, blp.blplStats.CopyRowCount.Get())
+	updateRecovery := GenerateUpdatePos(blp.uid, position, now, tx.EventToken.Timestamp, blp.blplStats.CopyRowCount.Get(), false)
 
 	qr, err := blp.exec(updateRecovery)
 	if err != nil {
@@ -593,7 +596,7 @@ func ReadVRSettings(dbClient DBClient, uid uint32) (VRSettings, error) {
 	if err != nil {
 		return VRSettings{}, fmt.Errorf("failed to parse max_replication_lag column: %v", err)
 	}
-	startPos, err := mysql.DecodePosition(vrRow[0].ToString())
+	startPos, err := DecodePosition(vrRow[0].ToString())
 	if err != nil {
 		return VRSettings{}, fmt.Errorf("failed to parse pos column: %v", err)
 	}
@@ -630,16 +633,18 @@ func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource,
 
 // GenerateUpdatePos returns a statement to update a value in the
 // _vt.vreplication table.
-func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTimestamp int64, rowsCopied int64) string {
+func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTimestamp int64, rowsCopied int64, compress bool) string {
+	strGTID := encodeString(mysql.EncodePosition(pos))
+	if compress {
+		strGTID = fmt.Sprintf("compress(%s)", strGTID)
+	}
 	if txTimestamp != 0 {
 		return fmt.Sprintf(
 			"update _vt.vreplication set pos=%v, time_updated=%v, transaction_timestamp=%v, rows_copied=%v, message='' where id=%v",
-			encodeString(mysql.EncodePosition(pos)), timeUpdated, txTimestamp, rowsCopied, uid)
+			strGTID, timeUpdated, txTimestamp, rowsCopied, uid)
 	}
-
 	return fmt.Sprintf(
-		"update _vt.vreplication set pos=%v, time_updated=%v, rows_copied=%v, message='' where id=%v",
-		encodeString(mysql.EncodePosition(pos)), timeUpdated, rowsCopied, uid)
+		"update _vt.vreplication set pos=%v, time_updated=%v, , rows_copied=%v, message='' where id=%v", strGTID, timeUpdated, rowsCopied, uid)
 }
 
 // GenerateUpdateTime returns a statement to update time_updated in the _vt.vreplication table.
@@ -701,6 +706,49 @@ func ReadVReplicationPos(index uint32) string {
 // given stream from the _vt.vreplication table.
 func ReadVReplicationStatus(index uint32) string {
 	return fmt.Sprintf("select pos, state, message from _vt.vreplication where id=%v", index)
+}
+
+// MysqlUncompress will uncompress a binary string in the format stored by mysql's compress() function
+// The first four bytes represent the size of the original string passed to compress()
+// Remaining part is the compressed string using zlib, which we uncompress here using golang's zlib library
+func MysqlUncompress(input string) []byte {
+	// consistency check
+	inputBytes := []byte(input)
+	if len(inputBytes) < 5 {
+		return nil
+	}
+
+	// determine length
+	dataLength := uint32(inputBytes[0]) + uint32(inputBytes[1])<<8 + uint32(inputBytes[2])<<16 + uint32(inputBytes[3])<<24
+	dataLengthBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(dataLengthBytes, dataLength)
+	dataLength = binary.LittleEndian.Uint32(dataLengthBytes)
+
+	// uncompress using zlib
+	inputData := inputBytes[4:]
+	inputDataBuf := bytes.NewBuffer(inputData)
+	reader, err := zlib.NewReader(inputDataBuf)
+	if err != nil {
+		return nil
+	}
+	var outputBytes bytes.Buffer
+	io.Copy(&outputBytes, reader)
+	if outputBytes.Len() == 0 {
+		return nil
+	}
+	if dataLength != uint32(outputBytes.Len()) { // double check that the stored and uncompressed lengths match
+		return nil
+	}
+	return outputBytes.Bytes()
+}
+
+// DecodePosition attempts to uncompress the passed value first and if it fails tries to decode it as a valid GTID
+func DecodePosition(gtid string) (mysql.Position, error) {
+	b := MysqlUncompress(gtid)
+	if b != nil {
+		gtid = string(b)
+	}
+	return mysql.DecodePosition(gtid)
 }
 
 // StatsHistoryRecord is used to store a Message with timestamp

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -560,6 +560,7 @@ var AlterVReplicationTable = []string{
 	"ALTER TABLE _vt.vreplication ADD COLUMN rows_copied BIGINT(20) NOT NULL DEFAULT 0",
 }
 
+// WithDDLInitialQueries contains the queries to be expected by the mock db client during tests
 var WithDDLInitialQueries = []string{
 	"SELECT db_name FROM _vt.vreplication LIMIT 0",
 	"SELECT rows_copied FROM _vt.vreplication LIMIT 0",
@@ -644,7 +645,7 @@ func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTime
 			strGTID, timeUpdated, txTimestamp, rowsCopied, uid)
 	}
 	return fmt.Sprintf(
-		"update _vt.vreplication set pos=%v, time_updated=%v, , rows_copied=%v, message='' where id=%v", strGTID, timeUpdated, rowsCopied, uid)
+		"update _vt.vreplication set pos=%v, time_updated=%v, rows_copied=%v, message='' where id=%v", strGTID, timeUpdated, rowsCopied, uid)
 }
 
 // GenerateUpdateTime returns a statement to update time_updated in the _vt.vreplication table.

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -361,7 +361,7 @@ func TestUpdateVReplicationPos(t *testing.T) {
 		"set pos='MariaDB/0-1-8283', time_updated=88822, rows_copied=0, message='' " +
 		"where id=78522"
 
-	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0, 0,false)
+	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0, 0, false)
 	if got != want {
 		t.Errorf("updateVReplicationPos() = %#v, want %#v", got, want)
 	}

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -361,7 +361,7 @@ func TestUpdateVReplicationPos(t *testing.T) {
 		"set pos='MariaDB/0-1-8283', time_updated=88822, rows_copied=0, message='' " +
 		"where id=78522"
 
-	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0, 0)
+	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0, 0,false)
 	if got != want {
 		t.Errorf("updateVReplicationPos() = %#v, want %#v", got, want)
 	}
@@ -373,7 +373,7 @@ func TestUpdateVReplicationTimestamp(t *testing.T) {
 		"set pos='MariaDB/0-2-582', time_updated=88822, transaction_timestamp=481828, rows_copied=0, message='' " +
 		"where id=78522"
 
-	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 481828, 0)
+	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 481828, 0, false)
 	if got != want {
 		t.Errorf("updateVReplicationPos() = %#v, want %#v", got, want)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -340,7 +340,7 @@ func (vc *vcopier) fastForward(ctx context.Context, copyState map[string]*sqltyp
 		return err
 	}
 	if settings.StartPos.IsZero() {
-		update := binlogplayer.GenerateUpdatePos(vc.vr.id, pos, time.Now().Unix(), 0, vc.vr.stats.CopyRowCount.Get())
+		update := binlogplayer.GenerateUpdatePos(vc.vr.id, pos, time.Now().Unix(), 0, vc.vr.stats.CopyRowCount.Get(), *vreplicationStoreCompressedGTID)
 		_, err := vc.vr.dbClient.Execute(update)
 		return err
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -231,7 +231,7 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 
 func (vp *vplayer) updatePos(ts int64) (posReached bool, err error) {
 	vp.numAccumulatedHeartbeats = 0
-	update := binlogplayer.GenerateUpdatePos(vp.vr.id, vp.pos, time.Now().Unix(), ts, vp.vr.stats.CopyRowCount.Get())
+	update := binlogplayer.GenerateUpdatePos(vp.vr.id, vp.pos, time.Now().Unix(), ts, vp.vr.stats.CopyRowCount.Get(), *vreplicationStoreCompressedGTID)
 	if _, err := vp.vr.dbClient.Execute(update); err != nil {
 		return false, fmt.Errorf("error %v updating position", err)
 	}
@@ -428,7 +428,7 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 	stats := NewVrLogStats(event.Type.String())
 	switch event.Type {
 	case binlogdatapb.VEventType_GTID:
-		pos, err := mysql.DecodePosition(event.Gtid)
+		pos, err := binlogplayer.DecodePosition(event.Gtid)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -62,6 +62,8 @@ var (
 	vreplicationExperimentalFlags = flag.Int64("vreplication_experimental_flags", 0, "(Bitmask) of experimental features in vreplication to enable")
 
 	vreplicationExperimentalFlagOptimizeInserts int64 = 1
+
+	vreplicationStoreCompressedGTID = flag.Bool("vreplication_store_compressed_gtid", false, "Store compressed gtids in the pos column of _vt.vreplication")
 )
 
 // vreplicator provides the core logic to start vreplication streams

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 
 	"github.com/golang/protobuf/proto"
@@ -590,7 +591,7 @@ func (df *vdiff) stopTargets(ctx context.Context) error {
 			if err := proto.UnmarshalText(row[0].ToString(), &bls); err != nil {
 				return err
 			}
-			pos, err := mysql.DecodePosition(row[1].ToString())
+			pos, err := binlogplayer.DecodePosition(row[1].ToString())
 			if err != nil {
 				return err
 			}
@@ -726,7 +727,7 @@ func (df *vdiff) syncTargets(ctx context.Context, filteredReplicationWaitTime ti
 		if err != nil {
 			return err
 		}
-		mpos, err := mysql.DecodePosition(pos)
+		mpos, err := binlogplayer.DecodePosition(pos)
 		if err != nil {
 			return err
 		}

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -24,11 +24,12 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 
 	"github.com/golang/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"vitess.io/vitess/go/mysql"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"
@@ -410,12 +411,13 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqlty
 
 	// gtid in the pos column can be compressed, so check and possibly uncompress
 	pos = row[2].ToString()
-	mpos, err = binlogplayer.DecodePosition(pos)
-	pos = mpos.String()
-	if err != nil {
-		return nil, "", err
+	if pos != "" {
+		mpos, err = binlogplayer.DecodePosition(pos)
+		if err != nil {
+			return nil, "", err
+		}
+		pos = mpos.String()
 	}
-
 	stopPos = row[3].ToString()
 	state = row[5].ToString()
 	dbName = row[6].ToString()

--- a/go/vt/wrangler/vexec_test.go
+++ b/go/vt/wrangler/vexec_test.go
@@ -32,7 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 )
 
-func TestVExec(t *testing.T) {
+func TestVExec2(t *testing.T) {
 	ctx := context.Background()
 	workflow := "wrWorkflow"
 	keyspace := "target"
@@ -153,15 +153,15 @@ func TestVExec(t *testing.T) {
 	dryRunResults := []string{
 		"Query: delete from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'",
 		"will be run on the following streams in keyspace target for workflow wrWorkflow:\n\n",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
-		"|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
-		"| -80/zone1-0000000200 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |",
-		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
-		"| 80-/zone1-0000000210 |  1 | keyspace:\"source\" shard:\"0\"    | Copying | vt_target | pos          |",
-		"|                      |    | filter:<rules:<match:\"t1\" > >  |         |           |              |",
-		"+----------------------+----+--------------------------------+---------+-----------+--------------+",
+		`+----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   |               CURRENT GTID               |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+| -80/zone1-0000000200 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | 14b68925-696a-11ea-aee7-fec597a91f5e:1-3 |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |                                          |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+| 80-/zone1-0000000210 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | 14b68925-696a-11ea-aee7-fec597a91f5e:1-3 |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |                                          |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+`,
 	}
 	require.Equal(t, strings.Join(dryRunResults, "\n")+"\n\n\n\n\n", logger.String())
 }
@@ -228,7 +228,7 @@ func TestWorkflowListStreams(t *testing.T) {
 							]
 						}
 					},
-					"Pos": "pos",
+					"Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
 					"StopPos": "",
 					"State": "Copying",
 					"DBName": "vt_target",
@@ -263,7 +263,7 @@ func TestWorkflowListStreams(t *testing.T) {
 							]
 						}
 					},
-					"Pos": "pos",
+					"Pos": "14b68925-696a-11ea-aee7-fec597a91f5e:1-3",
 					"StopPos": "",
 					"State": "Copying",
 					"DBName": "vt_target",
@@ -312,15 +312,15 @@ func TestWorkflowListStreams(t *testing.T) {
 will be run on the following streams in keyspace target for workflow wrWorkflow:
 
 
-+----------------------+----+--------------------------------+---------+-----------+--------------+
-|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   | CURRENT GTID |
-+----------------------+----+--------------------------------+---------+-----------+--------------+
-| -80/zone1-0000000200 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |
-|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |
-+----------------------+----+--------------------------------+---------+-----------+--------------+
-| 80-/zone1-0000000210 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | pos          |
-|                      |    | filter:<rules:<match:"t1" > >  |         |           |              |
-+----------------------+----+--------------------------------+---------+-----------+--------------+
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+|        TABLET        | ID |          BINLOGSOURCE          |  STATE  |  DBNAME   |               CURRENT GTID               |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+| -80/zone1-0000000200 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | 14b68925-696a-11ea-aee7-fec597a91f5e:1-3 |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |                                          |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
+| 80-/zone1-0000000210 |  1 | keyspace:"source" shard:"0"    | Copying | vt_target | 14b68925-696a-11ea-aee7-fec597a91f5e:1-3 |
+|                      |    | filter:<rules:<match:"t1" > >  |         |           |                                          |
++----------------------+----+--------------------------------+---------+-----------+------------------------------------------+
 
 
 

--- a/go/vt/wrangler/wrangler_env_test.go
+++ b/go/vt/wrangler/wrangler_env_test.go
@@ -146,7 +146,7 @@ func newWranglerTestEnv(sourceShards, targetShards []string, query string, posit
 		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields(
 			"id|source|pos|stop_pos|max_replication_lag|state|db_name|time_updated|transaction_timestamp|message",
 			"int64|varchar|varchar|varchar|int64|varchar|varchar|int64|int64|varchar"),
-			fmt.Sprintf("1|%v|pos||0|Running|vt_target|%d|0|", bls, timeUpdated),
+			fmt.Sprintf("1|%v|MySQL56/14b68925-696a-11ea-aee7-fec597a91f5e:1-3||0|Running|vt_target|%d|0|", bls, timeUpdated),
 		)
 		env.tmc.setVRResults(master.tablet, "select id, source, pos, stop_pos, max_replication_lag, state, db_name, time_updated, transaction_timestamp, message from _vt.vreplication where db_name = 'vt_target' and workflow = 'wrWorkflow'", result)
 		env.tmc.setVRResults(

--- a/tools/rowlog/rowlog.go
+++ b/tools/rowlog/rowlog.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 
 	"vitess.io/vitess/go/mysql"
@@ -202,11 +203,11 @@ func startStreaming(ctx context.Context, vtgate, vtctld, keyspace, tablet, table
 			//fmt.Printf("stopPos %s\n", stopPos)
 			var err error
 			var currentPosition, stopPosition mysql.Position
-			currentPosition, err = mysql.DecodePosition(gtid)
+			currentPosition, err = binlogplayer.DecodePosition(gtid)
 			if err != nil {
 				fmt.Errorf("Error decoding position for %s:%vs\n", gtid, err.Error())
 			}
-			stopPosition, err = mysql.DecodePosition(stopPos)
+			stopPosition, err = binlogplayer.DecodePosition(stopPos)
 			if err != nil {
 				fmt.Errorf("Error decoding position for %s:%vs\n", stopPos, err.Error())
 			}


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description
During the replication phase of a workflow the gtid of every transaction is recorded in the `pos` column of the `_vt.vreplication` table so that the target can keep track of their current position with respect to the source. We also have a heartbeat (default 1 second, configurable to a maximum of one minute) that updates the `time_updated` column for a proof-of-life of the stream. 

For long running workflows this can cause a significant increase in the size of binlogs especially in cases where there is a high write QPS or if there have been a lot of reparenting operations increasing the size of each gtid. This problem is accentuated because in the full mode of RBR (which Vitess requires) the gtids are present both in the before and after images.

This PR adds an option to vttablet to compress gtids before storing it into the `pos` column. We use the same (zlib) algorithm as implemented by the `compress()` function. This makes it easier to inspect the column in sql using `select uncompress(pos) from _vt.vreplication`. This alss means we can use the (presumably efficient) mysql `compress()` function to compress and only need to write go code for the decompression. The compression achieved by this should be between 60-80% since the gtid is a hex string. 

We put this functionality behind the `-vreplication_store_compressed_gtid` boolean flag (default: false), since users may prefer to have clear text positions for readability. 

Independent of this option, we support both compressed and clear-text gtids while reading the `pos` column. So if a vttablet is first run with the option on and later it is turned off we will still be able to read the compressed gtid and future updates will store the pos in clear text. (and vice-versa).

Note that movetables or reshard workflows tend to be short-lived. Most of the data migration is done using in the copy phase which does not generate a lot of `pos` updates. So if you don't expect to use long-running Materialize flows it may not be very beneficial to enable this feature.

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
