### PR TITLE
WIP [vtctld] backup status

### DIFF
--- a/go/cmd/vtctldclient/internal/command/backups.go
+++ b/go/cmd/vtctldclient/internal/command/backups.go
@@ -36,8 +36,10 @@ var GetBackups = &cobra.Command{
 }
 
 var getBackupsOptions = struct {
-	Limit      uint32
-	OutputJSON bool
+	Limit         uint32
+	Detailed      bool
+	DetailedLimit uint32
+	OutputJSON    bool
 }{}
 
 func commandGetBackups(cmd *cobra.Command, args []string) error {
@@ -49,15 +51,17 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 	cli.FinishedParsing(cmd)
 
 	resp, err := client.GetBackups(commandCtx, &vtctldatapb.GetBackupsRequest{
-		Keyspace: keyspace,
-		Shard:    shard,
-		Limit:    getBackupsOptions.Limit,
+		Keyspace:      keyspace,
+		Shard:         shard,
+		Limit:         getBackupsOptions.Limit,
+		Detailed:      getBackupsOptions.Detailed,
+		DetailedLimit: getBackupsOptions.DetailedLimit,
 	})
 	if err != nil {
 		return err
 	}
 
-	if getBackupsOptions.OutputJSON {
+	if getBackupsOptions.OutputJSON || getBackupsOptions.Detailed {
 		data, err := cli.MarshalJSON(resp)
 		if err != nil {
 			return err
@@ -80,5 +84,7 @@ func commandGetBackups(cmd *cobra.Command, args []string) error {
 func init() {
 	GetBackups.Flags().Uint32VarP(&getBackupsOptions.Limit, "limit", "l", 0, "Retrieve only the most recent N backups")
 	GetBackups.Flags().BoolVarP(&getBackupsOptions.OutputJSON, "json", "j", false, "Output backup info in JSON format rather than a list of backups")
+	GetBackups.Flags().BoolVar(&getBackupsOptions.Detailed, "detailed", false, "Get detailed backup info, such as the engine used for each backup, and its status. Implies --json.")
+	GetBackups.Flags().Uint32Var(&getBackupsOptions.DetailedLimit, "detailed-limit", 0, "Get detailed backup info for only the most recent N backups. Ignored if --detailed is not passed.")
 	Root.AddCommand(GetBackups)
 }

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -262,6 +262,11 @@ func (bh *AZBlobBackupHandle) ReadFile(ctx context.Context, filename string) (io
 	}), nil
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *AZBlobBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	return false, nil
+}
+
 // AZBlobBackupStorage structs implements the BackupStorage interface for AZBlob
 type AZBlobBackupStorage struct {
 }

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -77,6 +77,12 @@ type BackupHandle interface {
 	// ReadCloser is closed.
 	ReadFile(ctx context.Context, filename string) (io.ReadCloser, error)
 
+	// CheckFile checks if a file is included in a backup. Only works for
+	// read-only backups (created by ListBackups). Returns a boolean to indicate
+	// if the file exists, and an error. Variants of "file not found" errors do
+	// result in an error, but instead result in (false, nil).
+	CheckFile(ctx context.Context, filename string) (bool, error)
+
 	// concurrency.ErrorRecorder is embedded here to coordinate reporting and
 	// handling of errors among all the components involved in taking a backup.
 	concurrency.ErrorRecorder

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -42,6 +42,8 @@ import (
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 )
 
 const (
@@ -454,6 +456,14 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 	// Save the hash.
 	fe.Hash = hasher.HashString()
 	return nil
+}
+
+// GetBackupStatus is part of the BackupEngine interface.
+//
+// This is currently not implemented for builtinbackupengine, so we always
+// return UNKNOWN.
+func (be *BuiltinBackupEngine) GetBackupStatus(ctx context.Context, bh backupstorage.BackupHandle, mfestBytes []byte) (mysqlctlpb.BackupInfo_Status, error) {
+	return mysqlctlpb.BackupInfo_UNKNOWN, nil
 }
 
 // ExecuteRestore restores from a backup. If the restore is successful

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -146,6 +146,12 @@ func (bh *CephBackupHandle) ReadFile(ctx context.Context, filename string) (io.R
 	return bh.client.GetObjectWithContext(ctx, bucket, object, minio.GetObjectOptions{})
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *CephBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	// (TODO) when we implement this, use bh.client.StatObject
+	return false, nil
+}
+
 // CephBackupStorage implements BackupStorage for Ceph Cloud Storage.
 type CephBackupStorage struct {
 	// client is the instance of the Ceph Cloud Storage Go client.

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -106,6 +106,25 @@ func (fbh *FileBackupHandle) ReadFile(ctx context.Context, filename string) (io.
 	return os.Open(p)
 }
 
+// CheckFile is part of the BackupHandle interface.
+func (fbh *FileBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	if !fbh.readOnly {
+		return false, fmt.Errorf("CheckFile cannot be called on read-write backup")
+	}
+
+	p := path.Join(*FileBackupStorageRoot, fbh.dir, fbh.name, filename)
+	_, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // FileBackupStorage implements BackupStorage for local file system.
 type FileBackupStorage struct{}
 

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -115,6 +115,11 @@ func (bh *GCSBackupHandle) ReadFile(ctx context.Context, filename string) (io.Re
 	return bh.client.Bucket(*bucket).Object(object).NewReader(ctx)
 }
 
+// CheckFile is part of the BackupHandle interface. It is currently unimplemented.
+func (bh *GCSBackupHandle) CheckFile(ctx context.Context, filename string) (bool, error) {
+	return false, nil
+}
+
 // GCSBackupStorage implements BackupStorage for Google Cloud Storage.
 type GCSBackupStorage struct {
 	// client is the instance of the Google Cloud Storage Go client.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

<details><summary>Demo</summary>

Note that for this, I made a quick change to `builtinbackupengine`'s `GetBackupStatus` method to return a random status, via:

```diff
diff --git a/go/vt/mysqlctl/builtinbackupengine.go b/go/vt/mysqlctl/builtinbackupengine.go
index 3f88b5eecd..4888eb6165 100644
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -23,6 +23,7 @@
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path"
 	"sync"
@@ -463,7 +464,16 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 // This is currently not implemented for builtinbackupengine, so we always
 // return UNKNOWN.
 func (be *BuiltinBackupEngine) GetBackupStatus(ctx context.Context, bh backupstorage.BackupHandle, mfestBytes []byte) (mysqlctlpb.BackupInfo_Status, error) {
-	return mysqlctlpb.BackupInfo_UNKNOWN, nil
+	// pick a random value from the map, only works because there are no gaps in the values
+	i := rand.Intn(len(mysqlctlpb.BackupInfo_Status_name))
+	status := int32(i)
+	if _, ok := mysqlctlpb.BackupInfo_Status_name[status]; !ok {
+		status = int32(mysqlctlpb.BackupInfo_UNKNOWN)
+	}
+
+	return mysqlctlpb.BackupInfo_Status(status), nil
+
+	// return mysqlctlpb.BackupInfo_UNKNOWN, nil
 }
 
 // ExecuteRestore restores from a backup. If the restore is successful
```

Anyway, the results, showing limiting and details (more to show that the backend impl is correct than anything about the CLI usability -- i am going to change the way we marshal json to convert enums from ints to their actual names separately):

```
❯ vtctlclient -server ":15999" Backup zone1-101
❯ vtctlclient -server ":15999" Backup zone1-102
❯ vtctldclient --server ":15999" GetBackups commerce/0
2021-06-15.003301.zone1-0000000101
2021-06-15.003310.zone1-0000000102
❯ vtctldclient --server ":15999" GetBackups commerce/0 -l1
2021-06-15.003310.zone1-0000000102
❯ vtctldclient --server ":15999" GetBackups commerce/0 --detailed
{
  "backups": [
    {
      "name": "2021-06-15.003301.zone1-0000000101",
      "directory": "commerce/0",
      "keyspace": "commerce",
      "shard": "0",
      "tablet_alias": {
        "cell": "zone1",
        "uid": 101
      },
      "time": {
        "seconds": "1623717181",
        "nanoseconds": 0
      },
      "engine": "builtin",
      "status": 2
    },
    {
      "name": "2021-06-15.003310.zone1-0000000102",
      "directory": "commerce/0",
      "keyspace": "commerce",
      "shard": "0",
      "tablet_alias": {
        "cell": "zone1",
        "uid": 102
      },
      "time": {
        "seconds": "1623717190",
        "nanoseconds": 0
      },
      "engine": "builtin",
      "status": 1
    }
  ]
}
```

</details>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->