### PR TITLE
vtgate: validate important flags during startup

### DIFF
--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -17,12 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"math/rand"
 	"strings"
 	"time"
 
-	"context"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/discovery"
@@ -32,6 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtgate"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
@@ -47,6 +50,63 @@ var legacyHealthCheck discovery.LegacyHealthCheck
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	servenv.RegisterDefaultFlags()
+}
+
+// CheckCellFlags will check validation of cell and cells_to_watch flag
+// it will help to avoid strange behaviors when vtgate runs but actually does not work
+func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cellsToWatch string) error {
+	//topo check
+	var topoServer *topo.Server
+	if serv != nil {
+		var err error
+		topoServer, err = serv.GetTopoServer()
+		if err != nil {
+			log.Exitf("Unable to create gateway: %v", err)
+		}
+	} else {
+		log.Exitf("topo server cannot be nil")
+	}
+	cellsInTopo, err := topoServer.GetKnownCells(ctx)
+	if err != nil {
+		return err
+	}
+	if len(cellsInTopo) == 0 {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "topo server should have at least one cell")
+	}
+
+	//cell valid check
+	if cell == "" || cell == "test_nj" {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell flag must be set")
+	}
+	hasCell := false
+	for _, v := range cellsInTopo {
+		if v == cell {
+			hasCell = true
+		}
+	}
+	if !hasCell {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell:[%v] does not exist in topo", cell)
+	}
+
+	//cells_to_watch valid check
+	cells := make([]string, 0, 1)
+	for _, c := range strings.Split(cellsToWatch, ",") {
+		if c == "" {
+			continue
+		}
+		//cell should be contained in cellsInTopo
+		exists := topo.InCellList(c, cellsInTopo)
+		if exists {
+			cells = append(cells, c)
+		} else {
+			return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell: [%v] is not valid. Available cells: [%v]", c, strings.Join(cellsInTopo, ","))
+		}
+	}
+	if len(cells) == 0 {
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cells_to_watch flag cannot be empty")
+	}
+
+	return nil
 }
 
 func main() {
@@ -68,8 +128,21 @@ func main() {
 				log.Errorf("unknown tablet type: %v", ttStr)
 				continue
 			}
-			tabletTypes = append(tabletTypes, tt)
+			if tabletserver.IsServingType(tt) {
+				tabletTypes = append(tabletTypes, tt)
+			}
 		}
+	} else {
+		log.Exitf("tablet_types_to_wait flag must be set")
+	}
+
+	if len(tabletTypes) == 0 {
+		log.Exitf("tablet_types_to_wait should contain at least one serving tablet type")
+	}
+
+	err := CheckCellFlags(context.Background(), resilientServer, *cell, *vtgate.CellsToWatch)
+	if err != nil {
+		log.Exitf("cells_to_watch validation failed: %v", err)
 	}
 
 	var vtg *vtgate.VTGate

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -75,7 +75,7 @@ func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cells
 	}
 
 	// cell valid check
-	if cell == "" || cell == "test_nj" {
+	if cell == "" {
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell flag must be set")
 	}
 	hasCell := false

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -55,7 +55,7 @@ func init() {
 // CheckCellFlags will check validation of cell and cells_to_watch flag
 // it will help to avoid strange behaviors when vtgate runs but actually does not work
 func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cellsToWatch string) error {
-	//topo check
+	// topo check
 	var topoServer *topo.Server
 	if serv != nil {
 		var err error
@@ -74,7 +74,7 @@ func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cells
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "topo server should have at least one cell")
 	}
 
-	//cell valid check
+	// cell valid check
 	if cell == "" || cell == "test_nj" {
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell flag must be set")
 	}
@@ -82,25 +82,24 @@ func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cells
 	for _, v := range cellsInTopo {
 		if v == cell {
 			hasCell = true
+			break
 		}
 	}
 	if !hasCell {
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell:[%v] does not exist in topo", cell)
 	}
 
-	//cells_to_watch valid check
+	// cells_to_watch valid check
 	cells := make([]string, 0, 1)
 	for _, c := range strings.Split(cellsToWatch, ",") {
 		if c == "" {
 			continue
 		}
-		//cell should be contained in cellsInTopo
-		exists := topo.InCellList(c, cellsInTopo)
-		if exists {
-			cells = append(cells, c)
-		} else {
+		// cell should contained in cellsInTopo
+		if exists := topo.InCellList(c, cellsInTopo); !exists {
 			return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell: [%v] is not valid. Available cells: [%v]", c, strings.Join(cellsInTopo, ","))
 		}
+		cells = append(cells, c)
 	}
 	if len(cells) == 0 {
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cells_to_watch flag cannot be empty")

--- a/go/vt/vtgate/discoverygateway.go
+++ b/go/vt/vtgate/discoverygateway.go
@@ -54,7 +54,7 @@ func init() {
 	RegisterGatewayCreator(GatewayImplementationDiscovery, createDiscoveryGateway)
 }
 
-// DiscoveryGateway is the default Gateway implementation.
+// DiscoveryGateway is not the default Gateway implementation anymore.
 // This implementation uses the legacy healthcheck module.
 type DiscoveryGateway struct {
 	queryservice.QueryService

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -36,7 +36,7 @@ import (
 // a query targeted to a keyspace/shard/tablet_type and send it off.
 
 var (
-	// GatewayImplementation allows you to choose which gateway to use for vtgate routing. Defaults to discoverygateway, other option is tabletgateway
+	// GatewayImplementation allows you to choose which gateway to use for vtgate routing. Defaults to tabletgateway, other option is discoverygateway
 	GatewayImplementation = flag.String("gateway_implementation", "tabletgateway", "Allowed values: discoverygateway (deprecated), tabletgateway (default)")
 	initialTabletTimeout  = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
 	// RetryCount is the number of times a query will be retried on error

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -83,6 +83,7 @@ func createHealthCheck(ctx context.Context, retryDelay, timeout time.Duration, t
 }
 
 // NewTabletGateway creates and returns a new TabletGateway
+// NewTabletGateway is the default Gateway implementation
 func NewTabletGateway(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, localCell string) *TabletGateway {
 	// hack to accomodate various users of gateway + tests
 	if hc == nil {

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -370,7 +370,7 @@ func (tsv *TabletServer) StopService() {
 // connect to the database and serving traffic), or an error explaining
 // the unhealthiness otherwise.
 func (tsv *TabletServer) IsHealthy() error {
-	if tsv.IsServingType() {
+	if IsServingType(tsv.sm.Target().TabletType) {
 		_, err := tsv.Execute(
 			tabletenv.LocalContext(),
 			nil,
@@ -387,8 +387,8 @@ func (tsv *TabletServer) IsHealthy() error {
 
 // IsServingType returns true if the tablet type is one that should be serving to be healthy, or false if the tablet type
 // should not be serving in it's healthy state.
-func (tsv *TabletServer) IsServingType() bool {
-	switch tsv.sm.Target().TabletType {
+func IsServingType(tabletType topodatapb.TabletType) bool {
+	switch tabletType {
 	case topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_BATCH, topodatapb.TabletType_EXPERIMENTAL:
 		return true
 	default:


### PR DESCRIPTION
Taken from https://github.com/vitessio/vitess/pull/7251 to get it merged.

1.modify proper annotations for gates
2.add CheckCellFlags function to give valid check before gates creating
3.CheckCellFlags will  help to avoid strange behaviors when there are invalid parameters of the cell-related set 
vtgate brings up but actually does not work correctly.

Before  : 
when you are setting cell wrong you will get some confusing error outputs like :
![image](https://user-images.githubusercontent.com/2297199/104847607-0010f600-591c-11eb-8d49-566e7797389e.png)
now you will see it a bit clear:
![image](https://user-images.githubusercontent.com/2297199/104847628-2e8ed100-591c-11eb-8dce-6d88c5b39c29.png)

You could also set cell flag correct but cells_to_watch flag with two does not existing cells but vtgate will could also bring up but just will serve not as expectingly. like below:
![image](https://user-images.githubusercontent.com/2297199/105122222-c81ed400-5b10-11eb-8c16-cbf1d91c5809.png)
![image](https://user-images.githubusercontent.com/2297199/105122254-d53bc300-5b10-11eb-8347-ddae88b6e4f7.png)

also if you Accidentally  configured -tablet_types_to_wait flag wrongly like below:
![image](https://user-images.githubusercontent.com/2297199/104848446-f7222380-591f-11eb-8b9b-1cead0da9a16.png)
also, vtgate will runs but when you are using a command like use @replica
and then you send a query like "select * from table1" it will send qps to all tablets with all types. 

CheckCellFlags will help to make an in advance valid check and give hints to make people check and be familiar with the key parameters on cell-related flags

<!-- if this PR is Work in Progress Please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Related Issue(s)
<!-- List related issues and pull requests: -->
Closes https://github.com/vitessio/vitess/issues/3955

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
