### PR TITLE
Fix information_schema query with system schema in table_schema filter

### DIFF
--- a/go/test/endtoend/vtgate/system_schema_test.go
+++ b/go/test/endtoend/vtgate/system_schema_test.go
@@ -71,9 +71,13 @@ func TestInformationSchemaQuery(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	assertSingleRowIsReturned(t, conn, "table_schema = 'ks'")
-	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'ks'", "vt_ks")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'vt_ks'", "vt_ks")
 	assertResultIsEmpty(t, conn, "table_schema = 'NONE'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema'", "performance_schema")
+	assertResultIsEmpty(t, conn, "table_schema = 'PERFORMANCE_SCHEMA'")
+	assertSingleRowIsReturned(t, conn, "table_schema = 'performance_schema' and table_name = 'users'", "performance_schema")
+	assertResultIsEmpty(t, conn, "table_schema = 'performance_schema' and table_name = 'foo'")
 }
 
 func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {
@@ -84,12 +88,12 @@ func assertResultIsEmpty(t *testing.T, conn *mysql.Conn, pre string) {
 	})
 }
 
-func assertSingleRowIsReturned(t *testing.T, conn *mysql.Conn, predicate string) {
+func assertSingleRowIsReturned(t *testing.T, conn *mysql.Conn, predicate string, expectedKs string) {
 	t.Run(predicate, func(t *testing.T) {
 		qr, err := conn.ExecuteFetch("SELECT distinct table_schema FROM information_schema.tables WHERE "+predicate, 1000, true)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(qr.Rows), "did not get enough rows back")
-		assert.Equal(t, "vt_ks", qr.Rows[0][0].ToString())
+		assert.Equal(t, expectedKs, qr.Rows[0][0].ToString())
 	})
 }
 

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -18,7 +18,6 @@ package vtgate
 
 import (
 	"fmt"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -56,30 +55,35 @@ func TestSelectNext(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
 	}}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%v, want\n%v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestSelectDBA(t *testing.T) {
 	executor, sbc1, _, _ := createLegacyExecutorEnv()
 
 	query := "select * from INFORMATION_SCHEMA.foo"
-	_, err := executor.Execute(
-		context.Background(),
-		"TestSelectDBA",
+	_, err := executor.Execute(context.Background(), "TestSelectDBA",
 		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
-		query,
-		map[string]*querypb.BindVariable{},
+		query, map[string]*querypb.BindVariable{},
 	)
 	require.NoError(t, err)
-	wantQueries := []*querypb.BoundQuery{{
-		Sql:           query,
-		BindVariables: map[string]*querypb.BindVariable{},
-	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	wantQueries := []*querypb.BoundQuery{{Sql: query, BindVariables: map[string]*querypb.BindVariable{}}}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
+	sbc1.Queries = nil
+
+	query = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'"
+	_, err = executor.Execute(context.Background(), "TestSelectDBA",
+		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
+		query, map[string]*querypb.BindVariable{},
+	)
+	require.NoError(t, err)
+	wantQueries = []*querypb.BoundQuery{{Sql: "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname and table_name = :__vttablename",
+		BindVariables: map[string]*querypb.BindVariable{
+			"__vtschemaname": sqltypes.StringBindVariable("performance_schema"),
+			"__vttablename":  sqltypes.StringBindVariable("foo"),
+		}}}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
+
 }
 
 func TestUnsharded(t *testing.T) {
@@ -91,9 +95,7 @@ func TestUnsharded(t *testing.T) {
 		Sql:           "select id from music_user_map where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestUnshardedComments(t *testing.T) {
@@ -105,9 +107,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "/* leading */ select id from music_user_map where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 
 	_, err = executorExec(executor, "update music_user_map set id = 1 /* trailing */", nil)
 	require.NoError(t, err)
@@ -118,9 +118,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "update music_user_map set id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "delete from music_user_map /* trailing */", nil)
@@ -129,9 +127,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "delete from music_user_map /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "insert into music_user_map values (1) /* trailing */", nil)
@@ -140,9 +136,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "insert into music_user_map values (1) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestStreamUnsharded(t *testing.T) {
@@ -216,12 +210,7 @@ func TestStreamBuffering(t *testing.T) {
 	for r := range results {
 		gotResults = append(gotResults, r)
 	}
-	if !reflect.DeepEqual(gotResults, wantResults) {
-		t.Logf("len: %d", len(gotResults))
-		for i := range gotResults {
-			t.Errorf("Buffered streaming:\n%v, want\n%v", gotResults[i], wantResults[i])
-		}
-	}
+	utils.MustMatch(t, wantResults, gotResults)
 }
 
 func TestStreamLimitOffset(t *testing.T) {
@@ -681,9 +670,7 @@ func TestSelectEqual(t *testing.T) {
 		Sql:           "select id from user where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -695,9 +682,7 @@ func TestSelectEqual(t *testing.T) {
 		Sql:           "select id from user where id = 3",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 	if execCount := sbc1.ExecCount.Get(); execCount != 1 {
 		t.Errorf("sbc1.ExecCount: %v, want 1\n", execCount)
 	}
@@ -712,9 +697,7 @@ func TestSelectEqual(t *testing.T) {
 		Sql:           "select id from user where id = '3'",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 	if execCount := sbc1.ExecCount.Get(); execCount != 1 {
 		t.Errorf("sbc1.ExecCount: %v, want 1\n", execCount)
 	}
@@ -733,9 +716,7 @@ func TestSelectEqual(t *testing.T) {
 		Sql:           "select id from user where `name` = 'foo'",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewVarBinary("foo")})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -744,9 +725,7 @@ func TestSelectEqual(t *testing.T) {
 			"name": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestSelectDual(t *testing.T) {
@@ -758,15 +737,11 @@ func TestSelectDual(t *testing.T) {
 		Sql:           "select @@aa.bb from dual",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 
 	_, err = executorExec(executor, "select @@aa.bb from TestUnsharded.dual", nil)
 	require.NoError(t, err)
-	if !reflect.DeepEqual(lookup.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, lookup.Queries)
 }
 
 func TestSelectComments(t *testing.T) {
@@ -778,9 +753,7 @@ func TestSelectComments(t *testing.T) {
 		Sql:           "/* leading */ select id from user where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -799,9 +772,7 @@ func TestSelectNormalize(t *testing.T) {
 			"vtg1": sqltypes.TestBindVariable(int64(1)),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -832,9 +803,7 @@ func TestSelectCaseSensitivity(t *testing.T) {
 		Sql:           "select Id from user where iD = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -862,9 +831,7 @@ func TestSelectKeyRange(t *testing.T) {
 		Sql:           "select krcol_unique, krcol from keyrange_table where krcol = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -880,9 +847,7 @@ func TestSelectKeyRangeUnique(t *testing.T) {
 		Sql:           "select krcol_unique, krcol from keyrange_table where krcol_unique = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -901,9 +866,7 @@ func TestSelectIN(t *testing.T) {
 			"__vals": sqltypes.TestBindVariable([]interface{}{int64(1)}),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
@@ -920,18 +883,14 @@ func TestSelectIN(t *testing.T) {
 			"__vals": sqltypes.TestBindVariable([]interface{}{int64(1)}),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select id from user where id in ::__vals",
 		BindVariables: map[string]*querypb.BindVariable{
 			"__vals": sqltypes.TestBindVariable([]interface{}{int64(3)}),
 		},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 
 	// In is a bind variable list, that will end up on two shards.
 	// This is using an []interface{} for the bind variable list.
@@ -948,9 +907,7 @@ func TestSelectIN(t *testing.T) {
 			"vals":   sqltypes.TestBindVariable([]interface{}{int64(1), int64(3)}),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select id from user where id in ::__vals",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -958,9 +915,7 @@ func TestSelectIN(t *testing.T) {
 			"vals":   sqltypes.TestBindVariable([]interface{}{int64(1), int64(3)}),
 		},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 
 	// Convert a non-list bind variable.
 	sbc1.Queries = nil
@@ -975,9 +930,7 @@ func TestSelectIN(t *testing.T) {
 		Sql:           "select id from user where `name` = 'foo'",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewVarBinary("foo")})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -986,9 +939,7 @@ func TestSelectIN(t *testing.T) {
 			"name": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestStreamSelectIN(t *testing.T) {
@@ -1033,9 +984,7 @@ func TestStreamSelectIN(t *testing.T) {
 			"name": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbclookup.Queries)
 }
 
 func TestSelectScatter(t *testing.T) {
@@ -1064,9 +1013,7 @@ func TestSelectScatter(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 	testQueryLog(t, logChan, "TestExecute", "SELECT", wantQueries[0].Sql, 8)
 }
@@ -1209,9 +1156,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1232,9 +1177,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 			wantResult.Rows = append(wantResult.Rows, row)
 		}
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 // TestSelectScatterOrderByVarChar will run an ORDER BY query that will scatter out to 8 shards and return the 8 rows (one per shard) sorted.
@@ -1280,9 +1223,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1303,9 +1244,7 @@ func TestSelectScatterOrderByVarChar(t *testing.T) {
 			wantResult.Rows = append(wantResult.Rows, row)
 		}
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 func TestStreamSelectScatterOrderBy(t *testing.T) {
@@ -1346,9 +1285,7 @@ func TestStreamSelectScatterOrderBy(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1364,9 +1301,7 @@ func TestStreamSelectScatterOrderBy(t *testing.T) {
 		}
 		wantResult.Rows = append(wantResult.Rows, row, row)
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 func TestStreamSelectScatterOrderByVarChar(t *testing.T) {
@@ -1408,9 +1343,7 @@ func TestStreamSelectScatterOrderByVarChar(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1426,9 +1359,7 @@ func TestStreamSelectScatterOrderByVarChar(t *testing.T) {
 		}
 		wantResult.Rows = append(wantResult.Rows, row, row)
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 // TestSelectScatterAggregate will run an aggregate query that will scatter out to 8 shards and return 4 aggregated rows.
@@ -1470,9 +1401,7 @@ func TestSelectScatterAggregate(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1490,9 +1419,7 @@ func TestSelectScatterAggregate(t *testing.T) {
 		}
 		wantResult.Rows = append(wantResult.Rows, row)
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 func TestStreamSelectScatterAggregate(t *testing.T) {
@@ -1533,9 +1460,7 @@ func TestStreamSelectScatterAggregate(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1551,9 +1476,7 @@ func TestStreamSelectScatterAggregate(t *testing.T) {
 		}
 		wantResult.Rows = append(wantResult.Rows, row)
 	}
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 // TestSelectScatterLimit will run a limit query (ordered for consistency) against
@@ -1596,9 +1519,7 @@ func TestSelectScatterLimit(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("got: conn.Queries = %v, want: %v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1623,9 +1544,7 @@ func TestSelectScatterLimit(t *testing.T) {
 			sqltypes.NewInt32(2),
 		})
 
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 // TestStreamSelectScatterLimit will run a streaming limit query (ordered for consistency) against
@@ -1668,9 +1587,7 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 		BindVariables: map[string]*querypb.BindVariable{"__upper_limit": sqltypes.Int64BindVariable(3)},
 	}}
 	for _, conn := range conns {
-		if !reflect.DeepEqual(conn.Queries, wantQueries) {
-			t.Errorf("got: conn.Queries = %v, want: %v", conn.Queries, wantQueries)
-		}
+		utils.MustMatch(t, wantQueries, conn.Queries)
 	}
 
 	wantResult := &sqltypes.Result{
@@ -1693,9 +1610,7 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 			sqltypes.NewInt32(2),
 		})
 
-	if !reflect.DeepEqual(gotResult, wantResult) {
-		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
-	}
+	utils.MustMatch(t, wantResult, gotResult)
 }
 
 // TODO(sougou): stream and non-stream testing are very similar.
@@ -1712,16 +1627,12 @@ func TestSimpleJoin(t *testing.T) {
 		Sql:           "select u1.id from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select u2.id from user as u2 where u2.id = 3",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			sandboxconn.SingleRowResult.Fields[0],
@@ -1754,16 +1665,12 @@ func TestJoinComments(t *testing.T) {
 		Sql:           "select u1.id from user as u1 where u1.id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select u2.id from user as u2 where u2.id = 3 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 
 	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
 }
@@ -1780,16 +1687,12 @@ func TestSimpleJoinStream(t *testing.T) {
 		Sql:           "select u1.id from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select u2.id from user as u2 where u2.id = 3",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc2.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			sandboxconn.SingleRowResult.Fields[0],
@@ -1835,9 +1738,7 @@ func TestVarJoin(t *testing.T) {
 		Sql:           "select u1.id, u1.col from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	// We have to use string representation because bindvars type is too complex.
 	got := fmt.Sprintf("%+v", sbc2.Queries)
 	want := `[sql:"select u2.id from user as u2 where u2.id = :u1_col" bind_variables:<key:"u1_col" value:<type:INT32 value:"3" > > ]`
@@ -1873,9 +1774,7 @@ func TestVarJoinStream(t *testing.T) {
 		Sql:           "select u1.id, u1.col from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	// We have to use string representation because bindvars type is too complex.
 	got := fmt.Sprintf("%+v", sbc2.Queries)
 	want := `[sql:"select u2.id from user as u2 where u2.id = :u1_col" bind_variables:<key:"u1_col" value:<type:INT32 value:"3" > > ]`
@@ -1998,9 +1897,7 @@ func TestEmptyJoin(t *testing.T) {
 			"u1_col": sqltypes.NullBindVariable,
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%v, want\n%v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -2036,9 +1933,7 @@ func TestEmptyJoinStream(t *testing.T) {
 			"u1_col": sqltypes.NullBindVariable,
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -2081,9 +1976,7 @@ func TestEmptyJoinRecursive(t *testing.T) {
 			"u2_col": sqltypes.NullBindVariable,
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -2127,9 +2020,7 @@ func TestEmptyJoinRecursiveStream(t *testing.T) {
 			"u2_col": sqltypes.NullBindVariable,
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -2163,9 +2054,7 @@ func TestCrossShardSubquery(t *testing.T) {
 		Sql:           "select u1.id as id1, u1.col from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	// We have to use string representation because bindvars type is too complex.
 	got := fmt.Sprintf("%+v", sbc2.Queries)
 	want := `[sql:"select u2.id from user as u2 where u2.id = :u1_col" bind_variables:<key:"u1_col" value:<type:INT32 value:"3" > > ]`
@@ -2208,9 +2097,7 @@ func TestCrossShardSubqueryStream(t *testing.T) {
 		Sql:           "select u1.id as id1, u1.col from user as u1 where u1.id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	// We have to use string representation because bindvars type is too complex.
 	got := fmt.Sprintf("%+v", sbc2.Queries)
 	want := `[sql:"select u2.id from user as u2 where u2.id = :u1_col" bind_variables:<key:"u1_col" value:<type:INT32 value:"3" > > ]`
@@ -2256,9 +2143,7 @@ func TestCrossShardSubqueryGetFields(t *testing.T) {
 			"u1_col": sqltypes.NullBindVariable,
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -2286,9 +2171,7 @@ func TestSelectBindvarswithPrepare(t *testing.T) {
 		Sql:           "select id from user where 1 != 1",
 		BindVariables: map[string]*querypb.BindVariable{"id": sqltypes.Int64BindVariable(1)},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	utils.MustMatch(t, wantQueries, sbc1.Queries)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -2447,3 +2447,21 @@
   }
 }
 
+# system schema in where clause of information_schema query
+"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'"
+{
+  "QueryType": "SELECT",
+  "Original": "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = 'performance_schema' AND table_name = 'foo'",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "FieldQuery": "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
+    "Query": "select COUNT(*) from INFORMATION_SCHEMA.`TABLES` where table_schema = :__vtschemaname and table_name = :__vttablename",
+    "SysTableTableName": "VARBINARY(\"foo\")",
+    "SysTableTableSchema": "VARBINARY(\"performance_schema\")"
+  }
+}


### PR DESCRIPTION
Backport of #7430
This is a combination of 6 commits.

* added system schema in where clause plan test
* added executor unit test
* added logic to check table_schema of where clause and redirect to default route if it is a system schema
* added e2e test
* set the bindvars for the normalized predicates and remove schema name from bv if tablet will replace it
* added e2e test having table_schema and table_name in where clause
