### PR TITLE
[9.0] Queryservice fix

### DIFF
--- a/go/vt/discovery/fake_healthcheck.go
+++ b/go/vt/discovery/fake_healthcheck.go
@@ -150,13 +150,6 @@ func (fhc *FakeHealthCheck) TabletConnection(alias *topodatapb.TabletAlias, targ
 	defer fhc.mu.RUnlock()
 	for _, item := range fhc.items {
 		if proto.Equal(alias, item.ts.Tablet.Alias) {
-			if !item.ts.Serving {
-				return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.NotServing)
-			}
-			if target != nil && !proto.Equal(item.ts.Target, target) {
-				return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "%s: target mismatch %v vs %v", vterrors.WrongTablet, item.ts.Target, target)
-			}
-
 			return item.ts.Conn, nil
 		}
 	}

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -45,8 +45,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-
 	"vitess.io/vitess/go/flagutil"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
@@ -699,12 +697,6 @@ func (hc *HealthCheckImpl) TabletConnection(alias *topodata.TabletAlias, target 
 	if thc == nil || thc.Conn == nil {
 		//TODO: test that throws this error
 		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "tablet: %v is either down or nonexistent", alias)
-	}
-	if !thc.Serving {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, vterrors.NotServing)
-	}
-	if target != nil && !proto.Equal(thc.Target, target) {
-		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "%s: target mismatch %v vs %v", vterrors.WrongTablet, thc.Target, target)
 	}
 	return thc.Connection(), nil
 }

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -17,28 +17,26 @@ limitations under the License.
 package vtgate
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
-	"vitess.io/vitess/go/test/utils"
-
 	"github.com/stretchr/testify/assert"
-
-	"context"
-
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/vterrors"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/srvtopo"
-	"vitess.io/vitess/go/vt/vterrors"
 )
 
 // This file uses the sandbox_test framework.
@@ -391,15 +389,17 @@ func TestMultiExecs(t *testing.T) {
 	rss := []*srvtopo.ResolvedShard{
 		{
 			Target: &querypb.Target{
-				Keyspace: "TestMultiExecs",
-				Shard:    "0",
+				Keyspace:   "TestMultiExecs",
+				Shard:      "0",
+				TabletType: topodatapb.TabletType_REPLICA,
 			},
 			Gateway: sbc0,
 		},
 		{
 			Target: &querypb.Target{
-				Keyspace: "TestMultiExecs",
-				Shard:    "1",
+				Keyspace:   "TestMultiExecs",
+				Shard:      "1",
+				TabletType: topodatapb.TabletType_REPLICA,
 			},
 			Gateway: sbc1,
 		},
@@ -419,7 +419,8 @@ func TestMultiExecs(t *testing.T) {
 		},
 	}
 
-	_, _ = sc.ExecuteMultiShard(ctx, rss, queries, NewSafeSession(nil), false, false)
+	_, err := sc.ExecuteMultiShard(ctx, rss, queries, NewSafeSession(nil), false, false)
+	require.NoError(t, vterrors.Aggregate(err))
 	if len(sbc0.Queries) == 0 || len(sbc1.Queries) == 0 {
 		t.Fatalf("didn't get expected query")
 	}

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -221,23 +221,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 
 			qs, err = getQueryService(rs, info)
 			if err != nil {
-				// an error here could mean that the tablet we were targeting earlier has changed type.
-				// if we have a transaction, we'll have to fail, but if we only had a reserved connection,
-				// we can create a new reserved connection to a new tablet that is on the right shard
-				// and has the right type
-				switch info.actionNeeded {
-				case nothing:
-					info.actionNeeded = reserve
-				case begin:
-					info.actionNeeded = reserveBegin
-				default:
-					return nil, err
-				}
-				retry := checkAndResetShardSession(info, err, session)
-				if retry != newQS {
-					return nil, err
-				}
-				qs = rs.Gateway
+				return nil, err
 			}
 
 			retryRequest := func(exec func()) {

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -351,12 +351,15 @@ func TestReservedConnFail(t *testing.T) {
 	})
 	sbc0Th := ths[0]
 	sbc0Th.Serving = false
+	sbc0.NotServing = true
 	sbc0Rep := hc.AddTestTablet("aa", "0", 2, keyspace, "0", topodatapb.TabletType_REPLICA, true, 1, nil)
 
 	sbc0.Queries = nil
+	sbc0.ExecCount.Set(0)
 	_ = executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations)
-	assert.Equal(t, 0, len(sbc0.Queries), "no attempt should be made as the tablet is not serving")
-	assert.Equal(t, 1, len(sbc0Rep.Queries), "first attempt should pass as it is healthy")
+	assert.EqualValues(t, 1, sbc0.ExecCount.Get(), "first attempt should be made on original tablet")
+	assert.EqualValues(t, 0, len(sbc0.Queries), "no query should be executed on it")
+	assert.Equal(t, 1, len(sbc0Rep.Queries), "this attempt on new healthy tablet should pass")
 	require.Equal(t, 1, len(session.ShardSessions))
 	assert.NotEqual(t, oldRId, session.Session.ShardSessions[0].ReservedId, "should have recreated a reserved connection since the last connection was lost")
 	assert.NotEqual(t, oldAlias, session.Session.ShardSessions[0].TabletAlias, "tablet alias should have changed as this is a different tablet")
@@ -376,12 +379,17 @@ func TestReservedConnFail(t *testing.T) {
 		Shard:      tablet0Rep.GetShard(),
 		TabletType: topodatapb.TabletType_SPARE,
 	}
+	sbc0Rep.Tablet().Type = topodatapb.TabletType_SPARE
 	sbc0Th.Serving = true
+	sbc0.NotServing = false
+	sbc0.ExecCount.Set(0)
 
 	sbc0Rep.Queries = nil
+	sbc0Rep.ExecCount.Set(0)
 	_ = executeOnShardsReturnsErr(t, res, keyspace, sc, session, destinations)
-	assert.Equal(t, 1, len(sbc0.Queries), "first attempt should pass as it is healthy and matches the target")
-	assert.Equal(t, 0, len(sbc0Rep.Queries), " no attempt should be made as the tablet target is changed")
+	assert.EqualValues(t, 1, sbc0Rep.ExecCount.Get(), "first attempt should be made on the changed tablet type")
+	assert.EqualValues(t, 0, len(sbc0Rep.Queries), "no query should be executed on it")
+	assert.Equal(t, 1, len(sbc0.Queries), "this attempt should pass as it is on new healthy tablet and matches the target")
 	require.Equal(t, 1, len(session.ShardSessions))
 	assert.NotEqual(t, oldRId, session.Session.ShardSessions[0].ReservedId, "should have recreated a reserved connection since the last connection was lost")
 	assert.NotEqual(t, oldAlias, session.Session.ShardSessions[0].TabletAlias, "tablet alias should have changed as this is a different tablet")

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"sync"
 
-	"vitess.io/vitess/go/vt/sqlparser"
-
 	"context"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -169,8 +167,7 @@ func (sbc *SandboxConn) Execute(ctx context.Context, target *querypb.Target, que
 	if err := sbc.getError(); err != nil {
 		return nil, err
 	}
-	parse, _ := sqlparser.Parse(query)
-	return sbc.getNextResult(parse), nil
+	return sbc.getNextResult(), nil
 }
 
 // ExecuteBatch is part of the QueryService interface.
@@ -185,9 +182,8 @@ func (sbc *SandboxConn) ExecuteBatch(ctx context.Context, target *querypb.Target
 	sbc.BatchQueries = append(sbc.BatchQueries, queries)
 	sbc.Options = append(sbc.Options, options)
 	result := make([]sqltypes.Result, 0, len(queries))
-	for _, query := range queries {
-		parse, _ := sqlparser.Parse(query.Sql)
-		result = append(result, *(sbc.getNextResult(parse)))
+	for range queries {
+		result = append(result, *(sbc.getNextResult()))
 	}
 	return result, nil
 }
@@ -210,15 +206,14 @@ func (sbc *SandboxConn) StreamExecute(ctx context.Context, target *querypb.Targe
 		sbc.sExecMu.Unlock()
 		return err
 	}
-	ast, _ := sqlparser.Parse(query)
 	if sbc.results == nil {
-		nextRs := sbc.getNextResult(ast)
+		nextRs := sbc.getNextResult()
 		sbc.sExecMu.Unlock()
 		return callback(nextRs)
 	}
 
 	for len(sbc.results) > 0 {
-		nextRs := sbc.getNextResult(ast)
+		nextRs := sbc.getNextResult()
 		sbc.sExecMu.Unlock()
 		err := callback(nextRs)
 		if err != nil {
@@ -391,7 +386,7 @@ func (sbc *SandboxConn) MessageStream(ctx context.Context, target *querypb.Targe
 	if err := sbc.getError(); err != nil {
 		return err
 	}
-	r := sbc.getNextResult(nil)
+	r := sbc.getNextResult()
 	if r == nil {
 		return nil
 	}
@@ -518,55 +513,13 @@ func (sbc *SandboxConn) Tablet() *topodatapb.Tablet {
 	return sbc.tablet
 }
 
-func (sbc *SandboxConn) getNextResult(stmt sqlparser.Statement) *sqltypes.Result {
+func (sbc *SandboxConn) getNextResult() *sqltypes.Result {
 	if len(sbc.results) != 0 {
 		r := sbc.results[0]
 		sbc.results = sbc.results[1:]
 		return r
 	}
-	if stmt == nil {
-		// if we didn't get a valid query, we'll assume we need a SELECT
-		return getSingleRowResult()
-	}
-	switch stmt.(type) {
-	case *sqlparser.Select,
-		*sqlparser.Union,
-		*sqlparser.Show,
-		*sqlparser.Explain,
-		*sqlparser.OtherRead:
-		return getSingleRowResult()
-	case *sqlparser.Set,
-		sqlparser.DDLStatement,
-		*sqlparser.AlterVschema,
-		*sqlparser.Use,
-		*sqlparser.OtherAdmin,
-		*sqlparser.SetTransaction,
-		*sqlparser.Savepoint,
-		*sqlparser.SRollback,
-		*sqlparser.Release:
-		return &sqltypes.Result{}
-	}
-
-	// for everything else we fake a single row being affected
-	return &sqltypes.Result{RowsAffected: 1}
-}
-
-// getSingleRowResult is used to get a SingleRowResult but it creates separate fields because some tests change the fields
-// If these fields are not created separately then the constants value also changes which leads to some other tests failing later
-func getSingleRowResult() *sqltypes.Result {
-	singleRowResult := &sqltypes.Result{
-		InsertID: SingleRowResult.InsertID,
-		Rows:     SingleRowResult.Rows,
-	}
-
-	for _, field := range SingleRowResult.Fields {
-		singleRowResult.Fields = append(singleRowResult.Fields, &querypb.Field{
-			Name: field.Name,
-			Type: field.Type,
-		})
-	}
-
-	return singleRowResult
+	return SingleRowResult
 }
 
 //StringQueries returns the queries executed as a slice of strings


### PR DESCRIPTION
An issue was introduced In a recent fix (#8041) which was a backport of #7879 

Before sending queries to a tablet, #7879 changed the behaviour to check if the tablet is ready to answer, by checking it's ServingStatus and that the tablet type hasn't changed.

If PlannedReparentShard is going on, this check should not be done for transactions in flight.
The vttablet waits for inflight transactions to get commit/rollback i.e. we want queries to existing transaction to be sent down to get the transaction completed, even if the tablet is currently saying it is NotServing.

The test that exposed this issue was already in the code base: go/test/endtoend/tabletgateway/buffer/buffer_test.go became flaky after #7879 was merged.

So, to fix the issue, the pre-check is removed from Gateway when getting the tablet connection for existing active shard_sessions with vttablet.

This also means that the reserved connection that used to reset based on this pre-check logic will have to hit the vttablet first and then only will reset the shard session on receiving the expected error making it two round trips.

## Related Issue(s)
Backport of #8089