### PR TITLE
VReplication Reverse Workflows: add keyspace scope to vindex while creating reverse vreplication streams

### DIFF
--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -42,7 +42,7 @@ create table tenant(tenant_id binary(16), name varbinary(16), primary key (tenan
 	    "reverse_bits": {
 	      "type": "reverse_bits"
 	    },
-		"binary_md5": {
+		"bmd5": {
           "type": "binary_md5"
 		}
 	  },
@@ -75,7 +75,7 @@ create table tenant(tenant_id binary(16), name varbinary(16), primary key (tenan
           "column_vindexes": [
 	        {
 	          "column": "tenant_id",
-	          "name": "binary_md5"
+	          "name": "bmd5"
 	        }
 	      ]
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2737,7 +2737,6 @@ func expectJSON(t *testing.T, table string, values [][]string, id int, exec func
 		want, err := ajson.Unmarshal([]byte(row[1]))
 		require.NoError(t, err)
 		match, err := got.Eq(want)
-		//log.Infof(">>>>>>>> got \n-----\n%s\n------\n, want \n-----\n%s\n------\n", got, want)
 		require.NoError(t, err)
 		require.True(t, match)
 	}

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -1128,7 +1128,7 @@ func (ts *trafficSwitcher) createReverseVReplication(ctx context.Context) error 
 					}
 					// TODO(sougou): handle degenerate cases like sequence, etc.
 					// We currently assume the primary vindex is the best way to filter, which may not be true.
-					inKeyrange = fmt.Sprintf(" where in_keyrange(%s, '%s', '%s')", sqlparser.String(vtable.ColumnVindexes[0].Columns[0]), vtable.ColumnVindexes[0].Type, key.KeyRangeString(source.GetShard().KeyRange))
+					inKeyrange = fmt.Sprintf(" where in_keyrange(%s, '%s.%s', '%s')", sqlparser.String(vtable.ColumnVindexes[0].Columns[0]), ts.sourceKeyspace, vtable.ColumnVindexes[0].Name, key.KeyRangeString(source.GetShard().KeyRange))
 				}
 				filter = fmt.Sprintf("select * from %s%s", rule.Match, inKeyrange)
 			}


### PR DESCRIPTION


## Description

For sharded streams we add filters like `select * from customer where in_keyrange(customer_id, 'keyspace1.hash', '-7f')` where the vindex is scoped by the source keyspace. This is needed since other keyspaces might also contain vindexes of the same name and using just the vindex name would create an ambiguity. 

This logic was missing while creating reverse streams which this PR adds.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
https://github.com/vitessio/vitess/issues/8259

## Checklist
- [X] Tests were added or are not required
