### PR TITLE
[vtadmin-api] Rename flag 'http-tablet-fqdn-tmpl' to 'http-tablet-url-tmpl' + update vtadmin flags for local example

### DIFF
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -8,9 +8,10 @@ vtadmin_api_port=14200
 vtadmin \
   --addr ":${vtadmin_api_port}" \
   --http-origin "http://localhost:3000" \
+  --http-tablet-url-tmpl "http://localhost:15{{ .Tablet.Alias.Uid }}" \
   --logtostderr \
   --alsologtostderr \
-  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json" \
+  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl=localhost:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 vtadmin_pid=$!
 
@@ -23,7 +24,7 @@ function cleanup() {
 
 trap cleanup INT QUIT TERM
 
-echo "vtadmin-api is up! Logs are in ${log_dir}/vtadmin-api.out, and its PID is ${vtadmin_pid}"
+echo "vtadmin-api is running on http://localhost:${vtadmin_api_port}. Logs are in ${log_dir}/vtadmin-api.out, and its PID is ${vtadmin_pid}"
 
 (
   cd ../../web/vtadmin &&

--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -85,10 +85,10 @@ func main() {
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
 	rootCmd.Flags().StringSliceVar(&httpOpts.CORSOrigins, "http-origin", []string{}, "repeated, comma-separated flag of allowed CORS origins. omit to disable CORS")
-	rootCmd.Flags().StringVar(&httpOpts.ExperimentalOptions.TabletFQDNTmpl,
-		"http-tablet-fqdn-tmpl",
-		"{{ .Tablet.Hostname }}:80",
-		"[EXPERIMENTAL] Go template string to generate a reachable http "+
+	rootCmd.Flags().StringVar(&httpOpts.ExperimentalOptions.TabletURLTmpl,
+		"http-tablet-url-tmpl",
+		"https://{{ .Tablet.Hostname }}:80",
+		"[EXPERIMENTAL] Go template string to generate a reachable http(s) "+
 			"address for a tablet. Currently used to make passthrough "+
 			"requests to /debug/vars endpoints.",
 	)

--- a/go/vt/vtadmin/http/api.go
+++ b/go/vt/vtadmin/http/api.go
@@ -38,7 +38,7 @@ type Options struct {
 	// the zero value has compression enabled.
 	DisableCompression  bool
 	ExperimentalOptions struct {
-		TabletFQDNTmpl string
+		TabletURLTmpl string
 	}
 }
 

--- a/go/vt/vtadmin/http/experimental/tablets.go
+++ b/go/vt/vtadmin/http/experimental/tablets.go
@@ -49,7 +49,7 @@ func TabletDebugVarsPassthrough(ctx context.Context, r vtadminhttp.Request, api 
 }
 
 func getDebugVars(ctx context.Context, api *vtadminhttp.API, tablet *vtadminpb.Tablet) (map[string]interface{}, error) {
-	tmpl, err := template.New("tablet-fqdn").Parse(api.Options().ExperimentalOptions.TabletFQDNTmpl)
+	tmpl, err := template.New("tablet-fqdn").Parse(api.Options().ExperimentalOptions.TabletURLTmpl)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

- Renames flag 'http-tablet-fqdn-tmpl' to 'http-tablet-url-tmpl' (since it requires the protocol)
- Updates the local example to include both `http-tablet-url-tmpl` and `tablet-fqdn-tmpl` flags

<details>
<summary> curl "http://localhost:14200/api/tablets" | jq . </summary>

```json
{
  "result": {
    "tablets": [
      {
        "cluster": {
          "id": "local",
          "name": "local"
        },
        "tablet": {
          "alias": {
            "cell": "zone1",
            "uid": 100
          },
          "hostname": "localhost",
          "keyspace": "commerce",
          "shard": "0",
          "type": 1,
          "master_term_start_time": {
            "seconds": 1621541573
          }
        },
        "state": 1,
        "FQDN": "localhost:15100"
      },
      {
        "cluster": {
          "id": "local",
          "name": "local"
        },
        "tablet": {
          "alias": {
            "cell": "zone1",
            "uid": 101
          },
          "hostname": "localhost",
          "keyspace": "commerce",
          "shard": "0",
          "type": 2
        },
        "state": 1,
        "FQDN": "localhost:15101"
      },
      {
        "cluster": {
          "id": "local",
          "name": "local"
        },
        "tablet": {
          "alias": {
            "cell": "zone1",
            "uid": 102
          },
          "hostname": "localhost",
          "keyspace": "commerce",
          "shard": "0",
          "type": 3
        },
        "state": 1,
        "FQDN": "localhost:15102"
      }
    ]
  },
  "ok": true
}
```
</details>

<details>
<summary>curl "http://localhost:14200/api/experimental/tablet/zone1-102/debug/vars"</summary>

(Redacted most of the response, since it's really long.)

```
{"result":{"AppConnPoolActive":0,"AppConnPoolAvailable":40,"AppConnPoolCapacity":40,"AppConnPoolExhausted":0,"AppConnPoolIdleClosed":0,"AppConnPoolIdleTimeout":60000000000,"AppConnPoolInUse":0,"AppConnPoolMaxCap":40,"AppConnPoolWaitCount":0,"AppConnPoolWaitTime":0,"BackupIsRunning":{},
```
</details>

## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A