### PR TITLE
Increase the default srv_topo_timeout

### DIFF
--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -48,7 +48,7 @@ var (
 	// setting the watch fails, we will use the last known value until
 	// srv_topo_cache_ttl elapses and we only try to re-establish the watch
 	// once every srv_topo_cache_refresh interval.
-	srvTopoTimeout      = flag.Duration("srv_topo_timeout", 1*time.Second, "topo server timeout")
+	srvTopoTimeout      = flag.Duration("srv_topo_timeout", 5*time.Second, "topo server timeout")
 	srvTopoCacheTTL     = flag.Duration("srv_topo_cache_ttl", 1*time.Second, "how long to use cached entries for topology")
 	srvTopoCacheRefresh = flag.Duration("srv_topo_cache_refresh", 1*time.Second, "how frequently to refresh the topology for cached entries")
 )


### PR DESCRIPTION
Addresses #8010 ;  allowing defaults to work in more cases, and bringing us somewhat closer to the effective value (infinite) before #7278.  Seems like a reasonable compromise.