### PR TITLE
vttablet/tabletmanager: add isInSRVKeyspace/isShardServing

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -94,6 +94,9 @@ var (
 	// statsBackupIsRunning is set to 1 (true) if a backup is running.
 	statsBackupIsRunning *stats.GaugesWithMultiLabels
 
+	// statsIsInSRVKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
+	statsIsInSRVKeyspace *stats.Gauge
+
 	statsKeyspace      = stats.NewString("TabletKeyspace")
 	statsShard         = stats.NewString("TabletShard")
 	statsKeyRangeStart = stats.NewString("TabletKeyRangeStart")
@@ -115,6 +118,7 @@ func init() {
 	statsTabletType = stats.NewString("TabletType")
 	statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
 	statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
+	statsIsInSRVKeyspace = stats.NewGauge("IsInSRVKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
 }
 
 // TabletManager is the main class for the tablet manager.

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -94,8 +94,8 @@ var (
 	// statsBackupIsRunning is set to 1 (true) if a backup is running.
 	statsBackupIsRunning *stats.GaugesWithMultiLabels
 
-	// statsIsInSRVKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
-	statsIsInSRVKeyspace *stats.Gauge
+	// statsIsInSrvKeyspace is set to 1 (true), 0 (false) whether the tablet is in the serving keyspace
+	statsIsInSrvKeyspace *stats.Gauge
 
 	statsKeyspace      = stats.NewString("TabletKeyspace")
 	statsShard         = stats.NewString("TabletShard")
@@ -118,7 +118,7 @@ func init() {
 	statsTabletType = stats.NewString("TabletType")
 	statsTabletTypeCount = stats.NewCountersWithSingleLabel("TabletTypeCount", "Number of times the tablet changed to the labeled type", "type")
 	statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
-	statsIsInSRVKeyspace = stats.NewGauge("IsInSRVKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
+	statsIsInSrvKeyspace = stats.NewGauge("IsInSrvKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
 }
 
 // TabletManager is the main class for the tablet manager.

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -62,6 +62,8 @@ type tmState struct {
 	mu                sync.Mutex
 	isOpen            bool
 	isResharding      bool
+	isInSRVKeyspace   bool
+	isShardServing    map[topodatapb.TabletType]bool
 	tabletControls    map[topodatapb.TabletType]bool
 	blacklistedTables map[topodatapb.TabletType][]string
 	tablet            *topodatapb.Tablet
@@ -139,8 +141,17 @@ func (ts *tmState) RefreshFromTopoInfo(ctx context.Context, shardInfo *topo.Shar
 	}
 
 	if srvKeyspace != nil {
+		ts.isShardServing = make(map[topodatapb.TabletType]bool)
 		ts.tabletControls = make(map[topodatapb.TabletType]bool)
+
 		for _, partition := range srvKeyspace.GetPartitions() {
+
+			for _, shard := range partition.GetShardReferences() {
+				if key.KeyRangeEqual(shard.GetKeyRange(), ts.tablet.KeyRange) {
+					ts.isShardServing[partition.GetServedType()] = true
+				}
+			}
+
 			for _, tabletControl := range partition.GetShardTabletControls() {
 				if key.KeyRangeEqual(tabletControl.GetKeyRange(), ts.KeyRange()) {
 					if tabletControl.QueryServiceDisabled {
@@ -250,6 +261,14 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 		} else {
 			ts.tm.VREngine.Close()
 		}
+	}
+
+	if ts.isShardServing[ts.tablet.Type] {
+		ts.isInSRVKeyspace = true
+		statsIsInSRVKeyspace.Set(1)
+	} else {
+		ts.isInSRVKeyspace = false
+		statsIsInSRVKeyspace.Set(0)
 	}
 
 	// Open TabletServer last so that it advertises serving after all other services are up.

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -62,7 +62,7 @@ type tmState struct {
 	mu                sync.Mutex
 	isOpen            bool
 	isResharding      bool
-	isInSRVKeyspace   bool
+	isInSrvKeyspace   bool
 	isShardServing    map[topodatapb.TabletType]bool
 	tabletControls    map[topodatapb.TabletType]bool
 	blacklistedTables map[topodatapb.TabletType][]string
@@ -264,11 +264,11 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 	}
 
 	if ts.isShardServing[ts.tablet.Type] {
-		ts.isInSRVKeyspace = true
-		statsIsInSRVKeyspace.Set(1)
+		ts.isInSrvKeyspace = true
+		statsIsInSrvKeyspace.Set(1)
 	} else {
-		ts.isInSRVKeyspace = false
-		statsIsInSRVKeyspace.Set(0)
+		ts.isInSrvKeyspace = false
+		statsIsInSrvKeyspace.Set(0)
 	}
 
 	// Open TabletServer last so that it advertises serving after all other services are up.

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/servenv"
 
 	"context"
@@ -152,6 +153,158 @@ func TestStateTabletControls(t *testing.T) {
 	qsc := tm.QueryServiceControl.(*tabletservermock.Controller)
 	assert.Equal(t, topodatapb.TabletType_REPLICA, qsc.CurrentTarget().TabletType)
 	assert.False(t, qsc.IsServing())
+}
+
+func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	tm := newTestTM(t, ts, 1, "ks", "0")
+	defer tm.Stop()
+
+	tm.tmState.mu.Lock()
+	tm.tmState.tablet.Type = topodatapb.TabletType_MASTER
+	tm.tmState.mu.Unlock()
+
+	leftKeyRange, err := key.ParseShardingSpec("-80")
+	if err != nil || len(leftKeyRange) != 1 {
+		t.Fatalf("ParseShardingSpec failed. Expected non error and only one element. Got err: %v, len(%v)", err, len(leftKeyRange))
+	}
+
+	rightKeyRange, err := key.ParseShardingSpec("80-")
+	if err != nil || len(rightKeyRange) != 1 {
+		t.Fatalf("ParseShardingSpec failed. Expected non error and only one element. Got err: %v, len(%v)", err, len(rightKeyRange))
+	}
+
+	keyRange, err := key.ParseShardingSpec("0")
+	if err != nil || len(keyRange) != 1 {
+		t.Fatalf("ParseShardingSpec failed. Expected non error and only one element. Got err: %v, len(%v)", err, len(keyRange))
+	}
+
+	// Shard not in the SrvKeyspace, ServedType not in SrvKeyspace
+	ks := &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_DRAINED,
+				ShardReferences: []*topodatapb.ShardReference{
+					{
+						Name:     "-80",
+						KeyRange: leftKeyRange[0],
+					},
+					{
+						Name:     "80-",
+						KeyRange: rightKeyRange[0],
+					},
+				},
+			},
+		},
+	}
+	want := map[topodatapb.TabletType]bool{}
+	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
+
+	tm.tmState.mu.Lock()
+	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.Equal(t, want, tm.tmState.isShardServing)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+
+	// Shard not in the SrvKeyspace, ServedType in SrvKeyspace
+	ks = &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_MASTER,
+				ShardReferences: []*topodatapb.ShardReference{
+					{
+						Name:     "-80",
+						KeyRange: leftKeyRange[0],
+					},
+					{
+						Name:     "80-",
+						KeyRange: rightKeyRange[0],
+					},
+				},
+			},
+		},
+	}
+	want = map[topodatapb.TabletType]bool{}
+	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
+
+	tm.tmState.mu.Lock()
+	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.Equal(t, want, tm.tmState.isShardServing)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+
+	// Shard in the SrvKeyspace, ServedType in the SrvKeyspace
+	ks = &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_MASTER,
+				ShardReferences: []*topodatapb.ShardReference{
+					{
+						Name:     "0",
+						KeyRange: keyRange[0],
+					},
+				},
+			},
+		},
+	}
+	want = map[topodatapb.TabletType]bool{
+		topodatapb.TabletType_MASTER: true,
+	}
+	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
+
+	tm.tmState.mu.Lock()
+	assert.True(t, tm.tmState.isInSRVKeyspace)
+	assert.Equal(t, want, tm.tmState.isShardServing)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+
+	// Shard in the SrvKeyspace, ServedType not in the SrvKeyspace
+	ks = &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{
+			{
+				ServedType: topodatapb.TabletType_RDONLY,
+				ShardReferences: []*topodatapb.ShardReference{
+					{
+						Name:     "0",
+						KeyRange: keyRange[0],
+					},
+				},
+			},
+		},
+	}
+	want = map[topodatapb.TabletType]bool{
+		topodatapb.TabletType_RDONLY: true,
+	}
+	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
+
+	tm.tmState.mu.Lock()
+	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.Equal(t, want, tm.tmState.isShardServing)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+
+	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
+	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_RDONLY, DBActionNone)
+	require.NoError(t, err)
+	tm.tmState.mu.Lock()
+	assert.True(t, tm.tmState.isInSRVKeyspace)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+
+	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
+	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_DRAINED, DBActionNone)
+	require.NoError(t, err)
+	tm.tmState.mu.Lock()
+	assert.False(t, tm.tmState.isInSRVKeyspace)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
 }
 
 func TestStateNonServing(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -155,7 +155,7 @@ func TestStateTabletControls(t *testing.T) {
 	assert.False(t, qsc.IsServing())
 }
 
-func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
+func TestStateIsShardServingisInSrvKeyspace(t *testing.T) {
 	ctx := context.Background()
 	ts := memorytopo.NewServer("cell1")
 	tm := newTestTM(t, ts, 1, "ks", "0")
@@ -202,11 +202,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Shard not in the SrvKeyspace, ServedType in SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -230,11 +230,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -256,11 +256,11 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.True(t, tm.tmState.isInSRVKeyspace)
+	assert.True(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(1), statsIsInSrvKeyspace.Get())
 
 	// Shard in the SrvKeyspace, ServedType not in the SrvKeyspace
 	ks = &topodatapb.SrvKeyspace{
@@ -282,29 +282,29 @@ func TestStateIsShardServingisInSRVKeyspace(t *testing.T) {
 	tm.tmState.RefreshFromTopoInfo(ctx, nil, ks)
 
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	assert.Equal(t, want, tm.tmState.isShardServing)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 
 	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_RDONLY, DBActionNone)
 	require.NoError(t, err)
 	tm.tmState.mu.Lock()
-	assert.True(t, tm.tmState.isInSRVKeyspace)
+	assert.True(t, tm.tmState.isInSrvKeyspace)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(1), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(1), statsIsInSrvKeyspace.Get())
 
 	// Test tablet type change - shard in the SrvKeyspace, ServedType in the SrvKeyspace
 	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_DRAINED, DBActionNone)
 	require.NoError(t, err)
 	tm.tmState.mu.Lock()
-	assert.False(t, tm.tmState.isInSRVKeyspace)
+	assert.False(t, tm.tmState.isInSrvKeyspace)
 	tm.tmState.mu.Unlock()
 
-	assert.Equal(t, int64(0), statsIsInSRVKeyspace.Get())
+	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
 }
 
 func TestStateNonServing(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Guido Iaquinti <giaquinti@slack-corp.com>

## Description
Add a new metric in `vttablet` to keep track if the keyspace partition it belongs to is serving or not. This metric can be useful for external systems to automatically enable/disable alerts.

In order to don't add additional watches to the topology service (as we don't want those to linearly scale with the number of vttablets), we refresh the serving keyspace view in TabletManager only when `RefreshFromTopoInfo` is called.

Note: this PR is still a WIP but I'll appreciate an early feedback. 

## Related Issue(s)
N/A

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [X]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
