### PR TITLE
[vtadmin-web] Add Keyspace detail view

### DIFF
--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -30,6 +30,7 @@ import { Stream } from './routes/Stream';
 import { Workflows } from './routes/Workflows';
 import { Workflow } from './routes/Workflow';
 import { VTExplain } from './routes/VTExplain';
+import { Keyspace } from './routes/keyspace/Keyspace';
 
 export const App = () => {
     return (
@@ -51,6 +52,10 @@ export const App = () => {
 
                         <Route path="/keyspaces">
                             <Keyspaces />
+                        </Route>
+
+                        <Route path="/keyspace/:clusterID/:name">
+                            <Keyspace />
                         </Route>
 
                         <Route path="/schemas">

--- a/web/vtadmin/src/components/links/KeyspaceLink.tsx
+++ b/web/vtadmin/src/components/links/KeyspaceLink.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { stringify } from '../../util/queryString';
+
+interface Props {
+    className?: string;
+    clusterID: string | null | undefined;
+    name: string | null | undefined;
+    // Shorthand property equivalent to "shardFilter:${shard}"
+    // Note that `shard` will be ignored if `shardFilter` is defined.
+    shard?: string | null | undefined;
+    shardFilter?: string | null | undefined;
+}
+
+export const KeyspaceLink: React.FunctionComponent<Props> = ({
+    children,
+    className,
+    clusterID,
+    name,
+    shard,
+    ...props
+}) => {
+    if (!clusterID || !name) {
+        return <span className={className}>{children}</span>;
+    }
+
+    let shardFilter = props.shardFilter;
+    if (!shardFilter && !!shard) {
+        shardFilter = `shard:${shard}`;
+    }
+
+    const to = {
+        pathname: `/keyspace/${clusterID}/${name}`,
+        search: stringify({ shardFilter }),
+    };
+
+    return (
+        <Link className={className} to={to}>
+            {children}
+        </Link>
+    );
+};

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -29,6 +29,7 @@ import { ContentContainer } from '../layout/ContentContainer';
 import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { DataFilter } from '../dataTable/DataFilter';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 
 export const Keyspaces = () => {
     useDocumentTitle('Keyspaces');
@@ -56,8 +57,10 @@ export const Keyspaces = () => {
         rows.map((row, idx) => (
             <tr key={idx}>
                 <DataCell>
-                    <div className="font-weight-bold">{row.name}</div>
-                    <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                    <KeyspaceLink clusterID={row.clusterID} name={row.name}>
+                        <div className="font-weight-bold">{row.name}</div>
+                        <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                    </KeyspaceLink>
                 </DataCell>
                 <DataCell>
                     {!!row.servingShards && (

--- a/web/vtadmin/src/components/routes/Schema.tsx
+++ b/web/vtadmin/src/components/routes/Schema.tsx
@@ -26,6 +26,7 @@ import { NavCrumbs } from '../layout/NavCrumbs';
 import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { Tooltip } from '../tooltip/Tooltip';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 
 interface RouteParams {
     clusterID: string;
@@ -70,7 +71,10 @@ export const Schema = () => {
                             Cluster: <code>{clusterID}</code>
                         </span>
                         <span>
-                            Keyspace: <code>{keyspace}</code>
+                            Keyspace:{' '}
+                            <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                                <code>{keyspace}</code>
+                            </KeyspaceLink>
                         </span>
                     </div>
                 </WorkspaceHeader>

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -29,6 +29,7 @@ import { DataTable } from '../dataTable/DataTable';
 import { ContentContainer } from '../layout/ContentContainer';
 import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 import { HelpTooltip } from '../tooltip/HelpTooltip';
 
 const TABLE_COLUMNS = [
@@ -90,8 +91,10 @@ export const Schemas = () => {
             return (
                 <tr key={idx}>
                     <DataCell>
-                        <div>{row.keyspace}</div>
-                        <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                        <KeyspaceLink clusterID={row.clusterID} name={row.keyspace}>
+                            <div>{row.keyspace}</div>
+                            <div className="font-size-small text-color-secondary">{row.cluster}</div>
+                        </KeyspaceLink>
                     </DataCell>
                     <DataCell className="font-weight-bold">
                         {href ? <Link to={href}>{row.table}</Link> : row.table}

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -30,6 +30,7 @@ import { ContentContainer } from '../layout/ContentContainer';
 import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { DataFilter } from '../dataTable/DataFilter';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -47,16 +48,25 @@ export const Tablets = () => {
             return rows.map((t, tdx) => (
                 <tr key={tdx}>
                     <DataCell>
-                        <div>{t.keyspace}</div>
-                        <div className="font-size-small text-color-secondary">{t.cluster}</div>
+                        <KeyspaceLink clusterID={t._raw.cluster?.id} name={t.keyspace}>
+                            <div>{t.keyspace}</div>
+                            <div className="font-size-small text-color-secondary">{t.cluster}</div>
+                        </KeyspaceLink>
                     </DataCell>
                     <DataCell>
-                        <ShardServingPip isLoading={ksQuery.isLoading} isServing={t.isShardServing} /> {t.shard}
-                        {ksQuery.isSuccess && (
-                            <div className="font-size-small text-color-secondary white-space-nowrap">
-                                {!t.isShardServing && 'NOT SERVING'}
-                            </div>
-                        )}
+                        <KeyspaceLink
+                            className="white-space-nowrap"
+                            clusterID={t._raw.cluster?.id}
+                            name={t.keyspace}
+                            shard={t.shard}
+                        >
+                            <ShardServingPip isLoading={ksQuery.isLoading} isServing={t.isShardServing} /> {t.shard}
+                            {ksQuery.isSuccess && (
+                                <div className="font-size-small text-color-secondary white-space-nowrap">
+                                    {!t.isShardServing && 'NOT SERVING'}
+                                </div>
+                            )}
+                        </KeyspaceLink>
                     </DataCell>
                     <DataCell className="white-space-nowrap">
                         <TabletServingPip state={t._raw.state} /> {t.type}

--- a/web/vtadmin/src/components/routes/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/Workflow.tsx
@@ -30,6 +30,7 @@ import { StreamStatePip } from '../pips/StreamStatePip';
 import { formatAlias } from '../../util/tablets';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { formatDateTime } from '../../util/time';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 
 interface RouteParams {
     clusterID: string;
@@ -63,6 +64,9 @@ export const Workflow = () => {
                     ? `/workflow/${clusterID}/${keyspace}/${name}/stream/${row.tablet.cell}/${row.tablet.uid}/${row.id}`
                     : null;
 
+            const source = getStreamSource(row);
+            const target = getStreamTarget(row, keyspace);
+
             return (
                 <tr key={row.key}>
                     <DataCell>
@@ -74,9 +78,27 @@ export const Workflow = () => {
                             Updated {formatDateTime(row.time_updated?.seconds)}
                         </div>
                     </DataCell>
-                    <DataCell>{getStreamSource(row) || <span className="text-color-secondary">N/A</span>}</DataCell>
                     <DataCell>
-                        {getStreamTarget(row, keyspace) || <span className="text-color-secondary">N/A</span>}
+                        {source ? (
+                            <KeyspaceLink
+                                clusterID={clusterID}
+                                name={row.binlog_source?.keyspace}
+                                shard={row.binlog_source?.shard}
+                            >
+                                {source}
+                            </KeyspaceLink>
+                        ) : (
+                            <span className="text-color-secondary">N/A</span>
+                        )}
+                    </DataCell>
+                    <DataCell>
+                        {target ? (
+                            <KeyspaceLink clusterID={clusterID} name={keyspace} shard={row.shard}>
+                                {source}
+                            </KeyspaceLink>
+                        ) : (
+                            <span className="text-color-secondary">N/A</span>
+                        )}
                     </DataCell>
                     <DataCell>{formatAlias(row.tablet)}</DataCell>
                 </tr>
@@ -97,7 +119,10 @@ export const Workflow = () => {
                         Cluster: <code>{clusterID}</code>
                     </span>
                     <span>
-                        Target keyspace: <code>{keyspace}</code>
+                        Target keyspace:{' '}
+                        <KeyspaceLink clusterID={clusterID} name={keyspace}>
+                            <code>{keyspace}</code>
+                        </KeyspaceLink>
                     </span>
                 </div>
             </WorkspaceHeader>

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -32,6 +32,7 @@ import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { DataFilter } from '../dataTable/DataFilter';
 import { Tooltip } from '../tooltip/Tooltip';
+import { KeyspaceLink } from '../links/KeyspaceLink';
 
 export const Workflows = () => {
     useDocumentTitle('Workflows');
@@ -71,7 +72,9 @@ export const Workflows = () => {
                     <DataCell>
                         {row.source ? (
                             <>
-                                <div>{row.source}</div>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.source}>
+                                    {row.source}
+                                </KeyspaceLink>
                                 <div className={style.shardList}>{(row.sourceShards || []).join(', ')}</div>
                             </>
                         ) : (
@@ -81,7 +84,9 @@ export const Workflows = () => {
                     <DataCell>
                         {row.target ? (
                             <>
-                                <div>{row.target}</div>
+                                <KeyspaceLink clusterID={row.clusterID} name={row.target}>
+                                    {row.target}
+                                </KeyspaceLink>
                                 <div className={style.shardList}>{(row.targetShards || []).join(', ')}</div>
                             </>
                         ) : (

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.module.scss
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.module.scss
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.headingMeta {
+  display: flex;
+}
+
+.headingMeta span {
+  display: inline-block;
+  line-height: 2;
+
+  &::after {
+    color: var(--colorScaffoldingHighlight);
+    content: '/';
+    display: inline-block;
+    margin: 0 1.2rem;
+  }
+
+  &:last-child::after {
+    content: none;
+  }
+}
+
+.placeholder {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: var(--fontSizeLarge);
+  justify-content: center;
+  margin: 25vh auto;
+  max-width: 720px;
+  text-align: center;
+
+  h1 {
+    margin: 1.6rem 0;
+  }
+}
+
+.errorEmoji {
+  display: block;
+  font-size: 5.6rem;
+}

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Switch, useLocation, useParams, useRouteMatch } from 'react-router';
+import { Link, Redirect, Route } from 'react-router-dom';
+
+import { useKeyspaces } from '../../../hooks/api';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import style from './Keyspace.module.scss';
+import { KeyspaceShards } from './KeyspaceShards';
+
+interface RouteParams {
+    clusterID: string;
+    name: string;
+}
+
+export const Keyspace = () => {
+    const { clusterID, name } = useParams<RouteParams>();
+    const { path } = useRouteMatch();
+    const { search } = useLocation();
+
+    useDocumentTitle(`${name} (${clusterID})`);
+
+    // TODO(doeg): add a vtadmin-api endpoint to fetch a single keyspace
+    // See https://github.com/vitessio/vitess/projects/12#card-59980087
+    const { data: keyspaces = [], ...kq } = useKeyspaces();
+    const keyspace = keyspaces.find((k) => k.cluster?.id === clusterID && k.keyspace?.name === name);
+
+    if (kq.error) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😰</span>
+                <h1>An error occurred</h1>
+                <code>{(kq.error as any).response?.error?.message || kq.error?.message}</code>
+                <p>
+                    <Link to="/keyspaces">← All keyspaces</Link>
+                </p>
+            </div>
+        );
+    }
+
+    if (!kq.isLoading && !keyspace) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😖</span>
+                <h1>Keyspace not found</h1>
+                <p>
+                    <Link to="/keyspaces">← All keyspaces</Link>
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/keyspaces">Keyspaces</Link>
+                </NavCrumbs>
+
+                <WorkspaceTitle className="font-family-monospace">{name}</WorkspaceTitle>
+
+                <div className={style.headingMeta}>
+                    <span>
+                        Cluster: <code>{clusterID}</code>
+                    </span>
+                </div>
+            </WorkspaceHeader>
+
+            {/* TODO skeleton placeholder */}
+            {!!kq.isLoading && <div className={style.placeholder}>Loading</div>}
+
+            <Switch>
+                <Route path={`${path}/shards`}>
+                    <KeyspaceShards keyspace={keyspace} />
+                </Route>
+
+                <Redirect exact from={path} to={{ pathname: `${path}/shards`, search }} />
+            </Switch>
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.test.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { topodata, vtadmin as pb } from '../../../proto/vtadmin';
+import { formatRows } from './KeyspaceShards';
+
+describe('KeyspaceShards', () => {
+    describe('formatRows', () => {
+        const tests: {
+            name: string;
+            params: Parameters<typeof formatRows>;
+            expected: ReturnType<typeof formatRows>;
+        }[] = [
+            {
+                name: 'should handle when keyspace is null',
+                params: [null, [], null],
+                expected: [],
+            },
+            {
+                name: 'should filter across shards and tablets',
+                params: [
+                    pb.Keyspace.create({
+                        cluster: {
+                            id: 'cluster1',
+                        },
+                        keyspace: {
+                            name: 'keyspace1',
+                        },
+                        shards: {
+                            '-80': {
+                                name: '-80',
+                                shard: {
+                                    is_master_serving: false,
+                                },
+                            },
+                            '80-': {
+                                name: '80-',
+                                shard: {
+                                    is_master_serving: true,
+                                },
+                            },
+                        },
+                    }),
+                    [
+                        pb.Tablet.create({
+                            cluster: { id: 'cluster1' },
+                            state: pb.Tablet.ServingState.SERVING,
+                            tablet: {
+                                alias: {
+                                    cell: 'zone1',
+                                    uid: 100,
+                                },
+                                keyspace: 'keyspace1',
+                                shard: '-80',
+                                type: topodata.TabletType.MASTER,
+                            },
+                        }),
+                        pb.Tablet.create({
+                            cluster: { id: 'cluster1' },
+                            state: pb.Tablet.ServingState.SERVING,
+                            tablet: {
+                                alias: {
+                                    cell: 'zone1',
+                                    uid: 200,
+                                },
+                                keyspace: 'keyspace2',
+                                shard: '-',
+                                type: topodata.TabletType.MASTER,
+                            },
+                        }),
+                        pb.Tablet.create({
+                            cluster: { id: 'cluster1' },
+                            state: pb.Tablet.ServingState.NOT_SERVING,
+                            tablet: {
+                                alias: {
+                                    cell: 'zone1',
+                                    uid: 300,
+                                },
+                                hostname: 'tablet-zone1-300-80-00',
+                                keyspace: 'keyspace1',
+                                shard: '80-',
+                                type: topodata.TabletType.MASTER,
+                            },
+                        }),
+                    ],
+                    'not',
+                ],
+                expected: [
+                    {
+                        // -80 matches the filter string "not" because shardState is "NOT_SERVING'",
+                        // however all of its tablets are serving and therefore none of them match.
+                        isShardServing: false,
+                        shard: '-80',
+                        shardState: 'NOT_SERVING',
+                        tablets: [],
+                    },
+                    {
+                        // 80- (the shard itself) does not match the filter string, since
+                        // its shardState is "SERVING'. However, its non-serving tablet
+                        // does match the filter string, so we include it.
+                        isShardServing: true,
+                        shard: '80-',
+                        shardState: 'SERVING',
+                        tablets: [
+                            {
+                                alias: 'zone1-300',
+                                hostname: 'tablet-zone1-300-80-00',
+                                shard: '80-',
+                                tabletState: 'NOT_SERVING',
+                                tabletType: 'PRIMARY',
+                                _tabletStateEnum: pb.Tablet.ServingState.NOT_SERVING,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        test.each(tests.map(Object.values))(
+            '%s',
+            (name: string, params: Parameters<typeof formatRows>, expected: ReturnType<typeof formatRows>) => {
+                const result = formatRows(...params);
+                expect(result).toMatchObject(expected);
+            }
+        );
+    });
+});

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -1,0 +1,229 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { groupBy, orderBy, uniq } from 'lodash';
+
+import { topodata, vtadmin as pb } from '../../../proto/vtadmin.d';
+import { useTablets } from '../../../hooks/api';
+import { formatAlias, formatDisplayType, formatState } from '../../../util/tablets';
+import { DataTable } from '../../dataTable/DataTable';
+import { DataCell } from '../../dataTable/DataCell';
+import { ShardServingPip } from '../../pips/ShardServingPip';
+import { TabletServingPip } from '../../pips/TabletServingPip';
+import { DataFilter } from '../../dataTable/DataFilter';
+import { useSyncedURLParam } from '../../../hooks/useSyncedURLParam';
+import { filterNouns } from '../../../util/filterNouns';
+import { ContentContainer } from '../../layout/ContentContainer';
+interface Props {
+    keyspace: pb.Keyspace | null | undefined;
+}
+
+type ShardState = 'SERVING' | 'NOT_SERVING';
+
+const TABLE_COLUMNS = ['Shard', 'Tablet', 'Tablet State', 'Alias', 'Hostname'];
+const PAGE_SIZE = 16;
+
+export const KeyspaceShards = ({ keyspace }: Props) => {
+    const { data: tablets = [], ...tq } = useTablets();
+    const { value: filter, updateValue: updateFilter } = useSyncedURLParam('shardFilter');
+
+    const data = React.useMemo(() => {
+        if (!keyspace || tq.isLoading) {
+            return [];
+        }
+
+        return formatRows(keyspace, tablets, filter);
+    }, [filter, keyspace, tablets, tq.isLoading]);
+
+    const renderRows = React.useCallback(
+        (rows: typeof data) => {
+            return rows.reduce((acc, row) => {
+                if (!row.tablets.length) {
+                    acc.push(
+                        <tr key={row.shard}>
+                            <DataCell rowSpan={1}>
+                                <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                {row.shardState === 'NOT_SERVING' && (
+                                    <div className="font-size-small text-color-secondary white-space-nowrap">
+                                        {row.shardState}
+                                    </div>
+                                )}
+                            </DataCell>
+                            <DataCell colSpan={TABLE_COLUMNS.length - 1}>
+                                <div className="font-size-small text-color-secondary">
+                                    No tablets in {keyspace?.keyspace?.name}/{row.shard}{' '}
+                                    {!!filter && 'matching filters'}
+                                </div>
+                            </DataCell>
+                        </tr>
+                    );
+                }
+
+                row.tablets.forEach((tablet, tdx) => {
+                    const rowKey = `${row.shard}-${tablet.alias}`;
+                    acc.push(
+                        <tr key={rowKey}>
+                            {tdx === 0 && (
+                                <DataCell rowSpan={row.tablets.length}>
+                                    <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                    {row.shardState === 'NOT_SERVING' && (
+                                        <div className="font-size-small text-color-secondary white-space-nowrap">
+                                            {row.shardState}
+                                        </div>
+                                    )}
+                                </DataCell>
+                            )}
+                            <DataCell>
+                                <TabletServingPip state={tablet._tabletStateEnum} /> {tablet.tabletType}
+                            </DataCell>
+                            <DataCell>{tablet.tabletState}</DataCell>
+                            <DataCell>{tablet.alias}</DataCell>
+                            <DataCell>{tablet.hostname}</DataCell>
+                        </tr>
+                    );
+                });
+
+                return acc;
+            }, [] as JSX.Element[]);
+        },
+        [filter, keyspace?.keyspace?.name]
+    );
+
+    if (!keyspace) {
+        return null;
+    }
+
+    return (
+        <ContentContainer>
+            <DataFilter
+                autoFocus
+                onChange={(e) => updateFilter(e.target.value)}
+                onClear={() => updateFilter('')}
+                placeholder="Filter shards and tablets"
+                value={filter || ''}
+            />
+
+            <DataTable columns={TABLE_COLUMNS} data={data} pageSize={PAGE_SIZE} renderRows={renderRows} />
+        </ContentContainer>
+    );
+};
+
+interface Row {
+    isShardServing: boolean;
+    shard: string | null | undefined;
+    shardState: ShardState;
+    tablets: {
+        alias: string | null;
+        hostname: string | null | undefined;
+        shard: string | null | undefined;
+        tabletState: string | pb.Tablet.ServingState.UNKNOWN;
+        tabletType: string | topodata.TabletType.UNKNOWN | null | undefined;
+        _tabletStateEnum: pb.Tablet.ServingState;
+    }[];
+}
+
+// Filtering data is complicated by how we group rows by their shard,
+// since we want the filtering to apply to both shard-level properties,
+// ("shard:-80") as well as nested tablet-level properties ("hostname:some-tablet-123").
+//
+// This gets surprisingly complex: what do you do when fuzzy filtering,
+// and you match a shard, and also _some_ tablets in the shard -- do you show all
+// of the tablets (since the shard matches), or (more likely) just the filtered ones?
+//
+// Instead of doing a complicated-and-hacky solution, this approach is a
+// fairly straightforward, fairly hacky, and definitely non-generalized approach
+// that still feels intuitive to use:
+//
+//  1. Filtering all the shards in the keyspace by filter string,
+//     which includes all of the tablets in that shards.
+//
+//  2. Filtering all the tablets in the keyspace (across all shards,
+//      not just the filtered shards) by filter string.
+//
+//  3. Taking the intersection of these two sets of shards/tablets.
+//
+// Investigating a more robust + general filtering implementation
+// that supports complex use cases is ticketed here:
+// https://github.com/vitessio/vitess/projects/12#card-60968004)
+export const formatRows = (
+    keyspace: pb.Keyspace | null | undefined,
+    tablets: pb.Tablet[],
+    filter: string | null | undefined
+): Row[] => {
+    if (!keyspace) {
+        return [];
+    }
+
+    // Reduce the set of tablets to just the ones for this keyspace,
+    // and map them to simplified objects to allow key/value filtering
+    // with `filterNouns`
+    const tabletsForKeyspace = orderBy(
+        tablets
+            .filter((t) => t.cluster?.id === keyspace.cluster?.id && t.tablet?.keyspace === keyspace.keyspace?.name)
+            .map((t) => ({
+                alias: formatAlias(t.tablet?.alias),
+                hostname: t.tablet?.hostname,
+                shard: t.tablet?.shard,
+                tabletState: formatState(t),
+                tabletType: formatDisplayType(t),
+                _tabletStateEnum: t.state,
+            })),
+        ['tabletType', 'alias']
+    );
+
+    // Compare tablets against the filter string
+    const filteredTablets = filterNouns(filter, tabletsForKeyspace);
+    const filteredTabletsByShard = groupBy(filteredTablets, 'shard');
+
+    const shardsForKeyspace = Object.values(keyspace.shards || {}).map((shard) => {
+        const isShardServing = !!shard.shard?.is_master_serving;
+        return {
+            isShardServing,
+            shard: shard.name,
+            shardState: (isShardServing ? 'SERVING' : 'NOT_SERVING') as ShardState,
+        };
+    });
+    const shardsForKeyspaceByShard = groupBy(shardsForKeyspace, 'shard');
+
+    const filteredShards = filterNouns(filter, shardsForKeyspace);
+    const filteredShardsByShard = groupBy(filteredShards, 'shard');
+
+    // Take the intersection of all shardNames across...
+    const allFilteredShards = uniq([
+        //  1. Shards with tablets matching the filter criteria
+        ...Object.keys(filteredShardsByShard),
+        //  2. Shards that themselves match the filter criteria
+        ...Object.keys(filteredTabletsByShard),
+    ]);
+
+    // "Hydrate" the filtered shard names into rows
+    const rows = allFilteredShards.reduce((acc, shardName) => {
+        const shard = shardsForKeyspaceByShard[shardName][0];
+        if (!shard) {
+            return acc;
+        }
+
+        acc.push({
+            ...shard,
+            // Make sure we only take the filtered tablets
+            tablets: filteredTabletsByShard[shardName] || [],
+        });
+
+        return acc;
+    }, [] as Row[]);
+
+    return orderBy(rows, 'shard');
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This PR adds the foundation for the Keyspace detail view, starting with a listing of shards + tablets.

A caveat: grouping table rows by shard complicates the filtering, since `filterNouns` wasn't written to handle nested properties. For now, "kinda gross but exhaustively commented hacks that work 90% of the time in this one place" seemed a better trade-off than "don't add filtering until we can handle this in a nicely generalized way". (Especially since using a library like https://fusejs.io is a better long-term filtering solution _anyway_ ... who wants to maintain regexes? (Not me!)). I ticketed https://github.com/vitessio/vitess/projects/12#card-60968004 to investigate a more robust solution, when we get time.

Here's what it looks like:

<img width="2672" alt="Screen Shot 2021-05-12 at 1 54 18 PM" src="https://user-images.githubusercontent.com/855595/118021752-91700200-b329-11eb-9f47-a36fe70360c8.png">
<img width="2672" alt="Screen Shot 2021-05-12 at 1 53 17 PM" src="https://user-images.githubusercontent.com/855595/118021777-9765e300-b329-11eb-8b0f-cc22a10922e6.png">
<img width="2672" alt="Screen Shot 2021-05-12 at 12 50 14 PM" src="https://user-images.githubusercontent.com/855595/118021783-9a60d380-b329-11eb-986c-8b4a61df5468.png">

And a weird, semi-error state just for fun:
<img width="2672" alt="Screen Shot 2021-05-12 at 1 53 41 PM" src="https://user-images.githubusercontent.com/855595/118021827-a51b6880-b329-11eb-9a27-65b172e0ca7a.png">


## Related Issue(s)

N/A

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A