### PR TITLE
check for read_only flag to turn off before draining buffered requests

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -231,7 +231,7 @@ func (b *Buffer) ProcessMasterHealth(th *discovery.TabletHealth) {
 		// Buffer is shut down. Ignore all calls.
 		return
 	}
-	sb.recordExternallyReparentedTimestamp(timestamp, th.Tablet.Alias)
+	sb.recordExternallyReparentedTimestamp(timestamp, th.Tablet.Alias, th.Target, th.Conn)
 }
 
 // StatsUpdate keeps track of the "tablet_externally_reparented_timestamp" of
@@ -254,7 +254,7 @@ func (b *Buffer) StatsUpdate(ts *discovery.LegacyTabletStats) {
 		// Buffer is shut down. Ignore all calls.
 		return
 	}
-	sb.recordExternallyReparentedTimestamp(timestamp, ts.Tablet.Alias)
+	sb.recordExternallyReparentedTimestamp(timestamp, ts.Tablet.Alias, ts.Target, nil)
 }
 
 // CausedByFailover returns true if "err" was supposedly caused by a failover.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->