### PR TITLE
[workflow] Cleanup wrangler wrappers, migrate `checkIfJournalExistsOnTablet` to package workflow

### DIFF
--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/utils"
+	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+type fakeTMC struct {
+	tmclient.TabletManagerClient
+	vrepQueriesByTablet map[string]map[string]*querypb.QueryResult
+}
+
+func (fake *fakeTMC) VReplicationExec(ctx context.Context, tablet *topodatapb.Tablet, query string) (*querypb.QueryResult, error) {
+	alias := topoproto.TabletAliasString(tablet.Alias)
+	tabletQueries, ok := fake.vrepQueriesByTablet[alias]
+	if !ok {
+		return nil, fmt.Errorf("no query map registered on fake for %s", alias)
+	}
+
+	p3qr, ok := tabletQueries[query]
+	if !ok {
+		return nil, fmt.Errorf("no result on fake for query %q on tablet %s", query, alias)
+	}
+
+	return p3qr, nil
+}
+
+func TestCheckReshardingJournalExistsOnTablet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: "zone1",
+			Uid:  100,
+		},
+	}
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_SHARDS,
+		Tables:        []string{"t1", "t2"},
+	}
+	journalBytes, err := prototext.Marshal(journal)
+	require.NoError(t, err, "could not marshal journal %+v into bytes", journal)
+
+	// get some bytes that will fail to unmarshal into a binlogdatapb.Journal
+	tabletBytes, err := prototext.Marshal(tablet)
+	require.NoError(t, err, "could not marshal tablet %+v into bytes", tablet)
+
+	p3qr := sqltypes.ResultToProto3(sqltypes.MakeTestResult([]*querypb.Field{
+		{
+			Name: "val",
+			Type: querypb.Type_BLOB,
+		},
+	}, string(journalBytes)))
+
+	tests := []struct {
+		name        string
+		tablet      *topodatapb.Tablet
+		result      *querypb.QueryResult
+		journal     *binlogdatapb.Journal
+		shouldExist bool
+		shouldErr   bool
+	}{
+		{
+			name:        "journal exists",
+			tablet:      tablet,
+			result:      p3qr,
+			shouldExist: true,
+			journal:     journal,
+		},
+		{
+			name:        "journal does not exist",
+			tablet:      tablet,
+			result:      sqltypes.ResultToProto3(sqltypes.MakeTestResult(nil)),
+			journal:     &binlogdatapb.Journal{},
+			shouldExist: false,
+		},
+		{
+			name:   "cannot unmarshal into journal",
+			tablet: tablet,
+			result: sqltypes.ResultToProto3(sqltypes.MakeTestResult([]*querypb.Field{
+				{
+					Name: "val",
+					Type: querypb.Type_BLOB,
+				},
+			}, string(tabletBytes))),
+			shouldErr: true,
+		},
+		{
+			name: "VReplicationExec fails on tablet",
+			tablet: &topodatapb.Tablet{ // Here we use a different tablet to force the fake to return an error
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone2",
+					Uid:  200,
+				},
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmc := &fakeTMC{
+				vrepQueriesByTablet: map[string]map[string]*querypb.QueryResult{
+					topoproto.TabletAliasString(tablet.Alias): { // always use the tablet shared by these tests cases
+						"select val from _vt.resharding_journal where id=1": tt.result,
+					},
+				},
+			}
+
+			ws := NewServer(nil, tmc)
+			journal, exists, err := ws.CheckReshardingJournalExistsOnTablet(ctx, tt.tablet, 1)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			existAssertionMsg := "expected journal to "
+			if tt.shouldExist {
+				existAssertionMsg += "already exist on tablet"
+			} else {
+				existAssertionMsg += "not exist"
+			}
+
+			assert.Equal(t, tt.shouldExist, exists, existAssertionMsg)
+			utils.MustMatch(t, tt.journal, journal, "journal in resharding_journal did not match")
+		})
+	}
+}

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -30,6 +30,8 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vtctl/workflow"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"context"
@@ -158,7 +160,7 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 	if externalTopo == nil {
 		// Save routing rules before vschema. If we save vschema first, and routing rules
 		// fails to save, we may generate duplicate table errors.
-		rules, err := wr.getRoutingRules(ctx)
+		rules, err := topotools.GetRoutingRules(ctx, wr.ts)
 		if err != nil {
 			return err
 		}
@@ -174,7 +176,7 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 			rules[sourceKeyspace+"."+table+"@replica"] = toSource
 			rules[sourceKeyspace+"."+table+"@rdonly"] = toSource
 		}
-		if err := wr.saveRoutingRules(ctx, rules); err != nil {
+		if err := topotools.SaveRoutingRules(ctx, wr.ts, rules); err != nil {
 			return err
 		}
 		if vschema != nil {

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -220,7 +220,7 @@ func newTestTableMigraterCustom(ctx context.Context, t *testing.T, sourceShards,
 		)
 	}
 
-	if err := tme.wr.saveRoutingRules(ctx, map[string][]string{
+	if err := topotools.SaveRoutingRules(ctx, tme.wr.ts, map[string][]string{
 		"t1":     {"ks1.t1"},
 		"ks2.t1": {"ks1.t1"},
 		"t2":     {"ks1.t2"},

--- a/go/vt/wrangler/traffic_switcher_test.go
+++ b/go/vt/wrangler/traffic_switcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package wrangler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -25,15 +26,14 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/stretchr/testify/require"
 
-	"context"
-
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topotools"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/topo"
 )
 
 var (
@@ -1737,7 +1737,7 @@ func TestReverseVReplicationUpdateQuery(t *testing.T) {
 func checkRouting(t *testing.T, wr *Wrangler, want map[string][]string) {
 	t.Helper()
 	ctx := context.Background()
-	got, err := wr.getRoutingRules(ctx)
+	got, err := topotools.GetRoutingRules(ctx, wr.ts)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

What it says in the title. I think long-term that the (newly-named) `CheckReshardingJournalExistsOnTablet` should stop being exported, but we need to access it from package wrangler for now, so I left a TODO comment.

Also, the previous implementation had an unnecessary check on `if !exists` which would always be true, so I removed the check.

[Edit] Oh, also, this is almost certainly going to run into merge conflicts with #8190 so 🤷 I'll just rebase whichever one loses

## Related Issue(s)

#7931 


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->