### PR TITLE
Update the schema copy with minimal changes

### DIFF
--- a/go/mysql/endtoend/schema_change_test.go
+++ b/go/mysql/endtoend/schema_change_test.go
@@ -18,7 +18,11 @@ package endtoend
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"vitess.io/vitess/go/vt/sqlparser"
 
 	"github.com/stretchr/testify/require"
 
@@ -79,6 +83,9 @@ func TestChangeSchemaIsNoticed(t *testing.T) {
 	}, {
 		name:    "change PK",
 		changeQ: "alter table vttest.product drop primary key, add primary key (name)",
+	}, {
+		name:    "two tables changes",
+		changeQ: "create table vttest.new_table2 (id bigint(20) primary key);alter table vttest.product drop column name",
 	}}
 
 	for _, test := range tests {
@@ -99,16 +106,35 @@ func TestChangeSchemaIsNoticed(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, rs.Rows)
 
-			// make the schema change
-			_, err = conn.ExecuteFetch(test.changeQ, 1000, true)
-			require.NoError(t, err)
+			for _, q := range strings.Split(test.changeQ, ";") {
+				// make the schema change
+				_, err = conn.ExecuteFetch(q, 1000, true)
+				require.NoError(t, err)
+			}
 
 			// make sure the change is detected
 			rs, err = conn.ExecuteFetch(mysql.DetectSchemaChange, 1000, true)
 			require.NoError(t, err)
 			require.NotEmpty(t, rs.Rows)
+
+			var tables []string
+			for _, row := range rs.Rows {
+				apa := sqlparser.NewStrLiteral(row[0].ToString())
+				tables = append(tables, "table_name = "+sqlparser.String(apa))
+			}
+			tableNamePredicates := strings.Join(tables, " OR ")
+			del := fmt.Sprintf("%s WHERE %s", mysql.ClearSchemaCopy, tableNamePredicates)
+			upd := fmt.Sprintf("%s AND %s", mysql.InsertIntoSchemaCopy, tableNamePredicates)
+
+			_, err = conn.ExecuteFetch(del, 1000, true)
+			require.NoError(t, err)
+			_, err = conn.ExecuteFetch(upd, 1000, true)
+			require.NoError(t, err)
+
+			// make sure the change is detected
+			rs, err = conn.ExecuteFetch(mysql.DetectSchemaChange, 1000, true)
+			require.NoError(t, err)
+			require.Empty(t, rs.Rows)
 		})
-
 	}
-
 }

--- a/go/vt/vttablet/tabletserver/health_streamer_test.go
+++ b/go/vt/vttablet/tabletserver/health_streamer_test.go
@@ -171,8 +171,8 @@ func TestReloadSchema(t *testing.T) {
 
 	db.AddQuery(mysql.CreateVTDatabase, &sqltypes.Result{})
 	db.AddQuery(mysql.CreateSchemaCopyTable, &sqltypes.Result{})
-	db.AddQuery(mysql.ClearSchemaCopy, &sqltypes.Result{})
-	db.AddQuery(mysql.InsertIntoSchemaCopy, &sqltypes.Result{})
+	db.AddQueryPattern(mysql.ClearSchemaCopy+".*", &sqltypes.Result{})
+	db.AddQueryPattern(mysql.InsertIntoSchemaCopy+".*", &sqltypes.Result{})
 	db.AddQuery("begin", &sqltypes.Result{})
 	db.AddQuery("commit", &sqltypes.Result{})
 	db.AddQuery("rollback", &sqltypes.Result{})


### PR DESCRIPTION
Instead of deleting everything and refilling the table on every change, we only remove the rows for the updated tables and fill those in again.

