### PR TITLE
livequeryz: livequeryz/terminate link should be relative

### DIFF
--- a/go/vt/vttablet/tabletserver/livequeryz.go
+++ b/go/vt/vttablet/tabletserver/livequeryz.go
@@ -49,7 +49,7 @@ var (
 			<td>{{.Duration}}</td>
 			<td>{{.Start}}</td>
 			<td>{{.ConnID}}</td>
-			<td><a href='/livequeryz/terminate?connID={{.ConnID}}'>Terminate</a></td>
+			<td><a href='terminate?connID={{.ConnID}}'>Terminate</a></td>
 		</tr>
 	`))
 )


### PR DESCRIPTION
The link is displayed on the /livequeryz endpoint so there is no need for the
link to be absolute. The fact that this link is absolute currently means that
it does not work when it is behind a proxy like the PlanetScale configuration.