### PR TITLE
workaround xtrabackup error with old_alter_table

### DIFF
--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -100,6 +100,11 @@ func TestMainImpl(m *testing.M) {
 		sql := string(initDb)
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 		sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
+		// https://github.com/vitessio/vitess/issues/8315
+		oldAlterTableMode := `
+SET GLOBAL old_alter_table = ON;
+`
+		sql = sql + oldAlterTableMode
 		ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
 
 		extraArgs := []string{"-db-credentials-file", dbCredentialFile}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Some of the xtrabackup tests have been flaky for a while. Today @vmg was able to extract the actual error from a failing test.
This seems to be a known issue with a documented workaround. Implementing the workaround.
https://www.percona.com/blog/2017/08/08/avoiding-the-an-optimized-without-redo-logging-ddloperation-has-been-performed-error-with-percona-xtrabackup/

The blog post has 3 suggestions:
* `--lock-ddl` : only works with Percona MySQL server, we are running community MySQL server in  CI
* `--lock-ddl-per-table`: did not fix the problem
* `old_alter_table`: :crossed_fingers: 

## Related Issue(s)
Fixes #8315 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->