### PR TITLE
Expose inner net.Conn to be able to write better unit tests

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1493,3 +1493,8 @@ func (c *Conn) GetTLSClientCerts() []*x509.Certificate {
 	}
 	return nil
 }
+
+// GetRawConn returns the raw net.Conn for nefarious purposes.
+func (c *Conn) GetRawConn() net.Conn {
+	return c.conn
+}

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -179,6 +179,17 @@ func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
 	}
 }
 
+func TestRawConnection(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+	assert.IsType(t, &net.TCPConn{}, sConn.GetRawConn())
+	assert.IsType(t, &net.TCPConn{}, cConn.GetRawConn())
+}
+
 func TestPackets(t *testing.T) {
 	listener, sConn, cConn := createSocketPair(t)
 	defer func() {


### PR DESCRIPTION
Signed-off-by: Harshit Gangal <harshit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The is needed to handle multiple net.Conn implementation and to know the type of connection created.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->