### PR TITLE
CI: fail PR if it does not have required labels

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -23,7 +23,7 @@ jobs:
         LABELS_JSON="/tmp/labels.json"
 
         # Get labels for this pull request
-        curl \
+        curl -s \
           -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-type: application/json" \
@@ -31,11 +31,11 @@ jobs:
           > "$LABELS_JSON"
 
         if ! cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'Component:' ; then
-          echo "Expecting label 'Component: ...'"
+          echo "Expecting PR to have label 'Component: ...'"
           exit 1
         fi
         if ! cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'Type:' ; then
-          echo "Expecting label 'Type: ...'"
+          echo "Expecting PR to have label 'Type: ...'"
           exit 1
         fi
         exit 0

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,5 +1,5 @@
 name: pr-labels
-on: [push, pull_request, label]
+on: [push, pull_request]
 jobs:
   build:
     - name: Tune the OS

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,7 +1,11 @@
 name: pr-labels
-on: [push, pull_request]
+on: [push, pull_request, label]
 jobs:
-  build:
+  analyze:
+    if: github.repository == 'vitessio/vitess'
+    name: analyze_pr_labels
+    runs-on: ubuntu-latest
+    steps:
     - name: Tune the OS
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,37 @@
+name: pr-labels
+on: [push, pull_request, label]
+jobs:
+  build:
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
+    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+      run: |
+        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
+
+    - name: analyze labels
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        LABELS_JSON="/tmp/labels.json"
+
+        # Get labels for this pull request
+        curl \
+          -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Content-type: application/json" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
+          > "$LABELS_JSON"
+
+        if ! cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'Component:' ; then
+          echo "Expecting label 'Component: ...'"
+          exit 1
+        fi
+        if ! cat ${LABELS_JSON} | jq -r '.[].name ' | grep -q 'Type:' ; then
+          echo "Expecting label 'Type: ...'"
+          exit 1
+        fi
+        exit 0


### PR DESCRIPTION
## Description

Fixes #8146 

Adding a ci job to fail a PR if it does not have at least one `Component: ...` label and at least one `Type: ...` label.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/8146

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->