### PR TITLE
added batch lookup param to lookup vindex

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -72,6 +72,15 @@ select count(*) from user where name in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
 11 ks_sharded/-40: select count(*) from `user` where `name` in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
+select count(*) from customer where email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate with batching */
+
+1 ks_sharded/-40: select email, user_id from email_customer_map where email in ('f', 'g', 'i', 'j') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/40-80: select email, user_id from email_customer_map where email in ('b', 'c', 'h') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/80-c0: select email, user_id from email_customer_map where email in ('e') limit 10001 /* scatter aggregate with batching */
+1 ks_sharded/c0-: select email, user_id from email_customer_map where email in ('a', 'd') limit 10001 /* scatter aggregate with batching */
+2 ks_sharded/-40: select count(*) from customer where email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate with batching */
+
+----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */
 
 1 ks_sharded/-40: select `name`, count(*) from `user` group by `name` limit 10001 /* scatter aggregate */

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -57,11 +57,19 @@ select count(*) from user where id = 1 /* point aggregate */
 1 ks_sharded/-40: select count(*) from `user` where id = 1 limit 10001 /* point aggregate */
 
 ----------------------------------------------------------------------
-select count(*) from user where name in ('alice','bob') /* scatter aggregate */
+select count(*) from user where name in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate */
 
-1 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('alice') limit 10001 /* scatter aggregate */
-2 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('bob') limit 10001 /* scatter aggregate */
-3 ks_sharded/-40: select count(*) from `user` where `name` in ('alice', 'bob') limit 10001 /* scatter aggregate */
+1 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('a') limit 10001 /* scatter aggregate */
+2 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('b') limit 10001 /* scatter aggregate */
+3 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('c') limit 10001 /* scatter aggregate */
+4 ks_sharded/c0-: select `name`, user_id from name_user_map where `name` in ('d') limit 10001 /* scatter aggregate */
+5 ks_sharded/80-c0: select `name`, user_id from name_user_map where `name` in ('e') limit 10001 /* scatter aggregate */
+6 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('f') limit 10001 /* scatter aggregate */
+7 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('g') limit 10001 /* scatter aggregate */
+8 ks_sharded/40-80: select `name`, user_id from name_user_map where `name` in ('h') limit 10001 /* scatter aggregate */
+9 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('i') limit 10001 /* scatter aggregate */
+10 ks_sharded/-40: select `name`, user_id from name_user_map where `name` in ('j') limit 10001 /* scatter aggregate */
+11 ks_sharded/-40: select count(*) from `user` where `name` in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -8,7 +8,7 @@ select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name =
 select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id where m.user_id = 100 /* join on int */;
 
 select count(*) from user where id = 1 /* point aggregate */;
-select count(*) from user where name in ('alice','bob') /* scatter aggregate */;
+select count(*) from user where name in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate */;
 select name, count(*) from user group by name /* scatter aggregate */;
 
 select 1, "hello", 3.14, null from user limit 10 /* select constant sql values */;

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -9,6 +9,7 @@ select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id wher
 
 select count(*) from user where id = 1 /* point aggregate */;
 select count(*) from user where name in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate */;
+select count(*) from customer where email in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j') /* scatter aggregate with batching */;
 select name, count(*) from user group by name /* scatter aggregate */;
 
 select 1, "hello", 3.14, null from user limit 10 /* select constant sql values */;

--- a/go/vt/vtexplain/testdata/test-schema.sql
+++ b/go/vt/vtexplain/testdata/test-schema.sql
@@ -61,3 +61,15 @@ create table test_partitioned (
 	primary key(id)
 ) Engine=InnoDB
 ;
+
+create table customer (
+  id bigint,
+  email varchar(64),
+  primary key (id)
+) Engine=InnoDB;
+
+create table email_customer_map (
+   email varchar(64),
+   user_id bigint,
+   primary key (email, user_id)
+) Engine=InnoDB;

--- a/go/vt/vtexplain/testdata/test-vschema.json
+++ b/go/vt/vtexplain/testdata/test-vschema.json
@@ -27,6 +27,16 @@
 					"to": "user_id"
 				}
 			},
+			"email_customer_map": {
+				"type": "lookup_hash_unique",
+				"owner": "customer",
+				"params": {
+					"table": "email_customer_map",
+					"from": "email",
+					"to": "user_id",
+					"batch_lookup": "true"
+				}
+			},
 			"hash": {
 				"type": "hash"
 			},
@@ -93,6 +103,26 @@
 						}
 				],
 					"column_list_authoritative": true
+			},
+			"customer": {
+				"column_vindexes": [
+					{
+						"column": "id",
+						"name": "hash"
+					},
+					{
+						"column": "email",
+						"name": "email_customer_map"
+					}
+				]
+			},
+			"email_customer_map": {
+				"column_vindexes": [
+					{
+						"column": "email",
+						"name": "md5"
+					}
+				]
 			}
 		}
 	}

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -37,6 +37,7 @@ type lookupInternal struct {
 	Autocommit    bool     `json:"autocommit,omitempty"`
 	Upsert        bool     `json:"upsert,omitempty"`
 	IgnoreNulls   bool     `json:"ignore_nulls,omitempty"`
+	BatchBinary   bool     `json:"batch_binary,omitempty"`
 	sel, ver, del string
 }
 
@@ -51,6 +52,10 @@ func (lkp *lookupInternal) Init(lookupQueryParams map[string]string, autocommit,
 
 	var err error
 	lkp.IgnoreNulls, err = boolFromMap(lookupQueryParams, "ignore_nulls")
+	if err != nil {
+		return err
+	}
+	lkp.BatchBinary, err = boolFromMap(lookupQueryParams, "batch_binary")
 	if err != nil {
 		return err
 	}
@@ -80,7 +85,7 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value, co vtga
 	if vcursor.InTransactionAndIsDML() {
 		sel = sel + " for update"
 	}
-	if ids[0].IsIntegral() {
+	if ids[0].IsIntegral() || (lkp.BatchBinary && ids[0].IsBinary()) {
 		// for integral types, batch query all ids and then map them back to the input order
 		vars, err := sqltypes.BuildBindVariable(ids)
 		if err != nil {

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -37,7 +37,7 @@ type lookupInternal struct {
 	Autocommit    bool     `json:"autocommit,omitempty"`
 	Upsert        bool     `json:"upsert,omitempty"`
 	IgnoreNulls   bool     `json:"ignore_nulls,omitempty"`
-	BatchBinary   bool     `json:"batch_binary,omitempty"`
+	BatchLookup   bool     `json:"batch_lookup,omitempty"`
 	sel, ver, del string
 }
 
@@ -55,7 +55,7 @@ func (lkp *lookupInternal) Init(lookupQueryParams map[string]string, autocommit,
 	if err != nil {
 		return err
 	}
-	lkp.BatchBinary, err = boolFromMap(lookupQueryParams, "batch_binary")
+	lkp.BatchLookup, err = boolFromMap(lookupQueryParams, "batch_lookup")
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value, co vtga
 	if vcursor.InTransactionAndIsDML() {
 		sel = sel + " for update"
 	}
-	if ids[0].IsIntegral() || (lkp.BatchBinary && ids[0].IsBinary()) {
+	if ids[0].IsIntegral() || lkp.BatchLookup {
 		// for integral types, batch query all ids and then map them back to the input order
 		vars, err := sqltypes.BuildBindVariable(ids)
 		if err != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Today only integral values are batches for lookup queries as they are comparable.
This PR introduces "batch_lookup" param to the Vindex and if provided, try to batch the result set.
This relies on that the collation is utf8 and case sensitive.

This helps optimize for the case where the user knows how the vindex will behave for its values.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->