### PR TITLE
[wrangler|workflow] Extract vrStream type to workflow.VReplicationStream

### DIFF
--- a/go/vt/vtctl/workflow/vreplication_stream.go
+++ b/go/vt/vtctl/workflow/vreplication_stream.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+
+	"vitess.io/vitess/go/mysql"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+// VReplicationStream represents a single stream of a vreplication workflow.
+type VReplicationStream struct {
+	ID           uint32
+	Workflow     string
+	BinlogSource *binlogdatapb.BinlogSource
+	Position     mysql.Position
+}
+
+// VReplicationStreams wraps a slice of VReplicationStream objects to provide
+// some aggregate functionality.
+type VReplicationStreams []*VReplicationStream
+
+// Values returns a string representing the IDs of the VReplicationStreams for
+// use in an IN clause.
+//
+// (TODO|@ajm188) This currently returns the literal ")" if len(streams) == 0.
+// We should probably update this function to return the full "IN" clause, and
+// then if len(streams) == 0, return "1 != 1" so that we can still execute a
+// valid SQL query.
+func (streams VReplicationStreams) Values() string {
+	buf := &strings.Builder{}
+	prefix := "("
+
+	for _, vrs := range streams {
+		fmt.Fprintf(buf, "%s%d", prefix, vrs.ID)
+		prefix = ", "
+	}
+
+	buf.WriteString(")")
+	return buf.String()
+}
+
+// Workflows returns a list of unique workflow names in the list of vreplication
+// streams.
+func (streams VReplicationStreams) Workflows() []string {
+	set := make(map[string]bool, len(streams))
+	for _, vrs := range streams {
+		set[vrs.Workflow] = true
+	}
+
+	list := make([]string, 0, len(set))
+	for k := range set {
+		list = append(list, k)
+	}
+
+	sort.Strings(list)
+	return list
+}
+
+// Copy returns a copy of the list of streams. All fields except .Position are
+// copied.
+func (streams VReplicationStreams) Copy() VReplicationStreams {
+	out := make([]*VReplicationStream, len(streams))
+
+	for i, vrs := range streams {
+		out[i] = &VReplicationStream{
+			ID:           vrs.ID,
+			Workflow:     vrs.Workflow,
+			BinlogSource: proto.Clone(vrs.BinlogSource).(*binlogdatapb.BinlogSource),
+			Position:     vrs.Position,
+		}
+	}
+
+	return VReplicationStreams(out)
+}
+
+// ToSlice unwraps a VReplicationStreams object into the underlying slice of
+// VReplicationStream objects.
+func (streams VReplicationStreams) ToSlice() []*VReplicationStream {
+	return []*VReplicationStream(streams)
+}

--- a/go/vt/wrangler/switcher_dry_run.go
+++ b/go/vt/wrangler/switcher_dry_run.go
@@ -157,7 +157,7 @@ func (dr *switcherDryRun) migrateStreams(ctx context.Context, sm *streamMigrater
 	dr.drLog.Log(fmt.Sprintf("Migrate streams to %s:", dr.ts.targetKeyspace))
 	for key, streams := range sm.streams {
 		for _, stream := range streams {
-			logs = append(logs, fmt.Sprintf("\tShard %s Id %d, Workflow %s, Pos %s, BinLogSource %v", key, stream.id, stream.workflow, mysql.EncodePosition(stream.pos), stream.bls))
+			logs = append(logs, fmt.Sprintf("\tShard %s Id %d, Workflow %s, Pos %s, BinLogSource %v", key, stream.ID, stream.Workflow, mysql.EncodePosition(stream.Position), stream.BinlogSource))
 		}
 	}
 	if len(logs) > 0 {
@@ -169,7 +169,7 @@ func (dr *switcherDryRun) migrateStreams(ctx context.Context, sm *streamMigrater
 		tabletStreams := copyTabletStreams(sm.templates)
 		for _, vrs := range tabletStreams {
 			logs = append(logs, fmt.Sprintf("\t Keyspace %s, Shard %s, Tablet %d, Workflow %s, Id %d, Pos %v, BinLogSource %s",
-				vrs.bls.Keyspace, vrs.bls.Shard, target.GetPrimary().Alias.Uid, vrs.workflow, vrs.id, mysql.EncodePosition(vrs.pos), vrs.bls))
+				vrs.BinlogSource.Keyspace, vrs.BinlogSource.Shard, target.GetPrimary().Alias.Uid, vrs.Workflow, vrs.ID, mysql.EncodePosition(vrs.Position), vrs.BinlogSource))
 		}
 	}
 	if len(logs) > 0 {
@@ -202,7 +202,7 @@ func (dr *switcherDryRun) stopStreams(ctx context.Context, sm *streamMigrater) (
 	for _, streams := range sm.streams {
 		for _, stream := range streams {
 			logs = append(logs, fmt.Sprintf("\tId %d Keyspace %s Shard %s Rules %s at Position %v",
-				stream.id, stream.bls.Keyspace, stream.bls.Shard, stream.bls.Filter, stream.pos))
+				stream.ID, stream.BinlogSource.Keyspace, stream.BinlogSource.Shard, stream.BinlogSource.Filter, stream.Position))
 		}
 	}
 	if len(logs) > 0 {

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -536,7 +536,7 @@ func (wr *Wrangler) SwitchWrites(ctx context.Context, targetKeyspace, workflow s
 			ts.wr.Logger().Errorf("stopStreams failed: %v", err)
 			for key, streams := range sm.streams {
 				for _, stream := range streams {
-					ts.wr.Logger().Errorf("stream in stopStreams: key %s shard %s stream %+v", key, stream.bls.Shard, stream.bls)
+					ts.wr.Logger().Errorf("stream in stopStreams: key %s shard %s stream %+v", key, stream.BinlogSource.Shard, stream.BinlogSource)
 				}
 			}
 			sw.cancelMigration(ctx, sm)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

More incremental refactors! This one pulls out the private `vrStream` type to `workflow.VReplicationStream` and also defines a list type to provide the behaviors of `tabletStreamValues`, `tabletStreamWorkflows`, `copyTabletStreams`

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #7931 

## Checklist
- [ ] Tests were added or are not required *n/a*
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->