### PR TITLE
Add `vttablet_restore_done` hook

### DIFF
--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -17,33 +17,28 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 	"time"
 
-	"vitess.io/vitess/go/vt/proto/vttime"
-
-	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
-
-	"vitess.io/vitess/go/vt/dbconfigs"
-
-	"vitess.io/vitess/go/vt/topo"
-	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vttablet/tmclient"
-
-	"context"
-
-	"vitess.io/vitess/go/vt/log"
-
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/hook"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/proto/vttime"
 )
 
 // This file handles the initial backup restore upon startup.
@@ -88,10 +83,47 @@ func (tm *TabletManager) RestoreData(ctx context.Context, logger logutil.Logger,
 			log.Warningf("Orchestrator BeginMaintenance failed: %v", err)
 		}
 	}()
-	err := tm.restoreDataLocked(ctx, logger, waitForBackupInterval, deleteBeforeRestore)
+
+	var (
+		err       error
+		startTime time.Time
+	)
+
+	defer func() {
+		stopTime := time.Now()
+
+		h := hook.NewSimpleHook("vttablet_restore_done")
+		h.ExtraEnv = tm.hookExtraEnv()
+		h.ExtraEnv["TM_RESTORE_DATA_START_TS"] = startTime.UTC().Format(time.RFC3339)
+		h.ExtraEnv["TM_RESTORE_DATA_STOP_TS"] = stopTime.UTC().Format(time.RFC3339)
+		h.ExtraEnv["TM_RESTORE_DATA_DURATION"] = stopTime.Sub(startTime).String()
+
+		if err != nil {
+			h.ExtraEnv["TM_RESTORE_DATA_ERROR"] = err.Error()
+		}
+
+		// vttablet_restore_done is best-effort (for now?).
+		go func() {
+			// Package vthook already logs the stdout/stderr of hooks when they
+			// are run, so we don't duplicate that here.
+			hr := h.Execute()
+			switch hr.ExitStatus {
+			case hook.HOOK_SUCCESS:
+			case hook.HOOK_DOES_NOT_EXIST:
+				log.Info("No vttablet_restore_done hook.")
+			default:
+				log.Warning("vttablet_restore_done hook failed")
+			}
+		}()
+	}()
+
+	startTime = time.Now()
+
+	err = tm.restoreDataLocked(ctx, logger, waitForBackupInterval, deleteBeforeRestore)
 	if err != nil {
 		return err
 	}
+
 	// Tell Orchestrator we're no longer stopped on purpose.
 	// Do this in the background, as it's best-effort.
 	go func() {

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -723,5 +723,11 @@ func (tm *TabletManager) BlacklistedTables() []string {
 
 // hookExtraEnv returns the map to pass to local hooks
 func (tm *TabletManager) hookExtraEnv() map[string]string {
-	return map[string]string{"TABLET_ALIAS": topoproto.TabletAliasString(tm.tabletAlias)}
+	tablet := tm.Tablet()
+
+	return map[string]string{
+		"TABLET_ALIAS": topoproto.TabletAliasString(tm.tabletAlias),
+		"KEYSPACE":     tablet.Keyspace,
+		"SHARD":        tablet.Shard,
+	}
 }


### PR DESCRIPTION
## Description

This PR adds a new hook called `vttablet_restore_done`, which fires, in a background goroutine, whenever a tablet has finished restoring. In the case where a restore failed, we include the error string in the hook env.

We also now track start/stop time of `restoreDataLocked`, and provide both of those as utc RFC3339 timestamps in the env, as well as the standard Go-formatted duration of `stop - start`.

Finally, I also updated the default `tabletmanager.hookExtraEnv` to include the tablet's keyspace and shard.

### Local example

<details><summary>No hook</summary>

```
$ cd "$VTROOT"
$ ls | grep vttablet_restore_done
$ cd examples/local && ./101_initial_cluster.sh >/dev/null && cd -
```

Snippet of tablet logs:

```
I0429 22:51:33.071145   30140 metadata_tables.go:72] Populating _vt.local_metadata table...
I0429 22:51:33.624373   30140 tm_state.go:172] Changing Tablet Type: RDONLY
I0429 22:51:33.624401   30140 tm_state.go:324] Publishing state: alias:<cell:"zone1" uid:102 > hostname:"SFO-M-AMASON02" port_map:<key:"grpc" value:
16102 > port_map:<key:"vt" value:15102 > keyspace:"commerce" shard:"0" type:RDONLY mysql_hostname:"SFO-M-AMASON02" mysql_port:17102 
I0429 22:51:33.625584   30140 shard_sync.go:70] Change to tablet state
I0429 22:51:33.625677   30140 restore.go:103] No vttablet_restore_done hook.
I0429 22:51:33.659298   30140 replmanager.go:79] Replication Manager: stopped
I0429 22:51:33.659318   30140 updatestreamctl.go:228] Enabling update stream, dbname: vt_commerce
I0429 22:51:33.659352   30140 state_manager.go:212] Starting transition to RDONLY Serving, timestamp: 0001-01-01 00:00:00 +0000 UTC
```

</details>

<details><summary>trivial hook</summary>

```
$ chmod +x vthook/vttablet_restore_done
$ cat vthook/vttablet_restore_done
#!/bin/bash

env | grep -E 'KEYSPACE|SHARD|TABLET_ALIAS|(^TM_.*)'
$ cd examples/local media && ./101_initial_cluster.sh >/dev/null && cd -
```

Snippet of tablet logs:

```
I0430 08:37:41.278019   62066 hook.go:125] hook: executing hook: /Users/amason/work/vitess/vthook/vttablet_restore_done 
I0430 08:37:41.278899   62066 replmanager.go:79] Replication Manager: stopped
I0430 08:37:41.279001   62066 updatestreamctl.go:228] Enabling update stream, dbname: vt_commerce
I0430 08:37:41.279080   62066 state_manager.go:212] Starting transition to RDONLY Serving, timestamp: 0001-01-01 00:00:00 +0000 UTC
E0430 08:37:41.283444   62066 state_manager.go:276] Error transitioning to the desired state: RDONLY, Serving, will keep retrying: Unknown database 
'vt_commerce' (errno 1049) (sqlstate 42000)
I0430 08:37:41.283488   62066 state_manager.go:661] State: exiting lameduck
E0430 08:37:41.283493   62066 tm_state.go:277] Cannot start query service: Unknown database 'vt_commerce' (errno 1049) (sqlstate 42000)
I0430 08:37:41.283541   62066 tm_state.go:324] Publishing state: alias:<cell:"zone1" uid:102 > hostname:"some-host" port_map:<key:"grpc" value:
16102 > port_map:<key:"vt" value:15102 > keyspace:"commerce" shard:"0" type:RDONLY mysql_hostname:"some-host" mysql_port:17102 
I0430 08:37:41.284409   62066 query.go:81] exec STOP SLAVE
I0430 08:37:41.284542   62066 query.go:81] exec RESET SLAVE ALL
I0430 08:37:41.285099   62066 query.go:81] exec RESET MASTER
I0430 08:37:41.285282   62066 hook.go:162] hook: result is result: HOOK_SUCCESS
stdout:
TM_RESTORE_DATA_START_TS=2021-04-30T12:37:40Z
KEYSPACE=commerce
TABLET_ALIAS=zone1-0000000102
SHARD=0
TM_RESTORE_DATA_DURATION=767.788809ms
TM_RESTORE_DATA_STOP_TS=2021-04-30T12:37:41Z
```

</details>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

* Fixes #8006 

## Checklist
- [x] Tests were added or are not required **N/A**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->