### PR TITLE
VDiff Debugging: Add logging to debug random failures during long running vdiff operations

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -819,9 +820,9 @@ func wrapError(err error, stopPos mysql.Position, vse *Engine) error {
 		vse.vstreamersEndedWithErrors.Add(1)
 		vse.errorCounts.Add("StreamEnded", 1)
 		err = fmt.Errorf("stream (at source tablet) error @ %v: %v", stopPos, err)
-		log.Error(err)
+		log.Error("Error: %s. StrackTrace:\n%s", err, debug.Stack())
 		return err
 	}
-	log.Infof("stream (at source tablet) ended @ %v", stopPos)
+	log.Infof("stream (at source tablet) ended @ %v. Stacktrace: %s", stopPos, debug.Stack())
 	return nil
 }


### PR DESCRIPTION
We are facing issues in an installation using release 8.0, where vdiff fails after 2-3 hours with insufficient information logged. This PR adds logs before and after grpc calls to vttablets in vdiff and display any errors/stacktrace in the vdiff's cancel context call.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [X]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
