### PR TITLE
Allow for configuration of the minimal TLS version

### DIFF
--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -18,6 +18,7 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"io/ioutil"
 	"net"
 	"os"
@@ -62,7 +63,8 @@ func TestValidCert(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
@@ -145,7 +147,8 @@ func TestNoCert(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -276,8 +276,13 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 			}
 		}
 
+		tlsVersion, err := vttls.TLSVersionToNumber(params.TLSMinVersion)
+		if err != nil {
+			return NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "error parsing minimal TLS version: %v", err)
+		}
+
 		// Build the TLS config.
-		clientConfig, err := vttls.ClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName, vttls.TLSVersionToNumber(params.TLSMinVersion))
+		clientConfig, err := vttls.ClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName, tlsVersion)
 		if err != nil {
 			return NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "error loading client cert and ca: %v", err)
 		}

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -277,7 +277,7 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 		}
 
 		// Build the TLS config.
-		clientConfig, err := vttls.ClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName)
+		clientConfig, err := vttls.ClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName, vttls.TLSVersionToNumber(params.TLSMinVersion))
 		if err != nil {
 			return NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "error loading client cert and ca: %v", err)
 		}

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -34,6 +34,7 @@ type ConnParams struct {
 	SslCaPath        string `json:"ssl_ca_path"`
 	SslCert          string `json:"ssl_cert"`
 	SslKey           string `json:"ssl_key"`
+	TLSMinVersion    string `json:"tls_min_version"`
 	ServerName       string `json:"server_name"`
 	ConnectTimeoutMs uint64 `json:"connect_timeout_ms"`
 

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"net"
 	"os"
@@ -125,7 +126,8 @@ func TestSSLConnection(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -232,7 +232,13 @@ func (lci *ClientImpl) Connect(network string, config *ServerConfig) error {
 	if err != nil {
 		return err
 	}
-	tlsConfig, err := vttls.ClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName, vttls.TLSVersionToNumber(config.LdapTLSMinVersion))
+
+	tlsVersion, err := vttls.TLSVersionToNumber(config.LdapTLSMinVersion)
+	if err != nil {
+		return err
+	}
+
+	tlsConfig, err := vttls.ClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName, tlsVersion)
 	if err != nil {
 		return err
 	}

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -199,10 +199,11 @@ func (lud *LdapUserData) Get() *querypb.VTGateCallerID {
 // ServerConfig holds the config for and LDAP server
 // * include port in ldapServer, "ldap.example.com:386"
 type ServerConfig struct {
-	LdapServer string
-	LdapCert   string
-	LdapKey    string
-	LdapCA     string
+	LdapServer        string
+	LdapCert          string
+	LdapKey           string
+	LdapCA            string
+	LdapTLSMinVersion string
 }
 
 // Client provides an interface we can mock
@@ -231,7 +232,7 @@ func (lci *ClientImpl) Connect(network string, config *ServerConfig) error {
 	if err != nil {
 		return err
 	}
-	tlsConfig, err := vttls.ClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName)
+	tlsConfig, err := vttls.ClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName, vttls.TLSVersionToNumber(config.LdapTLSMinVersion))
 	if err != nil {
 		return err
 	}

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -1,3 +1,4 @@
+// +build gofuzz
 /*
 Copyright 2021 The Vitess Authors.
 
@@ -13,12 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// +build gofuzz
 
 package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -356,7 +357,8 @@ func FuzzTLSServer(data []byte) int {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	if err != nil {
 		return -1
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -840,7 +840,8 @@ func TestTLSServer(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	require.NoError(t, err)
 	l.TLSConfig.Store(serverConfig)
 
@@ -939,7 +940,8 @@ func TestTLSRequired(t *testing.T) {
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"),
-		"")
+		"",
+		tls.VersionTLS12)
 	require.NoError(t, err)
 	l.TLSConfig.Store(serverConfig)
 	l.RequireSecureTransport = true

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -20,6 +20,7 @@ package grpcclient
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"time"
 
@@ -131,7 +132,7 @@ func SecureDialOption(cert, key, ca, name string) (grpc.DialOption, error) {
 	}
 
 	// Load the config.
-	config, err := vttls.ClientConfig(cert, key, ca, name)
+	config, err := vttls.ClientConfig(cert, key, ca, name, tls.VersionTLS12)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package servenv
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"math"
@@ -131,7 +132,7 @@ func createGRPCServer() {
 
 	var opts []grpc.ServerOption
 	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
-		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCServerCA)
+		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA, *GRPCServerCA, tls.VersionTLS12)
 		if err != nil {
 			log.Exitf("Failed to log gRPC cert/key/ca: %v", err)
 		}

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -66,7 +66,8 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ClientCA,
-		serverCA)
+		serverCA,
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
@@ -74,7 +75,8 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ClientCert,
 		clientServerKeyPairs.ClientKey,
 		clientServerKeyPairs.ServerCA,
-		clientServerKeyPairs.ServerName)
+		clientServerKeyPairs.ServerName,
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSClientConfig failed: %v", err)
 	}
@@ -134,7 +136,8 @@ func testClientServer(t *testing.T, combineCerts bool) {
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ServerCA,
-		clientServerKeyPairs.ServerName)
+		clientServerKeyPairs.ServerName,
+		tls.VersionTLS12)
 	if err != nil {
 		t.Fatalf("TLSClientConfig failed: %v", err)
 	}
@@ -184,7 +187,8 @@ func getServerConfigWithoutCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Co
 		keypairs.ServerCert,
 		keypairs.ServerKey,
 		keypairs.ClientCA,
-		"")
+		"",
+		tls.VersionTLS12)
 }
 
 func getServerConfigWithCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Config, error) {
@@ -192,7 +196,8 @@ func getServerConfigWithCombinedCerts(keypairs ClientServerKeyPairs) (*tls.Confi
 		keypairs.ServerCert,
 		keypairs.ServerKey,
 		keypairs.ClientCA,
-		keypairs.ServerCA)
+		keypairs.ServerCA,
+		tls.VersionTLS12)
 }
 
 func getClientConfig(keypairs ClientServerKeyPairs) (*tls.Config, error) {
@@ -200,7 +205,8 @@ func getClientConfig(keypairs ClientServerKeyPairs) (*tls.Config, error) {
 		keypairs.ClientCert,
 		keypairs.ClientKey,
 		keypairs.ServerCA,
-		keypairs.ServerName)
+		keypairs.ServerName,
+		tls.VersionTLS12)
 }
 
 func testServerTLSConfigCaching(t *testing.T, getServerConfig func(ClientServerKeyPairs) (*tls.Config, error)) {
@@ -288,7 +294,8 @@ func testNumberOfCertsWithOrWithoutCombining(t *testing.T, numCertsExpected int,
 		clientServerKeyPairs.ServerCert,
 		clientServerKeyPairs.ServerKey,
 		clientServerKeyPairs.ClientCA,
-		serverCA)
+		serverCA,
+		tls.VersionTLS12)
 
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -64,6 +64,8 @@ var (
 	mysqlSslKey  = flag.String("mysql_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
 	mysqlSslCa   = flag.String("mysql_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
 
+	mysqlTLSMinVersion = flag.String("mysql_server_tls_min_version", "", "Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.")
+
 	mysqlSslServerCA = flag.String("mysql_server_ssl_server_ca", "", "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
 
 	mysqlSlowConnectWarnThreshold = flag.Duration("mysql_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
@@ -362,8 +364,8 @@ var sigChan chan os.Signal
 var vtgateHandle *vtgateHandler
 
 // initTLSConfig inits tls config for the given mysql listener
-func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA string, mysqlServerRequireSecureTransport bool) error {
-	serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA)
+func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA string, mysqlServerRequireSecureTransport bool, mysqlMinTLSVersion uint16) error {
+	serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA, mysqlMinTLSVersion)
 	if err != nil {
 		log.Exitf("grpcutils.TLSServerConfig failed: %v", err)
 		return err
@@ -374,7 +376,7 @@ func initTLSConfig(mysqlListener *mysql.Listener, mysqlSslCert, mysqlSslKey, mys
 	signal.Notify(sigChan, syscall.SIGHUP)
 	go func() {
 		for range sigChan {
-			serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA)
+			serverConfig, err := vttls.ServerConfig(mysqlSslCert, mysqlSslKey, mysqlSslCa, mysqlSslServerCA, mysqlMinTLSVersion)
 			if err != nil {
 				log.Errorf("grpcutils.TLSServerConfig failed: %v", err)
 			} else {
@@ -430,7 +432,7 @@ func initMySQLProtocol() {
 			mysqlListener.ServerVersion = *servenv.MySQLServerVersion
 		}
 		if *mysqlSslCert != "" && *mysqlSslKey != "" {
-			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslServerCA, *mysqlServerRequireSecureTransport)
+			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslServerCA, *mysqlServerRequireSecureTransport, vttls.TLSVersionToNumber(*mysqlTLSMinVersion))
 		}
 		mysqlListener.AllowClearTextWithoutTLS.Set(*mysqlAllowClearTextWithoutTLS)
 		// Check for the connection threshold

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -432,7 +432,12 @@ func initMySQLProtocol() {
 			mysqlListener.ServerVersion = *servenv.MySQLServerVersion
 		}
 		if *mysqlSslCert != "" && *mysqlSslKey != "" {
-			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslServerCA, *mysqlServerRequireSecureTransport, vttls.TLSVersionToNumber(*mysqlTLSMinVersion))
+			tlsVersion, err := vttls.TLSVersionToNumber(*mysqlTLSMinVersion)
+			if err != nil {
+				log.Exitf("mysql.NewListener failed: %v", err)
+			}
+
+			initTLSConfig(mysqlListener, *mysqlSslCert, *mysqlSslKey, *mysqlSslCa, *mysqlSslServerCA, *mysqlServerRequireSecureTransport, tlsVersion)
 		}
 		mysqlListener.AllowClearTextWithoutTLS.Set(*mysqlAllowClearTextWithoutTLS)
 		// Check for the connection threshold

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -272,7 +273,7 @@ func testInitTLSConfig(t *testing.T, serverCA bool) {
 	}
 
 	listener := &mysql.Listener{}
-	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), serverCACert, true); err != nil {
+	if err := initTLSConfig(listener, path.Join(root, "server-cert.pem"), path.Join(root, "server-key.pem"), path.Join(root, "ca-cert.pem"), serverCACert, true, tls.VersionTLS12); err != nil {
 		t.Fatalf("init tls config failure due to: +%v", err)
 	}
 

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -30,28 +30,48 @@ import (
 // Updated list of acceptable cipher suits to address
 // Fixed upstream in https://github.com/golang/go/issues/13385
 // This removed CBC mode ciphers that are suseptiable to Lucky13 style attacks
-func newTLSConfig() *tls.Config {
-	return &tls.Config{
-		// MySQL Community edition has some problems with TLS1.2
-		// TODO: Validate this will not break servers using mysql community edition < 5.7.10
-		// MinVersion: tls.VersionTLS12,
+func newTLSConfig(minVersion uint16) *tls.Config {
 
-		// Default ordering taken from
-		// go 1.11 crypto/tls/cipher_suites.go
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	ciphers := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}
+
+	if minVersion < tls.VersionTLS12 {
+		ciphers = append(ciphers, []uint16{
 			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		},
+		}...)
+	}
+
+	return &tls.Config{
+		MinVersion:   minVersion,
+		CipherSuites: ciphers,
+	}
+}
+
+// TLSVersionToNumber converts a text description of the TLS protocol
+// to the internal Go number representation.
+func TLSVersionToNumber(tlsVersion string) uint16 {
+	switch tlsVersion {
+	case "TLSv1.3":
+		return tls.VersionTLS13
+	case "", "TLSv1.2":
+		return tls.VersionTLS12
+	case "TLSv1.1":
+		return tls.VersionTLS11
+	case "TLSv1.0":
+		return tls.VersionTLS10
+	default:
+		return tls.VersionTLS12
 	}
 }
 
@@ -59,8 +79,8 @@ var onceByKeys = sync.Map{}
 
 // ClientConfig returns the TLS config to use for a client to
 // connect to a server with the provided parameters.
-func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
-	config := newTLSConfig()
+func ClientConfig(cert, key, ca, name string, minTLSVersion uint16) (*tls.Config, error) {
+	config := newTLSConfig(minTLSVersion)
 
 	// Load the client-side cert & key if any.
 	if cert != "" && key != "" {
@@ -94,8 +114,8 @@ func ClientConfig(cert, key, ca, name string) (*tls.Config, error) {
 
 // ServerConfig returns the TLS config to use for a server to
 // accept client connections.
-func ServerConfig(cert, key, ca, serverCA string) (*tls.Config, error) {
-	config := newTLSConfig()
+func ServerConfig(cert, key, ca, serverCA string, minTLSVersion uint16) (*tls.Config, error) {
+	config := newTLSConfig(minTLSVersion)
 
 	var certificates *[]tls.Certificate
 	var err error

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -60,18 +60,18 @@ func newTLSConfig(minVersion uint16) *tls.Config {
 
 // TLSVersionToNumber converts a text description of the TLS protocol
 // to the internal Go number representation.
-func TLSVersionToNumber(tlsVersion string) uint16 {
-	switch tlsVersion {
-	case "TLSv1.3":
-		return tls.VersionTLS13
-	case "", "TLSv1.2":
-		return tls.VersionTLS12
-	case "TLSv1.1":
-		return tls.VersionTLS11
-	case "TLSv1.0":
-		return tls.VersionTLS10
+func TLSVersionToNumber(tlsVersion string) (uint16, error) {
+	switch strings.ToLower(tlsVersion) {
+	case "tlsv1.3":
+		return tls.VersionTLS13, nil
+	case "", "tlsv1.2":
+		return tls.VersionTLS12, nil
+	case "tlsv1.1":
+		return tls.VersionTLS11, nil
+	case "tlsv1.0":
+		return tls.VersionTLS10, nil
 	default:
-		return tls.VersionTLS12
+		return tls.VersionTLS12, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "Invalid TLS version specified: %s. Allowed options are TLSv1.0, TLSv1.1, TLSv1.2 & TLSv1.3", tlsVersion)
 	}
 }
 

--- a/misc/git/hooks/goimports
+++ b/misc/git/hooks/goimports
@@ -22,14 +22,14 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/')
 
 [ -z "$gofiles" ] && exit 0
-unformatted=$(goimports -local vitess.io/vitess -l=true $gofiles 2>&1 | awk -F: '{print $1}')
+unformatted=$($(go env GOPATH)/bin/goimports -local vitess.io/vitess -l=true $gofiles 2>&1 | awk -F: '{print $1}')
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not goimports'd. Print message and fail.
 
 echo >&2 "Go files must be formatted with goimports. Please run:"
 echo >&2
-echo -n >&2 "  goimports -local vitess.io/vitess -w"
+echo -n >&2 "  $(go env GOPATH)/bin/goimports -local vitess.io/vitess -w"
 for fn in $unformatted; do
     echo -n >&2 " $PWD/$fn"
 done


### PR DESCRIPTION
TLS 1.0 & TLS 1.1 are deprecated and shouldn't be used anymore. There are however many older MySQL versions out there where the latest 5.6, 5.7 or 8.0 patch release isn't used which means they don't have a build against OpenSSL with latest TLS support.

This means we can't easily change the minimum version to always be TLS 1.2, but the best possible option is to create flag instead.

The changes here add support for that flag. The default still is TLS 1.2 as the minimum version, but people who run against an older MySQL can use a new flag to override this and still allow TLS 1.0 or TLS 1.1 if desired.

## Related Issue(s)

Related to #4254 since this implements a minimal TLS version configuration option. The option is only added / used for the MySQL Vitess connects to and the LDAP server used.

Internally for Vitess and the GRPC layer, TLS 1.2 is set as flag. I don't think this changes anything in practice, since afaik those services already would have TLS 1.2 as the minimum themselves anyway. 

## Checklist

Not entire sure on tests here, if new enough MySQL versions are used everywhere nothing would break in testing. I'm going to let CI take a look at that. If older versions are in the text matrix, we can use the new option to let those still pass. 

As for documentation, the new option does need to be documented but that's in a separate repository. 

- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes

This changes the default minimum to TLS 1.2. I'd consider that a potentially breaking change for people so we'd need to make sure it's called out in the release notes that folks using an older MySQL version might need the option to lower the minimal TLS version. 