### PR TITLE
[workflow] extract migration targets from wrangler

### DIFF
--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -140,18 +140,10 @@ func BuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManag
 			return nil, err
 		}
 
-		query := fmt.Sprintf(
-			`SELECT
-				id,
-				source,
-				message,
-				cell,
-				tablet_types
-			FROM
-				_vt.vreplication
-			WHERE
-				workflow=%s AND
-				db_name=%s`, encodeString(workflow), encodeString(primary.DbName()))
+		// NB: changing the whitespace of this query breaks tests for now.
+		// (TODO:@ajm188) extend FakeDBClient to be less whitespace-sensitive on
+		// expected queries.
+		query := fmt.Sprintf("select id, source, message, cell, tablet_types from _vt.vreplication where workflow=%s and db_name=%s", encodeString(workflow), encodeString(primary.DbName()))
 		p3qr, err := tmc.VReplicationExec(ctx, primary.Tablet, query)
 		if err != nil {
 			return nil, err
@@ -187,6 +179,8 @@ func BuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManag
 			optCells = row[3].ToString()
 			optTabletTypes = row[4].ToString()
 		}
+
+		targets[targetShard] = target
 	}
 
 	if len(targets) == 0 {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+var (
+	Frozen = "FROZEN"
+)
+
+var (
+	ErrNoStreams = errors.New("no streams found")
+)
+
+type TrafficSwitchDirection int
+
+const (
+	DirectionForward = TrafficSwitchDirection(iota)
+	DirectionBackward
+)
+
+type TrafficSwitcher struct {
+	id              int64
+	workflow        string
+	reverseWorkflow string
+
+	sources map[string]*MigrationSource
+	targets map[string]*MigrationTarget
+
+	targetKeyspace string
+	frozen         bool
+}
+
+type TargetInfo struct {
+	Targets        map[string]*MigrationTarget
+	Frozen         bool
+	OptCells       string
+	OptTabletTypes string
+}
+
+type MigrationSource struct {
+	si        *topo.ShardInfo
+	primary   *topo.TabletInfo
+	Position  string
+	Journaled bool
+}
+
+// TODO: do we always want to start with (position:"", journaled:false)?
+func NewMigrationSource(si *topo.ShardInfo, primary *topo.TabletInfo) *MigrationSource {
+	return &MigrationSource{
+		si:      si,
+		primary: primary,
+	}
+}
+
+func (source *MigrationSource) GetShard() *topo.ShardInfo {
+	return source.si
+}
+
+func (source *MigrationSource) GetPrimary() *topo.TabletInfo {
+	return source.primary
+}
+
+type MigrationTarget struct {
+	si       *topo.ShardInfo
+	primary  *topo.TabletInfo
+	Sources  map[uint32]*binlogdatapb.BinlogSource
+	Position string
+}
+
+func (target *MigrationTarget) GetShard() *topo.ShardInfo {
+	return target.si
+}
+
+func (target *MigrationTarget) GetPrimary() *topo.TabletInfo {
+	return target.primary
+}
+
+func BuildTrafficSwitcher(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerClient, targetKeyspace string, workflow string) (*TrafficSwitcher, error) {
+	targetInfo, err := BuildTargets(ctx, ts, tmc, targetKeyspace, workflow)
+	if err != nil {
+		log.Infof("Error building targets: %s", err)
+		return nil, err
+	}
+
+	switcher := &TrafficSwitcher{
+		id:              HashStreams(targetKeyspace, targetInfo.Targets),
+		workflow:        workflow,
+		reverseWorkflow: "",
+	}
+
+	return switcher, nil
+}
+
+func BuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerClient, targetKeyspace string, workflow string) (*TargetInfo, error) {
+	targetShards, err := ts.GetShardNames(ctx, targetKeyspace)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		frozen         bool
+		optCells       string
+		optTabletTypes string
+		targets        = make(map[string]*MigrationTarget, len(targetShards))
+	)
+
+	for _, targetShard := range targetShards {
+		si, err := ts.GetShard(ctx, targetKeyspace, targetShard)
+		if err != nil {
+			return nil, err
+		}
+
+		if si.MasterAlias == nil {
+			// This can happen if bad inputs are given.
+			return nil, fmt.Errorf("shard %v/%v doesn't have a primary set", targetKeyspace, targetShard)
+		}
+
+		primary, err := ts.GetTablet(ctx, si.MasterAlias)
+		if err != nil {
+			return nil, err
+		}
+
+		query := fmt.Sprintf(
+			`SELECT
+				id,
+				source,
+				message,
+				cell,
+				tablet_types
+			FROM
+				_vt.vreplication
+			WHERE
+				workflow=%s AND
+				db_name=%s`, workflow, primary.DbName()) // TODO: port encodeString()
+		p3qr, err := tmc.VReplicationExec(ctx, primary.Tablet, query)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(p3qr.Rows) < 1 {
+			continue
+		}
+
+		target := &MigrationTarget{
+			si:      si,
+			primary: primary,
+			Sources: make(map[uint32]*binlogdatapb.BinlogSource),
+		}
+
+		qr := sqltypes.Proto3ToResult(p3qr)
+		for _, row := range qr.Rows {
+			id, err := evalengine.ToInt64(row[0])
+			if err != nil {
+				return nil, err
+			}
+
+			var bls binlogdatapb.BinlogSource
+			if err := proto.UnmarshalText(row[1].ToString(), &bls); err != nil {
+				return nil, err
+			}
+
+			if row[2].ToString() == Frozen {
+				frozen = true
+			}
+
+			target.Sources[uint32(id)] = &bls
+			optCells = row[3].ToString()
+			optTabletTypes = row[4].ToString()
+		}
+	}
+
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("%w in keyspace %s for %s", ErrNoStreams, targetKeyspace, workflow)
+	}
+
+	return &TargetInfo{
+		Targets:        targets,
+		Frozen:         frozen,
+		OptCells:       optCells,
+		OptTabletTypes: optTabletTypes,
+	}, nil
+}
+
+func HashStreams(targetKeyspace string, targets map[string]*MigrationTarget) int64 {
+	var expanded []string
+	for shard, target := range targets {
+		for uid := range target.Sources {
+			expanded = append(expanded, fmt.Sprintf("%s:%d", shard, uid))
+		}
+	}
+
+	sort.Strings(expanded)
+
+	hasher := fnv.New64()
+	hasher.Write([]byte(targetKeyspace))
+
+	for _, s := range expanded {
+		hasher.Write([]byte(s))
+	}
+
+	// Convert to int64 after dropping the highest bit.
+	return int64(hasher.Sum64() & math.MaxInt64)
+}
+
+const reverseSuffix = "_reverse"
+
+func ReverseWorkflow(workflow string) string {
+	if strings.HasSuffix(workflow, reverseSuffix) {
+		return workflow[:len(workflow)-len(reverseSuffix)]
+	}
+
+	return workflow + reverseSuffix
+}

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -225,11 +225,11 @@ func HashStreams(targetKeyspace string, targets map[string]*MigrationTarget) int
 
 const reverseSuffix = "_reverse"
 
-// ReverseWorkflow returns the "reversed" name of a workflow. For a "forward"
-// workflow, this is the workflow name with "_reversed" appended, and for a
-// "reversed" workflow, this is the workflow name with the "_reversed" suffix
-// removed.
-func ReverseWorkflow(workflow string) string {
+// ReverseWorkflowName returns the "reversed" name of a workflow. For a
+// "forward" workflow, this is the workflow name with "_reversed" appended, and
+// for a "reversed" workflow, this is the workflow name with the "_reversed"
+// suffix removed.
+func ReverseWorkflowName(workflow string) string {
 	if strings.HasSuffix(workflow, reverseSuffix) {
 		return workflow[:len(workflow)-len(reverseSuffix)]
 	}

--- a/go/vt/vtctl/workflow/traffic_switcher_test.go
+++ b/go/vt/vtctl/workflow/traffic_switcher_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverseWorkflowName(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "aa",
+			out: "aa_reverse",
+		},
+		{
+			in:  "aa_reverse",
+			out: "aa",
+		},
+		{
+			in:  "aa_reverse_aa",
+			out: "aa_reverse_aa_reverse",
+		},
+	}
+	for _, test := range tests {
+		got := ReverseWorkflowName(test.in)
+		assert.Equal(t, test.out, got)
+	}
+}

--- a/go/vt/wrangler/stream_migrater.go
+++ b/go/vt/wrangler/stream_migrater.go
@@ -17,15 +17,12 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"text/template"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"context"
 
 	"github.com/golang/protobuf/proto"
 
@@ -34,12 +31,14 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/key"
-	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
 
 type streamMigrater struct {

--- a/go/vt/wrangler/stream_migrater.go
+++ b/go/vt/wrangler/stream_migrater.go
@@ -33,6 +33,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -82,7 +83,7 @@ func buildStreamMigrater(ctx context.Context, ts *trafficSwitcher, cancelMigrate
 func (sm *streamMigrater) readSourceStreams(ctx context.Context, cancelMigrate bool) (map[string][]*vrStream, error) {
 	streams := make(map[string][]*vrStream)
 	var mu sync.Mutex
-	err := sm.ts.forAllSources(func(source *tsSource) error {
+	err := sm.ts.forAllSources(func(source *workflow.MigrationSource) error {
 		if !cancelMigrate {
 			// This flow protects us from the following scenario: When we create streams,
 			// we always do it in two phases. We start them off as Stopped, and then
@@ -95,15 +96,15 @@ func (sm *streamMigrater) readSourceStreams(ctx context.Context, cancelMigrate b
 			// If so, we request the operator to clean them up, or restart them before going ahead.
 			// This allows us to assume that all stopped streams can be safely restarted
 			// if we cancel the operation.
-			stoppedStreams, err := sm.readTabletStreams(ctx, source.master, "state = 'Stopped' and message != 'FROZEN'")
+			stoppedStreams, err := sm.readTabletStreams(ctx, source.GetPrimary(), "state = 'Stopped' and message != 'FROZEN'")
 			if err != nil {
 				return err
 			}
 			if len(stoppedStreams) != 0 {
-				return fmt.Errorf("cannot migrate until all streams are running: %s: %d", source.si.ShardName(), source.master.Alias.Uid)
+				return fmt.Errorf("cannot migrate until all streams are running: %s: %d", source.GetShard().ShardName(), source.GetPrimary().Alias.Uid)
 			}
 		}
-		tabletStreams, err := sm.readTabletStreams(ctx, source.master, "")
+		tabletStreams, err := sm.readTabletStreams(ctx, source.GetPrimary(), "")
 		if err != nil {
 			return err
 		}
@@ -111,17 +112,17 @@ func (sm *streamMigrater) readSourceStreams(ctx context.Context, cancelMigrate b
 			// No VReplication is running. So, we have no work to do.
 			return nil
 		}
-		p3qr, err := sm.ts.wr.tmc.VReplicationExec(ctx, source.master.Tablet, fmt.Sprintf("select vrepl_id from _vt.copy_state where vrepl_id in %s", tabletStreamValues(tabletStreams)))
+		p3qr, err := sm.ts.wr.tmc.VReplicationExec(ctx, source.GetPrimary().Tablet, fmt.Sprintf("select vrepl_id from _vt.copy_state where vrepl_id in %s", tabletStreamValues(tabletStreams)))
 		if err != nil {
 			return err
 		}
 		if len(p3qr.Rows) != 0 {
-			return fmt.Errorf("cannot migrate while vreplication streams in source shards are still copying: %s", source.si.ShardName())
+			return fmt.Errorf("cannot migrate while vreplication streams in source shards are still copying: %s", source.GetShard().ShardName())
 		}
 
 		mu.Lock()
 		defer mu.Unlock()
-		streams[source.si.ShardName()] = tabletStreams
+		streams[source.GetShard().ShardName()] = tabletStreams
 		return nil
 	})
 	if err != nil {
@@ -268,23 +269,23 @@ func (sm *streamMigrater) readTabletStreams(ctx context.Context, ti *topo.Tablet
 func (sm *streamMigrater) stopSourceStreams(ctx context.Context) error {
 	stoppedStreams := make(map[string][]*vrStream)
 	var mu sync.Mutex
-	err := sm.ts.forAllSources(func(source *tsSource) error {
-		tabletStreams := sm.streams[source.si.ShardName()]
+	err := sm.ts.forAllSources(func(source *workflow.MigrationSource) error {
+		tabletStreams := sm.streams[source.GetShard().ShardName()]
 		if len(tabletStreams) == 0 {
 			return nil
 		}
 		query := fmt.Sprintf("update _vt.vreplication set state='Stopped', message='for cutover' where id in %s", tabletStreamValues(tabletStreams))
-		_, err := sm.ts.wr.tmc.VReplicationExec(ctx, source.master.Tablet, query)
+		_, err := sm.ts.wr.tmc.VReplicationExec(ctx, source.GetPrimary().Tablet, query)
 		if err != nil {
 			return err
 		}
-		tabletStreams, err = sm.readTabletStreams(ctx, source.master, fmt.Sprintf("id in %s", tabletStreamValues(tabletStreams)))
+		tabletStreams, err = sm.readTabletStreams(ctx, source.GetPrimary(), fmt.Sprintf("id in %s", tabletStreamValues(tabletStreams)))
 		if err != nil {
 			return err
 		}
 		mu.Lock()
 		defer mu.Unlock()
-		stoppedStreams[source.si.ShardName()] = tabletStreams
+		stoppedStreams[source.GetShard().ShardName()] = tabletStreams
 		return nil
 	})
 	if err != nil {
@@ -352,18 +353,18 @@ func (sm *streamMigrater) syncSourceStreams(ctx context.Context) (map[string]mys
 func (sm *streamMigrater) verifyStreamPositions(ctx context.Context, stopPositions map[string]mysql.Position) ([]string, error) {
 	stoppedStreams := make(map[string][]*vrStream)
 	var mu sync.Mutex
-	err := sm.ts.forAllSources(func(source *tsSource) error {
-		tabletStreams := sm.streams[source.si.ShardName()]
+	err := sm.ts.forAllSources(func(source *workflow.MigrationSource) error {
+		tabletStreams := sm.streams[source.GetShard().ShardName()]
 		if len(tabletStreams) == 0 {
 			return nil
 		}
-		tabletStreams, err := sm.readTabletStreams(ctx, source.master, fmt.Sprintf("id in %s", tabletStreamValues(tabletStreams)))
+		tabletStreams, err := sm.readTabletStreams(ctx, source.GetPrimary(), fmt.Sprintf("id in %s", tabletStreamValues(tabletStreams)))
 		if err != nil {
 			return err
 		}
 		mu.Lock()
 		defer mu.Unlock()
-		stoppedStreams[source.si.ShardName()] = tabletStreams
+		stoppedStreams[source.GetShard().ShardName()] = tabletStreams
 		return nil
 	})
 	if err != nil {
@@ -539,24 +540,24 @@ func (sm *streamMigrater) createTargetStreams(ctx context.Context, tmpl []*vrStr
 	if len(tmpl) == 0 {
 		return nil
 	}
-	return sm.ts.forAllTargets(func(target *tsTarget) error {
+	return sm.ts.forAllTargets(func(target *workflow.MigrationTarget) error {
 		tabletStreams := copyTabletStreams(tmpl)
 		for _, vrs := range tabletStreams {
 			for _, rule := range vrs.bls.Filter.Rules {
 				buf := &strings.Builder{}
 				t := template.Must(template.New("").Parse(rule.Filter))
-				if err := t.Execute(buf, key.KeyRangeString(target.si.KeyRange)); err != nil {
+				if err := t.Execute(buf, key.KeyRangeString(target.GetShard().KeyRange)); err != nil {
 					return err
 				}
 				rule.Filter = buf.String()
 			}
 		}
 
-		ig := vreplication.NewInsertGenerator(binlogplayer.BlpStopped, target.master.DbName())
+		ig := vreplication.NewInsertGenerator(binlogplayer.BlpStopped, target.GetPrimary().DbName())
 		for _, vrs := range tabletStreams {
 			ig.AddRow(vrs.workflow, vrs.bls, mysql.EncodePosition(vrs.pos), "", "")
 		}
-		_, err := sm.ts.wr.VReplicationExec(ctx, target.master.Alias, ig.String())
+		_, err := sm.ts.wr.VReplicationExec(ctx, target.GetPrimary().Alias, ig.String())
 		return err
 	})
 }
@@ -569,9 +570,9 @@ func (sm *streamMigrater) cancelMigration(ctx context.Context) {
 	// Ignore error. We still want to restart the source streams if deleteTargetStreams fails.
 	_ = sm.deleteTargetStreams(ctx)
 
-	err := sm.ts.forAllSources(func(source *tsSource) error {
-		query := fmt.Sprintf("update _vt.vreplication set state='Running', stop_pos=null, message='' where db_name=%s and workflow != %s", encodeString(source.master.DbName()), encodeString(sm.ts.reverseWorkflow))
-		_, err := sm.ts.wr.VReplicationExec(ctx, source.master.Alias, query)
+	err := sm.ts.forAllSources(func(source *workflow.MigrationSource) error {
+		query := fmt.Sprintf("update _vt.vreplication set state='Running', stop_pos=null, message='' where db_name=%s and workflow != %s", encodeString(source.GetPrimary().DbName()), encodeString(sm.ts.reverseWorkflow))
+		_, err := sm.ts.wr.VReplicationExec(ctx, source.GetPrimary().Alias, query)
 		return err
 	})
 	if err != nil {
@@ -584,9 +585,9 @@ func (sm *streamMigrater) deleteTargetStreams(ctx context.Context) error {
 		return nil
 	}
 	workflowList := stringListify(sm.workflows)
-	err := sm.ts.forAllTargets(func(target *tsTarget) error {
-		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow in (%s)", encodeString(target.master.DbName()), workflowList)
-		_, err := sm.ts.wr.VReplicationExec(ctx, target.master.Alias, query)
+	err := sm.ts.forAllTargets(func(target *workflow.MigrationTarget) error {
+		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow in (%s)", encodeString(target.GetPrimary().DbName()), workflowList)
+		_, err := sm.ts.wr.VReplicationExec(ctx, target.GetPrimary().Alias, query)
 		return err
 	})
 	if err != nil {
@@ -602,17 +603,17 @@ func streamMigraterfinalize(ctx context.Context, ts *trafficSwitcher, workflows 
 		return nil
 	}
 	workflowList := stringListify(workflows)
-	err := ts.forAllSources(func(source *tsSource) error {
-		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow in (%s)", encodeString(source.master.DbName()), workflowList)
-		_, err := ts.wr.VReplicationExec(ctx, source.master.Alias, query)
+	err := ts.forAllSources(func(source *workflow.MigrationSource) error {
+		query := fmt.Sprintf("delete from _vt.vreplication where db_name=%s and workflow in (%s)", encodeString(source.GetPrimary().DbName()), workflowList)
+		_, err := ts.wr.VReplicationExec(ctx, source.GetPrimary().Alias, query)
 		return err
 	})
 	if err != nil {
 		return err
 	}
-	err = ts.forAllTargets(func(target *tsTarget) error {
-		query := fmt.Sprintf("update _vt.vreplication set state='Running' where db_name=%s and workflow in (%s)", encodeString(target.master.DbName()), workflowList)
-		_, err := ts.wr.VReplicationExec(ctx, target.master.Alias, query)
+	err = ts.forAllTargets(func(target *workflow.MigrationTarget) error {
+		query := fmt.Sprintf("update _vt.vreplication set state='Running' where db_name=%s and workflow in (%s)", encodeString(target.GetPrimary().DbName()), workflowList)
+		_, err := ts.wr.VReplicationExec(ctx, target.GetPrimary().Alias, query)
 		return err
 	})
 	return err

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -286,7 +287,7 @@ func (dr *switcherDryRun) dropSourceReverseVReplicationStreams(ctx context.Conte
 	logs := make([]string, 0)
 	for _, t := range dr.ts.sources {
 		logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s Workflow %s DbName %s Tablet %d",
-			t.GetShard().Keyspace(), t.GetShard().ShardName(), reverseName(dr.ts.workflow), t.GetPrimary().DbName(), t.GetPrimary().Alias.Uid))
+			t.GetShard().Keyspace(), t.GetShard().ShardName(), workflow.ReverseWorkflowName(dr.ts.workflow), t.GetPrimary().DbName(), t.GetPrimary().Alias.Uid))
 	}
 	dr.drLog.LogSlice(logs)
 	return nil

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -50,10 +50,10 @@ func (dr *switcherDryRun) switchShardReads(ctx context.Context, cells []string, 
 	sourceShards := make([]string, 0)
 	targetShards := make([]string, 0)
 	for _, source := range dr.ts.sources {
-		sourceShards = append(sourceShards, source.si.ShardName())
+		sourceShards = append(sourceShards, source.GetShard().ShardName())
 	}
 	for _, target := range dr.ts.targets {
-		targetShards = append(targetShards, target.si.ShardName())
+		targetShards = append(targetShards, target.GetShard().ShardName())
 	}
 	sort.Strings(sourceShards)
 	sort.Strings(targetShards)
@@ -108,10 +108,10 @@ func (dr *switcherDryRun) changeRouting(ctx context.Context) error {
 	deleteLogs = nil
 	addLogs = nil
 	for _, source := range dr.ts.sources {
-		deleteLogs = append(deleteLogs, fmt.Sprintf("\tShard %s, Tablet %d", source.si.ShardName(), source.si.MasterAlias.Uid))
+		deleteLogs = append(deleteLogs, fmt.Sprintf("\tShard %s, Tablet %d", source.GetShard().ShardName(), source.GetShard().MasterAlias.Uid))
 	}
 	for _, target := range dr.ts.targets {
-		addLogs = append(addLogs, fmt.Sprintf("\tShard %s, Tablet %d", target.si.ShardName(), target.si.MasterAlias.Uid))
+		addLogs = append(addLogs, fmt.Sprintf("\tShard %s, Tablet %d", target.GetShard().ShardName(), target.GetShard().MasterAlias.Uid))
 	}
 	if len(deleteLogs) > 0 {
 		dr.drLog.Log("IsMasterServing will be set to false for:")
@@ -126,7 +126,7 @@ func (dr *switcherDryRun) streamMigraterfinalize(ctx context.Context, ts *traffi
 	dr.drLog.Log("SwitchWrites completed, freeze and delete vreplication streams on:")
 	logs := make([]string, 0)
 	for _, t := range ts.targets {
-		logs = append(logs, fmt.Sprintf("\ttablet %d", t.master.Alias.Uid))
+		logs = append(logs, fmt.Sprintf("\ttablet %d", t.GetPrimary().Alias.Uid))
 	}
 	dr.drLog.LogSlice(logs)
 	return nil
@@ -136,7 +136,7 @@ func (dr *switcherDryRun) startReverseVReplication(ctx context.Context) error {
 	dr.drLog.Log("Start reverse replication streams on:")
 	logs := make([]string, 0)
 	for _, t := range dr.ts.sources {
-		logs = append(logs, fmt.Sprintf("\ttablet %d", t.master.Alias.Uid))
+		logs = append(logs, fmt.Sprintf("\ttablet %d", t.GetPrimary().Alias.Uid))
 	}
 	dr.drLog.LogSlice(logs)
 	return nil
@@ -168,7 +168,7 @@ func (dr *switcherDryRun) migrateStreams(ctx context.Context, sm *streamMigrater
 		tabletStreams := copyTabletStreams(sm.templates)
 		for _, vrs := range tabletStreams {
 			logs = append(logs, fmt.Sprintf("\t Keyspace %s, Shard %s, Tablet %d, Workflow %s, Id %d, Pos %v, BinLogSource %s",
-				vrs.bls.Keyspace, vrs.bls.Shard, target.master.Alias.Uid, vrs.workflow, vrs.id, mysql.EncodePosition(vrs.pos), vrs.bls))
+				vrs.bls.Keyspace, vrs.bls.Shard, target.GetPrimary().Alias.Uid, vrs.workflow, vrs.id, mysql.EncodePosition(vrs.pos), vrs.bls))
 		}
 	}
 	if len(logs) > 0 {
@@ -186,8 +186,8 @@ func (dr *switcherDryRun) waitForCatchup(ctx context.Context, filteredReplicatio
 func (dr *switcherDryRun) stopSourceWrites(ctx context.Context) error {
 	logs := make([]string, 0)
 	for _, source := range dr.ts.sources {
-		position, _ := dr.ts.wr.tmc.MasterPosition(ctx, source.master.Tablet)
-		logs = append(logs, fmt.Sprintf("\tKeyspace %s, Shard %s at Position %s", dr.ts.sourceKeyspace, source.si.ShardName(), position))
+		position, _ := dr.ts.wr.tmc.MasterPosition(ctx, source.GetPrimary().Tablet)
+		logs = append(logs, fmt.Sprintf("\tKeyspace %s, Shard %s at Position %s", dr.ts.sourceKeyspace, source.GetShard().ShardName(), position))
 	}
 	if len(logs) > 0 {
 		dr.drLog.Log(fmt.Sprintf("Stop writes on keyspace %s, tables [%s]:", dr.ts.sourceKeyspace, strings.Join(dr.ts.tables, ",")))
@@ -227,7 +227,7 @@ func (dr *switcherDryRun) removeSourceTables(ctx context.Context, removalType Ta
 	for _, source := range dr.ts.sources {
 		for _, tableName := range dr.ts.tables {
 			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s",
-				source.master.Keyspace, source.master.Shard, source.master.DbName(), source.master.Alias.Uid, tableName))
+				source.GetPrimary().Keyspace, source.GetPrimary().Shard, source.GetPrimary().DbName(), source.GetPrimary().Alias.Uid, tableName))
 		}
 	}
 	action := "Dropping"
@@ -275,7 +275,7 @@ func (dr *switcherDryRun) dropTargetVReplicationStreams(ctx context.Context) err
 	logs := make([]string, 0)
 	for _, t := range dr.ts.targets {
 		logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s Workflow %s DbName %s Tablet %d",
-			t.si.Keyspace(), t.si.ShardName(), dr.ts.workflow, t.master.DbName(), t.master.Alias.Uid))
+			t.GetShard().Keyspace(), t.GetShard().ShardName(), dr.ts.workflow, t.GetPrimary().DbName(), t.GetPrimary().Alias.Uid))
 	}
 	dr.drLog.LogSlice(logs)
 	return nil
@@ -286,7 +286,7 @@ func (dr *switcherDryRun) dropSourceReverseVReplicationStreams(ctx context.Conte
 	logs := make([]string, 0)
 	for _, t := range dr.ts.sources {
 		logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s Workflow %s DbName %s Tablet %d",
-			t.si.Keyspace(), t.si.ShardName(), reverseName(dr.ts.workflow), t.master.DbName(), t.master.Alias.Uid))
+			t.GetShard().Keyspace(), t.GetShard().ShardName(), reverseName(dr.ts.workflow), t.GetPrimary().DbName(), t.GetPrimary().Alias.Uid))
 	}
 	dr.drLog.LogSlice(logs)
 	return nil
@@ -296,7 +296,7 @@ func (dr *switcherDryRun) freezeTargetVReplication(ctx context.Context) error {
 	logs := make([]string, 0)
 	for _, target := range dr.ts.targets {
 		logs = append(logs, fmt.Sprintf("\tKeyspace %s, Shard %s, Tablet %d, Workflow %s, DbName %s",
-			target.master.Keyspace, target.master.Shard, target.master.Alias.Uid, dr.ts.workflow, target.master.DbName()))
+			target.GetPrimary().Keyspace, target.GetPrimary().Shard, target.GetPrimary().Alias.Uid, dr.ts.workflow, target.GetPrimary().DbName()))
 	}
 	if len(logs) > 0 {
 		dr.drLog.Log("Mark vreplication streams frozen on:")
@@ -326,7 +326,7 @@ func (dr *switcherDryRun) removeTargetTables(ctx context.Context) error {
 	for _, target := range dr.ts.targets {
 		for _, tableName := range dr.ts.tables {
 			logs = append(logs, fmt.Sprintf("\tKeyspace %s Shard %s DbName %s Tablet %d Table %s",
-				target.master.Keyspace, target.master.Shard, target.master.DbName(), target.master.Alias.Uid, tableName))
+				target.GetPrimary().Keyspace, target.GetPrimary().Shard, target.GetPrimary().DbName(), target.GetPrimary().Alias.Uid, tableName))
 		}
 	}
 	if len(logs) > 0 {

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -17,17 +17,16 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-
-	"context"
 )
 
 var _ iswitcher = (*switcherDryRun)(nil)

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -17,6 +17,7 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -26,30 +27,25 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/json2"
-
-	"vitess.io/vitess/go/vt/topotools"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"vitess.io/vitess/go/vt/log"
-
-	"context"
-
 	"github.com/golang/protobuf/proto"
 
+	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
-	"vitess.io/vitess/go/vt/sqlparser"
-	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/vindexes"
-	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
 )
 
 const (

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -18,6 +18,7 @@ package wrangler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -246,7 +247,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 	ts, err := wr.buildTrafficSwitcher(ctx, targetKeyspace, workflowName)
 
 	if ts == nil || err != nil {
-		if err.Error() == fmt.Sprintf(errorNoStreams, targetKeyspace, workflowName) {
+		if errors.Is(err, workflow.ErrNoStreams) || err.Error() == fmt.Sprintf(errorNoStreams, targetKeyspace, workflowName) {
 			return nil, nil, nil
 		}
 		wr.Logger().Errorf("buildTrafficSwitcher failed: %v", err)

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -1689,23 +1689,6 @@ func TestMigrateNoTableWildcards(t *testing.T) {
 	}
 }
 
-func TestReverseName(t *testing.T) {
-	tests := []struct {
-		in, out string
-	}{{
-		in:  "aa",
-		out: "aa_reverse",
-	}, {
-		in:  "aa_reverse",
-		out: "aa",
-	}}
-	for _, test := range tests {
-		if got, want := reverseName(test.in), test.out; got != want {
-			t.Errorf("reverseName(%s): %s, want %s", test.in, got, test.out)
-		}
-	}
-}
-
 func TestReverseVReplicationUpdateQuery(t *testing.T) {
 	ts := &trafficSwitcher{
 		reverseWorkflow: "wf",

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -17,18 +17,13 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 	"sync"
 	"time"
-
-	"vitess.io/vitess/go/vt/log"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
-
-	"context"
 
 	"github.com/golang/protobuf/proto"
 
@@ -38,17 +33,20 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/key"
-	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
-	querypb "vitess.io/vitess/go/vt/proto/query"
-	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // DiffReport is the summary of differences for one table.

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -116,10 +117,10 @@ type shardStreamer struct {
 }
 
 // VDiff reports differences between the sources and targets of a vreplication workflow.
-func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflow, sourceCell, targetCell, tabletTypesStr string,
+func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sourceCell, targetCell, tabletTypesStr string,
 	filteredReplicationWaitTime time.Duration, format string, maxRows int64, tables string) (map[string]*DiffReport, error) {
 	log.Infof("Starting VDiff for %s.%s, sourceCell %s, targetCell %s, tabletTypes %s, timeout %s",
-		targetKeyspace, workflow, sourceCell, targetCell, tabletTypesStr, filteredReplicationWaitTime.String())
+		targetKeyspace, workflowName, sourceCell, targetCell, tabletTypesStr, filteredReplicationWaitTime.String())
 	// Assign defaults to sourceCell and targetCell if not specified.
 	if sourceCell == "" && targetCell == "" {
 		cells, err := wr.ts.GetCellInfoNames(ctx)
@@ -141,7 +142,7 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflow, sourceC
 	}
 
 	// Reuse migrater code to fetch and validate initial metadata about the workflow.
-	ts, err := wr.buildTrafficSwitcher(ctx, targetKeyspace, workflow)
+	ts, err := wr.buildTrafficSwitcher(ctx, targetKeyspace, workflowName)
 	if err != nil {
 		wr.Logger().Errorf("buildTrafficSwitcher: %v", err)
 		return nil, err
@@ -163,28 +164,28 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflow, sourceC
 		tabletTypesStr: tabletTypesStr,
 		sources:        make(map[string]*shardStreamer),
 		targets:        make(map[string]*shardStreamer),
-		workflow:       workflow,
+		workflow:       workflowName,
 		targetKeyspace: targetKeyspace,
 		tables:         includeTables,
 	}
 	for shard, source := range ts.sources {
 		df.sources[shard] = &shardStreamer{
-			master: source.master,
+			master: source.GetPrimary(),
 		}
 	}
-	var oneTarget *tsTarget
+	var oneTarget *workflow.MigrationTarget
 	for shard, target := range ts.targets {
 		df.targets[shard] = &shardStreamer{
-			master: target.master,
+			master: target.GetPrimary(),
 		}
 		oneTarget = target
 	}
 	var oneFilter *binlogdatapb.Filter
-	for _, bls := range oneTarget.sources {
+	for _, bls := range oneTarget.Sources {
 		oneFilter = bls.Filter
 		break
 	}
-	schm, err := wr.GetSchema(ctx, oneTarget.master.Alias, nil, nil, false)
+	schm, err := wr.GetSchema(ctx, oneTarget.GetPrimary().Alias, nil, nil, false)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "GetSchema")
 	}
@@ -197,7 +198,7 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflow, sourceC
 	}
 	defer func(ctx context.Context) {
 		if err := df.restartTargets(ctx); err != nil {
-			wr.Logger().Errorf("Could not restart workflow %s: %v, please restart it manually", workflow, err)
+			wr.Logger().Errorf("Could not restart workflow %s: %v, please restart it manually", workflowName, err)
 		}
 	}(ctx)
 
@@ -688,15 +689,15 @@ func (df *vdiff) streamOne(ctx context.Context, keyspace, shard string, particip
 func (df *vdiff) syncTargets(ctx context.Context, filteredReplicationWaitTime time.Duration) error {
 	waitCtx, cancel := context.WithTimeout(ctx, filteredReplicationWaitTime)
 	defer cancel()
-	err := df.ts.forAllUids(func(target *tsTarget, uid uint32) error {
-		bls := target.sources[uid]
+	err := df.ts.forAllUids(func(target *workflow.MigrationTarget, uid uint32) error {
+		bls := target.Sources[uid]
 		pos := df.sources[bls.Shard].snapshotPosition
 		query := fmt.Sprintf("update _vt.vreplication set state='Running', stop_pos='%s', message='synchronizing for vdiff' where id=%d", pos, uid)
-		if _, err := df.ts.wr.tmc.VReplicationExec(ctx, target.master.Tablet, query); err != nil {
+		if _, err := df.ts.wr.tmc.VReplicationExec(ctx, target.GetPrimary().Tablet, query); err != nil {
 			return err
 		}
-		if err := df.ts.wr.tmc.VReplicationWaitForPos(waitCtx, target.master.Tablet, int(uid), pos); err != nil {
-			return vterrors.Wrapf(err, "VReplicationWaitForPos for tablet %v", topoproto.TabletAliasString(target.master.Tablet.Alias))
+		if err := df.ts.wr.tmc.VReplicationWaitForPos(waitCtx, target.GetPrimary().Tablet, int(uid), pos); err != nil {
+			return vterrors.Wrapf(err, "VReplicationWaitForPos for tablet %v", topoproto.TabletAliasString(target.GetPrimary().Tablet.Alias))
 		}
 		return nil
 	})

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -10,6 +10,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -422,7 +423,7 @@ func (vrw *VReplicationWorkflow) switchWrites() (*[]string, error) {
 		keyspace := vrw.params.SourceKeyspace
 		vrw.params.SourceKeyspace = vrw.params.TargetKeyspace
 		vrw.params.TargetKeyspace = keyspace
-		vrw.params.Workflow = reverseName(vrw.params.Workflow)
+		vrw.params.Workflow = workflow.ReverseWorkflowName(vrw.params.Workflow)
 		log.Infof("In VReplicationWorkflow.switchWrites(reverse) for %+v", vrw)
 	}
 	journalID, dryRunResults, err = vrw.wr.SwitchWrites(vrw.ctx, vrw.params.TargetKeyspace, vrw.params.Workflow, vrw.params.Timeout,

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
-	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
 // VReplicationWorkflowType specifies whether workflow is MoveTables or Reshard


### PR DESCRIPTION
<!--
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This is the first in a series of PRs to make VDiff runnable from the new `grpcvtctldserver` (in order to do that we eventually need the `vdiff` struct to be defined outside of `package wrangler` so that both `wrangler` and `grpcvtctldserver` can use it, so that's where this is headed).

To start, I extracted `buildTargets` as a publicly exported function, and then updated all callsites to work on the new types. These should be functionally equivalent.

In the next PR, I'll be looking at moving parts of `trafficSwitcher` struct to `package workflow`
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->

- #7931 

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required (other tests should be covered by other wrangler/vrep tests)
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
