### PR TITLE
Prepared statement buffer concurrent bug fix

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -883,7 +883,7 @@ func (c *Conn) handleComStmtReset(data []byte) bool {
 }
 
 func (c *Conn) handleComStmtSendLongData(data []byte) bool {
-	stmtID, paramID, chunkData, ok := c.parseComStmtSendLongData(data)
+	stmtID, paramID, chunk, ok := c.parseComStmtSendLongData(data)
 	c.recycleReadPacket()
 	if !ok {
 		err := fmt.Errorf("error parsing statement send long data from client %v, returning error: %v", c.ConnectionID, data)
@@ -902,9 +902,6 @@ func (c *Conn) handleComStmtSendLongData(data []byte) bool {
 		err := fmt.Errorf("invalid parameter Number from client %v, statement: %v", c.ConnectionID, prepare.PrepareStmt)
 		return c.writeErrorPacketFromErrorAndLog(err)
 	}
-
-	chunk := make([]byte, len(chunkData))
-	copy(chunk, chunkData)
 
 	key := fmt.Sprintf("v%d", paramID+1)
 	if val, ok := prepare.BindVars[key]; ok {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -516,7 +516,9 @@ func randSeq(n int) string {
 }
 
 func TestPrepareAndExecute(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// this test starts a lot of clients that all send prepared statement parameter values
+	// and check that the handler received the correct input
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	for i := 0; i < 1000; i++ {
 		startGoRoutine(ctx, t, randSeq(i))

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -845,7 +845,11 @@ func (c *Conn) parseComStmtSendLongData(data []byte) (uint32, uint16, []byte, bo
 		return 0, 0, nil, false
 	}
 
-	return statementID, paramID, data[pos:], true
+	chunkData := data[pos:]
+	chunk := make([]byte, len(chunkData))
+	copy(chunk, chunkData)
+
+	return statementID, paramID, chunk, true
 }
 
 func (c *Conn) parseComStmtClose(data []byte) (uint32, bool) {

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Utility function to write sql query as packets to test parseComPrepare
-func MockQueryPackets(t *testing.T, query string) []byte {
+func preparePacket(t *testing.T, query string) []byte {
 	data := make([]byte, len(query)+1+packetHeaderSize)
 	// Not sure if it makes a difference
 	pos := packetHeaderSize
@@ -127,7 +127,7 @@ func TestComStmtPrepare(t *testing.T) {
 	}()
 
 	sql := "select * from test_table where id = ?"
-	mockData := MockQueryPackets(t, sql)
+	mockData := preparePacket(t, sql)
 
 	if err := cConn.writePacket(mockData); err != nil {
 		t.Fatalf("writePacket failed: %v", err)


### PR DESCRIPTION
## Description
During high load, if prepared statements are used, the parameter values could accidentally get overwritten with dirty data from other concurrent connections.

This PR fixes this by copying the data before releasing the buffer.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required