### PR TITLE
Fix update query plan with table alias and owned vindex

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -309,6 +309,35 @@ Gen4 plan same as above
 }
 Gen4 plan same as above
 
+# update by primary keyspace id, changing one vindex column, with a table alias
+"update user_metadata as um set email = 'juan@vitess.io' where um.user_id = 1"
+{
+  "QueryType": "UPDATE",
+  "Original": "update user_metadata as um set email = 'juan@vitess.io' where um.user_id = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "MASTER",
+    "ChangedVindexValues": [
+      "email_user_map:3"
+    ],
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata as um where um.user_id = 1 for update",
+    "Query": "update user_metadata as um set email = 'juan@vitess.io' where um.user_id = 1",
+    "Table": "user_metadata",
+    "Values": [
+      1
+    ],
+    "Vindex": "user_index"
+  }
+}
+Gen4 plan same as above
+
 # update by primary keyspace id, changing same vindex twice
 "update user_metadata set email = 'a', email = 'b' where user_id = 1"
 "column has duplicate set values: 'email'"


### PR DESCRIPTION
Resolves #8050

Signed-off-by: David Weitzman <dweitzman@pinterest.com>

## Description

This is a bug fix for table aliases + owned vindexes, which might be a codepath that hasn't been exercised before

## Checklist
- [x] Tests were added
- [x] Documentation is not required

## Deployment Notes
n/a