### PR TITLE
Make TwoPC engine initialization async.

### DIFF
--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -164,6 +164,8 @@ func (client *QueryClient) ReadTransaction(dtid string) (*querypb.TransactionMet
 // It currently supports only master->replica and back.
 func (client *QueryClient) SetServingType(tabletType topodatapb.TabletType) error {
 	err := client.server.SetServingType(tabletType, time.Time{}, true /* serving */, "" /* reason */)
+	// Wait for TwoPC transition, if necessary
+	client.server.TwoPCEngineWait()
 	return err
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1152,7 +1152,7 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	err := tsv.StartService(target, dbconfigs, nil /* mysqld */)
 	if config.TwoPCEnable {
-		tsv.te.twoPCEngineWait()
+		tsv.TwoPCEngineWait()
 	}
 	if err != nil {
 		panic(err)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1151,6 +1151,9 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	dbconfigs := newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	err := tsv.StartService(target, dbconfigs, nil /* mysqld */)
+	if config.TwoPCEnable {
+		tsv.te.twoPCEngineWait()
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -453,6 +453,11 @@ func (tsv *TabletServer) TableGC() *gc.TableGC {
 	return tsv.tableGC
 }
 
+// TwoPCEngineWait waits until the TwoPC engine has been opened, and the redo read
+func (tsv *TabletServer) TwoPCEngineWait() {
+	tsv.te.twoPCReady.Wait()
+}
+
 // SchemaEngine returns the SchemaEngine part of TabletServer.
 func (tsv *TabletServer) SchemaEngine() *schema.Engine {
 	return tsv.se

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -131,7 +131,7 @@ func TestTabletServerRedoLogIsKeptBetweenRestarts(t *testing.T) {
 
 	turnOnTxEngine := func() {
 		tsv.SetServingType(topodatapb.TabletType_MASTER, time.Time{}, true, "")
-		tsv.te.twoPCEngineWait()
+		tsv.TwoPCEngineWait()
 	}
 	turnOffTxEngine := func() {
 		tsv.SetServingType(topodatapb.TabletType_REPLICA, time.Time{}, true, "")

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -131,6 +131,7 @@ func TestTabletServerRedoLogIsKeptBetweenRestarts(t *testing.T) {
 
 	turnOnTxEngine := func() {
 		tsv.SetServingType(topodatapb.TabletType_MASTER, time.Time{}, true, "")
+		tsv.te.twoPCEngineWait()
 	}
 	turnOffTxEngine := func() {
 		tsv.SetServingType(topodatapb.TabletType_REPLICA, time.Time{}, true, "")

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -197,6 +197,7 @@ func (tpc *TwoPC) Open(dbconfigs *dbconfigs.DBConfigs) error {
 		}
 	}
 	tpc.readPool.Open(dbconfigs.AppWithDB(), dbconfigs.DbaWithDB(), dbconfigs.DbaWithDB())
+	log.Infof("TwoPC: Engine open succeeded")
 	return nil
 }
 

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -254,6 +254,15 @@ func (te *TxEngine) Rollback(ctx context.Context, transactionID int64) (int64, e
 	})
 }
 
+// Wait until the TwoPC engine has been opened, and the redo read (for testing)
+func (te *TxEngine) twoPCEngineWait() {
+	for {
+		if te.ticks.Running() {
+			return
+		}
+	}
+}
+
 func (te *TxEngine) txFinish(transactionID int64, reason tx.ReleaseReason, f func(*StatefulConnection) error) (int64, error) {
 	conn, err := te.txPool.GetAndLock(transactionID, reason.String())
 	if err != nil {
@@ -364,7 +373,7 @@ outer:
 	for _, preparedTx := range prepared {
 		txid, err := dtids.TransactionID(preparedTx.Dtid)
 		if err != nil {
-			log.Errorf("Error extracting transaction ID from ditd: %v", err)
+			log.Errorf("Error extracting transaction ID from dtid: %v", err)
 		}
 		if txid > maxid {
 			maxid = txid
@@ -394,7 +403,7 @@ outer:
 	for _, preparedTx := range failed {
 		txid, err := dtids.TransactionID(preparedTx.Dtid)
 		if err != nil {
-			log.Errorf("Error extracting transaction ID from ditd: %v", err)
+			log.Errorf("Error extracting transaction ID from dtid: %v", err)
 		}
 		if txid > maxid {
 			maxid = txid

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -257,11 +257,6 @@ func (te *TxEngine) Rollback(ctx context.Context, transactionID int64) (int64, e
 	})
 }
 
-// Wait until the TwoPC engine has been opened, and the redo read (for testing)
-func (te *TxEngine) twoPCEngineWait() {
-	te.twoPCReady.Wait()
-}
-
 func (te *TxEngine) txFinish(transactionID int64, reason tx.ReleaseReason, f func(*StatefulConnection) error) (int64, error) {
 	conn, err := te.txPool.GetAndLock(transactionID, reason.String())
 	if err != nil {


### PR DESCRIPTION
There was a "deadlock" here if you use semi-sync **and**
twopc during a failover, because we open the twopc
engine first, and it immediately tries to create its 
metadata tables in `_vt`.  On the PRS target, that
then hangs if using semi-sync, and since the code
to do the repointing of the replicas to the new master
sits "behind" the twopc engine open, the PRS would
never complete. 

Signed-off-by: Jacques Grove <aquarapid@gmail.com>
