### PR TITLE
New VReplication lag metric 

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -98,6 +98,9 @@ type Stats struct {
 	CopyLoopCount  *stats.Counter
 	ErrorCounts    *stats.CountersWithMultiLabels
 	NoopQueryCount *stats.CountersWithSingleLabel
+
+	VReplicationLags     *stats.Timings
+	VReplicationLagRates *stats.Rates
 }
 
 // RecordHeartbeat updates the time the last heartbeat from vstreamer was seen
@@ -154,6 +157,8 @@ func NewStats() *Stats {
 	bps.CopyLoopCount = stats.NewCounter("", "")
 	bps.ErrorCounts = stats.NewCountersWithMultiLabels("", "", []string{"type"})
 	bps.NoopQueryCount = stats.NewCountersWithSingleLabel("", "", "Statement", "")
+	bps.VReplicationLags = stats.NewTimings("", "", "")
+	bps.VReplicationLagRates = stats.NewRates("", bps.VReplicationLags, 15*60/5, 5*time.Second)
 	return bps
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -113,6 +113,21 @@ func (st *vrStats) register() {
 			return result
 		})
 
+	stats.NewRateFunc(
+		"VReplicationLag",
+		"vreplication lag per stream",
+		func() map[string][]float64 {
+			st.mu.Lock()
+			defer st.mu.Unlock()
+			result := make(map[string][]float64)
+			for _, ct := range st.controllers {
+				for k, v := range ct.blpStats.VReplicationLagRates.Get() {
+					result[k] = v
+				}
+			}
+			return result
+		})
+
 	stats.Publish("VReplicationSource", stats.StringMapFunc(func() map[string]string {
 		st.mu.Lock()
 		defer st.mu.Unlock()

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -331,6 +332,7 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 	// TODO(sougou): if we also stored the time of the last event, we
 	// can estimate this value more accurately.
 	defer vp.vr.stats.SecondsBehindMaster.Set(math.MaxInt64)
+	defer vp.vr.stats.VReplicationLags.Add(strconv.Itoa(int(vp.vr.id)), math.MaxInt64)
 	var sbm int64 = -1
 	for {
 		// check throttler.
@@ -347,6 +349,7 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 		if len(items) == 0 {
 			behind := time.Now().UnixNano() - vp.lastTimestampNs - vp.timeOffsetNs
 			vp.vr.stats.SecondsBehindMaster.Set(behind / 1e9)
+			vp.vr.stats.VReplicationLags.Add(strconv.Itoa(int(vp.vr.id)), time.Duration(behind/1e9)*time.Second)
 		}
 		// Empty transactions are saved at most once every idleTimeout.
 		// This covers two situations:
@@ -401,6 +404,7 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 		}
 		if sbm >= 0 {
 			vp.vr.stats.SecondsBehindMaster.Set(sbm)
+			vp.vr.stats.VReplicationLags.Add(strconv.Itoa(int(vp.vr.id)), time.Duration(sbm)*time.Second)
 		}
 
 	}


### PR DESCRIPTION
## Description

Adds a new metric to display vreplication lags in the form of a gauge for easier display in VTAdmin.

Example:
```
"VReplicationLag": {"1":[1.6,4.8,4.8,4.8,4.8,10.8,13.8,9,4.8,4.8,4.6,4.8,9.6,5.2,10.2,6.4,5.8,6.4,6.4,6.4,6.4,6.4,6.4,6.4,6.4,6.4,7.2,6.4,6.4,6.4,6.4,6.4,6.4,6.4,6.4,9.8,8,8,8.2,7.6,8.4,7.2,8,6.8,6.4],
"10":[4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.6,4.8,4.8,5.2,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,0,0,0,0,0,0,0,0,0],
"11":[4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.4,4.8,4.8,5.2,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,5,0,0,0,0,0,0,0,0,0],
"All":[4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.8,4.6,4.8,4.8,5.2,4.8,4.8,4.8,4.8,4.8,4.
```

Signed-off-by: Rohit Nayak <rohit@planetscale.com>
