### PR TITLE
Schema Tracking Flaky Test: Ignore unrelated gtid progress events

### DIFF
--- a/go/vt/vttablet/endtoend/vstreamer_test.go
+++ b/go/vt/vttablet/endtoend/vstreamer_test.go
@@ -357,6 +357,13 @@ func expectLogs(ctx context.Context, t *testing.T, query string, eventCh chan []
 			if !ok {
 				t.Fatal("expectLogs: not ok, stream ended early")
 			}
+			// Ignore unrelated gtid progress events that can race with the events that the test expects
+			if len(allevs) == 3 &&
+				allevs[0].Type == binlogdatapb.VEventType_BEGIN &&
+				allevs[1].Type == binlogdatapb.VEventType_GTID &&
+				allevs[2].Type == binlogdatapb.VEventType_COMMIT {
+				continue
+			}
 			for _, ev := range allevs {
 				// Ignore spurious heartbeats that can happen on slow machines.
 				if ev.Type == binlogdatapb.VEventType_HEARTBEAT {


### PR DESCRIPTION

## Description

This PR is an attempt to fix the flakiness detected recently in `TestSchemaVersioning` such as 
```
--- FAIL: TestSchemaVersioning (0.18s)
Error:     vstreamer_test.go:168: expectLog: got too many events: insert into vitess_version values(1, 10): evs
        [type:GTID timestamp:1623069305 gtid:"MySQL56/b1f2fc17-c78c-11eb-a879-000d3ae5ac36:1-323" current_time:1623069305115892459 type:FIELD timestamp:1623069305 field_event:{table_name:"vitess_version" fields:{name:"id1" type:INT32 table:"vitess_version" org_table:"vitess_version" database:"vttest" org_name:"id1" column_length:11 charset:63 flags:32768} fields:{name:"id2" type:INT32 table:"vitess_version" org_table:"vitess_version" database:"vttest" org_name:"id2" column_length:11 charset:63 flags:32768}} current_time:1623069305196910293 type:ROW timestamp:1623069305 row_event:{table_name:"vitess_version" row_changes:{after:{lengths:1 lengths:2 values:"110"}}} current_time:1623069305196926493 type:GTID timestamp:1623069305 gtid:"MySQL56/b1f2fc17-c78c-11eb-a879-000d3ae5ac36:1-324" current_time:1623069305196936493], want
        [type:FIELD field_event:{table_name:"vitess_version" fields:{name:"id1" type:INT32 table:"vitess_version" org_table:"vitess_version" database:"vttest" org_name:"id1" column_length:11 charset:63} fields:{name:"id2" type:INT32 table:"vitess_version" org_table:"vitess_version" database:"vttest" org_name:"id2" column_length:11 charset:63}} type:ROW row_event:{table_name:"vitess_version" row_changes:{after:{lengths:1 lengths:2 values:"110"}}} gtid], >> got length 4, wanted length 3
```

Local failures indicate this is happening due to an additional BEGIN/GTID/COMMIT group of events that happens at different times in the test causing event comparisons to fail at different points in that test. It is not clear what is causing it: it could be some `_vt` schema changes or some unrelated dmls from parallel or teardowns previous tests that are running concurrently.

This PR ignores such gtid progress events that can race with the events that the schema versioning test expects.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>
