### PR TITLE
WIP: Vreplication streamer to convert textual columns to UTF8

### DIFF
--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -83,6 +83,18 @@ from information_schema.columns as ISC
 		ISC.ordinal_position = c.ordinal_position
 where c.table_schema = database() AND ISC.table_schema is null`
 
+	// FetchTableColumn queries information about columns in a given table
+	FetchTableColumns = `select
+	column_name as column_name, data_type as data_type, character_set_name as character_set_name,
+	(data_type rlike '.*int') as is_int,
+	(data_type rlike '.*text' or data_type rlike '.*char') as is_string,
+	(character_set_name rlike 'utf8.*') as is_utf8,
+	(data_type='enum') as is_enum
+from information_schema.columns
+where table_schema = database() and
+	table_name=%a
+order by ordinal_position`
+
 	// DetectSchemaChange query detects if there is any schema change from previous copy.
 	DetectSchemaChange = detectChangeColumns + " UNION " + detectNewColumns + " UNION " + detectRemoveColumns
 

--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -472,6 +472,7 @@ func (v *VRepl) generateFilterQuery(ctx context.Context) error {
 				}
 			}
 			// We will always read strings as utf8mb4.
+			// sb.WriteString(escapeName(name))
 			sb.WriteString(fmt.Sprintf("convert(%s using utf8mb4)", escapeName(name)))
 		default:
 			sb.WriteString(escapeName(name))

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -297,6 +297,7 @@ func (tp *TablePlan) isOutsidePKRange(bindvars map[string]*querypb.BindVariable,
 // - ...any other future possible values
 func (tp *TablePlan) bindFieldVal(field *querypb.Field, val *sqltypes.Value) (*querypb.BindVariable, error) {
 	if conversion, ok := tp.ConvertCharset[field.Name]; ok && !val.IsNull() {
+		fmt.Printf("============== conversion for %v: from %v to %v\n", field.Name, conversion.FromCharset, conversion.ToCharset)
 		// Non-null string value, for which we have a charset conversion instruction
 		valString := val.ToString()
 		fromEncoding, encodingOK := mysql.CharacterSetEncoding[conversion.FromCharset]

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -383,17 +383,6 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 		colName:    as,
 		references: make(map[string]bool),
 	}
-	if expr, ok := aliased.Expr.(*sqlparser.ConvertUsingExpr); ok {
-		selExpr := &sqlparser.ConvertUsingExpr{
-			Type: "utf8mb4",
-			Expr: &sqlparser.ColName{Name: as},
-		}
-		cexpr.expr = expr
-		cexpr.operation = opExpr
-		tpb.sendSelect.SelectExprs = append(tpb.sendSelect.SelectExprs, &sqlparser.AliasedExpr{Expr: selExpr, As: as})
-		cexpr.references[as.Lowered()] = true
-		return cexpr, nil
-	}
 	if expr, ok := aliased.Expr.(*sqlparser.FuncExpr); ok {
 		if expr.Distinct {
 			return nil, fmt.Errorf("unexpected: %v", sqlparser.String(expr))

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -250,10 +250,19 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			fieldEvent := &binlogdatapb.FieldEvent{
 				TableName: initialPlan.SendRule.Match,
 			}
+
+			for _, f := range rows.Fields {
+				fmt.Printf("========= vcopier field: name=%v\n", f.Name)
+				fmt.Printf("========= vcopier field: %v\n", f)
+			}
 			fieldEvent.Fields = append(fieldEvent.Fields, rows.Fields...)
 			vc.tablePlan, err = plan.buildExecutionPlan(fieldEvent)
 			if err != nil {
 				return err
+			}
+			for _, f := range rows.Pkfields {
+				fmt.Printf("========= vcopier pkfields: name=%v\n", f.Name)
+				fmt.Printf("========= vcopier pkfields: %v\n", f)
 			}
 			pkfields = append(pkfields, rows.Pkfields...)
 			buf := sqlparser.NewTrackedBuffer(nil)

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -48,8 +48,6 @@ type Plan struct {
 	// in the stream.
 	ColExprs []ColExpr
 
-	convertUsingUTF8Columns map[string]bool
-
 	// Filters is the list of filters to be applied to the columns
 	// of the table.
 	Filters []Filter
@@ -442,24 +440,6 @@ func analyzeSelect(query string) (sel *sqlparser.Select, fromTable sqlparser.Tab
 	return sel, fromTable, nil
 }
 
-// isConvertColumnUsingUTF8 returns 'true' when given column needs to be converted as UTF8
-// while read from source table
-func (plan *Plan) isConvertColumnUsingUTF8(columnName string) bool {
-	if plan.convertUsingUTF8Columns == nil {
-		return false
-	}
-	return plan.convertUsingUTF8Columns[columnName]
-}
-
-// setConvertColumnUsingUTF8 marks given column as needs to be converted as UTF8
-// while read from source table
-func (plan *Plan) setConvertColumnUsingUTF8(columnName string) {
-	if plan.convertUsingUTF8Columns == nil {
-		plan.convertUsingUTF8Columns = map[string]bool{}
-	}
-	plan.convertUsingUTF8Columns[columnName] = true
-}
-
 func (plan *Plan) analyzeWhere(vschema *localVSchema, where *sqlparser.Where) error {
 	if where == nil {
 		return nil
@@ -619,17 +599,6 @@ func (plan *Plan) analyzeExpr(vschema *localVSchema, selExpr sqlparser.SelectExp
 			},
 			ColNum:     -1,
 			FixedValue: sqltypes.NewInt64(num),
-		}, nil
-	case *sqlparser.ConvertUsingExpr:
-		colnum, err := findColumn(plan.Table, aliased.As)
-		if err != nil {
-			return ColExpr{}, err
-		}
-		field := plan.Table.Fields[colnum]
-		plan.setConvertColumnUsingUTF8(field.Name)
-		return ColExpr{
-			ColNum: colnum,
-			Field:  field,
 		}, nil
 	default:
 		log.Infof("Unsupported expression: %v", inner)


### PR DESCRIPTION
**Experimental**

## Description

In https://github.com/vitessio/vitess/pull/8322 we introduced support for non-UTF8 characters. In https://github.com/vitessio/vitess/pull/8322 it was the responsibility of the initiator of the stream (online DDL in this case) to analyze which columns had to convert to UTF8. It then needed to signal to the streamer the identities of those columns. This was done by applying `CONVERT(col USING utf8mb4)`. Streamer analyzed the query, found a `ConvertUsing` expression, and re-applied `CONVERT(col USING utf8mb4)` in `SendQuery`.

This PR moves the burden to the streamer. The streamer reads columns from a table. It has direct access to the table. It is in the best position to determine which columns are textual and not UTF8.

In this PR the streamer issues a query on `information_schema.columns` to determine which columns need to be converted to UTF8. Online DDL doesn't need to hint any more, and we are able to strip out some excessive code.

### But there's a problem

This doesn't work yet. Curiously, it is apparently still required that `vrepl.go` issues a `sb.WriteString(fmt.Sprintf("convert(%s using utf8mb4)", escapeName(name)))`. If I replace that with `sb.WriteString(escapeName(name))`, then a `latin1` text in a `latin1` character set gets garbled and deciphered incorrectly.

To elaborate, what `vrepl.go` does is to generate the Filter/Rule query for vreplication.

But this confuses me. I thought the filter query in VReplication is _mostly_ meaningless. That is, it is not the actual query that runs on the source table. Vstreamer completely rewrites the query after analyzing its expressions. Assuming vstreamer always reads textual columns via `convert(col using utf8mb4)`, I don't see why it matters if the filter query does or does not have `convert(col using utf8mb4)`.

The code as it is today, works. But I do want to clean it up and make the filter query as simple as possible. So I'd like to pursue this issue.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/8322

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->