### PR TITLE
[topo] Refactor `ExpandCells` to not error on valid aliases

### DIFF
--- a/go/vt/topo/topotests/cell_info_test.go
+++ b/go/vt/topo/topotests/cell_info_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"context"
@@ -176,4 +177,52 @@ func TestExpandCells(t *testing.T) {
 		})
 	}
 
+	t.Run("aliases", func(t *testing.T) {
+		cells := []string{"cell1", "cell2", "cell3"}
+		ts := memorytopo.NewServer(cells...)
+		err := ts.CreateCellsAlias(ctx, "alias", &topodatapb.CellsAlias{Cells: cells})
+		require.NoError(t, err)
+
+		tests := []struct {
+			name      string
+			in        string
+			out       []string
+			shouldErr bool
+		}{
+			{
+				name: "alias only",
+				in:   "alias",
+				out:  []string{"cell1", "cell2", "cell3"},
+			},
+			{
+				name: "alias and cell in alias", // test deduping logic
+				in:   "alias,cell1",
+				out:  []string{"cell1", "cell2", "cell3"},
+			},
+			{
+				name: "just cells",
+				in:   "cell1",
+				out:  []string{"cell1"},
+			},
+			{
+				name:      "missing alias",
+				in:        "not_an_alias",
+				shouldErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				expanded, err := ts.ExpandCells(ctx, tt.in)
+				if tt.shouldErr {
+					assert.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.ElementsMatch(t, expanded, tt.out)
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Description

A couple other changes here, in addition to the title:
- Store the output cells in a set to dedupe the final slice. This covers
the case where a caller passes `"alias,cell1"` where `cell1` is in the
cell list for `alias`. Without a set, it would appear twice in the final
result.
- Add an inner function to correct `defer` semantics on the cancel
funcs. Defering within the scope of a for loop is generally not what we
want, since all of the deferred functions will pile up until the total
function is done.

## Related Issue(s)

Fixes #8290

## Checklist
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->