### PR TITLE
[vtadmin-web] Add filtering and source/target shards to Workflows view

### DIFF
--- a/web/vtadmin/src/components/routes/Workflows.module.scss
+++ b/web/vtadmin/src/components/routes/Workflows.module.scss
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.controls {
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: 1fr min-content;
+  margin-bottom: 24px;
+}

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -47,10 +47,28 @@ export const Workflows = () => {
                         <div className="font-size-small text-color-secondary">{cluster?.name}</div>
                     </DataCell>
                     <DataCell>
-                        {workflow?.source?.keyspace || <span className="text-color-secondary">n/a</span>}
+                        {workflow?.source?.keyspace ? (
+                            <>
+                                <div>{workflow.source.keyspace}</div>
+                                <div className="font-size-small text-color-secondary">
+                                    {(workflow.source.shards || []).join(', ')}
+                                </div>
+                            </>
+                        ) : (
+                            <span className="text-color-secondary">N/A</span>
+                        )}
                     </DataCell>
                     <DataCell>
-                        {workflow?.target?.keyspace || <span className="text-color-secondary">n/a</span>}
+                        {workflow?.target?.keyspace ? (
+                            <>
+                                <div>{workflow.target.keyspace}</div>
+                                <div className="font-size-small text-color-secondary">
+                                    {(workflow.target.shards || []).join(', ')}
+                                </div>
+                            </>
+                        ) : (
+                            <span className="text-color-secondary">N/A</span>
+                        )}
                     </DataCell>
                 </tr>
             );


### PR DESCRIPTION
## Description

A couple of minor changes to the Workflows view, namely:
- Adds URL-persisted filtering
- Renders the source/target shards for each workflow in the list

Before:

<img width="1792" alt="Screen Shot 2021-04-25 at 3 10 07 PM" src="https://user-images.githubusercontent.com/855595/116006326-bac62980-a5d8-11eb-98cb-9e804067f84f.png">

After: 

<img width="1792" alt="Screen Shot 2021-04-25 at 3 10 26 PM" src="https://user-images.githubusercontent.com/855595/116006342-c6b1eb80-a5d8-11eb-87bc-f7893fc84b94.png">


## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported? **No**
- [ ] Tests were added or are not required **N/A**
- [ ] Documentation was added or is not required **N/A**

## Deployment Notes

N/A

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [x]  VTAdmin
