### PR TITLE
perf: vreplication client CPU usage

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -129,6 +129,7 @@ type Conn struct {
 
 	bufferedReader *bufio.Reader
 	flushTimer     *time.Timer
+	header         [packetHeaderSize]byte
 
 	// Keep track of how and of the buffer we allocated for an
 	// ephemeral packet on the read and write sides.
@@ -324,14 +325,13 @@ func (c *Conn) getReader() io.Reader {
 }
 
 func (c *Conn) readHeaderFrom(r io.Reader) (int, error) {
-	var header [packetHeaderSize]byte
 	// Note io.ReadFull will return two different types of errors:
 	// 1. if the socket is already closed, and the go runtime knows it,
 	//   then ReadFull will return an error (different than EOF),
 	//   something like 'read: connection reset by peer'.
 	// 2. if the socket is not closed while we start the read,
 	//   but gets closed after the read is started, we'll get io.EOF.
-	if _, err := io.ReadFull(r, header[:]); err != nil {
+	if _, err := io.ReadFull(r, c.header[:]); err != nil {
 		// The special casing of propagating io.EOF up
 		// is used by the server side only, to suppress an error
 		// message if a client just disconnects.
@@ -344,14 +344,14 @@ func (c *Conn) readHeaderFrom(r io.Reader) (int, error) {
 		return 0, vterrors.Wrapf(err, "io.ReadFull(header size) failed")
 	}
 
-	sequence := uint8(header[3])
+	sequence := uint8(c.header[3])
 	if sequence != c.sequence {
 		return 0, vterrors.Errorf(vtrpc.Code_INTERNAL, "invalid sequence, expected %v got %v", c.sequence, sequence)
 	}
 
 	c.sequence++
 
-	return int(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16), nil
+	return int(uint32(c.header[0]) | uint32(c.header[1])<<8 | uint32(c.header[2])<<16), nil
 }
 
 // readEphemeralPacket attempts to read a packet into buffer from sync.Pool.  Do

--- a/go/mysql/endtoend/query_test.go
+++ b/go/mysql/endtoend/query_test.go
@@ -220,7 +220,7 @@ func readRowsUsingStream(t *testing.T, conn *mysql.Conn, expectedCount int) {
 	// Read the rows.
 	count := 0
 	for {
-		row, err := conn.FetchNext()
+		row, err := conn.FetchNext(nil)
 		if err != nil {
 			t.Fatalf("FetchNext failed: %v", err)
 		}

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -702,7 +702,7 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 			got.Fields = nil
 		}
 		for {
-			row, err := cConn.FetchNext()
+			row, err := cConn.FetchNext(nil)
 			if err != nil {
 				fatalError = fmt.Sprintf("FetchNext(%v) failed: %v", query, err)
 				return

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1282,7 +1282,7 @@ func TestServerFlush(t *testing.T) {
 	}}
 	assert.Equal(t, want1, flds)
 
-	row, err := c.FetchNext()
+	row, err := c.FetchNext(nil)
 	require.NoError(t, err)
 	if duration, want := time.Since(start), 50*time.Millisecond; duration < want {
 		assert.Fail(t, "duration: %v, want > %v", duration, want)
@@ -1290,7 +1290,7 @@ func TestServerFlush(t *testing.T) {
 	want2 := []sqltypes.Value{sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("delayed"))}
 	assert.Equal(t, want2, row)
 
-	row, err = c.FetchNext()
+	row, err = c.FetchNext(nil)
 	require.NoError(t, err)
 	assert.Nil(t, row)
 }

--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -30,12 +30,12 @@ import (
 // RowToProto3 converts []Value to proto3.
 func RowToProto3(row []Value) *querypb.Row {
 	result := &querypb.Row{}
-	_ = RowToProto3Inplace(result, row)
+	_ = RowToProto3Inplace(row, result)
 	return result
 }
 
 // RowToProto3Inplace converts []Value to proto3 and stores the conversion in the provided Row
-func RowToProto3Inplace(result *querypb.Row, row []Value) int {
+func RowToProto3Inplace(row []Value, result *querypb.Row) int {
 	if result.Lengths == nil {
 		result.Lengths = make([]int64, 0, len(row))
 	} else {

--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -30,7 +30,17 @@ import (
 // RowToProto3 converts []Value to proto3.
 func RowToProto3(row []Value) *querypb.Row {
 	result := &querypb.Row{}
-	result.Lengths = make([]int64, 0, len(row))
+	_ = RowToProto3Inplace(result, row)
+	return result
+}
+
+// RowToProto3Inplace converts []Value to proto3 and stores the conversion in the provided Row
+func RowToProto3Inplace(result *querypb.Row, row []Value) int {
+	if result.Lengths == nil {
+		result.Lengths = make([]int64, 0, len(row))
+	} else {
+		result.Lengths = result.Lengths[:0]
+	}
 	total := 0
 	for _, c := range row {
 		if c.IsNull() {
@@ -41,14 +51,18 @@ func RowToProto3(row []Value) *querypb.Row {
 		result.Lengths = append(result.Lengths, int64(length))
 		total += length
 	}
-	result.Values = make([]byte, 0, total)
+	if result.Values == nil {
+		result.Values = make([]byte, 0, total)
+	} else {
+		result.Values = result.Values[:0]
+	}
 	for _, c := range row {
 		if c.IsNull() {
 			continue
 		}
 		result.Values = append(result.Values, c.Raw()...)
 	}
-	return result
+	return total
 }
 
 // RowsToProto3 converts [][]Value to proto3.

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -104,7 +104,7 @@ func TestMessage(t *testing.T) {
 
 	// Consume first message.
 	start := time.Now().UnixNano()
-	got, err := streamConn.FetchNext()
+	got, err := streamConn.FetchNext(nil)
 	require.NoError(t, err)
 
 	want := []sqltypes.Value{
@@ -131,7 +131,7 @@ func TestMessage(t *testing.T) {
 	}
 
 	// Consume the resend.
-	_, err = streamConn.FetchNext()
+	_, err = streamConn.FetchNext(nil)
 	require.NoError(t, err)
 	qr = exec(t, conn, "select time_next, epoch from vitess_message where id = 1")
 	next, epoch = getTimeEpoch(qr)
@@ -219,7 +219,7 @@ func TestThreeColMessage(t *testing.T) {
 
 	exec(t, conn, "insert into vitess_message3(id, msg1, msg2) values(1, 'hello world', 3)")
 
-	got, err := streamConn.FetchNext()
+	got, err := streamConn.FetchNext(nil)
 	require.NoError(t, err)
 	want := []sqltypes.Value{
 		sqltypes.NewInt64(1),

--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -77,7 +77,7 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 	qr := alloc()
 	byteCount := 0
 	for {
-		row, err := dbc.FetchNext()
+		row, err := dbc.FetchNext(nil)
 		if err != nil {
 			dbc.handleError(err)
 			return err

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -111,50 +111,49 @@ func (plan *Plan) fields() []*querypb.Field {
 	return fields
 }
 
-// filter filters the row against the plan. It returns false if the row did not match.
-// If the row matched, it returns the columns to be sent.
-func (plan *Plan) filter(values []sqltypes.Value) (bool, []sqltypes.Value, error) {
+func (plan *Plan) filter(values, result []sqltypes.Value) (bool, error) {
+	if len(result) != len(plan.ColExprs) {
+		return false, fmt.Errorf("expected %d values in result slice", len(plan.ColExprs))
+	}
 	for _, filter := range plan.Filters {
 		switch filter.Opcode {
 		case Equal:
 			result, err := evalengine.NullsafeCompare(values[filter.ColNum], filter.Value)
 			if err != nil {
-				return false, nil, err
+				return false, err
 			}
 			if result != 0 {
-				return false, nil, nil
+				return false, nil
 			}
 		case VindexMatch:
 			ksid, err := getKeyspaceID(values, filter.Vindex, filter.VindexColumns)
 			if err != nil {
-				return false, nil, err
+				return false, err
 			}
 			if !key.KeyRangeContains(filter.KeyRange, ksid) {
-				return false, nil, nil
+				return false, nil
 			}
 		}
 	}
-
-	result := make([]sqltypes.Value, len(plan.ColExprs))
 	for i, colExpr := range plan.ColExprs {
 		if colExpr.ColNum == -1 {
 			result[i] = colExpr.FixedValue
 			continue
 		}
 		if colExpr.ColNum >= len(values) {
-			return false, nil, fmt.Errorf("index out of range, colExpr.ColNum: %d, len(values): %d", colExpr.ColNum, len(values))
+			return false, fmt.Errorf("index out of range, colExpr.ColNum: %d, len(values): %d", colExpr.ColNum, len(values))
 		}
 		if colExpr.Vindex == nil {
 			result[i] = values[colExpr.ColNum]
 		} else {
 			ksid, err := getKeyspaceID(values, colExpr.Vindex, colExpr.VindexColumns)
 			if err != nil {
-				return false, nil, err
+				return false, err
 			}
 			result[i] = sqltypes.MakeTrusted(sqltypes.VarBinary, []byte(ksid))
 		}
 	}
-	return true, result, nil
+	return true, nil
 }
 
 func getKeyspaceID(values []sqltypes.Value, vindex vindexes.Vindex, vindexColumns []int) (key.DestinationKeyspaceID, error) {

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -111,6 +111,10 @@ func (plan *Plan) fields() []*querypb.Field {
 	return fields
 }
 
+// filter filters the row against the plan. It returns false if the row did not match.
+// The output of the filtering operation is stored in the 'result' argument because
+// filtering cannot be performed in-place. The result argument must be a slice of
+// length equal to ColExprs
 func (plan *Plan) filter(values, result []sqltypes.Value) (bool, error) {
 	if len(result) != len(plan.ColExprs) {
 		return false, fmt.Errorf("expected %d values in result slice", len(plan.ColExprs))

--- a/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/resultstreamer.go
@@ -105,7 +105,7 @@ func (rs *resultStreamer) Stream() error {
 			continue
 		}
 
-		row, err := conn.FetchNext()
+		row, err := conn.FetchNext(nil)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -877,7 +877,9 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 		values[colNum] = value
 		valueIndex++
 	}
-	return plan.filter(values)
+	filtered := make([]sqltypes.Value, len(plan.ColExprs))
+	ok, err := plan.filter(values, filtered)
+	return ok, filtered, err
 }
 
 func wrapError(err error, stopPos mysql.Position, vse *Engine) error {


### PR DESCRIPTION
## Description

Hi all! This week we're doing performance for the `vreplication` _client_. As discussed on our previous PR, the replication process is already bottlenecked on MySQL insert performance, so any optimizations we perform on the client at this point are not going to show up on wall time, but they're still very relevant because the replicator runs inside of the `vttablet`s, so reducing CPU usage here allows us to serve more queries concurrently with the replication process.

For this round of optimizations, I've simply chipped away at all the warm points in the profile for a `vttablet` client performing replication. Let's break down the individual optimizations in this PR, starting with the whole profile:

![szoter_annotated_image](https://user-images.githubusercontent.com/42793/116101029-c8011800-a6ad-11eb-8154-fea00e99f98a.jpeg)

I've annotated the warm spots in the profile in green. Let's go through them from left to right.

### 1. `mysql.(*Conn).readOnePacket`

There is an interesting "glitch" in this part of the flame graph that caught my attention. You can see that most of the calls into the runtime's allocation code are warranted (we are allocating a byte slice for each packet because the slice is later re-used as backing storage for the parsed rows -- this is efficient enough), but there's a significant amount of CPU time spent allocating memory in the middle column, under `mysql.(*Conn).readHeaderFrom`.

Looking at the code for this function, it's clear that it was designed to **not** allocate memory, with a tiny buffer on the stack, and yet it's a constant source of allocations:

https://github.com/vitessio/vitess/blob/c5cd3067aeb9d952a2f45084c37634267e4f9062/go/mysql/conn.go#L326-L355

The issue can be found trivially with escape analysis (running the compiler with `go build -gcflags="-m"`): the 4-byte array that is supposed to be in the stack is actually being allocated on the heap for each function call. This is because the Go compiler really struggles to perform escape analysis across interface calls (such as `io.Reader`). It can't tell that the subslice into the array is not being kept by the called code, so it needs to place it into the heap.

Unfortunately, we cannot monomorphise the `io.Reader` argument to help the compiler with escape analysis (because the `Conn` can be either a buffered or unbuffered conn), so we resort to the second best option: if we move the small array into `Conn` itself, it'll only be allocated once _per `Conn`_ as opposed to once per packet. https://github.com/vitessio/vitess/commit/e0b90daebe9e6b98d969934a24899b41d25e3a68

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/42793/116101544-334aea00-a6ae-11eb-9bd6-dfb279a4fb80.png) |  ![image](https://user-images.githubusercontent.com/42793/116101870-7f962a00-a6ae-11eb-96e3-02feefb0b4c9.png) |

### 2. `mysql.(*Conn).parseRow`

The `parseRow` function in Vitess' `Conn` was already optimized very significantly in a previous PR: [**we stopped copying the contents from the row's backing storage when converting them into individual `Value`s**](https://github.com/vitessio/vitess/pull/7800/commits/91d9627d1f4dbe152f9a97e7774c86e68804ef94). However, we can still see in the flame graph that there is a significant amount of CPU usage in runtime allocation code. What is being allocated here is the actual slice that contains the `Value`s, i.e. `result []Value`, and this is a particularly wasteful allocation because the slice is always the exact same size for a query, so it could be reused over and over again while reading rows. 

Commit https://github.com/vitessio/vitess/commit/d6674b66779f3e02c32b045218b055927d0868e9 does just that, but taking special care towards backwards compatibility in the API. The `parseRow` function now takes an _optional_ target slice where the `Value`s will be stored, but still handles gracefully the case where the target slice is `nil` and allocates it to the required size. This allows users of the API to continue using the allocating version by passing `nil` instead of an existing slice. It also allows ergonomic usage by keeping the argument and return value of the function the same:

https://github.com/vitessio/vitess/blob/d6674b66779f3e02c32b045218b055927d0868e9/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go#L261-L264

With this calling design, the first time `FetchNext` is called, its argument will be `nil`, so a new slice will be allocated to store the rows, but in subsequent calls, the slice will be automatically reused. 

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/42793/116105083-457a5780-a6b1-11eb-9636-7b0ce738e31b.png) | ![image](https://user-images.githubusercontent.com/42793/116105142-53c87380-a6b1-11eb-92c1-57a03e4ccd00.png) |

### 3. `sqltypes.RowToProto3`

The conversion of Vitess row data (`[]Value`) into the ProtoBuf form that will be sent over the wire is the most expensive part of the whole row streaming process. This is bad, particularly because there is actually no conversion to be performed here: it's just copying the raw data of the rows into the equivalent ProtoBuf-specified struct. As seen on the flame graph, the massive cost comes from allocating the same `Row` objects over and over again.

There are many ways to work around this performance issue. The most obvious one would be using an object pool to reuse `Row` objects between calls. This would be simple to implement but it has a shortcoming: a shared pool of `Row` objects would contain very different sizes of pooled objects, because the average size of an individual row varies wildly depending on the specific _table_ that is being currently copied. We can do better than a global pool if we scope down memory reuse to our local copying operation, where all the `Row` objects will be similarly sized, as they contain the exact same amount of columns.

Commit https://github.com/vitessio/vitess/commit/dafc1cb729d7be7dff2c05bd05a926005eb9a044 performs the local memory reuse without using a memory pool: instead, it uses a slice of `Row` objects, which is faster than a pool, also bounded (because there is a maximum size for the packets that the streamer will send) and it can be reused directly into the `Response` object. A new `sqltypes.RowToProto3Inplace` has been implemented to allow conversion without allocating a new `Row` object, and to minimize duplication, the old `RowToProto3` has been implemented on top of the new API.

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/42793/116106882-ca19a580-a6b2-11eb-85aa-d7ce5009ae71.png) | ![image](https://user-images.githubusercontent.com/42793/116106927-d7369480-a6b2-11eb-8f60-c111b2a3a016.png) |

### 4. `throttle.(*Client).ThrottleCheckOK`

Ooh, here's a spicy one. It's not often that one sees a significant amount of CPU time spent in wall-clock time acquisition (i.e. `runtime.nanotime` for Go programs). Getting the system's time has been an extremely fast operation in Linux systems for many years; back in the day, clock access was gated behind a syscall, with the consequent overhead of context switching into kernel space. This is not the case anymore: time access for userland process is now available via a [vDSO](https://lwn.net/Articles/446528/), wherein the kernel maps the relevant clock data directly into our process' memory space so there is essentially no overhead when accessing it from our programs. Of course, the Go runtime takes advantage of this optimization (manually -- the Go runtime has to re-implement a lot of the vDSO logic that exists in `libc` because the Go runtime doesn't use `libc` :upside_down_face:), and yet we are spending _a lot_ of CPU time in our Throttler implementation just measuring the current time.

Why is this? Well, the Throttler is calling `time.Since` to make sure that we don't call the external throttler service too often. The throttler is effectively throttled at 250ms per call. How ironic. But it turns out that we do a lot of throttler checks -- we attempt to throttle once per row, which results in millions of checks per second. We need a more efficient way to keep the throttler from only running once every 250ms.

In a more advanced systems language, I believe the correct approach would be to use a **coarse clock source** for this time calculation (i.e. `CLOCK_MONOTONIC_COARSE`, https://linux.die.net/man/2/clock_gettime), but such interface is not exposed by the Go runtime. Commit https://github.com/vitessio/vitess/commit/f5af1334c812e17bdd933d17f479d1e325274510 works around this manually by creating a global ticker, shared between all the Throttlers in a process, that increments a counter once per 250ms. This way, we can delay all the throttle checks simply by ensuring that the current "tick" is newer than the "tick" when the last throttle was performed. :sparkles:

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/42793/116109340-f9c9ad00-a6b4-11eb-93d4-5f07a55e395d.png) | _`ThrottleCheckOK` is now missing from the profile because it uses essentially no CPU time_ |

### 5. `vstreamer.(*Plan).filter`

Last, but not least, the `filter` functionality of the replication engine seems to be allocating a very significant amount of memory to perform the filtering. Why? Because it stores the resulting slice of `Value`s into a new slice of `Values`, instead of filtering it in-place. 

https://github.com/vitessio/vitess/blob/c5cd3067aeb9d952a2f45084c37634267e4f9062/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L116-L158

If we look at the actual filtering code, we learn that the trivial optimization, filtering in-place, is not feasible, because the ordering of the resulting slice is not always linear with the input (see `result[i] = values[colExpr.ColNum]` in line 148). Our only choice is, again, to pass in a backing slice to store the results so that it can be reused between calls. Not the most elegant refactoring, but one with a significant impact in the profile:

| Before | After |
|----------|--------|
| ![image](https://user-images.githubusercontent.com/42793/116110390-eff47980-a6b5-11eb-98d5-5278259549d2.png) | ![image](https://user-images.githubusercontent.com/42793/116110443-fb47a500-a6b5-11eb-8c5a-531ff0b598a6.png) |

### Conclusion

These 5 commits bring down the total CPU usage for our `vreplication` benchmark from `17.21s` to `8.43s`, **a 49% decrease**.

![image](https://user-images.githubusercontent.com/42793/116110985-7d37ce00-a6b6-11eb-8812-608947fafcea.png)

The profile after this round of optimizations is now dominated by MySQL client reads and GRPC serialization. There is very little we can do about MySQL because we need to read from MySQL and that's not free; and there's very little we can do to GRPC without forking it, so as far as I'm concerned this is a pretty flat profile.

Again, and sadly, these optimizations have no visible impact in wall times because of the bottleneck in MySQL insertion speed, but they have a massive impact in `vttablet` throughput as a whole because we have halved the amount of CPU cycles that the replication process uses. The key takeaway here, for those following at home, is that **reducing memory allocations in a GC language doesn't just save _memory_, it mostly saves CPU time**.

## Related Issue(s)
<!-- List related issues and pull requests: -->

- 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

## Impacted Areas in Vitess
Components that this PR will affect:

- [ ]  Query Serving
- [x]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
