### PR TITLE
Make sure to only allow codegen when the rest of the code compiles

### DIFF
--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -25,6 +25,8 @@ import (
 	"path"
 	"strings"
 
+	"vitess.io/vitess/go/tools/common"
+
 	"github.com/dave/jennifer/jen"
 	"golang.org/x/tools/go/packages"
 )
@@ -201,7 +203,8 @@ func GenerateASTHelpers(packagePatterns []string, rootIface, exceptCloneType str
 		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports | packages.NeedModule,
 	}, packagePatterns...)
 
-	if err != nil {
+	if err != nil || common.PkgFailed(loaded) {
+		log.Fatal("error loading packaged")
 		return nil, err
 	}
 

--- a/go/tools/asthelpergen/main/main.go
+++ b/go/tools/asthelpergen/main/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/go/tools/common/common.go
+++ b/go/tools/common/common.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"log"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// PkgFailed returns true if any of the packages contain errors
+func PkgFailed(loaded []*packages.Package) bool {
+	failed := false
+	for _, pkg := range loaded {
+		for _, e := range pkg.Errors {
+			log.Println(e.Error())
+			failed = true
+		}
+	}
+	return failed
+}

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/tools/common"
+
 	"github.com/dave/jennifer/jen"
 	"golang.org/x/tools/go/packages"
 )
@@ -505,6 +507,10 @@ func GenerateSizeHelpers(packagePatterns []string, typePatterns []string) (map[s
 
 	if err != nil {
 		return nil, err
+	}
+
+	if common.PkgFailed(loaded) {
+		return nil, fmt.Errorf("failed to load packages")
 	}
 
 	sizegen := newSizegen(loaded[0].Module, loaded[0].TypesSizes)


### PR DESCRIPTION
## Description
During code generation, we were not checking if the loaded packages contained any errors. 
We should only use the input packages if they can load without errors

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required