### PR TITLE
Backport 7809: Update rowlog for the API change made for the vstream skew alignment feature

### DIFF
--- a/tools/rowlog/rowlog.go
+++ b/tools/rowlog/rowlog.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -155,7 +156,7 @@ func startStreaming(ctx context.Context, vtgate, vtctld, keyspace, tablet, table
 		log.Fatal(err)
 	}
 	defer conn.Close()
-	reader, err := conn.VStream(ctx, topodatapb.TabletType_MASTER, vgtid, filter)
+	reader, err := conn.VStream(ctx, topodatapb.TabletType_MASTER, vgtid, filter, &vtgatepb.VStreamFlags{})
 	var fields []*query.Field
 	var gtid string
 	var plan *TablePlan


### PR DESCRIPTION
## Description
Backporting: Rowlog: Update rowlog for the API change made for the vstream skew alignment feature #7809

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
