### PR TITLE
[trace] Add optional flags to support flexible jaeger configs

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -122,7 +122,9 @@ func main() {
 	rootCmd.Flags().Var(&clusterFileConfig, "cluster-config", "path to a yaml cluster configuration. see clusters.example.yaml") // (TODO:@amason) provide example config.
 	rootCmd.Flags().Var(&defaultClusterConfig, "cluster-defaults", "default options for all clusters")
 
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer")) // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-type")) // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-rate")) // defined in go/vt/trace
 	rootCmd.Flags().BoolVar(&opts.EnableTracing, "grpc-tracing", false, "whether to enable tracing on the gRPC server")
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 

--- a/go/flagutil/optional.go
+++ b/go/flagutil/optional.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"errors"
+	"flag"
+	"strconv"
+)
+
+// OptionalFlag augements the flag.Value interface with a method to determine
+// if a flag was set explicitly on the comand-line.
+//
+// Though not part of the interface, because the return type would be different
+// for each implementation, by convention, each implementation should define a
+// Get() method to access the underlying value.
+type OptionalFlag interface {
+	flag.Value
+	IsSet() bool
+}
+
+var (
+	_ OptionalFlag = (*OptionalFloat64)(nil)
+	_ OptionalFlag = (*OptionalString)(nil)
+)
+
+// OptionalFloat64 implements OptionalFlag for float64 values.
+type OptionalFloat64 struct {
+	val float64
+	set bool
+}
+
+// NewOptionalFloat64 returns an OptionalFloat64 with the specified value as its
+// starting value.
+func NewOptionalFloat64(val float64) *OptionalFloat64 {
+	return &OptionalFloat64{
+		val: val,
+		set: false,
+	}
+}
+
+// Set is part of the flag.Value interface.
+func (f *OptionalFloat64) Set(arg string) error {
+	v, err := strconv.ParseFloat(arg, 64)
+	if err != nil {
+		return numError(err)
+	}
+
+	f.val = v
+	f.set = true
+
+	return nil
+}
+
+// String is part of the flag.Value interface.
+func (f *OptionalFloat64) String() string {
+	return strconv.FormatFloat(f.val, 'g', -1, 64)
+}
+
+// Get returns the underlying float64 value of this flag. If the flag was not
+// explicitly set, this will be the initial value passed to the constructor.
+func (f *OptionalFloat64) Get() float64 {
+	return f.val
+}
+
+// IsSet is part of the OptionalFlag interface.
+func (f *OptionalFloat64) IsSet() bool {
+	return f.set
+}
+
+// OptionalString implements OptionalFlag for string values.
+type OptionalString struct {
+	val string
+	set bool
+}
+
+// NewOptionalString returns an OptionalString with the specified value as its
+// starting value.
+func NewOptionalString(val string) *OptionalString {
+	return &OptionalString{
+		val: val,
+		set: false,
+	}
+}
+
+// Set is part of the flag.Value interface.
+func (f *OptionalString) Set(arg string) error {
+	f.val = arg
+	f.set = true
+	return nil
+}
+
+// String is part of the flag.Value interface.
+func (f *OptionalString) String() string {
+	return f.val
+}
+
+// Get returns the underlying string value of this flag. If the flag was not
+// explicitly set, this will be the initial value passed to the constructor.
+func (f *OptionalString) Get() string {
+	return f.val
+}
+
+// IsSet is part of the OptionalFlag interface.
+func (f *OptionalString) IsSet() bool {
+	return f.set
+}
+
+// lifted directly from package flag to make the behavior of numeric parsing
+// consistent with the standard library for our custom optional types.
+var (
+	errParse = errors.New("parse error")
+	errRange = errors.New("value out of range")
+)
+
+// lifted directly from package flag to make the behavior of numeric parsing
+// consistent with the standard library for our custom optional types.
+func numError(err error) error {
+	ne, ok := err.(*strconv.NumError)
+	if !ok {
+		return err
+	}
+
+	switch ne.Err {
+	case strconv.ErrSyntax:
+		return errParse
+	case strconv.ErrRange:
+		return errRange
+	default:
+		return err
+	}
+}

--- a/go/trace/plugin_datadog.go
+++ b/go/trace/plugin_datadog.go
@@ -24,7 +24,7 @@ func newDatadogTracer(serviceName string) (tracingService, io.Closer, error) {
 		ddtracer.WithAgentAddr(*dataDogHost+":"+*dataDogPort),
 		ddtracer.WithServiceName(serviceName),
 		ddtracer.WithDebugMode(true),
-		ddtracer.WithSampler(ddtracer.NewRateSampler(*samplingRate)),
+		ddtracer.WithSampler(ddtracer.NewRateSampler(samplingRate.Get())),
 	)
 
 	opentracing.SetGlobalTracer(t)


### PR DESCRIPTION
Closes #8198.

## Description

A common pain point with the standard `package flag` is the inability to
tell whether a flag was set on the command line or not. You can check
against the default value, but that's not perfect either, because then
you cannot tell the difference between a flag that was not specified at
all and a flag that was set to exactly the default value.

Enter `OptionalFlag`. We define some structs that wrap a primitive
(`float64` for example) with a boolean flag to track whether `Set()` was
ever called on the flag. Since, for the jaeger sampler params, we only
need a `string` for the sampler type and a `float64` for the sampling
rate, I only implemented `OptionalFlag` for those two types for now.
Plus, all of this becomes obsolete if we move to `cobra`, so I wasn't
highly-motivated to implement this interface for every primitive type
(and we can also add more implementations if we need them).

Anyway. Armed with our optional flags, we can make the configuration in
`newJaegerTracerFromEnv` more sophisticated, giving flags precedence
over environment variables, but also not ignoring environment variables
(which we were previously doing by indiscriminately setting the sampler
type to `const`).

Signed-off-by: Andrew Mason <amason@slack-corp.com>

### Examples!

(for all examples `pwd` is `./examples/local`)

<details>
<summary>No flags set, no environment variables set</summary>

```
❯ ./scripts/vtadmin-up.sh
I0527 21:18:46.510285   21494 plugin_jaeger.go:80] Tracing to: localhost:6831 as vtadmin
I0527 21:18:46.510393   21494 plugin_jaeger.go:95] -tracing-sampler-type was not set, and JAEGER_SAMPLER_TYPE was not set, defaulting to const sampler
I0527 21:18:46.510400   21494 plugin_jaeger.go:99] Tracing sampler type const (param: 0.1)
I0527 21:18:46.511120   21494 trace.go:153] successfully started tracing with [opentracing-jaeger]
I0527 21:18:46.512268   21494 server.go:231] server vtadmin listening on :14200
```

</details>

<details>
<summary>Configure sampler type via environment</summary>

```
❯ JAEGER_SAMPLER_TYPE=probabilistic ./scripts/vtadmin-up.sh 
I0527 22:08:13.579681   26067 plugin_jaeger.go:80] Tracing to: localhost:6831 as vtadmin
I0527 22:08:13.579784   26067 plugin_jaeger.go:99] Tracing sampler type probabilistic (param: 0.1)
I0527 22:08:13.583424   26067 trace.go:153] successfully started tracing with [opentracing-jaeger]
I0527 22:08:13.586123   26067 server.go:231] server vtadmin listening on :14200
```

</details>

<details>
<summary>Bad sampler type (mostly to check that jaeger would complain, and that we didn't need extra validation)</summary>

```
❯ JAEGER_SAMPLER_TYPE=notatype ./scripts/vtadmin-up.sh
I0527 21:21:28.897821   21552 plugin_jaeger.go:80] Tracing to: localhost:6831 as vtadmin
I0527 21:21:28.897882   21552 plugin_jaeger.go:99] Tracing sampler type notatype (param: 0.1)
E0527 21:21:28.898293   21552 trace.go:147] Unknown sampler type notatype
failed to create a opentracing-jaeger tracer
I0527 21:21:28.900949   21552 server.go:231] server vtadmin listening on :14200
```

</details>

<details>
<summary>Overriding on the command line</summary>

```

❯ git d -- ./scripts/vtadmin-up.sh | cat
diff --git a/examples/local/scripts/vtadmin-up.sh b/examples/local/scripts/vtadmin-up.sh
index e76a920618..2a1858ec9d 100755
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -10,6 +10,8 @@ vtadmin \
   --http-origin "http://localhost:3000" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
   --tracer "opentracing-jaeger" \
+  --tracing-sampling-type "probabilistic" \
+  --tracing-sampling-rate 0.2 \
   --grpc-tracing \
   --http-tracing \
   --logtostderr \
❯ JAEGER_SAMPLER_TYPE=rateLimiting ./scripts/vtadmin-up.sh
I0527 22:12:20.122315   26227 plugin_jaeger.go:80] Tracing to: localhost:6831 as vtadmin
I0527 22:12:20.122360   26227 plugin_jaeger.go:99] Tracing sampler type probabilistic (param: 0.2)
I0527 22:12:20.123125   26227 trace.go:153] successfully started tracing with [opentracing-jaeger]
I0527 22:12:20.123967   26227 server.go:231] server vtadmin listening on :14200
```

</details>

## Checklist
- [x] Tests were added or are not required -- N/A
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->