### PR TITLE
CI: using GitHub Actions 'concurrency' to cancel in progress workflows

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (11)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (11)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (12)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (12)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (13)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (13)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (14)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (14)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (15)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (15)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (16)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (16)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (17)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (17)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (18)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (18)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (19)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (19)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (20)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (20)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (21)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (21)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (22)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (22)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (23)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (23)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (24)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (24)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (26)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (26)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_declarative)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_ghost)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_revert)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_singleton)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl_stress)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl_suite)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (resharding)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (resharding_bytes)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_tablegc)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_throttler)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_throttler_custom_config)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_migrate)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_buffer)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_buffer)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_concurrentdml)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_gen4)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_readafterwrite)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_reservedconn)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_schema)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_topo)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_transaction)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_unsharded)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_vindex)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_vschema)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtorc)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (xb_recovery)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
     runs-on: ubuntu-18.04

--- a/.github/workflows/unit_test_mariadb101.yml
+++ b/.github/workflows/unit_test_mariadb101.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mariadb101)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mariadb102)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mariadb103)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mysql57)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mysql80)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (percona56)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -1,7 +1,10 @@
 name: {{.Name}}
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{"{{"}} github.head_ref {{"}}"}}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     runs-on: ubuntu-18.04

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -1,7 +1,10 @@
 name: {{.Name}}
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{"{{"}} github.head_ref {{"}}"}}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 


### PR DESCRIPTION

## Description
Per (Beta feature) https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency, it is now possible for a new `push` to cancel any previous running and pending CIs for same ref, which saves queue, electricity, time.



## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
