### PR TITLE
pr-labels workflow: only check actual PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -2,8 +2,6 @@ name: pr-labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-  push:
-  label:
 jobs:
   analyze:
     if: github.repository == 'vitessio/vitess'
@@ -24,6 +22,9 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
+        if [ -z "$PR_NUMBER" ] ; then
+          exit 0
+        fi
         LABELS_JSON="/tmp/labels.json"
 
         # Get labels for this pull request


### PR DESCRIPTION
## Description

fixes https://github.com/vitessio/vitess/issues/8324

`pr-labels` workflow to only check for an actual pull request.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/8324

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->