### PR TITLE
vtctl: return error on invalid ddl_strategy

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2840,7 +2840,7 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		executor.SkipPreflight()
 	}
 	if err := executor.SetDDLStrategy(*ddlStrategy); err != nil {
-		return nil
+		return err
 	}
 
 	return schemamanager.Run(


### PR DESCRIPTION

## Description

Quick fix for a minor bug: if you run `vtctl ApplySchema -ddl_strategy=foobar ...`, then `vtctl` must return error because `foobar` is an invalid strategy. Right now it skips the migration but does not report an error.

## Related Issue(s)

- Backport of https://github.com/vitessio/vitess/pull/7923

## Checklist
- [x] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
