### PR TITLE
VDIff: fix performance regression introduced by progress logging 

### DIFF
--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -842,19 +841,6 @@ func humanInt(n int64) string {
 	return fmt.Sprintf("%s%s", s, unit)
 }
 
-// logSteps returns a "human" readable value of n, for proportional steps of n (so as not to spam logs)
-// the go-humanize package doesn't support counts atm
-func logSteps(n int64) string {
-	if n == 0 {
-		return ""
-	}
-	step := int64(math.Floor(math.Pow(10, math.Floor(math.Log10(float64(n))))))
-	if (n%step == 0) || (n%1e6 == 0) { // min step is a million
-		return humanInt(n)
-	}
-	return ""
-}
-
 //-----------------------------------------------------------------
 // tableDiffer
 
@@ -867,8 +853,8 @@ func (td *tableDiffer) diff(ctx context.Context, wr *Wrangler, rowsToCompare *in
 	advanceSource := true
 	advanceTarget := true
 	for {
-		if s := logSteps(int64(dr.ProcessedRows)); s != "" {
-			log.Infof("VDiff progress:: table %s: %s rows", td.targetTable, s)
+		if dr.ProcessedRows%1e7 == 0 { // log progress every 10 million rows
+			log.Infof("VDiff progress:: table %s: %s rows", td.targetTable, humanInt(int64(dr.ProcessedRows)))
 		}
 		*rowsToCompare--
 		if *rowsToCompare < 0 {

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package wrangler
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -984,22 +983,6 @@ func TestVDiffFindPKs(t *testing.T) {
 		})
 	}
 
-}
-
-func TestLogSteps(t *testing.T) {
-	testcases := []struct {
-		n   int64
-		log string
-	}{
-		{1, "1"}, {2000, "2k"}, {1000000, "1m"}, {330000, ""}, {330001, ""},
-		{4000000, "4m"}, {40000000, "40m"}, {41000000, "41m"}, {4110000, ""},
-		{5000000000, "5b"}, {5010000000, "5.010b"}, {5011000000, "5.011b"},
-	}
-	for _, tc := range testcases {
-		t.Run(strconv.Itoa(int(tc.n)), func(t *testing.T) {
-			require.Equal(t, tc.log, logSteps(tc.n))
-		})
-	}
 }
 
 func TestVDiffPlanInclude(t *testing.T) {


### PR DESCRIPTION

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Description

VDiff takes a long time to run (from several hours to days). We had added logging to show progress in the vtctld log files to give users an ability to monitor liveness of the vdiff run as well as get an idea of when it might complete. The code added used a logarithmic algo so that it should log some output even for small tables. On profiling it turns out to use 5-10% of the total VDiff CPU utilization. As users start running vreplication workflows on huge tables this can add up.

This PR simpifies this by logging only once every 10 million rows. This is perfectly fine for really long running since it should print the logs every few minutes. VDiffs on small tables anyway finish within a few minutes.

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
