### PR TITLE
System schema query predicate fix

### DIFF
--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -78,6 +78,8 @@ func TestInformationSchemaQuery(t *testing.T) {
 	assertResultIsEmpty(t, conn, "table_schema = 'PERFORMANCE_SCHEMA'")
 	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema' and table_name = 'users'", "performance_schema")
 	assertResultIsEmpty(t, conn, "table_schema = 'performance_schema' and table_name = 'foo'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks' and table_name = 't1'", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'ks' and table_name = 't1'", "vt_ks")
 }
 
 func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -491,6 +491,11 @@ func (route *Route) routeInfoSchemaQuery(vcursor VCursor, bindVars map[string]*q
 	if tableName != "" {
 		rss, err := route.paramsRoutedTable(vcursor, bindVars, specifiedKS, tableName)
 		if err != nil {
+			// Only if keyspace is not found in vschema, we try with default keyspace.
+			// As the in the table_schema predicates for a keyspace 'ks' it can contain 'vt_ks'.
+			if vterrors.ErrState(err) == vterrors.BadDb {
+				return defaultRoute()
+			}
 			return nil, err
 		}
 		if rss != nil {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -70,8 +70,8 @@ func TestSelectDBA(t *testing.T) {
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{Sql: query, BindVariables: map[string]*querypb.BindVariable{}}}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	sbc1.Queries = nil
 
+	sbc1.Queries = nil
 	query = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'"
 	_, err = executor.Execute(context.Background(), "TestSelectDBA",
 		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
@@ -82,6 +82,33 @@ func TestSelectDBA(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{
 			"__vtschemaname": sqltypes.StringBindVariable("performance_schema"),
 			"__vttablename":  sqltypes.StringBindVariable("foo"),
+		}}}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
+
+	sbc1.Queries = nil
+	query = "select 1 from information_schema.table_constraints where constraint_schema = 'vt_ks' and table_name = 'user'"
+	_, err = executor.Execute(context.Background(), "TestSelectDBA",
+		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
+		query, map[string]*querypb.BindVariable{},
+	)
+	require.NoError(t, err)
+	wantQueries = []*querypb.BoundQuery{{Sql: "select 1 from information_schema.table_constraints where constraint_schema = :__vtschemaname and table_name = :__vttablename",
+		BindVariables: map[string]*querypb.BindVariable{
+			"__vtschemaname": sqltypes.StringBindVariable("vt_ks"),
+			"__vttablename":  sqltypes.StringBindVariable("user"),
+		}}}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
+
+	sbc1.Queries = nil
+	query = "select 1 from information_schema.table_constraints where constraint_schema = 'vt_ks'"
+	_, err = executor.Execute(context.Background(), "TestSelectDBA",
+		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
+		query, map[string]*querypb.BindVariable{},
+	)
+	require.NoError(t, err)
+	wantQueries = []*querypb.BoundQuery{{Sql: "select 1 from information_schema.table_constraints where constraint_schema = :__vtschemaname",
+		BindVariables: map[string]*querypb.BindVariable{
+			"__vtschemaname": sqltypes.StringBindVariable("vt_ks"),
 		}}}
 	utils.MustMatch(t, wantQueries, sbc1.Queries)
 

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.txt
@@ -94,7 +94,7 @@
 
 #Alter table with unknown qualifier
 "alter table a.b ADD id int"
-"keyspace a not found in vschema"
+"Unknown database 'a' in vschema"
 
 # create db foo
 "create database foo"

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -239,7 +239,7 @@ Gen4 plan same as above
 
 # routing rules bad table
 "select * from bad_table"
-"keyspace noks not found in vschema"
+"Unknown database 'noks' in vschema"
 Gen4 plan same as above
 
 # routing rules disabled table

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -23,6 +23,9 @@ import (
 	"io/ioutil"
 	"sort"
 
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -481,7 +484,7 @@ func (vschema *VSchema) findTable(keyspace, tablename string) (*Table, error) {
 	}
 	ks, ok := vschema.Keyspaces[keyspace]
 	if !ok {
-		return nil, fmt.Errorf("keyspace %s not found in vschema", keyspace)
+		return nil, vterrors.NewErrorf(vtrpcpb.Code_NOT_FOUND, vterrors.BadDb, "Unknown database '%s' in vschema", keyspace)
 	}
 	table := ks.Tables[tablename]
 	if table == nil {
@@ -559,7 +562,7 @@ func (vschema *VSchema) FindVindex(keyspace, name string) (Vindex, error) {
 	}
 	ks, ok := vschema.Keyspaces[keyspace]
 	if !ok {
-		return nil, fmt.Errorf("keyspace %s not found in vschema", keyspace)
+		return nil, vterrors.NewErrorf(vtrpcpb.Code_NOT_FOUND, vterrors.BadDb, "Unknown database '%s' in vschema", keyspace)
 	}
 	return ks.Vindexes[name], nil
 }

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -772,7 +772,7 @@ func TestVSchemaRoutingRules(t *testing.T) {
 				Error: errors.New("table t1 must be qualified"),
 			},
 			"badkeyspace": {
-				Error: errors.New("keyspace ks3 not found in vschema"),
+				Error: errors.New("Unknown database 'ks3' in vschema"),
 			},
 			"notfound": {
 				Error: errors.New("table t2 not found"),
@@ -2156,33 +2156,24 @@ func TestFindTable(t *testing.T) {
 	}
 	vschema, _ := BuildVSchema(&input)
 	_, err := vschema.FindTable("", "t1")
-	wantErr := "ambiguous table reference: t1"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
-	}
+	require.EqualError(t, err, "ambiguous table reference: t1")
+
 	_, err = vschema.FindTable("", "none")
-	wantErr = "table none not found"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
-	}
-	got, err := vschema.FindTable("", "ta")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.EqualError(t, err, "table none not found")
+
 	ta := &Table{
 		Name: sqlparser.NewTableIdent("ta"),
 		Keyspace: &Keyspace{
 			Name: "ksa",
 		},
 	}
-	if !reflect.DeepEqual(got, ta) {
-		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, ta)
-	}
+	got, err := vschema.FindTable("", "ta")
+	require.NoError(t, err)
+	require.Equal(t, ta, got)
+
 	got, _ = vschema.FindTable("ksa", "ta")
-	if !reflect.DeepEqual(got, ta) {
-		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, ta)
-	}
+	require.Equal(t, ta, got)
+
 	none := &Table{
 		Name: sqlparser.NewTableIdent("none"),
 		Keyspace: &Keyspace{
@@ -2190,19 +2181,13 @@ func TestFindTable(t *testing.T) {
 		},
 	}
 	got, _ = vschema.FindTable("ksa", "none")
-	if !reflect.DeepEqual(got, none) {
-		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, none)
-	}
+	require.Equal(t, none, got)
+
 	_, err = vschema.FindTable("ksb", "none")
-	wantErr = "table none not found"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
-	}
+	require.EqualError(t, err, "table none not found")
+
 	_, err = vschema.FindTable("none", "aa")
-	wantErr = "keyspace none not found in vschema"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
-	}
+	require.EqualError(t, err, "Unknown database 'none' in vschema")
 }
 
 func TestFindTableOrVindex(t *testing.T) {

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -149,7 +149,7 @@ func TestVTGateExecuteWithKeyspaceShard(t *testing.T) {
 		"select id from none",
 		nil,
 	)
-	want := "keyspace invalid_keyspace not found in vschema"
+	want := "Unknown database 'invalid_keyspace' in vschema"
 	assert.EqualError(t, err, want)
 
 	// Valid keyspace/shard.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

If the information_schema query contains a table and schema both and schema is actual db name different from keyspace name, then the query fails.

```
mysql> use commerce;
Database changed
mysql> select CONSTRAINT_NAME, TABLE_NAME from information_schema.table_constraints where constraint_schema = 'vt_commerce' and table_name = 't';
ERROR 1105 (HY000): keyspace vt_commerce not found in vschema
```

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required