### PR TITLE
Heuristic fix for a flaky test: allow for some noise to pass through

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -481,12 +481,24 @@ func shouldIgnoreQuery(query string) bool {
 	return heartbeatRe.MatchString(query)
 }
 
-func expectDBClientQueries(t *testing.T, queries []string) {
+func expectDBClientQueries(t *testing.T, queries []string, skippableOnce ...string) {
 	extraQueries := withDDL.DDLs()
 	extraQueries = append(extraQueries, withDDLInitialQueries...)
 	// Either 'queries' or 'queriesWithDDLs' must match globalDBQueries
 	t.Helper()
 	failed := false
+	skippedOnce := false
+
+	queryMatch := func(query string, got string) bool {
+		if query[0] == '/' {
+			result, err := regexp.MatchString(query[1:], got)
+			if err != nil {
+				panic(err)
+			}
+			return result
+		}
+		return (got == query)
+	}
 	for i, query := range queries {
 		if failed {
 			t.Errorf("no query received, expecting %s", query)
@@ -507,17 +519,16 @@ func expectDBClientQueries(t *testing.T, queries []string) {
 				}
 			}
 
-			var match bool
-			if query[0] == '/' {
-				result, err := regexp.MatchString(query[1:], got)
-				if err != nil {
-					panic(err)
+			if !queryMatch(query, got) {
+				if !skippedOnce {
+					// let's see if "got" is a skippable query
+					for _, skippable := range skippableOnce {
+						if queryMatch(skippable, got) {
+							skippedOnce = true
+							goto retry
+						}
+					}
 				}
-				match = result
-			} else {
-				match = (got == query)
-			}
-			if !match {
 				t.Errorf("query:\n%q, does not match query %d:\n%q", got, i, query)
 			}
 		case <-time.After(5 * time.Second):

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -529,7 +529,7 @@ func expectDBClientQueries(t *testing.T, queries []string, skippableOnce ...stri
 						}
 					}
 				}
-				t.Errorf("query:\n%q, does not match query %d:\n%q", got, i, query)
+				t.Errorf("query:\n%q, does not match expected query %d:\n%q", got, i, query)
 			}
 		case <-time.After(5 * time.Second):
 			t.Errorf("no query received, expecting %s", query)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1902,7 +1902,9 @@ func TestPlayerIdleUpdate(t *testing.T) {
 		"insert into t1(id,val) values (1,'aaa')",
 		"/update _vt.vreplication set pos=",
 		"commit",
-	})
+	},
+		"/update _vt.vreplication set pos=",
+	)
 	// The above write will generate a new binlog event, and
 	// that event will loopback into player as an empty event.
 	// But it must not get saved until idleTimeout has passed.


### PR DESCRIPTION

## Description

An attempt at fixing #8323 

What happens in #8323 is that a `update _vt.vreplication set pos=` query is encountered unexpectedly. This query can appear due to heartbeat leftovers from a previous test or from a heartbeat race condition.

This PR allows for just a little bit of noise to pass through: `expectDBClientQueries` supports `skippableOnce` optional list of queries. It's OK to hit _at most_ one of given skippable queries, _once_, while iterating expected queries.


## Related Issue(s)

- https://github.com/vitessio/vitess/issues/8323
- 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
