### PR TITLE
VReplication Copy Phase: Increase default replica lag tolerance. Also make it and copy timeout modifiable via flags

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -141,8 +141,6 @@ func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, cell string, mys
 		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckPrimaryWrite),
 	}
 
-	copyTimeout = time.Duration(*copyPhaseDurationSeconds) * time.Second
-	replicaLagTolerance = time.Duration(*replicaLagToleranceSeconds) * time.Second
 	return vre
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -140,6 +140,9 @@ func NewEngine(config *tabletenv.TabletConfig, ts *topo.Server, cell string, mys
 		ec:              newExternalConnector(config.ExternalConnections),
 		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerAppName, throttle.ThrottleCheckPrimaryWrite),
 	}
+
+	copyTimeout = time.Duration(*copyPhaseDurationSeconds) * time.Second
+	replicaLagTolerance = time.Duration(*replicaLagToleranceSeconds) * time.Second
 	return vre
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -167,7 +167,7 @@ func (vc *vcopier) catchup(ctx context.Context, copyState map[string]*sqltypes.R
 	// Wait for catchup.
 	tkr := time.NewTicker(waitRetryTime)
 	defer tkr.Stop()
-	seconds := int64(replicaLagTolerance / time.Second)
+	seconds := int64(*replicaLagTolerance / time.Second)
 	for {
 		sbm := vc.vr.stats.SecondsBehindMaster.Get()
 		if sbm < seconds {
@@ -211,7 +211,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 		return fmt.Errorf("plan not found for table: %s, current plans are: %#v", tableName, plan.TargetTables)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, copyTimeout)
+	ctx, cancel := context.WithTimeout(ctx, *copyPhaseDuration)
 	defer cancel()
 
 	var lastpkpb *querypb.QueryResult

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -38,10 +38,10 @@ func TestPlayerCopyCharPK(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
+	savedCopyPhaseDuration := *copyPhaseDuration
+	// copyPhaseDuration should be low enough to have time to send one row.
+	*copyPhaseDuration = 500 * time.Millisecond
+	defer func() { *copyPhaseDuration = savedCopyPhaseDuration }()
 
 	savedWaitRetryTime := waitRetryTime
 	// waitRetry time should be very low to cause the wait loop to execute multipel times.
@@ -139,10 +139,10 @@ func TestPlayerCopyVarcharPKCaseInsensitive(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
+	savedCopyPhaseDuration := *copyPhaseDuration
+	// copyPhaseDuration should be low enough to have time to send one row.
+	*copyPhaseDuration = 500 * time.Millisecond
+	defer func() { *copyPhaseDuration = savedCopyPhaseDuration }()
 
 	savedWaitRetryTime := waitRetryTime
 	// waitRetry time should be very low to cause the wait loop to execute multipel times.
@@ -243,10 +243,10 @@ func TestPlayerCopyVarcharCompositePKCaseSensitiveCollation(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
+	savedCopyPhaseDuration := *copyPhaseDuration
+	// copyPhaseDuration should be low enough to have time to send one row.
+	*copyPhaseDuration = 500 * time.Millisecond
+	defer func() { *copyPhaseDuration = savedCopyPhaseDuration }()
 
 	savedWaitRetryTime := waitRetryTime
 	// waitRetry time should be very low to cause the wait loop to execute multipel times.
@@ -550,10 +550,10 @@ func TestPlayerCopyBigTable(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
+	savedCopyPhaseDuration := *copyPhaseDuration
+	// copyPhaseDuration should be low enough to have time to send one row.
+	*copyPhaseDuration = 500 * time.Millisecond
+	defer func() { *copyPhaseDuration = savedCopyPhaseDuration }()
 
 	savedWaitRetryTime := waitRetryTime
 	// waitRetry time shoulw be very low to cause the wait loop to execute multipel times.
@@ -666,10 +666,10 @@ func TestPlayerCopyWildcardRule(t *testing.T) {
 	reset := vstreamer.AdjustPacketSize(1)
 	defer reset()
 
-	savedCopyTimeout := copyTimeout
-	// copyTimeout should be low enough to have time to send one row.
-	copyTimeout = 500 * time.Millisecond
-	defer func() { copyTimeout = savedCopyTimeout }()
+	savedCopyPhaseDuration := *copyPhaseDuration
+	// copyPhaseDuration should be low enough to have time to send one row.
+	*copyPhaseDuration = 500 * time.Millisecond
+	defer func() { *copyPhaseDuration = savedCopyPhaseDuration }()
 
 	savedWaitRetryTime := waitRetryTime
 	// waitRetry time shoulw be very low to cause the wait loop to execute multipel times.
@@ -1216,14 +1216,14 @@ func TestPlayerCopyTableCancel(t *testing.T) {
 	})
 	env.SchemaEngine.Reload(context.Background())
 
-	saveTimeout := copyTimeout
-	copyTimeout = 1 * time.Millisecond
-	defer func() { copyTimeout = saveTimeout }()
+	saveTimeout := *copyPhaseDuration
+	*copyPhaseDuration = 1 * time.Millisecond
+	defer func() { *copyPhaseDuration = saveTimeout }()
 
 	// Set a hook to reset the copy timeout after first call.
 	vstreamRowsHook = func(ctx context.Context) {
 		<-ctx.Done()
-		copyTimeout = saveTimeout
+		*copyPhaseDuration = saveTimeout
 		vstreamRowsHook = nil
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -47,11 +47,8 @@ var (
 	relayLogMaxSize  = flag.Int("relay_log_max_size", 250000, "Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time.")
 	relayLogMaxItems = flag.Int("relay_log_max_items", 5000, "Maximum number of rows for VReplication target buffering.")
 
-	copyTimeout              = 1 * time.Hour
-	copyPhaseDurationSeconds = flag.Int("vreplication_copy_phase_duration", 3600, "Duration (seconds) for each copy phase loop (before running the next catchup)")
-
-	replicaLagTolerance        = 60 * time.Second
-	replicaLagToleranceSeconds = flag.Int("vreplication_replica_lag_tolerance", 60, "Replica lag threshold (seconds): once lag is below this we switch from copy phase to the replication (streaming) phase")
+	copyPhaseDuration   = flag.Duration("vreplication_copy_phase_duration", 1*time.Hour, "Duration for each copy phase loop (before running the next catchup: default 1h)")
+	replicaLagTolerance = flag.Duration("vreplication_replica_lag_tolerance", 1*time.Minute, "Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase")
 
 	// vreplicationHeartbeatUpdateInterval determines how often the time_updated column is updated if there are no real events on the source and the source
 	// vstream is only sending heartbeats for this long. Keep this low if you expect high QPS and are monitoring this column to alert about potential

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -43,11 +43,15 @@ var (
 	// between the two timeouts.
 	idleTimeout = 1100 * time.Millisecond
 
-	dbLockRetryDelay    = 1 * time.Second
-	relayLogMaxSize     = flag.Int("relay_log_max_size", 250000, "Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time.")
-	relayLogMaxItems    = flag.Int("relay_log_max_items", 5000, "Maximum number of rows for VReplication target buffering.")
-	copyTimeout         = 1 * time.Hour
-	replicaLagTolerance = 10 * time.Second
+	dbLockRetryDelay = 1 * time.Second
+	relayLogMaxSize  = flag.Int("relay_log_max_size", 250000, "Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time.")
+	relayLogMaxItems = flag.Int("relay_log_max_items", 5000, "Maximum number of rows for VReplication target buffering.")
+
+	copyTimeout              = 1 * time.Hour
+	copyPhaseDurationSeconds = flag.Int("vreplication_copy_phase_duration", 3600, "Duration (seconds) for each copy phase loop (before running the next catchup)")
+
+	replicaLagTolerance        = 60 * time.Second
+	replicaLagToleranceSeconds = flag.Int("vreplication_replica_lag_tolerance", 60, "Replica lag threshold (seconds): once lag is below this we switch from copy phase to the replication (streaming) phase")
 
 	// vreplicationHeartbeatUpdateInterval determines how often the time_updated column is updated if there are no real events on the source and the source
 	// vstream is only sending heartbeats for this long. Keep this low if you expect high QPS and are monitoring this column to alert about potential


### PR DESCRIPTION
## Description

VReplication decides to switch from catchup to bulk copy when the replica lag is under a threshold. This was 10 seconds, which could cause a problem under certain circumstances (see https://github.com/vitessio/vitess/issues/8104). 

The default has been increased to a minute and it also been made into a flag `-vreplication_replica_lag_tolerance <seconds>` in case fine tuning is needed. 

The time for which the bulk insert phase runs is currently 1 hour. That can now be changed via a flag `-vreplication_copy_phase_duration <seconds>`. You will not need to modify either of these normally.


Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
https://github.com/vitessio/vitess/issues/8104

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
