### PR TITLE
VReplication Online DDL: fix classification of virtual columns

### DIFF
--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -136,7 +136,7 @@ func (v *VRepl) readTableColumns(ctx context.Context, conn *dbconnpool.DBConnect
 		columnNames = append(columnNames, columnName)
 
 		extra := row.AsString("Extra", "")
-		if strings.Contains(extra, " GENERATED") {
+		if strings.Contains(extra, "VIRTUAL") {
 			virtualColumnNames = append(virtualColumnNames, columnName)
 		}
 


### PR DESCRIPTION
Signed-off-by: Shlomi Noach <2607934+shlomi-noach@users.noreply.github.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

A small fix. While reviewing some work @fatih was doing  I realized that the way OnlineDDL/Vrepl identifies virtual columns is incorrect. Per documentation: https://dev.mysql.com/doc/refman/8.0/en/show-columns.html, a virtual columns is identified by either `VIRTUAL GENERATED` or `VIRTUAL STORED`.

The existing code only identifies `VIRTUAL GENERATED` columns; this PR identifies both types of virtual columns.

## Related Issue(s)

- tracking: #6926 

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
