### PR TITLE
Remove lingering mysqld sock files on vttestserver container startup

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -24,6 +24,11 @@ if [[ -z $MYSQL_MAX_CONNECTIONS ]]; then
 fi
 echo "max_connections = $MYSQL_MAX_CONNECTIONS" >> /vt/config/mycnf/default-fast.cnf
 
+# Delete socket files before running mysqlctld if exists.
+# This is the primary reason for unhealthy state on restart.
+# https://github.com/vitessio/vitess/pull/5115/files
+rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
+
 # Run the vttestserver binary
 /vt/bin/vttestserver \
 	-port "$PORT" \


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

When restarting vttestserver after an ungraceful shutdown mysql doesn't start up due to the lingering sock files. Took the snippet from `vitess/examples/compose/vttablet-up.sh` and added it to `vttestserver`'s `run.sh`: https://github.com/vitessio/vitess/blob/345d30a061c2d30a88ab986728bbdda44230b9ac/examples/compose/vttablet-up.sh#L90-L94 

## Related Issue(s)

- https://github.com/vitessio/vitess/pull/5115 


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->