### PR TITLE
Modification of the Markdown list format in the release notes template

### DIFF
--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -63,7 +63,7 @@ const (
 {{- range $component := $type.Components }} 
 ### {{ $component.Name }}
 {{- range $prInfo := $component.PrInfos }}
- - {{ $prInfo.Title }} #{{ $prInfo.Number }}
+ * {{ $prInfo.Title }} #{{ $prInfo.Number }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Florent Poinsard <florent.poinsard@outlook.fr>

## Description
Changing the way we list items in the release notes template. We were previously using `-`, which is now replaced by `*`. This is done to ease the work on release notes once they are on Goolge Docs.

cc @askdba

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
