### PR TITLE
VReplication: tracking `rows_copied`

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -476,7 +476,7 @@ func (blp *BinlogPlayer) writeRecoveryPosition(tx *binlogdatapb.BinlogTransactio
 	}
 
 	now := time.Now().Unix()
-	updateRecovery := GenerateUpdatePos(blp.uid, position, now, tx.EventToken.Timestamp)
+	updateRecovery := GenerateUpdatePos(blp.uid, position, now, tx.EventToken.Timestamp, blp.blplStats.CopyRowCount.Get())
 
 	qr, err := blp.exec(updateRecovery)
 	if err != nil {
@@ -554,6 +554,7 @@ var AlterVReplicationTable = []string{
 	"ALTER TABLE _vt.vreplication ADD COLUMN db_name VARBINARY(255) NOT NULL",
 	"ALTER TABLE _vt.vreplication MODIFY source BLOB NOT NULL",
 	"ALTER TABLE _vt.vreplication ADD KEY workflow_idx (workflow(64))",
+	"ALTER TABLE _vt.vreplication ADD COLUMN rows_copied BIGINT(20) NOT NULL DEFAULT 0",
 }
 
 // VRSettings contains the settings of a vreplication table.
@@ -624,16 +625,16 @@ func CreateVReplicationState(workflow string, source *binlogdatapb.BinlogSource,
 
 // GenerateUpdatePos returns a statement to update a value in the
 // _vt.vreplication table.
-func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTimestamp int64) string {
+func GenerateUpdatePos(uid uint32, pos mysql.Position, timeUpdated int64, txTimestamp int64, rowsCopied int64) string {
 	if txTimestamp != 0 {
 		return fmt.Sprintf(
-			"update _vt.vreplication set pos=%v, time_updated=%v, transaction_timestamp=%v, message='' where id=%v",
-			encodeString(mysql.EncodePosition(pos)), timeUpdated, txTimestamp, uid)
+			"update _vt.vreplication set pos=%v, time_updated=%v, transaction_timestamp=%v, rows_copied=%v, message='' where id=%v",
+			encodeString(mysql.EncodePosition(pos)), timeUpdated, txTimestamp, rowsCopied, uid)
 	}
 
 	return fmt.Sprintf(
-		"update _vt.vreplication set pos=%v, time_updated=%v, message='' where id=%v",
-		encodeString(mysql.EncodePosition(pos)), timeUpdated, uid)
+		"update _vt.vreplication set pos=%v, time_updated=%v, rows_copied=%v, message='' where id=%v",
+		encodeString(mysql.EncodePosition(pos)), timeUpdated, rowsCopied, uid)
 }
 
 // GenerateUpdateTime returns a statement to update time_updated in the _vt.vreplication table.

--- a/go/vt/binlog/binlogplayer/binlog_player_test.go
+++ b/go/vt/binlog/binlogplayer/binlog_player_test.go
@@ -358,10 +358,10 @@ func TestCreateVReplicationTables(t *testing.T) {
 func TestUpdateVReplicationPos(t *testing.T) {
 	gtid := mysql.MustParseGTID("MariaDB", "0-1-8283")
 	want := "update _vt.vreplication " +
-		"set pos='MariaDB/0-1-8283', time_updated=88822, message='' " +
+		"set pos='MariaDB/0-1-8283', time_updated=88822, rows_copied=0, message='' " +
 		"where id=78522"
 
-	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0)
+	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 0, 0)
 	if got != want {
 		t.Errorf("updateVReplicationPos() = %#v, want %#v", got, want)
 	}
@@ -370,10 +370,10 @@ func TestUpdateVReplicationPos(t *testing.T) {
 func TestUpdateVReplicationTimestamp(t *testing.T) {
 	gtid := mysql.MustParseGTID("MariaDB", "0-2-582")
 	want := "update _vt.vreplication " +
-		"set pos='MariaDB/0-2-582', time_updated=88822, transaction_timestamp=481828, message='' " +
+		"set pos='MariaDB/0-2-582', time_updated=88822, transaction_timestamp=481828, rows_copied=0, message='' " +
 		"where id=78522"
 
-	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 481828)
+	got := GenerateUpdatePos(78522, mysql.Position{GTIDSet: gtid.GTIDSet()}, 88822, 481828, 0)
 	if got != want {
 		t.Errorf("updateVReplicationPos() = %#v, want %#v", got, want)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -498,6 +498,7 @@ func TestCreateDBAndTable(t *testing.T) {
 		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD COLUMN db_name.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication MODIFY source.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD KEY.*", &sqltypes.Result{}, nil)
+		dbClient.ExpectRequestRE("ALTER TABLE _vt.vreplication ADD COLUMN rows_copied.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("create table if not exists _vt.resharding_journal.*", &sqltypes.Result{}, nil)
 		dbClient.ExpectRequestRE("create table if not exists _vt.copy_state.*", &sqltypes.Result{}, nil)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -484,18 +484,17 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 				}
 			}
 
-			matchQuery := func() bool {
-				if query[0] == '/' {
-					result, err := regexp.MatchString(query[1:], got)
-					if err != nil {
-						panic(err)
-					}
-					return result
+			var match bool
+			if query[0] == '/' {
+				result, err := regexp.MatchString(query[1:], got)
+				if err != nil {
+					panic(err)
 				}
-				return (got == query)
+				match = result
+			} else {
+				match = (got == query)
 			}
-
-			if !matchQuery() {
+			if !match {
 				t.Errorf("query:\n%q, does not match query %d:\n%q", got, i, query)
 			}
 		case <-time.After(5 * time.Second):

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -342,8 +342,8 @@ func (vc *vcopier) fastForward(ctx context.Context, copyState map[string]*sqltyp
 		return err
 	}
 	if settings.StartPos.IsZero() {
-		update := binlogplayer.GenerateUpdatePos(vc.vr.id, pos, time.Now().Unix(), 0)
-		_, err := vc.vr.dbClient.Execute(update)
+		update := binlogplayer.GenerateUpdatePos(vc.vr.id, pos, time.Now().Unix(), 0, vc.vr.stats.CopyRowCount.Get())
+		_, err := withDDL.Exec(vc.vr.vre.ctx, update, vc.vr.dbClient.Execute)
 		return err
 	}
 	return newVPlayer(vc.vr, settings, copyState, pos, "fastforward").play(ctx)

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -80,9 +80,6 @@ type vstreamer struct {
 	vse   *Engine
 }
 
-// CopyState contains the last PK for tables to be copied
-type CopyState map[string][]*sqltypes.Result
-
 // streamerPlan extends the original plan to also include
 // the TableMap, which comes from the binlog. It's used
 // to extract values from the ROW events.

--- a/go/vt/withddl/withddl.go
+++ b/go/vt/withddl/withddl.go
@@ -45,6 +45,11 @@ func New(ddls []string) *WithDDL {
 	}
 }
 
+// DDLs returns a copy of the ddls
+func (wd *WithDDL) DDLs() []string {
+	return wd.ddls[:]
+}
+
 // Exec executes the query using the supplied function.
 // If there are any schema errors, it applies the DDLs and retries.
 // Funcs can be any of these types:


### PR DESCRIPTION

## Description

`_vt.vreplication` has new column, `rows_copied`, which is updated periodically during `vreplication` work, to reflect the actual number of rows written on the target table.

The value is written together with `time_updated`, so it does not get transactionally synced with each copy iteration, it follows closely though, and makes a good estimate.

This will be later used by Online DDL to track Vreplication-based migration progress & ETA. 

## Related Issue(s)

- Replaces https://github.com/vitessio/vitess/pull/7950
- Tracking: #6926 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->