### PR TITLE
Fix TableGC flaky test by reducing check interval

### DIFF
--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -88,6 +88,7 @@ func TestMain(m *testing.M) {
 			"-heartbeat_enable",
 			"-heartbeat_interval", "250ms",
 			"-gc_check_interval", "5s",
+			"-gc_purge_check_interval", "5s",
 			"-table_gc_lifecycle", "hold,purge,evac,drop",
 		}
 		// We do not need semiSync for this test case.
@@ -323,7 +324,7 @@ func TestPurge(t *testing.T) {
 		checkTableRows(t, tableName, 1024)
 	}
 
-	time.Sleep(2 * time.Minute) // purgeReentranceInterval
+	time.Sleep(15 * time.Second) // purgeReentranceInterval
 	{
 		// We're now both beyond table's timestamp as well as a tableGC interval
 		exists, _, err := tableExists(tableName)

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -41,8 +41,7 @@ import (
 )
 
 const (
-	leaderCheckInterval     = 5 * time.Second
-	purgeReentranceInterval = 1 * time.Minute
+	leaderCheckInterval = 5 * time.Second
 	// evacHours is a hard coded, reasonable time for a table to spend in EVAC state
 	evacHours        = 72
 	throttlerAppName = "tablegc"
@@ -50,6 +49,9 @@ const (
 
 // checkInterval marks the interval between looking for tables in mysql server/schema
 var checkInterval = flag.Duration("gc_check_interval", 1*time.Hour, "Interval between garbage collection checks")
+
+// purgeReentranceInterval marks the interval between searching tables to purge
+var purgeReentranceInterval = flag.Duration("gc_purge_check_interval", 1*time.Minute, "Interval between purge discovery checks")
 
 // gcLifecycle is the sequence of steps the table goes through in the process of getting dropped
 var gcLifecycle = flag.String("table_gc_lifecycle", "hold,purge,evac,drop", "States for a DROP TABLE garbage collection cycle. Default is 'hold,purge,evac,drop', use any subset ('drop' implcitly always included)")
@@ -209,7 +211,7 @@ func (collector *TableGC) Operate(ctx context.Context) {
 	}
 	tableCheckTicker := addTicker(*checkInterval)
 	leaderCheckTicker := addTicker(leaderCheckInterval)
-	purgeReentranceTicker := addTicker(purgeReentranceInterval)
+	purgeReentranceTicker := addTicker(*purgeReentranceInterval)
 
 	log.Info("TableGC: operating")
 	for {


### PR DESCRIPTION

## Description
Fixes https://github.com/vitessio/vitess/issues/7984

https://github.com/vitessio/vitess/issues/7984 only happens on GitHub CI, never locally. This is the 2nd time I'm looking into it, with same conclusion: it's a timing/timeout issue. In this PR I make the parge check interval configurable, and set it to `5s` as opposed to `1min`, expecting the test to now pass.

## Related Issue(s)
https://github.com/vitessio/vitess/issues/7984

## Checklist
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required
