### PR TITLE
docker/lite/install_dependencies.sh:  If the dependency install loop reaches its max number of retries, consider that a failure; exit the script nonzero so the build halts.

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -232,6 +232,9 @@ esac
 # Install flavor-specific packages
 apt-get update
 for i in $(seq 1 $MAX_RETRY); do apt-get install -y --no-install-recommends "${PACKAGES[@]}" && break; done
+if [[ "$i" = "$MAX_RETRY" ]]; then
+    exit 1
+fi
 
 # Clean up files we won't need in the final image.
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description
In #7943, we fixed the `vitess/lite:mysql80` build; however, we observed that a failure to install dependencies was still "successfully" building a container image.

This fixes that - if installing dependencies fails enough times to exhaust the retry loop, we will now exit nonzero.

Tested manually by reverting #7943 in my local copy and attempting a build.  It failed, as expected.

## Related Issue(s)
* #7943

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required