### PR TITLE
[vtadmin-web] The hastiest Tablet view (+ experimental debug vars)

### DIFF
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -8,13 +8,13 @@ vtadmin_api_port=14200
 vtadmin \
   --addr ":${vtadmin_api_port}" \
   --http-origin "http://localhost:3000" \
-  --http-tablet-url-tmpl "http://localhost:15{{ .Tablet.Alias.Uid }}" \
+  --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
   --http-tracing \
   --logtostderr \
   --alsologtostderr \
-  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl=localhost:15{{ .Tablet.Alias.Uid }}" \
+  --cluster "id=local,name=local,discovery=staticfile,discovery-staticfile-path=./vtadmin/discovery.json,tablet-fqdn-tmpl={{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   > "${log_dir}/vtadmin-api.out" 2>&1 &
 vtadmin_pid=$!
 
@@ -33,5 +33,6 @@ echo "vtadmin-api is running on http://localhost:${vtadmin_api_port}. Logs are i
   cd ../../web/vtadmin &&
   npm install &&
   REACT_APP_VTADMIN_API_ADDRESS="http://127.0.0.1:${vtadmin_api_port}" \
+  REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
     npm run start
 )

--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -171,6 +171,29 @@ export const fetchSchema = async ({ clusterID, keyspace, table }: FetchSchemaPar
     return pb.Schema.create(result);
 };
 
+export interface FetchTabletParams {
+    clusterID: string;
+    alias: string;
+}
+
+export const fetchTablet = async ({ clusterID, alias }: FetchTabletParams) => {
+    const { result } = await vtfetch(`/api/tablet/${alias}?cluster=${clusterID}`);
+
+    const err = pb.Tablet.verify(result);
+    if (err) throw Error(err);
+
+    return pb.Tablet.create(result);
+};
+
+export const fetchExperimentalTabletDebugVars = async ({ clusterID, alias }: FetchTabletParams) => {
+    if (!process.env.REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS) {
+        return Promise.resolve({});
+    }
+
+    const { result } = await vtfetch(`/api/experimental/tablet/${alias}/debug/vars?cluster=${clusterID}`);
+    return result;
+};
+
 export const fetchTablets = async () =>
     vtfetchEntities({
         endpoint: '/api/tablets',
@@ -181,7 +204,6 @@ export const fetchTablets = async () =>
             return pb.Tablet.create(e);
         },
     });
-
 export interface FetchVSchemaParams {
     clusterID: string;
     keyspace: string;

--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -31,6 +31,7 @@ import { Workflows } from './routes/Workflows';
 import { Workflow } from './routes/Workflow';
 import { VTExplain } from './routes/VTExplain';
 import { Keyspace } from './routes/keyspace/Keyspace';
+import { Tablet } from './routes/tablet/Tablet';
 
 export const App = () => {
     return (
@@ -68,6 +69,10 @@ export const App = () => {
 
                         <Route path="/tablets">
                             <Tablets />
+                        </Route>
+
+                        <Route path="/tablet/:clusterID/:alias">
+                            <Tablet />
                         </Route>
 
                         <Route path="/vtexplain">

--- a/web/vtadmin/src/components/links/ExternalTabletLink.tsx
+++ b/web/vtadmin/src/components/links/ExternalTabletLink.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface Props {
+    className?: string;
+    fqdn?: string | null | undefined;
+}
+
+export const ExternalTabletLink: React.FunctionComponent<Props> = ({ children, className, fqdn }) => {
+    if (!fqdn) {
+        return <span className={className}>{children}</span>;
+    }
+
+    return (
+        <a className={className} href={`//${fqdn}`} rel="noreferrer" target="_blank">
+            {children}
+        </a>
+    );
+};

--- a/web/vtadmin/src/components/links/TabletLink.tsx
+++ b/web/vtadmin/src/components/links/TabletLink.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+    alias: string | null | undefined;
+    className?: string;
+    clusterID: string | null | undefined;
+}
+
+export const TabletLink: React.FunctionComponent<Props> = ({ alias, children, className, clusterID }) => {
+    if (!clusterID || !alias) {
+        return <span className={className}>{children}</span>;
+    }
+
+    const to = { pathname: `/tablet/${clusterID}/${alias}` };
+
+    return (
+        <Link className={className} to={to}>
+            {children}
+        </Link>
+    );
+};

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -31,6 +31,8 @@ import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
 import { DataFilter } from '../dataTable/DataFilter';
 import { KeyspaceLink } from '../links/KeyspaceLink';
+import { TabletLink } from '../links/TabletLink';
+import { ExternalTabletLink } from '../links/ExternalTabletLink';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -68,12 +70,20 @@ export const Tablets = () => {
                             )}
                         </KeyspaceLink>
                     </DataCell>
-                    <DataCell className="white-space-nowrap">
-                        <TabletServingPip state={t._raw.state} /> {t.type}
+                    <DataCell>
+                        <TabletLink alias={t.alias} className="font-weight-bold" clusterID={t._raw.cluster?.id}>
+                            {t.alias}
+                        </TabletLink>
                     </DataCell>
-                    <DataCell>{t.state}</DataCell>
-                    <DataCell>{t.alias}</DataCell>
-                    <DataCell>{t.hostname}</DataCell>
+                    <DataCell className="white-space-nowrap">{t.type}</DataCell>
+
+                    <DataCell>
+                        <TabletServingPip state={t._raw.state} /> {t.state}
+                    </DataCell>
+
+                    <DataCell>
+                        <ExternalTabletLink fqdn={`//${t._raw.FQDN}`}>{t.hostname}</ExternalTabletLink>
+                    </DataCell>
                 </tr>
             ));
         },
@@ -94,7 +104,7 @@ export const Tablets = () => {
                     value={filter || ''}
                 />
                 <DataTable
-                    columns={['Keyspace', 'Shard', 'Type', 'Tablet State', 'Alias', 'Hostname']}
+                    columns={['Keyspace', 'Shard', 'Alias', 'Type', 'Tablet State', 'Hostname']}
                     data={filteredData}
                     renderRows={renderRows}
                 />

--- a/web/vtadmin/src/components/routes/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/Workflow.tsx
@@ -31,6 +31,7 @@ import { formatAlias } from '../../util/tablets';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { formatDateTime } from '../../util/time';
 import { KeyspaceLink } from '../links/KeyspaceLink';
+import { TabletLink } from '../links/TabletLink';
 
 interface RouteParams {
     clusterID: string;
@@ -100,7 +101,11 @@ export const Workflow = () => {
                             <span className="text-color-secondary">N/A</span>
                         )}
                     </DataCell>
-                    <DataCell>{formatAlias(row.tablet)}</DataCell>
+                    <DataCell>
+                        <TabletLink alias={formatAlias(row.tablet)} clusterID={clusterID}>
+                            {formatAlias(row.tablet)}
+                        </TabletLink>
+                    </DataCell>
                 </tr>
             );
         });

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -27,13 +27,14 @@ import { DataFilter } from '../../dataTable/DataFilter';
 import { useSyncedURLParam } from '../../../hooks/useSyncedURLParam';
 import { filterNouns } from '../../../util/filterNouns';
 import { ContentContainer } from '../../layout/ContentContainer';
+import { TabletLink } from '../../links/TabletLink';
 interface Props {
     keyspace: pb.Keyspace | null | undefined;
 }
 
 type ShardState = 'SERVING' | 'NOT_SERVING';
 
-const TABLE_COLUMNS = ['Shard', 'Tablet', 'Tablet State', 'Alias', 'Hostname'];
+const TABLE_COLUMNS = ['Shard', 'Alias', 'Tablet Type', 'Tablet State', 'Hostname'];
 const PAGE_SIZE = 16;
 
 export const KeyspaceShards = ({ keyspace }: Props) => {
@@ -87,10 +88,14 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
                                 </DataCell>
                             )}
                             <DataCell>
-                                <TabletServingPip state={tablet._tabletStateEnum} /> {tablet.tabletType}
+                                <TabletLink alias={tablet.alias} clusterID={keyspace?.cluster?.id}>
+                                    {tablet.alias}
+                                </TabletLink>
                             </DataCell>
-                            <DataCell>{tablet.tabletState}</DataCell>
-                            <DataCell>{tablet.alias}</DataCell>
+                            <DataCell>{tablet.tabletType}</DataCell>
+                            <DataCell>
+                                <TabletServingPip state={tablet._tabletStateEnum} /> {tablet.tabletState}
+                            </DataCell>
                             <DataCell>{tablet.hostname}</DataCell>
                         </tr>
                     );
@@ -99,7 +104,7 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
                 return acc;
             }, [] as JSX.Element[]);
         },
-        [filter, keyspace?.keyspace?.name]
+        [filter, keyspace?.cluster?.id, keyspace?.keyspace?.name]
     );
 
     if (!keyspace) {

--- a/web/vtadmin/src/components/routes/tablet/Tablet.module.scss
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.module.scss
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.headingMeta {
+  display: flex;
+}
+
+.headingMeta span {
+  display: inline-block;
+  line-height: 2;
+
+  &::after {
+    color: var(--colorScaffoldingHighlight);
+    content: '/';
+    display: inline-block;
+    margin: 0 1.2rem;
+  }
+
+  &:last-child::after {
+    content: none;
+  }
+}
+
+.placeholder {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: var(--fontSizeLarge);
+  justify-content: center;
+  margin: 25vh auto;
+  max-width: 720px;
+  text-align: center;
+
+  h1 {
+    margin: 1.6rem 0;
+  }
+}
+
+.errorEmoji {
+  display: block;
+  font-size: 5.6rem;
+}

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useExperimentalTabletDebugVars, useTablet } from '../../../hooks/api';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { Code } from '../../Code';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { ExternalTabletLink } from '../../links/ExternalTabletLink';
+import style from './Tablet.module.scss';
+
+interface RouteParams {
+    alias: string;
+    clusterID: string;
+}
+
+export const Tablet = () => {
+    const { clusterID, alias } = useParams<RouteParams>();
+
+    useDocumentTitle(alias);
+
+    const { data: tablet, ...tq } = useTablet({ alias, clusterID });
+    const { data: debugVars } = useExperimentalTabletDebugVars({ alias, clusterID });
+
+    if (tq.error) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😰</span>
+                <h1>An error occurred</h1>
+                <code>{(tq.error as any).response?.error?.message || tq.error?.message}</code>
+                <p>
+                    <Link to="/tablets">← All tablets</Link>
+                </p>
+            </div>
+        );
+    }
+
+    if (!tq.isLoading && !tablet) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😖</span>
+                <h1>Tablet not found</h1>
+                <p>
+                    <Link to="/tablets">← All tablets</Link>
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/tablets">Tablets</Link>
+                </NavCrumbs>
+
+                <WorkspaceTitle className="font-family-monospace">{alias}</WorkspaceTitle>
+
+                <div className={style.headingMeta}>
+                    <span>
+                        Cluster: <code>{clusterID}</code>
+                    </span>
+                    <span>
+                        <ExternalTabletLink className="font-family-monospace" fqdn={tablet?.FQDN}>
+                            {tablet?.tablet?.hostname}
+                        </ExternalTabletLink>
+                    </span>
+                </div>
+            </WorkspaceHeader>
+
+            {/* TODO skeleton placeholder */}
+            {!!tq.isLoading && <div className={style.placeholder}>Loading</div>}
+
+            <Code code={JSON.stringify(tablet, null, 2)} />
+
+            {process.env.REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS && (
+                <Code code={JSON.stringify(debugVars, null, 2)} />
+            )}
+        </div>
+    );
+};

--- a/web/vtadmin/src/react-app-env.d.ts
+++ b/web/vtadmin/src/react-app-env.d.ts
@@ -8,6 +8,10 @@ declare namespace NodeJS {
         // Example: "http://127.0.0.1:12345"
         REACT_APP_VTADMIN_API_ADDRESS: string;
 
+        // Optional, but recommended. When true, enables front-end components that query
+        // vtadmin-api's /api/experimental/tablet/{tablet}/debug/vars endpoint.
+        REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS: boolean;
+
         // Optional. Configures the `credentials` property for fetch requests.
         // made against vtadmin-api. If unspecified, uses fetch defaults.
         // See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

- Adds a very hasty Tablet view... who doesn't love un-highlighted JSON? 
- Adds links to external tablet pages (i.e., on the tablet itself) when the FQDN build flag is defined
- Adds a feature flag + hooks, etc. for querying the experimental /debug/vars endpoint

I'm not going to include a screenshot since some of debug vars contain machine information. 😎 And.. y'know, it looks like JSON. 


## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A