### PR TITLE
Change vreplication error metric name to start with a string to pass prometheus validations

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -321,7 +321,7 @@ func (st *vrStats) register() {
 			result := make(map[string]int64)
 			for _, ct := range st.controllers {
 				for key, val := range ct.blpStats.ErrorCounts.Counts() {
-					result[fmt.Sprintf("%d.%s", ct.id, key)] = val
+					result[fmt.Sprintf("%s.%d.%s", ct.workflow, ct.id, key)] = val
 				}
 			}
 			return result


### PR DESCRIPTION
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description

The vreplication error metric started with a number. Fixed by prefixing with the workflow name. Per prometheus docs the required naming convention is:

```
Label names may contain ASCII letters, numbers, as well as underscores. They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning with __ are reserved for internal use.
```

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required
