### PR TITLE
CI: Revert docker change for unit tests from #7868

### DIFF
--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -46,4 +46,4 @@ jobs:
     - name: endtoend
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -print-log -follow -retry=1 e2e
+        eatmydata -- tools/e2e_test_runner.sh

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -46,4 +46,4 @@ jobs:
     - name: unit_race
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -print-log -follow -retry=1 unit_race
+        eatmydata -- make unit_test_race

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -68,4 +68,4 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb101 unit
+        eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -1,4 +1,6 @@
-name: {{.Name}}
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+name: Unit Test (mariadb102)
 on: [push, pull_request]
 jobs:
 
@@ -29,13 +31,6 @@ jobs:
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
 
-        {{if (eq .Platform "mysql57")}}
-
-        # mysql57
-        sudo apt-get install -y mysql-server mysql-client
-
-        {{else}}
-
         # !mysql57
 
         # Uninstall any previously installed MySQL first
@@ -47,63 +42,12 @@ jobs:
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
 
-        {{if (eq .Platform "percona56")}}
-
-        # percona56
-        sudo rm -rf /var/lib/mysql
-        sudo apt install -y gnupg2
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y percona-server-server-5.6 percona-server-client-5.6
-
-        {{end}}
-
-        {{if (eq .Platform "mysql80")}}
-
-        # mysql80
-        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.14-1_all.deb
-        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-
-        {{end}}
-
-        {{if (eq .Platform "mariadb101")}}
-
-        # mariadb101
-        sudo apt-get install -y software-properties-common
-        sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-        sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu bionic main'
-        sudo apt update
-        sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
-
-        {{end}}
-
-        {{if (eq .Platform "mariadb102")}}
-
         # mariadb102
         sudo apt-get install -y software-properties-common
         sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
         sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu bionic main'
         sudo apt update
         sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
-
-        {{end}}
-
-        {{if (eq .Platform "mariadb103")}}
-
-        # mariadb103
-        sudo apt-get install -y software-properties-common
-        sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-        sudo add-apt-repository 'deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu bionic main'
-        sudo apt update
-        sudo DEBIAN_FRONTEND="noninteractive" apt install -y mariadb-server
-
-        {{end}}
-
-        {{end}} {{/*outer if*/}}
 
         sudo apt-get install -y make unzip g++ curl git wget ant openjdk-8-jdk eatmydata
         sudo service mysql stop

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -68,4 +68,4 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb103 unit
+        eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -53,4 +53,4 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mysql57 unit
+        eatmydata -- make unit_test

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -68,4 +68,4 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mysql80 unit
+        eatmydata -- make unit_test

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -69,4 +69,4 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=percona56 unit
+        eatmydata -- make unit_test

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -29,7 +29,7 @@ const (
 	workflowConfigDir = "../.github/workflows"
 
 	unitTestTemplate  = "templates/unit_test.tpl"
-	unitTestDatabases = "percona56, mysql57, mysql80, mariadb101, mariadb103"
+	unitTestDatabases = "percona56, mysql57, mysql80, mariadb101, mariadb102, mariadb103"
 
 	clusterTestTemplate = "templates/cluster_endtoend_test.tpl"
 )


### PR DESCRIPTION
## Description
Revert running unit tests inside docker.
This allows us to add mariadb102 back to the unit test matrix.

## Related Issue(s)
#7868 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [x]  Build/CI
- [ ]  VTAdmin
