### PR TITLE
Enhance k8stopo flag documentation

### DIFF
--- a/go/vt/topo/k8stopo/server.go
+++ b/go/vt/topo/k8stopo/server.go
@@ -49,7 +49,7 @@ import (
 
 var (
 	// kubeconfigPath is a string that gives the location of a valid kubeconfig file
-	kubeconfigPath = flag.String("topo_k8s_kubeconfig", "", "Path to a valid kubeconfig file.")
+	kubeconfigPath = flag.String("topo_k8s_kubeconfig", "", "Path to a valid kubeconfig file. When running as a k8s pod inside the same cluster you wish to use as the topo, you may omit this and the below arguments, and Vitess is capable of auto-discovering the correct values. https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod")
 
 	// configContext is a string that can be used to override the default context
 	configContext = flag.String("topo_k8s_context", "", "The kubeconfig context to use, overrides the 'current-context' from the config")


### PR DESCRIPTION
## Description
The existing documentation was sparse, and didn't explain that
Vitess is capable of auto-discovering its enclosing Kubernetes
API server if the topo_k8s_* flags are left unspecified.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required - This flag documentation update should be used to re-generate the flag documentation on the website, after this PR is merged.