### PR TITLE
Use shared testing helper which guards against races in tmclient construction

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -304,7 +304,9 @@ func TestApplyRoutingRules(t *testing.T) {
 				factory.SetError(errors.New("topo down for testing"))
 			}
 
-			vtctld := NewVtctldServer(ts)
+			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
+				return NewVtctldServer(ts)
+			})
 			_, err := vtctld.ApplyRoutingRules(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Related Issue(s)

Fixes #8299 

## Checklist
- [ ] Tests were added or are not required -- n/a
- [ ] Documentation was added or is not required -- n/a

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->