### PR TITLE
tm state: don't populate metadata in updateLocked 

### DIFF
--- a/go/test/endtoend/reparent/utils_test.go
+++ b/go/test/endtoend/reparent/utils_test.go
@@ -116,6 +116,7 @@ func setupCluster(ctx context.Context, t *testing.T, shardName string, cells []s
 	clusterInstance.VtTabletExtraArgs = []string{
 		"-lock_tables_timeout", "5s",
 		"-enable_semi_sync",
+		"-init_populate_metadata",
 		"-track_schema_versions=true",
 	}
 

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -239,7 +239,6 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 	// before other services are shutdown.
 	reason := ts.canServe(ts.tablet.Type)
 	if reason != "" {
-		ts.populateLocalMetadataLocked()
 		log.Infof("Disabling query service: %v", reason)
 		if err := ts.tm.QueryServiceControl.SetServingType(ts.tablet.Type, terTime, false, reason); err != nil {
 			log.Errorf("SetServingType(serving=false) failed: %v", err)
@@ -281,8 +280,6 @@ func (ts *tmState) updateLocked(ctx context.Context) {
 		if err := ts.tm.QueryServiceControl.SetServingType(ts.tablet.Type, terTime, true, ""); err != nil {
 			log.Errorf("Cannot start query service: %v", err)
 		}
-
-		ts.populateLocalMetadataLocked()
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This is a partial revert of #8107. Calling `populateMetadata` in `updateLocked` causes `publishState` to fail when semi-sync is enabled.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
TBD

## Checklist
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->