### PR TITLE
Add options to vttestserver to pass -foreign_key_mode, -enable_online_ddl, and -enable_direct_ddl through to vtcombo

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -24,6 +24,9 @@
 	-mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" \
 	-mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" \
 	-charset "${CHARSET:-utf8mb4}" \
+	-foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
+	-enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
+	-enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
 	-vschema_ddl_authorized_users=% \
 	-schema_dir="/vt/schema/"
 

--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -17,4 +17,13 @@
 # Setup the Vschema Folder
 /vt/setup_vschema_folder.sh "$KEYSPACES" "$NUM_SHARDS"
 # Run the vttestserver binary
-/vt/bin/vttestserver -port "$PORT" -keyspaces "$KEYSPACES" -num_shards "$NUM_SHARDS" -mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" -mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" -charset "${CHARSET:-utf8mb4}" -vschema_ddl_authorized_users=% -schema_dir="/vt/schema/"
+/vt/bin/vttestserver \
+	-port "$PORT" \
+	-keyspaces "$KEYSPACES" \
+	-num_shards "$NUM_SHARDS" \
+	-mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" \
+	-mysql_server_version "${MYSQL_SERVER_VERSION:-$1}" \
+	-charset "${CHARSET:-utf8mb4}" \
+	-vschema_ddl_authorized_users=% \
+	-schema_dir="/vt/schema/"
+

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -147,6 +147,10 @@ func init() {
 	flag.BoolVar(&config.InitWorkflowManager, "workflow_manager_init", false, "Enable workflow manager")
 
 	flag.StringVar(&config.VSchemaDDLAuthorizedUsers, "vschema_ddl_authorized_users", "", "Comma separated list of users authorized to execute vschema ddl operations via vtgate")
+
+	flag.StringVar(&config.ForeignKeyMode, "foreign_key_mode", "allow", "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
+	flag.BoolVar(&config.EnableOnlineDDL, "enable_online_ddl", true, "Allow users to submit, review and control Online DDL")
+	flag.BoolVar(&config.EnableDirectDDL, "enable_direct_ddl", true, "Allow users to submit direct DDL statements")
 }
 
 func (t *topoFlags) buildTopology() (*vttestpb.VTTestTopology, error) {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -117,6 +117,15 @@ type Config struct {
 
 	// Authorize vschema ddl operations to a list of users
 	VSchemaDDLAuthorizedUsers string
+
+	// How to handle foreign key constraint in CREATE/ALTER TABLE.  Valid values are "allow", "disallow"
+	ForeignKeyMode string
+
+	// Allow users to submit, view, and control Online DDL
+	EnableOnlineDDL bool
+
+	// Allow users to submit direct DDL statements
+	EnableDirectDDL bool
 }
 
 // InitSchemas is a shortcut for tests that just want to setup a single

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -224,6 +224,9 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 		"-normalize_queries",
 		"-enable_query_plan_field_caching=false",
 		"-dbddl_plugin", "vttest",
+		"-foreign_key_mode", args.ForeignKeyMode,
+		fmt.Sprintf("-enable_online_ddl=%t", args.EnableOnlineDDL),
+		fmt.Sprintf("-enable_direct_ddl=%t", args.EnableDirectDDL),
 	}...)
 
 	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)


### PR DESCRIPTION
## Description
* Add `-foreign_key_mode`, `enable_online_ddl`, and `-enable_direct_ddl` to `vttestserver`
* Pass all three through to underlying `vtcombo` process
* Add `$FOREIGN_KEY_MODE`, `$ENABLE_ONLINE_DDL`, and `$ENABLE_DIRECT_DDL` to `vttestserver` container image

## Related Issue(s)
N/A

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
N/A
