### PR TITLE
Tablet Picker: add metric to record lack of available tablets

### DIFF
--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -329,6 +329,7 @@ func TestPickError(t *testing.T) {
 	defer cancel()
 	_, err = tp.PickForStreaming(ctx)
 	require.EqualError(t, err, "context has expired")
+	require.Greater(t, globalTPStats.noTabletFoundError.Counts()["cell.ks.0.replica"], int64(0))
 }
 
 type pickerTestEnv struct {


### PR DESCRIPTION
## Description

Add a new metric to count number of times that a picker did not find a tablet  for streaming. The count is keyed of the tuple (cells, keyspace, shard, tablet types).

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

