### PR TITLE
[vtadmin-web] Add filtering + shard counts/status to Keyspaces view

### DIFF
--- a/web/vtadmin/src/components/dataTable/DataCell.module.scss
+++ b/web/vtadmin/src/components/dataTable/DataCell.module.scss
@@ -13,18 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from 'react';
-import cx from 'classnames';
-
-import style from './DataCell.module.scss';
-
-interface Props
-    extends React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> {}
-
-export const DataCell: React.FunctionComponent<Props> = ({ children, className, ...tdProps }) => {
-    return (
-        <td {...tdProps} className={cx(className, style.cell)}>
-            {children}
-        </td>
-    );
-};
+.cell {
+  font-family: var(--fontFamilyMonospace);
+  line-height: 1.6;
+}

--- a/web/vtadmin/src/components/routes/Keyspaces.module.scss
+++ b/web/vtadmin/src/components/routes/Keyspaces.module.scss
@@ -1,0 +1,17 @@
+/**
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+.controls {
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: 1fr min-content;
+  margin-bottom: 24px;
+}

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -15,32 +15,81 @@
  */
 import { orderBy } from 'lodash-es';
 import * as React from 'react';
+
+import style from './Keyspaces.module.scss';
 import { useKeyspaces } from '../../hooks/api';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
-import { vtadmin as pb } from '../../proto/vtadmin';
+import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
 import { DataCell } from '../dataTable/DataCell';
 import { DataTable } from '../dataTable/DataTable';
+import { Button } from '../Button';
+import { Icons } from '../Icon';
+import { TextInput } from '../TextInput';
+import { Pip } from '../pips/Pip';
+import { filterNouns } from '../../util/filterNouns';
+import { getShardsByState } from '../../util/keyspaces';
 
 export const Keyspaces = () => {
     useDocumentTitle('Keyspaces');
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
+
     const { data } = useKeyspaces();
 
-    const rows = React.useMemo(() => {
-        return orderBy(data, ['cluster.name', 'keyspace.name']);
-    }, [data]);
+    const ksRows = React.useMemo(() => {
+        const mapped = (data || []).map((k) => {
+            const shardsByState = getShardsByState(k);
 
-    const renderRows = (rows: pb.Keyspace[]) =>
-        rows.map((keyspace, idx) => (
+            return {
+                clusterID: k.cluster?.id,
+                cluster: k.cluster?.name,
+                name: k.keyspace?.name,
+                servingShards: shardsByState.serving.length,
+                nonservingShards: shardsByState.nonserving.length,
+            };
+        });
+        const filtered = filterNouns(filter, mapped);
+        return orderBy(filtered, ['cluster', 'name']);
+    }, [data, filter]);
+
+    const renderRows = (rows: typeof ksRows) =>
+        rows.map((row, idx) => (
             <tr key={idx}>
-                <DataCell>{keyspace.cluster?.name}</DataCell>
-                <DataCell>{keyspace.keyspace?.name}</DataCell>
+                <DataCell>
+                    <div className="font-weight-bold">{row.name}</div>
+                    <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                </DataCell>
+                <DataCell>
+                    {!!row.servingShards && (
+                        <div>
+                            <Pip state="success" /> {row.servingShards} {row.servingShards === 1 ? 'shard' : 'shards'}
+                        </div>
+                    )}
+                    {!!row.nonservingShards && (
+                        <div className="font-weight-bold">
+                            <Pip state="danger" /> {row.nonservingShards}{' '}
+                            {row.nonservingShards === 1 ? 'shard' : 'shards'} not serving
+                        </div>
+                    )}
+                </DataCell>
             </tr>
         ));
 
     return (
         <div className="max-width-content">
             <h1>Keyspaces</h1>
-            <DataTable columns={['Cluster', 'Keyspace']} data={rows} renderRows={renderRows} />
+            <div className={style.controls}>
+                <TextInput
+                    autoFocus
+                    iconLeft={Icons.search}
+                    onChange={(e) => updateFilter(e.target.value)}
+                    placeholder="Filter keyspaces"
+                    value={filter || ''}
+                />
+                <Button disabled={!filter} onClick={() => updateFilter('')} secondary>
+                    Clear filters
+                </Button>
+            </div>
+            <DataTable columns={['Keyspace', 'Shards']} data={ksRows} renderRows={renderRows} />
         </div>
     );
 };

--- a/web/vtadmin/src/util/keyspaces.test.ts
+++ b/web/vtadmin/src/util/keyspaces.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getShardsByState, ShardsByState, ShardState } from './keyspaces';
+import { vtadmin as pb } from '../proto/vtadmin';
+
+describe('getShardsByState', () => {
+    const tests: {
+        name: string;
+        keyspace: pb.Keyspace | null | undefined;
+        expected: ShardsByState;
+    }[] = [
+        {
+            name: 'should return shards by state',
+            keyspace: pb.Keyspace.create({
+                shards: {
+                    '-80': {
+                        name: '-80',
+                        shard: { is_master_serving: true },
+                    },
+                    '-': {
+                        name: '-',
+                        shard: { is_master_serving: false },
+                    },
+                    '80-': {
+                        name: '80-',
+                        shard: { is_master_serving: true },
+                    },
+                },
+            }),
+            expected: {
+                [ShardState.serving]: [
+                    {
+                        name: '-80',
+                        shard: { is_master_serving: true },
+                    },
+                    {
+                        name: '80-',
+                        shard: { is_master_serving: true },
+                    },
+                ],
+                [ShardState.nonserving]: [
+                    {
+                        name: '-',
+                        shard: { is_master_serving: false },
+                    },
+                ],
+            },
+        },
+        {
+            name: 'should handle shard states without any shards',
+            keyspace: pb.Keyspace.create({
+                shards: {
+                    '-': {
+                        name: '-',
+                        shard: { is_master_serving: true },
+                    },
+                },
+            }),
+            expected: {
+                [ShardState.serving]: [
+                    {
+                        name: '-',
+                        shard: { is_master_serving: true },
+                    },
+                ],
+                [ShardState.nonserving]: [],
+            },
+        },
+        {
+            name: 'should handle keyspaces without any shards',
+            keyspace: pb.Keyspace.create(),
+            expected: {
+                [ShardState.serving]: [],
+                [ShardState.nonserving]: [],
+            },
+        },
+        {
+            name: 'should handle empty input',
+            keyspace: null,
+            expected: {
+                [ShardState.serving]: [],
+                [ShardState.nonserving]: [],
+            },
+        },
+    ];
+
+    test.each(tests.map(Object.values))('%s', (name: string, keyspace: pb.Keyspace, expected: ShardsByState) => {
+        const result = getShardsByState(keyspace);
+        expect(result).toEqual(expected);
+    });
+});

--- a/web/vtadmin/src/util/keyspaces.ts
+++ b/web/vtadmin/src/util/keyspaces.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { groupBy } from 'lodash-es';
+import { vtadmin as pb, vtctldata } from '../proto/vtadmin';
+
+export enum ShardState {
+    serving = 'serving',
+    nonserving = 'nonserving',
+}
+
+export type ShardsByState = { [k in ShardState]: vtctldata.IShard[] };
+
+export const getShardsByState = <K extends pb.IKeyspace>(keyspace: K | null | undefined): ShardsByState => {
+    const grouped = groupBy(Object.values(keyspace?.shards || {}), (s) =>
+        s.shard?.is_master_serving ? ShardState.serving : ShardState.nonserving
+    );
+
+    // Add exhaustive enum keys (since groupBy only returns a dictionary), as well as define defaults
+    return {
+        [ShardState.serving]: grouped.serving || [],
+        [ShardState.nonserving]: grouped.nonserving || [],
+    };
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

The branch I'm working on to add the Keyspace details view is getting big, so I'm peeling off this PR-sized chonk to add standard URL filtering to the Keyspaces view. 

<img width="2672" alt="Screen Shot 2021-04-28 at 5 38 13 PM" src="https://user-images.githubusercontent.com/855595/116475982-91133980-a848-11eb-9f1c-9d5f6b89dd0c.png">
<img width="2672" alt="Screen Shot 2021-04-28 at 5 38 19 PM" src="https://user-images.githubusercontent.com/855595/116475987-93759380-a848-11eb-8c93-76940962c284.png">

Important note that filtering keyspaces by "has non-serving shards" will require some changes to how the `filterNouns` function works + is not included this change. 

## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A