### PR TITLE
Update vreplicator docs

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -93,8 +93,9 @@ type vreplicator struct {
 //   "select * from t where in_keyrange(col1, 'hash', '-80')",
 //   "select col1, col2 from t where...",
 //   "select col1, keyspace_id() as ksid from t where...",
-//   "select id, count(*), sum(price) from t group by id".
-//   Only "in_keyrange" expressions are supported in the where clause.
+//   "select id, count(*), sum(price) from t group by id",
+//   "select * from t where customer_id=1 and val = 'newton'".
+//   Only "in_keyrange" expressions, integer and string comparisons are supported in the where clause.
 //   The select expressions can be any valid non-aggregate expressions,
 //   or count(*), or sum(col).
 //   If the target column name does not match the source expression, an


### PR DESCRIPTION
In a few references in code and in the docs website I found that `Only "in_keyrange" expressions are supported in the where clause` - while that's not true and `vreplication` also supports plain equality comparisons like `WHERE somecol='blah'` (here's [the code](https://github.com/vitessio/vitess/blob/172fac7dec8b11937a4efb26ebf4bedf1771f189/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go#L374); it was shipped as part of https://github.com/vitessio/vitess/pull/5949).

I'd like this to be clearly documented for others.

