### PR TITLE
etcd: add grpc.WithBlock to client config

### DIFF
--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -40,6 +40,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/tlsutil"
 
@@ -116,11 +118,13 @@ func newTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
 	return tlscfg, nil
 }
 
+// NewServerWithOpts creates a new server with the provided TLS options
 func NewServerWithOpts(serverAddr, root, certPath, keyPath, caPath string) (*Server, error) {
 	// TODO: Rename this to NewServer and change NewServer to a name that signifies it uses the process-wide TLS settings.
 	config := clientv3.Config{
 		Endpoints:   strings.Split(serverAddr, ","),
 		DialTimeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 
 	tlscfg, err := newTLSConfig(certPath, keyPath, caPath)


### PR DESCRIPTION
## Description
Add `WithBlock` to client config.
Ref: https://etcd.io/docs/next/upgrades/upgrade_3_3/#upgrades-to--v3314
This is backwards-compatible with etcd 3.3.10.

## Related Issue(s)
#8204

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required - website docs just say "version 3 and up"

Unit and endtoend tests ran locally with 3.3.10 and 3.3.14

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->