### PR TITLE
[wrangler|workflow] Extract `workflowState` and `workflowType` out to `package workflow`

### DIFF
--- a/go/vt/vtctl/workflow/state.go
+++ b/go/vt/vtctl/workflow/state.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+// Type is the type of a workflow.
+type Type string
+
+// Workflow types.
+const (
+	TypeReshard    Type = "Reshard"
+	TypeMoveTables Type = "MoveTables"
+)
+
+// State represents the state of a workflow.
+type State struct {
+	Workflow       string
+	SourceKeyspace string
+	TargetKeyspace string
+	WorkflowType   Type
+
+	ReplicaCellsSwitched    []string
+	ReplicaCellsNotSwitched []string
+
+	RdonlyCellsSwitched    []string
+	RdonlyCellsNotSwitched []string
+
+	WritesSwitched bool
+}

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -115,26 +115,6 @@ type trafficSwitcher struct {
 	externalTopo    *topo.Server
 }
 
-const (
-	workflowTypeReshard    = "Reshard"
-	workflowTypeMoveTables = "MoveTables"
-)
-
-type workflowState struct {
-	Workflow       string
-	SourceKeyspace string
-	TargetKeyspace string
-	WorkflowType   string
-
-	ReplicaCellsSwitched    []string
-	ReplicaCellsNotSwitched []string
-
-	RdonlyCellsSwitched    []string
-	RdonlyCellsNotSwitched []string
-
-	WritesSwitched bool
-}
-
 // For a Reshard, to check whether we have switched reads for a tablet type, we check if any one of the source shards has
 // the query service disabled in its tablet control record
 func (wr *Wrangler) getCellsWithShardReadsSwitched(ctx context.Context, targetKeyspace string, si *topo.ShardInfo, tabletType string) (
@@ -243,7 +223,7 @@ func (wr *Wrangler) getCellsWithTableReadsSwitched(ctx context.Context, targetKe
 	return cellsSwitched, cellsNotSwitched, nil
 }
 
-func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workflowName string) (*trafficSwitcher, *workflowState, error) {
+func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workflowName string) (*trafficSwitcher, *workflow.State, error) {
 	ts, err := wr.buildTrafficSwitcher(ctx, targetKeyspace, workflowName)
 
 	if ts == nil || err != nil {
@@ -254,7 +234,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 		return nil, nil, err
 	}
 
-	ws := &workflowState{Workflow: workflowName, TargetKeyspace: targetKeyspace}
+	ws := &workflow.State{Workflow: workflowName, TargetKeyspace: targetKeyspace}
 	ws.SourceKeyspace = ts.sourceKeyspace
 	var cellsSwitched, cellsNotSwitched []string
 	var keyspace string
@@ -271,7 +251,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 		keyspace = targetKeyspace
 	}
 	if ts.migrationType == binlogdatapb.MigrationType_TABLES {
-		ws.WorkflowType = workflowTypeMoveTables
+		ws.WorkflowType = workflow.TypeMoveTables
 
 		// we assume a consistent state, so only choose routing rule for one table for replica/rdonly
 		if len(ts.tables) == 0 {
@@ -302,7 +282,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 			}
 		}
 	} else {
-		ws.WorkflowType = workflowTypeReshard
+		ws.WorkflowType = workflow.TypeReshard
 
 		// we assume a consistent state, so only choose one shard
 		var shard *topo.ShardInfo

--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -44,7 +44,7 @@ type VReplicationWorkflow struct {
 	wr           *Wrangler
 	params       *VReplicationWorkflowParams
 	ts           *trafficSwitcher
-	ws           *workflowState
+	ws           *workflow.State
 }
 
 func (vrw *VReplicationWorkflow) String() string {
@@ -122,7 +122,7 @@ func (vrw *VReplicationWorkflow) Exists() bool {
 	return vrw.ws != nil
 }
 
-func (vrw *VReplicationWorkflow) stateAsString(ws *workflowState) string {
+func (vrw *VReplicationWorkflow) stateAsString(ws *workflow.State) string {
 	log.Infof("Workflow state is %+v", ws)
 	var stateInfo []string
 	s := ""

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -17,17 +17,17 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"vitess.io/vitess/go/vt/topo"
-
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 )
 
 func getMoveTablesWorkflow(t *testing.T, cells, tabletTypes string) *VReplicationWorkflow {
@@ -57,7 +57,7 @@ func testComplete(t *testing.T, vrwf *VReplicationWorkflow) error {
 func TestReshardingWorkflowErrorsAndMisc(t *testing.T) {
 	mtwf := getMoveTablesWorkflow(t, "cell1,cell2", "replica,rdonly")
 	require.False(t, mtwf.Exists())
-	mtwf.ws = &workflowState{}
+	mtwf.ws = &workflow.State{}
 	require.True(t, mtwf.Exists())
 	require.Errorf(t, testComplete(t, mtwf), ErrWorkflowNotFullySwitched)
 	mtwf.ws.WritesSwitched = true


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

Even _moar_ refactors! ~~This is the last one before the Big One to move traffic switcher out~~ (I lied, there's one more after this :lolsob:). This one moves out `wrangler.workflowState` to `workflow.State`.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #7931 

## Checklist
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->