### PR TITLE
vttablet/tabletmanager - add additional test for tmstate.Open()

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -305,6 +305,24 @@ func TestStateIsShardServingisInSrvKeyspace(t *testing.T) {
 	tm.tmState.mu.Unlock()
 
 	assert.Equal(t, int64(0), statsIsInSrvKeyspace.Get())
+
+	// Test tablet isOpen
+	tm.tmState.mu.Lock()
+	tm.tmState.isOpen = false
+	tm.tmState.isInSrvKeyspace = false
+	tm.tmState.tablet.Type = topodatapb.TabletType_REPLICA
+	tm.tmState.isShardServing = map[topodatapb.TabletType]bool{
+		topodatapb.TabletType_REPLICA: true,
+	}
+	tm.tmState.mu.Unlock()
+
+	tm.tmState.Open()
+
+	tm.tmState.mu.Lock()
+	assert.True(t, tm.tmState.isInSrvKeyspace)
+	tm.tmState.mu.Unlock()
+
+	assert.Equal(t, int64(1), statsIsInSrvKeyspace.Get())
 }
 
 func TestStateNonServing(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Guido Iaquinti <giaquinti@slack-corp.com>

## Description
This is a follow up of #7929 to add an additional test for `func (ts *tmState) Open()` as requested by @rafael [here](https://github.com/vitessio/vitess/pull/7929#discussion_r622267106).

## Related Issue(s)
N/A

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
N/A