### PR TITLE
Ignore Internal Operation Tables From Vdiff

### DIFF
--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
+	vtschema "vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -243,6 +244,10 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 	diffReports := make(map[string]*DiffReport)
 	jsonOutput := ""
 	for table, td := range df.differs {
+		// Skip internal operation tables for vdiff
+		if vtschema.IsInternalOperationTableName(table) {
+			continue
+		}
 		if err := df.diffTable(ctx, wr, table, td, filteredReplicationWaitTime); err != nil {
 			return nil, err
 		}

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -37,7 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
-	vtschema "vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -245,7 +245,7 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 	jsonOutput := ""
 	for table, td := range df.differs {
 		// Skip internal operation tables for vdiff
-		if vtschema.IsInternalOperationTableName(table) {
+		if schema.IsInternalOperationTableName(table) {
 			continue
 		}
 		if err := df.diffTable(ctx, wr, table, td, filteredReplicationWaitTime); err != nil {

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -749,7 +749,7 @@ func TestVDiffSharded(t *testing.T) {
 	})
 	defer env.close()
 
-	schmWithGhostTable := &tabletmanagerdatapb.SchemaDefinition{
+	schm := &tabletmanagerdatapb.SchemaDefinition{
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
 			Name:              "t1",
 			Columns:           []string{"c1", "c2"},
@@ -764,7 +764,7 @@ func TestVDiffSharded(t *testing.T) {
 			}},
 	}
 
-	env.tmc.schema = schmWithGhostTable
+	env.tmc.schema = schm
 
 	query := "select c1, c2 from t1 order by c1 asc"
 	fields := sqltypes.MakeTestFields(

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -749,15 +749,31 @@ func TestVDiffSharded(t *testing.T) {
 	})
 	defer env.close()
 
-	schm := &tabletmanagerdatapb.SchemaDefinition{
+	// schm := &tabletmanagerdatapb.SchemaDefinition{
+	// 	TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
+	// 		Name:              "t1",
+	// 		Columns:           []string{"c1", "c2"},
+	// 		PrimaryKeyColumns: []string{"c1"},
+	// 		Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
+	// 	}},
+	// }
+
+	schmWithGhostTable := &tabletmanagerdatapb.SchemaDefinition{
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
 			Name:              "t1",
 			Columns:           []string{"c1", "c2"},
 			PrimaryKeyColumns: []string{"c1"},
 			Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
-		}},
+		},
+			{
+				Name:              "t1_gho",
+				Columns:           []string{"c1", "c2", "c3"},
+				PrimaryKeyColumns: []string{"c2"},
+				Fields:            sqltypes.MakeTestFields("c1|c2|c3", "int64|int64|int64"),
+			}},
 	}
-	env.tmc.schema = schm
+
+	env.tmc.schema = schmWithGhostTable
 
 	query := "select c1, c2 from t1 order by c1 asc"
 	fields := sqltypes.MakeTestFields(

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -757,7 +757,7 @@ func TestVDiffSharded(t *testing.T) {
 			Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
 		},
 			{
-				Name:              "t1_gho",
+				Name:              "_t1_gho",
 				Columns:           []string{"c1", "c2", "c3"},
 				PrimaryKeyColumns: []string{"c2"},
 				Fields:            sqltypes.MakeTestFields("c1|c2|c3", "int64|int64|int64"),

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -749,15 +749,6 @@ func TestVDiffSharded(t *testing.T) {
 	})
 	defer env.close()
 
-	// schm := &tabletmanagerdatapb.SchemaDefinition{
-	// 	TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
-	// 		Name:              "t1",
-	// 		Columns:           []string{"c1", "c2"},
-	// 		PrimaryKeyColumns: []string{"c1"},
-	// 		Fields:            sqltypes.MakeTestFields("c1|c2", "int64|int64"),
-	// 	}},
-	// }
-
 	schmWithGhostTable := &tabletmanagerdatapb.SchemaDefinition{
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
 			Name:              "t1",


### PR DESCRIPTION
Signed-off-by: Malcolm Akinje <makinje@slack-corp.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR modifies VDiff by now ignoring tables that pass the `IsInternalOperationTableName` method.
## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->