### PR TITLE
[vtadmin-web] Display shard state on Tablets view + extract tablet utilities 

### DIFF
--- a/web/vtadmin/src/components/pips/ShardServingPip.tsx
+++ b/web/vtadmin/src/components/pips/ShardServingPip.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pip, PipState } from './Pip';
+
+interface Props {
+    // If shard status is still pending, a neutral pip is used.
+    // The distinction between "is loading" and "is_master_serving is undefined"
+    // is useful, as it's common for the shard `shard.is_master_serving` to be
+    // excluded from API responses for non-serving shards (instead of being
+    // explicitly false.)
+    isLoading?: boolean | null | undefined;
+    isServing?: boolean | null | undefined;
+}
+
+export const ShardServingPip = ({ isLoading, isServing }: Props) => {
+    let state: PipState = isServing ? 'success' : 'danger';
+    return <Pip state={isLoading ? null : state} />;
+};

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -16,8 +16,8 @@
 import * as React from 'react';
 
 import { useTablets } from '../../hooks/api';
-import { vtadmin as pb, topodata } from '../../proto/vtadmin';
-import { invertBy, orderBy } from 'lodash-es';
+import { vtadmin as pb } from '../../proto/vtadmin';
+import { orderBy } from 'lodash-es';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { DataTable } from '../dataTable/DataTable';
 import { TextInput } from '../TextInput';
@@ -28,6 +28,7 @@ import { Button } from '../Button';
 import { DataCell } from '../dataTable/DataCell';
 import { TabletServingPip } from '../pips/TabletServingPip';
 import { useSyncedURLParam } from '../../hooks/useSyncedURLParam';
+import { formatAlias, formatDisplayType, formatState, formatType } from '../../util/tablets';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -80,32 +81,6 @@ export const Tablets = () => {
         </div>
     );
 };
-
-const SERVING_STATES = Object.keys(pb.Tablet.ServingState);
-
-// TABLET_TYPES maps numeric tablet types back to human readable strings.
-// Note that topodata.TabletType allows duplicate values: specifically,
-// both RDONLY (new name) and BATCH (old name) share the same numeric value.
-// So, we make the assumption that if there are duplicate keys, we will
-// always take the first value.
-const TABLET_TYPES = Object.entries(invertBy(topodata.TabletType)).reduce((acc, [k, vs]) => {
-    acc[k] = vs[0];
-    return acc;
-}, {} as { [k: string]: string });
-
-const formatAlias = (t: pb.Tablet) =>
-    t.tablet?.alias?.cell && t.tablet?.alias?.uid && `${t.tablet.alias.cell}-${t.tablet.alias.uid}`;
-
-const formatType = (t: pb.Tablet) => {
-    return t.tablet?.type && TABLET_TYPES[t.tablet?.type];
-};
-
-const formatDisplayType = (t: pb.Tablet) => {
-    const tt = formatType(t);
-    return tt === 'MASTER' ? 'PRIMARY' : tt;
-};
-
-const formatState = (t: pb.Tablet) => t.state && SERVING_STATES[t.state];
 
 export const formatRows = (tablets: pb.Tablet[] | null | undefined, filter: string | null | undefined) => {
     if (!tablets) return [];

--- a/web/vtadmin/src/util/tablets.ts
+++ b/web/vtadmin/src/util/tablets.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { invertBy } from 'lodash-es';
+import { topodata, vtadmin as pb } from '../proto/vtadmin';
+
+/**
+ * TABLET_TYPES maps numeric tablet types back to human readable strings.
+ * Note that topodata.TabletType allows duplicate values: specifically,
+ * both RDONLY (new name) and BATCH (old name) share the same numeric value.
+ * So, we make the assumption that if there are duplicate keys, we will
+ * always take the first value.
+ */
+export const TABLET_TYPES = Object.entries(invertBy(topodata.TabletType)).reduce((acc, [k, vs]) => {
+    acc[k] = vs[0];
+    return acc;
+}, {} as { [k: string]: string });
+
+/**
+ * formatAlias formats a tablet.alias object as a single string, The Vitess Way™.
+ */
+export const formatAlias = <T extends pb.ITablet>(t: T) =>
+    t.tablet?.alias?.cell && t.tablet?.alias?.uid ? `${t.tablet.alias.cell}-${t.tablet.alias.uid}` : null;
+
+export const formatType = (t: pb.Tablet) => t.tablet?.type && TABLET_TYPES[t.tablet?.type];
+
+export const formatDisplayType = (t: pb.Tablet) => {
+    const tt = formatType(t);
+    return tt === 'MASTER' ? 'PRIMARY' : tt;
+};
+
+export const SERVING_STATES = Object.keys(pb.Tablet.ServingState);
+
+export const formatState = (t: pb.Tablet) => t.state && SERVING_STATES[t.state];


### PR DESCRIPTION
## Description

A few more small changes that will come in handy for the Keyspace + Workflow views:

- Extracts some Tablet formatters + other utils to `utils/tablets.ts`
- Displays shard serving status on the Tablets view

Before:

<img width="2672" alt="Screen Shot 2021-04-29 at 4 00 40 PM" src="https://user-images.githubusercontent.com/855595/116611217-1ad40d00-a904-11eb-81a2-e872ea6ab445.png">


After:

<img width="2672" alt="Screen Shot 2021-04-29 at 4 00 49 PM" src="https://user-images.githubusercontent.com/855595/116611225-1dcefd80-a904-11eb-9e38-ebb4cd7674ea.png">



## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A