### PR TITLE
Small build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
 
 # build the vitess binaries statically
@@ -69,11 +69,11 @@ ifndef NOBANNER
 endif
 	bash ./build.env
 	# build all the binaries by default with CGO disabled
-	CGO_ENABLED=0 go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	CGO_ENABLED=0 go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 	# embed local resources in the vttablet executable
 	(cd go/cmd/vttablet && go run github.com/GeertJohan/go.rice/rice append --exec=../../../bin/vttablet)
 	# build vtorc with CGO, because it depends on sqlite
-	CGO_ENABLED=1 go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
+	CGO_ENABLED=1 go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/cmd/vtorc/...
 
 # cross-build can be used to cross-compile Vitess client binaries
 # Outside of select client binaries (namely vtctlclient & vtexplain), cross-compiled Vitess Binaries are not recommended for production deployments
@@ -86,7 +86,7 @@ endif
 	# In order to cross-compile, go install requires GOBIN to be unset
 	export GOBIN=""
 	# For the specified GOOS + GOARCH, build all the binaries by default with CGO disabled
-	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
+	CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 	# unset GOOS and embed local resources in the vttablet executable
 	(cd go/cmd/vttablet && unset GOOS && go run github.com/GeertJohan/go.rice/rice --verbose append --exec=$${HOME}/go/bin/${GOOS}_${GOARCH}/vttablet)
 	# Cross-compiling w/ cgo isn't trivial and we don't need vtorc, so we can skip building it 
@@ -96,7 +96,7 @@ ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
 	bash ./build.env
-	go install $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" -gcflags -'N -l' ./go/...
+	go install -trimpath $(EXTRA_BUILD_FLAGS) $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" -gcflags -'N -l' ./go/...
 
 # install copies the files needed to run Vitess into the given directory tree.
 # This target is optimized for docker images. It only installs the files needed for running vitess in docker

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ MAKEFLAGS = -s
 GIT_STATUS := $(shell git status --porcelain)
 
 export GOBIN=$(PWD)/bin
-export GO111MODULE=on
 export REWRITER=go/vt/sqlparser/rewriter.go
 
 # Disabled parallel processing of target prerequisites to avoid that integration tests are racing each other (e.g. for ports) and may fail.

--- a/misc/git/commit-msg
+++ b/misc/git/commit-msg
@@ -9,12 +9,6 @@ if [ -z "$GIT_DIR" ]; then
   GIT_DIR="${DIR}/.."
 fi
 
-# This is necessary because the Atom packages don't set GOPATH
-if [ -z "$GOPATH" ]; then
-  GOPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../../../.." && pwd )
-  export GOPATH
-fi
-
 for hook in $GIT_DIR/../misc/git/commit-msg.*; do
   $hook $@
 done

--- a/misc/git/hooks/golint
+++ b/misc/git/hooks/golint
@@ -18,11 +18,6 @@
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
 
-if [ -z "$GOPATH" ]; then
-  echo "ERROR: pre-commit hook for golint: \$GOPATH is empty. Please run 'source dev.env' to set the correct \$GOPATH."
-  exit 1
-fi
-
 # This script does not handle file names that contain spaces.
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -18,11 +18,6 @@
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
 
-if [ -z "$GOPATH" ]; then
-  echo "ERROR: pre-commit hook for go vet: \$GOPATH is empty. Please run 'source dev.env' to set the correct \$GOPATH."
-  exit 1
-fi
-
 # This script does not handle file names that contain spaces.
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 if [ "$gofiles" = "" ]; then

--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -9,12 +9,6 @@ if [ -z "$GIT_DIR" ]; then
   GIT_DIR="${DIR}/.."
 fi
 
-# This is necessary because the Atom packages don't set GOPATH
-if [ -z "$GOPATH" ]; then
-  GOPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../../../.." && pwd )
-  export GOPATH
-fi
-
 for hook in $GIT_DIR/../misc/git/hooks/*; do
   $hook
 done


### PR DESCRIPTION
## Description

This improves a few bits for the Go build setup. With the recent move to Go 1.16, there's no need anymore to specify GO111MODULE as the default value is now that it is on.

Additionally, it enables `-trimpath` to remove build specific paths from the final release artifacts.

Lastly, this cleans up a bunch of usage of GOPATH. Go itself now falls back to `~/go` if it is not set and we can depend on this default for commands and don't need to set anything manually.

`go env GOPATH` still works and returns this fallback if GOPATH is not set. This further simplifies setup and means people don't need to configure GOPATH anymore separately either.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required