### PR TITLE
Replace t.Logf with log.Infof, to avoid confusing red colored logs in CI logs

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -214,7 +214,7 @@ func (vc *VitessCluster) AddKeyspace(t *testing.T, cells []*Cell, ksName string,
 	keyspace.VSchema = vschema
 	for _, cell := range cells {
 		if len(cell.Vtgates) == 0 {
-			t.Logf("Starting vtgate")
+			log.Infof("Starting vtgate")
 			vc.StartVtgate(t, cell, cellsToWatch)
 		}
 	}
@@ -274,7 +274,7 @@ func (vc *VitessCluster) AddTablet(t testing.TB, cell *Cell, keyspace *Keyspace,
 // AddShards creates shards given list of comma-separated keys with specified tablets in each shard
 func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspace, names string, numReplicas int, numRdonly int, tabletIDBase int) error {
 	arrNames := strings.Split(names, ",")
-	t.Logf("Addshards got %d shards with %+v", len(arrNames), arrNames)
+	log.Infof("Addshards got %d shards with %+v", len(arrNames), arrNames)
 	isSharded := len(arrNames) > 1
 	masterTabletUID := 0
 	for ind, shardName := range arrNames {
@@ -282,9 +282,9 @@ func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspa
 		tabletIndex := 0
 		shard := &Shard{Name: shardName, IsSharded: isSharded, Tablets: make(map[string]*Tablet, 1)}
 		if _, ok := keyspace.Shards[shardName]; ok {
-			t.Logf("Shard %s already exists, not adding", shardName)
+			log.Infof("Shard %s already exists, not adding", shardName)
 		} else {
-			t.Logf("Adding Shard %s", shardName)
+			log.Infof("Adding Shard %s", shardName)
 			if err := vc.VtctlClient.ExecuteCommand("CreateShard", keyspace.Name+"/"+shardName); err != nil {
 				t.Fatalf("CreateShard command failed with %+v\n", err)
 			}
@@ -295,7 +295,7 @@ func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspa
 			tablets := make([]*Tablet, 0)
 			if i == 0 {
 				// only add master tablet for first cell, so first time CreateShard is called
-				t.Logf("Adding Master tablet")
+				log.Infof("Adding Master tablet")
 				master, proc, err := vc.AddTablet(t, cell, keyspace, shard, "replica", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, master)
@@ -307,7 +307,7 @@ func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspa
 			}
 
 			for i := 0; i < numReplicas; i++ {
-				t.Logf("Adding Replica tablet")
+				log.Infof("Adding Replica tablet")
 				tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "replica", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, tablet)
@@ -316,7 +316,7 @@ func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspa
 				dbProcesses = append(dbProcesses, proc)
 			}
 			for i := 0; i < numRdonly; i++ {
-				t.Logf("Adding RdOnly tablet")
+				log.Infof("Adding RdOnly tablet")
 				tablet, proc, err := vc.AddTablet(t, cell, keyspace, shard, "rdonly", tabletID+tabletIndex)
 				require.NoError(t, err)
 				require.NotNil(t, tablet)
@@ -326,27 +326,27 @@ func (vc *VitessCluster) AddShards(t testing.TB, cells []*Cell, keyspace *Keyspa
 			}
 
 			for ind, proc := range dbProcesses {
-				t.Logf("Waiting for mysql process for tablet %s", tablets[ind].Name)
+				log.Infof("Waiting for mysql process for tablet %s", tablets[ind].Name)
 				if err := proc.Wait(); err != nil {
 					t.Fatalf("%v :: Unable to start mysql server for %v", err, tablets[ind].Vttablet)
 				}
 			}
 			for ind, tablet := range tablets {
-				t.Logf("Creating vt_keyspace database for tablet %s", tablets[ind].Name)
+				log.Infof("Creating vt_keyspace database for tablet %s", tablets[ind].Name)
 				if _, err := tablet.Vttablet.QueryTablet(fmt.Sprintf("create database vt_%s", keyspace.Name),
 					keyspace.Name, false); err != nil {
 					t.Fatalf("Unable to start create database vt_%s for tablet %v", keyspace.Name, tablet.Vttablet)
 				}
-				t.Logf("Running Setup() for vttablet %s", tablets[ind].Name)
+				log.Infof("Running Setup() for vttablet %s", tablets[ind].Name)
 				if err := tablet.Vttablet.Setup(); err != nil {
 					t.Fatalf(err.Error())
 				}
 			}
 		}
 		require.NotEqual(t, 0, masterTabletUID, "Should have created a master tablet")
-		t.Logf("InitShardMaster for %d", masterTabletUID)
+		log.Infof("InitShardMaster for %d", masterTabletUID)
 		require.NoError(t, vc.VtctlClient.InitShardMaster(keyspace.Name, shardName, cells[0].Name, masterTabletUID))
-		t.Logf("Finished creating shard %s", shard.Name)
+		log.Infof("Finished creating shard %s", shard.Name)
 	}
 	return nil
 }
@@ -356,10 +356,10 @@ func (vc *VitessCluster) DeleteShard(t testing.TB, cellName string, ksName strin
 	shard := vc.Cells[cellName].Keyspaces[ksName].Shards[shardName]
 	require.NotNil(t, shard)
 	for _, tab := range shard.Tablets {
-		t.Logf("Shutting down tablet %s", tab.Name)
+		log.Infof("Shutting down tablet %s", tab.Name)
 		tab.Vttablet.TearDown()
 	}
-	t.Logf("Deleting Shard %s", shardName)
+	log.Infof("Deleting Shard %s", shardName)
 	//TODO how can we avoid the use of even_if_serving?
 	if output, err := vc.VtctlClient.ExecuteCommandWithOutput("DeleteShard", "-recursive", "-even_if_serving", ksName+"/"+shardName); err != nil {
 		t.Fatalf("DeleteShard command failed with error %+v and output %s\n", err, output)
@@ -412,12 +412,12 @@ func (vc *VitessCluster) TearDown(t testing.TB) {
 				for _, tablet := range shard.Tablets {
 					if tablet.DbServer != nil && tablet.DbServer.TabletUID > 0 {
 						if _, err := tablet.DbServer.StopProcess(); err != nil {
-							t.Logf("Error stopping mysql process: %s", err.Error())
+							log.Infof("Error stopping mysql process: %s", err.Error())
 						}
 					}
-					t.Logf("Stopping vttablet %s", tablet.Name)
+					log.Infof("Stopping vttablet %s", tablet.Name)
 					if err := tablet.Vttablet.TearDown(); err != nil {
-						t.Logf("Stopped vttablet %s %s", tablet.Name, err.Error())
+						log.Infof("Stopped vttablet %s %s", tablet.Name, err.Error())
 					}
 				}
 			}
@@ -425,12 +425,12 @@ func (vc *VitessCluster) TearDown(t testing.TB) {
 	}
 
 	if err := vc.Vtctld.TearDown(); err != nil {
-		t.Logf("Error stopping Vtctld:  %s", err.Error())
+		log.Infof("Error stopping Vtctld:  %s", err.Error())
 	}
 
 	for _, cell := range vc.Cells {
 		if err := vc.Topo.TearDown(cell.Name, originalVtdataroot, vtdataroot, false, "etcd2"); err != nil {
-			t.Logf("Error in etcd teardown - %s", err.Error())
+			log.Infof("Error in etcd teardown - %s", err.Error())
 		}
 	}
 }
@@ -441,7 +441,7 @@ func (vc *VitessCluster) getVttabletsInKeyspace(t *testing.T, cell *Cell, ksName
 	for _, shard := range keyspace.Shards {
 		for _, tablet := range shard.Tablets {
 			if tablet.Vttablet.GetTabletStatus() == "SERVING" && strings.EqualFold(tablet.Vttablet.VreplicationTabletType, tabletType) {
-				t.Logf("Serving status of tablet %s is %s, %s", tablet.Name, tablet.Vttablet.ServingStatus, tablet.Vttablet.GetTabletStatus())
+				log.Infof("Serving status of tablet %s is %s, %s", tablet.Name, tablet.Vttablet.ServingStatus, tablet.Vttablet.GetTabletStatus())
 				tablets[tablet.Name] = tablet.Vttablet
 			}
 		}


### PR DESCRIPTION

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->