### PR TITLE
Make timestamp authoritative for master information

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/topo.go
+++ b/go/vt/vtctl/grpcvtctldserver/topo.go
@@ -19,6 +19,7 @@ package grpcvtctldserver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/log"
@@ -217,7 +218,7 @@ func deleteTablet(ctx context.Context, ts *topo.Server, alias *topodatapb.Tablet
 			}
 
 			si.MasterAlias = nil
-
+			si.SetMasterTermStartTime(time.Now())
 			return nil
 		}); err != nil {
 			return err

--- a/go/vt/vtctl/grpcvtctldserver/topo.go
+++ b/go/vt/vtctl/grpcvtctldserver/topo.go
@@ -216,7 +216,6 @@ func deleteTablet(ctx context.Context, ts *topo.Server, alias *topodatapb.Tablet
 
 				return topo.NewError(topo.NoUpdateNeeded, si.Keyspace()+"/"+si.ShardName())
 			}
-
 			si.MasterAlias = nil
 			si.SetMasterTermStartTime(time.Now())
 			return nil

--- a/go/vt/vttablet/tabletmanager/shard_sync_test.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo/topoproto"
+
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+const (
+	keyspace = "ks"
+	shard    = "0"
+)
+
+func TestShardSync(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	statsTabletTypeCount.ResetAll()
+	tm := newTestTM(t, ts, 100, keyspace, shard)
+	defer tm.Stop()
+
+	// update the master info in the shard record and set it to nil
+	originalTime := time.Now()
+	updateMasterInfoInShardRecord(ctx, t, tm, nil, originalTime)
+
+	// now try to promote the tablet to primary
+	err := tm.tmState.ChangeTabletType(ctx, topodata.TabletType_MASTER, DBActionSetReadWrite)
+	require.NoError(t, err)
+	// verify that the tablet record has been updated
+	ti, err := ts.GetTablet(ctx, tm.tabletAlias)
+	require.NoError(t, err)
+	assert.Equal(t, topodata.TabletType_MASTER, ti.Type)
+	assert.NotNil(t, ti.MasterTermStartTime)
+
+	// wait for syncing to work correctly
+	time.Sleep(1 * time.Second)
+
+	// this should also have updated the shard record since it is a more recent operation
+	// We check here that the shard record and the tablet record are in sync.
+	si, err := ts.GetShard(ctx, keyspace, shard)
+	require.NoError(t, err)
+	assert.Equal(t, ti.Alias, si.MasterAlias)
+	assert.Equal(t, ti.MasterTermStartTime, si.MasterTermStartTime)
+
+	// even if try to update the shard record with the old timestamp, it should be reverted again
+	updateMasterInfoInShardRecord(ctx, t, tm, nil, originalTime)
+
+	// wait for syncing to work correctly
+	time.Sleep(1 * time.Second)
+
+	// this should have also updated the shard record because of the timestamp.
+	si, err = ts.GetShard(ctx, keyspace, shard)
+	require.NoError(t, err)
+	assert.Equal(t, ti.Alias, si.MasterAlias)
+	assert.Equal(t, ti.MasterTermStartTime, si.MasterTermStartTime)
+
+	// updating the shard record with the latest time should trigger an update in the tablet
+	updateMasterInfoInShardRecord(ctx, t, tm, nil, time.Now())
+
+	// wait for syncing to work correctly
+	time.Sleep(1 * time.Second)
+
+	// verify that the tablet record has been updated
+	ti, err = ts.GetTablet(ctx, tm.tabletAlias)
+	require.NoError(t, err)
+	assert.Equal(t, topodata.TabletType_REPLICA, ti.Type)
+	assert.Nil(t, ti.MasterTermStartTime)
+
+	// this should not have updated.
+	si, err = ts.GetShard(ctx, keyspace, shard)
+	require.NoError(t, err)
+	assert.Nil(t, si.MasterAlias)
+}
+
+func updateMasterInfoInShardRecord(ctx context.Context, t *testing.T, tm *TabletManager, masterAlias *topodata.TabletAlias, time time.Time) {
+	ctx, unlock, lockErr := tm.TopoServer.LockShard(ctx, keyspace, shard, fmt.Sprintf("updateMasterInfoInShardRecord(%v)", topoproto.TabletAliasString(tm.tabletAlias)))
+	require.NoError(t, lockErr)
+	defer unlock(&lockErr)
+
+	_, err := tm.TopoServer.UpdateShardFields(ctx, keyspace, shard, func(si *topo.ShardInfo) error {
+		si.MasterAlias = masterAlias
+		si.SetMasterTermStartTime(time)
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -125,6 +125,7 @@ func TestStartCreateKeyspaceShard(t *testing.T) {
 	rebuildKeyspaceRetryInterval = 10 * time.Millisecond
 
 	ctx := context.Background()
+	statsTabletTypeCount.ResetAll()
 	cell := "cell1"
 	ts := memorytopo.NewServer(cell)
 	tm := newTestTM(t, ts, 1, "ks", "0")

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -139,6 +139,7 @@ func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.Ta
 				return topo.NewError(topo.NoUpdateNeeded, si.Keyspace()+"/"+si.ShardName())
 			}
 			si.MasterAlias = nil
+			si.SetMasterTermStartTime(time.Now())
 			return nil
 		}); err != nil {
 			return err


### PR DESCRIPTION
## Description
This PR makes it explicit in all the places and `shard_sync` that the timestamp for the master term is the authoritative source of information for who is the master. We sync the information between the tablet record and shard record based on the timestamp.

## Related Issue(s)

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
