### PR TITLE
VDiff: Add BIT datatype to list of byte comparable types

### DIFF
--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -58,19 +58,11 @@ func (vtctl *VtctlProcess) AddCellInfo(Cell string) (err error) {
 
 // CreateKeyspace executes vtctl command to create keyspace
 func (vtctl *VtctlProcess) CreateKeyspace(keyspace string) (err error) {
-	tmpProcess := exec.Command(
-		vtctl.Binary,
-		"-topo_implementation", vtctl.TopoImplementation,
-		"-topo_global_server_address", vtctl.TopoGlobalAddress,
-		"-topo_global_root", vtctl.TopoGlobalRoot,
-	)
-	if *isCoverage {
-		tmpProcess.Args = append(tmpProcess.Args, "-test.coverprofile="+getCoveragePath("vtctl-create-ks.out"))
+	output, err := vtctl.ExecuteCommandWithOutput("CreateKeyspace", keyspace)
+	if err != nil {
+		log.Errorf("CreateKeyspace returned err: %s, output: %s", err, output)
 	}
-	tmpProcess.Args = append(tmpProcess.Args,
-		"CreateKeyspace", keyspace)
-	log.Infof("Running CreateKeyspace with command: %v", strings.Join(tmpProcess.Args, " "))
-	return tmpProcess.Run()
+	return err
 }
 
 // ExecuteCommandWithOutput executes any vtctlclient command and returns output

--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -3,7 +3,7 @@ package vreplication
 var (
 	initialProductSchema = `
 create table product(pid int, description varbinary(128), primary key(pid));
-create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, primary key(cid))  CHARSET=utf8mb4;
+create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, bits bit(2) default b'11', primary key(cid))  CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table orders(oid int, cid int, pid int, mname varchar(128), price int, qty int, total int as (qty * price), total2 int as (qty * price) stored, primary key(oid));

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -243,7 +243,7 @@ func isByteComparable(v sqltypes.Value) bool {
 		return true
 	}
 	switch v.Type() {
-	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set, sqltypes.TypeJSON:
+	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set, sqltypes.TypeJSON, sqltypes.Bit:
 		return true
 	}
 	return false

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -567,6 +567,21 @@ func TestNullsafeCompare(t *testing.T) {
 		v1:  TestValue(querypb.Type_DATETIME, "1000-01-01 00:00:00"),
 		v2:  TestValue(querypb.Type_BINARY, "2000-01-01 00:00:00"),
 		out: -1,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "101"),
+		v2:  TestValue(querypb.Type_BIT, "101"),
+		out: 0,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "1"),
+		v2:  TestValue(querypb.Type_BIT, "0"),
+		out: 1,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "0"),
+		v2:  TestValue(querypb.Type_BIT, "1"),
+		out: -1,
 	}}
 	for _, tcase := range tcases {
 		got, err := NullsafeCompare(tcase.v1, tcase.v2)

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -451,7 +451,6 @@ func TestConsistentLookupUpdateBecauseUncomparableTypes(t *testing.T) {
 		{querypb.Type_TEXT, "some string"},
 		{querypb.Type_VARCHAR, "some string"},
 		{querypb.Type_CHAR, "some string"},
-		{querypb.Type_BIT, "some string"},
 		{querypb.Type_GEOMETRY, "some string"},
 	}
 

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -253,10 +253,10 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 		}
 		// Perform the diff of source and target streams.
 		dr, err := td.diff(ctx, df.ts.wr, &rowsToCompare, debug, onlyPks)
-		dr.TableName = table
 		if err != nil {
 			return nil, vterrors.Wrap(err, "diff")
 		}
+		dr.TableName = table
 		diffReports[table] = dr
 	}
 	if format == "json" {


### PR DESCRIPTION

## Description

Fixed an issue in `VDiff`, which was failing for columns of the BIT data type since it was not part of the comparable types in `NullsafeCompare()`. 

Couple of additional changes found during testing:
* `CreateKeyspace` fails randomly in CI. Added additional logging to debug this if it happens again
* Fix for a regression introduced where an error was being checked late in `vdiff`, causing a panic on accessing the returned object. 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
