### PR TITLE
[vtadmin-web] Display timestamps + stream counts on Workflows view

### DIFF
--- a/web/vtadmin/package-lock.json
+++ b/web/vtadmin/package-lock.json
@@ -5133,6 +5133,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",

--- a/web/vtadmin/package.json
+++ b/web/vtadmin/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^16.9.10",
     "@types/react-router-dom": "^5.1.7",
     "classnames": "^2.2.6",
+    "dayjs": "^1.10.4",
     "downshift": "^6.1.0",
     "history": "^5.0.0",
     "lodash-es": "^4.17.20",

--- a/web/vtadmin/src/components/pips/StreamStatePip.tsx
+++ b/web/vtadmin/src/components/pips/StreamStatePip.tsx
@@ -13,16 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.controls {
-  display: grid;
-  grid-gap: 8px;
-  grid-template-columns: 1fr min-content;
-  margin-bottom: 24px;
+import { Pip, PipState } from './Pip';
+
+interface Props {
+    state?: string | null | undefined;
 }
 
-.shardList {
-  color: var(--textColorSecondary);
-  font-size: var(--fontSizeSmall);
-  max-width: 20rem;
-  padding-right: 24px;
-}
+// TODO(doeg): add a protobuf enum for this (https://github.com/vitessio/vitess/projects/12#card-60190340)
+const STREAM_STATES: { [key: string]: PipState } = {
+    Copying: 'primary',
+    Error: 'danger',
+    Running: 'success',
+    Stopped: null,
+};
+
+export const StreamStatePip = ({ state }: Props) => {
+    const pipState = state ? STREAM_STATES[state] : null;
+    return <Pip state={pipState} />;
+};

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -203,6 +203,10 @@ table tbody td[rowSpan] {
   font-family: var(--fontFamilyMonospace);
 }
 
+.font-family-primary {
+  font-family: var(--fontFamilyPrimary);
+}
+
 .font-size-small {
   font-size: var(--fontSizeSmall);
 }

--- a/web/vtadmin/src/util/time.ts
+++ b/web/vtadmin/src/util/time.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(localizedFormat);
+dayjs.extend(relativeTime);
+
+export const parse = (timestamp: number | null | undefined): dayjs.Dayjs | null => {
+    if (typeof timestamp !== 'number') {
+        return null;
+    }
+    return dayjs.unix(timestamp);
+};
+
+export const format = (timestamp: number | null | undefined, template: string | undefined): string | null => {
+    const u = parse(timestamp);
+    return u ? u.format(template) : null;
+};
+
+export const formatDateTime = (timestamp: number | null | undefined): string | null => {
+    return format(timestamp, 'YYYY-MM-DD LT');
+};
+
+export const formatRelativeTime = (timestamp: number | null | undefined): string | null => {
+    const u = parse(timestamp);
+    return u ? u.fromNow() : null;
+};

--- a/web/vtadmin/src/util/workflows.test.ts
+++ b/web/vtadmin/src/util/workflows.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vtadmin as pb } from '../proto/vtadmin';
+import { getStreams } from './workflows';
+
+describe('getStreams', () => {
+    const tests: {
+        name: string;
+        input: Parameters<typeof getStreams>;
+        expected: ReturnType<typeof getStreams>;
+    }[] = [
+        {
+            name: 'should return a flat list of streams',
+            input: [
+                pb.Workflow.create({
+                    workflow: {
+                        shard_streams: {
+                            '-80/us_east_1a-123456': {
+                                streams: [
+                                    { id: 1, shard: '-80' },
+                                    { id: 2, shard: '-80' },
+                                ],
+                            },
+                            '80-/us_east_1a-789012': {
+                                streams: [
+                                    { id: 1, shard: '80-' },
+                                    { id: 2, shard: '80-' },
+                                ],
+                            },
+                        },
+                    },
+                }),
+            ],
+            expected: [
+                { id: 1, shard: '-80' },
+                { id: 2, shard: '-80' },
+                { id: 1, shard: '80-' },
+                { id: 2, shard: '80-' },
+            ],
+        },
+        {
+            name: 'should handle when shard streams undefined',
+            input: [pb.Workflow.create()],
+            expected: [],
+        },
+        {
+            name: 'should handle null input',
+            input: [null],
+            expected: [],
+        },
+    ];
+
+    test.each(tests.map(Object.values))(
+        '%s',
+        (name: string, input: Parameters<typeof getStreams>, expected: ReturnType<typeof getStreams>) => {
+            expect(getStreams(...input)).toEqual(expected);
+        }
+    );
+});

--- a/web/vtadmin/src/util/workflows.ts
+++ b/web/vtadmin/src/util/workflows.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vtctldata, vtadmin as pb } from '../proto/vtadmin';
+
+/**
+ * getStreams returns a flat list of streams across all keyspaces/shards in the workflow.
+ */
+export const getStreams = <W extends pb.IWorkflow>(workflow: W | null | undefined): vtctldata.Workflow.IStream[] => {
+    if (!workflow) {
+        return [];
+    }
+
+    return Object.values(workflow.workflow?.shard_streams || {}).reduce((acc, shardStream) => {
+        (shardStream.streams || []).forEach((stream) => {
+            acc.push(stream);
+        });
+        return acc;
+    }, [] as vtctldata.Workflow.IStream[]);
+};
+
+/**
+ * getTimeUpdated returns the `time_updated` timestamp of the most recently
+ * updated stream in the workflow.
+ */
+export const getTimeUpdated = <W extends pb.IWorkflow>(workflow: W | null | undefined): number => {
+    // Note: long-term it may be better to get this from the `vreplication_log` data
+    // added by https://github.com/vitessio/vitess/pull/7831
+    const timestamps = getStreams(workflow).map((s) => parseInt(`${s.time_updated?.seconds}`, 10));
+    return Math.max(...timestamps);
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

What the title says! This adds timestamps and stream counts to the Workflows view.

Before:

<img width="2672" alt="Screen Shot 2021-04-30 at 12 19 31 PM" src="https://user-images.githubusercontent.com/855595/116724209-5deaba80-a9ae-11eb-96c3-ba1a28db108e.png">

Various afters:

<img width="2672" alt="Screen Shot 2021-04-30 at 11 51 39 AM" src="https://user-images.githubusercontent.com/855595/116724222-63480500-a9ae-11eb-8414-f288f4091e8a.png">
<img width="2672" alt="Screen Shot 2021-04-30 at 11 51 26 AM" src="https://user-images.githubusercontent.com/855595/116724236-65aa5f00-a9ae-11eb-8ef0-5a91dd292fa1.png">


## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A