### PR TITLE
Delete table reference alias support

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1274,7 +1274,7 @@ func TestServerFlush(t *testing.T) {
 	flds, err := c.Fields()
 	require.NoError(t, err)
 	if duration, want := time.Since(start), 20*time.Millisecond; duration < *mysqlServerFlushDelay || duration > want {
-		assert.Fail(t, "duration: %v, want between %v and %v", duration, *mysqlServerFlushDelay, want)
+		assert.Fail(t, "duration: %v, want between %v and %v", duration.String(), (*mysqlServerFlushDelay).String(), want.String())
 	}
 	want1 := []*querypb.Field{{
 		Name: "result",

--- a/go/mysql/sql_error.go
+++ b/go/mysql/sql_error.go
@@ -179,6 +179,7 @@ var stateToMysqlCode = map[vterrors.State]struct {
 	vterrors.NetPacketTooLarge:            {num: ERNetPacketTooLarge, state: SSNetError},
 	vterrors.NonUniqError:                 {num: ERNonUniq, state: SSConstraintViolation},
 	vterrors.NonUniqTable:                 {num: ERNonUniqTable, state: SSClientError},
+	vterrors.NonUpdateableTable:           {num: ERNonUpdateableTable, state: SSUnknownSQLState},
 	vterrors.QueryInterrupted:             {num: ERQueryInterrupted, state: SSQueryInterrupted},
 	vterrors.SPDoesNotExist:               {num: ERSPDoesNotExist, state: SSClientError},
 	vterrors.SyntaxError:                  {num: ERSyntaxError, state: SSClientError},

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -655,7 +655,8 @@ func TestDeleteAlias(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	exec(t, conn, "delete t from t1 t where t.id1 = 1 order by t.id1")
+	exec(t, conn, "delete t1 from t1 where id1 = 1")
+	exec(t, conn, "delete t.* from t1 t where t.id1 = 1")
 }
 
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -650,6 +650,14 @@ func TestQueryAndSubQWithLimit(t *testing.T) {
 	assert.Equal(t, 10, len(result.Rows))
 }
 
+func TestDeleteAlias(t *testing.T) {
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "delete t from t1 t where t.id1 = 1 order by t.id1")
+}
+
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
 	qr := exec(t, conn, query)

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -445,7 +445,8 @@ func TestDeleteAlias(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	exec(t, conn, "delete t from t1 t where t.c1 = 1")
+	exec(t, conn, "delete t1 from t1 where c1 = 1")
+	exec(t, conn, "delete t.* from t1 t where t.c1 = 1")
 }
 
 func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {

--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -436,6 +436,18 @@ func TestNumericPrecisionScale(t *testing.T) {
 	assert.True(t, qr.Rows[0][1].Type() == sqltypes.Uint64 || qr.Rows[0][1].Type() == sqltypes.Uint32)
 }
 
+func TestDeleteAlias(t *testing.T) {
+	vtParams := mysql.ConnParams{
+		Host: "localhost",
+		Port: clusterInstance.VtgateMySQLPort,
+	}
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "delete t from t1 t where t.c1 = 1")
+}
+
 func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
 	t.Helper()
 	qr, err := conn.ExecuteFetch(query, 1000, true)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -801,6 +801,12 @@ var (
 	}, {
 		input: "delete /* limit */ from a limit b",
 	}, {
+		input:  "delete /* alias where */ t.* from a as t where t.id = 2",
+		output: "delete /* alias where */ t from a as t where t.id = 2",
+	}, {
+		input:  "delete t.* from t, t1",
+		output: "delete t from t, t1",
+	}, {
 		input:  "delete a from a join b on a.id = b.id where b.name = 'test'",
 		output: "delete a from a join b on a.id = b.id where b.`name` = 'test'",
 	}, {

--- a/go/vt/vterrors/state.go
+++ b/go/vt/vterrors/state.go
@@ -33,6 +33,7 @@ const (
 	IncorrectGlobalLocalVar
 	NonUniqError
 	NonUniqTable
+	NonUpdateableTable
 	SyntaxError
 	WrongGroupField
 	WrongTypeForVar

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -26,6 +26,13 @@ import (
 // buildDeletePlan builds the instructions for a DELETE statement.
 func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, vschema ContextVSchema) (engine.Primitive, error) {
 	del := stmt.(*sqlparser.Delete)
+	var err error
+	if len(del.TableExprs) == 1 && len(del.Targets) == 1 {
+		del, err = rewriteSingleTbl(del)
+		if err != nil {
+			return nil, err
+		}
+	}
 	dml, ksidVindex, ksidCol, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
 	if err != nil {
 		return nil, err
@@ -52,4 +59,40 @@ func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedV
 	}
 
 	return edel, nil
+}
+
+func rewriteSingleTbl(del *sqlparser.Delete) (*sqlparser.Delete, error) {
+	atExpr, ok := del.TableExprs[0].(*sqlparser.AliasedTableExpr)
+	if !ok {
+		return del, nil
+	}
+	if !atExpr.As.IsEmpty() && !sqlparser.EqualsTableIdent(del.Targets[0].Name, atExpr.As) {
+		//Unknown table in MULTI DELETE
+		return nil, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.UnknownTable, "Unknown table '%s' in MULTI DELETE", del.Targets[0].Name.String())
+	}
+
+	tbl, ok := atExpr.Expr.(sqlparser.TableName)
+	if !ok {
+		// derived table
+		return nil, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.NonUpdateableTable, "The target table %s of the DELETE is not updatable", atExpr.As.String())
+	}
+	if atExpr.As.IsEmpty() && !sqlparser.EqualsTableIdent(del.Targets[0].Name, tbl.Name) {
+		//Unknown table in MULTI DELETE
+		return nil, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.UnknownTable, "Unknown table '%s' in MULTI DELETE", del.Targets[0].Name.String())
+	}
+
+	del.TableExprs = sqlparser.TableExprs{&sqlparser.AliasedTableExpr{Expr: tbl}}
+	del.Targets = nil
+	if del.Where != nil {
+		_ = sqlparser.Rewrite(del.Where, func(cursor *sqlparser.Cursor) bool {
+			switch node := cursor.Node().(type) {
+			case *sqlparser.ColName:
+				if !node.Qualifier.IsEmpty() {
+					node.Qualifier = tbl
+				}
+			}
+			return true
+		}, nil)
+	}
+	return del, nil
 }

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2168,7 +2168,7 @@ Gen4 plan same as above
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
-    "Query": "delete music from music where id = 1",
+    "Query": "delete from music where id = 1",
     "Table": "music",
     "Values": [
       1
@@ -2389,4 +2389,41 @@ Gen4 plan same as above
     "Table": "user_extra"
   }
 }
+Gen4 plan same as above
+
+# multi-table delete with single table
+"delete u.* from user u where u.id * u.col = u.foo"
+{
+  "QueryType": "DELETE",
+  "Original": "delete u.* from user u where u.id * u.col = u.foo",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Scatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "MASTER",
+    "KsidVindex": "user_index",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id * `user`.col = `user`.foo for update",
+    "Query": "delete from `user` where `user`.id * `user`.col = `user`.foo",
+    "Table": "user"
+  }
+}
+Gen4 plan same as above
+
+# delete with unknown reference
+"delete music from user where id = 1"
+"Unknown table 'music' in MULTI DELETE"
+Gen4 plan same as above
+
+# delete with derived tables
+"delete music from (select * from user) music where id = 1"
+"The target table music of the DELETE is not updatable"
+Gen4 plan same as above
+
+# delete with derived tables with unknown table
+"delete user from (select * from user) music where id = 1"
+"Unknown table 'user' in MULTI DELETE"
 Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -370,11 +370,6 @@ Gen4 plan same as above
 "select func(keyspace_id) from user_index where id = :id"
 "unsupported: expression on results of a vindex function"
 
-# delete with unknown reference
-"delete music from user where id = 1"
-"Unknown table 'music' in MULTI DELETE"
-Gen4 plan same as above
-
 # delete with multi-table targets
 "delete music,user from music inner join user where music.id = user.id"
 "unsupported: multi-shard or vindex write statement"

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -355,7 +355,8 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
 
-	conn1, _, _ = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+	conn1, _, err = txPool.Begin(ctx, &querypb.ExecuteOptions{}, false, 0, nil)
+	require.NoError(t, err, "unable to start transaction: %v", err)
 	conn1.Unlock()
 	id = conn1.ReservedID()
 	time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

DML queries are rewritten to add a `limit` clause to protect from rogue queries. 
Delete has some special syntax that does not allow the `limit` clause.
To overcome the limitation, a special case of single table reference is rewritten to allow the `limit` clause.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

https://github.com/vitessio/vitess/issues/6854

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->