### PR TITLE
[vtadmin-web] Set Backup status indicators to the correct colours 

### DIFF
--- a/web/vtadmin/src/components/pips/BackupStatusPip.tsx
+++ b/web/vtadmin/src/components/pips/BackupStatusPip.tsx
@@ -22,11 +22,11 @@ interface Props {
 }
 
 const STATUS_STATES: { [s in mysqlctl.BackupInfo.Status]: PipState } = {
-    [mysqlctl.BackupInfo.Status.UNKNOWN]: 'danger',
-    [mysqlctl.BackupInfo.Status.INCOMPLETE]: 'danger',
-    [mysqlctl.BackupInfo.Status.COMPLETE]: 'danger',
+    [mysqlctl.BackupInfo.Status.UNKNOWN]: null,
+    [mysqlctl.BackupInfo.Status.INCOMPLETE]: 'warning',
+    [mysqlctl.BackupInfo.Status.COMPLETE]: 'primary',
     [mysqlctl.BackupInfo.Status.INVALID]: 'danger',
-    [mysqlctl.BackupInfo.Status.VALID]: 'danger',
+    [mysqlctl.BackupInfo.Status.VALID]: 'success',
 };
 
 export const BackupStatusPip = ({ status }: Props) => {


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

A small fix for https://github.com/vitessio/vitess/pull/8409. As it says in the title, this sets Backup status indicators to be the correct colours. (Sigh. Juggling too many things today.) 😊 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/pull/8409

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A