### PR TITLE
vreplication: performance & benchmarks (table copying)

### DIFF
--- a/config/mycnf/default.cnf
+++ b/config/mycnf/default.cnf
@@ -10,6 +10,10 @@ relay-log-index =  {{.RelayLogIndexPath}}
 pid-file = {{.PidFile}}
 port = {{.MysqlPort}}
 
+{{if .SecureFilePriv}}
+secure-file-priv = {{.SecureFilePriv}}
+{{end}}
+
 # all db instances should start in read-only mode - once the db is started and
 # fully functional, we'll push it into read-write mode
 read-only

--- a/go/bytes2/buffer.go
+++ b/go/bytes2/buffer.go
@@ -61,10 +61,14 @@ func (buf *Buffer) String() string {
 	return string(buf.bytes)
 }
 
+// StringUnsafe is equivalent to String, but the copy of the string that it returns
+// is _not_ allocated, so modifying this buffer after calling StringUnsafe will lead
+// to undefined behavior.
 func (buf *Buffer) StringUnsafe() string {
 	return *(*string)(unsafe.Pointer(&buf.bytes))
 }
 
+// Reset is equivalent to bytes.Buffer.Reset.
 func (buf *Buffer) Reset() {
 	buf.bytes = buf.bytes[:0]
 }

--- a/go/bytes2/buffer.go
+++ b/go/bytes2/buffer.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package bytes2
 
+import "unsafe"
+
 // Buffer implements a subset of the write portion of
 // bytes.Buffer, but more efficiently. This is meant to
 // be used in very high QPS operations, especially for
@@ -57,6 +59,14 @@ func (buf *Buffer) Bytes() []byte {
 // Strings is equivalent to bytes.Buffer.Strings.
 func (buf *Buffer) String() string {
 	return string(buf.bytes)
+}
+
+func (buf *Buffer) StringUnsafe() string {
+	return *(*string)(unsafe.Pointer(&buf.bytes))
+}
+
+func (buf *Buffer) Reset() {
+	buf.bytes = buf.bytes[:0]
 }
 
 // Len is equivalent to bytes.Buffer.Len.

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -284,6 +284,36 @@ func (v Value) EncodeSQL(b BinWriter) {
 	}
 }
 
+// EncodeSQLStringBuilder is identical to EncodeSQL but it takes a strings.Builder
+// as its writer, so it can be inlined for performance.
+func (v Value) EncodeSQLStringBuilder(b *strings.Builder) {
+	switch {
+	case v.typ == Null:
+		b.Write(nullstr)
+	case v.IsQuoted():
+		encodeBytesSQLStringBuilder(v.val, b)
+	case v.typ == Bit:
+		encodeBytesSQLBits(v.val, b)
+	default:
+		b.Write(v.val)
+	}
+}
+
+// EncodeSQLBytes2 is identical to EncodeSQL but it takes a bytes2.Buffer
+// as its writer, so it can be inlined for performance.
+func (v Value) EncodeSQLBytes2(b *bytes2.Buffer) {
+	switch {
+	case v.typ == Null:
+		b.Write(nullstr)
+	case v.IsQuoted():
+		encodeBytesSQLBytes2(v.val, b)
+	case v.typ == Bit:
+		encodeBytesSQLBits(v.val, b)
+	default:
+		b.Write(v.val)
+	}
+}
+
 // EncodeASCII encodes the value using 7-bit clean ascii bytes.
 func (v Value) EncodeASCII(b BinWriter) {
 	switch {
@@ -387,6 +417,11 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 
 func encodeBytesSQL(val []byte, b BinWriter) {
 	buf := &bytes2.Buffer{}
+	encodeBytesSQLBytes2(val, buf)
+	b.Write(buf.Bytes())
+}
+
+func encodeBytesSQLBytes2(val []byte, buf *bytes2.Buffer) {
 	buf.WriteByte('\'')
 	for _, ch := range val {
 		if encodedChar := SQLEncodeMap[ch]; encodedChar == DontEscape {
@@ -397,7 +432,19 @@ func encodeBytesSQL(val []byte, b BinWriter) {
 		}
 	}
 	buf.WriteByte('\'')
-	b.Write(buf.Bytes())
+}
+
+func encodeBytesSQLStringBuilder(val []byte, buf *strings.Builder) {
+	buf.WriteByte('\'')
+	for _, ch := range val {
+		if encodedChar := SQLEncodeMap[ch]; encodedChar == DontEscape {
+			buf.WriteByte(ch)
+		} else {
+			buf.WriteByte('\\')
+			buf.WriteByte(encodedChar)
+		}
+	}
+	buf.WriteByte('\'')
 }
 
 // BufEncodeStringSQL encodes the string into a strings.Builder

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -48,6 +48,9 @@ var (
 	forceVTDATAROOT    = flag.String("force-vtdataroot", "", "force path for VTDATAROOT, which may already be populated")
 	forcePortStart     = flag.Int("force-port-start", 0, "force assigning ports based on this seed")
 	forceBaseTabletUID = flag.Int("force-base-tablet-uid", 0, "force assigning tablet ports based on this seed")
+
+	// PerfTest controls whether to run the slower end-to-end tests that check the system's performance
+	PerfTest = flag.Bool("perf-test", false, "include end-to-end performance tests")
 )
 
 // LocalProcessCluster Testcases need to use this to iniate a cluster

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -203,7 +203,7 @@ func (vtgate *VtgateProcess) TearDown() error {
 		vtgate.proc = nil
 		return nil
 
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		vtgate.proc.Process.Kill()
 		vtgate.proc = nil
 		return <-vtgate.exit

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -103,10 +103,12 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vreplication_tablet_type", vttablet.VreplicationTabletType,
-		"-pprof", fmt.Sprintf("cpu,waitSig,path=vttablet_pprof_%s", vttablet.Name),
 	)
 	if *isCoverage {
 		vttablet.proc.Args = append(vttablet.proc.Args, "-test.coverprofile="+getCoveragePath("vttablet.out"))
+	}
+	if *PerfTest {
+		vttablet.proc.Args = append(vttablet.proc.Args, "-pprof", fmt.Sprintf("cpu,waitSig,path=vttablet_pprof_%s", vttablet.Name))
 	}
 
 	if vttablet.SupportsBackup {

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -100,6 +100,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vreplication_tablet_type", vttablet.VreplicationTabletType,
+		"-pprof", fmt.Sprintf("cpu,waitSig,path=cpu_prof_%s.pb.gz", vttablet.Name),
 	)
 	if *isCoverage {
 		vttablet.proc.Args = append(vttablet.proc.Args, "-test.coverprofile="+getCoveragePath("vttablet.out"))
@@ -360,6 +361,10 @@ func (vttablet *VttabletProcess) getDBSystemValues(placeholder string, value str
 		return fmt.Sprintf("%s", output.Rows[0][1].ToBytes()), nil
 	}
 	return "", nil
+}
+
+func (vttablet *VttabletProcess) StartProfiling() error {
+	return vttablet.proc.Process.Signal(syscall.SIGUSR1)
 }
 
 // VttabletProcessInstance returns a VttabletProcess handle for vttablet process

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -18,9 +18,11 @@ limitations under the License.
 package cluster
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -29,6 +31,7 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 
 	"vitess.io/vitess/go/mysql"
@@ -100,7 +103,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vtctld_addr", vttablet.VtctldAddress,
 		"-vreplication_tablet_type", vttablet.VreplicationTabletType,
-		"-pprof", fmt.Sprintf("cpu,waitSig,path=cpu_prof_%s.pb.gz", vttablet.Name),
+		"-pprof", fmt.Sprintf("cpu,waitSig,path=vttablet_pprof_%s", vttablet.Name),
 	)
 	if *isCoverage {
 		vttablet.proc.Args = append(vttablet.proc.Args, "-test.coverprofile="+getCoveragePath("vttablet.out"))
@@ -315,11 +318,15 @@ func (vttablet *VttabletProcess) QueryTablet(query string, keyspace string, useD
 		keyspace = ""
 	}
 	dbParams := NewConnParams(vttablet.DbPort, vttablet.DbPassword, path.Join(vttablet.Directory, "mysql.sock"), keyspace)
-	return executeQuery(dbParams, query)
+	conn, err := vttablet.conn(&dbParams)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return executeQuery(conn, query)
 }
 
-// QueryTabletWithDB lets you execute query on a specific DB in this tablet and get the result
-func (vttablet *VttabletProcess) QueryTabletWithDB(query string, dbname string) (*sqltypes.Result, error) {
+func (vttablet *VttabletProcess) defaultConn(dbname string) (*mysql.Conn, error) {
 	dbParams := mysql.ConnParams{
 		Uname:      "vt_dba",
 		UnixSocket: path.Join(vttablet.Directory, "mysql.sock"),
@@ -328,18 +335,26 @@ func (vttablet *VttabletProcess) QueryTabletWithDB(query string, dbname string) 
 	if vttablet.DbPassword != "" {
 		dbParams.Pass = vttablet.DbPassword
 	}
-	return executeQuery(dbParams, query)
+	return vttablet.conn(&dbParams)
 }
 
-func executeQuery(dbParams mysql.ConnParams, query string) (*sqltypes.Result, error) {
+func (vttablet *VttabletProcess) conn(dbParams *mysql.ConnParams) (*mysql.Conn, error) {
 	ctx := context.Background()
-	dbConn, err := mysql.Connect(ctx, &dbParams)
+	return mysql.Connect(ctx, dbParams)
+}
+
+// QueryTabletWithDB lets you execute query on a specific DB in this tablet and get the result
+func (vttablet *VttabletProcess) QueryTabletWithDB(query string, dbname string) (*sqltypes.Result, error) {
+	conn, err := vttablet.defaultConn(dbname)
 	if err != nil {
 		return nil, err
 	}
-	defer dbConn.Close()
-	qr, err := dbConn.ExecuteFetch(query, 10000, true)
-	return qr, err
+	defer conn.Close()
+	return executeQuery(conn, query)
+}
+
+func executeQuery(dbConn *mysql.Conn, query string) (*sqltypes.Result, error) {
+	return dbConn.ExecuteFetch(query, 10000, true)
 }
 
 // GetDBVar returns first matching database variable's value
@@ -363,8 +378,89 @@ func (vttablet *VttabletProcess) getDBSystemValues(placeholder string, value str
 	return "", nil
 }
 
-func (vttablet *VttabletProcess) StartProfiling() error {
+// ToggleProfiling enables or disables the configured CPU profiler on this vttablet
+func (vttablet *VttabletProcess) ToggleProfiling() error {
 	return vttablet.proc.Process.Signal(syscall.SIGUSR1)
+}
+
+// WaitForVReplicationToCatchup waits for "workflow" to finish copying
+func (vttablet *VttabletProcess) WaitForVReplicationToCatchup(t testing.TB, workflow, database string, duration time.Duration) {
+	queries := [3]string{
+		fmt.Sprintf(`select count(*) from _vt.vreplication where workflow = "%s" and db_name = "%s" and pos = ''`, workflow, database),
+		"select count(*) from information_schema.tables where table_schema='_vt' and table_name='copy_state' limit 1;",
+		fmt.Sprintf(`select count(*) from _vt.copy_state where vrepl_id in (select id from _vt.vreplication where workflow = "%s" and db_name = "%s" )`, workflow, database),
+	}
+	results := [3]string{"[INT64(0)]", "[INT64(1)]", "[INT64(0)]"}
+
+	conn, err := vttablet.defaultConn("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	var lastChecked time.Time
+	for ind, query := range queries {
+		waitDuration := 500 * time.Millisecond
+		for duration > 0 {
+			t.Logf("Executing query %s on %s", query, vttablet.Name)
+			lastChecked = time.Now()
+			qr, err := conn.ExecuteFetch(query, 1000, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if qr != nil && qr.Rows != nil && len(qr.Rows) > 0 && fmt.Sprintf("%v", qr.Rows[0]) == string(results[ind]) {
+				break
+			} else {
+				t.Logf("In WaitForVReplicationToCatchup: %s %+v", query, qr.Rows)
+			}
+			time.Sleep(waitDuration)
+			duration -= waitDuration
+		}
+		if duration <= 0 {
+			t.Fatalf("WaitForVReplicationToCatchup timed out for workflow %s, keyspace %s", workflow, database)
+		}
+	}
+	t.Logf("WaitForVReplicationToCatchup succeeded at %v", lastChecked)
+}
+
+// BulkLoad performs a bulk load of rows into a given vttablet.
+func (vttablet *VttabletProcess) BulkLoad(t testing.TB, db, table string, bulkInsert func(io.Writer)) {
+	tmpbulk, err := ioutil.TempFile(path.Join(vttablet.Directory, "tmp"), "bulk_load")
+	if err != nil {
+		t.Fatalf("failed to create tmp file for loading: %v", err)
+	}
+	defer os.Remove(tmpbulk.Name())
+
+	t.Logf("create temporary file for bulk loading %q", tmpbulk.Name())
+	bufStart := time.Now()
+
+	bulkBuffer := bufio.NewWriter(tmpbulk)
+	bulkInsert(bulkBuffer)
+	bulkBuffer.Flush()
+
+	pos, _ := tmpbulk.Seek(0, 1)
+	bufFinish := time.Now()
+	t.Logf("bulk loading %d bytes from %q...", pos, tmpbulk.Name())
+
+	if err := tmpbulk.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := vttablet.defaultConn("vt_" + db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	query := fmt.Sprintf("LOAD DATA INFILE '%s' INTO TABLE `%s` FIELDS TERMINATED BY ',' ENCLOSED BY '\"'", tmpbulk.Name(), table)
+	_, err = conn.ExecuteFetch(query, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	end := time.Now()
+	t.Logf("bulk insert successful (write tmp file = %v, mysql bulk load = %v, total = %v",
+		bufFinish.Sub(bufStart), end.Sub(bufFinish), end.Sub(bufStart))
 }
 
 // VttabletProcessInstance returns a VttabletProcess handle for vttablet process

--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -48,6 +48,7 @@ type ClusterConfig struct {
 
 // VitessCluster represents all components within the test cluster
 type VitessCluster struct {
+	T             testing.TB
 	ClusterConfig *ClusterConfig
 	Name          string
 	Cells         map[string]*Cell
@@ -211,7 +212,7 @@ func (vc *VitessCluster) AddKeyspace(t *testing.T, cells []*Cell, ksName string,
 	keyspace.VSchema = vschema
 	for _, cell := range cells {
 		if len(cell.Vtgates) == 0 {
-			fmt.Println("Starting vtgate")
+			t.Logf("Starting vtgate")
 			vc.StartVtgate(t, cell, cellsToWatch)
 		}
 	}
@@ -220,7 +221,7 @@ func (vc *VitessCluster) AddKeyspace(t *testing.T, cells []*Cell, ksName string,
 }
 
 // AddTablet creates new tablet with specified attributes
-func (vc *VitessCluster) AddTablet(t *testing.T, cell *Cell, keyspace *Keyspace, shard *Shard, tabletType string, tabletID int) (*Tablet, *exec.Cmd, error) {
+func (vc *VitessCluster) AddTablet(t testing.TB, cell *Cell, keyspace *Keyspace, shard *Shard, tabletType string, tabletID int) (*Tablet, *exec.Cmd, error) {
 	tablet := &Tablet{}
 
 	vttablet := cluster.VttabletProcessInstance(
@@ -263,9 +264,9 @@ func (vc *VitessCluster) AddTablet(t *testing.T, cell *Cell, keyspace *Keyspace,
 }
 
 // AddShards creates shards given list of comma-separated keys with specified tablets in each shard
-func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspace, names string, numReplicas int, numRdonly int, tabletIDBase int) error {
+func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspace, names string, numReplicas int, numRdonly int, tabletIDBase int) error {
 	arrNames := strings.Split(names, ",")
-	fmt.Printf("Addshards got %d shards with %+v\n", len(arrNames), arrNames)
+	t.Logf("Addshards got %d shards with %+v", len(arrNames), arrNames)
 	isSharded := len(arrNames) > 1
 	masterTabletUID := 0
 	for ind, shardName := range arrNames {
@@ -273,9 +274,9 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 		tabletIndex := 0
 		shard := &Shard{Name: shardName, IsSharded: isSharded, Tablets: make(map[string]*Tablet, 1)}
 		if _, ok := keyspace.Shards[shardName]; ok {
-			fmt.Printf("Shard %s already exists, not adding\n", shardName)
+			t.Logf("Shard %s already exists, not adding", shardName)
 		} else {
-			fmt.Printf("Adding Shard %s\n", shardName)
+			t.Logf("Adding Shard %s", shardName)
 			if err := vc.VtctlClient.ExecuteCommand("CreateShard", keyspace.Name+"/"+shardName); err != nil {
 				t.Fatalf("CreateShard command failed with %+v\n", err)
 			}
@@ -286,7 +287,7 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 			tablets := make([]*Tablet, 0)
 			if i == 0 {
 				// only add master tablet for first cell, so first time CreateShard is called
-				fmt.Println("Adding Master tablet")
+				t.Logf("Adding Master tablet")
 				master, proc, err := vc.AddTablet(t, cell, keyspace, shard, "replica", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, master)
@@ -298,7 +299,7 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 			}
 
 			for i := 0; i < numReplicas; i++ {
-				fmt.Println("Adding Replica tablet")
+				t.Logf("Adding Replica tablet")
 				tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "replica", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, tablet)
@@ -307,7 +308,7 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 				dbProcesses = append(dbProcesses, proc)
 			}
 			for i := 0; i < numRdonly; i++ {
-				fmt.Println("Adding RdOnly tablet")
+				t.Logf("Adding RdOnly tablet")
 				tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "rdonly", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, tablet)
@@ -317,40 +318,40 @@ func (vc *VitessCluster) AddShards(t *testing.T, cells []*Cell, keyspace *Keyspa
 			}
 
 			for ind, proc := range dbProcesses {
-				fmt.Printf("Waiting for mysql process for tablet %s\n", tablets[ind].Name)
+				t.Logf("Waiting for mysql process for tablet %s", tablets[ind].Name)
 				if err := proc.Wait(); err != nil {
 					t.Fatalf("%v :: Unable to start mysql server for %v", err, tablets[ind].Vttablet)
 				}
 			}
 			for ind, tablet := range tablets {
-				fmt.Printf("Creating vt_keyspace database for tablet %s\n", tablets[ind].Name)
+				t.Logf("Creating vt_keyspace database for tablet %s", tablets[ind].Name)
 				if _, err := tablet.Vttablet.QueryTablet(fmt.Sprintf("create database vt_%s", keyspace.Name),
 					keyspace.Name, false); err != nil {
 					t.Fatalf("Unable to start create database vt_%s for tablet %v", keyspace.Name, tablet.Vttablet)
 				}
-				fmt.Printf("Running Setup() for vttablet %s\n", tablets[ind].Name)
+				t.Logf("Running Setup() for vttablet %s", tablets[ind].Name)
 				if err := tablet.Vttablet.Setup(); err != nil {
 					t.Fatalf(err.Error())
 				}
 			}
 		}
 		require.NotEqual(t, 0, masterTabletUID, "Should have created a master tablet")
-		fmt.Printf("InitShardMaster for %d\n", masterTabletUID)
+		t.Logf("InitShardMaster for %d", masterTabletUID)
 		require.NoError(t, vc.VtctlClient.InitShardMaster(keyspace.Name, shardName, cells[0].Name, masterTabletUID))
-		fmt.Printf("Finished creating shard %s\n", shard.Name)
+		t.Logf("Finished creating shard %s", shard.Name)
 	}
 	return nil
 }
 
 // DeleteShard deletes a shard
-func (vc *VitessCluster) DeleteShard(t *testing.T, cellName string, ksName string, shardName string) {
+func (vc *VitessCluster) DeleteShard(t testing.TB, cellName string, ksName string, shardName string) {
 	shard := vc.Cells[cellName].Keyspaces[ksName].Shards[shardName]
 	require.NotNil(t, shard)
 	for _, tab := range shard.Tablets {
-		fmt.Printf("Shutting down tablet %s\n", tab.Name)
+		t.Logf("Shutting down tablet %s", tab.Name)
 		tab.Vttablet.TearDown()
 	}
-	fmt.Printf("Deleting Shard %s\n", shardName)
+	t.Logf("Deleting Shard %s", shardName)
 	//TODO how can we avoid the use of even_if_serving?
 	if output, err := vc.VtctlClient.ExecuteCommandWithOutput("DeleteShard", "-recursive", "-even_if_serving", ksName+"/"+shardName); err != nil {
 		t.Fatalf("DeleteShard command failed with error %+v and output %s\n", err, output)
@@ -359,7 +360,7 @@ func (vc *VitessCluster) DeleteShard(t *testing.T, cellName string, ksName strin
 }
 
 // StartVtgate starts a vtgate process
-func (vc *VitessCluster) StartVtgate(t *testing.T, cell *Cell, cellsToWatch string) {
+func (vc *VitessCluster) StartVtgate(t testing.TB, cell *Cell, cellsToWatch string) {
 	vtgate := cluster.VtgateProcessInstance(
 		vc.ClusterConfig.vtgatePort,
 		vc.ClusterConfig.vtgateGrpcPort,
@@ -379,14 +380,14 @@ func (vc *VitessCluster) StartVtgate(t *testing.T, cell *Cell, cellsToWatch stri
 }
 
 // AddCell adds a new cell to the cluster
-func (vc *VitessCluster) AddCell(t *testing.T, name string) (*Cell, error) {
+func (vc *VitessCluster) AddCell(t testing.TB, name string) (*Cell, error) {
 	cell := &Cell{Name: name, Keyspaces: make(map[string]*Keyspace), Vtgates: make([]*cluster.VtgateProcess, 0)}
 	vc.Cells[name] = cell
 	return cell, nil
 }
 
 // TearDown brings down a cluster, deleting processes, removing topo keys
-func (vc *VitessCluster) TearDown() {
+func (vc *VitessCluster) TearDown(t testing.TB) {
 	for _, cell := range vc.Cells {
 		for _, vtgate := range cell.Vtgates {
 			if err := vtgate.TearDown(); err != nil {
@@ -400,12 +401,12 @@ func (vc *VitessCluster) TearDown() {
 				for _, tablet := range shard.Tablets {
 					if tablet.DbServer != nil && tablet.DbServer.TabletUID > 0 {
 						if _, err := tablet.DbServer.StopProcess(); err != nil {
-							log.Errorf("Error stopping mysql process: %s", err.Error())
+							t.Logf("Error stopping mysql process: %s", err.Error())
 						}
 					}
-					fmt.Printf("Stopping vttablet %s\n", tablet.Name)
+					t.Logf("Stopping vttablet %s", tablet.Name)
 					if err := tablet.Vttablet.TearDown(); err != nil {
-						fmt.Printf("Stopped vttablet %s %s\n", tablet.Name, err.Error())
+						t.Logf("Stopped vttablet %s %s", tablet.Name, err.Error())
 					}
 				}
 			}
@@ -413,18 +414,18 @@ func (vc *VitessCluster) TearDown() {
 	}
 
 	if err := vc.Vtctld.TearDown(); err != nil {
-		fmt.Printf("Error stopping Vtctld:  %s\n", err.Error())
+		t.Logf("Error stopping Vtctld:  %s", err.Error())
 	}
 
 	for _, cell := range vc.Cells {
 		if err := vc.Topo.TearDown(cell.Name, originalVtdataroot, vtdataroot, false, "etcd2"); err != nil {
-			fmt.Printf("Error in etcd teardown - %s\n", err.Error())
+			t.Logf("Error in etcd teardown - %s", err.Error())
 		}
 	}
 }
 
 // WaitForVReplicationToCatchup waits for "workflow" to finish copying
-func (vc *VitessCluster) WaitForVReplicationToCatchup(vttablet *cluster.VttabletProcess, workflow string, database string, duration time.Duration) error {
+func (vc *VitessCluster) WaitForVReplicationToCatchup(t testing.TB, vttablet *cluster.VttabletProcess, workflow string, database string, duration time.Duration) error {
 	queries := [3]string{
 		fmt.Sprintf(`select count(*) from _vt.vreplication where workflow = "%s" and db_name = "%s" and pos = ''`, workflow, database),
 		"select count(*) from information_schema.tables where table_schema='_vt' and table_name='copy_state' limit 1;",
@@ -435,7 +436,7 @@ func (vc *VitessCluster) WaitForVReplicationToCatchup(vttablet *cluster.Vttablet
 	for ind, query := range queries {
 		waitDuration := 500 * time.Millisecond
 		for duration > 0 {
-			fmt.Printf("Executing query %s on %s\n", query, vttablet.Name)
+			t.Logf("Executing query %s on %s", query, vttablet.Name)
 			lastChecked = time.Now()
 			qr, err := vc.execTabletQuery(vttablet, query)
 			if err != nil {
@@ -444,17 +445,17 @@ func (vc *VitessCluster) WaitForVReplicationToCatchup(vttablet *cluster.Vttablet
 			if qr != nil && qr.Rows != nil && len(qr.Rows) > 0 && fmt.Sprintf("%v", qr.Rows[0]) == string(results[ind]) {
 				break
 			} else {
-				fmt.Printf("In WaitForVReplicationToCatchup: %s %+v\n", query, qr.Rows)
+				t.Logf("In WaitForVReplicationToCatchup: %s %+v", query, qr.Rows)
 			}
 			time.Sleep(waitDuration)
 			duration -= waitDuration
 		}
 		if duration <= 0 {
-			fmt.Printf("WaitForVReplicationToCatchup timed out for workflow %s, keyspace %s\n", workflow, database)
+			t.Logf("WaitForVReplicationToCatchup timed out for workflow %s, keyspace %s", workflow, database)
 			return errors.New("WaitForVReplicationToCatchup timed out")
 		}
 	}
-	fmt.Printf("WaitForVReplicationToCatchup succeeded at %v\n", lastChecked)
+	t.Logf("WaitForVReplicationToCatchup succeeded at %v", lastChecked)
 	return nil
 }
 
@@ -479,7 +480,7 @@ func (vc *VitessCluster) getVttabletsInKeyspace(t *testing.T, cell *Cell, ksName
 	for _, shard := range keyspace.Shards {
 		for _, tablet := range shard.Tablets {
 			if tablet.Vttablet.GetTabletStatus() == "SERVING" && strings.EqualFold(tablet.Vttablet.VreplicationTabletType, tabletType) {
-				fmt.Printf("Serving status of tablet %s is %s, %s\n", tablet.Name, tablet.Vttablet.ServingStatus, tablet.Vttablet.GetTabletStatus())
+				t.Logf("Serving status of tablet %s is %s, %s", tablet.Name, tablet.Vttablet.ServingStatus, tablet.Vttablet.GetTabletStatus())
 				tablets[tablet.Name] = tablet.Vttablet
 			}
 		}

--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -52,7 +52,7 @@ func TestMigrate(t *testing.T) {
 	require.NotNil(t, vc)
 	defaultReplicas = 0
 	defaultRdonly = 0
-	defer vc.TearDown()
+	defer vc.TearDown(t)
 
 	defaultCell = vc.Cells[defaultCellName]
 	vc.AddKeyspace(t, []*Cell{defaultCell}, "product", "0", initialProductVSchema, initialProductSchema, defaultReplicas, defaultRdonly, 100)
@@ -70,7 +70,7 @@ func TestMigrate(t *testing.T) {
 	extCells := []string{extCell}
 	extVc := NewVitessCluster(t, "TestMigrateExternal", extCells, externalClusterConfig)
 	require.NotNil(t, extVc)
-	defer extVc.TearDown()
+	defer extVc.TearDown(t)
 
 	extCell2 := extVc.Cells[extCell]
 	extVc.AddKeyspace(t, []*Cell{extCell2}, "rating", "0", initialExternalVSchema, initialExternalSchema, 0, 0, 1000)

--- a/go/test/endtoend/vreplication/performance_test.go
+++ b/go/test/endtoend/vreplication/performance_test.go
@@ -1,0 +1,104 @@
+package vreplication
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var perfTest = flag.Bool("perftest", false, "run end-to-end performance tests")
+
+func TestReplicationStress(t *testing.T) {
+	if !*perfTest {
+		t.Skip("performance tests disabled")
+	}
+
+	const initialStressVSchema = `
+{
+  "tables": {
+	"largebin": {},
+	"customer": {}
+  }
+}
+`
+	const initialStressSchema = `
+create table largebin(pid int, maindata varbinary(4096), primary key(pid));
+create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, primary key(cid))  CHARSET=utf8mb4;
+`
+
+	const defaultCellName = "zone1"
+
+	const sourceKs = "stress_src"
+	const targetKs = "stress_tgt"
+
+	allCells := []string{defaultCellName}
+	allCellNames = defaultCellName
+
+	vc = NewVitessCluster(t, "TestReplicationStress", allCells, mainClusterConfig)
+	require.NotNil(t, vc)
+
+	defer vc.TearDown(t)
+
+	defaultCell = vc.Cells[defaultCellName]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, sourceKs, "0", initialStressVSchema, initialStressSchema, 0, 0, 100)
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", "product", "0"), 1)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+
+	verifyClusterHealth(t, vc)
+
+	const insertCount = 16 * 1024 * 1024
+
+	tablet := defaultCell.Keyspaces[sourceKs].Shards["0"].Tablets["zone1-100"].Vttablet
+	tablet.BulkLoad(t, "stress_src", "largebin", func(w io.Writer) {
+		for i := 0; i < insertCount; i++ {
+			fmt.Fprintf(w, "\"%d\",%q\n", i, "foobar")
+		}
+	})
+
+	validateCount(t, vtgateConn, "stress_src:0", "largebin", insertCount)
+
+	t.Logf("creating new keysepace '%s'", targetKs)
+	vc.AddKeyspace(t, []*Cell{defaultCell}, targetKs, "0", initialStressVSchema, initialStressSchema, 0, 0, 200)
+	validateCount(t, vtgateConn, "stress_tgt:0", "largebin", 0)
+
+	t.Logf("moving 'largebin' table...")
+	moveStart := time.Now()
+
+	for _, ks := range defaultCell.Keyspaces {
+		for _, shard := range ks.Shards {
+			for _, tablet := range shard.Tablets {
+				tablet.Vttablet.ToggleProfiling()
+			}
+		}
+	}
+
+	moveTables(t, defaultCell.Name, "stress_workflow", sourceKs, targetKs, "largebin")
+
+	keyspaceTgt := defaultCell.Keyspaces[targetKs]
+	for _, shard := range keyspaceTgt.Shards {
+		for _, tablet := range shard.Tablets {
+			t.Logf("catchup shard=%v, tablet=%v", shard.Name, tablet.Name)
+			tablet.Vttablet.WaitForVReplicationToCatchup(t, "stress_workflow", fmt.Sprintf("vt_%s", tablet.Vttablet.Keyspace), 5*time.Minute)
+		}
+	}
+
+	for _, ks := range defaultCell.Keyspaces {
+		for _, shard := range ks.Shards {
+			for _, tablet := range shard.Tablets {
+				tablet.Vttablet.ToggleProfiling()
+			}
+		}
+	}
+
+	t.Logf("finished catching up after MoveTables (%v)", time.Since(moveStart))
+	validateCount(t, vtgateConn, "stress_tgt:0", "largebin", insertCount)
+}

--- a/go/test/endtoend/vreplication/performance_test.go
+++ b/go/test/endtoend/vreplication/performance_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package vreplication
 
 import (

--- a/go/test/endtoend/vreplication/performance_test.go
+++ b/go/test/endtoend/vreplication/performance_test.go
@@ -17,19 +17,18 @@ limitations under the License.
 package vreplication
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/test/endtoend/cluster"
+
 	"github.com/stretchr/testify/require"
 )
 
-var perfTest = flag.Bool("perftest", false, "run end-to-end performance tests")
-
 func TestReplicationStress(t *testing.T) {
-	if !*perfTest {
+	if !*cluster.PerfTest {
 		t.Skip("performance tests disabled")
 	}
 

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -233,7 +233,7 @@ func getCurrentState(t *testing.T) string {
 func TestBasicV2Workflows(t *testing.T) {
 	vc = setupCluster(t)
 	defer vtgateConn.Close()
-	defer vc.TearDown()
+	defer vc.TearDown(t)
 
 	testMoveTablesV2Workflow(t)
 	testReshardV2Workflow(t)
@@ -438,7 +438,7 @@ func setupCustomerKeyspace(t *testing.T) {
 
 func TestSwitchReadsWritesInAnyOrder(t *testing.T) {
 	vc = setupCluster(t)
-	defer vc.TearDown()
+	defer vc.TearDown(t)
 	moveCustomerTableSwitchFlows(t, []*Cell{vc.Cells["zone1"]}, "zone1")
 }
 

--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -55,6 +55,10 @@ type Mycnf struct {
 	// (used by vt software for Clone)
 	InnodbLogGroupHomeDir string
 
+	// SecureFilePriv is the path for loading secure files
+	// (used by vt software for bulk loading into tablet instances)
+	SecureFilePriv string
+
 	// SocketFile is the path to the local mysql.sock file.
 	// (used by vt software to check server is running)
 	SocketFile string
@@ -203,6 +207,7 @@ func ReadMycnf(mycnf *Mycnf) (*Mycnf, error) {
 		"master-info-file":          &mycnf.MasterInfoFile,
 		"pid-file":                  &mycnf.PidFile,
 		"tmpdir":                    &mycnf.TmpDir,
+		"secure-file-priv":          &mycnf.SecureFilePriv,
 	}
 	for key, member := range mapping {
 		val, err := mycnf.lookupWithDefault(key, *member)

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -44,6 +44,7 @@ var (
 	flagMasterInfoFile        *string
 	flagPidFile               *string
 	flagTmpDir                *string
+	flagSecureFilePriv        *string
 
 	// the file to use to specify them all
 	flagMycnfFile *string
@@ -69,6 +70,7 @@ func RegisterFlags() {
 	flagMasterInfoFile = flag.String("mycnf_master_info_file", "", "mysql master.info file")
 	flagPidFile = flag.String("mycnf_pid_file", "", "mysql pid file")
 	flagTmpDir = flag.String("mycnf_tmp_dir", "", "mysql tmp directory")
+	flagSecureFilePriv = flag.String("mycnf_secure_file_priv", "", "mysql path for loading secure files")
 
 	flagMycnfFile = flag.String("mycnf-file", "", "path to my.cnf, if reading all config params from there")
 }
@@ -107,6 +109,7 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 			MasterInfoFile:        *flagMasterInfoFile,
 			PidFile:               *flagPidFile,
 			TmpDir:                *flagTmpDir,
+			SecureFilePriv:        *flagSecureFilePriv,
 
 			// This is probably not going to be used by anybody,
 			// but fill in a default value. (Note it's used by

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -84,6 +84,8 @@ func NewMycnf(tabletUID uint32, mysqlPort int32) *Mycnf {
 	cnf.MasterInfoFile = path.Join(tabletDir, "master.info")
 	cnf.PidFile = path.Join(tabletDir, "mysql.pid")
 	cnf.TmpDir = path.Join(tabletDir, "tmp")
+	// by default the secure-file-priv path is `tmp`
+	cnf.SecureFilePriv = cnf.TmpDir
 	return cnf
 }
 

--- a/go/vt/mysqlctl/rice-box.go
+++ b/go/vt/mysqlctl/rice-box.go
@@ -11,103 +11,103 @@ func init() {
 	// define files
 	file2 := &embedded.EmbeddedFile{
 		Filename:    "gomysql.pc.tmpl",
-		FileModTime: time.Unix(1539121419, 0),
+		FileModTime: time.Unix(1610730002, 0),
 
 		Content: string("Name: GoMysql\nDescription: Flags for using mysql C client in go\n"),
 	}
 	file3 := &embedded.EmbeddedFile{
 		Filename:    "init_db.sql",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is executed immediately after mysql_install_db,\n# to initialize a fresh data directory.\n\n###############################################################################\n# WARNING: This sql is *NOT* safe for production use,\n#          as it contains default well-known users and passwords.\n#          Care should be taken to change these users and passwords\n#          for production.\n###############################################################################\n\n###############################################################################\n# Equivalent of mysql_secure_installation\n###############################################################################\n\n# Changes during the init db should not make it to the binlog.\n# They could potentially create errant transactions on replicas.\nSET sql_log_bin = 0;\n# Remove anonymous users.\nDELETE FROM mysql.user WHERE User = '';\n\n# Disable remote root access (only allow UNIX socket).\nDELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';\n\n# Remove test database.\nDROP DATABASE IF EXISTS test;\n\n###############################################################################\n# Vitess defaults\n###############################################################################\n\n# Vitess-internal database.\nCREATE DATABASE IF NOT EXISTS _vt;\n# Note that definitions of local_metadata and shard_metadata should be the same\n# as in production which is defined in go/vt/mysqlctl/metadata_tables.go.\nCREATE TABLE IF NOT EXISTS _vt.local_metadata (\n  name VARCHAR(255) NOT NULL,\n  value VARCHAR(255) NOT NULL,\n  db_name VARBINARY(255) NOT NULL,\n  PRIMARY KEY (db_name, name)\n  ) ENGINE=InnoDB;\nCREATE TABLE IF NOT EXISTS _vt.shard_metadata (\n  name VARCHAR(255) NOT NULL,\n  value MEDIUMBLOB NOT NULL,\n  db_name VARBINARY(255) NOT NULL,\n  PRIMARY KEY (db_name, name)\n  ) ENGINE=InnoDB;\n\n# Admin user with all privileges.\nCREATE USER 'vt_dba'@'localhost';\nGRANT ALL ON *.* TO 'vt_dba'@'localhost';\nGRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';\n\n# User for app traffic, with global read-write access.\nCREATE USER 'vt_app'@'localhost';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,\n  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,\n  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,\n  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER\n  ON *.* TO 'vt_app'@'localhost';\n\n# User for app debug traffic, with global read access.\nCREATE USER 'vt_appdebug'@'localhost';\nGRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';\n\n# User for administrative operations that need to be executed as non-SUPER.\n# Same permissions as vt_app here.\nCREATE USER 'vt_allprivs'@'localhost';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,\n  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,\n  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,\n  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER\n  ON *.* TO 'vt_allprivs'@'localhost';\n\n# User for slave replication connections.\nCREATE USER 'vt_repl'@'%';\nGRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';\n\n# User for Vitess filtered replication (binlog player).\n# Same permissions as vt_app.\nCREATE USER 'vt_filtered'@'localhost';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,\n  REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,\n  LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,\n  SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER\n  ON *.* TO 'vt_filtered'@'localhost';\n\n# User for general MySQL monitoring.\nCREATE USER 'vt_monitoring'@'localhost';\nGRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD\n  ON *.* TO 'vt_monitoring'@'localhost';\nGRANT SELECT, UPDATE, DELETE, DROP\n  ON performance_schema.* TO 'vt_monitoring'@'localhost';\n\n# User for Orchestrator (https://github.com/openark/orchestrator).\nCREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';\nGRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD\n  ON *.* TO 'orc_client_user'@'%';\nGRANT SELECT\n  ON _vt.* TO 'orc_client_user'@'%';\n\nFLUSH PRIVILEGES;\n\nRESET SLAVE ALL;\nRESET MASTER;\n"),
 	}
 	file5 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/default-fast.cnf",
-		FileModTime: time.Unix(1600988485, 0),
+		FileModTime: time.Unix(1616603510, 0),
 
 		Content: string("# This sets some unsafe settings specifically for \n# the test-suite which is currently MySQL 5.7 based\n# In future it should be renamed testsuite.cnf\n\ninnodb_buffer_pool_size = 32M\ninnodb_flush_log_at_trx_commit = 0\ninnodb_log_buffer_size = 1M\ninnodb_log_file_size = 5M\n\n# Native AIO tends to run into aio-max-nr limit during test startup.\ninnodb_use_native_aio = 0\n\nkey_buffer_size = 2M\nsync_binlog=0\ninnodb_doublewrite=0\n\n# These two settings are required for the testsuite to pass, \n# but enabling them does not spark joy. They should be removed\n# in the future. See:\n# https://github.com/vitessio/vitess/issues/5396\n\nsql_mode = STRICT_TRANS_TABLES\n\n# set a short heartbeat interval in order to detect failures quickly\nslave_net_timeout = 4\n"),
 	}
 	file6 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/default.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1618483631, 0),
 
-		Content: string("# Global configuration that is auto-included for all MySQL/MariaDB versions\n\ndatadir = {{.DataDir}}\ninnodb_data_home_dir = {{.InnodbDataHomeDir}}\ninnodb_log_group_home_dir = {{.InnodbLogGroupHomeDir}}\nlog-error = {{.ErrorLogPath}}\nlog-bin = {{.BinLogPath}}\nrelay-log = {{.RelayLogPath}}\nrelay-log-index =  {{.RelayLogIndexPath}}\npid-file = {{.PidFile}}\nport = {{.MysqlPort}}\n\n# all db instances should start in read-only mode - once the db is started and\n# fully functional, we'll push it into read-write mode\nread-only\nserver-id = {{.ServerID}}\n\n# all db instances should skip the slave startup - that way we can do any\n# additional configuration (like enabling semi-sync) before we connect to\n# the master.\nskip_slave_start\nsocket = {{.SocketFile}}\ntmpdir = {{.TmpDir}}\n\nslow-query-log-file = {{.SlowLogPath}}\n\n# These are sensible defaults that apply to all MySQL/MariaDB versions\n\nlong_query_time = 2\nslow-query-log\nskip-name-resolve\nconnect_timeout = 30\ninnodb_lock_wait_timeout = 20\nmax_allowed_packet = 64M\nmax_connections = 500\n\n\n"),
+		Content: string("# Global configuration that is auto-included for all MySQL/MariaDB versions\n\ndatadir = {{.DataDir}}\ninnodb_data_home_dir = {{.InnodbDataHomeDir}}\ninnodb_log_group_home_dir = {{.InnodbLogGroupHomeDir}}\nlog-error = {{.ErrorLogPath}}\nlog-bin = {{.BinLogPath}}\nrelay-log = {{.RelayLogPath}}\nrelay-log-index =  {{.RelayLogIndexPath}}\npid-file = {{.PidFile}}\nport = {{.MysqlPort}}\n\n{{if .SecureFilePriv}}\nsecure-file-priv = {{.SecureFilePriv}}\n{{end}}\n\n# all db instances should start in read-only mode - once the db is started and\n# fully functional, we'll push it into read-write mode\nread-only\nserver-id = {{.ServerID}}\n\n# all db instances should skip the slave startup - that way we can do any\n# additional configuration (like enabling semi-sync) before we connect to\n# the master.\nskip_slave_start\nsocket = {{.SocketFile}}\ntmpdir = {{.TmpDir}}\n\nslow-query-log-file = {{.SlowLogPath}}\n\n# These are sensible defaults that apply to all MySQL/MariaDB versions\n\nlong_query_time = 2\nslow-query-log\nskip-name-resolve\nconnect_timeout = 30\ninnodb_lock_wait_timeout = 20\nmax_allowed_packet = 64M\nmax_connections = 500\n\n\n"),
 	}
 	file7 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb100.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MariaDB 10.0 is detected.\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\nslave_net_timeout = 60\n\n# MariaDB 10.0 is unstrict by default\nsql_mode = STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION\n\n# enable strict mode so it's safe to compare sequence numbers across different server IDs.\ngtid_strict_mode = 1\ninnodb_stats_persistent = 0\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\nexpire_logs_days = 3\n\nsync_binlog = 1\nbinlog_format = ROW\nlog_slave_updates\nexpire_logs_days = 3\n\n# In MariaDB the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\n"),
 	}
 	file8 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb101.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MariaDB 10.1 is detected.\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\nslave_net_timeout = 60\n\n# MariaDB 10.1 default is only no-engine-substitution and no-auto-create-user\nsql_mode = STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION,NO_AUTO_CREATE_USER\n\n# enable strict mode so it's safe to compare sequence numbers across different server IDs.\ngtid_strict_mode = 1\ninnodb_stats_persistent = 0\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\nexpire_logs_days = 3\n\nsync_binlog = 1\nbinlog_format = ROW\nlog_slave_updates\nexpire_logs_days = 3\n\n# In MariaDB the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n"),
 	}
 	file9 := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb102.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MariaDB 10.2 is detected.\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\n# enable strict mode so it's safe to compare sequence numbers across different server IDs.\ngtid_strict_mode = 1\ninnodb_stats_persistent = 0\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\nexpire_logs_days = 3\n\nsync_binlog = 1\nbinlog_format = ROW\nlog_slave_updates\nexpire_logs_days = 3\n\n# In MariaDB the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n"),
 	}
 	filea := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb103.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MariaDB 10.3 is detected.\n\n# enable strict mode so it's safe to compare sequence numbers across different server IDs.\ngtid_strict_mode = 1\ninnodb_stats_persistent = 0\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\nexpire_logs_days = 3\n\nsync_binlog = 1\nbinlog_format = ROW\nlog_slave_updates\nexpire_logs_days = 3\n\n# In MariaDB the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\n\n"),
 	}
 	fileb := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mariadb104.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MariaDB 10.4 is detected.\n\n# enable strict mode so it's safe to compare sequence numbers across different server IDs.\ngtid_strict_mode = 1\ninnodb_stats_persistent = 0\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\nexpire_logs_days = 3\n\nsync_binlog = 1\nbinlog_format = ROW\nlog_slave_updates\nexpire_logs_days = 3\n\n# In MariaDB the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\n\n"),
 	}
 	filec := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mysql56.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MySQL 5.6 is detected.\n\n# MySQL 5.6 does not enable the binary log by default, and \n# the default for sync_binlog is unsafe. The format is TABLE, and\n# info repositories also default to file.\n\nsync_binlog = 1\ngtid_mode = ON\nbinlog_format = ROW\nlog_slave_updates\nenforce_gtid_consistency\nexpire_logs_days = 3\nmaster_info_repository = TABLE\nrelay_log_info_repository = TABLE\nrelay_log_purge = 1\nrelay_log_recovery = 1\nslave_net_timeout = 60\n\n# In MySQL 5.6 the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\n# MySQL 5.6 is unstrict by default\nsql_mode = STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n"),
 	}
 	filed := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mysql57.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MySQL 5.7 is detected.\n\n# MySQL 5.7 does not enable the binary log by default, and \n# info repositories default to file\n\ngtid_mode = ON\nlog_slave_updates\nenforce_gtid_consistency\nexpire_logs_days = 3\nmaster_info_repository = TABLE\nrelay_log_info_repository = TABLE\nrelay_log_purge = 1\nrelay_log_recovery = 1\n\n# In MySQL 5.7 the default charset is latin1\n\ncharacter_set_server = utf8\ncollation_server = utf8_general_ci\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\n# When semi-sync is enabled, don't allow fallback to async\n# if you get no ack, or have no slaves. This is necessary to\n# prevent alternate futures when doing a failover in response to\n# a master that becomes unresponsive.\nrpl_semi_sync_master_timeout = 1000000000000000000\nrpl_semi_sync_master_wait_no_slave = 1\n\n"),
 	}
 	filee := &embedded.EmbeddedFile{
 		Filename:    "mycnf/master_mysql80.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is auto-included when MySQL 8.0 is detected.\n\n# MySQL 8.0 enables binlog by default with sync_binlog and TABLE info repositories\n# It does not enable GTIDs or enforced GTID consistency\n\ngtid_mode = ON\nenforce_gtid_consistency\nrelay_log_recovery = 1\nbinlog_expire_logs_seconds = 259200\n\n# disable mysqlx\nmysqlx = 0\n\n# 8.0 changes the default auth-plugin to caching_sha2_password\ndefault_authentication_plugin = mysql_native_password\n\n# Semi-sync replication is required for automated unplanned failover\n# (when the master goes away). Here we just load the plugin so it's\n# available if desired, but it's disabled at startup.\n#\n# If the -enable_semi_sync flag is used, VTTablet will enable semi-sync\n# at the proper time when replication is set up, or when masters are\n# promoted or demoted.\nplugin-load = rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so\n\n# MySQL 8.0 will not load plugins during --initialize\n# which makes these options unknown. Prefixing with --loose\n# tells the server it's fine if they are not understood.\nloose_rpl_semi_sync_master_timeout = 1000000000000000000\nloose_rpl_semi_sync_master_wait_no_slave = 1\n\n"),
 	}
 	filef := &embedded.EmbeddedFile{
 		Filename:    "mycnf/sbr.cnf",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1610730036, 0),
 
 		Content: string("# This file is used to allow legacy tests to pass\n# In theory it should not be required\nbinlog_format=statement\n"),
 	}
 	fileh := &embedded.EmbeddedFile{
 		Filename:    "orchestrator/default.json",
-		FileModTime: time.Unix(1600387438, 0),
+		FileModTime: time.Unix(1616603510, 0),
 
 		Content: string("{\n  \"Debug\": true,\n  \"MySQLTopologyUser\": \"orc_client_user\",\n  \"MySQLTopologyPassword\": \"orc_client_user_password\",\n  \"MySQLReplicaUser\": \"vt_repl\",\n  \"MySQLReplicaPassword\": \"\",\n  \"RecoveryPeriodBlockSeconds\": 5\n}\n"),
 	}
 	filej := &embedded.EmbeddedFile{
 		Filename:    "tablet/default.yaml",
-		FileModTime: time.Unix(1599694847, 0),
+		FileModTime: time.Unix(1616603510, 0),
 
-		Content: string("tabletID: zone-1234\n\ninit:\n  dbName:            # init_db_name_override\n  keyspace:          # init_keyspace\n  shard:             # init_shard\n  tabletType:        # init_tablet_type\n  timeoutSeconds: 60 # init_timeout\n\ndb:\n  socket:     # db_socket\n  host:       # db_host\n  port: 0     # db_port\n  charSet:    # db_charset\n  flags: 0    # db_flags\n  flavor:     # db_flavor\n  sslCa:      # db_ssl_ca\n  sslCaPath:  # db_ssl_ca_path\n  sslCert:    # db_ssl_cert\n  sslKey:     # db_ssl_key\n  serverName: # db_server_name\n  connectTimeoutMilliseconds: 0 # db_connect_timeout_ms\n  app:\n    user: vt_app      # db_app_user\n    password:         # db_app_password\n    useSsl: true      # db_app_use_ssl\n    preferTcp: false\n  dba:\n    user: vt_dba      # db_dba_user\n    password:         # db_dba_password\n    useSsl: true      # db_dba_use_ssl\n    preferTcp: false\n  filtered:\n    user: vt_filtered # db_filtered_user\n    password:         # db_filtered_password\n    useSsl: true      # db_filtered_use_ssl\n    preferTcp: false\n  repl:\n    user: vt_repl     # db_repl_user\n    password:         # db_repl_password\n    useSsl: true      # db_repl_use_ssl\n    preferTcp: false\n  appdebug:\n    user: vt_appdebug # db_appdebug_user\n    password:         # db_appdebug_password\n    useSsl: true      # db_appdebug_use_ssl\n    preferTcp: false\n  allprivs:\n    user: vt_allprivs # db_allprivs_user\n    password:         # db_allprivs_password\n    useSsl: true      # db_allprivs_use_ssl\n    preferTcp: false\n\noltpReadPool:\n  size: 16                 # queryserver-config-pool-size\n  timeoutSeconds: 0        # queryserver-config-query-pool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-pool-prefill-parallelism\n  maxWaiters: 50000        # queryserver-config-query-pool-waiter-cap\n\nolapReadPool:\n  size: 200                # queryserver-config-stream-pool-size\n  timeoutSeconds: 0        # queryserver-config-query-pool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-stream-pool-prefill-parallelism\n  maxWaiters: 0\n\ntxPool:\n  size: 20                 # queryserver-config-transaction-cap\n  timeoutSeconds: 1        # queryserver-config-txpool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-transaction-prefill-parallelism\n  maxWaiters: 50000        # queryserver-config-txpool-waiter-cap\n\noltp:\n  queryTimeoutSeconds: 30 # queryserver-config-query-timeout\n  txTimeoutSeconds: 30    # queryserver-config-transaction-timeout\n  maxRows: 10000          # queryserver-config-max-result-size\n  warnRows: 0             # queryserver-config-warn-result-size\n\nhealthcheck:\n  intervalSeconds: 20             # health_check_interval\n  degradedThresholdSeconds: 30    # degraded_threshold\n  unhealthyThresholdSeconds: 7200 # unhealthy_threshold\n\ngracePeriods:\n  transactionShutdownSeconds: 0 # transaction_shutdown_grace_period\n  transitionSeconds: 0          # serving_state_grace_period\n\nreplicationTracker:\n  mode: disable                    # enable_replication_reporter\n  heartbeatIntervalMilliseconds: 0 # heartbeat_enable, heartbeat_interval\n\nhotRowProtection:\n  mode: disable|dryRun|enable # enable_hot_row_protection, enable_hot_row_protection_dry_run\n  # Recommended value: same as txPool.size.\n  maxQueueSize: 20            # hot_row_protection_max_queue_size\n  maxGlobalQueueSize: 1000    # hot_row_protection_max_global_queue_size\n  maxConcurrency: 5           # hot_row_protection_concurrent_transactions\n\nconsolidator: enable|disable|notOnMaster # enable-consolidator, enable-consolidator-replicas\npassthroughDML: false                    # queryserver-config-passthrough-dmls\nstreamBufferSize: 32768                  # queryserver-config-stream-buffer-size\nqueryCacheSize: 5000                     # queryserver-config-query-cache-size\nschemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time\nwatchReplication: false                  # watch_replication_stream\nterseErrors: false                       # queryserver-config-terse-errors\nmessagePostponeParallelism: 4            # queryserver-config-message-postpone-cap\ncacheResultFields: true                  # enable-query-plan-field-caching\n\n\n# The following flags are currently not supported.\n# enforce_strict_trans_tables\n# queryserver-config-strict-table-acl\n# queryserver-config-enable-table-acl-dry-run\n# queryserver-config-acl-exempt-acl\n# enable-tx-throttler\n# tx-throttler-config\n# tx-throttler-healthcheck-cells\n# enable_transaction_limit\n# enable_transaction_limit_dry_run\n# transaction_limit_per_user\n# transaction_limit_by_username\n# transaction_limit_by_principal\n# transaction_limit_by_component\n# transaction_limit_by_subcomponent\n"),
+		Content: string("tabletID: zone-1234\n\ninit:\n  dbName:            # init_db_name_override\n  keyspace:          # init_keyspace\n  shard:             # init_shard\n  tabletType:        # init_tablet_type\n  timeoutSeconds: 60 # init_timeout\n\ndb:\n  socket:     # db_socket\n  host:       # db_host\n  port: 0     # db_port\n  charSet:    # db_charset\n  flags: 0    # db_flags\n  flavor:     # db_flavor\n  sslCa:      # db_ssl_ca\n  sslCaPath:  # db_ssl_ca_path\n  sslCert:    # db_ssl_cert\n  sslKey:     # db_ssl_key\n  serverName: # db_server_name\n  connectTimeoutMilliseconds: 0 # db_connect_timeout_ms\n  app:\n    user: vt_app      # db_app_user\n    password:         # db_app_password\n    useSsl: true      # db_app_use_ssl\n    preferTcp: false\n  dba:\n    user: vt_dba      # db_dba_user\n    password:         # db_dba_password\n    useSsl: true      # db_dba_use_ssl\n    preferTcp: false\n  filtered:\n    user: vt_filtered # db_filtered_user\n    password:         # db_filtered_password\n    useSsl: true      # db_filtered_use_ssl\n    preferTcp: false\n  repl:\n    user: vt_repl     # db_repl_user\n    password:         # db_repl_password\n    useSsl: true      # db_repl_use_ssl\n    preferTcp: false\n  appdebug:\n    user: vt_appdebug # db_appdebug_user\n    password:         # db_appdebug_password\n    useSsl: true      # db_appdebug_use_ssl\n    preferTcp: false\n  allprivs:\n    user: vt_allprivs # db_allprivs_user\n    password:         # db_allprivs_password\n    useSsl: true      # db_allprivs_use_ssl\n    preferTcp: false\n\noltpReadPool:\n  size: 16                 # queryserver-config-pool-size\n  timeoutSeconds: 0        # queryserver-config-query-pool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-pool-prefill-parallelism\n  maxWaiters: 50000        # queryserver-config-query-pool-waiter-cap\n\nolapReadPool:\n  size: 200                # queryserver-config-stream-pool-size\n  timeoutSeconds: 0        # queryserver-config-query-pool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-stream-pool-prefill-parallelism\n  maxWaiters: 0\n\ntxPool:\n  size: 20                 # queryserver-config-transaction-cap\n  timeoutSeconds: 1        # queryserver-config-txpool-timeout\n  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout\n  prefillParallelism: 0    # queryserver-config-transaction-prefill-parallelism\n  maxWaiters: 50000        # queryserver-config-txpool-waiter-cap\n\noltp:\n  queryTimeoutSeconds: 30 # queryserver-config-query-timeout\n  txTimeoutSeconds: 30    # queryserver-config-transaction-timeout\n  maxRows: 10000          # queryserver-config-max-result-size\n  warnRows: 0             # queryserver-config-warn-result-size\n\nhealthcheck:\n  intervalSeconds: 20             # health_check_interval\n  degradedThresholdSeconds: 30    # degraded_threshold\n  unhealthyThresholdSeconds: 7200 # unhealthy_threshold\n\ngracePeriods:\n  shutdownSeconds:   0 # shutdown_grace_period\n  transitionSeconds: 0 # serving_state_grace_period\n\nreplicationTracker:\n  mode: disable                    # enable_replication_reporter\n  heartbeatIntervalMilliseconds: 0 # heartbeat_enable, heartbeat_interval\n\nhotRowProtection:\n  mode: disable|dryRun|enable # enable_hot_row_protection, enable_hot_row_protection_dry_run\n  # Recommended value: same as txPool.size.\n  maxQueueSize: 20            # hot_row_protection_max_queue_size\n  maxGlobalQueueSize: 1000    # hot_row_protection_max_global_queue_size\n  maxConcurrency: 5           # hot_row_protection_concurrent_transactions\n\nconsolidator: enable|disable|notOnMaster # enable-consolidator, enable-consolidator-replicas\npassthroughDML: false                    # queryserver-config-passthrough-dmls\nstreamBufferSize: 32768                  # queryserver-config-stream-buffer-size\nqueryCacheSize: 5000                     # queryserver-config-query-cache-size\nschemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time\nwatchReplication: false                  # watch_replication_stream\nterseErrors: false                       # queryserver-config-terse-errors\nmessagePostponeParallelism: 4            # queryserver-config-message-postpone-cap\ncacheResultFields: true                  # enable-query-plan-field-caching\n\n\n# The following flags are currently not supported.\n# enforce_strict_trans_tables\n# queryserver-config-strict-table-acl\n# queryserver-config-enable-table-acl-dry-run\n# queryserver-config-acl-exempt-acl\n# enable-tx-throttler\n# tx-throttler-config\n# tx-throttler-healthcheck-cells\n# enable_transaction_limit\n# enable_transaction_limit_dry_run\n# transaction_limit_per_user\n# transaction_limit_by_username\n# transaction_limit_by_principal\n# transaction_limit_by_component\n# transaction_limit_by_subcomponent\n"),
 	}
 	filek := &embedded.EmbeddedFile{
 		Filename:    "zk-client-dev.json",
-		FileModTime: time.Unix(1539121419, 0),
+		FileModTime: time.Unix(1610730002, 0),
 
 		Content: string("{\n  \"local\": \"localhost:3863\",\n  \"global\": \"localhost:3963\"\n}\n"),
 	}
 	filem := &embedded.EmbeddedFile{
 		Filename:    "zkcfg/zoo.cfg",
-		FileModTime: time.Unix(1539121419, 0),
+		FileModTime: time.Unix(1610730002, 0),
 
 		Content: string("tickTime=2000\ndataDir={{.DataDir}}\nclientPort={{.ClientPort}}\ninitLimit=5\nsyncLimit=2\nmaxClientCnxns=0\n{{range .Servers}}\nserver.{{.ServerId}}={{.Hostname}}:{{.LeaderPort}}:{{.ElectionPort}}\n{{end}}\n"),
 	}
@@ -115,7 +115,7 @@ func init() {
 	// define dirs
 	dir1 := &embedded.EmbeddedDir{
 		Filename:   "",
-		DirModTime: time.Unix(1599765277, 0),
+		DirModTime: time.Unix(1616603510, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			file2, // "gomysql.pc.tmpl"
 			file3, // "init_db.sql"
@@ -125,7 +125,7 @@ func init() {
 	}
 	dir4 := &embedded.EmbeddedDir{
 		Filename:   "mycnf",
-		DirModTime: time.Unix(1600988485, 0),
+		DirModTime: time.Unix(1618483631, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			file5, // "mycnf/default-fast.cnf"
 			file6, // "mycnf/default.cnf"
@@ -143,7 +143,7 @@ func init() {
 	}
 	dirg := &embedded.EmbeddedDir{
 		Filename:   "orchestrator",
-		DirModTime: time.Unix(1600387438, 0),
+		DirModTime: time.Unix(1616603510, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			fileh, // "orchestrator/default.json"
 
@@ -151,7 +151,7 @@ func init() {
 	}
 	diri := &embedded.EmbeddedDir{
 		Filename:   "tablet",
-		DirModTime: time.Unix(1599694847, 0),
+		DirModTime: time.Unix(1616603510, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			filej, // "tablet/default.yaml"
 
@@ -159,7 +159,7 @@ func init() {
 	}
 	dirl := &embedded.EmbeddedDir{
 		Filename:   "zkcfg",
-		DirModTime: time.Unix(1539121419, 0),
+		DirModTime: time.Unix(1610730002, 0),
 		ChildFiles: []*embedded.EmbeddedFile{
 			filem, // "zkcfg/zoo.cfg"
 
@@ -182,7 +182,7 @@ func init() {
 	// register embeddedBox
 	embedded.RegisterEmbeddedBox(`../../../config`, &embedded.EmbeddedBox{
 		Name: `../../../config`,
-		Time: time.Unix(1599765277, 0),
+		Time: time.Unix(1616603510, 0),
 		Dirs: map[string]*embedded.EmbeddedDir{
 			"":             dir1,
 			"mycnf":        dir4,

--- a/go/vt/servenv/pprof.go
+++ b/go/vt/servenv/pprof.go
@@ -19,6 +19,7 @@ package servenv
 import (
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -164,11 +165,7 @@ func stopCallback(stop func()) func() {
 	}
 }
 
-// init returns a start function that begins the configured profiling process and
-// returns a cleanup function that must be executed before process termination to
-// flush the profile to disk.
-// Based on the profiling code in github.com/pkg/profile
-func (prof *profile) init() (start func(), stop func()) {
+func (prof *profile) mkprofile() io.WriteCloser {
 	var (
 		path string
 		err  error
@@ -196,20 +193,32 @@ func (prof *profile) init() (start func(), stop func()) {
 	}
 	logf("pprof: %s profiling enabled, %s", string(prof.mode), fn)
 
+	return f
+}
+
+// init returns a start function that begins the configured profiling process and
+// returns a cleanup function that must be executed before process termination to
+// flush the profile to disk.
+// Based on the profiling code in github.com/pkg/profile
+func (prof *profile) init() (start func(), stop func()) {
+	var pf io.WriteCloser
+
 	switch prof.mode {
 	case profileCPU:
 		start = startCallback(func() {
-			pprof.StartCPUProfile(f)
+			pf = prof.mkprofile()
+			pprof.StartCPUProfile(pf)
 		})
 		stop = stopCallback(func() {
 			pprof.StopCPUProfile()
-			f.Close()
+			pf.Close()
 		})
 		return start, stop
 
 	case profileMemHeap, profileMemAllocs:
 		old := runtime.MemProfileRate
 		start = startCallback(func() {
+			pf = prof.mkprofile()
 			runtime.MemProfileRate = prof.rate
 		})
 		stop = stopCallback(func() {
@@ -217,65 +226,72 @@ func (prof *profile) init() (start func(), stop func()) {
 			if prof.mode == profileMemAllocs {
 				tt = "allocs"
 			}
-			pprof.Lookup(tt).WriteTo(f, 0)
-			f.Close()
+			pprof.Lookup(tt).WriteTo(pf, 0)
+			pf.Close()
 			runtime.MemProfileRate = old
 		})
 		return start, stop
 
 	case profileMutex:
 		start = startCallback(func() {
+			pf = prof.mkprofile()
 			runtime.SetMutexProfileFraction(prof.rate)
 		})
 		stop = stopCallback(func() {
 			if mp := pprof.Lookup("mutex"); mp != nil {
-				mp.WriteTo(f, 0)
+				mp.WriteTo(pf, 0)
 			}
-			f.Close()
+			pf.Close()
 			runtime.SetMutexProfileFraction(0)
 		})
 		return start, stop
 
 	case profileBlock:
 		start = startCallback(func() {
+			pf = prof.mkprofile()
 			runtime.SetBlockProfileRate(prof.rate)
 		})
 		stop = stopCallback(func() {
-			pprof.Lookup("block").WriteTo(f, 0)
-			f.Close()
+			pprof.Lookup("block").WriteTo(pf, 0)
+			pf.Close()
 			runtime.SetBlockProfileRate(0)
 		})
 		return start, stop
 
 	case profileThreads:
-		start = startCallback(func() {})
+		start = startCallback(func() {
+			pf = prof.mkprofile()
+		})
 		stop = stopCallback(func() {
 			if mp := pprof.Lookup("threadcreate"); mp != nil {
-				mp.WriteTo(f, 0)
+				mp.WriteTo(pf, 0)
 			}
-			f.Close()
+			pf.Close()
 		})
 		return start, stop
 
 	case profileTrace:
 		start = startCallback(func() {
-			if err := trace.Start(f); err != nil {
+			pf = prof.mkprofile()
+			if err := trace.Start(pf); err != nil {
 				log.Fatalf("pprof: could not start trace: %v", err)
 			}
 		})
 		stop = stopCallback(func() {
 			trace.Stop()
-			f.Close()
+			pf.Close()
 		})
 		return start, stop
 
 	case profileGoroutine:
-		start = startCallback(func() {})
+		start = startCallback(func() {
+			pf = prof.mkprofile()
+		})
 		stop = stopCallback(func() {
 			if mp := pprof.Lookup("goroutine"); mp != nil {
-				mp.WriteTo(f, 0)
+				mp.WriteTo(pf, 0)
 			}
-			f.Close()
+			pf.Close()
 		})
 		return start, stop
 

--- a/go/vt/sqlparser/parsed_query.go
+++ b/go/vt/sqlparser/parsed_query.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"vitess.io/vitess/go/bytes2"
+
 	"vitess.io/vitess/go/sqltypes"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -80,6 +82,39 @@ func (pq *ParsedQuery) Append(buf *strings.Builder, bindVariables map[string]*qu
 	return nil
 }
 
+// AppendFromRow behaves like Append but takes a querypb.Row directly, assuming that
+// the fields in the row are in the same order as the placeholders in this query.
+func (pq *ParsedQuery) AppendFromRow(buf *bytes2.Buffer, fields []*querypb.Field, row *querypb.Row) error {
+	if len(fields) != len(pq.bindLocations) {
+		return fmt.Errorf("wrong number of fields: got %d fields for %d bind locations ", len(fields), len(pq.bindLocations))
+	}
+	var offsetQuery int
+	var offsetRow int64
+	for i, loc := range pq.bindLocations {
+		buf.WriteString(pq.Query[offsetQuery:loc.offset])
+
+		typ := fields[i].Type
+		switch typ {
+		case querypb.Type_TUPLE:
+			return fmt.Errorf("unexpected Type_TUPLE for value %d", i)
+
+		case querypb.Type_NULL_TYPE:
+			// null variables don't have a length in row.Length, so serialize them directly
+			buf.WriteString("null")
+
+		default:
+			length := row.Lengths[i]
+			vv := sqltypes.MakeTrusted(typ, row.Values[offsetRow:offsetRow+length])
+			vv.EncodeSQLBytes2(buf)
+			offsetRow += length
+		}
+
+		offsetQuery = loc.offset + loc.length
+	}
+	buf.WriteString(pq.Query[offsetQuery:])
+	return nil
+}
+
 // MarshalJSON is a custom JSON marshaler for ParsedQuery.
 // Note that any queries longer that 512 bytes will be truncated.
 func (pq *ParsedQuery) MarshalJSON() ([]byte, error) {
@@ -91,7 +126,7 @@ func EncodeValue(buf *strings.Builder, value *querypb.BindVariable) {
 	if value.Type != querypb.Type_TUPLE {
 		// Since we already check for TUPLE, we don't expect an error.
 		v, _ := sqltypes.BindVariableToValue(value)
-		v.EncodeSQL(buf)
+		v.EncodeSQLStringBuilder(buf)
 		return
 	}
 
@@ -101,7 +136,7 @@ func EncodeValue(buf *strings.Builder, value *querypb.BindVariable) {
 		if i != 0 {
 			buf.WriteString(", ")
 		}
-		sqltypes.ProtoToValue(bv).EncodeSQL(buf)
+		sqltypes.ProtoToValue(bv).EncodeSQLStringBuilder(buf)
 	}
 	buf.WriteByte(')')
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -218,12 +218,14 @@ func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows *binlogdatap
 		if i > 0 {
 			sqlbuffer.WriteString(", ")
 		}
-		tp.BulkInsertValues.AppendFromRow(sqlbuffer, tp.Fields, row)
+		if err := tp.BulkInsertValues.AppendFromRow(sqlbuffer, tp.Fields, row); err != nil {
+			return nil, err
+		}
 	}
 	if tp.BulkInsertOnDup != nil {
 		sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
 	}
-	return executor(sqlbuffer.String())
+	return executor(sqlbuffer.StringUnsafe())
 }
 
 // During the copy phase we run catchup and fastforward, which stream binlogs. While streaming we should only process

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/bytes2"
+
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
@@ -207,27 +209,21 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
-func (tp *TablePlan) applyBulkInsert(rows *binlogdatapb.VStreamRowsResponse, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
-	bindvars := make(map[string]*querypb.BindVariable, len(tp.Fields))
-	var buf strings.Builder
-	if err := tp.BulkInsertFront.Append(&buf, nil, nil); err != nil {
-		return nil, err
-	}
-	buf.WriteString(" values ")
-	separator := ""
-	for _, row := range rows.Rows {
-		vals := sqltypes.MakeRowTrusted(tp.Fields, row)
-		for i, field := range tp.Fields {
-			bindvars["a_"+field.Name] = sqltypes.ValueBindVariable(vals[i])
+func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows *binlogdatapb.VStreamRowsResponse, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
+	sqlbuffer.Reset()
+	sqlbuffer.WriteString(tp.BulkInsertFront.Query)
+	sqlbuffer.WriteString(" values ")
+
+	for i, row := range rows.Rows {
+		if i > 0 {
+			sqlbuffer.WriteString(", ")
 		}
-		buf.WriteString(separator)
-		separator = ", "
-		tp.BulkInsertValues.Append(&buf, bindvars, nil)
+		tp.BulkInsertValues.AppendFromRow(sqlbuffer, tp.Fields, row)
 	}
 	if tp.BulkInsertOnDup != nil {
-		tp.BulkInsertOnDup.Append(&buf, nil, nil)
+		sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
 	}
-	return executor(buf.String())
+	return executor(sqlbuffer.String())
 }
 
 // During the copy phase we run catchup and fastforward, which stream binlogs. While streaming we should only process


### PR DESCRIPTION
## Description

These upcoming weeks I'm going to be working on `vreplication` performance. It's a pretty complex part of Vitess' codebase and it hasn't received a lot of performance tuning in the past so I'm hoping to get up to speed with the implementation and give it some perf attention.

Let's take a look at the changes in this PR, commit by commit:

- `endtoend: improve vreplication tests`: Critically, there are currently no benchmarks for `vreplication`, and it turns out, the system is complex enough (with interdependencies between `vtctl`, `vtgate`, `vttablet` and `mysqld`) that writing microbenchmarks for it is not feasible. To get a starting point for performance tuning instead, I've written some end-to-end performance tests, which give us benchmarking estimates and let us look at the performance profiles for all the moving parts in the system. The first test included here tackles the simplest (possibly?) and most performance sensitive part of replication: the initial table copying.

    For those following at home, I might as well explain a little bit some `vreplication` basics:

    A `vreplication` stream links **two** `vttablet` instances by copying and keeping in sync one or more tables between the underlying `mysqld` instances of each tablet. To accomplish this, the stream is divided in three phases: first off, there is a table copying phase (what we're profiling and optimizing in this PR), which does bulk reads from the source tablet and sends them to the target for bulk inserting. Afterwards, there is a catchup phase, which catches up any row changes that have become outdated during the initial copy of the table. Once the stream has caught up and there's no significant replication lag between the two tablets, we switch to the final phase where we replicate rows in real time from the MySQL binary log.

    The table copying phase is, for many `vreplication` workflows, the most performance intensive part of the process. For instance, if you're using `vreplication` to re-shard a cluster, you'll want to copy the tables as fast as possible, and once the target has caught up, you want to switch traffic to the new sharding. Hence, you'd spend the vast majority of time doing a copy, and very little time actually streaming. Other uses, just as materializing views, make much more use of streaming, but streaming can often keep up with the changes in the source cluster, because most clusters are not write-heavy, so optimizing that doesn't feel as urgent to me. We'll look at the streaming in the following weeks.

- `pprof: do not create profiles until we start profiling`: this is a small cleanup to the profiling handlers that we wrote for `vtgate` and `vttablet`. These profiling handlers don't start profiling in their respective processes until they receive an USR2 signal, but they were previously creating an on-disk profile as soon as the process started. Since our integration suite doesn't profile _all_ the available tablets in the integration cluster, this resulted in several zero-sized profiles on disk for the tablets that were not being profiled.

- `endtoend: allow bulk-loading databases`: another important cleanup for our endtoend suite. We need very large datasets in MySQL in order to gather realistic profiling benchmarks, and building these for each test run can be very expensive (expensive enough to make the profile-optimize-build cycle very painful). To speed up this operation, this commit improves Vitess' `mysqlctl` helper so that spawned `mysqld` instances can have a configurable `secure-file-priv` path. This flag allows us to use MySQL's `LOAD DATA INFILE` to bulk-load millions of rows from CSV files on disk.

- `vreplication: improve copy performance`: this is the first actual optimization from the CPU profiles of our copy test. It tackles table copy performance on the **target** side (i.e. the one receiving the rows to be inserted locally). The result is very good, **it reduces CPU usage by 60% and memory allocations by 90%**. Unfortunately, the effective performance improvement in wall time is not as large: between 15% and 20% faster runtime.

    Some thoughts on this: one of the issues that we've seen in large production clusters that use `vreplication` is that, since the replication streams connect two `vttablet`s, the replication process is competing for CPU cycles with the actual query serving code, which also runs in the `vttablet`s. From this point of view, the massive CPU reduction in this optimization is a very good thing, because it means more spare CPU cycles to continue serving MySQL queries from the tablet. Why does it translate into only a 15% reduction in runtime? If we look at a syscall blocking profile of the tablet, the answer is clear: the optimization of the query inserts is so comprehensive that it brings down the runtime of the table copying process all the way down to MySQL insert performance. The copying process cannot go any faster because MySQL doesn't ingest our rows any faster.

    Not all is lost, of course: there are still things we can do to make MySQL ingest the rows faster. I intend to look into that next week. Another side effect of the fact that the receiving `vttablet` is now bottlenecked in MySQL insert performance, is that are no gains to be obtained by optimizing the row generation in the _source_ `vttablet` -- in theory. In practice, the same issue we've just discussed also applies to the source tablet: the replication flow also competes for CPU cycles with the actual query load, so any optimizations we perform there, while not reducing the actual wall runtime of the replication process, will result in more query throughput for production servers, so I intend to tackle that next week too.

For now, let's wrap this up by taking a look at the impact of this optimization on the flame graphs for the `vttablet` process:

#### Before
![image](https://user-images.githubusercontent.com/42793/115049497-1575cc00-9edb-11eb-8be7-cec0931bc947.png)

#### After
![image](https://user-images.githubusercontent.com/42793/115049561-26bed880-9edb-11eb-80f9-6a8298b8d7ed.png)

We can see two clear columns in both profiles: Go runtime (on the left), and our own code (on the right). The profile of our own code is further divided in two clear columns: GRPC streaming reads (left) and query preparation for MySQL bulk inserts (right). The result optimizing the query preparation step is significant, and it shows in how the relative CPU usage of GRPC, which used to be roughly 25% of the runtime, now becomes 75% of the total runtime. Obviously, the actual CPU usage of GRPC is constant between the two profiles, so the fact that it now dominates our CPU profile means that the query preparation is basically using residual amounts of CPU. The next possible optimization here is Protobuf (de)serialization for the incoming rows, which I intend to do next week.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
