### PR TITLE
Add missing return on a failed `GetShard` call in `FindAllShardsInKeyspace`

### DIFF
--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -234,7 +234,7 @@ func (ts *Server) FindAllShardsInKeyspace(ctx context.Context, keyspace string) 
 			if IsErrType(err, NoNode) {
 				log.Warningf("GetShard(%v, %v) returned ErrNoNode, consider checking the topology.", keyspace, shard)
 			} else {
-				vterrors.Wrapf(err, "GetShard(%v, %v) failed", keyspace, shard)
+				return nil, vterrors.Wrapf(err, "GetShard(%v, %v) failed", keyspace, shard)
 			}
 		}
 		result[shard] = si


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

I caught this while setting up `errcheck` in our linter, and I'm glad I did!

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
    - @deepthi I'm not sure how to force a failure on a single `GetShard` call (without failing the earlier `GetShardNames` call) in order to write a test case; do you have any ideas/suggestions?
- [x] Documentation was added or is not required => n/a

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->