### PR TITLE
EXPERIMENTAL: breaking up vstreamer source query

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -344,6 +344,6 @@ func (rs *rowStreamer) streamQuery(conn *snapshotConn, send func(*binlogdatapb.V
 	}
 
 	fmt.Printf("===========1 rowCount=%v\n", rowCount)
-	hasMoreRows = (rowCount > 0)
+	hasMoreRows = (len(rows) > 0)
 	return hasMoreRows, gtid, nil
 }


### PR DESCRIPTION
# DO NOT MERGE. Known to be breaking

## Description

This PR is an **EXPERIMENT** in breaking up `vstreamer` source query into multiple chunks. Instead of a single `select <column-list> from <table-name> order by <pk-columns>` query/transaction, we run multiple queries, transactions, of the form `select <column-list> from <table-name> order by <pk-columns> where <pk-columns > :lastPK> limit 1000` -- notice **limit 1000**, hard coded for now.

This is known to be breaking and I see the following issues:

1. Currently all queries still in same transaction. They need to be in different transactions.
2. Snapshot. In this experiment we only take snapshot & GTID at first transaction/query. But this means streaming of 2nd chunk and onwards have a different GTID context.
3. Chasing the end: we need to first measure lastPK on table, and limit query by that PK, otherwise we run into a scenario where rows are added and added during the operation, and row copy keeps chasing them and never completes.
4. In this simplified experiment there's a lot of iterative code that can probably be executed just once for all shards, or otherwise share memory better between invocations.

## Related Issue(s)

#7997 

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

cc @rohit-nayak-ps 