### PR TITLE
vreplication: fix vreplication timing metrics

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -140,9 +140,7 @@ func (vc *vcopier) copyNext(ctx context.Context, settings binlogplayer.VRSetting
 func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.Result) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	defer func() {
-		vc.vr.stats.PhaseTimings.Record("catchup", time.Now())
-	}()
+	defer vc.vr.stats.PhaseTimings.Record("catchup", time.Now())
 
 	settings, err := binlogplayer.ReadVRSettings(vc.vr.dbClient, vc.vr.id)
 	if err != nil {
@@ -192,10 +190,8 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 // committed with the lastpk. This allows for consistent resumability.
 func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState map[string]*sqltypes.Result) error {
 	defer vc.vr.dbClient.Rollback()
-	defer func() {
-		vc.vr.stats.PhaseTimings.Record("copy", time.Now())
-		vc.vr.stats.CopyLoopCount.Add(1)
-	}()
+	defer vc.vr.stats.PhaseTimings.Record("copy", time.Now())
+	defer vc.vr.stats.CopyLoopCount.Add(1)
 
 	log.Infof("Copying table %s, lastpk: %v", tableName, copyState[tableName])
 
@@ -321,9 +317,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 }
 
 func (vc *vcopier) fastForward(ctx context.Context, copyState map[string]*sqltypes.Result, gtid string) error {
-	defer func() {
-		vc.vr.stats.PhaseTimings.Record("fastforward", time.Now())
-	}()
+	defer vc.vr.stats.PhaseTimings.Record("fastforward", time.Now())
 	pos, err := mysql.DecodePosition(gtid)
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport of #8024 

Several of the vreplication metrics were recently updated to no longer be
correct. Specifically time.Now() is no longer executed when the function
starts and is instead executed when the defer statement is called after the end
of the function.

This updates the metrics to properly execute time.Now() at the start
of the functions.

Signed-off-by: Dylan Visher <dvisher@figma.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->