### PR TITLE
Online DDL: introducing ddl_strategy `-singleton-context` flag

### DIFF
--- a/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
+++ b/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
@@ -231,7 +231,7 @@ func TestSchemaChange(t *testing.T) {
 		throttledUUIDs = strings.Split(uuidList, "\n")
 		assert.Equal(t, 3, len(throttledUUIDs))
 		for _, uuid := range throttledUUIDs {
-			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
+			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusQueued)
 		}
 	})
 	t.Run("failed migrations, singleton-context", func(t *testing.T) {
@@ -251,7 +251,7 @@ func TestSchemaChange(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		for _, uuid := range throttledUUIDs {
 			uuid = strings.TrimSpace(uuid)
-			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusFailed)
+			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusFailed, schema.OnlineDDLStatusCancelled)
 		}
 	})
 

--- a/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
+++ b/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
@@ -63,9 +63,9 @@ var (
 		ALTER TABLE stress_test DROP COLUMN created_timestamp
 	`
 	multiAlterTableThrottlingStatement = `
-		ALTER TABLE stress_test ENGINE=InnoDB,
-		ALTER TABLE stress_test ENGINE=InnoDB,
-		ALTER TABLE stress_test ENGINE=InnoDB
+		ALTER TABLE stress_test ENGINE=InnoDB;
+		ALTER TABLE stress_test ENGINE=InnoDB;
+		ALTER TABLE stress_test ENGINE=InnoDB;
 	`
 	// A trivial statement which must succeed and does not change the schema
 	alterTableTrivialStatement = `
@@ -74,7 +74,7 @@ var (
 	dropStatement = `
 		DROP TABLE stress_test
 	`
-	multiDropStatements = `DROP TABLE IF EXISTS t1, DROP TABLE IF EXISTS t2, DROP TABLE IF EXISTS t3`
+	multiDropStatements = `DROP TABLE IF EXISTS t1; DROP TABLE IF EXISTS t2; DROP TABLE IF EXISTS t3;`
 )
 
 func TestMain(m *testing.M) {
@@ -318,7 +318,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 	fmt.Printf("<%s>\n", uuid)
 
 	if !strategySetting.Strategy.IsDirect() && !skipWait {
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 20)
 	}
 
 	if expectError == "" && expectHint != "" {

--- a/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
+++ b/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
@@ -239,7 +239,7 @@ func TestSchemaChange(t *testing.T) {
 	})
 	t.Run("terminate throttled migrations", func(t *testing.T) {
 		for _, uuid := range throttledUUIDs {
-			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning)
+			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusRunning, schema.OnlineDDLStatusQueued)
 			onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, true)
 		}
 		time.Sleep(2 * time.Second)

--- a/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
+++ b/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
@@ -318,7 +318,7 @@ func testOnlineDDLStatement(t *testing.T, alterStatement string, ddlStrategy str
 	fmt.Printf("<%s>\n", uuid)
 
 	if !strategySetting.Strategy.IsDirect() && !skipWait {
-		time.Sleep(time.Second * 20)
+		time.Sleep(time.Second * 10)
 	}
 
 	if expectError == "" && expectHint != "" {

--- a/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
+++ b/go/test/endtoend/onlineddl/singleton/onlineddl_singleton_test.go
@@ -235,13 +235,7 @@ func TestSchemaChange(t *testing.T) {
 		}
 	})
 	t.Run("failed migrations, singleton-context", func(t *testing.T) {
-		uuidList := testOnlineDDLStatement(t, multiAlterTableThrottlingStatement, "gh-ost -singleton-context --max-load=Threads_running=1", "vtctl", "hint_col", "", false)
-		throttledUUIDs = strings.Split(uuidList, "\n")
-		assert.Equal(t, 3, len(throttledUUIDs))
-		for _, uuid := range throttledUUIDs {
-			uuid = strings.TrimSpace(uuid)
-			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusFailed)
-		}
+		_ = testOnlineDDLStatement(t, multiAlterTableThrottlingStatement, "gh-ost -singleton-context --max-load=Threads_running=1", "vtctl", "hint_col", "rejected", false)
 	})
 	t.Run("terminate throttled migrations", func(t *testing.T) {
 		for _, uuid := range throttledUUIDs {

--- a/go/vt/schema/ddl_strategy.go
+++ b/go/vt/schema/ddl_strategy.go
@@ -28,9 +28,10 @@ var (
 )
 
 const (
-	declarativeFlag = "declarative"
-	skipTopoFlag    = "skip-topo"
-	singletonFlag   = "singleton"
+	declarativeFlag      = "declarative"
+	skipTopoFlag         = "skip-topo"
+	singletonFlag        = "singleton"
+	singletonContextFlag = "singleton-context"
 )
 
 // DDLStrategy suggests how an ALTER TABLE should run (e.g. "direct", "online", "gh-ost" or "pt-osc")
@@ -123,6 +124,11 @@ func (setting *DDLStrategySetting) IsSingleton() bool {
 	return setting.hasFlag(singletonFlag)
 }
 
+// IsSingletonContext checks if strategy options include -singleton-context
+func (setting *DDLStrategySetting) IsSingletonContext() bool {
+	return setting.hasFlag(singletonContextFlag)
+}
+
 // RuntimeOptions returns the options used as runtime flags for given strategy, removing any internal hint options
 func (setting *DDLStrategySetting) RuntimeOptions() []string {
 	opts, _ := shlex.Split(setting.Options)
@@ -132,6 +138,7 @@ func (setting *DDLStrategySetting) RuntimeOptions() []string {
 		case isFlag(opt, declarativeFlag):
 		case isFlag(opt, skipTopoFlag):
 		case isFlag(opt, singletonFlag):
+		case isFlag(opt, singletonContextFlag):
 		default:
 			validOpts = append(validOpts, opt)
 		}
@@ -142,7 +149,7 @@ func (setting *DDLStrategySetting) RuntimeOptions() []string {
 // IsSkipTopo suggests that DDL should apply to tables bypassing global topo request
 func (setting *DDLStrategySetting) IsSkipTopo() bool {
 	switch {
-	case setting.IsSingleton():
+	case setting.IsSingleton(), setting.IsSingletonContext():
 		return true
 	case setting.hasFlag(skipTopoFlag):
 		return true

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -250,7 +250,9 @@ func (exec *TabletExecutor) executeSQL(ctx context.Context, sql string, execResu
 			for _, onlineDDL := range onlineDDLs {
 				if exec.ddlStrategySetting.IsSkipTopo() {
 					exec.executeOnAllTablets(ctx, execResult, onlineDDL.SQL, true)
-					exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
+					if len(execResult.SuccessShards) > 0 {
+						exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
+					}
 				} else {
 					exec.executeOnlineDDL(ctx, execResult, onlineDDL)
 				}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -2544,6 +2544,11 @@ func (e *Executor) SubmitMigration(
 		return nil, err
 	}
 
+	if err := e.initSchema(ctx); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
 	if onlineDDL.StrategySetting().IsSingleton() || onlineDDL.StrategySetting().IsSingletonContext() {
 		e.migrationMutex.Lock()
 		defer e.migrationMutex.Unlock()

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -2519,7 +2519,7 @@ func (e *Executor) SubmitMigration(
 
 	onlineDDL, err := schema.OnlineDDLFromCommentedStatement(stmt)
 	if err != nil {
-		return nil, fmt.Errorf("Error submitting migration %s: %v", sqlparser.String(stmt), err)
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Error submitting migration %s: %v", sqlparser.String(stmt), err)
 	}
 	_, actionStr, err := onlineDDL.GetActionStr()
 	if err != nil {
@@ -2561,7 +2561,7 @@ func (e *Executor) SubmitMigration(
 		case onlineDDL.StrategySetting().IsSingleton():
 			// We will reject this migration if there's any pending migration
 			if len(pendingUUIDs) > 0 {
-				return result, fmt.Errorf("singleton migration rejected: found pending migrations [%s]", strings.Join(pendingUUIDs, ", "))
+				return result, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "singleton migration rejected: found pending migrations [%s]", strings.Join(pendingUUIDs, ", "))
 			}
 		case onlineDDL.StrategySetting().IsSingletonContext():
 			// We will reject this migration if there's any pending migration within a different context
@@ -2571,7 +2571,7 @@ func (e *Executor) SubmitMigration(
 					return nil, err
 				}
 				if pendingOnlineDDL.RequestContext != onlineDDL.RequestContext {
-					return nil, fmt.Errorf("singleton migration rejected: found pending migration: %s in different context: %s", pendingUUID, pendingOnlineDDL.RequestContext)
+					return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "singleton migration rejected: found pending migration: %s in different context: %s", pendingUUID, pendingOnlineDDL.RequestContext)
 				}
 			}
 		}

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -248,7 +248,8 @@ const (
 			retries,
 			ddl_action,
 			artifacts,
-			tablet
+			tablet,
+			migration_context
 		FROM _vt.schema_migrations
 		WHERE
 			migration_uuid=%a
@@ -273,7 +274,8 @@ const (
 			retries,
 			ddl_action,
 			artifacts,
-			tablet
+			tablet,
+			migration_context
 		FROM _vt.schema_migrations
 		WHERE
 			migration_status='ready'


### PR DESCRIPTION

## Description

Followup to #7785

This PR introduces `ddl_strategy` now supports `-singleton-context` flag.

- `-singleton` rejects a migration if there's any other pending migration
- `-singleton-context` rejects a migration is there's any other pending migration that has a different migration context.
With `-singleton-context`, it is possible to submit multiple migrations which all share the same migration context. For example, the following is allowed:
```
vtctlclient ApplySchema -ddl_strategy="online -singleton-context" -sql "drop table if exists t1; drop table if exists t2; drop table if exists t3;" commerce
```

The above submits three migrations. All three will be accepted. For comparison, running the above with `-singleton` would accept the first migration (`drop table if exists t1`) and reject the other two.

## Related Issue(s)

- #7785 
- #6926  

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
