### PR TITLE
Add `rows` as keyword in sqlparser

### DIFF
--- a/go/vt/sqlparser/keywords.go
+++ b/go/vt/sqlparser/keywords.go
@@ -401,6 +401,7 @@ var keywords = []keyword{
 	{"right", RIGHT},
 	{"rlike", REGEXP},
 	{"rollback", ROLLBACK},
+	{"row", UNUSED},
 	{"row_format", ROW_FORMAT},
 	{"row_number", UNUSED},
 	{"rows", UNUSED},

--- a/go/vt/sqlparser/keywords.go
+++ b/go/vt/sqlparser/keywords.go
@@ -403,6 +403,7 @@ var keywords = []keyword{
 	{"rollback", ROLLBACK},
 	{"row_format", ROW_FORMAT},
 	{"row_number", UNUSED},
+	{"rows", UNUSED},
 	{"s3", S3},
 	{"savepoint", SAVEPOINT},
 	{"schema", SCHEMA},

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2003,8 +2003,8 @@ var (
 	}, {
 		input: "call proc(@param)",
 	}, {
-		input:  "create table unused_reserved_keywords (dense_rank bigint, lead VARCHAR(255), percent_rank decimal(3, 0), rows CHAR(10), constraint PK_project PRIMARY KEY (dense_rank))",
-		output: "create table unused_reserved_keywords (\n\t`dense_rank` bigint,\n\t`lead` VARCHAR(255),\n\t`percent_rank` decimal(3,0),\n\t`rows` CHAR(10),\n\tconstraint PK_project PRIMARY KEY (`dense_rank`)\n)",
+		input:  "create table unused_reserved_keywords (dense_rank bigint, lead VARCHAR(255), percent_rank decimal(3, 0), row TINYINT, rows CHAR(10), constraint PK_project PRIMARY KEY (dense_rank))",
+		output: "create table unused_reserved_keywords (\n\t`dense_rank` bigint,\n\t`lead` VARCHAR(255),\n\t`percent_rank` decimal(3,0),\n\t`row` TINYINT,\n\t`rows` CHAR(10),\n\tconstraint PK_project PRIMARY KEY (`dense_rank`)\n)",
 	}}
 )
 

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2003,8 +2003,8 @@ var (
 	}, {
 		input: "call proc(@param)",
 	}, {
-		input:  "create table unused_reserved_keywords (dense_rank bigint, lead VARCHAR(255), percent_rank decimal(3, 0), constraint PK_project PRIMARY KEY (dense_rank))",
-		output: "create table unused_reserved_keywords (\n\t`dense_rank` bigint,\n\t`lead` VARCHAR(255),\n\t`percent_rank` decimal(3,0),\n\tconstraint PK_project PRIMARY KEY (`dense_rank`)\n)",
+		input:  "create table unused_reserved_keywords (dense_rank bigint, lead VARCHAR(255), percent_rank decimal(3, 0), rows CHAR(10), constraint PK_project PRIMARY KEY (dense_rank))",
+		output: "create table unused_reserved_keywords (\n\t`dense_rank` bigint,\n\t`lead` VARCHAR(255),\n\t`percent_rank` decimal(3,0),\n\t`rows` CHAR(10),\n\tconstraint PK_project PRIMARY KEY (`dense_rank`)\n)",
 	}}
 )
 

--- a/go/vt/vtgate/planbuilder/testdata/show_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/show_cases.txt
@@ -64,7 +64,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetDestination": "AnyShard()",
-    "Query": "show table status where Rows \u003e 70",
+    "Query": "show table status where `Rows` \u003e 70",
     "SingleShardOnly": true
   }
 }


### PR DESCRIPTION
## Description

Rows is a reserved word as of [MariaDB 10.2.4](https://mariadb.com/kb/en/mariadb-1024-release-notes/) and [MySQL 8.0.2](https://dev.mysql.com/doc/mysqld-version-reference/en/keywords-8-0.html). If a table has a column named `rows` (an unfortunate legacy choice) then, for example, VReplication will fail to copy data from the table with:

```
Error: vttablet: rpc error: code = Unknown desc = You have an error in your SQL syntax; check the 
manual that corresponds to your MariaDB server version for the right syntax to use near 'rows, othercol1,
othercol2' at line 1 (errno 1064) (sqlstate 42000) during query: select id, rows, othercol1, othercol2 
from table_xyz order by id
```

## Notes

I am not very clear on the responsibility of these keywords, listed in `sqlparser/keywords.go` vs. the `[non_]reserved_keywords` in `sqlparser/sql.y`. If i made the change in the wrong place, or need to do it in both, please let me know. I was inspred by https://github.com/vitessio/vitess/pull/8086.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
