### PR TITLE
OnlineDDL/Vreplication stress test: investigating failures

### DIFF
--- a/go/test/endtoend/onlineddl/exec_util.go
+++ b/go/test/endtoend/onlineddl/exec_util.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onlineddl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+// CreateTempScript creates a script in the temporary directory with given content
+func CreateTempScript(t *testing.T, content string) (fileName string) {
+	f, err := ioutil.TempFile("", "onlineddl-test-")
+	require.NoError(t, err)
+
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	return f.Name()
+}
+
+// MysqlClientExecFile runs a file through the mysql client
+func MysqlClientExecFile(t *testing.T, mysqlParams *mysql.ConnParams, testDataPath, testName string, fileName string) (output string) {
+	t.Helper()
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err)
+	mysqlPath, err := exec.LookPath("mysql")
+	require.NoError(t, err)
+
+	filePath := fileName
+	if !filepath.IsAbs(fileName) {
+		filePath, _ = filepath.Abs(path.Join(testDataPath, testName, fileName))
+	}
+	bashCommand := fmt.Sprintf(`%s -u%s --socket=%s --database=%s -s -s < %s 2> /tmp/error.log`, mysqlPath, mysqlParams.Uname, mysqlParams.UnixSocket, mysqlParams.DbName, filePath)
+	cmd, err := exec.Command(
+		bashPath,
+		"-c",
+		bashCommand,
+	).Output()
+
+	require.NoError(t, err)
+	return string(cmd)
+}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -505,6 +505,18 @@ func (e *Executor) validateTableForAlterAction(ctx context.Context, onlineDDL *s
 	return nil
 }
 
+// primaryPosition returns the MySQL/MariaDB position (typically GTID pos) on the tablet
+func (e *Executor) primaryPosition(ctx context.Context) (pos mysql.Position, err error) {
+	conn, err := dbconnpool.NewDBConnection(ctx, e.env.Config().DB.DbaWithDB())
+	if err != nil {
+		return pos, err
+	}
+	defer conn.Close()
+
+	pos, err = conn.PrimaryPosition()
+	return pos, err
+}
+
 // terminateVReplMigration stops vreplication, then removes the _vt.vreplication entry for the given migration
 func (e *Executor) terminateVReplMigration(ctx context.Context, uuid string) error {
 	tmClient := tmclient.NewTabletManagerClient()
@@ -606,7 +618,7 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 	if isVreplicationTestSuite {
 		// The testing suite may inject queries internally from the server via a recurring EVENT.
 		// Those queries are unaffected by UpdateSourceBlacklistedTables() because they don't go through Vitess.
-		// We therefore hard-rename the table elsewhere, such that the queries will hard-fail.
+		// We therefore hard-rename the table here, such that the queries will hard-fail.
 		beforeTableName := fmt.Sprintf("%s_before", onlineDDL.Table)
 		parsed := sqlparser.BuildParsedQuery(sqlRenameTable,
 			onlineDDL.Table, beforeTableName,
@@ -614,6 +626,10 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 		if _, err = e.execQuery(ctx, parsed.Query); err != nil {
 			return err
 		}
+	}
+	postWritesPos, err := e.primaryPosition(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Writes are now disabled on table. Read up-to-date vreplication info, specifically to get latest (and fixed) pos:
@@ -626,12 +642,13 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 		ctx, cancel := context.WithTimeout(ctx, 2*cutOverThreshold)
 		defer cancel()
 		// Wait for target to reach the up-to-date pos
-		if err := tmClient.VReplicationWaitForPos(ctx, tablet.Tablet, int(s.id), s.pos); err != nil {
+		if err := tmClient.VReplicationWaitForPos(ctx, tablet.Tablet, int(s.id), mysql.EncodePosition(postWritesPos)); err != nil {
 			return err
 		}
 		// Target is now in sync with source!
 		return nil
 	}
+	log.Infof("VReplication migration %v waiting for position %v", s.workflow, mysql.EncodePosition(postWritesPos))
 	if err := waitForPos(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description update

Fixes a bug in OnlineDDL/VReplication where we would not wait for the correct position before cutting over. Now waiting for the correct position.

## Description

In https://github.com/vitessio/vitess/pull/8364#issuecomment-869136323 I found data inconsistency that didn't seem to be related to the PR.

In this PR we intensify the stress in the `onlineddl_vrepl_stress` test so as to surface the problem.

## Related Issue(s)

#6926 

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->