### PR TITLE
Panic when EOF after @ symbol

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2320,6 +2320,12 @@ func TestConvert(t *testing.T) {
 	}, {
 		input:  "set transaction isolation level 12345",
 		output: "syntax error at position 38 near '12345'",
+	}, {
+		input:  "@",
+		output: "syntax error at position 2",
+	}, {
+		input:  "@@",
+		output: "syntax error at position 3",
 	}}
 
 	for _, tcase := range invalidSQL {

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -136,6 +136,8 @@ func (tkn *Tokenizer) Scan() (int, string) {
 		if tkn.cur() == '`' {
 			tkn.skip(1)
 			tID, tBytes = tkn.scanLiteralIdentifier()
+		} else if tkn.cur() == eofChar {
+			return LEX_ERROR, ""
 		} else {
 			tID, tBytes = tkn.scanIdentifier(true)
 		}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Handles the panic when there is an EOF after @ symbol as the tokenizer used to try to find a token after the @ symbol.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
