### PR TITLE
Check tablet alias before removing after error stream

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -391,6 +391,11 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	th.cancelFunc()
 	delete(hc.healthByAlias, tabletAlias)
 	// delete from map by keyspace.shard.tabletType
+	hc.deleteHealthDateLocked(key, tabletAlias)
+}
+
+func (hc *HealthCheckImpl) deleteHealthDateLocked(key keyspaceShardTabletType, tabletAlias tabletAliasString) {
+	// delete from map by keyspace.shard.tabletType
 	ths, ok := hc.healthData[key]
 	if !ok {
 		log.Warningf("We have no health data for target: %v", key)
@@ -448,8 +453,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 			}
 		}
 	case isPrimary && !isPrimaryUp:
-		// No healthy master tablet
-		hc.healthy[targetKey] = []*TabletHealth{}
+		hc.deleteHealthDateLocked(targetKey, tabletAlias)
 	}
 
 	if !trivialUpdate {


### PR DESCRIPTION
Signed-off-by: crowu <y.wu4515@gmail.com>

<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
When VTGate gets an error from the primary tablet connection, it should not just nuke out all the healthy tablets. Because an external reparent process might have already changed the primary tablet.

Instead we should only try to remove the tablet with stream error from the map

## Related Issue(s)
<!-- List related issues and pull requests: -->

- https://github.com/vitessio/vitess/issues/7906

## Checklist
- [x] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [X]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
