### PR TITLE
[vtctldserver] Add guard against self-reparent, plus misc updates

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -4581,6 +4581,44 @@ func TestReparentTablet(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name: "requested tablet is shard primary",
+			tablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  100,
+					},
+					Type:     topodatapb.TabletType_MASTER,
+					Keyspace: "testkeyspace",
+					Shard:    "-",
+				},
+			},
+			shards: []*vtctldatapb.Shard{
+				{
+					Keyspace: "testkeyspace",
+					Name:     "-",
+					Shard: &topodatapb.Shard{
+						MasterAlias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+						MasterTermStartTime: &vttime.Time{
+							Seconds: 1010,
+						},
+						IsMasterServing: true,
+					},
+				},
+			},
+			req: &vtctldatapb.ReparentTabletRequest{
+				Tablet: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			},
+			expected:  nil,
+			shouldErr: true,
+		},
+		{
 			name: "tmc.SetMaster failure",
 			tmc: &testutil.TabletManagerClient{
 				SetMasterResults: map[string]error{


### PR DESCRIPTION
## Description

"misc updates" such as:
* s/master/primary in error messages in `ReparentTablet`.
* Reimplement wrangler's `ReparentTablet` to use grpcvtctldserver's
  implementation under the hood.
* Add a test case for the self-reparent error case.

Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

## Related Issue(s)

Fixes #8077 


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required -- N/A

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->