### PR TITLE
Removing BindVariables when preparing statements.

### DIFF
--- a/go/cmd/vtgateclienttest/services/fallback.go
+++ b/go/cmd/vtgateclienttest/services/fallback.go
@@ -17,7 +17,7 @@ limitations under the License.
 package services
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/vtgateservice"

--- a/go/cmd/vtgateclienttest/services/terminal.go
+++ b/go/cmd/vtgateclienttest/services/terminal.go
@@ -61,6 +61,14 @@ func (c *terminalClient) StreamExecute(ctx context.Context, session *vtgatepb.Se
 	return errTerminal
 }
 
+func (c *terminalClient) Prepare(ctx context.Context, session *vtgatepb.Session, sql string) (*vtgatepb.Session, []*querypb.Field, error) {
+	return session, nil, errTerminal
+}
+
+func (c *terminalClient) CloseSession(ctx context.Context, session *vtgatepb.Session) error {
+	return errTerminal
+}
+
 func (c *terminalClient) ResolveTransaction(ctx context.Context, dtid string) error {
 	return errTerminal
 }

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -432,7 +432,7 @@ func (db *DB) ComPrepare(c *mysql.Conn, query string) ([]*querypb.Field, error) 
 }
 
 // ComStmtExecute is part of the mysql.Handler interface.
-func (db *DB) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {
+func (db *DB) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, bindVars map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -103,7 +103,7 @@ type Handler interface {
 
 	// ComStmtExecute is called when a connection receives a statement
 	// execute query.
-	ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error
+	ComStmtExecute(c *Conn, prepare *PrepareData, bindVars map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error
 
 	// WarningCount is called at the end of each query to obtain
 	// the value to be returned to the client in the EOF packet.

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -224,7 +224,7 @@ func (th *testHandler) ComPrepare(c *Conn, query string) ([]*querypb.Field, erro
 	return nil, nil
 }
 
-func (th *testHandler) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComStmtExecute(c *Conn, prepare *PrepareData, bindVars map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -131,6 +131,29 @@ func (f *fakeVTGateService) StreamExecute(ctx context.Context, session *vtgatepb
 	return nil
 }
 
+// Prepare is part of the VTGateService interface
+func (f *fakeVTGateService) Prepare(ctx context.Context, session *vtgatepb.Session, sql string) (*vtgatepb.Session, []*querypb.Field, error) {
+	execCase, ok := execMap[sql]
+	if !ok {
+		return session, nil, fmt.Errorf("no match for: %s", sql)
+	}
+	query := &queryExecute{
+		SQL:     sql,
+		Session: session,
+	}
+	if !query.Equal(execCase.execQuery) {
+		return session, nil, fmt.Errorf("Prepare request mismatch: got %+v, want %+v", query, execCase.execQuery)
+	}
+	if execCase.session != nil {
+		*session = *execCase.session
+	}
+	return session, execCase.result.Fields, nil
+}
+
+func (f *fakeVTGateService) CloseSession(ctx context.Context, session *vtgatepb.Session) error {
+	return nil
+}
+
 // ResolveTransaction is part of the VTGateService interface
 func (f *fakeVTGateService) ResolveTransaction(ctx context.Context, dtid string) error {
 	if dtid != dtid2 {

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1627,10 +1627,7 @@ func TestUpdateEqualWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "update music set a = :a0 where id = :id0", map[string]*querypb.BindVariable{
-		"a0":  sqltypes.Int64BindVariable(3),
-		"id0": sqltypes.Int64BindVariable(2),
-	})
+	_, err := executorPrepare(executor, "update music set a = :a0 where id = :id0")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
@@ -1651,11 +1648,7 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')", map[string]*querypb.BindVariable{
-		"_Id0":    sqltypes.Int64BindVariable(1),
-		"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
-		"__seq0":  sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
@@ -1674,9 +1667,7 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 
 func TestDeleteEqualWithPrepare(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
-	_, err := executorPrepare(executor, "delete from user where id = :id0", map[string]*querypb.BindVariable{
-		"id0": sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, "delete from user where id = :id0")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -412,13 +412,12 @@ func executorExec(executor *Executor, sql string, bv map[string]*querypb.BindVar
 		bv)
 }
 
-func executorPrepare(executor *Executor, sql string, bv map[string]*querypb.BindVariable) ([]*querypb.Field, error) {
+func executorPrepare(executor *Executor, sql string) ([]*querypb.Field, error) {
 	return executor.Prepare(
 		context.Background(),
 		"TestExecute",
 		NewSafeSession(masterSession),
-		sql,
-		bv)
+		sql)
 }
 
 func executorStream(executor *Executor, sql string) (qr *sqltypes.Result, err error) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2112,18 +2112,13 @@ func TestSelectBindvarswithPrepare(t *testing.T) {
 	defer QueryLogger.Unsubscribe(logChan)
 
 	sql := "select id from user where id = :id"
-	_, err := executorPrepare(executor, sql, map[string]*querypb.BindVariable{
-		"id": sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, sql)
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id from user where 1 != 1",
-		BindVariables: map[string]*querypb.BindVariable{"id": sqltypes.Int64BindVariable(1)},
+		Sql: "select id from user where 1 != 1",
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	require.Equal(t, sbc1.Queries[0].Sql, wantQueries[0].Sql)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}

--- a/go/vt/vtgate/plan_executor_dml_test.go
+++ b/go/vt/vtgate/plan_executor_dml_test.go
@@ -1619,10 +1619,7 @@ func TestPlanUpdateEqualWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "update music set a = :a0 where id = :id0", map[string]*querypb.BindVariable{
-		"a0":  sqltypes.Int64BindVariable(3),
-		"id0": sqltypes.Int64BindVariable(2),
-	})
+	_, err := executorPrepare(executor, "update music set a = :a0 where id = :id0")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
@@ -1643,11 +1640,7 @@ func TestPlanInsertShardedWithPrepare(t *testing.T) {
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
-	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')", map[string]*querypb.BindVariable{
-		"_Id0":    sqltypes.Int64BindVariable(1),
-		"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
-		"__seq0":  sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, "insert into user(id, v, name) values (:_Id0, 2, ':_name_0')")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery
@@ -1666,9 +1659,7 @@ func TestPlanInsertShardedWithPrepare(t *testing.T) {
 
 func TestPlanDeleteEqualWithPrepare(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnvUsing(planAllTheThings)
-	_, err := executorPrepare(executor, "delete from user where id = :id0", map[string]*querypb.BindVariable{
-		"id0": sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, "delete from user where id = :id0")
 	require.NoError(t, err)
 
 	var wantQueries []*querypb.BoundQuery

--- a/go/vt/vtgate/plan_executor_select_test.go
+++ b/go/vt/vtgate/plan_executor_select_test.go
@@ -2107,18 +2107,13 @@ func TestPlanSelectBindvarswithPrepare(t *testing.T) {
 	defer QueryLogger.Unsubscribe(logChan)
 
 	sql := "select id from user where id = :id"
-	_, err := executorPrepare(executor, sql, map[string]*querypb.BindVariable{
-		"id": sqltypes.Int64BindVariable(1),
-	})
+	_, err := executorPrepare(executor, sql)
 	require.NoError(t, err)
 
 	wantQueries := []*querypb.BoundQuery{{
-		Sql:           "select id from user where 1 != 1",
-		BindVariables: map[string]*querypb.BindVariable{"id": sqltypes.Int64BindVariable(1)},
+		Sql: "select id from user where 1 != 1",
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
+	require.Equal(t, sbc1.Queries[0].Sql, wantQueries[0].Sql)
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -54,7 +54,7 @@ func (th *testHandler) ComPrepare(c *mysql.Conn, q string) ([]*querypb.Field, er
 func (th *testHandler) ComResetConnection(c *mysql.Conn) {
 }
 
-func (th *testHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, bindVars map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 

--- a/go/vt/vtgate/vcursor_impl_test.go
+++ b/go/vt/vtgate/vcursor_impl_test.go
@@ -2,6 +2,7 @@ package vtgate
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"vitess.io/vitess/go/vt/proto/vschema"
@@ -205,7 +206,7 @@ func TestSetTarget(t *testing.T) {
 	}}
 
 	for i, tc := range tests {
-		t.Run(string(i)+"#"+tc.targetString, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d# %s", i, tc.targetString), func(t *testing.T) {
 			vc, _ := newVCursorImpl(context.Background(), NewSafeSession(&vtgatepb.Session{InTransaction: true}), sqlparser.MarginComments{}, nil, nil, &fakeVSchemaOperator{vschema: tc.vschema}, tc.vschema, nil)
 			vc.vschema = tc.vschema
 			err := vc.SetTarget(tc.targetString)


### PR DESCRIPTION
## Description

BindVariables should only be used when doing execute statements, not in prepare statements. This pull request removes them from `PrepareData`.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
