### PR TITLE
VReplication: remove noisy vexec logs

### DIFF
--- a/go/vt/vtctl/workflow/vexec/query_plan.go
+++ b/go/vt/vtctl/workflow/vexec/query_plan.go
@@ -48,26 +48,17 @@ func (qp *QueryPlan) Execute(ctx context.Context, target *topo.TabletInfo) (qr *
 
 	targetAliasStr := target.AliasString()
 
-	log.Infof("Running %v on %v", qp.ParsedQuery.Query, targetAliasStr)
 	defer func() {
 		if err != nil {
 			log.Warningf("Result on %v: %v", targetAliasStr, err)
-
 			return
 		}
-
-		log.Infof("Result on %v: %v", targetAliasStr, qr)
 	}()
 
 	qr, err = qp.tmc.VReplicationExec(ctx, target.Tablet, qp.ParsedQuery.Query)
 	if err != nil {
 		return nil, err
 	}
-
-	if qr.RowsAffected == 0 {
-		log.Infof("no matching streams found for workflows %s, tablet %s, query %s", qp.workflow, targetAliasStr, qp.ParsedQuery.Query)
-	}
-
 	return qr, nil
 }
 

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -33,7 +33,6 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/concurrency"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	vtctldvexec "vitess.io/vitess/go/vt/vtctl/workflow/vexec" // renamed to avoid a collision with the vexec struct in this package
@@ -209,9 +208,7 @@ func (vx *vexec) exec() (map[*topo.TabletInfo]*querypb.QueryResult, error) {
 		wg.Add(1)
 		go func(ctx context.Context, master *topo.TabletInfo) {
 			defer wg.Done()
-			log.Infof("Running %s on %s\n", vx.plannedQuery, master.AliasString())
 			qr, err := vx.planner.exec(ctx, master.Alias, vx.plannedQuery)
-			log.Infof("Result is %s: %v", master.AliasString(), qr)
 			if err != nil {
 				allErrors.RecordError(err)
 			} else {


### PR DESCRIPTION
## Description

We have users listing workflows frequently using vexec looking for monitoring purposes and the log lines removed in the PR are spamming their logs.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

