### PR TITLE
[tablet, queryrules] Extend query rules to check comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432
 	github.com/dave/jennifer v1.4.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
 	github.com/go-sql-driver/mysql v1.5.1-0.20210202043019-fe2230a8b20c
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -924,6 +926,7 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go/cmd/rulesctl/cmd/add.go
+++ b/go/cmd/rulesctl/cmd/add.go
@@ -13,13 +13,15 @@ import (
 )
 
 var (
-	addOptDryrun      bool
-	addOptName        string
-	addOptDescription string
-	addOptAction      string
-	addOptPlans       []string
-	addOptTables      []string
-	addOptQueryRE     string
+	addOptDryrun            bool
+	addOptName              string
+	addOptDescription       string
+	addOptAction            string
+	addOptPlans             []string
+	addOptTables            []string
+	addOptQueryRE           string
+	addOptLeadingCommentRE  string
+	addOptTrailingCommentRE string
 	// TODO: other stuff, bind vars etc
 )
 
@@ -36,8 +38,20 @@ func runAdd(cmd *cobra.Command, args []string) {
 		rule.AddTableCond(t)
 	}
 
-	if err := rule.SetQueryCond(addOptQueryRE); err != nil {
-		log.Fatalf("Query condition invalid '%v': %v", addOptQueryRE, err)
+	if addOptQueryRE != "" {
+		if err := rule.SetQueryCond(addOptQueryRE); err != nil {
+			log.Fatalf("Query condition invalid '%v': %v", addOptQueryRE, err)
+		}
+	}
+	if addOptLeadingCommentRE != "" {
+		if err := rule.SetLeadingCommentCond(addOptLeadingCommentRE); err != nil {
+			log.Fatalf("Leading comment condition invalid '%v': %v", addOptLeadingCommentRE, err)
+		}
+	}
+	if addOptTrailingCommentRE != "" {
+		if err := rule.SetTrailingCommentCond(addOptTrailingCommentRE); err != nil {
+			log.Fatalf("Trailing comment condition invalid '%v': %v", addOptTrailingCommentRE, err)
+		}
 	}
 
 	var rules *vtrules.Rules
@@ -141,6 +155,16 @@ func Add() *cobra.Command {
 		"query", "q",
 		"",
 		"A regexp that will be applied to a query in order to determine if it matches")
+	addCmd.Flags().StringVarP(
+		&addOptLeadingCommentRE,
+		"leading-comment", "l",
+		"",
+		"A regexp that will be applied to comments prefacing a SQL statement")
+	addCmd.Flags().StringVarP(
+		&addOptTrailingCommentRE,
+		"trailing-comment", "r",
+		"",
+		"A regexp that will be applied to comments after a SQL statement")
 
 	for _, f := range []string{"name", "action"} {
 		addCmd.MarkFlagRequired(f)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -385,7 +385,7 @@ func (qre *QueryExecutor) checkPermissions() error {
 		remoteAddr = ci.RemoteAddr()
 		username = ci.Username()
 	}
-	action, desc := qre.plan.Rules.GetAction(remoteAddr, username, qre.bindVars)
+	action, desc := qre.plan.Rules.GetAction(remoteAddr, username, qre.bindVars, qre.marginComments)
 	switch action {
 	case rules.QRFail:
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "disallowed due to rule: %s", desc)

--- a/go/vt/vttablet/tabletserver/rules/cached_size.go
+++ b/go/vt/vttablet/tabletserver/rules/cached_size.go
@@ -43,7 +43,7 @@ func (cached *Rule) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(184)
+		size += int64(232)
 	}
 	// field Description string
 	size += int64(len(cached.Description))
@@ -55,6 +55,10 @@ func (cached *Rule) CachedSize(alloc bool) int64 {
 	size += cached.user.CachedSize(false)
 	// field query vitess.io/vitess/go/vt/vttablet/tabletserver/rules.namedRegexp
 	size += cached.query.CachedSize(false)
+	// field leadingComment vitess.io/vitess/go/vt/vttablet/tabletserver/rules.namedRegexp
+	size += cached.leadingComment.CachedSize(false)
+	// field trailingComment vitess.io/vitess/go/vt/vttablet/tabletserver/rules.namedRegexp
+	size += cached.trailingComment.CachedSize(false)
 	// field plans []vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder.PlanType
 	{
 		size += int64(cap(cached.plans)) * int64(8)

--- a/go/vt/vttablet/tabletserver/rules/rules.go
+++ b/go/vt/vttablet/tabletserver/rules/rules.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 
@@ -166,9 +167,14 @@ func (qrs *Rules) FilterByPlan(query string, planid planbuilder.PlanType, tableN
 }
 
 // GetAction runs the input against the rules engine and returns the action to be performed.
-func (qrs *Rules) GetAction(ip, user string, bindVars map[string]*querypb.BindVariable) (action Action, desc string) {
+func (qrs *Rules) GetAction(
+	ip,
+	user string,
+	bindVars map[string]*querypb.BindVariable,
+	marginComments sqlparser.MarginComments,
+) (action Action, desc string) {
 	for _, qr := range qrs.rules {
-		if act := qr.GetAction(ip, user, bindVars); act != QRContinue {
+		if act := qr.GetAction(ip, user, bindVars, marginComments); act != QRContinue {
 			return act, qr.Description
 		}
 	}
@@ -192,7 +198,7 @@ type Rule struct {
 	// All defined conditions must match for the rule to fire (AND).
 
 	// Regexp conditions. nil conditions are ignored (TRUE).
-	requestIP, user, query namedRegexp
+	requestIP, user, query, leadingComment, trailingComment namedRegexp
 
 	// Any matched plan will make this condition true (OR)
 	plans []planbuilder.PlanType
@@ -241,6 +247,8 @@ func (qr *Rule) Equal(other *Rule) bool {
 		qr.requestIP.Equal(other.requestIP) &&
 		qr.user.Equal(other.user) &&
 		qr.query.Equal(other.query) &&
+		qr.leadingComment.Equal(other.leadingComment) &&
+		qr.trailingComment.Equal(other.trailingComment) &&
 		reflect.DeepEqual(qr.plans, other.plans) &&
 		reflect.DeepEqual(qr.tableNames, other.tableNames) &&
 		reflect.DeepEqual(qr.bindVarConds, other.bindVarConds) &&
@@ -250,12 +258,14 @@ func (qr *Rule) Equal(other *Rule) bool {
 // Copy performs a deep copy of a Rule.
 func (qr *Rule) Copy() (newqr *Rule) {
 	newqr = &Rule{
-		Description: qr.Description,
-		Name:        qr.Name,
-		requestIP:   qr.requestIP,
-		user:        qr.user,
-		query:       qr.query,
-		act:         qr.act,
+		Description:     qr.Description,
+		Name:            qr.Name,
+		requestIP:       qr.requestIP,
+		user:            qr.user,
+		query:           qr.query,
+		leadingComment:  qr.leadingComment,
+		trailingComment: qr.trailingComment,
+		act:             qr.act,
 	}
 	if qr.plans != nil {
 		newqr.plans = make([]planbuilder.PlanType, len(qr.plans))
@@ -285,6 +295,12 @@ func (qr *Rule) MarshalJSON() ([]byte, error) {
 	}
 	if qr.query.Regexp != nil {
 		safeEncode(b, `,"Query":`, qr.query)
+	}
+	if qr.leadingComment.Regexp != nil {
+		safeEncode(b, `,"LeadingComment":`, qr.leadingComment)
+	}
+	if qr.trailingComment.Regexp != nil {
+		safeEncode(b, `,"TrailingComment":`, qr.trailingComment)
 	}
 	if qr.plans != nil {
 		safeEncode(b, `,"Plans":`, qr.plans)
@@ -336,6 +352,20 @@ func (qr *Rule) AddTableCond(tableName string) {
 func (qr *Rule) SetQueryCond(pattern string) (err error) {
 	qr.query.name = pattern
 	qr.query.Regexp, err = regexp.Compile(makeExact(pattern))
+	return
+}
+
+// SetLeadingCommentCond adds a regular expression condition for a leading query comment.
+func (qr *Rule) SetLeadingCommentCond(pattern string) (err error) {
+	qr.leadingComment.name = pattern
+	qr.leadingComment.Regexp, err = regexp.Compile(makeExact(pattern))
+	return
+}
+
+// SetTrailingCommentCond adds a regular expression condition for a trailing query comment.
+func (qr *Rule) SetTrailingCommentCond(pattern string) (err error) {
+	qr.trailingComment.name = pattern
+	qr.trailingComment.Regexp, err = regexp.Compile(makeExact(pattern))
 	return
 }
 
@@ -418,13 +448,26 @@ func (qr *Rule) FilterByPlan(query string, planid planbuilder.PlanType, tableNam
 	}
 	newqr = qr.Copy()
 	newqr.query = namedRegexp{}
+	// Note we explicitly don't remove the leading/trailing comments as they
+	// must be evaluated at execution time.
 	newqr.plans = nil
 	newqr.tableNames = nil
 	return newqr
 }
 
 // GetAction returns the action for a single rule.
-func (qr *Rule) GetAction(ip, user string, bindVars map[string]*querypb.BindVariable) Action {
+func (qr *Rule) GetAction(
+	ip,
+	user string,
+	bindVars map[string]*querypb.BindVariable,
+	marginComments sqlparser.MarginComments,
+) Action {
+	if !reMatch(qr.leadingComment.Regexp, marginComments.Leading) {
+		return QRContinue
+	}
+	if !reMatch(qr.trailingComment.Regexp, marginComments.Trailing) {
+		return QRContinue
+	}
 	if !reMatch(qr.requestIP.Regexp, ip) {
 		return QRContinue
 	}
@@ -791,7 +834,7 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *Rule, err error) {
 		var lv []interface{}
 		var ok bool
 		switch k {
-		case "Name", "Description", "RequestIP", "User", "Query", "Action":
+		case "Name", "Description", "RequestIP", "User", "Query", "Action", "LeadingComment", "TrailingComment":
 			sv, ok = v.(string)
 			if !ok {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "want string for %s", k)
@@ -823,6 +866,16 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *Rule, err error) {
 			err = qr.SetQueryCond(sv)
 			if err != nil {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not set Query condition: %v", sv)
+			}
+		case "LeadingComment":
+			err = qr.SetLeadingCommentCond(sv)
+			if err != nil {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not set LeadingComment condition: %v", sv)
+			}
+		case "TrailingComment":
+			err = qr.SetTrailingCommentCond(sv)
+			if err != nil {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "could not set TrailingComment condition: %v", sv)
 			}
 		case "Plans":
 			for _, p := range lv {

--- a/go/vt/vttablet/tabletserver/rules/rules_test.go
+++ b/go/vt/vttablet/tabletserver/rules/rules_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 
@@ -496,31 +497,68 @@ func TestAction(t *testing.T) {
 
 	bv := make(map[string]*querypb.BindVariable)
 	bv["a"] = sqltypes.Uint64BindVariable(0)
-	action, desc := qrs.GetAction("123", "user1", bv)
+
+	mc := sqlparser.MarginComments{
+		Leading:  "some comments leading the query",
+		Trailing: "other trailing comments",
+	}
+
+	action, desc := qrs.GetAction("123", "user1", bv, mc)
 	if action != QRFail {
 		t.Errorf("want fail")
 	}
 	if desc != "rule 1" {
 		t.Errorf("want rule 1, got %s", desc)
 	}
-	action, desc = qrs.GetAction("1234", "user", bv)
+	action, desc = qrs.GetAction("1234", "user", bv, mc)
 	if action != QRFailRetry {
 		t.Errorf("want fail_retry")
 	}
 	if desc != "rule 2" {
 		t.Errorf("want rule 2, got %s", desc)
 	}
-	action, _ = qrs.GetAction("1234", "user1", bv)
+	action, _ = qrs.GetAction("1234", "user1", bv, mc)
 	if action != QRContinue {
 		t.Errorf("want continue")
 	}
+
 	bv["a"] = sqltypes.Uint64BindVariable(1)
-	action, desc = qrs.GetAction("1234", "user1", bv)
+	action, desc = qrs.GetAction("1234", "user1", bv, mc)
 	if action != QRFail {
 		t.Errorf("want fail")
 	}
 	if desc != "rule 3" {
-		t.Errorf("want rule 2, got %s", desc)
+		t.Errorf("want rule 3, got %s", desc)
+	}
+
+	// reset bound variable 'a' to 0 so it doesn't match rule 3
+	bv["a"] = sqltypes.Uint64BindVariable(0)
+
+	qr4 := NewQueryRule("rule 4", "r4", QRFail)
+	qr4.SetTrailingCommentCond(".*trailing.*")
+
+	newQrs := qrs.Copy()
+	newQrs.Add(qr4)
+
+	action, desc = newQrs.GetAction("1234", "user1", bv, mc)
+	if action != QRFail {
+		t.Errorf("want fail")
+	}
+	if desc != "rule 4" {
+		t.Errorf("want rule 4, got %s", desc)
+	}
+
+	qr5 := NewQueryRule("rule 5", "r4", QRFail)
+	qr5.SetLeadingCommentCond(".*leading.*")
+
+	newQrs = qrs.Copy()
+	newQrs.Add(qr5)
+	action, desc = newQrs.GetAction("1234", "user1", bv, mc)
+	if action != QRFail {
+		t.Errorf("want fail")
+	}
+	if desc != "rule 5" {
+		t.Errorf("want rule 5, got %s", desc)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/rules/rules_test.go
+++ b/go/vt/vttablet/tabletserver/rules/rules_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -504,32 +506,20 @@ func TestAction(t *testing.T) {
 	}
 
 	action, desc := qrs.GetAction("123", "user1", bv, mc)
-	if action != QRFail {
-		t.Errorf("want fail")
-	}
-	if desc != "rule 1" {
-		t.Errorf("want rule 1, got %s", desc)
-	}
+	assert.Equalf(t, action, QRFail, "expected fail, got %v", action)
+	assert.Equalf(t, desc, "rule 1", "want rule 1, got %s", desc)
+
 	action, desc = qrs.GetAction("1234", "user", bv, mc)
-	if action != QRFailRetry {
-		t.Errorf("want fail_retry")
-	}
-	if desc != "rule 2" {
-		t.Errorf("want rule 2, got %s", desc)
-	}
+	assert.Equalf(t, action, QRFailRetry, "want fail_retry, got: %s", action)
+	assert.Equalf(t, desc, "rule 2", "want rule 2, got %s", desc)
+
 	action, _ = qrs.GetAction("1234", "user1", bv, mc)
-	if action != QRContinue {
-		t.Errorf("want continue")
-	}
+	assert.Equalf(t, action, QRContinue, "want continue, got %s", action)
 
 	bv["a"] = sqltypes.Uint64BindVariable(1)
 	action, desc = qrs.GetAction("1234", "user1", bv, mc)
-	if action != QRFail {
-		t.Errorf("want fail")
-	}
-	if desc != "rule 3" {
-		t.Errorf("want rule 3, got %s", desc)
-	}
+	assert.Equalf(t, action, QRFail, "want fail, got %s", action)
+	assert.Equalf(t, desc, "rule 3", "want rule 3, got %s", desc)
 
 	// reset bound variable 'a' to 0 so it doesn't match rule 3
 	bv["a"] = sqltypes.Uint64BindVariable(0)
@@ -541,12 +531,8 @@ func TestAction(t *testing.T) {
 	newQrs.Add(qr4)
 
 	action, desc = newQrs.GetAction("1234", "user1", bv, mc)
-	if action != QRFail {
-		t.Errorf("want fail")
-	}
-	if desc != "rule 4" {
-		t.Errorf("want rule 4, got %s", desc)
-	}
+	assert.Equalf(t, action, QRFail, "want fail, got %s", action)
+	assert.Equalf(t, desc, "rule 4", "want rule 4, got %s", desc)
 
 	qr5 := NewQueryRule("rule 5", "r4", QRFail)
 	qr5.SetLeadingCommentCond(".*leading.*")
@@ -554,12 +540,8 @@ func TestAction(t *testing.T) {
 	newQrs = qrs.Copy()
 	newQrs.Add(qr5)
 	action, desc = newQrs.GetAction("1234", "user1", bv, mc)
-	if action != QRFail {
-		t.Errorf("want fail")
-	}
-	if desc != "rule 5" {
-		t.Errorf("want rule 5, got %s", desc)
-	}
+	assert.Equalf(t, action, QRFail, "want fail, got %s", action)
+	assert.Equalf(t, desc, "rule 5", "want rule 5, got %s", desc)
 }
 
 func TestImport(t *testing.T) {


### PR DESCRIPTION
:warning: Caveat is that I pulled the PR and description from https://github.com/vitessio/vitess/pull/7784 since it was accidentally merged that into upstream instead of the TS branch so it's a little non-trivial to just reopen it due to the revert (afaik). I did _not_ do any additional retesting relying on the unit tests etc to do their thing.

## Description

This PR makes three changes

1. It introduces an optional us of `fsnotify` to watch for changes vs the rules file
2. it extends rules evaluation to support comparison vs leading/trailing comments
3. It adds support to specify leading/trailing comments as part of rule creation in `rulesctl`

### Details: Watching the file

We use [fsnotify](https://pkg.go.dev/github.com/fsnotify/fsnotify) which seems to be the generally accepted approach. There are some gymnastics necessary as watching the specific file is prone to losing track of it in the event that the file is deleted+recreated. To handle this case we watch the directory containing the file and react only when the node we receive events for matches the file we are watching.

### Details: Filtering on MarginComments

This was mostly plumbing within the `Rule` itself + the application callstack as the `tabletserver/query_executor::QueryExecutor` has already baked margin comments into it during the initial phase of [the Execute call](https://github.com/vitessio/vitess/blob/master/go/vt/vttablet/tabletserver/tabletserver.go#L729).

Evaluation is _similar to_ but not the same as the Query regexp because that is stable across query shapes (otherwise it wouldn't be the same query). For margin comments we need to defer evaluation until after the plan cache which is why Query & comments take different paths.

### Test failures
The only listed failure is `endtoend/tabletmanager/tablegc` which seems unlikely to be related afaict.

## Related Issue(s)

n/a

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required.

## Deployment Notes
No changes necessary for existing deployments.

## Impacted Areas in Vitess
Components that this PR will affect:

- [x]  Query Serving
- [ ]  VReplication
- [ ]  Cluster Management
- [ ]  Build/CI
- [ ]  VTAdmin
