### PR TITLE
[vtctldproxy] Add more annotations to vtctld Dial calls

### DIFF
--- a/go/vt/vtadmin/vtctldclient/proxy.go
+++ b/go/vt/vtadmin/vtctldclient/proxy.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/vtadmin/cluster/discovery"
+	"vitess.io/vitess/go/vt/vtadmin/vtadminproto"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldclient"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
 
@@ -90,9 +91,12 @@ func (vtctld *ClientProxy) Dial(ctx context.Context) error {
 	span, ctx := trace.NewSpan(ctx, "VtctldClientProxy.Dial")
 	defer span.Finish()
 
+	vtadminproto.AnnotateClusterSpan(vtctld.cluster, span)
+
 	if vtctld.VtctldClient != nil {
 		if !vtctld.closed {
 			span.Annotate("is_noop", true)
+			span.Annotate("vtctld_host", vtctld.host)
 
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

Exactly what it says in the title. This gives us info about the cluster that we're dialing, as well as the underlying vtctld hostname we're using, including when the dial is a no-op.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required -- n/a
- [ ] Documentation was added or is not required -- n/a

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->