### PR TITLE
naming: master to primary

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -447,8 +447,8 @@ func startReplication(ctx context.Context, mysqld mysqlctl.MysqlDaemon, topoServ
 	}
 
 	// Stop replication (in case we're restarting), set master, and start replication.
-	if err := mysqld.SetMaster(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
-		return vterrors.Wrap(err, "MysqlDaemon.SetMaster failed")
+	if err := mysqld.SetReplicationSource(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
+		return vterrors.Wrap(err, "MysqlDaemon.SetReplicationSource failed")
 	}
 	return nil
 }

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -57,7 +57,7 @@ const (
 // 1. Oracle MySQL 5.6, 5.7, 8.0, ...
 // 2. MariaDB 10.X
 type flavor interface {
-	// primaryGTIDSet returns the current GTIDSet of a server
+	// primaryGTIDSet returns the current GTIDSet of a server.
 	primaryGTIDSet(c *Conn) (GTIDSet, error)
 
 	// startReplicationCommand returns the command to start the replication.
@@ -176,7 +176,7 @@ func (c *Conn) IsMariaDB() bool {
 	return false
 }
 
-// PrimaryPosition returns the current master replication position.
+// PrimaryPosition returns the current primary's replication position.
 func (c *Conn) PrimaryPosition() (Position, error) {
 	gtidSet, err := c.flavor.primaryGTIDSet(c)
 	if err != nil {
@@ -350,8 +350,8 @@ func (c *Conn) ShowReplicationStatus() (ReplicationStatus, error) {
 	return c.flavor.status(c)
 }
 
-// parseMasterStatus parses the common fields of SHOW MASTER STATUS.
-func parseMasterStatus(fields map[string]string) PrimaryStatus {
+// parsePrimaryStatus parses the common fields of SHOW MASTER STATUS.
+func parsePrimaryStatus(fields map[string]string) PrimaryStatus {
 	status := PrimaryStatus{}
 
 	fileExecPosStr := fields["Position"]

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -34,8 +34,8 @@ var (
 	// Returned by ShowReplicationStatus().
 	ErrNotReplica = errors.New("no replication status")
 
-	// ErrNoMasterStatus means no status was returned by ShowMasterStatus().
-	ErrNoMasterStatus = errors.New("no master status")
+	// ErrNoPrimaryStatus means no status was returned by ShowPrimaryStatus().
+	ErrNoPrimaryStatus = errors.New("no master status")
 )
 
 const (
@@ -57,8 +57,8 @@ const (
 // 1. Oracle MySQL 5.6, 5.7, 8.0, ...
 // 2. MariaDB 10.X
 type flavor interface {
-	// masterGTIDSet returns the current GTIDSet of a server.
-	masterGTIDSet(c *Conn) (GTIDSet, error)
+	// primaryGTIDSet returns the current GTIDSet of a server
+	primaryGTIDSet(c *Conn) (GTIDSet, error)
 
 	// startReplicationCommand returns the command to start the replication.
 	startReplicationCommand() string
@@ -91,17 +91,17 @@ type flavor interface {
 	// replication position at which the replica will resume.
 	setReplicationPositionCommands(pos Position) []string
 
-	// changeMasterArg returns the specific parameter to add to
-	// a change master command.
-	changeMasterArg() string
+	// changeReplicationSourceArg returns the specific parameter to add to
+	// a "change master" command.
+	changeReplicationSourceArg() string
 
 	// status returns the result of the appropriate status command,
 	// with parsed replication position.
 	status(c *Conn) (ReplicationStatus, error)
 
-	// masterStatus returns the result of 'SHOW MASTER STATUS',
+	// primaryStatus returns the result of 'SHOW MASTER STATUS',
 	// with parsed executed position.
-	masterStatus(c *Conn) (MasterStatus, error)
+	primaryStatus(c *Conn) (PrimaryStatus, error)
 
 	// waitUntilPositionCommand returns the SQL command to issue
 	// to wait until the given position, until the context
@@ -176,9 +176,9 @@ func (c *Conn) IsMariaDB() bool {
 	return false
 }
 
-// MasterPosition returns the current master replication position.
-func (c *Conn) MasterPosition() (Position, error) {
-	gtidSet, err := c.flavor.masterGTIDSet(c)
+// PrimaryPosition returns the current master replication position.
+func (c *Conn) PrimaryPosition() (Position, error) {
+	gtidSet, err := c.flavor.primaryGTIDSet(c)
 	if err != nil {
 		return Position{}, err
 	}
@@ -187,10 +187,10 @@ func (c *Conn) MasterPosition() (Position, error) {
 	}, nil
 }
 
-// MasterFilePosition returns the current master's file based replication position.
-func (c *Conn) MasterFilePosition() (Position, error) {
+// PrimaryFilePosition returns the current primary's file based replication position.
+func (c *Conn) PrimaryFilePosition() (Position, error) {
 	filePosFlavor := filePosFlavor{}
-	gtidSet, err := filePosFlavor.masterGTIDSet(c)
+	gtidSet, err := filePosFlavor.primaryGTIDSet(c)
 	if err != nil {
 		return Position{}, err
 	}
@@ -245,22 +245,22 @@ func (c *Conn) ResetReplicationCommands() []string {
 
 // SetReplicationPositionCommands returns the commands to set the
 // replication position at which the replica will resume
-// when it is later reparented with SetMasterCommands.
+// when it is later reparented with SetReplicationSourceCommand.
 func (c *Conn) SetReplicationPositionCommands(pos Position) []string {
 	return c.flavor.setReplicationPositionCommands(pos)
 }
 
-// SetMasterCommand returns the command to use the provided master
-// as the new master (without changing any GTID position).
+// SetReplicationSourceCommand returns the command to use the provided host/port
+// as the new replication source (without changing any GTID position).
 // It is guaranteed to be called with replication stopped.
 // It should not start or stop replication.
-func (c *Conn) SetMasterCommand(params *ConnParams, masterHost string, masterPort int, masterConnectRetry int) string {
+func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int, connectRetry int) string {
 	args := []string{
-		fmt.Sprintf("MASTER_HOST = '%s'", masterHost),
-		fmt.Sprintf("MASTER_PORT = %d", masterPort),
+		fmt.Sprintf("MASTER_HOST = '%s'", host),
+		fmt.Sprintf("MASTER_PORT = %d", port),
 		fmt.Sprintf("MASTER_USER = '%s'", params.Uname),
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
-		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", masterConnectRetry),
+		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
 	if params.SslEnabled() {
 		args = append(args, "MASTER_SSL = 1")
@@ -277,7 +277,7 @@ func (c *Conn) SetMasterCommand(params *ConnParams, masterHost string, masterPor
 	if params.SslKey != "" {
 		args = append(args, fmt.Sprintf("MASTER_SSL_KEY = '%s'", params.SslKey))
 	}
-	args = append(args, c.flavor.changeMasterArg())
+	args = append(args, c.flavor.changeReplicationSourceArg())
 	return "CHANGE MASTER TO\n  " + strings.Join(args, ",\n  ")
 }
 
@@ -351,8 +351,8 @@ func (c *Conn) ShowReplicationStatus() (ReplicationStatus, error) {
 }
 
 // parseMasterStatus parses the common fields of SHOW MASTER STATUS.
-func parseMasterStatus(fields map[string]string) MasterStatus {
-	status := MasterStatus{}
+func parseMasterStatus(fields map[string]string) PrimaryStatus {
+	status := PrimaryStatus{}
 
 	fileExecPosStr := fields["Position"]
 	file := fields["File"]
@@ -369,10 +369,10 @@ func parseMasterStatus(fields map[string]string) MasterStatus {
 	return status
 }
 
-// ShowMasterStatus executes the right SHOW MASTER STATUS command,
+// ShowPrimaryStatus executes the right SHOW MASTER STATUS command,
 // and returns a parsed executed Position, as well as file based Position.
-func (c *Conn) ShowMasterStatus() (MasterStatus, error) {
-	return c.flavor.masterStatus(c)
+func (c *Conn) ShowPrimaryStatus() (PrimaryStatus, error) {
+	return c.flavor.primaryStatus(c)
 }
 
 // WaitUntilPositionCommand returns the SQL command to issue

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -38,14 +37,14 @@ func newFilePosFlavor() flavor {
 	return &filePosFlavor{}
 }
 
-// masterGTIDSet is part of the Flavor interface.
+// primaryGTIDSet is part of the Flavor interface.
 func (flv *filePosFlavor) primaryGTIDSet(c *Conn) (GTIDSet, error) {
 	qr, err := c.ExecuteFetch("SHOW MASTER STATUS", 100, true /* wantfields */)
 	if err != nil {
 		return nil, err
 	}
 	if len(qr.Rows) == 0 {
-		return nil, errors.New("no master status")
+		return nil, ErrNoPrimaryStatus
 	}
 
 	resultMap, err := resultToMap(qr)
@@ -233,7 +232,7 @@ func (flv *filePosFlavor) primaryStatus(c *Conn) (PrimaryStatus, error) {
 }
 
 func parseFilePosMasterStatus(resultMap map[string]string) (PrimaryStatus, error) {
-	status := parseMasterStatus(resultMap)
+	status := parsePrimaryStatus(resultMap)
 
 	status.Position = status.FilePosition
 

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -39,7 +39,7 @@ func newFilePosFlavor() flavor {
 }
 
 // masterGTIDSet is part of the Flavor interface.
-func (flv *filePosFlavor) masterGTIDSet(c *Conn) (GTIDSet, error) {
+func (flv *filePosFlavor) primaryGTIDSet(c *Conn) (GTIDSet, error) {
 	qr, err := c.ExecuteFetch("SHOW MASTER STATUS", 100, true /* wantfields */)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (flv *filePosFlavor) setReplicationPositionCommands(pos Position) []string 
 }
 
 // setReplicationPositionCommands is part of the Flavor interface.
-func (flv *filePosFlavor) changeMasterArg() string {
+func (flv *filePosFlavor) changeReplicationSourceArg() string {
 	return "unsupported"
 }
 
@@ -214,25 +214,25 @@ func parseFilePosReplicationStatus(resultMap map[string]string) (ReplicationStat
 }
 
 // masterStatus is part of the Flavor interface.
-func (flv *filePosFlavor) masterStatus(c *Conn) (MasterStatus, error) {
+func (flv *filePosFlavor) primaryStatus(c *Conn) (PrimaryStatus, error) {
 	qr, err := c.ExecuteFetch("SHOW MASTER STATUS", 100, true /* wantfields */)
 	if err != nil {
-		return MasterStatus{}, err
+		return PrimaryStatus{}, err
 	}
 	if len(qr.Rows) == 0 {
 		// The query returned no data. We don't know how this could happen.
-		return MasterStatus{}, ErrNoMasterStatus
+		return PrimaryStatus{}, ErrNoPrimaryStatus
 	}
 
 	resultMap, err := resultToMap(qr)
 	if err != nil {
-		return MasterStatus{}, err
+		return PrimaryStatus{}, err
 	}
 
 	return parseFilePosMasterStatus(resultMap)
 }
 
-func parseFilePosMasterStatus(resultMap map[string]string) (MasterStatus, error) {
+func parseFilePosMasterStatus(resultMap map[string]string) (PrimaryStatus, error) {
 	status := parseMasterStatus(resultMap)
 
 	status.Position = status.FilePosition

--- a/go/mysql/flavor_filepos_test.go
+++ b/go/mysql/flavor_filepos_test.go
@@ -64,7 +64,7 @@ func TestFilePosShouldGetMasterPosition(t *testing.T) {
 		"File":     "source-bin.000003",
 	}
 
-	want := MasterStatus{
+	want := PrimaryStatus{
 		Position:     Position{GTIDSet: filePosGTID{file: "source-bin.000003", pos: 1307}},
 		FilePosition: Position{GTIDSet: filePosGTID{file: "source-bin.000003", pos: 1307}},
 	}

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -41,7 +41,7 @@ func TestMariadbSetMasterCommands(t *testing.T) {
   MASTER_USE_GTID = current_pos`
 
 	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
+	got := conn.SetReplicationSourceCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mariadbFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
 	}
@@ -74,7 +74,7 @@ func TestMariadbSetMasterCommandsSSL(t *testing.T) {
   MASTER_USE_GTID = current_pos`
 
 	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
+	got := conn.SetReplicationSourceCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mariadbFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
 	}

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -140,7 +140,7 @@ func TestMysqlShouldGetMasterPosition(t *testing.T) {
 		Position:     Position{GTIDSet: Mysql56GTIDSet{sid: []interval{{start: 1, end: 5}}}},
 		FilePosition: Position{GTIDSet: filePosGTID{file: "source-bin.000003", pos: 1307}},
 	}
-	got, err := parseMysqlMasterStatus(resultMap)
+	got, err := parseMysqlPrimaryStatus(resultMap)
 	require.NoError(t, err)
 	assert.Equalf(t, got.Position.GTIDSet.String(), want.Position.GTIDSet.String(), "got Position: %v; want Position: %v", got.Position.GTIDSet, want.Position.GTIDSet)
 	assert.Equalf(t, got.FilePosition.GTIDSet.String(), want.FilePosition.GTIDSet.String(), "got FilePosition: %v; want FilePosition: %v", got.FilePosition.GTIDSet, want.FilePosition.GTIDSet)

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -40,9 +40,9 @@ func TestMysql56SetMasterCommands(t *testing.T) {
   MASTER_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor57{}}
-	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
+	got := conn.SetReplicationSourceCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
-		t.Errorf("mysqlFlavor.SetMasterCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
+		t.Errorf("mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestMysql56SetMasterCommandsSSL(t *testing.T) {
   MASTER_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor57{}}
-	got := conn.SetMasterCommand(params, masterHost, masterPort, masterConnectRetry)
+	got := conn.SetReplicationSourceCommand(params, masterHost, masterPort, masterConnectRetry)
 	if got != want {
 		t.Errorf("mysqlFlavor.SetMasterCommands(%#v, %#v, %#v, %#v) = %#v, want %#v", params, masterHost, masterPort, masterConnectRetry, got, want)
 	}
@@ -136,7 +136,7 @@ func TestMysqlShouldGetMasterPosition(t *testing.T) {
 	}
 
 	sid, _ := ParseSID("3e11fa47-71ca-11e1-9e33-c80aa9429562")
-	want := MasterStatus{
+	want := PrimaryStatus{
 		Position:     Position{GTIDSet: Mysql56GTIDSet{sid: []interval{{start: 1, end: 5}}}},
 		FilePosition: Position{GTIDSet: filePosGTID{file: "source-bin.000003", pos: 1307}},
 	}

--- a/go/mysql/master_status.go
+++ b/go/mysql/master_status.go
@@ -20,16 +20,16 @@ import (
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 )
 
-// MasterStatus holds replication information from SHOW MASTER STATUS.
-type MasterStatus struct {
+// PrimaryStatus holds replication information from SHOW MASTER STATUS.
+type PrimaryStatus struct {
 	// Position represents the master's GTID based position.
 	Position Position
 	// FilePosition represents the master's file based position.
 	FilePosition Position
 }
 
-// MasterStatusToProto translates a MasterStatus to proto3.
-func MasterStatusToProto(s MasterStatus) *replicationdatapb.MasterStatus {
+// PrimaryStatusToProto translates a PrimaryStatus to proto3.
+func PrimaryStatusToProto(s PrimaryStatus) *replicationdatapb.MasterStatus {
 	return &replicationdatapb.MasterStatus{
 		Position:     EncodePosition(s.Position),
 		FilePosition: EncodePosition(s.FilePosition),

--- a/go/mysql/primary_status.go
+++ b/go/mysql/primary_status.go
@@ -22,9 +22,9 @@ import (
 
 // PrimaryStatus holds replication information from SHOW MASTER STATUS.
 type PrimaryStatus struct {
-	// Position represents the master's GTID based position.
+	// Position represents the server's GTID based position.
 	Position Position
-	// FilePosition represents the master's file based position.
+	// FilePosition represents the server's file based position.
 	FilePosition Position
 }
 

--- a/go/vt/binlog/binlog_connection.go
+++ b/go/vt/binlog/binlog_connection.go
@@ -100,7 +100,7 @@ func connectForReplication(cp dbconfigs.Connector) (*mysql.Conn, error) {
 func (bc *BinlogConnection) StartBinlogDumpFromCurrent(ctx context.Context) (mysql.Position, <-chan mysql.BinlogEvent, error) {
 	ctx, bc.cancel = context.WithCancel(ctx)
 
-	masterPosition, err := bc.Conn.MasterPosition()
+	masterPosition, err := bc.Conn.PrimaryPosition()
 	if err != nil {
 		return mysql.Position{}, nil, fmt.Errorf("failed to get master position: %v", err)
 	}

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -142,10 +142,10 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 
 	// Save initial state so we can restore.
 	replicaStartRequired := false
-	sourceIsMaster := false
+	sourceIsPrimary := false
 	readOnly := true //nolint
 	var replicationPosition mysql.Position
-	semiSyncMaster, semiSyncReplica := params.Mysqld.SemiSyncEnabled()
+	semiSyncSource, semiSyncReplica := params.Mysqld.SemiSyncEnabled()
 
 	// See if we need to restart replication after backup.
 	params.Logger.Infof("getting current replication status")
@@ -154,8 +154,8 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 	case nil:
 		replicaStartRequired = replicaStatus.ReplicationRunning() && !*DisableActiveReparents
 	case mysql.ErrNotReplica:
-		// keep going if we're the master, might be a degenerate case
-		sourceIsMaster = true
+		// keep going if we're the primary, might be a degenerate case
+		sourceIsPrimary = true
 	default:
 		return false, vterrors.Wrap(err, "can't get replica status")
 	}
@@ -167,16 +167,16 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 	}
 
 	// get the replication position
-	if sourceIsMaster {
+	if sourceIsPrimary {
 		if !readOnly {
-			params.Logger.Infof("turning master read-only before backup")
+			params.Logger.Infof("turning primary read-only before backup")
 			if err = params.Mysqld.SetReadOnly(true); err != nil {
 				return false, vterrors.Wrap(err, "can't set read-only status")
 			}
 		}
 		replicationPosition, err = params.Mysqld.PrimaryPosition()
 		if err != nil {
-			return false, vterrors.Wrap(err, "can't get master position")
+			return false, vterrors.Wrap(err, "can't get position on primary")
 		}
 	} else {
 		if err = params.Mysqld.StopReplication(params.HookExtraEnv); err != nil {
@@ -216,12 +216,12 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 	}
 
 	// Restore original mysqld state that we saved above.
-	if semiSyncMaster || semiSyncReplica {
+	if semiSyncSource || semiSyncReplica {
 		// Only do this if one of them was on, since both being off could mean
 		// the plugin isn't even loaded, and the server variables don't exist.
 		params.Logger.Infof("restoring semi-sync settings from before backup: master=%v, replica=%v",
-			semiSyncMaster, semiSyncReplica)
-		err := params.Mysqld.SetSemiSyncEnabled(semiSyncMaster, semiSyncReplica)
+			semiSyncSource, semiSyncReplica)
+		err := params.Mysqld.SetSemiSyncEnabled(semiSyncSource, semiSyncReplica)
 		if err != nil {
 			return usable, err
 		}
@@ -241,7 +241,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 
 		// We know that we stopped at replicationPosition.
 		// If PrimaryPosition is the same, that means no writes
-		// have happened to master, so we are up-to-date.
+		// have happened to primary, so we are up-to-date.
 		// Otherwise, we wait for replica's Position to change from
 		// the saved replicationPosition before proceeding
 		tmc := tmclient.NewTabletManagerClient()
@@ -249,12 +249,12 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 		remoteCtx, remoteCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 		defer remoteCancel()
 
-		masterPos, err := getMasterPosition(remoteCtx, tmc, params.TopoServer, params.Keyspace, params.Shard)
-		// If we are unable to get master position, return error.
+		pos, err := getPrimaryPosition(remoteCtx, tmc, params.TopoServer, params.Keyspace, params.Shard)
+		// If we are unable to get the primary's position, return error.
 		if err != nil {
 			return usable, err
 		}
-		if !replicationPosition.Equal(masterPos) {
+		if !replicationPosition.Equal(pos) {
 			for {
 				if err := ctx.Err(); err != nil {
 					return usable, err
@@ -621,7 +621,7 @@ func (be *BuiltinBackupEngine) ShouldDrainForBackup() bool {
 	return true
 }
 
-func getMasterPosition(ctx context.Context, tmc tmclient.TabletManagerClient, ts *topo.Server, keyspace, shard string) (mysql.Position, error) {
+func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, ts *topo.Server, keyspace, shard string) (mysql.Position, error) {
 	si, err := ts.GetShard(ctx, keyspace, shard)
 	if err != nil {
 		return mysql.Position{}, vterrors.Wrap(err, "can't read shard")

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -174,7 +174,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 				return false, vterrors.Wrap(err, "can't set read-only status")
 			}
 		}
-		replicationPosition, err = params.Mysqld.MasterPosition()
+		replicationPosition, err = params.Mysqld.PrimaryPosition()
 		if err != nil {
 			return false, vterrors.Wrap(err, "can't get master position")
 		}
@@ -240,7 +240,7 @@ func (be *BuiltinBackupEngine) ExecuteBackup(ctx context.Context, params BackupP
 		// Wait for a reliable value for SecondsBehindMaster from ReplicationStatus()
 
 		// We know that we stopped at replicationPosition.
-		// If MasterPosition is the same, that means no writes
+		// If PrimaryPosition is the same, that means no writes
 		// have happened to master, so we are up-to-date.
 		// Otherwise, we wait for replica's Position to change from
 		// the saved replicationPosition before proceeding

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -68,12 +68,12 @@ type FakeMysqlDaemon struct {
 	Replicating bool
 
 	// IOThreadRunning is always true except in one testcase
-	// where we want to test error handling during SetMaster
+	// where we want to test error handling during SetReplicationSource
 	IOThreadRunning bool
 
-	// CurrentMasterPosition is returned by MasterPosition
+	// CurrentPrimaryPosition is returned by PrimaryPosition
 	// and ReplicationStatus
-	CurrentMasterPosition mysql.Position
+	CurrentPrimaryPosition mysql.Position
 
 	// CurrentMasterFilePosition is used to determine the executed file based positioning of the master.
 	CurrentMasterFilePosition mysql.Position
@@ -84,8 +84,8 @@ type FakeMysqlDaemon struct {
 	// StartReplicationError is used by StartReplication
 	StartReplicationError error
 
-	// MasterStatusError is used by MasterStatus
-	MasterStatusError error
+	// PrimaryStatusError is used by PrimaryStatus
+	PrimaryStatusError error
 
 	// CurrentMasterHost is returned by ReplicationStatus
 	CurrentMasterHost string
@@ -109,16 +109,16 @@ type FakeMysqlDaemon struct {
 	// StartReplicationUntilAfterPos is matched against the input
 	StartReplicationUntilAfterPos mysql.Position
 
-	// SetMasterInput is matched against the input of SetMaster
-	// (as "%v:%v"). If it doesn't match, SetMaster will return an error.
-	SetMasterInput string
+	// SetReplicationSourceInput is matched against the input of SetReplicationSource
+	// (as "%v:%v"). If it doesn't match, SetReplicationSource will return an error.
+	SetReplicationSourceInput string
 
-	// SetMasterError is used by SetMaster
-	SetMasterError error
+	// SetReplicationSourceError is used by SetReplicationSource
+	SetReplicationSourceError error
 
-	// WaitMasterPosition is checked by WaitMasterPos, if the
+	// WaitPrimaryPosition is checked by WaitSourcePos, if the
 	// same it returns nil, if different it returns an error
-	WaitMasterPosition mysql.Position
+	WaitPrimaryPosition mysql.Position
 
 	// PromoteResult is returned by Promote
 	PromoteResult mysql.Position
@@ -250,11 +250,11 @@ func (fmd *FakeMysqlDaemon) GetMysqlPort() (int32, error) {
 	return fmd.MysqlPort.Get(), nil
 }
 
-// CurrentMasterPositionLocked is thread-safe
-func (fmd *FakeMysqlDaemon) CurrentMasterPositionLocked(pos mysql.Position) {
+// CurrentPrimaryPositionLocked is thread-safe
+func (fmd *FakeMysqlDaemon) CurrentPrimaryPositionLocked(pos mysql.Position) {
 	fmd.mu.Lock()
 	defer fmd.mu.Unlock()
-	fmd.CurrentMasterPosition = pos
+	fmd.CurrentPrimaryPosition = pos
 }
 
 // ReplicationStatus is part of the MysqlDaemon interface
@@ -265,7 +265,7 @@ func (fmd *FakeMysqlDaemon) ReplicationStatus() (mysql.ReplicationStatus, error)
 	fmd.mu.Lock()
 	defer fmd.mu.Unlock()
 	return mysql.ReplicationStatus{
-		Position:             fmd.CurrentMasterPosition,
+		Position:             fmd.CurrentPrimaryPosition,
 		FilePosition:         fmd.CurrentMasterFilePosition,
 		FileRelayLogPosition: fmd.CurrentMasterFilePosition,
 		SecondsBehindMaster:  fmd.SecondsBehindMaster,
@@ -278,13 +278,13 @@ func (fmd *FakeMysqlDaemon) ReplicationStatus() (mysql.ReplicationStatus, error)
 	}, nil
 }
 
-// MasterStatus is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) MasterStatus(ctx context.Context) (mysql.MasterStatus, error) {
-	if fmd.MasterStatusError != nil {
-		return mysql.MasterStatus{}, fmd.MasterStatusError
+// PrimaryStatus is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error) {
+	if fmd.PrimaryStatusError != nil {
+		return mysql.PrimaryStatus{}, fmd.PrimaryStatusError
 	}
-	return mysql.MasterStatus{
-		Position:     fmd.CurrentMasterPosition,
+	return mysql.PrimaryStatus{
+		Position:     fmd.CurrentPrimaryPosition,
 		FilePosition: fmd.CurrentMasterFilePosition,
 	}, nil
 }
@@ -296,9 +296,9 @@ func (fmd *FakeMysqlDaemon) ResetReplication(ctx context.Context) error {
 	})
 }
 
-// MasterPosition is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) MasterPosition() (mysql.Position, error) {
-	return fmd.CurrentMasterPosition, nil
+// PrimaryPosition is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) PrimaryPosition() (mysql.Position, error) {
+	return fmd.CurrentPrimaryPosition, nil
 }
 
 // IsReadOnly is part of the MysqlDaemon interface
@@ -373,14 +373,14 @@ func (fmd *FakeMysqlDaemon) SetReplicationPosition(ctx context.Context, pos mysq
 	})
 }
 
-// SetMaster is part of the MysqlDaemon interface.
-func (fmd *FakeMysqlDaemon) SetMaster(ctx context.Context, masterHost string, masterPort int, stopReplicationBefore bool, startReplicationAfter bool) error {
+// SetReplicationSource is part of the MysqlDaemon interface.
+func (fmd *FakeMysqlDaemon) SetReplicationSource(ctx context.Context, masterHost string, masterPort int, stopReplicationBefore bool, startReplicationAfter bool) error {
 	input := fmt.Sprintf("%v:%v", masterHost, masterPort)
-	if fmd.SetMasterInput != input {
-		return fmt.Errorf("wrong input for SetMasterCommands: expected %v got %v", fmd.SetMasterInput, input)
+	if fmd.SetReplicationSourceInput != input {
+		return fmt.Errorf("wrong input for SetReplicationSourceCommands: expected %v got %v", fmd.SetReplicationSourceInput, input)
 	}
-	if fmd.SetMasterError != nil {
-		return fmd.SetMasterError
+	if fmd.SetReplicationSourceError != nil {
+		return fmd.SetReplicationSourceError
 	}
 	cmds := []string{}
 	if stopReplicationBefore {
@@ -398,20 +398,20 @@ func (fmd *FakeMysqlDaemon) WaitForReparentJournal(ctx context.Context, timeCrea
 	return nil
 }
 
-// DemoteMaster is deprecated: use mysqld.MasterPosition() instead
+// DemoteMaster is deprecated: use mysqld.PrimaryPosition() instead
 func (fmd *FakeMysqlDaemon) DemoteMaster() (mysql.Position, error) {
-	return fmd.CurrentMasterPosition, nil
+	return fmd.CurrentPrimaryPosition, nil
 }
 
-// WaitMasterPos is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) WaitMasterPos(_ context.Context, pos mysql.Position) error {
+// WaitSourcePos is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) WaitSourcePos(_ context.Context, pos mysql.Position) error {
 	if fmd.TimeoutHook != nil {
 		return fmd.TimeoutHook()
 	}
-	if reflect.DeepEqual(fmd.WaitMasterPosition, pos) {
+	if reflect.DeepEqual(fmd.WaitPrimaryPosition, pos) {
 		return nil
 	}
-	return fmt.Errorf("wrong input for WaitMasterPos: expected %v got %v", fmd.WaitMasterPosition, pos)
+	return fmt.Errorf("wrong input for WaitSourcePos: expected %v got %v", fmd.WaitPrimaryPosition, pos)
 }
 
 // Promote is part of the MysqlDaemon interface

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -47,24 +47,24 @@ type MysqlDaemon interface {
 	StopReplication(hookExtraEnv map[string]string) error
 	StopIOThread(ctx context.Context) error
 	ReplicationStatus() (mysql.ReplicationStatus, error)
-	MasterStatus(ctx context.Context) (mysql.MasterStatus, error)
-	SetSemiSyncEnabled(master, replica bool) error
-	SemiSyncEnabled() (master, replica bool)
+	PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error)
+	SetSemiSyncEnabled(source, replica bool) error
+	SemiSyncEnabled() (source, replica bool)
 	SemiSyncReplicationStatus() (bool, error)
 
 	// reparenting related methods
 	ResetReplication(ctx context.Context) error
-	MasterPosition() (mysql.Position, error)
+	PrimaryPosition() (mysql.Position, error)
 	IsReadOnly() (bool, error)
 	SetReadOnly(on bool) error
 	SetSuperReadOnly(on bool) error
 	SetReplicationPosition(ctx context.Context, pos mysql.Position) error
-	SetMaster(ctx context.Context, masterHost string, masterPort int, stopReplicationBefore bool, startReplicationAfter bool) error
+	SetReplicationSource(ctx context.Context, host string, port int, stopReplicationBefore bool, startReplicationAfter bool) error
 	WaitForReparentJournal(ctx context.Context, timeCreatedNS int64) error
 
-	WaitMasterPos(context.Context, mysql.Position) error
+	WaitSourcePos(context.Context, mysql.Position) error
 
-	// Promote makes the current server master. It will not change
+	// Promote makes the current server the primary. It will not change
 	// the read_only state of the server.
 	Promote(map[string]string) (mysql.Position, error)
 

--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -116,5 +116,5 @@ func (mysqld *Mysqld) Promote(hookExtraEnv map[string]string) (mysql.Position, e
 	if err := mysqld.executeSuperQueryListConn(ctx, conn, cmds); err != nil {
 		return mysql.Position{}, err
 	}
-	return conn.MasterPosition()
+	return conn.PrimaryPosition()
 }

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -190,11 +190,6 @@ func (mysqld *Mysqld) SetReadOnly(on bool) error {
 	return mysqld.ExecuteSuperQuery(context.TODO(), query)
 }
 
-var (
-	// ErrNotMaster means there is no master status
-	ErrNotMaster = errors.New("no master status")
-)
-
 // SetSuperReadOnly set/unset the super_read_only flag
 func (mysqld *Mysqld) SetSuperReadOnly(on bool) error {
 	query := "SET GLOBAL super_read_only = "

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -206,8 +206,8 @@ func (mysqld *Mysqld) SetSuperReadOnly(on bool) error {
 	return mysqld.ExecuteSuperQuery(context.TODO(), query)
 }
 
-// WaitMasterPos lets replicas wait to given replication position
-func (mysqld *Mysqld) WaitMasterPos(ctx context.Context, targetPos mysql.Position) error {
+// WaitSourcePos lets replicas wait to given replication position
+func (mysqld *Mysqld) WaitSourcePos(ctx context.Context, targetPos mysql.Position) error {
 	// Get a connection.
 	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
@@ -223,9 +223,9 @@ func (mysqld *Mysqld) WaitMasterPos(ctx context.Context, targetPos mysql.Positio
 		// If we are the master, WaitUntilFilePositionCommand will fail.
 		// But position is most likely reached. So, check the position
 		// first.
-		mpos, err := conn.MasterFilePosition()
+		mpos, err := conn.PrimaryFilePosition()
 		if err != nil {
-			return fmt.Errorf("WaitMasterPos: MasterFilePosition failed: %v", err)
+			return fmt.Errorf("WaitSourcePos: PrimaryFilePosition failed: %v", err)
 		}
 		if mpos.AtLeast(targetPos) {
 			return nil
@@ -241,9 +241,9 @@ func (mysqld *Mysqld) WaitMasterPos(ctx context.Context, targetPos mysql.Positio
 		// If we are the master, WaitUntilPositionCommand will fail.
 		// But position is most likely reached. So, check the position
 		// first.
-		mpos, err := conn.MasterPosition()
+		mpos, err := conn.PrimaryPosition()
 		if err != nil {
-			return fmt.Errorf("WaitMasterPos: MasterPosition failed: %v", err)
+			return fmt.Errorf("WaitSourcePos: PrimaryPosition failed: %v", err)
 		}
 		if mpos.AtLeast(targetPos) {
 			return nil
@@ -285,26 +285,26 @@ func (mysqld *Mysqld) ReplicationStatus() (mysql.ReplicationStatus, error) {
 	return conn.ShowReplicationStatus()
 }
 
-// MasterStatus returns the master replication statuses
-func (mysqld *Mysqld) MasterStatus(ctx context.Context) (mysql.MasterStatus, error) {
+// PrimaryStatus returns the master replication statuses
+func (mysqld *Mysqld) PrimaryStatus(ctx context.Context) (mysql.PrimaryStatus, error) {
 	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
 	if err != nil {
-		return mysql.MasterStatus{}, err
+		return mysql.PrimaryStatus{}, err
 	}
 	defer conn.Recycle()
 
-	return conn.ShowMasterStatus()
+	return conn.ShowPrimaryStatus()
 }
 
-// MasterPosition returns the master replication position.
-func (mysqld *Mysqld) MasterPosition() (mysql.Position, error) {
+// PrimaryPosition returns the master replication position.
+func (mysqld *Mysqld) PrimaryPosition() (mysql.Position, error) {
 	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
 	if err != nil {
 		return mysql.Position{}, err
 	}
 	defer conn.Recycle()
 
-	return conn.MasterPosition()
+	return conn.PrimaryPosition()
 }
 
 // SetReplicationPosition sets the replication position at which the replica will resume
@@ -321,9 +321,9 @@ func (mysqld *Mysqld) SetReplicationPosition(ctx context.Context, pos mysql.Posi
 	return mysqld.executeSuperQueryListConn(ctx, conn, cmds)
 }
 
-// SetMaster makes the provided host / port the master. It optionally
+// SetReplicationSource makes the provided host / port the master. It optionally
 // stops replication before, and starts it after.
-func (mysqld *Mysqld) SetMaster(ctx context.Context, masterHost string, masterPort int, replicationStopBefore bool, replicationStartAfter bool) error {
+func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, masterHost string, masterPort int, replicationStopBefore bool, replicationStartAfter bool) error {
 	params, err := mysqld.dbcfgs.ReplConnector().MysqlParams()
 	if err != nil {
 		return err
@@ -338,7 +338,7 @@ func (mysqld *Mysqld) SetMaster(ctx context.Context, masterHost string, masterPo
 	if replicationStopBefore {
 		cmds = append(cmds, conn.StopReplicationCommand())
 	}
-	smc := conn.SetMasterCommand(params, masterHost, masterPort, int(masterConnectRetry.Seconds()))
+	smc := conn.SetReplicationSourceCommand(params, masterHost, masterPort, int(masterConnectRetry.Seconds()))
 	cmds = append(cmds, smc)
 	if replicationStartAfter {
 		cmds = append(cmds, conn.StartReplicationCommand())

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -139,7 +139,7 @@ func (be *XtrabackupEngine) ExecuteBackup(ctx context.Context, params BackupPara
 	if err != nil {
 		return false, vterrors.Wrap(err, "unable to obtain a connection to the database")
 	}
-	pos, err := conn.MasterPosition()
+	pos, err := conn.PrimaryPosition()
 	if err != nil {
 		return false, vterrors.Wrap(err, "unable to obtain master position")
 	}

--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -66,7 +66,7 @@ func TestInitShardPrimary(t *testing.T) {
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	tablet2.FakeMysqlDaemon.SetMasterInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
+	tablet2.FakeMysqlDaemon.SetReplicationSourceInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
 
 	tablet3.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE RESET ALL REPLICATION",
@@ -75,7 +75,7 @@ func TestInitShardPrimary(t *testing.T) {
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	tablet3.FakeMysqlDaemon.SetMasterInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
+	tablet3.FakeMysqlDaemon.SetReplicationSourceInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
 
 	for _, tablet := range []*testlib.FakeTablet{tablet1, tablet2, tablet3} {
 		tablet.StartActionLoop(t, wr)
@@ -122,7 +122,7 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	tablet2.FakeMysqlDaemon.SetMasterInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
+	tablet2.FakeMysqlDaemon.SetReplicationSourceInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
 
 	tablet3.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE RESET ALL REPLICATION",
@@ -130,7 +130,7 @@ func TestInitShardPrimaryNoFormerPrimary(t *testing.T) {
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	tablet3.FakeMysqlDaemon.SetMasterInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
+	tablet3.FakeMysqlDaemon.SetReplicationSourceInput = fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort)
 
 	for _, tablet := range []*testlib.FakeTablet{tablet1, tablet2, tablet3} {
 		tablet.StartActionLoop(t, wr)

--- a/go/vt/vtgate/endtoend/vstream_test.go
+++ b/go/vt/vtgate/endtoend/vstream_test.go
@@ -65,7 +65,7 @@ func TestVStream(t *testing.T) {
 	gconn, conn, mconn, closeConnections := initialize(ctx, t)
 	defer closeConnections()
 
-	mpos, err := mconn.MasterPosition()
+	mpos, err := mconn.PrimaryPosition()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/grpctmserver/server.go
+++ b/go/vt/vttablet/grpctmserver/server.go
@@ -260,7 +260,7 @@ func (s *server) ReplicationStatus(ctx context.Context, request *tabletmanagerda
 }
 
 func (s *server) MasterStatus(ctx context.Context, request *tabletmanagerdatapb.MasterStatusRequest) (response *tabletmanagerdatapb.MasterStatusResponse, err error) {
-	defer s.tm.HandleRPCPanic(ctx, "MasterStatus", request, response, false /*verbose*/, &err)
+	defer s.tm.HandleRPCPanic(ctx, "PrimaryStatus", request, response, false /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response = &tabletmanagerdatapb.MasterStatusResponse{}
 	status, err := s.tm.MasterStatus(ctx)
@@ -271,7 +271,7 @@ func (s *server) MasterStatus(ctx context.Context, request *tabletmanagerdatapb.
 }
 
 func (s *server) MasterPosition(ctx context.Context, request *tabletmanagerdatapb.MasterPositionRequest) (response *tabletmanagerdatapb.MasterPositionResponse, err error) {
-	defer s.tm.HandleRPCPanic(ctx, "MasterPosition", request, response, false /*verbose*/, &err)
+	defer s.tm.HandleRPCPanic(ctx, "PrimaryPosition", request, response, false /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response = &tabletmanagerdatapb.MasterPositionResponse{}
 	position, err := s.tm.MasterPosition(ctx)

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -336,7 +336,7 @@ func (tm *TabletManager) getGTIDFromTimestamp(ctx context.Context, pos mysql.Pos
 		return "", "", err
 	}
 	defer binlogConn.Close()
-	lastPos, err := binlogConn.MasterPosition()
+	lastPos, err := binlogConn.PrimaryPosition()
 	if err != nil {
 		return "", "", err
 	}
@@ -437,14 +437,14 @@ func (tm *TabletManager) catchupToGTID(ctx context.Context, afterGTIDPos string,
 		return vterrors.Wrap(err, fmt.Sprintf("failed to restart the replication until %s GTID", afterGTIDStr))
 	}
 	log.Infof("Waiting for position to reach", beforeGTIDPosParsed.GTIDSet.Last())
-	// Could not use `agent.MysqlDaemon.WaitMasterPos` as replication is stopped with `START SLAVE UNTIL SQL_BEFORE_GTIDS`
+	// Could not use `agent.MysqlDaemon.WaitSourcePos` as replication is stopped with `START SLAVE UNTIL SQL_BEFORE_GTIDS`
 	// this is as per https://dev.mysql.com/doc/refman/5.6/en/start-slave.html
 	// We need to wait until replication catches upto the specified afterGTIDPos
 	chGTIDCaughtup := make(chan bool)
 	go func() {
 		timeToWait := time.Now().Add(*timeoutForGTIDLookup)
 		for time.Now().Before(timeToWait) {
-			pos, err := tm.MysqlDaemon.MasterPosition()
+			pos, err := tm.MysqlDaemon.PrimaryPosition()
 			if err != nil {
 				chGTIDCaughtup <- false
 			}
@@ -526,8 +526,8 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 	}
 
 	// Set master and start replication.
-	if err := tm.MysqlDaemon.SetMaster(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), false /* stopReplicationBefore */, !*mysqlctl.DisableActiveReparents /* startReplicationAfter */); err != nil {
-		return vterrors.Wrap(err, "MysqlDaemon.SetMaster failed")
+	if err := tm.MysqlDaemon.SetReplicationSource(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), false /* stopReplicationBefore */, !*mysqlctl.DisableActiveReparents /* startReplicationAfter */); err != nil {
+		return vterrors.Wrap(err, "MysqlDaemon.SetReplicationSource failed")
 	}
 
 	// If active reparents are disabled, we don't restart replication. So it makes no sense to wait for an update on the replica.
@@ -537,7 +537,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 	}
 	// wait for reliable seconds behind master
 	// we have pos where we want to resume from
-	// if MasterPosition is the same, that means no writes
+	// if PrimaryPosition is the same, that means no writes
 	// have happened to master, so we are up-to-date
 	// otherwise, wait for replica's Position to change from
 	// the initial pos before proceeding

--- a/go/vt/vttablet/tabletmanager/rpc_agent.go
+++ b/go/vt/vttablet/tabletmanager/rpc_agent.go
@@ -79,7 +79,10 @@ type RPCTM interface {
 	ExecuteFetchAsApp(ctx context.Context, query []byte, maxrows int) (*querypb.QueryResult, error)
 
 	// Replication related methods
+	// Deprecated, use PrimaryStatus instead
 	MasterStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error)
+
+	PrimaryStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error)
 
 	ReplicationStatus(ctx context.Context) (*replicationdatapb.Status, error)
 
@@ -92,8 +95,10 @@ type RPCTM interface {
 	StartReplicationUntilAfter(ctx context.Context, position string, waitTime time.Duration) error
 
 	GetReplicas(ctx context.Context) ([]string, error)
-
+	// Deprecated, use PrimaryPosition instead
 	MasterPosition(ctx context.Context) (string, error)
+
+	PrimaryPosition(ctx context.Context) (string, error)
 
 	WaitForPosition(ctx context.Context, pos string) error
 
@@ -108,19 +113,31 @@ type RPCTM interface {
 
 	ResetReplication(ctx context.Context) error
 
+	// Deprecated, use InitPrimary instead
 	InitMaster(ctx context.Context) (string, error)
+
+	InitPrimary(ctx context.Context) (string, error)
 
 	PopulateReparentJournal(ctx context.Context, timeCreatedNS int64, actionName string, masterAlias *topodatapb.TabletAlias, pos string) error
 
 	InitReplica(ctx context.Context, parent *topodatapb.TabletAlias, replicationPosition string, timeCreatedNS int64) error
 
+	// Deprecated, use DemotePrimary instead
 	DemoteMaster(ctx context.Context) (*replicationdatapb.MasterStatus, error)
 
+	// Deprecated, use UndoDemotePrimary instead
 	UndoDemoteMaster(ctx context.Context) error
+
+	DemotePrimary(ctx context.Context) (*replicationdatapb.MasterStatus, error)
+
+	UndoDemotePrimary(ctx context.Context) error
 
 	ReplicaWasPromoted(ctx context.Context) error
 
+	// Deprecated, use SetReplicationSource instead
 	SetMaster(ctx context.Context, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error
+
+	SetReplicationSource(ctx context.Context, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error
 
 	StopReplicationAndGetStatus(ctx context.Context, stopReplicationMode replicationdatapb.StopReplicationMode) (StopReplicationAndGetStatusResponse, error)
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -53,29 +53,39 @@ func (tm *TabletManager) ReplicationStatus(ctx context.Context) (*replicationdat
 
 // MasterStatus returns the replication status fopr a master tablet.
 func (tm *TabletManager) MasterStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
-	status, err := tm.MysqlDaemon.MasterStatus(ctx)
+	return tm.PrimaryStatus(ctx)
+}
+
+// PrimaryStatus returns the replication status fopr a master tablet.
+func (tm *TabletManager) PrimaryStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
+	status, err := tm.MysqlDaemon.PrimaryStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return mysql.MasterStatusToProto(status), nil
+	return mysql.PrimaryStatusToProto(status), nil
 }
 
 // MasterPosition returns the master position
 func (tm *TabletManager) MasterPosition(ctx context.Context) (string, error) {
-	pos, err := tm.MysqlDaemon.MasterPosition()
+	return tm.PrimaryPosition(ctx)
+}
+
+// PrimaryPosition returns the position of a primary database
+func (tm *TabletManager) PrimaryPosition(ctx context.Context) (string, error) {
+	pos, err := tm.MysqlDaemon.PrimaryPosition()
 	if err != nil {
 		return "", err
 	}
 	return mysql.EncodePosition(pos), nil
 }
 
-// WaitForPosition returns the master position
+// WaitForPosition waits until replication reaches the desired position
 func (tm *TabletManager) WaitForPosition(ctx context.Context, pos string) error {
 	mpos, err := mysql.DecodePosition(pos)
 	if err != nil {
 		return err
 	}
-	return tm.MysqlDaemon.WaitMasterPos(ctx, mpos)
+	return tm.MysqlDaemon.WaitSourcePos(ctx, mpos)
 }
 
 // StopReplication will stop the mysql. Works both when Vitess manages
@@ -144,13 +154,13 @@ func (tm *TabletManager) StopReplicationMinimum(ctx context.Context, position st
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, waitTime)
 	defer cancel()
-	if err := tm.MysqlDaemon.WaitMasterPos(waitCtx, pos); err != nil {
+	if err := tm.MysqlDaemon.WaitSourcePos(waitCtx, pos); err != nil {
 		return "", err
 	}
 	if err := tm.stopReplicationLocked(ctx); err != nil {
 		return "", err
 	}
-	pos, err = tm.MysqlDaemon.MasterPosition()
+	pos, err = tm.MysqlDaemon.PrimaryPosition()
 	if err != nil {
 		return "", err
 	}
@@ -222,12 +232,17 @@ func (tm *TabletManager) ResetReplication(ctx context.Context) error {
 
 // InitMaster enables writes and returns the replication position.
 func (tm *TabletManager) InitMaster(ctx context.Context) (string, error) {
+	return tm.InitPrimary(ctx)
+}
+
+// InitPrimary enables writes and returns the replication position.
+func (tm *TabletManager) InitPrimary(ctx context.Context) (string, error) {
 	if err := tm.lock(ctx); err != nil {
 		return "", err
 	}
 	defer tm.unlock()
 
-	// Initializing as master implies undoing any previous "do not replicate".
+	// Initializing as primary implies undoing any previous "do not replicate".
 	tm.replManager.setReplicationStopped(false)
 
 	// we need to insert something in the binlogs, so we can get the
@@ -238,7 +253,7 @@ func (tm *TabletManager) InitMaster(ctx context.Context) (string, error) {
 	}
 
 	// get the current replication position
-	pos, err := tm.MysqlDaemon.MasterPosition()
+	pos, err := tm.MysqlDaemon.PrimaryPosition()
 	if err != nil {
 		return "", err
 	}
@@ -250,8 +265,8 @@ func (tm *TabletManager) InitMaster(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// Enforce semi-sync after changing the type to master. Otherwise, the
-	// master will hang while trying to create the database.
+	// Enforce semi-sync after changing the tablet)type to MASTER. Otherwise, the
+	// primary will hang while trying to create the database.
 	if err := tm.fixSemiSync(topodatapb.TabletType_MASTER); err != nil {
 		return "", err
 	}
@@ -313,7 +328,7 @@ func (tm *TabletManager) InitReplica(ctx context.Context, parent *topodatapb.Tab
 	if err := tm.MysqlDaemon.SetReplicationPosition(ctx, pos); err != nil {
 		return err
 	}
-	if err := tm.MysqlDaemon.SetMaster(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), false /* stopReplicationBefore */, true /* stopReplicationAfter */); err != nil {
+	if err := tm.MysqlDaemon.SetReplicationSource(ctx, ti.Tablet.MysqlHostname, int(ti.Tablet.MysqlPort), false /* stopReplicationBefore */, true /* stopReplicationAfter */); err != nil {
 		return err
 	}
 
@@ -321,7 +336,7 @@ func (tm *TabletManager) InitReplica(ctx context.Context, parent *topodatapb.Tab
 	return tm.MysqlDaemon.WaitForReparentJournal(ctx, timeCreatedNS)
 }
 
-// DemoteMaster prepares a MASTER tablet to give up mastership to another tablet.
+// DemotePrimary prepares a MASTER tablet to give up leadership to another tablet.
 //
 // It attemps to idempotently ensure the following guarantees upon returning
 // successfully:
@@ -336,16 +351,21 @@ func (tm *TabletManager) InitReplica(ctx context.Context, parent *topodatapb.Tab
 // or on a tablet that already transitioned to REPLICA.
 //
 // If a step fails in the middle, it will try to undo any changes it made.
-func (tm *TabletManager) DemoteMaster(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
+func (tm *TabletManager) DemotePrimary(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
 	// The public version always reverts on partial failure.
-	return tm.demoteMaster(ctx, true /* revertPartialFailure */)
+	return tm.demotePrimary(ctx, true /* revertPartialFailure */)
 }
 
-// demoteMaster implements DemoteMaster with an additional, private option.
+// DemoteMaster is the old version of DemotePrimary
+func (tm *TabletManager) DemoteMaster(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
+	return tm.DemotePrimary(ctx)
+}
+
+// demotePrimary implements DemotePrimary with an additional, private option.
 //
 // If revertPartialFailure is true, and a step fails in the middle, it will try
 // to undo any changes it made.
-func (tm *TabletManager) demoteMaster(ctx context.Context, revertPartialFailure bool) (masterStatus *replicationdatapb.MasterStatus, finalErr error) {
+func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure bool) (masterStatus *replicationdatapb.MasterStatus, finalErr error) {
 	if err := tm.lock(ctx); err != nil {
 		return nil, err
 	}
@@ -371,7 +391,7 @@ func (tm *TabletManager) demoteMaster(ctx context.Context, revertPartialFailure 
 			if tm.orc == nil {
 				return
 			}
-			if err := tm.orc.BeginMaintenance(tm.Tablet(), "vttablet has been told to DemoteMaster"); err != nil {
+			if err := tm.orc.BeginMaintenance(tm.Tablet(), "vttablet has been told to DemotePrimary"); err != nil {
 				log.Warningf("Orchestrator BeginMaintenance failed: %v", err)
 			}
 		}()
@@ -381,7 +401,7 @@ func (tm *TabletManager) demoteMaster(ctx context.Context, revertPartialFailure 
 		// have to be killed at the end of their timeout, this will be
 		// considered successful. If we are already not serving, this will be
 		// idempotent.
-		log.Infof("DemoteMaster disabling query service")
+		log.Infof("DemotePrimary disabling query service")
 		if err := tm.QueryServiceControl.SetServingType(tablet.Type, logutil.ProtoToTime(tablet.MasterTermStartTime), false, "demotion in progress"); err != nil {
 			return nil, vterrors.Wrap(err, "SetServingType(serving=false) failed")
 		}
@@ -431,24 +451,29 @@ func (tm *TabletManager) demoteMaster(ctx context.Context, revertPartialFailure 
 	}()
 
 	// Return the current replication position.
-	status, err := tm.MysqlDaemon.MasterStatus(ctx)
+	status, err := tm.MysqlDaemon.PrimaryStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
-	masterStatusProto := mysql.MasterStatusToProto(status)
+	masterStatusProto := mysql.PrimaryStatusToProto(status)
 	return masterStatusProto, nil
 }
 
-// UndoDemoteMaster reverts a previous call to DemoteMaster
+// UndoDemoteMaster is the old version of UndoDemotePrimary
+func (tm *TabletManager) UndoDemoteMaster(ctx context.Context) error {
+	return tm.UndoDemotePrimary(ctx)
+}
+
+// UndoDemotePrimary reverts a previous call to DemotePrimary
 // it sets read-only to false, fixes semi-sync
 // and returns its master position.
-func (tm *TabletManager) UndoDemoteMaster(ctx context.Context) error {
+func (tm *TabletManager) UndoDemotePrimary(ctx context.Context) error {
 	if err := tm.lock(ctx); err != nil {
 		return err
 	}
 	defer tm.unlock()
 
-	// If using semi-sync, we need to enable master-side.
+	// If using semi-sync, we need to enable source-side.
 	if err := tm.fixSemiSync(topodatapb.TabletType_MASTER); err != nil {
 		return err
 	}
@@ -460,7 +485,7 @@ func (tm *TabletManager) UndoDemoteMaster(ctx context.Context) error {
 
 	// Update serving graph
 	tablet := tm.Tablet()
-	log.Infof("UndoDemoteMaster re-enabling query service")
+	log.Infof("UndoDemotePrimary re-enabling query service")
 	if err := tm.QueryServiceControl.SetServingType(tablet.Type, logutil.ProtoToTime(tablet.MasterTermStartTime), true, ""); err != nil {
 		return vterrors.Wrap(err, "SetServingType(serving=true) failed")
 	}
@@ -482,18 +507,23 @@ func (tm *TabletManager) ReplicaWasPromoted(ctx context.Context) error {
 	return tm.ChangeType(ctx, topodatapb.TabletType_MASTER)
 }
 
-// SetMaster sets replication master, and waits for the
+// SetReplicationSource sets replication master, and waits for the
 // reparent_journal table entry up to context timeout
-func (tm *TabletManager) SetMaster(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
+func (tm *TabletManager) SetReplicationSource(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
 	if err := tm.lock(ctx); err != nil {
 		return err
 	}
 	defer tm.unlock()
 
-	return tm.setMasterLocked(ctx, parentAlias, timeCreatedNS, waitPosition, forceStartReplication)
+	return tm.setReplicationSourceLocked(ctx, parentAlias, timeCreatedNS, waitPosition, forceStartReplication)
 }
 
-func (tm *TabletManager) setMasterRepairReplication(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) (err error) {
+// SetMaster is the old version of SetReplicationSource
+func (tm *TabletManager) SetMaster(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
+	return tm.SetReplicationSource(ctx, parentAlias, timeCreatedNS, waitPosition, forceStartReplication)
+}
+
+func (tm *TabletManager) setReplicationSourceRepairReplication(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) (err error) {
 	parent, err := tm.TopoServer.GetTablet(ctx, parentAlias)
 	if err != nil {
 		return err
@@ -506,10 +536,10 @@ func (tm *TabletManager) setMasterRepairReplication(ctx context.Context, parentA
 
 	defer unlock(&err)
 
-	return tm.setMasterLocked(ctx, parentAlias, timeCreatedNS, waitPosition, forceStartReplication)
+	return tm.setReplicationSourceLocked(ctx, parentAlias, timeCreatedNS, waitPosition, forceStartReplication)
 }
 
-func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) (err error) {
+func (tm *TabletManager) setReplicationSourceLocked(ctx context.Context, parentAlias *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) (err error) {
 	// End orchestrator maintenance at the end of fixing replication.
 	// This is a best effort operation, so it should happen in a goroutine
 	defer func() {
@@ -524,7 +554,7 @@ func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topod
 	}()
 
 	// Change our type to REPLICA if we used to be MASTER.
-	// Being sent SetMaster means another MASTER has been successfully promoted,
+	// Being sent SetReplicationSource means another MASTER has been successfully promoted,
 	// so we convert to REPLICA first, since we want to do it even if other
 	// steps fail below.
 	// Note it is important to check for MASTER here so that we don't
@@ -561,7 +591,7 @@ func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topod
 		shouldbeReplicating = true
 	}
 
-	// If using semi-sync, we need to enable it before connecting to master.
+	// If using semi-sync, we need to enable it before connecting to primary.
 	// If we are currently MASTER, assume we are about to become REPLICA.
 	tabletType := tm.Tablet().Type
 	if tabletType == topodatapb.TabletType_MASTER {
@@ -570,7 +600,7 @@ func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topod
 	if err := tm.fixSemiSync(tabletType); err != nil {
 		return err
 	}
-	// Update the master address only if needed.
+	// Update the primary/source address only if needed.
 	// We don't want to interrupt replication for no reason.
 	if parentAlias == nil {
 		// if there is no master in the shard, return an error so that we can retry
@@ -584,7 +614,7 @@ func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topod
 	masterPort := int(parent.Tablet.MysqlPort)
 	if status.MasterHost != masterHost || status.MasterPort != masterPort {
 		// This handles both changing the address and starting replication.
-		if err := tm.MysqlDaemon.SetMaster(ctx, masterHost, masterPort, wasReplicating, shouldbeReplicating); err != nil {
+		if err := tm.MysqlDaemon.SetReplicationSource(ctx, masterHost, masterPort, wasReplicating, shouldbeReplicating); err != nil {
 			if err := tm.handleRelayLogError(err); err != nil {
 				return err
 			}
@@ -610,7 +640,7 @@ func (tm *TabletManager) setMasterLocked(ctx context.Context, parentAlias *topod
 			if err != nil {
 				return err
 			}
-			if err := tm.MysqlDaemon.WaitMasterPos(ctx, pos); err != nil {
+			if err := tm.MysqlDaemon.WaitSourcePos(ctx, pos); err != nil {
 				return err
 			}
 		}
@@ -884,5 +914,5 @@ func (tm *TabletManager) repairReplication(ctx context.Context) error {
 		}
 	}
 
-	return tm.setMasterRepairReplication(ctx, si.MasterAlias, 0, "", true)
+	return tm.setReplicationSourceRepairReplication(ctx, si.MasterAlias, 0, "", true)
 }

--- a/go/vt/vttablet/tabletmanager/rpc_schema.go
+++ b/go/vt/vttablet/tabletmanager/rpc_schema.go
@@ -49,7 +49,7 @@ func (tm *TabletManager) ReloadSchema(ctx context.Context, waitPosition string) 
 			return vterrors.Wrapf(err, "ReloadSchema: can't parse wait position (%q)", waitPosition)
 		}
 		log.Infof("ReloadSchema: waiting for replication position: %v", waitPosition)
-		if err := tm.MysqlDaemon.WaitMasterPos(ctx, pos); err != nil {
+		if err := tm.MysqlDaemon.WaitSourcePos(ctx, pos); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -219,7 +219,7 @@ func (tm *TabletManager) abortMasterTerm(ctx context.Context, masterAlias *topod
 	log.Infof("Active reparents are enabled; converting MySQL to replica.")
 	demoteMasterCtx, cancelDemoteMaster := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer cancelDemoteMaster()
-	if _, err := tm.demoteMaster(demoteMasterCtx, false /* revertPartialFailure */); err != nil {
+	if _, err := tm.demotePrimary(demoteMasterCtx, false /* revertPartialFailure */); err != nil {
 		return vterrors.Wrap(err, "failed to demote master")
 	}
 	setMasterCtx, cancelSetMaster := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -151,7 +151,7 @@ func resetBinlogClient() {
 
 func masterPosition(t *testing.T) string {
 	t.Helper()
-	pos, err := env.Mysqld.MasterPosition()
+	pos, err := env.Mysqld.PrimaryPosition()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -178,7 +178,7 @@ func (tr *Tracker) currentPosition(ctx context.Context) (mysql.Position, error) 
 		return mysql.Position{}, err
 	}
 	defer conn.Close()
-	return conn.MasterPosition()
+	return conn.PrimaryPosition()
 }
 
 func (tr *Tracker) isSchemaVersionTableEmpty(ctx context.Context) (bool, error) {

--- a/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/snapshot_conn.go
@@ -81,7 +81,7 @@ func (conn *snapshotConn) startSnapshot(ctx context.Context, table string) (gtid
 		log.Infof("Error locking table %s to read", tableIdent)
 		return "", err
 	}
-	mpos, err := lockConn.MasterPosition()
+	mpos, err := lockConn.PrimaryPosition()
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -100,7 +100,7 @@ func Init() (*Env, error) {
 	config.DB = te.Dbcfgs
 	te.TabletEnv = tabletenv.NewEnv(config, "VStreamerTest")
 	te.Mysqld = mysqlctl.NewMysqld(te.Dbcfgs)
-	pos, _ := te.Mysqld.MasterPosition()
+	pos, _ := te.Mysqld.PrimaryPosition()
 	te.Flavor = pos.GTIDSet.Flavor()
 
 	te.SchemaEngine = schema.NewEngine(te.TabletEnv)

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go
@@ -338,7 +338,7 @@ func (uvs *uvstreamer) currentPosition() (mysql.Position, error) {
 		return mysql.Position{}, err
 	}
 	defer conn.Close()
-	return conn.MasterPosition()
+	return conn.PrimaryPosition()
 }
 
 func (uvs *uvstreamer) init() error {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -2101,7 +2101,7 @@ func masterPosition(t *testing.T) string {
 		t.Fatal(err)
 	}
 	defer conn.Close()
-	pos, err := conn.MasterPosition()
+	pos, err := conn.PrimaryPosition()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -716,6 +716,14 @@ var testReplicationStatus = &replicationdatapb.Status{
 
 var testMasterStatus = &replicationdatapb.MasterStatus{Position: "MariaDB/1-345-789"}
 
+func (fra *fakeRPCTM) PrimaryStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	return testMasterStatus, nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) MasterStatus(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -742,6 +750,14 @@ func tmRPCTestReplicationStatusPanic(ctx context.Context, t *testing.T, client t
 
 var testReplicationPosition = "MariaDB/5-456-890"
 
+func (fra *fakeRPCTM) PrimaryPosition(ctx context.Context) (string, error) {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	return testReplicationPosition, nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) MasterPosition(ctx context.Context) (string, error) {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -755,12 +771,12 @@ func (fra *fakeRPCTM) WaitForPosition(ctx context.Context, pos string) error {
 
 func tmRPCTestMasterPosition(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.Tablet) {
 	rs, err := client.MasterPosition(ctx, tablet)
-	compareError(t, "MasterPosition", err, rs, testReplicationPosition)
+	compareError(t, "PrimaryPosition", err, rs, testReplicationPosition)
 }
 
 func tmRPCTestMasterPositionPanic(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.Tablet) {
 	_, err := client.MasterPosition(ctx, tablet)
-	expectHandleRPCPanic(t, "MasterPosition", false /*verbose*/, err)
+	expectHandleRPCPanic(t, "PrimaryPosition", false /*verbose*/, err)
 }
 
 var testStopReplicationCalled = false
@@ -934,6 +950,14 @@ func tmRPCTestResetReplicationPanic(ctx context.Context, t *testing.T, client tm
 	expectHandleRPCPanic(t, "ResetReplication", true /*verbose*/, err)
 }
 
+func (fra *fakeRPCTM) InitPrimary(ctx context.Context) (string, error) {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	return testReplicationPosition, nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) InitMaster(ctx context.Context) (string, error) {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -1005,6 +1029,14 @@ func tmRPCTestInitReplicaPanic(ctx context.Context, t *testing.T, client tmclien
 	expectHandleRPCPanic(t, "InitReplica", true /*verbose*/, err)
 }
 
+func (fra *fakeRPCTM) DemotePrimary(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	return testMasterStatus, nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) DemoteMaster(ctx context.Context) (*replicationdatapb.MasterStatus, error) {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -1024,6 +1056,14 @@ func tmRPCTestDemoteMasterPanic(ctx context.Context, t *testing.T, client tmclie
 
 var testUndoDemoteMasterCalled = false
 
+func (fra *fakeRPCTM) UndoDemotePrimary(ctx context.Context) error {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	return nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) UndoDemoteMaster(ctx context.Context) error {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -1067,6 +1107,19 @@ func tmRPCTestReplicaWasPromotedPanic(ctx context.Context, t *testing.T, client 
 var testSetMasterCalled = false
 var testForceStartReplica = true
 
+func (fra *fakeRPCTM) SetReplicationSource(ctx context.Context, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplica bool) error {
+	if fra.panics {
+		panic(fmt.Errorf("test-triggered panic"))
+	}
+	compare(fra.t, "SetMaster parent", parent, testMasterAlias)
+	compare(fra.t, "SetMaster timeCreatedNS", timeCreatedNS, testTimeCreatedNS)
+	compare(fra.t, "SetMaster waitPosition", waitPosition, testWaitPosition)
+	compare(fra.t, "SetMaster forceStartReplica", forceStartReplica, testForceStartReplica)
+	testSetMasterCalled = true
+	return nil
+}
+
+// Deprecated
 func (fra *fakeRPCTM) SetMaster(ctx context.Context, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplica bool) error {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))

--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -171,7 +171,7 @@ func (tc *legacySplitCloneTestCase) setUp(v3 bool) {
 				},
 			},
 		}
-		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+		sourceRdonly.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/worker/split_clone_flaky_test.go
+++ b/go/vt/worker/split_clone_flaky_test.go
@@ -215,7 +215,7 @@ func (tc *splitCloneTestCase) setUpWithConcurrency(v3 bool, concurrency, writeQu
 				},
 			},
 		}
-		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+		sourceRdonly.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 		}
 		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -139,7 +139,7 @@ func TestVerticalSplitClone(t *testing.T) {
 			},
 		},
 	}
-	sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	sourceRdonly.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{12: mysql.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678}},
 	}
 	sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -89,7 +89,7 @@ func TestTabletExternallyReparentedBasic(t *testing.T) {
 		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
 	}
 
-	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
@@ -168,7 +168,7 @@ func TestTabletExternallyReparentedToReplica(t *testing.T) {
 
 	// Second test: reparent to a replica, and pretend the old
 	// master is still good to go.
-	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
@@ -246,7 +246,7 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	newMaster.StartActionLoop(t, wr)
 	defer newMaster.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
@@ -327,7 +327,7 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 	newMaster.StartActionLoop(t, wr)
 	defer newMaster.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
@@ -404,7 +404,7 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 	newMaster.StartActionLoop(t, wr)
 	defer newMaster.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
@@ -414,7 +414,7 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 	oldMaster.StartActionLoop(t, wr)
 	defer oldMaster.StopActionLoop(t)
 
-	goodReplica.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
 	// On the good replica, we will respond to
 	// TabletActionReplicaWasRestarted.
 	goodReplica.StartActionLoop(t, wr)

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -89,7 +89,7 @@ func TestMigrateServedFrom(t *testing.T) {
 
 	// sourceMaster will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	sourceMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -130,7 +130,7 @@ func TestMigrateServedTypes(t *testing.T) {
 
 	// sourceMaster will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	sourceMaster.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	sourceMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -339,7 +339,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 
 	// source1Master will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	source1Master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	source1Master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -385,7 +385,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 
 	// sourceMaster will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	source2Master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	source2Master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -62,7 +62,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	}
 
 	// master action loop (to initialize host and port)
-	master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -75,7 +75,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 	defer master.StopActionLoop(t)
 
 	// replica loop
-	replica.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+	replica.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -147,7 +147,7 @@ func TestReparentTablet(t *testing.T) {
 	// which ends up making this test unpredictable.
 	replica.FakeMysqlDaemon.Replicating = true
 	replica.FakeMysqlDaemon.IOThreadRunning = true
-	replica.FakeMysqlDaemon.SetMasterInput = topoproto.MysqlAddr(master.Tablet)
+	replica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
 	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",

--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -404,7 +404,7 @@ func (tme *testMigraterEnv) createDBClients(ctx context.Context, t *testing.T) {
 
 func (tme *testMigraterEnv) setMasterPositions() {
 	for _, master := range tme.sourceMasters {
-		master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+		master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{
 				5: mysql.MariadbGTID{
 					Domain:   5,
@@ -415,7 +415,7 @@ func (tme *testMigraterEnv) setMasterPositions() {
 		}
 	}
 	for _, master := range tme.targetMasters {
-		master.FakeMysqlDaemon.CurrentMasterPosition = mysql.Position{
+		master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 			GTIDSet: mysql.MariadbGTIDSet{
 				5: mysql.MariadbGTID{
 					Domain:   5,


### PR DESCRIPTION
## Description
Rename funcs on mysqld, add new funcs on tabletmanager and deprecate old funcs.
These changes are purely internal right now, the new RPCs have not yet been exposed. That will be a separate PR.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#7114

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->