### PR TITLE
Update do_release to work in the 9.0 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,18 +287,12 @@ else
 endif
 # Pre checks passed. Let's change the current version
 	cd java && mvn versions:set -DnewVersion=$(RELEASE_VERSION)
-	echo package servenv > go/vt/servenv/version.go
-	echo  >> go/vt/servenv/version.go
-	echo const versionName = \"$(RELEASE_VERSION)\" >> go/vt/servenv/version.go
 	echo -n Pausing so relase notes can be added. Press enter to continue
 	read line
 	git add --all
 	git commit -n -s -m "Release commit for $(RELEASE_VERSION)" 
 	git tag -m Version\ $(RELEASE_VERSION) v$(RELEASE_VERSION)
 	cd java && mvn versions:set -DnewVersion=$(DEV_VERSION)
-	echo package servenv > go/vt/servenv/version.go
-	echo  >> go/vt/servenv/version.go
-	echo const versionName = \"$(DEV_VERSION)\" >> go/vt/servenv/version.go
 	git add --all
 	git commit -n -s -m "Back to dev mode"
 	echo "Release preparations successful" 


### PR DESCRIPTION
## Description
In the 9.0 branch, we are not using the `version.go` file, so it should not be created by the release script
