### PR TITLE
[consultopo] Add flag to limit MaxConnsPerHost in consultopo servers

### DIFF
--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	consulAuthClientStaticFile = flag.String("consul_auth_static_file", "", "JSON File to read the topos/tokens from.")
+	maxConnsPerHost            = flag.Int("consultopo_max_conns_per_host", 0, "limit the MaxConnsPerHost used in the consul client's http Transport. Zero means no limit.")
 )
 
 // ClientAuthCred credential to use for consul clusters
@@ -118,6 +119,10 @@ func NewServer(cell, serverAddr, root string) (*Server, error) {
 		} else {
 			log.Warningf("Client auth not configured for cell: %v", cell)
 		}
+	}
+
+	if *maxConnsPerHost > 0 {
+		cfg.Transport.MaxConnsPerHost = *maxConnsPerHost
 	}
 
 	client, err := api.NewClient(cfg)


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

This PR introduces a new flag to control the `MaxConnsPerHost` setting in the consul client's http.Transport, to prevent unbounded connection growth during highly concurrent topo calls

## Related Issue(s)

None yet, will file after testing


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->