### PR TITLE
[tm_state] updateLocked should re-populate local metadata tables to reflect promotion rule changes

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -96,15 +96,15 @@ func main() {
 		log.Exitf("failed to parse -tablet-path: %v", err)
 	}
 	tm = &tabletmanager.TabletManager{
-		BatchCtx:               context.Background(),
-		TopoServer:             ts,
-		Cnf:                    mycnf,
-		MysqlDaemon:            mysqld,
-		DBConfigs:              config.DB.Clone(),
-		QueryServiceControl:    qsc,
-		UpdateStream:           binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
-		VREngine:               vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
-		LocalMetadataPopulator: mysqlctl.PopulateMetadataTables,
+		BatchCtx:            context.Background(),
+		TopoServer:          ts,
+		Cnf:                 mycnf,
+		MysqlDaemon:         mysqld,
+		DBConfigs:           config.DB.Clone(),
+		QueryServiceControl: qsc,
+		UpdateStream:        binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
+		VREngine:            vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
+		MetadataManager:     &mysqlctl.MetadataManager{},
 	}
 	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
 		log.Exitf("failed to parse -tablet-path or initialize DB credentials: %v", err)

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -96,14 +96,15 @@ func main() {
 		log.Exitf("failed to parse -tablet-path: %v", err)
 	}
 	tm = &tabletmanager.TabletManager{
-		BatchCtx:            context.Background(),
-		TopoServer:          ts,
-		Cnf:                 mycnf,
-		MysqlDaemon:         mysqld,
-		DBConfigs:           config.DB.Clone(),
-		QueryServiceControl: qsc,
-		UpdateStream:        binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
-		VREngine:            vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
+		BatchCtx:               context.Background(),
+		TopoServer:             ts,
+		Cnf:                    mycnf,
+		MysqlDaemon:            mysqld,
+		DBConfigs:              config.DB.Clone(),
+		QueryServiceControl:    qsc,
+		UpdateStream:           binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine()),
+		VREngine:               vreplication.NewEngine(config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
+		LocalMetadataPopulator: mysqlctl.PopulateMetadataTables,
 	}
 	if err := tm.Start(tablet, config.Healthcheck.IntervalSeconds.Get()); err != nil {
 		log.Exitf("failed to parse -tablet-path or initialize DB credentials: %v", err)

--- a/go/vt/mysqlctl/metadata_tables.go
+++ b/go/vt/mysqlctl/metadata_tables.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -58,16 +59,103 @@ var (
 	}
 )
 
-// PopulateMetadataTables creates and fills the _vt.local_metadata table and
-// creates _vt.shard_metadata table. _vt.local_metadata table is
-// a per-tablet table that is never replicated. This allows queries
-// against local_metadata to return different values on different tablets,
-// which is used for communicating between Vitess and MySQL-level tools like
-// Orchestrator (https://github.com/openark/orchestrator).
+// CreateMetadataTables creates the _vt.local_metadata and _vt.shard_metadata
+// tables.
+//
+// _vt.local_metadata table is a per-tablet table that is never replicated.
+// This allows queries against local_metadata to return different values on
+// different tablets, which is used for communicating between Vitess and
+// MySQL-level tools like Orchestrator (https://github.com/openark/orchestrator).
+//
 // _vt.shard_metadata is a replicated table with per-shard information, but it's
 // created here to make it easier to create it on databases that were running
 // old version of Vitess, or databases that are getting converted to run under
 // Vitess.
+func CreateMetadataTables(mysqld MysqlDaemon, dbName string) error {
+	log.Infof("Creating _vt.local_metadata and _vt.shard_metadata tables ...")
+
+	conn, err := mysqld.GetDbaConnection(context.TODO())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Disable replication on this session. We close the connection after using
+	// it, so there's no need to re-enable replication when we're done.
+	if _, err := conn.ExecuteFetch("SET @@session.sql_log_bin = 0", 0, false); err != nil {
+		return err
+	}
+
+	return createMetadataTables(conn, dbName)
+}
+
+func createMetadataTables(conn *dbconnpool.DBConnection, dbName string) error {
+	if _, err := conn.ExecuteFetch("CREATE DATABASE IF NOT EXISTS _vt", 0, false); err != nil {
+		return err
+	}
+
+	if err := createLocalMetadataTable(conn, dbName); err != nil {
+		return err
+	}
+
+	if err := createShardMetadataTable(conn, dbName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createLocalMetadataTable(conn *dbconnpool.DBConnection, dbName string) error {
+	if _, err := conn.ExecuteFetch(sqlCreateLocalMetadataTable, 0, false); err != nil {
+		return err
+	}
+
+	for _, sql := range sqlAlterLocalMetadataTable {
+		if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
+			// Ignore "Duplicate column name 'db_name'" errors which can happen on every restart.
+			if merr, ok := err.(*mysql.SQLError); !ok || merr.Num != mysql.ERDupFieldName {
+				log.Errorf("Error executing %v: %v", sql, err)
+				return err
+			}
+		}
+	}
+
+	sql := fmt.Sprintf(sqlUpdateLocalMetadataTable, dbName)
+	if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
+		log.Errorf("Error executing %v: %v, continuing. Please check the data in _vt.local_metadata and take corrective action.", sql, err)
+	}
+
+	return nil
+}
+
+func createShardMetadataTable(conn *dbconnpool.DBConnection, dbName string) error {
+	if _, err := conn.ExecuteFetch(sqlCreateShardMetadataTable, 0, false); err != nil {
+		return err
+	}
+
+	for _, sql := range sqlAlterShardMetadataTable {
+		if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
+			// Ignore "Duplicate column name 'db_name'" errors which can happen on every restart.
+			if merr, ok := err.(*mysql.SQLError); !ok || merr.Num != mysql.ERDupFieldName {
+				log.Errorf("Error executing %v: %v", sql, err)
+				return err
+			}
+		}
+	}
+
+	sql := fmt.Sprintf(sqlUpdateShardMetadataTable, dbName)
+	if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
+		log.Errorf("Error executing %v: %v, continuing. Please check the data in _vt.shard_metadata and take corrective action.", sql, err)
+	}
+
+	return nil
+}
+
+// PopulateMetadataTables creates and fills the _vt.local_metadata table and
+// creates _vt.shard_metadata table.
+//
+// This function is semantically equivalent to calling CreateMetadataTables
+// followed immediately by UpsertLocalMetadata.
 func PopulateMetadataTables(mysqld MysqlDaemon, localMetadata map[string]string, dbName string) error {
 	log.Infof("Populating _vt.local_metadata table...")
 
@@ -85,42 +173,42 @@ func PopulateMetadataTables(mysqld MysqlDaemon, localMetadata map[string]string,
 	}
 
 	// Create the database and table if necessary.
-	if _, err := conn.ExecuteFetch("CREATE DATABASE IF NOT EXISTS _vt", 0, false); err != nil {
+	if err := createMetadataTables(conn, dbName); err != nil {
 		return err
-	}
-	if _, err := conn.ExecuteFetch(sqlCreateLocalMetadataTable, 0, false); err != nil {
-		return err
-	}
-	for _, sql := range sqlAlterLocalMetadataTable {
-		if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
-			// Ignore "Duplicate column name 'db_name'" errors which can happen on every restart.
-			if merr, ok := err.(*mysql.SQLError); !ok || merr.Num != mysql.ERDupFieldName {
-				log.Errorf("Error executing %v: %v", sql, err)
-				return err
-			}
-		}
-	}
-	sql := fmt.Sprintf(sqlUpdateLocalMetadataTable, dbName)
-	if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
-		log.Errorf("Error executing %v: %v, continuing. Please check the data in _vt.local_metadata and take corrective action.", sql, err)
-	}
-	if _, err := conn.ExecuteFetch(sqlCreateShardMetadataTable, 0, false); err != nil {
-		return err
-	}
-	for _, sql := range sqlAlterShardMetadataTable {
-		if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
-			// Ignore "Duplicate column name 'db_name'" errors which can happen on every restart.
-			if merr, ok := err.(*mysql.SQLError); !ok || merr.Num != mysql.ERDupFieldName {
-				log.Errorf("Error executing %v: %v", sql, err)
-				return err
-			}
-		}
-	}
-	sql = fmt.Sprintf(sqlUpdateShardMetadataTable, dbName)
-	if _, err := conn.ExecuteFetch(sql, 0, false); err != nil {
-		log.Errorf("Error executing %v: %v, continuing. Please check the data in _vt.shard_metadata and take corrective action.", sql, err)
 	}
 
+	// Populate local_metadata from the passed list of values.
+	return upsertLocalMetadata(conn, localMetadata, dbName)
+}
+
+// UpsertLocalMetadata adds the given metadata map to the _vt.local_metadata
+// table, updating any rows that exist for a given `_vt.local_metadata.name`
+// with the map value. The session that performs these upserts sets
+// sql_log_bin=0, as the _vt.local_metadata table is meant to never be
+// replicated.
+//
+// Callers are responsible for ensuring the _vt.local_metadata table exists
+// before calling this function, usually by calling CreateMetadataTables at
+// least once prior.
+func UpsertLocalMetadata(mysqld MysqlDaemon, localMetadata map[string]string, dbName string) error {
+	log.Infof("Upserting _vt.local_metadata ...")
+
+	conn, err := mysqld.GetDbaConnection(context.TODO())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Disable replication on this session. We close the connection after using
+	// it, so there's no need to re-enable replication when we're done.
+	if _, err := conn.ExecuteFetch("SET @@session.sql_log_bin = 0", 0, false); err != nil {
+		return err
+	}
+
+	return upsertLocalMetadata(conn, localMetadata, dbName)
+}
+
+func upsertLocalMetadata(conn *dbconnpool.DBConnection, localMetadata map[string]string, dbName string) error {
 	// Populate local_metadata from the passed list of values.
 	if _, err := conn.ExecuteFetch("BEGIN", 0, false); err != nil {
 		return err
@@ -144,6 +232,10 @@ func PopulateMetadataTables(mysqld MysqlDaemon, localMetadata map[string]string,
 			return err
 		}
 	}
-	_, err = conn.ExecuteFetch("COMMIT", 0, false)
-	return err
+
+	if _, err := conn.ExecuteFetch("COMMIT", 0, false); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/go/vt/mysqlctl/metadata_tables.go
+++ b/go/vt/mysqlctl/metadata_tables.go
@@ -59,6 +59,29 @@ var (
 	}
 )
 
+// MetadataManager manages the creation and filling of the _vt.local_metadata
+// and _vt.shard_metadata tables.
+type MetadataManager struct{}
+
+// CreateMetadataTables creates the metadata tables. See the package-level
+// function for more details.
+func (m *MetadataManager) CreateMetadataTables(mysqld MysqlDaemon, dbName string) error {
+	return CreateMetadataTables(mysqld, dbName)
+}
+
+// PopulateMetadataTables creates and fills the metadata tables. See the
+// package-level function for more details.
+func (m *MetadataManager) PopulateMetadataTables(mysqld MysqlDaemon, localMetadata map[string]string, dbName string) error {
+	return PopulateMetadataTables(mysqld, localMetadata, dbName)
+}
+
+// UpsertLocalMetadata adds the given metadata map to the _vt.local_metadata
+// table, updating any duplicate rows to the values in the map. See the package-
+// level function for more details.
+func (m *MetadataManager) UpsertLocalMetadata(mysqld MysqlDaemon, localMetadata map[string]string, dbName string) error {
+	return UpsertLocalMetadata(mysqld, localMetadata, dbName)
+}
+
 // CreateMetadataTables creates the _vt.local_metadata and _vt.shard_metadata
 // tables.
 //

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
@@ -335,7 +337,7 @@ func TestStartCheckMysql(t *testing.T) {
 	tm := &TabletManager{
 		BatchCtx:            context.Background(),
 		TopoServer:          ts,
-		MysqlDaemon:         &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(-1)},
+		MysqlDaemon:         newTestMysqlDaemon(t, 1),
 		DBConfigs:           dbconfigs.NewTestDBConfigs(cp, cp, ""),
 		QueryServiceControl: tabletservermock.NewController(),
 	}
@@ -357,7 +359,7 @@ func TestStartFindMysqlPort(t *testing.T) {
 	cell := "cell1"
 	ts := memorytopo.NewServer(cell)
 	tablet := newTestTablet(t, 1, "ks", "0")
-	fmd := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(-1)}
+	fmd := newTestMysqlDaemon(t, -1)
 	tm := &TabletManager{
 		BatchCtx:            context.Background(),
 		TopoServer:          ts,
@@ -504,6 +506,31 @@ func TestCheckTabletTypeResets(t *testing.T) {
 	tm.Stop()
 }
 
+func newTestMysqlDaemon(t *testing.T, port int32) *fakemysqldaemon.FakeMysqlDaemon {
+	db := fakesqldb.New(t)
+	db.AddQueryPattern("SET @@.*", &sqltypes.Result{})
+	db.AddQueryPattern("BEGIN", &sqltypes.Result{})
+	db.AddQueryPattern("COMMIT", &sqltypes.Result{})
+
+	db.AddQueryPattern("CREATE DATABASE IF NOT EXISTS _vt", &sqltypes.Result{})
+	db.AddQueryPattern("CREATE TABLE IF NOT EXISTS _vt\\.(local|shard)_metadata.*", &sqltypes.Result{})
+
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata ADD COLUMN (db_name).*", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata DROP PRIMARY KEY, ADD PRIMARY KEY\\(name, db_name\\)", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.local_metadata CHANGE value.*", &sqltypes.Result{})
+
+	db.AddQueryPattern("ALTER TABLE _vt\\.shard_metadata ADD COLUMN (db_name).*", &sqltypes.Result{})
+	db.AddQueryPattern("ALTER TABLE _vt\\.shard_metadata DROP PRIMARY KEY, ADD PRIMARY KEY\\(name, db_name\\)", &sqltypes.Result{})
+
+	db.AddQueryPattern("UPDATE _vt\\.(local|shard)_metadata SET db_name='.+' WHERE db_name=''", &sqltypes.Result{})
+	db.AddQueryPattern("INSERT INTO _vt\\.local_metadata \\(.+\\) VALUES \\(.+\\) ON DUPLICATE KEY UPDATE value ?= ?'.+'.*", &sqltypes.Result{})
+
+	mysqld := fakemysqldaemon.NewFakeMysqlDaemon(db)
+	mysqld.MysqlPort = sync2.NewAtomicInt32(port)
+
+	return mysqld
+}
+
 func newTestTM(t *testing.T, ts *topo.Server, uid int, keyspace, shard string) *TabletManager {
 	t.Helper()
 	ctx := context.Background()
@@ -511,7 +538,7 @@ func newTestTM(t *testing.T, ts *topo.Server, uid int, keyspace, shard string) *
 	tm := &TabletManager{
 		BatchCtx:            ctx,
 		TopoServer:          ts,
-		MysqlDaemon:         &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(1)},
+		MysqlDaemon:         newTestMysqlDaemon(t, 1),
 		DBConfigs:           &dbconfigs.DBConfigs{},
 		QueryServiceControl: tabletservermock.NewController(),
 	}

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -507,6 +507,8 @@ func TestCheckTabletTypeResets(t *testing.T) {
 }
 
 func newTestMysqlDaemon(t *testing.T, port int32) *fakemysqldaemon.FakeMysqlDaemon {
+	t.Helper()
+
 	db := fakesqldb.New(t)
 	db.AddQueryPattern("SET @@.*", &sqltypes.Result{})
 	db.AddQueryPattern("BEGIN", &sqltypes.Result{})

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -229,6 +229,12 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 		return
 	}
 
+	localMetadata := ts.tm.getLocalMetadataValues(ts.tablet.Type)
+	err := mysqlctl.PopulateMetadataTables(ts.tm.MysqlDaemon, localMetadata, topoproto.TabletDbName(ts.tablet))
+	if err != nil {
+		log.Errorf("PopulateMetadataTables(%v) failed: %v", localMetadata, err)
+	}
+
 	terTime := logutil.ProtoToTime(ts.tablet.MasterTermStartTime)
 
 	// Disable TabletServer first so the nonserving state gets advertised

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -163,6 +163,7 @@ func TestStateIsShardServingisInSrvKeyspace(t *testing.T) {
 
 	tm.tmState.mu.Lock()
 	tm.tmState.tablet.Type = topodatapb.TabletType_MASTER
+	tm.tmState.updateLocked(ctx)
 	tm.tmState.mu.Unlock()
 
 	leftKeyRange, err := key.ParseShardingSpec("-80")


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

TODO.

This means we call `PopulateMetadataTables` on:
* `(*tmState).ChangeTabletType`
* `(*tmState).RefreshFromTopoInfo`
* `(*tmState).RefreshFromTopo` (via `RefreshFromTopoInfo`)
* `(*tmState).Open`

### See it in action

```
❯ vtctldclient --server "localhost:15999" GetTablets
zone1-0000000100 commerce 0 master SFO-M-AMASON02:15100 SFO-M-AMASON02:17100 [] 2021-05-12T15:48:34Z
zone1-0000000101 commerce 0 replica SFO-M-AMASON02:15101 SFO-M-AMASON02:17101 [] <null>
zone1-0000000102 commerce 0 rdonly SFO-M-AMASON02:15102 SFO-M-AMASON02:17102 [] <null>

# on zone1-101
mysql> select * from _vt.local_metadata;
+---------------+------------------+-------------+
| name          | value            | db_name     |
+---------------+------------------+-------------+
| Alias         | zone1-0000000101 | vt_commerce |
| ClusterAlias  | commerce.0       | vt_commerce |
| DataCenter    | zone1            | vt_commerce |
| PromotionRule | neutral          | vt_commerce |
+---------------+------------------+-------------+
4 rows in set (0.00 sec)

# now, the tablet type change
❯ vtctldclient --server "localhost:15999" ChangeTabletType zone1-0000000101 rdonly
- zone1-0000000101 commerce 0 replica SFO-M-AMASON02:15101 SFO-M-AMASON02:17101 [] <null>
+ zone1-0000000101 commerce 0 rdonly SFO-M-AMASON02:15101 SFO-M-AMASON02:17101 [] <null>

mysql> mysql> select * from _vt.local_metadata;
+---------------+------------------+-------------+
| name          | value            | db_name     |
+---------------+------------------+-------------+
| Alias         | zone1-0000000101 | vt_commerce |
| ClusterAlias  | commerce.0       | vt_commerce |
| DataCenter    | zone1            | vt_commerce |
| PromotionRule | must_not         | vt_commerce |
+---------------+------------------+-------------+
4 rows in set (0.01 sec)
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->