### PR TITLE
Add VtctldServer to vtcombo

### DIFF
--- a/go/cmd/vtcombo/plugin_grpcvtctldserver.go
+++ b/go/cmd/vtcombo/plugin_grpcvtctldserver.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
+)
+
+func init() {
+	servenv.OnRun(func() {
+		if servenv.GRPCCheckServiceMap("vtctld") {
+			grpcvtctldserver.StartServer(servenv.GRPCServer, ts)
+		}
+	})
+}

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -184,7 +184,7 @@ func (env *LocalTestEnv) ProcessHealthCheck(name string) HealthChecker {
 func (env *LocalTestEnv) VtcomboArguments() []string {
 	return []string{
 		"-service_map", strings.Join(
-			[]string{"grpc-vtgateservice", "grpc-vtctl"}, ",",
+			[]string{"grpc-vtgateservice", "grpc-vtctl", "grpc-vtctld"}, ",",
 		),
 		"-enable_queries",
 	}

--- a/go/vt/vttest/environment_test.go
+++ b/go/vt/vttest/environment_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttest
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVtcomboArguments(t *testing.T) {
+	env := &LocalTestEnv{}
+	args := env.VtcomboArguments()
+
+	t.Run("service_map flag", func(t *testing.T) {
+		require.Contains(t, args, "-service_map", "vttest.LocalTestEnv must contain provide `-service_map` flag to vtcombo")
+
+		x := sort.SearchStrings(args, "-service_map")
+		require.Less(t, x+1, len(args), "-service_map vtcombo flag (idx = %d) must take an argument. full arg list: %v", x, args)
+
+		expectedServiceList := []string{
+			"grpc-vtgateservice",
+			"grpc-vtctl",
+			"grpc-vtctld",
+		}
+		serviceMapList := strings.Split(args[x+1], ",")
+		assert.ElementsMatch(t, expectedServiceList, serviceMapList, "-service_map list does not contain expected vtcombo services")
+	})
+}

--- a/go/vt/vttest/environment_test.go
+++ b/go/vt/vttest/environment_test.go
@@ -30,7 +30,7 @@ func TestVtcomboArguments(t *testing.T) {
 	args := env.VtcomboArguments()
 
 	t.Run("service_map flag", func(t *testing.T) {
-		require.Contains(t, args, "-service_map", "vttest.LocalTestEnv must contain provide `-service_map` flag to vtcombo")
+		require.Contains(t, args, "-service_map", "vttest.LocalTestEnv must provide `-service_map` flag to vtcombo")
 
 		x := sort.SearchStrings(args, "-service_map")
 		require.Less(t, x+1, len(args), "-service_map vtcombo flag (idx = %d) must take an argument. full arg list: %v", x, args)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

### Testing

1. build and run vttestserver: `make build; ./bin/vttestserver`
2. get gRPC port: `sudo lsof -iTCP -P -sTCP:LISTEN | grep vtcombo | awk '{print $9}' | sort | head -n 2 | head -n 1 | sed 's/.*://'`
3. run client:
```
❯ ./bin/vtctldclient --server "localhost:12592" GetKeyspaces
[
  {
    "name": "test_keyspace",
    "keyspace": {}
  }
]
```

## Related Issue(s)
<!-- List related issues and pull requests: -->

- Closes #7894 

## Checklist
- [ ] Should this PR be backported? **no**
- [ ] Tests were added or are not required **n/a**
- [ ] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [x]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
