### PR TITLE
[trace] Add logging support to opentracing plugins

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -123,9 +123,10 @@ func main() {
 	rootCmd.Flags().Var(&clusterFileConfig, "cluster-config", "path to a yaml cluster configuration. see clusters.example.yaml") // (TODO:@amason) provide example config.
 	rootCmd.Flags().Var(&defaultClusterConfig, "cluster-defaults", "default options for all clusters")
 
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                // defined in go/vt/trace
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-type")) // defined in go/vt/trace
-	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-rate")) // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracer"))                 // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-enable-logging")) // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-type"))  // defined in go/vt/trace
+	rootCmd.Flags().AddGoFlag(flag.Lookup("tracing-sampling-rate"))  // defined in go/vt/trace
 	rootCmd.Flags().BoolVar(&opts.EnableTracing, "grpc-tracing", false, "whether to enable tracing on the gRPC server")
 	rootCmd.Flags().BoolVar(&httpOpts.EnableTracing, "http-tracing", false, "whether to enable tracing on the HTTP server")
 

--- a/go/trace/logger.go
+++ b/go/trace/logger.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trace
+
+import "vitess.io/vitess/go/vt/log"
+
+// traceLogger wraps the standard vitess log package to satisfy the datadog and
+// jaeger logger interfaces.
+type traceLogger struct{}
+
+// Log is part of the ddtrace.Logger interface. Datadog only ever logs errors.
+func (*traceLogger) Log(msg string) { log.Errorf(msg) }
+
+// Error is part of the jaeger.Logger interface.
+func (*traceLogger) Error(msg string) { log.Errorf(msg) }
+
+// Infof is part of the jaeger.Logger interface.
+func (*traceLogger) Infof(msg string, args ...interface{}) { log.Infof(msg, args...) }

--- a/go/trace/plugin_datadog.go
+++ b/go/trace/plugin_datadog.go
@@ -20,12 +20,18 @@ func newDatadogTracer(serviceName string) (tracingService, io.Closer, error) {
 		return nil, nil, fmt.Errorf("need host and port to datadog agent to use datadog tracing")
 	}
 
-	t := opentracer.New(
-		ddtracer.WithAgentAddr(*dataDogHost+":"+*dataDogPort),
+	opts := []ddtracer.StartOption{
+		ddtracer.WithAgentAddr(*dataDogHost + ":" + *dataDogPort),
 		ddtracer.WithServiceName(serviceName),
 		ddtracer.WithDebugMode(true),
 		ddtracer.WithSampler(ddtracer.NewRateSampler(samplingRate.Get())),
-	)
+	}
+
+	if *enableLogging {
+		opts = append(opts, ddtracer.WithLogger(&traceLogger{}))
+	}
+
+	t := opentracer.New(opts...)
 
 	opentracing.SetGlobalTracer(t)
 

--- a/go/trace/plugin_jaeger.go
+++ b/go/trace/plugin_jaeger.go
@@ -98,7 +98,14 @@ func newJagerTracerFromEnv(serviceName string) (tracingService, io.Closer, error
 
 	log.Infof("Tracing sampler type %v (param: %v)", cfg.Sampler.Type, cfg.Sampler.Param)
 
-	tracer, closer, err := cfg.NewTracer()
+	var opts []config.Option
+	if *enableLogging {
+		opts = append(opts, config.Logger(&traceLogger{}))
+	} else if cfg.Reporter.LogSpans {
+		log.Warningf("JAEGER_REPORTER_LOG_SPANS was set, but -tracing-enable-logging was not; spans will not be logged")
+	}
+
+	tracer, closer, err := cfg.NewTracer(opts...)
 
 	if err != nil {
 		return nil, &nilCloser{}, err

--- a/go/trace/trace.go
+++ b/go/trace/trace.go
@@ -133,6 +133,7 @@ var currentTracer tracingService = noopTracingServer{}
 
 var (
 	tracingServer = flag.String("tracer", "noop", "tracing service to use")
+	enableLogging = flag.Bool("tracing-enable-logging", false, "whether to enable logging in the tracing service")
 )
 
 // StartTracing enables tracing for a named service


### PR DESCRIPTION
## Description

This PR adds a new flag to `package trace` to initialize the opentracing tracer (either jaeger or datadog) with a logger attached. I've also introduced a struct that implements both jaeger's and datadog's logger interfaces using the `go/vt/log` package under the hood.

### Demo

<details>
<summary> jaeger + <code>JAEGER_REPORTER_LOG_SPANS=true</code> + <code>-tracing-enable-logging</code></summary>

```
I0608 12:08:21.671954       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb:1
I0608 12:08:21.671978       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:bbbbbbbbbbbbbbbb:cccccccccccccccc:1
I0608 12:08:21.672031       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:dddddddddddddddd:eeeeeeeeeeeeeeee:1
I0608 12:08:21.765381       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:ffffffffffffffff:gggggggggggggggg:1
I0608 12:08:21.765405       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:gggggggggggggggg:eeeeeeeeeeeeeeee:1
I0608 12:08:21.864331       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:hhhhhhhhhhhhhhhh:yyyyyyyyyyyyyyyy:1
I0608 12:08:21.864354       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:yyyyyyyyyyyyyyyy:eeeeeeeeeeeeeeee:1
I0608 12:08:21.864369       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:eeeeeeeeeeeeeeee:cccccccccccccccc:1
I0608 12:08:21.864388       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:cccccccccccccccc:xxxxxxxxxxxxxxxx:1
I0608 12:08:21.913089       8 logger.go:32] Reporting span xxxxxxxxxxxxxxxx:xxxxxxxxxxxxxxxx:0:1
```

</details>

## Related Issue(s)

Closes #8288


## Checklist
- [ ] Tests were added or are not required - n/a
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->