### PR TITLE
[vtadmin-web] Add getStream util + tune refetch intervals

### DIFF
--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -36,7 +36,7 @@ import { KeyspaceLink } from '../links/KeyspaceLink';
 
 export const Workflows = () => {
     useDocumentTitle('Workflows');
-    const { data } = useWorkflows({ refetchInterval: 1000 });
+    const { data } = useWorkflows();
     const { value: filter, updateValue: updateFilter } = useSyncedURLParam('filter');
 
     const sortedData = React.useMemo(() => {

--- a/web/vtadmin/src/components/routes/stream/Stream.tsx
+++ b/web/vtadmin/src/components/routes/stream/Stream.tsx
@@ -17,7 +17,7 @@ import { Link, useParams } from 'react-router-dom';
 
 import { useWorkflow } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
-import { formatStreamKey, getStreams } from '../../../util/workflows';
+import { formatStreamKey, getStream } from '../../../util/workflows';
 import { Code } from '../../Code';
 import { ContentContainer } from '../../layout/ContentContainer';
 import { NavCrumbs } from '../../layout/NavCrumbs';
@@ -36,14 +36,11 @@ interface RouteParams {
 
 export const Stream = () => {
     const params = useParams<RouteParams>();
-    const { data: workflow } = useWorkflow(
-        {
-            clusterID: params.clusterID,
-            keyspace: params.keyspace,
-            name: params.workflowName,
-        },
-        { refetchInterval: 1000 }
-    );
+    const { data: workflow } = useWorkflow({
+        clusterID: params.clusterID,
+        keyspace: params.keyspace,
+        name: params.workflowName,
+    });
 
     const streamID = parseInt(params.streamID, 10);
     const tabletUID = parseInt(params.tabletUID, 10);
@@ -52,9 +49,7 @@ export const Stream = () => {
 
     useDocumentTitle(`${streamKey} (${params.workflowName})`);
 
-    const stream = getStreams(workflow).find(
-        (s) => s.id === streamID && s.tablet?.cell === tabletAlias.cell && s.tablet?.uid === tabletAlias.uid
-    );
+    const stream = getStream(workflow, streamKey);
 
     return (
         <div>

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -42,7 +42,7 @@ export const Workflow = () => {
 
     useDocumentTitle(`${name} (${keyspace})`);
 
-    const { data } = useWorkflow({ clusterID, keyspace, name }, { refetchInterval: 1000 });
+    const { data } = useWorkflow({ clusterID, keyspace, name });
     const streams = getStreams(data);
 
     return (

--- a/web/vtadmin/src/index.tsx
+++ b/web/vtadmin/src/index.tsx
@@ -25,7 +25,13 @@ import * as errorHandler from './errors/errorHandler';
 
 errorHandler.initialize();
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            refetchOnWindowFocus: false,
+        },
+    },
+});
 
 ReactDOM.render(
     <React.StrictMode>

--- a/web/vtadmin/src/util/workflows.test.ts
+++ b/web/vtadmin/src/util/workflows.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { vtadmin as pb } from '../proto/vtadmin';
-import { getStreams, getStreamTablets } from './workflows';
+import { getStream, getStreams, getStreamTablets } from './workflows';
 
 describe('getStreams', () => {
     const tests: {
@@ -67,6 +67,129 @@ describe('getStreams', () => {
         '%s',
         (name: string, input: Parameters<typeof getStreams>, expected: ReturnType<typeof getStreams>) => {
             expect(getStreams(...input)).toEqual(expected);
+        }
+    );
+});
+
+describe('getStream', () => {
+    const tests: {
+        name: string;
+        input: Parameters<typeof getStream>;
+        expected: ReturnType<typeof getStream>;
+    }[] = [
+        {
+            name: 'should return the stream for the streamKey',
+            input: [
+                pb.Workflow.create({
+                    workflow: {
+                        shard_streams: {
+                            '-80/us_east_1a-123456': {
+                                streams: [
+                                    {
+                                        id: 1,
+                                        shard: '-80',
+                                        tablet: {
+                                            cell: 'us_east_1a',
+                                            uid: 123456,
+                                        },
+                                    },
+                                    {
+                                        id: 2,
+                                        shard: '-80',
+                                        tablet: {
+                                            cell: 'us_east_1a',
+                                            uid: 123456,
+                                        },
+                                    },
+                                ],
+                            },
+                            '-80/us_east_1a-789012': {
+                                streams: [
+                                    {
+                                        id: 1,
+                                        shard: '-80',
+                                        tablet: {
+                                            cell: 'us_east_1a',
+                                            uid: 789012,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                }),
+                'us_east_1a-123456/2',
+            ],
+            expected: {
+                id: 2,
+                shard: '-80',
+                tablet: {
+                    cell: 'us_east_1a',
+                    uid: 123456,
+                },
+            },
+        },
+        {
+            name: 'should handle no matching stream in workflow',
+            input: [
+                pb.Workflow.create({
+                    workflow: {
+                        shard_streams: {
+                            '-80/us_east_1a-123456': {
+                                streams: [
+                                    {
+                                        id: 1,
+                                        shard: '-80',
+                                        tablet: {
+                                            cell: 'us_east_1a',
+                                            uid: 123456,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                }),
+                'us_east_1a-123456/2',
+            ],
+            expected: undefined,
+        },
+        {
+            name: 'should handle undefined streamKey',
+            input: [
+                pb.Workflow.create({
+                    workflow: {
+                        shard_streams: {
+                            '-80/us_east_1a-123456': {
+                                streams: [
+                                    {
+                                        id: 1,
+                                        shard: '-80',
+                                        tablet: {
+                                            cell: 'us_east_1a',
+                                            uid: 123456,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                }),
+                undefined,
+            ],
+            expected: undefined,
+        },
+        {
+            name: 'should handle undefined workflow',
+            input: [undefined, 'us_east_1a-123456/1'],
+            expected: undefined,
+        },
+    ];
+
+    test.each(tests.map(Object.values))(
+        '%s',
+        (name: string, input: Parameters<typeof getStream>, expected: ReturnType<typeof getStream>) => {
+            expect(getStream(...input)).toEqual(expected);
         }
     );
 });

--- a/web/vtadmin/src/util/workflows.ts
+++ b/web/vtadmin/src/util/workflows.ts
@@ -32,6 +32,20 @@ export const getStreams = <W extends pb.IWorkflow>(workflow: W | null | undefine
     }, [] as vtctldata.Workflow.IStream[]);
 };
 
+/**
+ * getStream returns the stream in the workflow with the given streamKey.
+ */
+export const getStream = <W extends pb.IWorkflow>(
+    workflow: W | null | undefined,
+    streamKey: string | null | undefined
+): vtctldata.Workflow.IStream | undefined => {
+    if (!streamKey || !workflow) {
+        return undefined;
+    }
+
+    return getStreams(workflow).find((s) => formatStreamKey(s) === streamKey);
+};
+
 export const formatStreamKey = <S extends vtctldata.Workflow.IStream>(stream: S | null | undefined): string | null => {
     return stream?.tablet && stream?.id ? `${formatAlias(stream.tablet)}/${stream.id}` : null;
 };


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>


## Description

Two small things:

- Adds a `getStream` util + tests, which will be useful for the stream detail views over the next little bit.
- Removes a few `refetchInterval` parameters so queries will fetch less frequently. Once per second is more frequently than is really necessary, especially for views that aren't charts. 
- Updates all components by default to no longer refetch every time the window receives focus via react-query's [`refetchOnWindowFocus` option](https://react-query.tanstack.com/guides/important-defaults). In the future, this will be parameterized with build flags. 

## Related Issue(s)

N/A


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A