### PR TITLE
Memory Sort to close the goroutines when callback returns error 

### DIFF
--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -79,7 +79,7 @@ func (ms *MergeSort) StreamExecute(vcursor VCursor, bindVars map[string]*querypb
 
 	handles := make([]*streamHandle, len(ms.Primitives))
 	for i, input := range ms.Primitives {
-		handles[i] = runOneStream(vcursor, input, bindVars, wantfields)
+		handles[i] = runOneStream(ctx, vcursor, input, bindVars, wantfields)
 		// Need fields only from first handle, if wantfields was true.
 		wantfields = false
 	}
@@ -182,12 +182,11 @@ type streamHandle struct {
 }
 
 // runOnestream starts a streaming query on one shard, and returns a streamHandle for it.
-func runOneStream(vcursor VCursor, input StreamExecutor, bindVars map[string]*querypb.BindVariable, wantfields bool) *streamHandle {
+func runOneStream(ctx context.Context, vcursor VCursor, input StreamExecutor, bindVars map[string]*querypb.BindVariable, wantfields bool) *streamHandle {
 	handle := &streamHandle{
 		fields: make(chan []*querypb.Field, 1),
 		row:    make(chan []sqltypes.Value, 10),
 	}
-	ctx := vcursor.Context()
 
 	go func() {
 		defer close(handle.fields)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2369,5 +2369,5 @@ func TestStreamOrderByLimitWithMultipleResults(t *testing.T) {
 	utils.MustMatch(t, wantResult, gotResult)
 	// some sleep to close all goroutines.
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, before, runtime.NumGoroutine(), "left open goroutines lingering")
+	assert.GreaterOrEqual(t, before, runtime.NumGoroutine(), "left open goroutines lingering")
 }

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"vitess.io/vitess/go/cache"
 	"vitess.io/vitess/go/test/utils"
@@ -2366,5 +2367,7 @@ func TestStreamOrderByLimitWithMultipleResults(t *testing.T) {
 
 	wantResult := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|col", "int32|int32"), "1|1", "2|2")
 	utils.MustMatch(t, wantResult, gotResult)
+	// some sleep to close all goroutines.
+	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, before, runtime.NumGoroutine(), "left open goroutines lingering")
 }


### PR DESCRIPTION
Fixes https://github.com/vitessio/vitess/issues/7908
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Merge sort is used when VTGate needs to merge the incoming sorted streams. The Bug was around if the callback returns and go routines that are handling those streams needs to be closed.
This is usually achieved by using cancellable context. The new context that was created was not passed to those goroutines so even  the context was cancelled the goroutines were stuck waiting.

## Checklist
- [X] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [X]  Query Serving
