### PR TITLE
[vtadmin-web] Small bugfix where stream source displayed instead of target

### DIFF
--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -89,7 +89,7 @@ export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
                     <DataCell>
                         {target ? (
                             <KeyspaceLink clusterID={clusterID} name={keyspace} shard={row.shard}>
-                                {source}
+                                {target}
                             </KeyspaceLink>
                         ) : (
                             <span className="text-color-secondary">N/A</span>


### PR DESCRIPTION
## Description

A small bugfix to display target shard, instead of source shard, for workflow streams. 😊 

## Related Issue(s)

N/A

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

N/A