### PR TITLE
gen4: plan more opcodes

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1794,8 +1794,8 @@ type (
 
 	// IsExpr represents an IS ... or an IS NOT ... expression.
 	IsExpr struct {
-		Operator IsExprOperator
-		Expr     Expr
+		Left  Expr
+		Right IsExprOperator
 	}
 
 	// IsExprOperator is an enum for IsExpr.Operator

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -972,7 +972,7 @@ func CloneRefOfIsExpr(n *IsExpr) *IsExpr {
 		return nil
 	}
 	out := *n
-	out.Expr = CloneExpr(n.Expr)
+	out.Left = CloneExpr(n.Left)
 	return &out
 }
 

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -1709,8 +1709,8 @@ func EqualsRefOfIsExpr(a, b *IsExpr) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return a.Operator == b.Operator &&
-		EqualsExpr(a.Expr, b.Expr)
+	return EqualsExpr(a.Left, b.Left) &&
+		a.Right == b.Right
 }
 
 // EqualsJoinCondition does deep equals between the two objects.

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -960,7 +960,7 @@ func (node *RangeCond) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *IsExpr) Format(buf *TrackedBuffer) {
-	buf.astPrintf(node, "%v %s", node.Expr, node.Operator.ToString())
+	buf.astPrintf(node, "%v %s", node.Left, node.Right.ToString())
 }
 
 // Format formats the node.

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1300,9 +1300,9 @@ func (node *RangeCond) formatFast(buf *TrackedBuffer) {
 
 // formatFast formats the node.
 func (node *IsExpr) formatFast(buf *TrackedBuffer) {
-	buf.printExpr(node, node.Expr, true)
+	buf.printExpr(node, node.Left, true)
 	buf.WriteByte(' ')
-	buf.WriteString(node.Operator.ToString())
+	buf.WriteString(node.Right.ToString())
 }
 
 // formatFast formats the node.

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -2248,8 +2248,8 @@ func (a *application) rewriteRefOfIsExpr(parent SQLNode, node *IsExpr, replacer 
 			return true
 		}
 	}
-	if !a.rewriteExpr(node, node.Expr, func(newNode, parent SQLNode) {
-		parent.(*IsExpr).Expr = newNode.(Expr)
+	if !a.rewriteExpr(node, node.Left, func(newNode, parent SQLNode) {
+		parent.(*IsExpr).Left = newNode.(Expr)
 	}) {
 		return false
 	}

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -1206,7 +1206,7 @@ func VisitRefOfIsExpr(in *IsExpr, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	if err := VisitExpr(in.Expr, f); err != nil {
+	if err := VisitExpr(in.Left, f); err != nil {
 		return err
 	}
 	return nil

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -1176,10 +1176,10 @@ func (cached *IsExpr) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(24)
+		size += int64(17)
 	}
-	// field Expr vitess.io/vitess/go/vt/sqlparser.Expr
-	if cc, ok := cached.Expr.(cachedObject); ok {
+	// field Left vitess.io/vitess/go/vt/sqlparser.Expr
+	if cc, ok := cached.Left.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
 	return size

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -35,7 +35,7 @@ func readable(node Expr) string {
 	case *BinaryExpr:
 		return fmt.Sprintf("(%s %s %s)", readable(node.Left), node.Operator.ToString(), readable(node.Right))
 	case *IsExpr:
-		return fmt.Sprintf("(%s %s)", readable(node.Expr), node.Operator.ToString())
+		return fmt.Sprintf("(%s %s)", readable(node.Left), node.Right.ToString())
 	default:
 		return String(node)
 	}

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -314,7 +314,7 @@ func (g *generator) isExpr() Expr {
 	ops := []IsExprOperator{IsNullOp, IsNotNullOp, IsTrueOp, IsNotTrueOp, IsFalseOp, IsNotFalseOp}
 
 	return &IsExpr{
-		Operator: ops[g.r.Intn(len(ops))],
-		Expr:     g.booleanExpr(),
+		Right: ops[g.r.Intn(len(ops))],
+		Left:  g.booleanExpr(),
 	}
 }

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -10778,7 +10778,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:3515
 		{
-			yyLOCAL = &IsExpr{Right: yyDollar[3].isExprOperatorUnion(), Left: yyDollar[1].exprUnion()}
+			yyLOCAL = &IsExpr{Left: yyDollar[1].exprUnion(), Right: yyDollar[3].isExprOperatorUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 680:

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -10778,7 +10778,7 @@ yydefault:
 		var yyLOCAL Expr
 //line sql.y:3515
 		{
-			yyLOCAL = &IsExpr{Operator: yyDollar[3].isExprOperatorUnion(), Expr: yyDollar[1].exprUnion()}
+			yyLOCAL = &IsExpr{Right: yyDollar[3].isExprOperatorUnion(), Left: yyDollar[1].exprUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 680:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -3513,7 +3513,7 @@ expression:
   }
 | expression IS is_suffix
   {
-    $$ = &IsExpr{Operator: $3, Expr: $1}
+    $$ = &IsExpr{Left: $1, Right: $3}
   }
 | value_expression
   {

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -668,11 +668,11 @@ func (rb *route) computeEqualPlan(pb *primitiveBuilder, comparison *sqlparser.Co
 // computeIS computes the plan for an equality constraint.
 func (rb *route) computeISPlan(pb *primitiveBuilder, comparison *sqlparser.IsExpr) (opcode engine.RouteOpcode, vindex vindexes.SingleColumn, expr sqlparser.Expr) {
 	// we only handle IS NULL correct. IsExpr can contain other expressions as well
-	if comparison.Operator != sqlparser.IsNullOp {
+	if comparison.Right != sqlparser.IsNullOp {
 		return engine.SelectScatter, nil, nil
 	}
 
-	vindex = pb.st.Vindex(comparison.Expr, rb)
+	vindex = pb.st.Vindex(comparison.Left, rb)
 	// fallback to scatter gather if there is no vindex
 	if vindex == nil {
 		return engine.SelectScatter, nil, nil

--- a/go/vt/vtgate/planbuilder/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/route_planning_test.go
@@ -108,9 +108,7 @@ func TestMergeJoins(t *testing.T) {
 func TestClone(t *testing.T) {
 	original := &routePlan{
 		routeOpCode: engine.SelectEqualUnique,
-		vindexPreds: []*vindexPlusPredicates{{
-			covered: false,
-		}},
+		vindexPreds: []*vindexPlusPredicates{{}},
 	}
 
 	clone := original.clone()
@@ -120,7 +118,7 @@ func TestClone(t *testing.T) {
 	assert.Equal(t, clonedRP.routeOpCode, engine.SelectDBA)
 	assert.Equal(t, original.routeOpCode, engine.SelectEqualUnique)
 
-	clonedRP.vindexPreds[0].covered = true
-	assert.True(t, clonedRP.vindexPreds[0].covered)
-	assert.False(t, original.vindexPreds[0].covered)
+	clonedRP.vindexPreds[0].foundVindex = &vindexes.Null{}
+	assert.NotNil(t, clonedRP.vindexPreds[0].foundVindex)
+	assert.Nil(t, original.vindexPreds[0].foundVindex)
 }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1664,6 +1664,7 @@ Gen4 plan same as above
     "Vindex": "music_user_map"
   }
 }
+Gen4 plan same as above
 
 # SELECT with IS NOT NULL
 "select id from music where id is not null"

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1972,3 +1972,25 @@ Gen4 plan same as above
     "SysTableTableSchema": "[VARBINARY(\"ks\")]"
   }
 }
+
+# solving LIKE query with a CFC prefix vindex
+"select c2 from cfc_vindex_col where c1 like 'A%'"
+{
+  "QueryType": "SELECT",
+  "Original": "select c2 from cfc_vindex_col where c1 like 'A%'",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select c2 from cfc_vindex_col where 1 != 1",
+    "Query": "select c2 from cfc_vindex_col where c1 like 'A%'",
+    "Table": "cfc_vindex_col",
+    "Values": [
+      "A%"
+    ],
+    "Vindex": "cfc"
+  }
+}

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1762,6 +1762,27 @@ Gen4 plan same as above
     "Table": "music"
   }
 }
+Gen4 plan same as above
+
+# Single table with unique vindex match and NOT IN (null, 1, 2) predicates inverted
+"select id from music where id NOT IN (null, 1, 2) and user_id = 4"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from music where id NOT IN (null, 1, 2) and user_id = 4",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectNone",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from music where 1 != 1",
+    "Query": "select id from music where id not in (null, 1, 2) and user_id = 4",
+    "Table": "music"
+  }
+}
+Gen4 plan same as above
+
 
 # query trying to query two different keyspaces at the same time
 "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'user' AND TABLE_SCHEMA = 'main'"

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -1994,3 +1994,4 @@ Gen4 plan same as above
     "Vindex": "cfc"
   }
 }
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -78,6 +78,9 @@
         "vindex2": {
           "type": "lookup_test",
           "owner": "samecolvin"
+        },
+        "cfc": {
+          "type": "cfc"
         }
       },
       "tables": {
@@ -255,6 +258,24 @@
             {
               "column": "a`b*c",
               "name": "user_index"
+            }
+          ]
+        },
+        "cfc_vindex_col": {
+          "column_vindexes": [
+            {
+              "column": "c1",
+              "name": "cfc"
+            }
+          ],
+          "columns": [
+            {
+              "name": "c1",
+              "type": "VARCHAR"
+            },
+            {
+              "name": "c2",
+              "type": "VARCHAR"
             }
           ]
         }


### PR DESCRIPTION
## Description
Makes it possible for gen4 to plan `LIKE`, `IN`, `NOT IN`, and `IS NOT NULL` plans better.

## Related Issue(s)
#7280

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required