### PR TITLE
Bugfix: assign cexpr.references for column CONVERTed to utf8mb4

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -375,7 +375,6 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 			if _, err := execParsedQuery(tp.Delete, bindvars, executor); err != nil {
 				return nil, err
 			}
-
 		}
 		return execParsedQuery(tp.Insert, bindvars, executor)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -391,6 +391,7 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 		cexpr.expr = expr
 		cexpr.operation = opExpr
 		tpb.sendSelect.SelectExprs = append(tpb.sendSelect.SelectExprs, &sqlparser.AliasedExpr{Expr: selExpr, As: as})
+		cexpr.references[as.Lowered()] = true
 		return cexpr, nil
 	}
 	if expr, ok := aliased.Expr.(*sqlparser.FuncExpr); ok {
@@ -437,7 +438,6 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
-
 			if !node.Qualifier.IsEmpty() {
 				return false, fmt.Errorf("unsupported qualifier for column: %v", sqlparser.String(node))
 			}

--- a/test/config.json
+++ b/test/config.json
@@ -339,7 +339,7 @@
 		},
 		"onlineddl_vrepl_suite": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl_suite"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/onlineddl/vrepl_suite", "-timeout", "30m"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "onlineddl_vrepl_suite",


### PR DESCRIPTION

## Description
Fixes https://github.com/vitessio/vitess/issues/8351

These two PRs:

- https://github.com/vitessio/vitess/pull/8322
- https://github.com/vitessio/vitess/pull/8345

Introduced a conflict. Because both were open at the same time and both merged to `main` without merging the 1st into the 2nd, this conflict was only seen in `main` after both merged.

The nature of the bug:
- In #8322 we introduce casting to `utf8mb4` for texts. 
- In #8345 we introduce a test where a text column is part of a primary key, and is modified via `UPDATE`
Now, when the text is `CONVERT`ed, then it becomes a function and ceases to be a text, and is not found to be part of the primary key anymore.

This PR takes care of that edge case.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/8351

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->