### PR TITLE
[vtadmin] Add debug endpoints

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/vtadmin/cluster"
 	"vitess.io/vitess/go/vt/vtadmin/grpcserver"
 	vtadminhttp "vitess.io/vitess/go/vt/vtadmin/http"
+	"vitess.io/vitess/go/vt/vtadmin/http/debug"
 )
 
 var (
@@ -129,6 +130,9 @@ func main() {
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 
 	rootCmd.Flags().BoolVar(&httpOpts.DisableCompression, "http-no-compress", false, "whether to disable compression of HTTP API responses")
+	rootCmd.Flags().BoolVar(&httpOpts.DisableDebug, "http-no-debug", false, "whether to disable /debug/pprof/* and /debug/env HTTP endpoints")
+	rootCmd.Flags().Var(&debug.OmitEnv, "http-debug-omit-env", "name of an environment variable to omit from /debug/env, if http debug endpoints are enabled. specify multiple times to omit multiple env vars")
+	rootCmd.Flags().Var(&debug.SanitizeEnv, "http-debug-sanitize-env", "name of an environment variable to sanitize in /debug/env, if http debug endpoints are enabled. specify multiple times to sanitize multiple env vars")
 	rootCmd.Flags().StringSliceVar(&httpOpts.CORSOrigins, "http-origin", []string{}, "repeated, comma-separated flag of allowed CORS origins. omit to disable CORS")
 	rootCmd.Flags().StringVar(&httpOpts.ExperimentalOptions.TabletURLTmpl,
 		"http-tablet-url-tmpl",

--- a/go/flagutil/sets.go
+++ b/go/flagutil/sets.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	_ flag.Value  = (*StringSetFlag)(nil)
+	_ pflag.Value = (*StringSetFlag)(nil)
+)
+
+// StringSetFlag can be used to collect multiple instances of a flag into a set
+// of values.
+//
+// For example, defining the following:
+//
+//		var x flagutil.StringSetFlag
+//		flag.Var(&x, "foo", "")
+//
+// And then specifying "-foo x -foo y -foo x", will result in a set of {x, y}.
+//
+// In addition to implemnting the standard flag.Value interface, it also
+// provides an implementation of pflag.Value, so it is usable in libraries like
+// cobra.
+type StringSetFlag struct {
+	set sets.String
+}
+
+// ToSet returns the underlying string set, or an empty set if the underlying
+// set is nil.
+func (set *StringSetFlag) ToSet() sets.String {
+	if set.set == nil {
+		set.set = sets.NewString()
+	}
+
+	return set.set
+}
+
+// Set is part of the pflag.Value and flag.Value interfaces.
+func (set *StringSetFlag) Set(s string) error {
+	if set.set == nil {
+		set.set = sets.NewString(s)
+		return nil
+	}
+
+	set.set.Insert(s)
+	return nil
+}
+
+// String is part of the pflag.Value and flag.Value interfaces.
+func (set *StringSetFlag) String() string {
+	if set.set == nil {
+		return ""
+	}
+
+	return strings.Join(set.set.List(), ", ")
+}
+
+// Type is part of the pflag.Value interface.
+func (set *StringSetFlag) Type() string { return "StringSetFlag" }

--- a/go/vt/vtadmin/http/api.go
+++ b/go/vt/vtadmin/http/api.go
@@ -36,7 +36,10 @@ type Options struct {
 	// DisableCompression specifies whether to turn off gzip compression for API
 	// endpoints. It is named as the negative (as opposed to EnableTracing) so
 	// the zero value has compression enabled.
-	DisableCompression  bool
+	DisableCompression bool
+	// DisableDebug specifies whether to omit the /debug/pprof/* and /debug/env
+	// routes.
+	DisableDebug        bool
 	ExperimentalOptions struct {
 		TabletURLTmpl string
 	}

--- a/go/vt/vtadmin/http/debug/debug.go
+++ b/go/vt/vtadmin/http/debug/debug.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"vitess.io/vitess/go/flagutil"
+)
+
+var (
+	// SanitizeEnv is the set of environment variables to sanitize their values
+	// in the Env http handler.
+	SanitizeEnv flagutil.StringSetFlag
+	// OmitEnv is the set of environment variables to omit entirely in the Env
+	// http handler.
+	OmitEnv flagutil.StringSetFlag
+)
+
+const sanitized = "********"
+
+// Env responds with a plaintext listing of key=value pairs of the environment
+// variables, sorted by key name.
+//
+// If a variable appears in OmitEnv, it is excluded entirely. If a variable
+// appears in SanitizeEnv, its value is replaced with a sanitized string,
+// including if there was no value set in the environment.
+func Env(w http.ResponseWriter, r *http.Request) {
+	vars := readEnv()
+
+	msg := &strings.Builder{}
+	for i, kv := range vars {
+		msg.WriteString(fmt.Sprintf("%s=%s", kv[0], kv[1]))
+		if i < len(vars)-1 {
+			msg.WriteByte('\n')
+		}
+	}
+
+	w.Write([]byte(msg.String()))
+}
+
+func readEnv() [][2]string {
+	env := os.Environ()
+	vars := make([][2]string, 0, len(env))
+
+	var key, value string
+	for _, ev := range env {
+		parts := strings.SplitN(ev, "=", 2)
+		switch len(parts) {
+		case 0:
+			key = ev
+		case 1:
+			key = parts[0]
+		default:
+			key = parts[0]
+			value = parts[1]
+		}
+
+		if key == "" {
+			continue
+		}
+
+		if OmitEnv.ToSet().Has(key) {
+			continue
+		}
+
+		if SanitizeEnv.ToSet().Has(key) {
+			value = sanitized
+		}
+
+		vars = append(vars, [2]string{
+			key,
+			value,
+		})
+	}
+
+	// Sort by env var name, ascending.
+	sort.SliceStable(vars, func(i, j int) bool {
+		left, right := vars[i], vars[j]
+		return left[0] < right[0]
+	})
+
+	return vars
+}


### PR DESCRIPTION
## Description

This adds debug endpoints to vtadmin-api, namely the `/debug/pprof/` friends, and also a `/debug/env` to show environment variables available to the vtadmin-api process.

net/http/pprof was being stubborn about how to get it to play nicely with gorilla/mux, but I managed to get it working, unfortunately at the cost of making the route registration a bit more confusing.

We also add some config options to opt users out of debug endpoints entirely, as well as to control the behavior of the `/debug/env` endpoint to sanitize, or omit entirely, any environment variables that may be sensitive.

### Examples!

<details>
<summary>No changes to flags:</summary>

```
❯ curl -s localhost:14200/debug/env | grep CDPATH
CDPATH=:/Users/amason/work:/Users/amason/work
```

</details>

<details>
<summary>Adding sanitization:</summary>

```
diff --git a/examples/local/scripts/vtadmin-up.sh b/examples/local/scripts/vtadmin-up.sh
index e76a920618..4ceeee7b5d 100755
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -9,6 +9,7 @@ vtadmin \
   --addr ":${vtadmin_api_port}" \
   --http-origin "http://localhost:3000" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --http-debug-sanitize-env "CDPATH" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
   --http-tracing \
```

```
❯ curl -s localhost:14200/debug/env | grep CDPATH
CDPATH=********
```

</details>

<details>
<summary>Adding omission:</summary>

```
diff --git a/examples/local/scripts/vtadmin-up.sh b/examples/local/scripts/vtadmin-up.sh
index e76a920618..3172d4ddd6 100755
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -9,6 +9,7 @@ vtadmin \
   --addr ":${vtadmin_api_port}" \
   --http-origin "http://localhost:3000" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --http-debug-omit-env "CDPATH" \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
   --http-tracing \
```

```
❯ curl -s localhost:14200/debug/env | grep -c CDPATH
0
```

</details>

<details>
<summary>Disabling entirely:</summary>

```
diff --git a/examples/local/scripts/vtadmin-up.sh b/examples/local/scripts/vtadmin-up.sh
index e76a920618..221006c4a4 100755
--- a/examples/local/scripts/vtadmin-up.sh
+++ b/examples/local/scripts/vtadmin-up.sh
@@ -9,6 +9,7 @@ vtadmin \
   --addr ":${vtadmin_api_port}" \
   --http-origin "http://localhost:3000" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15{{ .Tablet.Alias.Uid }}" \
+  --http-no-debug \
   --tracer "opentracing-jaeger" \
   --grpc-tracing \
   --http-tracing \
```

```
❯ curl localhost:14200/debug/env
404 page not found
```

</details>

I also poked around in the pprof endpoints and took some profiles.

## Related Issue(s)

Closes #8267

## Checklist
- [x] Tests were added or are not required - n/a
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->