### PR TITLE
[vtadmin] Ensure we log any errors when closing the tracer

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -56,7 +56,7 @@ var (
 		},
 		Run: run,
 		PostRun: func(cmd *cobra.Command, args []string) {
-			traceCloser.Close()
+			trace.LogErrorsWhenClosing(traceCloser)
 		},
 	}
 )
@@ -64,7 +64,7 @@ var (
 // fatal ensures the tracer is closed and final spans are sent before issuing
 // a log.Fatal call with the given args.
 func fatal(args ...interface{}) {
-	traceCloser.Close()
+	trace.LogErrorsWhenClosing(traceCloser)
 	log.Fatal(args...)
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

This is a very small improvement to the current tracing setup in vtadmin. Rather than calling `.Close()` on the traceCloser directly, we call the wrapper in `package trace` which logs, and therefore gives us visibility into, errors that happen during the close.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required -- N/A
- [ ] Documentation was added or is not required -- N/A

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->