### PR TITLE
[vtadmin] cluster rpc pools

### DIFF
--- a/go/pools/rpc_pool.go
+++ b/go/pools/rpc_pool.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pools
+
+import (
+	"context"
+	"time"
+)
+
+// RPCPool is a specialized version of the ResourcePool, for bounding concurrent
+// access to making RPC calls.
+//
+// Whether you use this, or a sync2.Semaphore to gate RPCs (or shared access to
+// any shared resource) depends on what timeout semantics you need. A sync2.Semaphore
+// takes a global timeout, which applies to calls to Acquire(); if you need to
+// respect a context's deadline, you can call AcquireContext(context.Context),
+// but that ignores the global timeout. Conversely, an RPCPool provides only
+// one method of acquisition, Acquire(context.Context), which always uses the
+// lower of the pool-global timeout or the context deadline.
+type RPCPool struct {
+	rp          *ResourcePool
+	waitTimeout time.Duration
+}
+
+// NewRPCPool returns an RPCPool with the given size and wait timeout. A zero
+// timeout will be ignored on calls to Acquire, and only the context deadline
+// will be used. If a logWait function is provided, it will be called whenever
+// a call to Acquire has to wait for a resource, but only after a successful
+// wait (meaning if we hit a timeout before a resource becomes available, it
+// will not be called).
+func NewRPCPool(size int, waitTimeout time.Duration, logWait func(time.Time)) *RPCPool {
+	return &RPCPool{
+		rp:          NewResourcePool(rpcResourceFactory, size, size, 0, size, logWait),
+		waitTimeout: waitTimeout,
+	}
+}
+
+// Acquire acquires one slot in the RPCPool. If a slot is not immediately
+// available, it will block until one becomes available or until a timeout is
+// reached. The lower of the context deadline and the pool's waitTimeout will
+// be used as the timeout, except when the pool's waitTimeout is zero, in which
+// case the context deadline will always serve as the overall timeout.
+//
+// It returns nil on successful acquisition, and an error if a timeout occurred
+// before a slot became available.
+//
+// Note: For every successful call to Acquire, the caller must make a
+// corresponding call to Release.
+func (pool *RPCPool) Acquire(ctx context.Context) error {
+	if pool.waitTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, pool.waitTimeout)
+		defer cancel()
+	}
+
+	_, err := pool.rp.Get(ctx)
+	return err
+}
+
+// Release frees a slot in the pool. It must only be called after a successful
+// call to Acquire.
+func (pool *RPCPool) Release() { pool.rp.Put(rpc) }
+
+// Close empties the pool, preventing further Acquire calls from succeeding.
+// It waits for all slots to be freed via Release.
+func (pool *RPCPool) Close() { pool.rp.Close() }
+
+type _rpc struct{}
+
+var rpc = &_rpc{}
+
+// Close implements Resource for _rpc.
+func (*_rpc) Close() {}
+
+// we only ever return the same rpc pointer. it's used as a sentinel and is
+// only used internally so using the same one over and over doesn't matter.
+func rpcResourceFactory(ctx context.Context) (Resource, error) { return rpc, nil }

--- a/go/pools/rpc_pool_test.go
+++ b/go/pools/rpc_pool_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCPool(t *testing.T) {
+	t.Parallel()
+
+	pool := NewRPCPool(1, time.Millisecond*100, nil)
+
+	err := pool.Acquire(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*5)
+	err = pool.Acquire(ctx)
+	cancel()
+	assert.Error(t, err)
+
+	pool.Release()
+	err = pool.Acquire(context.Background())
+	require.NoError(t, err)
+
+	t.Run("context timeout exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+
+		err := pool.Acquire(ctx)
+		assert.Error(t, err)
+
+		select {
+		case <-ctx.Done():
+		default:
+			assert.Fail(t, "calling context should be done after failed Acquire")
+		}
+	})
+
+	t.Run("pool timeout exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		defer cancel()
+
+		err := pool.Acquire(ctx)
+		assert.Error(t, err)
+
+		select {
+		case <-ctx.Done():
+			assert.Fail(t, "calling context should not be done after failed Acquire")
+		default:
+		}
+	})
+}
+
+func BenchmarkRPCPoolAllocs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewRPCPool(1000, 0, nil)
+		// p.Close()
+	}
+}

--- a/go/vt/vtadmin/api_test.go
+++ b/go/vt/vtadmin/api_test.go
@@ -514,7 +514,7 @@ func TestFindSchema(t *testing.T) {
 
 			clusters := make([]*cluster.Cluster, len(tt.clusters))
 			for i, cfg := range tt.clusters {
-				clusters[i] = vtadmintestutil.BuildCluster(cfg)
+				clusters[i] = vtadmintestutil.BuildCluster(t, cfg)
 			}
 
 			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
@@ -543,94 +543,52 @@ func TestFindSchema(t *testing.T) {
 			Name: "cluster2",
 		}
 
-		c1 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: c1pb,
-				VtctldClient: &fakevtctldclient.VtctldClient{
-					FindAllShardsInKeyspaceResults: map[string]struct {
-						Response *vtctldatapb.FindAllShardsInKeyspaceResponse
-						Error    error
-					}{
-						"testkeyspace": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-80": {
-										Keyspace: "testkeyspace",
-										Name:     "-80",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  100,
-											},
-										},
-									},
-									"80-": {
-										Keyspace: "testkeyspace",
-										Name:     "80-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  200,
-											},
+		c1 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: c1pb,
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"testkeyspace": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-80": {
+									Keyspace: "testkeyspace",
+									Name:     "-80",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  100,
 										},
 									},
 								},
-							},
-						},
-						"ks1": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-": {
-										Keyspace: "ks1",
-										Name:     "-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  300,
-											},
+								"80-": {
+									Keyspace: "testkeyspace",
+									Name:     "80-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  200,
 										},
 									},
 								},
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
-						Keyspaces []*vtctldatapb.Keyspace
-						Error     error
-					}{
-						Keyspaces: []*vtctldatapb.Keyspace{
-							{Name: "testkeyspace"},
-							{Name: "ks1"},
-						},
-					},
-					GetSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetSchemaResponse
-						Error    error
-					}{
-						"c1zone1-0000000100": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   10,
-											DataLength: 100,
-										},
-									},
-								},
-							},
-						},
-						"c1zone1-0000000200": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   20,
-											DataLength: 200,
+					"ks1": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "ks1",
+									Name:     "-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  300,
 										},
 									},
 								},
@@ -638,94 +596,134 @@ func TestFindSchema(t *testing.T) {
 						},
 					},
 				},
-				Tablets: []*vtadminpb.Tablet{
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  100,
-							},
-							Keyspace: "testkeyspace",
-							Shard:    "-80",
-						},
-						State: vtadminpb.Tablet_SERVING,
+				GetKeyspacesResults: struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{Name: "testkeyspace"},
+						{Name: "ks1"},
 					},
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  200,
+				},
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"c1zone1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   10,
+										DataLength: 100,
+									},
+								},
 							},
-							Keyspace: "testkeyspace",
-							Shard:    "80-",
 						},
-						State: vtadminpb.Tablet_SERVING,
+					},
+					"c1zone1-0000000200": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   20,
+										DataLength: 200,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
+			Tablets: []*vtadminpb.Tablet{
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  100,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "-80",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  200,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "80-",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+			},
+		},
 		)
-		c2 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: c2pb,
-				VtctldClient: &fakevtctldclient.VtctldClient{
-					FindAllShardsInKeyspaceResults: map[string]struct {
-						Response *vtctldatapb.FindAllShardsInKeyspaceResponse
-						Error    error
-					}{
-						"ks2": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-": {
-										Keyspace: "ks2",
-										Name:     "-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c2z1",
-												Uid:  100,
-											},
+		c2 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: c2pb,
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"ks2": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "ks2",
+									Name:     "-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c2z1",
+											Uid:  100,
 										},
 									},
 								},
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
-						Keyspaces []*vtctldatapb.Keyspace
-						Error     error
-					}{
-						Keyspaces: []*vtctldatapb.Keyspace{
-							{
-								Name: "ks2",
-							},
-						},
-					},
-					GetSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetSchemaResponse
-						Error    error
-					}{
-						"c2z1-0000000100": {
-							Response: &vtctldatapb.GetSchemaResponse{},
+				},
+				GetKeyspacesResults: struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{
+							Name: "ks2",
 						},
 					},
 				},
-				Tablets: []*vtadminpb.Tablet{
-					{
-						Cluster: c2pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c2z1",
-								Uid:  100,
-							},
-							Keyspace: "ks2",
-							Shard:    "-",
-						},
-						State: vtadminpb.Tablet_SERVING,
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"c2z1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{},
 					},
 				},
 			},
+			Tablets: []*vtadminpb.Tablet{
+				{
+					Cluster: c2pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c2z1",
+							Uid:  100,
+						},
+						Keyspace: "ks2",
+						Shard:    "-",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+			},
+		},
 		)
 
 		api := NewAPI([]*cluster.Cluster{c1, c2}, grpcserver.Options{}, http.Options{})
@@ -1031,7 +1029,7 @@ func TestGetKeyspace(t *testing.T) {
 			testutil.WithTestServers(t, func(t *testing.T, clients ...vtctldclient.VtctldClient) {
 				clusters := make([]*cluster.Cluster, len(clients))
 				for i, client := range clients {
-					clusters[i] = vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					clusters[i] = vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   fmt.Sprintf("cluster-%d", i),
 							Name: fmt.Sprintf("cluster-%d", i),
@@ -1277,14 +1275,14 @@ func TestGetKeyspaces(t *testing.T) {
 
 			testutil.WithTestServers(t, func(t *testing.T, clients ...vtctldclient.VtctldClient) {
 				clusters := []*cluster.Cluster{
-					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   "c0",
 							Name: "cluster0",
 						},
 						VtctldClient: clients[0],
 					}),
-					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   "c1",
 							Name: "cluster1",
@@ -1509,7 +1507,7 @@ func TestGetSchema(t *testing.T) {
 			testutil.AddTablets(ctx, t, tt.ts, nil, vtadmintestutil.TopodataTabletsFromVTAdminTablets(tt.tablets)...)
 
 			testutil.WithTestServer(t, vtctld, func(t *testing.T, client vtctldclient.VtctldClient) {
-				c := vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+				c := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 					Cluster: &vtadminpb.Cluster{
 						Id:   fmt.Sprintf("c%d", tt.clusterID),
 						Name: fmt.Sprintf("cluster%d", tt.clusterID),
@@ -1539,68 +1537,35 @@ func TestGetSchema(t *testing.T) {
 			Id:   "c1",
 			Name: "cluster1",
 		}
-		c1 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: c1pb,
-				VtctldClient: &fakevtctldclient.VtctldClient{
-					FindAllShardsInKeyspaceResults: map[string]struct {
-						Response *vtctldatapb.FindAllShardsInKeyspaceResponse
-						Error    error
-					}{
-						"testkeyspace": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-80": {
-										Keyspace: "testkeyspace",
-										Name:     "-80",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  100,
-											},
-										},
-									},
-									"80-": {
-										Keyspace: "testkeyspace",
-										Name:     "80-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  200,
-											},
+		c1 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: c1pb,
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"testkeyspace": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-80": {
+									Keyspace: "testkeyspace",
+									Name:     "-80",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  100,
 										},
 									},
 								},
-							},
-						},
-					},
-					GetSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetSchemaResponse
-						Error    error
-					}{
-						"c1zone1-0000000100": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   10,
-											DataLength: 100,
-										},
-									},
-								},
-							},
-						},
-						"c1zone1-0000000200": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   20,
-											DataLength: 200,
+								"80-": {
+									Keyspace: "testkeyspace",
+									Name:     "80-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  200,
 										},
 									},
 								},
@@ -1608,41 +1573,72 @@ func TestGetSchema(t *testing.T) {
 						},
 					},
 				},
-				Tablets: []*vtadminpb.Tablet{
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  100,
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"c1zone1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   10,
+										DataLength: 100,
+									},
+								},
 							},
-							Keyspace: "testkeyspace",
-							Shard:    "-80",
 						},
-						State: vtadminpb.Tablet_SERVING,
 					},
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  200,
+					"c1zone1-0000000200": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   20,
+										DataLength: 200,
+									},
+								},
 							},
-							Keyspace: "testkeyspace",
-							Shard:    "80-",
 						},
-						State: vtadminpb.Tablet_SERVING,
 					},
 				},
 			},
+			Tablets: []*vtadminpb.Tablet{
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  100,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "-80",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  200,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "80-",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+			},
+		},
 		)
-		c2 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: &vtadminpb.Cluster{
-					Id:   "c2",
-					Name: "cluster2",
-				},
+		c2 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: &vtadminpb.Cluster{
+				Id:   "c2",
+				Name: "cluster2",
 			},
+		},
 		)
 
 		api := NewAPI([]*cluster.Cluster{c1, c2}, grpcserver.Options{}, http.Options{})
@@ -2185,7 +2181,7 @@ func TestGetSchemas(t *testing.T) {
 						}
 					}
 
-					clusters[cdx] = vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					clusters[cdx] = vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   fmt.Sprintf("c%d", cdx),
 							Name: fmt.Sprintf("cluster%d", cdx),
@@ -2217,94 +2213,52 @@ func TestGetSchemas(t *testing.T) {
 			Name: "cluster2",
 		}
 
-		c1 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: c1pb,
-				VtctldClient: &fakevtctldclient.VtctldClient{
-					FindAllShardsInKeyspaceResults: map[string]struct {
-						Response *vtctldatapb.FindAllShardsInKeyspaceResponse
-						Error    error
-					}{
-						"testkeyspace": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-80": {
-										Keyspace: "testkeyspace",
-										Name:     "-80",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  100,
-											},
-										},
-									},
-									"80-": {
-										Keyspace: "testkeyspace",
-										Name:     "80-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone1",
-												Uid:  200,
-											},
+		c1 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: c1pb,
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"testkeyspace": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-80": {
+									Keyspace: "testkeyspace",
+									Name:     "-80",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  100,
 										},
 									},
 								},
-							},
-						},
-						"ks1": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-": {
-										Keyspace: "ks1",
-										Name:     "-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c1zone2",
-												Uid:  100,
-											},
+								"80-": {
+									Keyspace: "testkeyspace",
+									Name:     "80-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone1",
+											Uid:  200,
 										},
 									},
 								},
 							},
 						},
 					},
-					GetKeyspacesResults: struct {
-						Keyspaces []*vtctldatapb.Keyspace
-						Error     error
-					}{
-						Keyspaces: []*vtctldatapb.Keyspace{
-							{Name: "testkeyspace"},
-							{Name: "ks1"},
-						},
-					},
-					GetSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetSchemaResponse
-						Error    error
-					}{
-						"c1zone1-0000000100": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   10,
-											DataLength: 100,
-										},
-									},
-								},
-							},
-						},
-						"c1zone1-0000000200": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "testtable",
-											RowCount:   20,
-											DataLength: 200,
+					"ks1": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "ks1",
+									Name:     "-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c1zone2",
+											Uid:  100,
 										},
 									},
 								},
@@ -2312,87 +2266,93 @@ func TestGetSchemas(t *testing.T) {
 						},
 					},
 				},
-				Tablets: []*vtadminpb.Tablet{
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  100,
-							},
-							Keyspace: "testkeyspace",
-							Shard:    "-80",
-						},
-						State: vtadminpb.Tablet_SERVING,
+				GetKeyspacesResults: struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{Name: "testkeyspace"},
+						{Name: "ks1"},
 					},
-					{
-						Cluster: c1pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c1zone1",
-								Uid:  200,
+				},
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"c1zone1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   10,
+										DataLength: 100,
+									},
+								},
 							},
-							Keyspace: "testkeyspace",
-							Shard:    "80-",
 						},
-						State: vtadminpb.Tablet_SERVING,
+					},
+					"c1zone1-0000000200": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "testtable",
+										RowCount:   20,
+										DataLength: 200,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
+			Tablets: []*vtadminpb.Tablet{
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  100,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "-80",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+				{
+					Cluster: c1pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c1zone1",
+							Uid:  200,
+						},
+						Keyspace: "testkeyspace",
+						Shard:    "80-",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+			},
+		},
 		)
-		c2 := vtadmintestutil.BuildCluster(
-			vtadmintestutil.TestClusterConfig{
-				Cluster: c2pb,
-				VtctldClient: &fakevtctldclient.VtctldClient{
-					FindAllShardsInKeyspaceResults: map[string]struct {
-						Response *vtctldatapb.FindAllShardsInKeyspaceResponse
-						Error    error
-					}{
-						"ks2": {
-							Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
-								Shards: map[string]*vtctldatapb.Shard{
-									"-": {
-										Keyspace: "ks2",
-										Name:     "-",
-										Shard: &topodatapb.Shard{
-											IsMasterServing: true,
-											MasterAlias: &topodatapb.TabletAlias{
-												Cell: "c2z1",
-												Uid:  100,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					GetKeyspacesResults: struct {
-						Keyspaces []*vtctldatapb.Keyspace
-						Error     error
-					}{
-						Keyspaces: []*vtctldatapb.Keyspace{
-							{
-								Name: "ks2",
-							},
-						},
-					},
-					GetSchemaResults: map[string]struct {
-						Response *vtctldatapb.GetSchemaResponse
-						Error    error
-					}{
-						"c2z1-0000000100": {
-							Response: &vtctldatapb.GetSchemaResponse{
-								Schema: &tabletmanagerdatapb.SchemaDefinition{
-									TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-										{
-											Name:       "t2",
-											DataLength: 5,
-											RowCount:   7,
-										},
-										{
-											Name:       "_t2_ghc",
-											DataLength: 5,
-											RowCount:   7,
+		c2 := vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
+			Cluster: c2pb,
+			VtctldClient: &fakevtctldclient.VtctldClient{
+				FindAllShardsInKeyspaceResults: map[string]struct {
+					Response *vtctldatapb.FindAllShardsInKeyspaceResponse
+					Error    error
+				}{
+					"ks2": {
+						Response: &vtctldatapb.FindAllShardsInKeyspaceResponse{
+							Shards: map[string]*vtctldatapb.Shard{
+								"-": {
+									Keyspace: "ks2",
+									Name:     "-",
+									Shard: &topodatapb.Shard{
+										IsMasterServing: true,
+										MasterAlias: &topodatapb.TabletAlias{
+											Cell: "c2z1",
+											Uid:  100,
 										},
 									},
 								},
@@ -2400,21 +2360,55 @@ func TestGetSchemas(t *testing.T) {
 						},
 					},
 				},
-				Tablets: []*vtadminpb.Tablet{
-					{
-						Cluster: c2pb,
-						Tablet: &topodatapb.Tablet{
-							Alias: &topodatapb.TabletAlias{
-								Cell: "c2z1",
-								Uid:  100,
-							},
-							Keyspace: "ks2",
-							Shard:    "-",
+				GetKeyspacesResults: struct {
+					Keyspaces []*vtctldatapb.Keyspace
+					Error     error
+				}{
+					Keyspaces: []*vtctldatapb.Keyspace{
+						{
+							Name: "ks2",
 						},
-						State: vtadminpb.Tablet_SERVING,
+					},
+				},
+				GetSchemaResults: map[string]struct {
+					Response *vtctldatapb.GetSchemaResponse
+					Error    error
+				}{
+					"c2z1-0000000100": {
+						Response: &vtctldatapb.GetSchemaResponse{
+							Schema: &tabletmanagerdatapb.SchemaDefinition{
+								TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+									{
+										Name:       "t2",
+										DataLength: 5,
+										RowCount:   7,
+									},
+									{
+										Name:       "_t2_ghc",
+										DataLength: 5,
+										RowCount:   7,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
+			Tablets: []*vtadminpb.Tablet{
+				{
+					Cluster: c2pb,
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "c2z1",
+							Uid:  100,
+						},
+						Keyspace: "ks2",
+						Shard:    "-",
+					},
+					State: vtadminpb.Tablet_SERVING,
+				},
+			},
+		},
 		)
 
 		api := NewAPI([]*cluster.Cluster{c1, c2}, grpcserver.Options{}, http.Options{})
@@ -2639,7 +2633,7 @@ func TestGetSrvVSchema(t *testing.T) {
 				}
 
 				clusters := []*cluster.Cluster{
-					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   clusterID,
 							Name: clusterName,
@@ -2933,7 +2927,7 @@ func TestGetSrvVSchemas(t *testing.T) {
 				}
 
 				clusters := []*cluster.Cluster{
-					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   clusterID,
 							Name: clusterName,
@@ -3188,7 +3182,7 @@ func TestGetTablet(t *testing.T) {
 				cid := fmt.Sprintf("c%d", i)
 				dbconfigs := tt.dbconfigs[cid]
 
-				clusters[i] = vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+				clusters[i] = vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 					Cluster: &vtadminpb.Cluster{
 						Id:   cid,
 						Name: fmt.Sprintf("cluster%d", i),
@@ -3383,7 +3377,7 @@ func TestGetTablets(t *testing.T) {
 				cid := fmt.Sprintf("c%d", i)
 				dbconfigs := tt.dbconfigs[cid]
 
-				clusters[i] = vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+				clusters[i] = vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 					Cluster: &vtadminpb.Cluster{
 						Id:   cid,
 						Name: fmt.Sprintf("cluster%d", i),
@@ -3523,7 +3517,7 @@ func TestGetVSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			clusters := []*cluster.Cluster{vtadmintestutil.BuildCluster(tt.clusterCfg)}
+			clusters := []*cluster.Cluster{vtadmintestutil.BuildCluster(t, tt.clusterCfg)}
 			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
 
 			resp, err := api.GetVSchema(ctx, tt.req)
@@ -3853,7 +3847,7 @@ func TestGetVSchemas(t *testing.T) {
 				t.SkipNow()
 			}
 
-			clusters := vtadmintestutil.BuildClusters(tt.clusterCfgs...)
+			clusters := vtadmintestutil.BuildClusters(t, tt.clusterCfgs...)
 			api := NewAPI(clusters, grpcserver.Options{}, http.Options{})
 
 			resp, err := api.GetVSchemas(ctx, tt.req)
@@ -3984,7 +3978,7 @@ func TestGetWorkflow(t *testing.T) {
 			t.Parallel()
 
 			api := NewAPI(
-				vtadmintestutil.BuildClusters(tt.cfgs...),
+				vtadmintestutil.BuildClusters(t, tt.cfgs...),
 				grpcserver.Options{},
 				http.Options{},
 			)
@@ -4427,7 +4421,7 @@ func TestGetWorkflows(t *testing.T) {
 			t.Parallel()
 
 			api := NewAPI(
-				vtadmintestutil.BuildClusters(tt.cfgs...),
+				vtadmintestutil.BuildClusters(t, tt.cfgs...),
 				grpcserver.Options{},
 				http.Options{},
 			)
@@ -4714,7 +4708,7 @@ func TestVTExplain(t *testing.T) {
 				}
 
 				clusters := []*cluster.Cluster{
-					vtadmintestutil.BuildCluster(vtadmintestutil.TestClusterConfig{
+					vtadmintestutil.BuildCluster(t, vtadmintestutil.TestClusterConfig{
 						Cluster: &vtadminpb.Cluster{
 							Id:   "c0",
 							Name: "cluster0",

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -242,6 +242,11 @@ type FindAllShardsInKeyspaceOptions struct {
 	// SkipDial indicates that the cluster can assume the vtctldclient has
 	// already dialed up a connection to a vtctld.
 	SkipDial bool
+	// skipPool indicates that the caller has already made a successful call to
+	// Acquire on the topoReadPool. It is not exported, because the cluster
+	// pools are not exported, so it's not possible to manually Acquire from
+	// outside this package.
+	skipPool bool
 }
 
 // FindAllShardsInKeyspace proxies a FindAllShardsInKeyspace RPC to a cluster's
@@ -260,6 +265,13 @@ func (c *Cluster) FindAllShardsInKeyspace(ctx context.Context, keyspace string, 
 		if err := c.Vtctld.Dial(ctx); err != nil {
 			return nil, fmt.Errorf("failed to Dial vtctld for cluster = %s for FindAllShardsInKeyspace: %w", c.ID, err)
 		}
+	}
+
+	if !opts.skipPool {
+		if err := c.topoReadPool.Acquire(ctx); err != nil {
+			return nil, fmt.Errorf("FindAllShardsInKeyspace(%s) failed to acquire topoReadPool: %w", keyspace, err)
+		}
+		defer c.topoReadPool.Release()
 	}
 
 	resp, err := c.Vtctld.FindAllShardsInKeyspace(ctx, &vtctldatapb.FindAllShardsInKeyspaceRequest{
@@ -321,7 +333,14 @@ func (c *Cluster) findWorkflows(ctx context.Context, keyspaces []string, opts Fi
 		span, ctx := trace.NewSpan(ctx, "Cluster.GetKeyspaces")
 		AnnotateSpan(c, span)
 
+		if err := c.topoReadPool.Acquire(ctx); err != nil {
+			span.Finish()
+			return nil, fmt.Errorf("findWorkflows(keyspaces = %v, opts = %+v) failed to acquire topoReadPool: %w", keyspaces, opts, err)
+		}
+
 		resp, err := c.Vtctld.GetKeyspaces(ctx, &vtctldatapb.GetKeyspacesRequest{})
+		c.topoReadPool.Release()
+
 		if err != nil {
 			span.Finish()
 			return nil, fmt.Errorf("GetKeyspaces(cluster = %s) failed: %w", c.ID, err)
@@ -373,12 +392,21 @@ func (c *Cluster) findWorkflows(ctx context.Context, keyspaces []string, opts Fi
 			span.Annotate("keyspace", ks)
 			span.Annotate("active_only", opts.ActiveOnly)
 
+			if err := c.workflowReadPool.Acquire(ctx); err != nil {
+				err = fmt.Errorf("GetWorkflows(keyspace = %s, active_only = %v) failed to acquire workflowReadPool: %w", ks, opts.ActiveOnly, err)
+				rec.RecordError(err)
+
+				return
+			}
+
 			resp, err := c.Vtctld.GetWorkflows(ctx, &vtctldatapb.GetWorkflowsRequest{
 				Keyspace:   ks,
 				ActiveOnly: opts.ActiveOnly,
 			})
+			c.workflowReadPool.Release()
+
 			if err != nil {
-				err = fmt.Errorf("GetWorkflows(cluster = %s, keyspace = %s, active_only = %v) failed: %w", c.ID, ks, opts.ActiveOnly, err)
+				err = fmt.Errorf("GetWorkflows(keyspace = %s, active_only = %v) failed: %w", ks, opts.ActiveOnly, err)
 				rec.RecordError(err)
 
 				return
@@ -452,6 +480,11 @@ func (c *Cluster) GetBackups(ctx context.Context, req *vtadminpb.GetBackupsReque
 				span.Annotate("keyspace", keyspace)
 				span.Annotate("shard", shard)
 
+				if err := c.backupReadPool.Acquire(ctx); err != nil {
+					rec.RecordError(fmt.Errorf("GetBackups(%s/%s) failed to acquire backupReadPool: %w", keyspace, shard, err))
+					return
+				}
+
 				resp, err := c.Vtctld.GetBackups(ctx, &vtctldatapb.GetBackupsRequest{
 					Keyspace:      keyspace,
 					Shard:         shard,
@@ -459,6 +492,8 @@ func (c *Cluster) GetBackups(ctx context.Context, req *vtadminpb.GetBackupsReque
 					Detailed:      req.RequestOptions.Detailed,
 					DetailedLimit: req.RequestOptions.DetailedLimit,
 				})
+				c.backupReadPool.Release()
+
 				if err != nil {
 					rec.RecordError(fmt.Errorf("GetBackups(%s/%s): %w", keyspace, shard, err))
 					return
@@ -634,6 +669,11 @@ func (c *Cluster) GetKeyspace(ctx context.Context, name string) (*vtadminpb.Keys
 		return nil, fmt.Errorf("Vtctld.Dial failed for cluster = %s: %w", c.ID, err)
 	}
 
+	if err := c.topoReadPool.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("GetKeyspace(%s) failed to acquire topoReadPool: %w", name, err)
+	}
+	defer c.topoReadPool.Release()
+
 	resp, err := c.Vtctld.GetKeyspace(ctx, &vtctldatapb.GetKeyspaceRequest{
 		Keyspace: name,
 	})
@@ -641,7 +681,10 @@ func (c *Cluster) GetKeyspace(ctx context.Context, name string) (*vtadminpb.Keys
 		return nil, err
 	}
 
-	shards, err := c.FindAllShardsInKeyspace(ctx, name, FindAllShardsInKeyspaceOptions{SkipDial: true})
+	shards, err := c.FindAllShardsInKeyspace(ctx, name, FindAllShardsInKeyspaceOptions{
+		SkipDial: true,
+		skipPool: true, // we already acquired before making the GetKeyspace call
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +707,13 @@ func (c *Cluster) GetKeyspaces(ctx context.Context) ([]*vtadminpb.Keyspace, erro
 		return nil, fmt.Errorf("Vtctld.Dial(cluster=%s) failed: %w", c.ID, err)
 	}
 
+	if err := c.topoReadPool.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("GetKeyspaces() failed to acquire topoReadPool: %w", err)
+	}
+
 	resp, err := c.Vtctld.GetKeyspaces(ctx, &vtctldatapb.GetKeyspacesRequest{})
+	c.topoReadPool.Release()
+
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +935,15 @@ func (c *Cluster) getSchemaFromTablets(ctx context.Context, keyspace string, tab
 			span.Annotate("keyspace", keyspace)
 			span.Annotate("shard", tablet.Tablet.Shard)
 
+			if err := c.schemaReadPool.Acquire(ctx); err != nil {
+				err = fmt.Errorf("GetSchema(cluster = %s, keyspace = %s, tablet = %s) failed to acquire schemaReadPool: %w", c.ID, keyspace, tablet.Tablet.Alias, err)
+				rec.RecordError(err)
+				return
+			}
+
 			resp, err := c.Vtctld.GetSchema(ctx, req)
+			c.schemaReadPool.Release()
+
 			if err != nil {
 				err = fmt.Errorf("GetSchema(cluster = %s, keyspace = %s, tablet = %s) failed: %w", c.ID, keyspace, tablet.Tablet.Alias, err)
 				rec.RecordError(err)
@@ -1014,6 +1071,11 @@ func (c *Cluster) GetSrvVSchema(ctx context.Context, cell string) (*vtadminpb.Sr
 		return nil, fmt.Errorf("Vtctld.Dial(cluster=%s) failed: %w", c.ID, err)
 	}
 
+	if err := c.topoReadPool.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("GetSrvVSchema(%s) failed to acquire topoReadPool: %w", cell, err)
+	}
+	defer c.topoReadPool.Release()
+
 	sv, err := c.Vtctld.GetSrvVSchema(ctx, &vtctldatapb.GetSrvVSchemaRequest{
 		Cell: cell,
 	})
@@ -1041,17 +1103,21 @@ func (c *Cluster) GetSrvVSchemas(ctx context.Context, cells []string) ([]*vtadmi
 		return nil, fmt.Errorf("Vtctld.Dial(cluster=%s) failed: %w", c.ID, err)
 	}
 
-	res, err := c.Vtctld.GetSrvVSchemas(ctx, &vtctldatapb.GetSrvVSchemasRequest{
+	if err := c.topoReadPool.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("GetSrvVSchema(cluster = %s, cells = %v) failed to acquire topoReadPool: %w", c.ID, cells, err)
+	}
+	resp, err := c.Vtctld.GetSrvVSchemas(ctx, &vtctldatapb.GetSrvVSchemasRequest{
 		Cells: cells,
 	})
+	c.topoReadPool.Release()
 
 	if err != nil {
 		return nil, err
 	}
 
-	svs := make([]*vtadminpb.SrvVSchema, 0)
+	svs := make([]*vtadminpb.SrvVSchema, 0, len(resp.SrvVSchemas))
 
-	for cell, s := range res.SrvVSchemas {
+	for cell, s := range resp.SrvVSchemas {
 		svs = append(svs, &vtadminpb.SrvVSchema{
 			Cell:       cell,
 			Cluster:    c.ToProto(),
@@ -1071,6 +1137,11 @@ func (c *Cluster) GetVSchema(ctx context.Context, keyspace string) (*vtadminpb.V
 
 	AnnotateSpan(c, span)
 	span.Annotate("keyspace", keyspace)
+
+	if err := c.topoReadPool.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("GetVSchema(%s) failed to acquire topoReadPool: %w", keyspace, err)
+	}
+	defer c.topoReadPool.Release()
 
 	vschema, err := c.Vtctld.GetVSchema(ctx, &vtctldatapb.GetVSchemaRequest{
 		Keyspace: keyspace,

--- a/go/vt/vtadmin/cluster/cluster.go
+++ b/go/vt/vtadmin/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/textutil"
 	"vitess.io/vitess/go/trace"
 	"vitess.io/vitess/go/vt/concurrency"
@@ -64,6 +65,11 @@ type Cluster struct {
 
 	// Fields for generating FQDNs for tablets
 	TabletFQDNTmpl *template.Template
+
+	backupReadPool   *pools.RPCPool
+	schemaReadPool   *pools.RPCPool
+	topoReadPool     *pools.RPCPool
+	workflowReadPool *pools.RPCPool
 }
 
 // New creates a new Cluster from a Config.
@@ -107,6 +113,11 @@ func New(cfg Config) (*Cluster, error) {
 			return nil, fmt.Errorf("failed to parse tablet fqdn template %s: %w", cfg.TabletFQDNTmplStr, err)
 		}
 	}
+
+	cluster.backupReadPool = cfg.BackupReadPoolConfig.NewReadPool()
+	cluster.schemaReadPool = cfg.SchemaReadPoolConfig.NewReadPool()
+	cluster.topoReadPool = cfg.TopoReadPoolConfig.NewReadPool()
+	cluster.workflowReadPool = cfg.WorkflowReadPoolConfig.NewReadPool()
 
 	return cluster, nil
 }

--- a/go/vt/vtadmin/cluster/cluster_internal_test.go
+++ b/go/vt/vtadmin/cluster/cluster_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"vitess.io/vitess/go/pools"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtadmin/vtctldclient/fakevtctldclient"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
@@ -119,6 +120,7 @@ func Test_getShardSets(t *testing.T) {
 				},
 			},
 		},
+		topoReadPool: pools.NewRPCPool(5, 0, nil),
 	}
 	require.NoError(t, c.Vtctld.Dial(context.Background()))
 

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -148,7 +148,7 @@ func TestFindTablet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
+			cluster := testutil.BuildCluster(t, testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   "c0",
 					Name: "cluster0",
@@ -359,7 +359,7 @@ func TestFindTablets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cluster := testutil.BuildCluster(testutil.TestClusterConfig{
+			cluster := testutil.BuildCluster(t, testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   "c0",
 					Name: "cluster0",
@@ -505,7 +505,7 @@ func TestGetSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := testutil.BuildCluster(testutil.TestClusterConfig{
+			c := testutil.BuildCluster(t, testutil.TestClusterConfig{
 				Cluster: &vtadminpb.Cluster{
 					Id:   fmt.Sprintf("c%d", i),
 					Name: fmt.Sprintf("cluster%d", i),
@@ -562,7 +562,7 @@ func TestGetSchema(t *testing.T) {
 			},
 		}
 
-		c := testutil.BuildCluster(testutil.TestClusterConfig{
+		c := testutil.BuildCluster(t, testutil.TestClusterConfig{
 			Cluster: &vtadminpb.Cluster{
 				Id:   "c0",
 				Name: "cluster0",
@@ -1518,7 +1518,7 @@ func TestGetSchema(t *testing.T) {
 					t.SkipNow()
 				}
 
-				c := testutil.BuildCluster(tt.cfg)
+				c := testutil.BuildCluster(t, tt.cfg)
 				schema, err := c.GetSchema(ctx, tt.keyspace, tt.opts)
 				if tt.shouldErr {
 					assert.Error(t, err)
@@ -1917,7 +1917,7 @@ func TestFindWorkflows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := testutil.BuildCluster(tt.cfg)
+			c := testutil.BuildCluster(t, tt.cfg)
 			workflows, err := c.FindWorkflows(ctx, tt.keyspaces, tt.opts)
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -2030,7 +2030,7 @@ func TestGetVSchema(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cluster := testutil.BuildCluster(tt.cfg)
+			cluster := testutil.BuildCluster(t, tt.cfg)
 			err := cluster.Vtctld.Dial(ctx)
 			require.NoError(t, err, "could not dial test vtctld")
 
@@ -2190,7 +2190,7 @@ func TestGetWorkflow(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := testutil.BuildCluster(tt.cfg)
+			c := testutil.BuildCluster(t, tt.cfg)
 			workflow, err := c.GetWorkflow(ctx, tt.keyspace, tt.workflow, tt.opts)
 			if tt.shouldErr {
 				assert.Error(t, err)
@@ -2356,7 +2356,7 @@ func TestGetWorkflows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := testutil.BuildCluster(tt.cfg)
+			c := testutil.BuildCluster(t, tt.cfg)
 			workflows, err := c.GetWorkflows(ctx, tt.keyspaces, tt.opts)
 			if tt.shouldErr {
 				assert.Error(t, err)

--- a/go/vt/vtadmin/cluster/flags.go
+++ b/go/vt/vtadmin/cluster/flags.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -159,6 +160,50 @@ func parseOne(cfg *Config, name string, val string) error {
 			}
 
 			cfg.VtctldFlags[strings.TrimPrefix(name, "vtctld-")] = val
+		case strings.HasPrefix(name, "backup-read-pool-"):
+			if cfg.BackupReadPoolConfig == nil {
+				cfg.BackupReadPoolConfig = &RPCPoolConfig{
+					Size:        -1,
+					WaitTimeout: -1,
+				}
+			}
+
+			if err := cfg.BackupReadPoolConfig.parseFlag(strings.TrimPrefix(name, "backup-read-pool-"), val); err != nil {
+				return fmt.Errorf("error parsing %s: %w", name, err)
+			}
+		case strings.HasPrefix(name, "schema-read-pool-"):
+			if cfg.BackupReadPoolConfig == nil {
+				cfg.BackupReadPoolConfig = &RPCPoolConfig{
+					Size:        -1,
+					WaitTimeout: -1,
+				}
+			}
+
+			if err := cfg.SchemaReadPoolConfig.parseFlag(strings.TrimPrefix(name, "schema-read-pool-"), val); err != nil {
+				return fmt.Errorf("error parsing %s: %w", name, err)
+			}
+		case strings.HasPrefix(name, "topo-read-pool-"):
+			if cfg.TopoReadPoolConfig == nil {
+				cfg.TopoReadPoolConfig = &RPCPoolConfig{
+					Size:        -1,
+					WaitTimeout: -1,
+				}
+			}
+
+			if err := cfg.TopoReadPoolConfig.parseFlag(strings.TrimPrefix(name, "topo-read-pool-"), val); err != nil {
+				return fmt.Errorf("error parsing %s: %w", name, err)
+			}
+		case strings.HasPrefix(name, "workflow-read-pool-"):
+			if cfg.WorkflowReadPoolConfig == nil {
+				cfg.WorkflowReadPoolConfig = &RPCPoolConfig{
+					Size:        -1,
+					WaitTimeout: -1,
+				}
+			}
+
+			if err := cfg.WorkflowReadPoolConfig.parseFlag(strings.TrimPrefix(name, "workflow-read-pool-"), val); err != nil {
+				return fmt.Errorf("error parsing %s: %w", name, err)
+			}
 		default:
 			match := discoveryFlagRegexp.FindStringSubmatch(name)
 			if match == nil {

--- a/go/vt/vtadmin/cluster/flags.go
+++ b/go/vt/vtadmin/cluster/flags.go
@@ -146,51 +146,48 @@ func parseOne(cfg *Config, name string, val string) error {
 	case "tablet-fqdn-tmpl":
 		cfg.TabletFQDNTmplStr = val
 	default:
-		if strings.HasPrefix(name, "vtsql-") {
+		switch {
+		case strings.HasPrefix(name, "vtsql-"):
 			if cfg.VtSQLFlags == nil {
 				cfg.VtSQLFlags = map[string]string{}
 			}
 
 			cfg.VtSQLFlags[strings.TrimPrefix(name, "vtsql-")] = val
-
-			return nil
-		} else if strings.HasPrefix(name, "vtctld-") {
+		case strings.HasPrefix(name, "vtctld-"):
 			if cfg.VtctldFlags == nil {
 				cfg.VtctldFlags = map[string]string{}
 			}
 
 			cfg.VtctldFlags[strings.TrimPrefix(name, "vtctld-")] = val
-
-			return nil
-		}
-
-		match := discoveryFlagRegexp.FindStringSubmatch(name)
-		if match == nil {
-			// not a discovery flag
-			log.Warningf("Attempted to parse %q as a discovery flag, ignoring ...", name)
-			return nil
-		}
-
-		var impl, flag string
-
-		for i, g := range discoveryFlagRegexp.SubexpNames() {
-			switch g {
-			case "impl":
-				impl = match[i]
-			case "flag":
-				flag = match[i]
+		default:
+			match := discoveryFlagRegexp.FindStringSubmatch(name)
+			if match == nil {
+				// not a discovery flag
+				log.Warningf("Attempted to parse %q as a discovery flag, ignoring ...", name)
+				return nil
 			}
-		}
 
-		if cfg.DiscoveryFlagsByImpl == nil {
-			cfg.DiscoveryFlagsByImpl = map[string]map[string]string{}
-		}
+			var impl, flag string
 
-		if cfg.DiscoveryFlagsByImpl[impl] == nil {
-			cfg.DiscoveryFlagsByImpl[impl] = map[string]string{}
-		}
+			for i, g := range discoveryFlagRegexp.SubexpNames() {
+				switch g {
+				case "impl":
+					impl = match[i]
+				case "flag":
+					flag = match[i]
+				}
+			}
 
-		cfg.DiscoveryFlagsByImpl[impl][flag] = val
+			if cfg.DiscoveryFlagsByImpl == nil {
+				cfg.DiscoveryFlagsByImpl = map[string]map[string]string{}
+			}
+
+			if cfg.DiscoveryFlagsByImpl[impl] == nil {
+				cfg.DiscoveryFlagsByImpl[impl] = map[string]string{}
+			}
+
+			cfg.DiscoveryFlagsByImpl[impl][flag] = val
+		}
 	}
 
 	return nil

--- a/go/vt/vtadmin/errors/errors.go
+++ b/go/vt/vtadmin/errors/errors.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 )
 
+// Errors returned by API endpoints.
 var (
 	// ErrAmbiguousSchema occurs when more than one schema is found for a given
 	// set of filter criteria.
@@ -49,4 +50,11 @@ var (
 	ErrNoWorkflow = errors.New("no such workflow")
 	// ErrUnsupportedCluster occurs when a cluster parameter is invalid.
 	ErrUnsupportedCluster = errors.New("unsupported cluster(s)")
+)
+
+// Errors returned by cluster setup and flag parsing.
+var (
+	// ErrNoFlag occurs when cluster config parsing encounters a flag specified
+	// in the DSN that is not defined.
+	ErrNoFlag = errors.New("flag provided but not defined")
 )


### PR DESCRIPTION
## Description

This adds an RPCPool specialization on top of the generic pools.ResourcePool, and then adds several read pools (named this way so we don't need to rename (and rename the flags) when we add the r/w pools later). The main reason I'm not using sync2.Semaphore is because the timeout/context semantics don't work for our use case. With the semaphore, you can _either_ use the semaphore's timeout _or_ the context timeout, but what I want is to always use the minimum of the two. RPCPool does exactly that, plus we get all the stats/metrics of ResourcePool "for free".

From there, we add 4 rpc pools:
* topoReadPool - for making general requests that end up reading from the topo, things like GetKeyspace, GetVSchema, etc
* backupReadPool - for making requests that hit the backups endpoints, this is separate in case you need to control request rates to your backing store (s3, gcp, azure, etc)
* schemaReadPool
* workflowReadPool

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/7866

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->