### PR TITLE
[vtadmin-web] Do not parse numbers/booleans in URL query parameters by default

### DIFF
--- a/web/vtadmin/src/hooks/useSyncedURLParam.ts
+++ b/web/vtadmin/src/hooks/useSyncedURLParam.ts
@@ -43,7 +43,9 @@ export const useSyncedURLParam = (
     // (3) navigated away, and then (4) clicked a nav link back to /tablets, the "filter" parameter
     // parameter you typed in (2) will be lost, since it's only preserved on the history stack,
     // which is only traversable with the "back" button.
-    const { query, pushQuery, replaceQuery } = useURLQuery();
+
+    // Ensure we never parse booleans/numbers since the contract (noted above) is that the value is always a string.
+    const { query, pushQuery, replaceQuery } = useURLQuery({ parseBooleans: false, parseNumbers: false });
     const value = `${query[key] || ''}`;
 
     const updateValue = useCallback(

--- a/web/vtadmin/src/hooks/useURLPagination.ts
+++ b/web/vtadmin/src/hooks/useURLPagination.ts
@@ -38,7 +38,7 @@ const FIRST_PAGE = 1;
 export const useURLPagination = ({ totalPages }: PaginationOpts): PaginationParams => {
     const history = useHistory();
     const location = useLocation();
-    const { query, replaceQuery } = useURLQuery();
+    const { query, replaceQuery } = useURLQuery({ parseNumbers: true });
 
     // A slight nuance here -- if `page` is not in the URL at all, then we can assume
     // it's the first page. This makes for slightly nicer URLs for the first/default page:

--- a/web/vtadmin/src/hooks/useURLQuery.test.tsx
+++ b/web/vtadmin/src/hooks/useURLQuery.test.tsx
@@ -19,45 +19,55 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import { QueryParams } from '../util/queryString';
 
-import { useURLQuery } from './useURLQuery';
+import { useURLQuery, URLQueryOptions } from './useURLQuery';
 
 describe('useURLQuery', () => {
     describe('parsing', () => {
         const tests: {
             name: string;
             url: string;
+            opts: URLQueryOptions | undefined;
             expected: ReturnType<typeof useURLQuery>['query'];
         }[] = [
             {
+                name: 'parses complex URLs',
+                url: '/test?page=1&isTrue=true&isFalse=false&list=one&list=two&list=three&foo=bar',
+                opts: undefined,
+                expected: { page: '1', isTrue: 'true', isFalse: 'false', list: ['one', 'two', 'three'], foo: 'bar' },
+            },
+            {
                 name: 'parses numbers',
                 url: '/test?page=1',
+                opts: { parseNumbers: true },
                 expected: { page: 1 },
             },
             {
                 name: 'parses booleans',
                 url: '/test?foo=true&bar=false',
+                opts: { parseBooleans: true },
                 expected: { foo: true, bar: false },
             },
             {
                 name: 'parses arrays by duplicate keys',
                 url: '/test?list=1&list=2&list=3',
+                opts: { parseNumbers: true },
                 expected: { list: [1, 2, 3] },
-            },
-            {
-                name: 'parses complex URLs',
-                url: '/test?page=1&isTrue=true&isFalse=false&list=one&list=two&list=three&foo=bar',
-                expected: { page: 1, isTrue: true, isFalse: false, list: ['one', 'two', 'three'], foo: 'bar' },
             },
         ];
 
         test.each(tests.map(Object.values))(
             '%s',
-            (name: string, url: string, expected: ReturnType<typeof useURLQuery>) => {
+            (
+                name: string,
+                url: string,
+                opts: URLQueryOptions | undefined,
+                expected: ReturnType<typeof useURLQuery>
+            ) => {
                 const history = createMemoryHistory({
                     initialEntries: [url],
                 });
 
-                const { result } = renderHook(() => useURLQuery(), {
+                const { result } = renderHook(() => useURLQuery(opts), {
                     wrapper: ({ children }) => {
                         return <Router history={history}>{children}</Router>;
                     },
@@ -90,8 +100,8 @@ describe('useURLQuery', () => {
             {
                 name: 'it does not merge array-like queries',
                 initialEntries: ['/test?arr=one&arr=two'],
-                nextQuery: { arr: [3, 4, 5] },
-                expected: { arr: [3, 4, 5] },
+                nextQuery: { arr: ['three', 'four', 'five'] },
+                expected: { arr: ['three', 'four', 'five'] },
             },
         ];
 
@@ -142,8 +152,8 @@ describe('useURLQuery', () => {
             {
                 name: 'it does not merge array-like queries',
                 initialEntries: ['/test?arr=one&arr=two'],
-                nextQuery: { arr: [3, 4, 5] },
-                expected: { arr: [3, 4, 5] },
+                nextQuery: { arr: ['three', 'four', 'five'] },
+                expected: { arr: ['three', 'four', 'five'] },
             },
         ];
 

--- a/web/vtadmin/src/util/queryString.ts
+++ b/web/vtadmin/src/util/queryString.ts
@@ -29,8 +29,8 @@ const DEFAULT_ARRAY_FORMAT = 'none';
 
 const DEFAULT_PARSE_OPTIONS: qs.ParseOptions = {
     arrayFormat: DEFAULT_ARRAY_FORMAT,
-    parseBooleans: true,
-    parseNumbers: true,
+    parseBooleans: false,
+    parseNumbers: false,
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

Currently, VTAdmin by default parses numeric URL query parameters as numbers. This resulted in unintended behaviour with shard filtering, where filtering by a string like "000" (to, say, find shard `0001-0002`) would be parsed as `0` (no leading zeroes) and would _also_ evaluate as falsey, which caused a host of other unfun side-effects. 

In this screenshot, I tried to filter by "00". Note the `?filter=0` in the URL and the empty text input:

<img width="2672" alt="Screen Shot 2021-05-11 at 1 48 50 PM" src="https://user-images.githubusercontent.com/855595/117861922-feb76080-b25f-11eb-950b-170c51a8d034.png">

It turns out that _not_ parsing booleans/numbers is the more common VTAdmin use case. The one exception so far is pagination, were we do want `page=1` to parse as an integer. 

Here's what it looks like with the fix:

<img width="2672" alt="Screen Shot 2021-05-11 at 1 48 42 PM" src="https://user-images.githubusercontent.com/855595/117863731-168fe400-b262-11eb-8e2e-a2ffcc6c71c6.png">


## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A