### PR TITLE
ExternalizeVindex: refresh SrvVSchema after an ExternalizeVindex flow

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -612,7 +612,10 @@ func (wr *Wrangler) ExternalizeVindex(ctx context.Context, qualifiedVindexName s
 
 	// Remove the write_only param and save the source vschema.
 	delete(sourceVindex.Params, "write_only")
-	return wr.ts.SaveVSchema(ctx, sourceKeyspace, sourceVSchema)
+	if err := wr.ts.SaveVSchema(ctx, sourceKeyspace, sourceVSchema); err != nil {
+		return err
+	}
+	return wr.ts.RebuildSrvVSchema(ctx, nil)
 }
 
 //


### PR DESCRIPTION
## Description

ExternalizeVindex was missing a step to rebuild the SrvVSchema at the end. Without this vtgate won’t be notified of the vschema change. Reported by a user who faced this issue: they are on 8.0.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

