### PR TITLE
ignore the error and log as warn if not able to validate the current system settings value

### DIFF
--- a/go/vt/vtgate/engine/set.go
+++ b/go/vt/vtgate/engine/set.go
@@ -247,7 +247,11 @@ func (svci *SysVarCheckAndIgnore) Execute(vcursor VCursor, env evalengine.Expres
 	checkSysVarQuery := fmt.Sprintf("select 1 from dual where @@%s = %s", svci.Name, svci.Expr)
 	result, err := execShard(vcursor, checkSysVarQuery, env.BindVars, rss[0], false /* rollbackOnError */, false /* canAutocommit */)
 	if err != nil {
-		return err
+		// Rather than returning the error, we will just log the error
+		// as the intention for executing the query it to validate the current setting and eventually ignore it anyways.
+		// There is no benefit of returning the error back to client.
+		log.Warningf("unable to validate the current settings for '%s': %s", svci.Name, err.Error())
+		return nil
 	}
 	if result.RowsAffected == 0 {
 		log.Infof("Ignored inapplicable SET %v = %v", svci.Name, svci.Expr)


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Rather than returning the error, we will just log the error as the intention for executing the query it to validate the current setting and eventually ignore it anyways. There is no benefit of returning the error back to client.
	

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #7981
Backport of #8004 
