### PR TITLE
Tracker/VStreamer: only reload schema for tables in current database and not for internal table artifacts

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -25,6 +25,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"vitess.io/vitess/go/vt/schema"
+
 	"vitess.io/vitess/go/mysql"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -136,7 +138,7 @@ func (tr *Tracker) process(ctx context.Context) {
 	defer tr.env.LogError()
 	defer tr.wg.Done()
 	if err := tr.possiblyInsertInitialSchema(ctx); err != nil {
-		log.Errorf("possiblyInsertInitialSchema eror: %v", err)
+		log.Errorf("error inserting initial schema: %v", err)
 		return
 	}
 
@@ -153,10 +155,13 @@ func (tr *Tracker) process(ctx context.Context) {
 				if event.Type == binlogdatapb.VEventType_GTID {
 					gtid = event.Gtid
 				}
-				if event.Type == binlogdatapb.VEventType_DDL {
+				if event.Type == binlogdatapb.VEventType_DDL &&
+					MustReloadSchemaOnDDL(event.Statement, tr.engine.cp.DBName()) {
+
 					if err := tr.schemaUpdated(gtid, event.Statement, event.Timestamp); err != nil {
 						tr.env.Stats().ErrorCounters.Add(vtrpcpb.Code_INTERNAL.String(), 1)
-						log.Errorf("Error updating schema: %s", sqlparser.TruncateForLog(err.Error()))
+						log.Errorf("Error updating schema: %s for ddl %s, gtid %s",
+							sqlparser.TruncateForLog(err.Error()), event.Statement, gtid)
 					}
 				}
 			}
@@ -277,4 +282,30 @@ func encodeString(in string) string {
 	buf := bytes.NewBuffer(nil)
 	sqltypes.NewVarChar(in).EncodeSQL(buf)
 	return buf.String()
+}
+
+// MustReloadSchemaOnDDL returns true if the ddl is for the db which is part of the workflow and is not an online ddl artifact
+func MustReloadSchemaOnDDL(sql string, dbname string) bool {
+	ast, err := sqlparser.Parse(sql)
+	if err != nil {
+		return false
+	}
+	switch stmt := ast.(type) {
+	case sqlparser.DBDDLStatement:
+		return false
+	case sqlparser.DDLStatement:
+		table := stmt.GetTable()
+		if table.IsEmpty() {
+			return false
+		}
+		if !table.Qualifier.IsEmpty() && table.Qualifier.String() != dbname {
+			return false
+		}
+		tableName := table.Name.String()
+		if schema.IsOnlineDDLTableName(tableName) {
+			return false
+		}
+		return true
+	}
+	return false
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -463,7 +463,9 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent) ([]*binlogdatapb.VEvent, e
 					Type: binlogdatapb.VEventType_OTHER,
 				})
 			}
-			vs.se.ReloadAt(context.Background(), vs.pos)
+			if schema.MustReloadSchemaOnDDL(q.SQL, vs.cp.DBName()) {
+				vs.se.ReloadAt(context.Background(), vs.pos)
+			}
 		case sqlparser.StmtSavepoint:
 			mustSend := mustSendStmt(q, vs.cp.DBName())
 			if mustSend {


### PR DESCRIPTION
## Description

A user had a problem migrating from Vitess 7.0 to Vitess 10.0. Their vreplication workflows were not making any forward progress in the replication mode after the migration. The cause was a custom heartbeat that was running at 2 qps which was implementing a `pseudo-gtid` similar to http://code.openark.org/blog/mysql/pseudo-gtid-ascending. The query would look like `DROP VIEW IF EXISTS pseudo_gtid._pseudo_gtid_hint__asc:55B364E3:0000000000056EE2:6DD57B85`

As part of DDL processing the VStreamer reloaded the schema for each heartbeat. In addition the tracker would also have tried to update the schema version table. Reloading schemas is expensive and doing it twice a second broke vstreamer processing.

This PR changes the logic to only reload schemas if a ddl is for a table in the current database. This automatically results in the pseudo-gtid ddls to be noops for the reloading logic. In addition we also ignore temporary tables generated by `online ddl` because vstreamer never sends events for those.

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
