### PR TITLE
[vtadmin-api] Replace magic numbers with `net/http` constants

### DIFF
--- a/go/vt/vtadmin/errors/typed_error.go
+++ b/go/vt/vtadmin/errors/typed_error.go
@@ -40,7 +40,7 @@ type BadRequest struct {
 func (e *BadRequest) Error() string        { return e.Err.Error() }
 func (e *BadRequest) Code() string         { return "bad request" }
 func (e *BadRequest) Details() interface{} { return e.ErrDetails }
-func (e *BadRequest) HTTPStatus() int      { return 400 }
+func (e *BadRequest) HTTPStatus() int      { return http.StatusBadRequest }
 
 // Unknown is the generic error, used when a more specific error is either
 // unspecified or inappropriate.
@@ -52,7 +52,7 @@ type Unknown struct {
 func (e *Unknown) Error() string        { return e.Err.Error() }
 func (e *Unknown) Code() string         { return "unknown" }
 func (e *Unknown) Details() interface{} { return e.ErrDetails }
-func (e *Unknown) HTTPStatus() int      { return 500 }
+func (e *Unknown) HTTPStatus() int      { return http.StatusInternalServerError }
 
 // ErrInvalidCluster is returned when a cluster parameter, either in a route or
 // as a query param, is invalid.
@@ -63,7 +63,7 @@ type ErrInvalidCluster struct {
 func (e *ErrInvalidCluster) Error() string        { return e.Err.Error() }
 func (e *ErrInvalidCluster) Code() string         { return "invalid cluster" }
 func (e *ErrInvalidCluster) Details() interface{} { return nil }
-func (e *ErrInvalidCluster) HTTPStatus() int      { return 400 }
+func (e *ErrInvalidCluster) HTTPStatus() int      { return http.StatusBadRequest }
 
 // MissingParams is returned when an HTTP handler requires parameters that were
 // not provided.
@@ -77,7 +77,7 @@ func (e *MissingParams) Error() string {
 
 func (e *MissingParams) Code() string         { return "missing params" }
 func (e *MissingParams) Details() interface{} { return nil }
-func (e *MissingParams) HTTPStatus() int      { return 400 }
+func (e *MissingParams) HTTPStatus() int      { return http.StatusBadRequest }
 
 // NoSuchSchema is returned when a schema definition cannot be found for a given
 // set of filter criteria. Both GetSchema and FindSchema can return this error.


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

* Fixes #8126 

## Checklist
- [x] Tests were added or are not required -- N/A
- [x] Documentation was added or is not required -- N/A

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->