### PR TITLE
docker/vttestserver/run.sh:  Add $CHARSET environment variable

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -17,4 +17,4 @@
 # Setup the Vschema Folder
 /vt/setup_vschema_folder.sh "$KEYSPACES" "$NUM_SHARDS"
 # Run the vttestserver binary
-/vt/bin/vttestserver -port "$PORT" -keyspaces "$KEYSPACES" -num_shards "$NUM_SHARDS" -mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" -mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" -vschema_ddl_authorized_users=% -schema_dir="/vt/schema/"
+/vt/bin/vttestserver -port "$PORT" -keyspaces "$KEYSPACES" -num_shards "$NUM_SHARDS" -mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" -mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" -charset "${CHARSET:-utf8mb4}" -vschema_ddl_authorized_users=% -schema_dir="/vt/schema/"


### PR DESCRIPTION
## Description
This adds an environment variable to pass through to vttestserver's `-charset` command-line flag, and defaults it to `utf8mb4`.  This, among other things, enables a portion Prisma's integration test suite that validates certain Unicode support.

## Related Issue(s)
#7942

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
This only changes the vttestserver containers.  @harshit-gangal mentioned in #7942 making it the default in vttablet.  This PR does _not_ do that, so I don't disagree with leaving that issue open if we consider that a requirement.