### PR TITLE
[vtctldclient] Add legacy shim

### DIFF
--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -67,6 +67,10 @@ func main() {
 			logutil.LogEvent(logger, e)
 		})
 	if err != nil {
+		if strings.Contains(err.Error(), "flag: help requested") {
+			return
+		}
+
 		errStr := strings.Replace(err.Error(), "remote error: ", "", -1)
 		fmt.Printf("%s Error: %s\n", flag.Arg(0), errStr)
 		log.Error(err)

--- a/go/cmd/vtctldclient/internal/command/legacy_shim.go
+++ b/go/cmd/vtctldclient/internal/command/legacy_shim.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/cli"
 	"vitess.io/vitess/go/vt/log"
@@ -38,13 +37,41 @@ var (
 	// RPCs. This allows users to use a single binary to make RPCs against both
 	// the new and old vtctld gRPC APIs.
 	LegacyVtctlCommand = &cobra.Command{
-		Use:   "LegacyVtctlCommand",
+		Use:   "LegacyVtctlCommand -- <command> [flags ...] [args ...]",
 		Short: "Invoke a legacy vtctlclient command. Flag parsing is best effort.",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli.FinishedParsing(cmd)
 			return runLegacyCommand(args)
 		},
+		Long: strings.TrimSpace(`
+LegacyVtctlCommand uses the legacy vtctl grpc client to make an ExecuteVtctlCommand
+rpc to a vtctld.
+
+This command exists to support a smooth transition of any scripts that relied on
+vtctlclient during the migration to the new vtctldclient, and will be removed,
+following the Vitess project's standard deprecation cycle, once all commands
+have been migrated to the new VtctldServer api.
+
+To see the list of available legacy commands, run "LegacyVtctlCommand -- help".
+Note that, as with the old client, this requires a running server, as the flag
+parsing and help/usage text generation, is done server-side.
+
+Also note that, in order to defer that flag parsing to the server side, you must
+use the double-dash ("--") after the LegacyVtctlCommand subcommand string, or
+the client-side flag parsing library we are using will attempt to parse those
+flags (and fail).
+`),
+		Example: strings.TrimSpace(`
+LegacyVtctlCommand help # displays this help message
+LegacyVtctlCommand -- help # displays help for supported legacy vtctl commands
+
+# When using legacy command that take arguments, a double dash must be used
+# before the first flag argument, like in the first example. The double dash may
+# be used, however, at any point after the "LegacyVtctlCommand" string, as in
+# the second example.
+LegacyVtctlCommand AddCellInfo -- -server_address "localhost:1234" -root "/vitess/cell1"
+LegacyVtctlCommand -- AddCellInfo -server_address "localhost:5678" -root "/vitess/cell1"`),
 	}
 )
 
@@ -73,29 +100,5 @@ func runLegacyCommand(args []string) error {
 }
 
 func init() {
-	LegacyVtctlCommand.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		// PreRun (and PersistentPreRun) do not run when a Help command is
-		// being executed, so we need to duplicate the `--server` flag check
-		// here before we attempt to invoke the legacy help command.
-		if err := ensureServerArg(); err != nil {
-			log.Error(err)
-			return
-		}
-
-		realArgs := cmd.Flags().Args()
-
-		if len(realArgs) == 0 {
-			realArgs = append(realArgs, "help")
-		}
-
-		argSet := sets.NewString(realArgs...)
-		if !argSet.HasAny("help", "-h", "--help") {
-			// Cobra tends to swallow the help flag, so we need to put it back
-			// into the arg slice that we pass to runLegacyCommand.
-			realArgs = append(realArgs, "-h")
-		}
-
-		_ = runLegacyCommand(realArgs)
-	})
 	Root.AddCommand(LegacyVtctlCommand)
 }

--- a/go/cmd/vtctldclient/internal/command/legacy_shim.go
+++ b/go/cmd/vtctldclient/internal/command/legacy_shim.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"vitess.io/vitess/go/cmd/vtctldclient/cli"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
+
+	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
+)
+
+var (
+	// LegacyVtctlCommand provides a shim to make legacy ExecuteVtctlCommand
+	// RPCs. This allows users to use a single binary to make RPCs against both
+	// the new and old vtctld gRPC APIs.
+	LegacyVtctlCommand = &cobra.Command{
+		Use:   "LegacyVtctlCommand",
+		Short: "Invoke a legacy vtctlclient command. Flag parsing is best effort.",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli.FinishedParsing(cmd)
+			return runLegacyCommand(args)
+		},
+	}
+)
+
+func runLegacyCommand(args []string) error {
+	// Duplicated (mostly) from go/cmd/vtctlclient/main.go.
+	logger := logutil.NewConsoleLogger()
+
+	ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+	defer cancel()
+
+	err := vtctlclient.RunCommandAndWait(ctx, server, args, func(e *logutilpb.Event) {
+		logutil.LogEvent(logger, e)
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "flag: help requested") {
+			// Help is caught by SetHelpFunc, so we don't want to indicate this as an error.
+			return nil
+		}
+
+		errStr := strings.Replace(err.Error(), "remote error: ", "", -1)
+		fmt.Printf("%s Error: %s\n", flag.Arg(0), errStr)
+		log.Error(err)
+	}
+
+	return err
+}
+
+func init() {
+	LegacyVtctlCommand.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		// PreRun (and PersistentPreRun) do not run when a Help command is
+		// being executed, so we need to duplicate the `--server` flag check
+		// here before we attempt to invoke the legacy help command.
+		if err := ensureServerArg(); err != nil {
+			log.Error(err)
+			return
+		}
+
+		realArgs := cmd.Flags().Args()
+
+		if len(realArgs) == 0 {
+			realArgs = append(realArgs, "help")
+		}
+
+		argSet := sets.NewString(realArgs...)
+		if !argSet.HasAny("help", "-h", "--help") {
+			// Cobra tends to swallow the help flag, so we need to put it back
+			// into the arg slice that we pass to runLegacyCommand.
+			realArgs = append(realArgs, "-h")
+		}
+
+		_ = runLegacyCommand(realArgs)
+	})
+	Root.AddCommand(LegacyVtctlCommand)
+}

--- a/go/cmd/vtctldclient/internal/command/root.go
+++ b/go/cmd/vtctldclient/internal/command/root.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/trace"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
 )
 
@@ -44,9 +43,7 @@ var (
 		// command context for every command.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			traceCloser = trace.StartTracing("vtctldclient")
-			if server == "" {
-				err = errors.New("please specify -server <vtctld_host:vtctld_port> to specify the vtctld server to connect to")
-				log.Error(err)
+			if err := ensureServerArg(); err != nil {
 				return err
 			}
 
@@ -74,6 +71,17 @@ var (
 		SilenceErrors: true,
 	}
 )
+
+var errNoServer = errors.New("please specify -server <vtctld_host:vtctld_port> to specify the vtctld server to connect to")
+
+// ensureServerArg validates that --server was passed to the CLI.
+func ensureServerArg() error {
+	if server == "" {
+		return errNoServer
+	}
+
+	return nil
+}
 
 func init() {
 	Root.PersistentFlags().StringVar(&server, "server", "", "server to use for connection")

--- a/go/cmd/vtctldclient/plugin_grpcvtctlclient.go
+++ b/go/cmd/vtctldclient/plugin_grpcvtctlclient.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2021 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-// Imports and register the gRPC vtctl client.
+// Imports and registers the gRPC vtctl client.
 
 import (
 	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"

--- a/go/cmd/vtctldclient/plugin_grpcvtctlclient.go
+++ b/go/cmd/vtctldclient/plugin_grpcvtctlclient.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Imports and register the gRPC vtctl client.
+
+import (
+	_ "vitess.io/vitess/go/vt/vtctl/grpcvtctlclient"
+)

--- a/go/vt/vtctl/grpcclientcommon/dial_option.go
+++ b/go/vt/vtctl/grpcclientcommon/dial_option.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package grpcclientcommon defines the flags shared by both grpcvtctlclient and
+// grpcvtctldclient.
+package grpcclientcommon
+
+import (
+	"flag"
+
+	"google.golang.org/grpc"
+
+	"vitess.io/vitess/go/vt/grpcclient"
+)
+
+var (
+	cert = flag.String("vtctld_grpc_cert", "", "the cert to use to connect")
+	key  = flag.String("vtctld_grpc_key", "", "the key to use to connect")
+	ca   = flag.String("vtctld_grpc_ca", "", "the server ca to use to validate servers when connecting")
+	name = flag.String("vtctld_grpc_server_name", "", "the server name to use to validate server certificate")
+)
+
+// SecureDialOption returns a grpc.DialOption configured to use TLS (or
+// insecure if no flags were set) based on the vtctld_grpc_* flags declared by
+// this package.
+func SecureDialOption() (grpc.DialOption, error) {
+	return grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+}

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -18,7 +18,6 @@ limitations under the License.
 package grpcvtctlclient
 
 import (
-	"flag"
 	"time"
 
 	"context"
@@ -27,18 +26,12 @@ import (
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/vtctl/grpcclientcommon"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
-)
-
-var (
-	cert = flag.String("vtctld_grpc_cert", "", "the cert to use to connect")
-	key  = flag.String("vtctld_grpc_key", "", "the key to use to connect")
-	ca   = flag.String("vtctld_grpc_ca", "", "the server ca to use to validate servers when connecting")
-	name = flag.String("vtctld_grpc_server_name", "", "the server name to use to validate server certificate")
 )
 
 type gRPCVtctlClient struct {
@@ -47,7 +40,7 @@ type gRPCVtctlClient struct {
 }
 
 func gRPCVtctlClientFactory(addr string) (vtctlclient.VtctlClient, error) {
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclientcommon.SecureDialOption()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctldclient/client.go
+++ b/go/vt/vtctl/grpcvtctldclient/client.go
@@ -19,33 +19,16 @@ limitations under the License.
 package grpcvtctldclient
 
 import (
-	"flag"
-
 	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/vt/grpcclient"
+	"vitess.io/vitess/go/vt/vtctl/grpcclientcommon"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
 
 	vtctlservicepb "vitess.io/vitess/go/vt/proto/vtctlservice"
 )
 
 const connClosedMsg = "grpc: the client connection is closed"
-
-// (TODO:@amason) - These flags match exactly the flags used in grpcvtctlclient.
-// If a program attempts to import both of these packages, it will panic during
-// startup due to the duplicate flags.
-//
-// For everything else I've been doing a sed s/vtctl/vtctld, but I cannot do
-// that here, since these flags are already "vtctld_*". My other options are to
-// name them "vtctld2_*" or to omit them completely.
-//
-// Not to pitch project ideas in comments, but a nice project to solve
-var (
-	cert = flag.String("vtctld_grpc_cert", "", "the cert to use to connect")
-	key  = flag.String("vtctld_grpc_key", "", "the key to use to connect")
-	ca   = flag.String("vtctld_grpc_ca", "", "the server ca to use to validate servers when connecting")
-	name = flag.String("vtctld_grpc_server_name", "", "the server name to use to validate server certificate")
-)
 
 type gRPCVtctldClient struct {
 	cc *grpc.ClientConn
@@ -56,7 +39,7 @@ type gRPCVtctldClient struct {
 //go:generate grpcvtctldclient -out client_gen.go
 
 func gRPCVtctldClientFactory(addr string) (vtctldclient.VtctldClient, error) {
-	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclientcommon.SecureDialOption()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR adds a shim to the new vtctldclient to allow running legacy vtctl commands that have not yet been migrated. The intention here is to allow users to start updating any scripts they have now (going from `vtctlclient [args ...]` to `vtctldclient LegacyVtctlCommand -- [args ...]`), and then dropping the old client should be ideally a no-op, or at least far less painful.

### Examples!

<details>
<summary>client-side help</summary>

```
❯ vtctldclient LegacyVtctlCommand -h
LegacyVtctlCommand uses the legacy vtctl grpc client to make an
ExecuteVtctlCommand rpc to a vtctld.

This command exists to support a smooth transition of any scripts that relied on
vtctlclient during the migration to the new vtctldclient, and will be removed,
following the Vitess project's standard deprecation cycle, once all commands
have been migrated to the new VtctldServer api.

To see the list of available legacy commands, run "LegacyVtctlCommand -- help".
Note that, as with the old client, this requires a running server, as the flag
parsing and help/usage text generation, is done server-side.

Also note that, in order to defer that flag parsing to the server side, you must
use the double-dash ("--") after the LegacyVtctlCommand subcommand string, or
the client-side flag parsing library we are using will attempt to parse those
flags (and fail).

Usage:
   LegacyVtctlCommand -- <command> [flags ...] [args ...] [flags]

Examples:
LegacyVtctlCommand help # displays this help message
LegacyVtctlCommand -- help # displays help for supported legacy vtctl commands

# When using legacy command that take arguments, a double dash must be used
# before the first flag argument, like in the first example. The double dash may
# be used, however, at any point after the "LegacyVtctlCommand" string, as in
# the second example.
LegacyVtctlCommand AddCellInfo -- -server_address "localhost:1234" -root "/vitess/cell1"
LegacyVtctlCommand -- AddCellInfo -server_address "localhost:5678" -root "/vitess/cell1"

Flags:
  -h, --help   help for LegacyVtctlCommand

Global Flags:
      --action_timeout duration                                          timeout for the total command (default 1h0m0s)
      --alsologtostderr                                                  log to standard error as well as files
      --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
      --cpu_profile string                                               deprecated: use '-pprof=cpu' instead
      --datadog-agent-host string                                        host to send spans to. if empty, no tracing will be done
      --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
      --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
      --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
      --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
      --grpc_auth_static_client_creds string                             when using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server
      --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
      --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
      --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
      --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
      --grpc_enable_optional_tls                                         enable optional TLS mode when a server accepts both TLS and plain-text connections on the same port
      --grpc_enable_tracing                                              Enable GRPC tracing
      --grpc_initial_conn_window_size int                                gRPC initial connection window size
      --grpc_initial_window_size int                                     gRPC initial window size
      --grpc_keepalive_time duration                                     After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
      --grpc_keepalive_timeout duration                                  After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
      --grpc_key string                                                  server private key to use for gRPC connections, requires grpc_cert, enables TLS
      --grpc_max_connection_age duration                                 Maximum age of a client connection before GoAway is sent. (default 2562047h47m16.854775807s)
      --grpc_max_connection_age_grace duration                           Additional grace period after grpc_max_connection_age, after which connections are forcibly closed. (default 2562047h47m16.854775807s)
      --grpc_max_message_size int                                        Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
      --grpc_port int                                                    Port to listen on for gRPC calls
      --grpc_prometheus                                                  Enable gRPC monitoring with Prometheus
      --grpc_server_ca string                                            path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
      --grpc_server_initial_conn_window_size int                         gRPC server initial connection window size
      --grpc_server_initial_window_size int                              gRPC server initial window size
      --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
      --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
      --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
      --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever) (default 0s)
      --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever) (default 0s)
      --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
      --log_backtrace_at traceLocation                                   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                                                   If non-empty, write log files in this directory
      --log_err_stacks                                                   log stack traces for errors
      --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
      --logtostderr                                                      log to standard error instead of files
      --mem-profile-rate int                                             deprecated: use '-pprof=mem' instead (default 524288)
      --mutex-profile-fraction int                                       deprecated: use '-pprof=mutex' instead
      --mysql_auth_server_static_file string                             JSON File to read the users/passwords from.
      --mysql_auth_server_static_string string                           JSON representation of the users/passwords config.
      --mysql_auth_static_reload_interval duration                       Ticker to reload credentials (default 0s)
      --mysql_auth_vault_addr string                                     URL to Vault server
      --mysql_auth_vault_path string                                     Vault path to vtgate credentials JSON blob, e.g.: secret/data/prod/vtgatecreds
      --mysql_auth_vault_role_mountpoint string                          Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
      --mysql_auth_vault_role_secretidfile string                        Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
      --mysql_auth_vault_roleid string                                   Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
      --mysql_auth_vault_timeout duration                                Timeout for vault API operations (default 10s)
      --mysql_auth_vault_tls_ca string                                   Path to CA PEM for validating Vault server certificate
      --mysql_auth_vault_tokenfile string                                Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
      --mysql_auth_vault_ttl duration                                    How long to cache vtgate credentials from the Vault server (default 30m0s)
      --mysql_clientcert_auth_method string                              client-side authentication method to use. Supported values: mysql_clear_password, dialog. (default "mysql_clear_password")
      --mysql_server_flush_delay duration                                Delay after which buffered response will be flushed to the client. (default 100ms)
      --mysql_server_version string                                      MySQL server version to advertise.
      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
      --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
      --pprof string                                                     enable profiling
      --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
      --remote_operation_timeout duration                                time to wait for a remote operation (default 30s)
      --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
      --server string                                                    server to use for connection
      --service_map StringList                                           comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-vtworker
      --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
      --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
      --stats_backend string                                             The name of the registered push-based monitoring/stats backend to use
      --stats_combine_dimensions string                                  List of dimensions to be combined into a single "all" value in exported stats vars
      --stats_common_tags string                                         Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
      --stats_drop_variables string                                      Variables to be dropped from the list of exported variables.
      --stats_emit_period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
      --stderrthreshold severity                                         logs at or above this threshold go to stderr (default 1)
      --topo_global_root string                                          the path of the global topology data in the global topology server
      --topo_global_server_address string                                the address of the global topology server
      --topo_implementation string                                       the topology implementation to use
      --tracer string                                                    tracing service to use (default "noop")
      --tracing-sampling-rate float                                      sampling rate for the probabilistic jaeger sampler (default 0.1)
  -v, --v Level                                                          log level for V logs
      --version                                                          print binary version
      --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
      --vtctl_client_protocol string                                     the protocol to use to talk to the vtctl server (default "grpc")
      --vtctld_grpc_ca string                                            the server ca to use to validate servers when connecting
      --vtctld_grpc_cert string                                          the cert to use to connect
      --vtctld_grpc_key string                                           the key to use to connect
      --vtctld_grpc_server_name string                                   the server name to use to validate server certificate
```

</details>

<details>
<summary>server-side help showing available commands</summary>

```
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- help
Available commands:

Tablets:
  InitTablet DEPRECATED [-allow_update] [-allow_different_shard] [-allow_master_override] [-parent] [-db_name_override=<db name>] [-hostname=<hostname>] [-mysql_port=<port>] [-port=<port>] [-grpc_port=<port>] [-tags=tag1:value1,tag2:value2] -keyspace=<keyspace> -shard=<shard> <tablet alias> <tablet type>
  GetTablet <tablet alias>
  DEPRECATED UpdateTabletAddrs [-hostname <hostname>] [-ip-addr <ip addr>] [-mysql-port <mysql port>] [-vt-port <vt port>] [-grpc-port <grpc port>] <tablet alias> 
  DeleteTablet [-allow_master] <tablet alias> ...
  SetReadOnly <tablet alias>
  SetReadWrite <tablet alias>
  StartReplication <table alias>
  StopReplication <tablet alias>
  ChangeTabletType [-dry-run] <tablet alias> <tablet type>
  Ping <tablet alias>
  RefreshState <tablet alias>
  RefreshStateByShard [-cells=c1,c2,...] <keyspace/shard>
  RunHealthCheck <tablet alias>
  IgnoreHealthError <tablet alias> <ignore regexp>
  Sleep <tablet alias> <duration>
  ExecuteHook <tablet alias> <hook name> [<param1=value1> <param2=value2> ...]
  ExecuteFetchAsApp [-max_rows=10000] [-json] [-use_pool] <tablet alias> <sql command>
  ExecuteFetchAsDba [-max_rows=10000] [-disable_binlogs] [-json] <tablet alias> <sql command>
  VReplicationExec [-json] <tablet alias> <sql command>
  Backup [-concurrency=4] [-allow_master=false] <tablet alias>
  RestoreFromBackup <tablet alias>
  ReparentTablet <tablet alias>

Shards:
  CreateShard [-force] [-parent] <keyspace/shard>
  GetShard <keyspace/shard>
  ValidateShard [-ping-tablets] <keyspace/shard>
  ShardReplicationPositions <keyspace/shard>
  ListShardTablets <keyspace/shard>
  SetShardIsMasterServing <keyspace/shard> <is_master_serving>
  SetShardTabletControl [--cells=c1,c2,...] [--blacklisted_tables=t1,t2,...] [--remove] [--disable_query_service] <keyspace/shard> <tablet type>
  UpdateSrvKeyspacePartition [--cells=c1,c2,...] [--remove] <keyspace/shard> <tablet type>
  SourceShardDelete <keyspace/shard> <uid>
  SourceShardAdd [--key_range=<keyrange>] [--tables=<table1,table2,...>] <keyspace/shard> <uid> <source keyspace/shard>
  ShardReplicationFix <cell> <keyspace/shard>
  WaitForFilteredReplication [-max_delay <max_delay, default 30s>] <keyspace/shard>
  RemoveShardCell [-force] [-recursive] <keyspace/shard> <cell>
  DeleteShard [-recursive] [-even_if_serving] <keyspace/shard> ...
  ListBackups <keyspace/shard>
  BackupShard [-allow_master=false] <keyspace/shard>
  RemoveBackup <keyspace/shard> <backup name>
  InitShardMaster [-force] [-wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>
  PlannedReparentShard -keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-avoid_master=<tablet alias>] [-wait_replicas_timeout=<duration>]
  EmergencyReparentShard -keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-wait_replicas_timeout=<duration>] [-ignore_replicas=<tablet alias list>]
  TabletExternallyReparented <tablet alias>

Keyspaces:
  CreateKeyspace [-sharding_column_name=name] [-sharding_column_type=type] [-served_from=tablettype1:ks1,tablettype2:ks2,...] [-force] [-keyspace_type=type] [-base_keyspace=base_keyspace] [-snapshot_time=time] <keyspace name>
  DeleteKeyspace [-recursive] <keyspace>
  RemoveKeyspaceCell [-force] [-recursive] <keyspace> <cell>
  GetKeyspace <keyspace>
  GetKeyspaces 
  SetKeyspaceShardingInfo [-force] <keyspace name> [<column name>] [<column type>]
  SetKeyspaceServedFrom [-source=<source keyspace name>] [-remove] [-cells=c1,c2,...] <keyspace name> <tablet type>
  RebuildKeyspaceGraph [-cells=c1,c2,...] [-allow_partial] <keyspace> ...
  ValidateKeyspace [-ping-tablets] <keyspace name>
  Reshard [-cells=<cells>] [-tablet_types=<source_tablet_types>] [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>
  MoveTables [-cells=<cells>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>
  Migrate [-cells=<cells>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>
  DropSources [-dry_run] [-rename_tables] <keyspace.workflow>
  CreateLookupVindex [-cell=<source_cells> DEPRECATED] [-cells=<source_cells>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>
  ExternalizeVindex <keyspace>.<vindex>
  Materialize [-cells=<cells>] [-tablet_types=<source_tablet_types>] <json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'
  SplitClone <keyspace> <from_shards> <to_shards>
  VerticalSplitClone <from_keyspace> <to_keyspace> <tables>
  VDiff [-source_cell=<cell>] [-target_cell=<cell>] [-tablet_types=replica] [-filtered_replication_wait_time=30s] <keyspace.workflow>
  MigrateServedTypes [-cells=c1,c2,...] [-reverse] [-skip-refresh-state] [-filtered_replication_wait_time=30s] [-reverse_replication=false] <keyspace/shard> <served tablet type>
  MigrateServedFrom [-cells=c1,c2,...] [-reverse] [-filtered_replication_wait_time=30s] <destination keyspace/shard> <served tablet type>
  SwitchReads [-cells=c1,c2,...] [-reverse] -tablet_type={replica|rdonly} [-dry-run] <keyspace.workflow>
  SwitchWrites [-timeout=30s] [-reverse] [-reverse_replication=true] [-dry-run] <keyspace.workflow>
  CancelResharding <keyspace/shard>
  ShowResharding <keyspace/shard>
  FindAllShardsInKeyspace <keyspace>
  WaitForDrain [-timeout <duration>] [-retry_delay <duration>] [-initial_wait <duration>] <keyspace/shard> <served tablet type>
  Mount [-topo_type=etcd2|consul|zookeeper] [-topo_server=topo_url] [-topo_root=root_topo_node> [-unmount] [-list] [-show]  [<cluster_name>]

Generic:
  Validate [-ping-tablets]
  ListAllTablets <cell name1>, <cell name2>, ...
  ListTablets <tablet alias> ...
  GenerateShardRanges <num shards>
  Help [command name]

Schema, Version, Permissions:
  GetSchema [-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] <tablet alias>
  ReloadSchema <tablet alias>
  ReloadSchemaShard [-concurrency=10] [-include_master=false] <keyspace/shard>
  ReloadSchemaKeyspace [-concurrency=10] [-include_master=false] <keyspace>
  ValidateSchemaShard [-exclude_tables=''] [-include-views] [-include-vschema] <keyspace/shard>
  ValidateSchemaKeyspace [-exclude_tables=''] [-include-views] [-skip-no-master] [-include-vschema] <keyspace name>
  ApplySchema [-allow_long_unavailability] [-wait_replicas_timeout=10s] [-ddl_strategy=<ddl_strategy>] [-request_context=<unique-request-context>] [-skip_preflight] {-sql=<sql> || -sql-file=<filename>} <keyspace>
  CopySchemaShard [-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] [-skip-verify] [-wait_replicas_timeout=10s] {<source keyspace/shard> || <source tablet alias>} <destination keyspace/shard>
  OnlineDDL <keyspace> <command> [<migration_uuid>]
  ValidateVersionShard <keyspace/shard>
  ValidateVersionKeyspace <keyspace name>
  GetPermissions <tablet alias>
  ValidatePermissionsShard <keyspace/shard>
  ValidatePermissionsKeyspace <keyspace name>
  GetVSchema <keyspace>
  ApplyVSchema {-vschema=<vschema> || -vschema_file=<vschema file> || -sql=<sql> || -sql_file=<sql file>} [-cells=c1,c2,...] [-skip_rebuild] [-dry-run] <keyspace>
  GetRoutingRules 
  ApplyRoutingRules {-rules=<rules> || -rules_file=<rules_file>} [-cells=c1,c2,...] [-skip_rebuild] [-dry-run]
  RebuildVSchemaGraph [-cells=c1,c2,...]

Serving Graph:
  GetSrvKeyspaceNames <cell>
  GetSrvKeyspace <cell> <keyspace>
  GetSrvVSchema <cell>
  DeleteSrvVSchema <cell>

Replication Graph:
  GetShardReplication <cell> <keyspace/shard>

Workflow:
  VExec <ks.workflow> <query> --dry-run

Workflow:
  Workflow <ks.workflow> <action> --dry-run

Cells:
  AddCellInfo [-server_address <addr>] [-root <root>] <cell>
  UpdateCellInfo [-server_address <addr>] [-root <root>] <cell>
  DeleteCellInfo [-force] <cell>
  GetCellInfoNames 
  GetCellInfo <cell>

CellsAliases:
  AddCellsAlias [-cells <cell,cell2...>] <alias>
  UpdateCellsAlias [-cells <cell,cell2,...>] <alias>
  DeleteCellsAlias <alias>
  GetCellsAliases 

Queries:
  VtGateExecute -server <vtgate> [-bind_variables <JSON map>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-options <proto text options>] [-json] <sql>
  VtTabletExecute [-username <TableACL user>] [-transaction_id <transaction_id>] [-options <proto text options>] [-json] <tablet alias> <sql>
  VtTabletBegin [-username <TableACL user>] <tablet alias>
  VtTabletCommit [-username <TableACL user>] <transaction_id>
  VtTabletRollback [-username <TableACL user>] <tablet alias> <transaction_id>
  VtTabletStreamHealth [-count <count, default 1>] <tablet alias>

Resharding Throttler:
  ThrottlerMaxRates -server <vtworker or vttablet>
  ThrottlerSetMaxRate -server <vtworker or vttablet> <rate>
  GetThrottlerConfiguration -server <vtworker or vttablet> [<throttler name>]
  UpdateThrottlerConfiguration -server <vtworker or vttablet> [-copy_zero_values] "<configuration protobuf text>" [<throttler name>]
  ResetThrottlerConfiguration -server <vtworker or vttablet> [<throttler name>]

Topo:
  TopoCat [-cell <cell>] [-decode_proto] [-decode_proto_json] [-long] <path> [<path>...]
  TopoCp [-cell <cell>] [-to_topo] <src> <dst>

Workflows:
  WorkflowCreate [-skip_start] <factoryName> [parameters...]
  WorkflowStart <uuid>
  WorkflowStop <uuid>
  WorkflowDelete <uuid>
  WorkflowWait <uuid>
  WorkflowTree 
  WorkflowAction <path> <name>
``` 

</details>

<details>
<summary>Getting tablets, both ways</summary>

```
❯ vtctldclient --server ":15999" GetTablets
zone1-0000000100 commerce 0 master SFO-M-AMASON02:15100 SFO-M-AMASON02:17100 [] 2021-06-08T12:17:57Z
zone1-0000000101 commerce 0 replica SFO-M-AMASON02:15101 SFO-M-AMASON02:17101 [] <null>
zone1-0000000102 commerce 0 rdonly SFO-M-AMASON02:15102 SFO-M-AMASON02:17102 [] <null>
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- ListShardTablets commerce/0
zone1-0000000101 commerce 0 replica SFO-M-AMASON02:15101 SFO-M-AMASON02:17101 [] <null>
zone1-0000000102 commerce 0 rdonly SFO-M-AMASON02:15102 SFO-M-AMASON02:17102 [] <null>
zone1-0000000100 commerce 0 master SFO-M-AMASON02:15100 SFO-M-AMASON02:17100 [] 2021-06-08T12:17:57Z
```

</details>

<details>
<summary>Getting per-command server-side help, using legacy commands that take flags, etc</summary>

```
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- CreateShard -h
Usage: CreateShard [-force] [-parent] <keyspace/shard>

Creates the specified shard.

  -force
        Proceeds with the command even if the shard already exists
  -parent
        Creates the parent keyspace if it doesn't already exist
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- CreateShard -force commerce/0
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- FindAllShardsInKeyspace commerce
{
  "0": {
    "master_alias": {
      "cell": "zone1",
      "uid": 100
    },
    "master_term_start_time": {
      "seconds": 1623154677,
      "nanoseconds": 989551000
    },
    "is_master_serving": true
  }
}
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- CreateShard -parent ks2/-80
❯ vtctldclient --server ":15999" LegacyVtctlCommand -- FindAllShardsInKeyspace ks2
{
  "-80": {
    "key_range": {
      "end": "gA=="
    },
    "is_master_serving": true
  }
}
❯ vtctldclient --server ":15999" FindAllShardsInKeyspace ks2
{
  "shards": {
    "-80": {
      "keyspace": "ks2",
      "name": "-80",
      "shard": {
        "master_alias": null,
        "master_term_start_time": null,
        "key_range": {
          "start": "",
          "end": "gA=="
        },
        "served_types": [],
        "source_shards": [],
        "tablet_controls": [],
        "is_master_serving": true
      }
    }
  }
}
```

</details>


## Related Issue(s)

#7058

## Checklist
- [x] Tests were added or are not required -- n/a
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->