### PR TITLE
Add libwww-perl to allow pt-osc wrapper to work in vitess/lite

### DIFF
--- a/docker/lite/install_dependencies.sh
+++ b/docker/lite/install_dependencies.sh
@@ -49,6 +49,7 @@ BASE_PACKAGES=(
     libatomic1
     libcurl4
     libdbd-mysql-perl
+    libwww-perl
     libev4
     libjemalloc2
     libtcmalloc-minimal4


### PR DESCRIPTION
Fixes #8140.  Increases image size by < 0.5 MB

Signed-off-by: Jacques Grove <aquarapid@gmail.com>
