### PR TITLE
[vtadmin-web] Display vindex data on Schema view

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -182,6 +182,20 @@ export const fetchTablets = async () =>
         },
     });
 
+export interface FetchVSchemaParams {
+    clusterID: string;
+    keyspace: string;
+}
+
+export const fetchVSchema = async ({ clusterID, keyspace }: FetchVSchemaParams) => {
+    const { result } = await vtfetch(`/api/vschema/${clusterID}/${keyspace}`);
+
+    const err = pb.VSchema.verify(result);
+    if (err) throw Error(err);
+
+    return pb.VSchema.create(result);
+};
+
 export const fetchWorkflows = async () => {
     const { result } = await vtfetch(`/api/workflows`);
 

--- a/web/vtadmin/src/components/routes/Schema.module.scss
+++ b/web/vtadmin/src/components/routes/Schema.module.scss
@@ -44,6 +44,11 @@
   }
 }
 
+.container {
+  display: grid;
+  grid-gap: 16px;
+}
+
 .panel {
   border: solid 1px var(--colorScaffoldingHighlight);
   border-radius: 6px;
@@ -70,4 +75,21 @@
 .errorEmoji {
   display: block;
   font-size: 5.6rem;
+}
+
+.skCol {
+  // Minimize column width
+  width: 1%;
+}
+
+.skBadge {
+  border: solid 1px var(--colorPrimary50);
+  border-radius: 6px;
+  color: var(--colorPrimary);
+  display: inline-block;
+  font-size: var(--fontSizeSmall);
+  margin: 0 8px;
+  padding: 4px 8px;
+  text-transform: uppercase;
+  white-space: nowrap;
 }

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -22,6 +22,8 @@ import {
     FetchSchemaParams,
     fetchSchemas,
     fetchTablets,
+    fetchVSchema,
+    FetchVSchemaParams,
     fetchWorkflow,
     fetchWorkflows,
 } from '../api/http';
@@ -103,6 +105,13 @@ export const useSchema = (params: FetchSchemaParams, options?: UseQueryOptions<p
         },
         ...options,
     });
+};
+
+/**
+ * useVSchema is a query hook that fetches a single vschema definition for the given parameters.
+ */
+export const useVSchema = (params: FetchVSchemaParams, options?: UseQueryOptions<pb.VSchema, Error> | undefined) => {
+    return useQuery(['vschema', params], () => fetchVSchema(params));
 };
 
 /**

--- a/web/vtadmin/src/util/vschemas.test.ts
+++ b/web/vtadmin/src/util/vschemas.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vtadmin as pb } from '../proto/vtadmin';
+import * as vs from './vschemas';
+
+describe('getVindexesForTable', () => {
+    const tests: {
+        name: string;
+        input: Parameters<typeof vs.getVindexesForTable>;
+        expected: ReturnType<typeof vs.getVindexesForTable>;
+    }[] = [
+        {
+            name: 'should return column vindexes',
+            input: [
+                pb.VSchema.create({
+                    v_schema: {
+                        tables: {
+                            customer: {
+                                column_vindexes: [{ column: 'customer_id', name: 'hash' }],
+                            },
+                        },
+                        vindexes: {
+                            hash: { type: 'hash' },
+                        },
+                    },
+                }),
+                'customer',
+            ],
+            expected: [
+                {
+                    column: 'customer_id',
+                    name: 'hash',
+                    meta: { type: 'hash' },
+                },
+            ],
+        },
+        {
+            name: 'should return column vindexes + metadata',
+            input: [
+                pb.VSchema.create({
+                    v_schema: {
+                        tables: {
+                            dogs: {
+                                column_vindexes: [
+                                    { column: 'id', name: 'hash' },
+                                    { name: 'dogs_domain_vdx', columns: ['domain', 'is_good_dog'] },
+                                ],
+                            },
+                        },
+                        vindexes: {
+                            hash: { type: 'hash' },
+                            dogs_domain_vdx: {
+                                type: 'lookup_hash',
+                                owner: 'dogs',
+                                params: {
+                                    from: 'domain,is_good_dog',
+                                    table: 'dogs_domain_idx',
+                                    to: 'id',
+                                },
+                            },
+                        },
+                    },
+                }),
+                'dogs',
+            ],
+            expected: [
+                {
+                    column: 'id',
+                    name: 'hash',
+                    meta: { type: 'hash' },
+                },
+                {
+                    columns: ['domain', 'is_good_dog'],
+                    name: 'dogs_domain_vdx',
+                    meta: {
+                        owner: 'dogs',
+                        params: {
+                            from: 'domain,is_good_dog',
+                            table: 'dogs_domain_idx',
+                            to: 'id',
+                        },
+                        type: 'lookup_hash',
+                    },
+                },
+            ],
+        },
+        {
+            name: 'should handle vschemas where the given table is not defined',
+            input: [
+                pb.VSchema.create({
+                    v_schema: {
+                        tables: {
+                            customer: {
+                                column_vindexes: [{ column: 'customer_id', name: 'hash' }],
+                            },
+                        },
+                        vindexes: {
+                            hash: { type: 'hash' },
+                        },
+                    },
+                }),
+                'does-not-exist',
+            ],
+            expected: [],
+        },
+    ];
+
+    test.each(tests.map(Object.values))(
+        '%s',
+        (
+            name: string,
+            input: Parameters<typeof vs.getVindexesForTable>,
+            expected: ReturnType<typeof vs.getVindexesForTable>
+        ) => {
+            const result = vs.getVindexesForTable(...input);
+            expect(result).toEqual(expected);
+        }
+    );
+});

--- a/web/vtadmin/src/util/vschemas.ts
+++ b/web/vtadmin/src/util/vschemas.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vtadmin as pb } from '../proto/vtadmin';
+
+/**
+ * getVindexesForTable returns Vindexes + Vindex metadata for the given table.
+ */
+export const getVindexesForTable = (vschema: pb.VSchema, tableName: string) => {
+    const table = (vschema.v_schema?.tables || {})[tableName];
+    if (!table) return [];
+
+    return (table.column_vindexes || []).map((cv) => ({
+        ...cv,
+        meta: cv.name ? (vschema.v_schema?.vindexes || {})[cv.name] : null,
+    }));
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

As the title says, this PR introduces vindexes (when defined) to the Schema view. 

Same general caveat that this is just a first pass -- indeed, I just copied this from our internal prototype. 😊  I think there's more we can do here, like link to other tables, add lil tooltips, etc. I'm certainly interested in ideas here, now or whenever. 

Here's what it looks like with local Vitess, for a table with vindexes and for one without:
<img width="1792" alt="Screen Shot 2021-04-21 at 4 22 25 PM" src="https://user-images.githubusercontent.com/855595/115617469-6c0a4e00-a2bf-11eb-95dc-799c851f59e1.png">


<img width="1792" alt="Screen Shot 2021-04-21 at 4 22 33 PM" src="https://user-images.githubusercontent.com/855595/115617460-6a408a80-a2bf-11eb-9e14-a3eadf430417.png">

And here's a slightly more complicated example from the unit tests 🐕 

<img width="1031" alt="Screen Shot 2021-04-21 at 4 46 28 PM" src="https://user-images.githubusercontent.com/855595/115618787-25b5ee80-a2c1-11eb-99e6-a0bef691a329.png">



## Related Issue(s)
<!-- List related issues and pull requests: -->

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
