### PR TITLE
query serving to continue when topo server restarts

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -205,7 +205,8 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 		topo.Binary, "agent",
 		"-server",
 		"-ui",
-		"-bootstrap-expect=1",
+		"-bootstrap-expect", "1",
+		"-bind", "127.0.0.1",
 		"-config-file", configFile,
 	)
 
@@ -214,7 +215,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 
 	topo.proc.Env = append(topo.proc.Env, os.Environ()...)
 
-	log.Infof("Starting consul with args %v", strings.Join(topo.proc.Args, " "))
+	log.Errorf("Starting consul with args %v", strings.Join(topo.proc.Args, " "))
 	err = topo.proc.Start()
 	if err != nil {
 		return

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -161,6 +161,7 @@ type PortsInfo struct {
 	HTTP    int `json:"http"`
 	SerfLan int `json:"serf_lan"`
 	SerfWan int `json:"serf_wan"`
+	Server  int `json:"server"`
 }
 
 // SetupConsul spawns a new consul service and initializes it with the defaults.
@@ -184,6 +185,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 			HTTP:    topo.Port,
 			SerfLan: cluster.GetAndReservePort(),
 			SerfWan: cluster.GetAndReservePort(),
+			Server:  cluster.GetAndReservePort(),
 		},
 		DataDir: topo.DataDirectory,
 		LogFile: logFile,

--- a/go/test/endtoend/topotest/consul/main_test.go
+++ b/go/test/endtoend/topotest/consul/main_test.go
@@ -107,7 +107,7 @@ func TestTopoDownServingQuery(t *testing.T) {
 	require.Nil(t, err)
 	defer conn.Close()
 
-	defer exec(t, conn, `delete from t1`)
+	defer execute(t, conn, `delete from t1`)
 
 	execMulti(t, conn, `insert into t1(c1, c2, c3, c4) values (300,100,300,'abc'); ;; insert into t1(c1, c2, c3, c4) values (301,101,301,'abcd');;`)
 	assertMatches(t, conn, `select c1,c2,c3 from t1`, `[[INT64(300) INT64(100) INT64(300)] [INT64(301) INT64(101) INT64(301)]]`)
@@ -116,7 +116,45 @@ func TestTopoDownServingQuery(t *testing.T) {
 	assertMatches(t, conn, `select c1,c2,c3 from t1`, `[[INT64(300) INT64(100) INT64(300)] [INT64(301) INT64(101) INT64(301)]]`)
 }
 
-func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
+func TestTopoRestart(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	execMulti(t, conn, `insert into t1(c1, c2, c3, c4) values (300,100,300,'abc'); ;; insert into t1(c1, c2, c3, c4) values (301,101,301,'abcd');;`)
+	assertMatches(t, conn, `select c1,c2,c3 from t1`, `[[INT64(300) INT64(100) INT64(300)] [INT64(301) INT64(101) INT64(301)]]`)
+
+	defer execute(t, conn, `delete from t1`)
+
+	ch := make(chan interface{})
+
+	go func() {
+		clusterInstance.TopoProcess.TearDown(clusterInstance.Cell, clusterInstance.OriginalVTDATAROOT, clusterInstance.CurrentVTDATAROOT, true, *clusterInstance.TopoFlavorString())
+		clusterInstance.TopoProcess.Setup(*clusterInstance.TopoFlavorString(), clusterInstance)
+		ch <- 1
+	}()
+
+	timeOut := time.After(5 * time.Second)
+
+	for {
+		select {
+		case <-ch:
+			return
+		case <-timeOut:
+			require.Fail(t, "timed out - topo process did not come up")
+		case <-time.After(100 * time.Millisecond):
+			assertMatches(t, conn, `select c1,c2,c3 from t1`, `[[INT64(300) INT64(100) INT64(300)] [INT64(301) INT64(101) INT64(301)]]`)
+		}
+	}
+}
+
+func execute(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
 	t.Helper()
 	qr, err := conn.ExecuteFetch(query, 1000, true)
 	require.NoError(t, err)
@@ -139,7 +177,7 @@ func execMulti(t *testing.T, conn *mysql.Conn, query string) []*sqltypes.Result 
 
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
-	qr := exec(t, conn, query)
+	qr := execute(t, conn, query)
 	got := fmt.Sprintf("%v", qr.Rows)
 	diff := cmp.Diff(expected, got)
 	if diff != "" {

--- a/go/test/endtoend/topotest/consul/main_test.go
+++ b/go/test/endtoend/topotest/consul/main_test.go
@@ -126,7 +126,7 @@ func TestTopoRestart(t *testing.T) {
 		ch <- 1
 	}()
 
-	timeOut := time.After(5 * time.Second)
+	timeOut := time.After(15 * time.Second)
 
 	for {
 		select {

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -466,11 +466,11 @@ func (server *ResilientServer) watchSrvKeyspace(callerCtx context.Context, entry
 		}
 
 		server.counts.Add(errorCategory, 1)
-		log.Errorf("Initial WatchSrvKeyspace failed for %v/%v: %v", cell, keyspace, current.Err)
+		log.Errorf("Initial WatchSrvKeyspace failed for %v/%v: %T %v", cell, keyspace, current.Err, current.Err)
 
 		// This watcher will able to continue to return the last value till it is not able to connect to the topo server even if the cache TTL is reached.
 		// TTL cache is only checked if the error is a known error i.e topo.Error.
-		_, topoErr := current.Err.(*topo.Error)
+		_, topoErr := current.Err.(topo.Error)
 		if topoErr && time.Since(entry.lastValueTime) > server.cacheTTL {
 			log.Errorf("WatchSrvKeyspace clearing cached entry for %v/%v", cell, keyspace)
 			entry.value = nil

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"net/url"
 	"sort"
 	"sync"
 	"time"
@@ -470,8 +469,9 @@ func (server *ResilientServer) watchSrvKeyspace(callerCtx context.Context, entry
 		log.Errorf("Initial WatchSrvKeyspace failed for %v/%v: %v", cell, keyspace, current.Err)
 
 		// This watcher will able to continue to return the last value till it is not able to connect to the topo server even if the cache TTL is reached.
-		_, netErr := current.Err.(*url.Error)
-		if !netErr && time.Since(entry.lastValueTime) > server.cacheTTL {
+		// TTL cache is only checked if the error is a known error i.e topo.Error.
+		_, topoErr := current.Err.(*topo.Error)
+		if topoErr && time.Since(entry.lastValueTime) > server.cacheTTL {
 			log.Errorf("WatchSrvKeyspace clearing cached entry for %v/%v", cell, keyspace)
 			entry.value = nil
 		}

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -141,7 +141,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 	// cached for at least half of the expected ttl.
 	errorTestStart := time.Now()
 	errorReqsBefore := rs.counts.Counts()[errorCategory]
-	forceErr := fmt.Errorf("test topo error")
+	forceErr := topo.NewError(topo.Timeout, "test topo error")
 	factory.SetError(forceErr)
 
 	expiry = time.Now().Add(*srvTopoCacheTTL / 2)
@@ -200,7 +200,7 @@ func TestGetSrvKeyspace(t *testing.T) {
 	// that even when there is no activity on the key, it is still cached
 	// for the full configured TTL.
 	time.Sleep(*srvTopoCacheTTL)
-	forceErr = fmt.Errorf("another test topo error")
+	forceErr = topo.NewError(topo.Interrupted, "another test topo error")
 	factory.SetError(forceErr)
 
 	expiry = time.Now().Add(*srvTopoCacheTTL / 2)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes an issue that arises when a topo server is unavailable to serve traffic either due to a new election or restart or any other cause. In the case where we find an unknown error, we should not clear the topo cache.
This PR also updates the consul test suite to spawn an actual server and not one using `-dev` option which creates an in-memory server.

## Related Issue(s)
Fixes #7191 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
