### PR TITLE
Materialize: Add additional comparison operators in Materialize and fix bug where they not applied for sharded keyspaces

### DIFF
--- a/go/test/endtoend/vreplication/materialize_test.go
+++ b/go/test/endtoend/vreplication/materialize_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const smSchema = `
+	CREATE TABLE tx (
+	id bigint NOT NULL,
+	val varbinary(10) NOT NULL,
+	ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	typ tinyint NOT NULL,
+	PRIMARY KEY (id),
+	KEY ts (ts),
+	KEY typ (typ)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`
+
+const smVSchema = `
+{
+  "sharded": true,
+  "tables": {
+      "tx": {
+          "column_vindexes": [
+              {
+                  "column": "id",
+                  "name": "hash"
+              }
+          ]
+      }
+  },
+  "vindexes": {
+      "hash": {
+          "type": "hash"
+      }
+  }
+}
+`
+
+const smMaterializeSpec = `{"workflow": "wf1", "source_keyspace": "ks1", "target_keyspace": "ks2", "table_settings": [ {"target_table": "tx", "source_expression": "select * from tx where typ>=2 and val > 'abc'"  }] }`
+
+const initDataQuery = `insert into ks1.tx(id, typ, val) values (1, 1, 'abc'), (2, 1, 'def'), (3, 2, 'def'), (4, 2, 'abc'), (5, 3, 'def'), (6, 3, 'abc')`
+
+func TestShardedMaterialize(t *testing.T) {
+	defaultCellName := "zone1"
+	allCells := []string{"zone1"}
+	allCellNames = "zone1"
+	vc = NewVitessCluster(t, "TestShardedMaterialize", allCells, mainClusterConfig)
+	ks1 := "ks1"
+	ks2 := "ks2"
+	require.NotNil(t, vc)
+	defaultReplicas = 0 // because of CI resource constraints we can only run this test with master tablets
+	defer func() { defaultReplicas = 1 }()
+
+	//defer vc.TearDown(t)
+
+	defaultCell = vc.Cells[defaultCellName]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, ks1, "-", smVSchema, smSchema, defaultReplicas, defaultRdonly, 100)
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", ks1, "0"), 1)
+
+	vc.AddKeyspace(t, []*Cell{defaultCell}, ks2, "-", smVSchema, smSchema, defaultReplicas, defaultRdonly, 200)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.master", ks2, "0"), 1)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+	verifyClusterHealth(t, vc)
+	_, err := vtgateConn.ExecuteFetch(initDataQuery, 0, false)
+	require.NoError(t, err)
+	materialize(t, smMaterializeSpec)
+	time.Sleep(5 * time.Second)
+	validateCount(t, vtgateConn, ks2, "tx", 2)
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -145,6 +145,11 @@ func getOpcode(comparison *sqlparser.ComparisonExpr) (Opcode, error) {
 
 // compare returns true after applying the comparison specified in the Filter to the actual data in the column
 func compare(comparison Opcode, columnValue, filterValue sqltypes.Value) (bool, error) {
+	// use null semantics: return false if either value is null
+	if columnValue.IsNull() || filterValue.IsNull() {
+		return false, nil
+	}
+	// at this point neither values can be null
 	// NullsafeCompare returns 0 if values match, -1 if columnValue < filterValue, 1 if columnValue > filterValue
 	result, err := evalengine.NullsafeCompare(columnValue, filterValue)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -22,12 +22,12 @@ import (
 	"strconv"
 	"strings"
 
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/vt/log"
-
-	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
@@ -57,10 +57,20 @@ type Plan struct {
 type Opcode int
 
 const (
-	// Equal is used to filter an integer column on a specific value
+	// Equal is used to filter a comparable column on a specific value
 	Equal = Opcode(iota)
 	// VindexMatch is used for an in_keyrange() construct
 	VindexMatch
+	// LessThan is used to filter a comparable column if < specific value
+	LessThan
+	// LessThanEqual is used to filter a comparable column if <= specific value
+	LessThanEqual
+	// GreaterThan is used to filter a comparable column if > specific value
+	GreaterThan
+	// GreaterThanEqual is used to filter a comparable column if >= specific value
+	GreaterThanEqual
+	// NotEqual is used to filter a comparable column if != specific value
+	NotEqual
 )
 
 // Filter contains opcodes for filtering.
@@ -111,6 +121,42 @@ func (plan *Plan) fields() []*querypb.Field {
 	return fields
 }
 
+// getOpcode returns the equivalent planbuilder opcode for operators that are supported in Filters
+func getOpcode(comparison *sqlparser.ComparisonExpr) (Opcode, error) {
+	var opcode Opcode
+	switch comparison.Operator {
+	case sqlparser.EqualOp:
+		opcode = Equal
+	case sqlparser.LessThanOp:
+		opcode = LessThan
+	case sqlparser.LessEqualOp:
+		opcode = LessThanEqual
+	case sqlparser.GreaterThanOp:
+		opcode = GreaterThan
+	case sqlparser.GreaterEqualOp:
+		opcode = GreaterThanEqual
+	case sqlparser.NotEqualOp:
+		opcode = NotEqual
+	default:
+		return -1, fmt.Errorf("comparison operator %s not supported", comparison.Operator.ToString())
+	}
+	return opcode, nil
+}
+
+// compare returns true after applying the comparison specified in the Filter to the actual data in the column
+func compare(comparison Opcode, columnValue, filterValue sqltypes.Value) (bool, error) {
+	result, err := evalengine.NullsafeCompare(columnValue, filterValue)
+	if err != nil {
+		return false, err
+	}
+	if result == 0 && (comparison == Equal || comparison == LessThanEqual || comparison == GreaterThanEqual) ||
+		result < 0 && (comparison == LessThan || comparison == LessThanEqual || comparison == NotEqual) ||
+		result > 0 && (comparison == GreaterThan || comparison == GreaterThanEqual || comparison == NotEqual) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // filter filters the row against the plan. It returns false if the row did not match.
 // The output of the filtering operation is stored in the 'result' argument because
 // filtering cannot be performed in-place. The result argument must be a slice of
@@ -121,20 +167,20 @@ func (plan *Plan) filter(values, result []sqltypes.Value) (bool, error) {
 	}
 	for _, filter := range plan.Filters {
 		switch filter.Opcode {
-		case Equal:
-			result, err := evalengine.NullsafeCompare(values[filter.ColNum], filter.Value)
-			if err != nil {
-				return false, err
-			}
-			if result != 0 {
-				return false, nil
-			}
 		case VindexMatch:
 			ksid, err := getKeyspaceID(values, filter.Vindex, filter.VindexColumns, plan.Table.Fields)
 			if err != nil {
 				return false, err
 			}
 			if !key.KeyRangeContains(filter.KeyRange, ksid) {
+				return false, nil
+			}
+		default:
+			match, err := compare(filter.Opcode, values[filter.ColNum], filter.Value)
+			if err != nil {
+				return false, err
+			}
+			if !match {
 				return false, nil
 			}
 		}
@@ -372,6 +418,10 @@ func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) er
 	for _, expr := range exprs {
 		switch expr := expr.(type) {
 		case *sqlparser.ComparisonExpr:
+			opcode, err := getOpcode(expr)
+			if err != nil {
+				return err
+			}
 			qualifiedName, ok := expr.Left.(*sqlparser.ColName)
 			if !ok {
 				return fmt.Errorf("unexpected: %v", sqlparser.String(expr))
@@ -400,7 +450,7 @@ func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) er
 				return err
 			}
 			plan.Filters = append(plan.Filters, Filter{
-				Opcode: Equal,
+				Opcode: opcode,
 				ColNum: colnum,
 				Value:  resolved,
 			})

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"vitess.io/vitess/go/vt/proto/topodata"
+
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/utils"
@@ -582,6 +584,83 @@ func TestPlanBuilder(t *testing.T) {
 				plan.Filters[ind].Vindex = nil
 			}
 			utils.MustMatch(t, tcase.outPlan, plan)
+		})
+	}
+}
+
+func TestPlanBuilderFilterComparison(t *testing.T) {
+	t1 := &Table{
+		Name: "t1",
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "val",
+			Type: sqltypes.VarBinary,
+		}},
+	}
+	hashVindex, err := vindexes.NewHash("hash", nil)
+	require.NoError(t, err)
+	testcases := []struct {
+		name       string
+		inFilter   string
+		outFilters []Filter
+		outErr     string
+	}{{
+		name:       "equal",
+		inFilter:   "select * from t1 where id = 1",
+		outFilters: []Filter{{Opcode: Equal, ColNum: 0, Value: sqltypes.NewInt64(1)}},
+	}, {
+		name:       "not-equal",
+		inFilter:   "select * from t1 where id <> 1",
+		outFilters: []Filter{{Opcode: NotEqual, ColNum: 0, Value: sqltypes.NewInt64(1)}},
+	}, {
+		name:       "greater",
+		inFilter:   "select * from t1 where val > 'abc'",
+		outFilters: []Filter{{Opcode: GreaterThan, ColNum: 1, Value: sqltypes.NewVarBinary("abc")}},
+	}, {
+		name:       "greater-than",
+		inFilter:   "select * from t1 where id >= 1",
+		outFilters: []Filter{{Opcode: GreaterThanEqual, ColNum: 0, Value: sqltypes.NewInt64(1)}},
+	}, {
+		name:     "less-than-with-and",
+		inFilter: "select * from t1 where id < 2 and val <= 'xyz'",
+		outFilters: []Filter{{Opcode: LessThan, ColNum: 0, Value: sqltypes.NewInt64(2)},
+			{Opcode: LessThanEqual, ColNum: 1, Value: sqltypes.NewVarBinary("xyz")},
+		},
+	}, {
+		name:     "vindex-and-operators",
+		inFilter: "select * from t1 where in_keyrange(id, 'hash', '-80') and id = 2 and val <> 'xyz'",
+		outFilters: []Filter{
+			{
+				Opcode:        VindexMatch,
+				ColNum:        0,
+				Value:         sqltypes.NULL,
+				Vindex:        hashVindex,
+				VindexColumns: []int{0},
+				KeyRange: &topodata.KeyRange{
+					Start: nil,
+					End:   []byte("\200"),
+				},
+			},
+			{Opcode: Equal, ColNum: 0, Value: sqltypes.NewInt64(2)},
+			{Opcode: NotEqual, ColNum: 1, Value: sqltypes.NewVarBinary("xyz")},
+		},
+	}}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			plan, err := buildPlan(t1, testLocalVSchema, &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{{Match: "t1", Filter: tcase.inFilter}},
+			})
+
+			if tcase.outErr != "" {
+				assert.Nil(t, plan)
+				assert.EqualError(t, err, tcase.outErr)
+				return
+			}
+			require.NotNil(t, plan)
+			require.ElementsMatchf(t, tcase.outFilters, plan.Filters, "want %+v, got: %+v", tcase.outFilters, plan.Filters)
 		})
 	}
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder_test.go
@@ -664,3 +664,39 @@ func TestPlanBuilderFilterComparison(t *testing.T) {
 		})
 	}
 }
+
+func TestCompare(t *testing.T) {
+	type testcase struct {
+		opcode                   Opcode
+		columnValue, filterValue sqltypes.Value
+		want                     bool
+	}
+	int1 := sqltypes.NewInt32(1)
+	int2 := sqltypes.NewInt32(2)
+	testcases := []*testcase{
+		{opcode: Equal, columnValue: int1, filterValue: int1, want: true},
+		{opcode: Equal, columnValue: int1, filterValue: int2, want: false},
+		{opcode: Equal, columnValue: int1, filterValue: sqltypes.NULL, want: false},
+		{opcode: LessThan, columnValue: int2, filterValue: int1, want: false},
+		{opcode: LessThan, columnValue: int1, filterValue: int2, want: true},
+		{opcode: LessThan, columnValue: int1, filterValue: sqltypes.NULL, want: false},
+		{opcode: GreaterThan, columnValue: int2, filterValue: int1, want: true},
+		{opcode: GreaterThan, columnValue: int1, filterValue: int2, want: false},
+		{opcode: GreaterThan, columnValue: int1, filterValue: sqltypes.NULL, want: false},
+		{opcode: NotEqual, columnValue: int1, filterValue: int1, want: false},
+		{opcode: NotEqual, columnValue: int1, filterValue: int2, want: true},
+		{opcode: NotEqual, columnValue: sqltypes.NULL, filterValue: int1, want: false},
+		{opcode: LessThanEqual, columnValue: int1, filterValue: sqltypes.NULL, want: false},
+		{opcode: GreaterThanEqual, columnValue: int2, filterValue: int1, want: true},
+		{opcode: LessThanEqual, columnValue: int2, filterValue: int1, want: false},
+		{opcode: GreaterThanEqual, columnValue: int1, filterValue: int1, want: true},
+		{opcode: LessThanEqual, columnValue: int1, filterValue: int2, want: true},
+	}
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			got, err := compare(tc.opcode, tc.columnValue, tc.filterValue)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -102,7 +102,7 @@ type streamerPlan struct {
 //   "select * from t where in_keyrange(col1, 'hash', '-80')",
 //   "select col1, col2 from t where...",
 //   "select col1, keyspace_id() from t where...".
-//   Only "in_keyrange" expressions are supported in the where clause.
+//   Only "in_keyrange" and limited comparison operators (see enum Opcode in planbuilder.go) are supported in the where clause.
 //   Other constructs like joins, group by, etc. are not supported.
 // vschema: the current vschema. This value can later be changed through the SetVSchema method.
 // send: callback function to send events.

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1068,10 +1068,7 @@ func (mz *materializer) generateInserts(ctx context.Context) (string, error) {
 				} else {
 					sel.Where = &sqlparser.Where{
 						Type: sqlparser.WhereClause,
-						Expr: &sqlparser.FuncExpr{
-							Name:  sqlparser.NewColIdent("in_keyrange"),
-							Exprs: subExprs,
-						},
+						Expr: inKeyRange,
 					}
 				}
 

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -1032,7 +1032,6 @@ func (mz *materializer) generateInserts(ctx context.Context) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("unrecognized statement: %s", ts.SourceExpression)
 			}
-
 			filter := ts.SourceExpression
 			if mz.targetVSchema.Keyspace.Sharded && mz.targetVSchema.Tables[ts.TargetTable].Type != vindexes.TypeReference {
 				cv, err := vindexes.FindBestColVindex(mz.targetVSchema.Tables[ts.TargetTable])
@@ -1054,12 +1053,26 @@ func (mz *materializer) generateInserts(ctx context.Context) (string, error) {
 				vindexName := fmt.Sprintf("%s.%s", mz.ms.TargetKeyspace, cv.Name)
 				subExprs = append(subExprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewStrLiteral(vindexName)})
 				subExprs = append(subExprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewStrLiteral("{{.keyrange}}")})
-				sel.Where = &sqlparser.Where{
-					Type: sqlparser.WhereClause,
-					Expr: &sqlparser.FuncExpr{
-						Name:  sqlparser.NewColIdent("in_keyrange"),
-						Exprs: subExprs,
-					},
+				inKeyRange := &sqlparser.FuncExpr{
+					Name:  sqlparser.NewColIdent("in_keyrange"),
+					Exprs: subExprs,
+				}
+				if sel.Where != nil {
+					sel.Where = &sqlparser.Where{
+						Type: sqlparser.WhereClause,
+						Expr: &sqlparser.AndExpr{
+							Left:  inKeyRange,
+							Right: sel.Where.Expr,
+						},
+					}
+				} else {
+					sel.Where = &sqlparser.Where{
+						Type: sqlparser.WhereClause,
+						Expr: &sqlparser.FuncExpr{
+							Name:  sqlparser.NewColIdent("in_keyrange"),
+							Exprs: subExprs,
+						},
+					}
 				}
 
 				filter = sqlparser.String(sel)

--- a/test/config.json
+++ b/test/config.json
@@ -752,6 +752,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"vreplication_materialize": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "ShardedMaterialize"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vreplication_multicell",
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"vreplication_cellalias": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "CellAlias"],


### PR DESCRIPTION
## Description

This PR fixes a bug where comparison filters were being ignored in Materialize workflows if the source keyspace was sharded.

In addition, it adds support for additional operators (`>, >=, <, <=, <>`) . The filter expression can chain multiple comparison operations using `and` only.

Examples:
```
select * from t1 where id = 1
select * from t1 where id <> 1
select * from t1 where val > 'abc'
select * from t1 where id >= 1
select * from t1 where id < 2 and val <= 'xyz'
```
Signed-off-by: Rohit Nayak <rohit@planetscale.com>
## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
