### PR TITLE
[vtctldserver] Update tests to prevent races during tmclient init

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -1328,7 +1328,9 @@ func TestDeleteCellsAlias(t *testing.T) {
 				require.NoError(t, err, "test setup failed")
 			}
 
-			vtctld := NewVtctldServer(tt.ts)
+			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, tt.ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
+				return NewVtctldServer(ts)
+			})
 			_, err := vtctld.DeleteCellsAlias(ctx, tt.req)
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -2719,6 +2721,8 @@ func TestFindAllShardsInKeyspace(t *testing.T) {
 }
 
 func TestGetBackups(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ts := memorytopo.NewServer()
 	vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
@@ -3003,7 +3007,9 @@ func TestGetRoutingRules(t *testing.T) {
 				factory.SetError(errors.New("topo down for testing"))
 			}
 
-			vtctld := NewVtctldServer(ts)
+			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
+				return NewVtctldServer(ts)
+			})
 			resp, err := vtctld.GetRoutingRules(ctx, &vtctldatapb.GetRoutingRulesRequest{})
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -4515,7 +4521,9 @@ func TestRebuildVSchemaGraph(t *testing.T) {
 				factory.SetError(errors.New("topo down for testing"))
 			}
 
-			vtctld := NewVtctldServer(ts)
+			vtctld := testutil.NewVtctldServerWithTabletManagerClient(t, ts, nil, func(ts *topo.Server) vtctlservicepb.VtctldServer {
+				return NewVtctldServer(ts)
+			})
 			_, err := vtctld.RebuildVSchemaGraph(ctx, req)
 			if tt.shouldErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

Prior to this change, running the full `grpcvtctldserver` test suite a few times would occasionally produce a panic, ultimately owing to: `fatal error: concurrent map read and map write`. The stack, which I didn't copy, and the RNG deities are not cooperating right now, points back to `tmclient.NewTabletManagerClient` coming from various tests here.

So, I went through the tests and found any test that was using `t.Parallel()` (good!) but not using the `testutil.NewVtctldServerWithTabletManagerClient()` (less good!).

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required -- n/a
- [ ] Documentation was added or is not required -- n/a

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->