### PR TITLE
workaround xtrabackup error using mysql global variable old_alter_table

### DIFF
--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -100,6 +100,11 @@ func TestMainImpl(m *testing.M) {
 		sql := string(initDb)
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 		sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
+		// https://github.com/vitessio/vitess/issues/8315
+		oldAlterTableMode := `
+SET GLOBAL old_alter_table = ON;
+`
+		sql = sql + oldAlterTableMode
 		ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
 
 		extraArgs := []string{"-db-credentials-file", dbCredentialFile}

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -299,6 +299,7 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 	// the replication position. Note that if we don't read stderr as we go, the
 	// xtrabackup process gets blocked when the write buffer fills up.
 	stderrBuilder := &strings.Builder{}
+	posBuilder := &strings.Builder{}
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
@@ -318,7 +319,7 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 				}
 				capture = true
 			}
-			fmt.Fprintln(stderrBuilder, line)
+			fmt.Fprintln(posBuilder, line)
 		}
 		if err := scanner.Err(); err != nil {
 			params.Logger.Errorf("error reading from xtrabackup stderr: %v", err)
@@ -359,10 +360,11 @@ func (be *XtrabackupEngine) backupFiles(ctx context.Context, params BackupParams
 	sterrOutput := stderrBuilder.String()
 
 	if err := backupCmd.Wait(); err != nil {
-		return replicationPosition, vterrors.Wrap(err, "xtrabackup failed with error")
+		return replicationPosition, vterrors.Wrap(err, fmt.Sprintf("xtrabackup failed with error. Output=%s", sterrOutput))
 	}
 
-	replicationPosition, rerr := findReplicationPosition(sterrOutput, flavor, params.Logger)
+	posOutput := posBuilder.String()
+	replicationPosition, rerr := findReplicationPosition(posOutput, flavor, params.Logger)
 	if rerr != nil {
 		return replicationPosition, vterrors.Wrap(rerr, "backup failed trying to find replication position")
 	}


### PR DESCRIPTION
## Description

Resubmission of https://github.com/vitessio/vitess/pull/8317
Instead of backporting commits into earlier versions, we want to apply changes in earlier versions, then merge forward.
This will merge into `release-9.0` branch

Copy of original comment from @deepthi :

---

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Some of the xtrabackup tests have been flaky for a while. Today @vmg was able to extract the actual error from a failing test.
This seems to be a known issue with a documented workaround. Implementing the workaround.
https://www.percona.com/blog/2017/08/08/avoiding-the-an-optimized-without-redo-logging-ddloperation-has-been-performed-error-with-percona-xtrabackup/

The blog post has 3 suggestions:
* `--lock-ddl` : only works with Percona MySQL server, we are running community MySQL server in  CI
* `--lock-ddl-per-table`: did not fix the problem
* `old_alter_table`: :crossed_fingers: 

## Related Issue(s)
Fixes #8315 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->