### PR TITLE
Automatically use the latest tag of Vitess for cluster upgrade E2E test

### DIFF
--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get latest Vitess tag
       run: |
-        echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
+        echo "latest_release=$(git show-ref --tags | grep -e 'refs/tags/v[0-9]' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
 
     - name: Tune the OS
       run: |

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Get latest Vitess tag
       run: |
-        echo "latest_release=git describe --tags $(git rev-list --tags --max-count=1)" >> $GITHUB_ENV
+        echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
     - name: Tune the OS
       run: |

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get latest Vitess tag
       run: |
-        echo "latest_release=$(git show-ref --tags | grep -e 'refs/tags/v[0-9]' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
+        echo "latest_release=v$(git show-ref --tags | grep -e 'refs/tags/v[0-9]' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
 
     - name: Tune the OS
       run: |

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -13,6 +13,10 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: Get latest Vitess tag
+      run: |
+        echo "latest_release=git describe --tags $(git rev-list --tags --max-count=1)" >> $GITHUB_ENV
+
     - name: Tune the OS
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
@@ -23,10 +27,10 @@ jobs:
         echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
 
-    - name: Check out v9.0.0
+    - name: Check out ${{ env.latest_release }}
       uses: actions/checkout@v2
       with:
-        ref: v9.0.0
+        ref: ${{ env.latest_release }}
 
     - name: Get dependencies
       run: |
@@ -46,23 +50,23 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    - name: Building v9.0.0 binaries
+    - name: Building ${{ env.latest_release }} binaries
       timeout-minutes: 10
       run: |
         # We build v9.0.0 binaries and save them in a temporary location
         source build.env
         make build
-        mkdir -p /tmp/vitess-build-v9.0.0/
-        cp -R bin /tmp/vitess-build-v9.0.0/
+        mkdir -p /tmp/vitess-build-${{ env.latest_release }}/
+        cp -R bin /tmp/vitess-build-${{ env.latest_release }}/
 
     - name: Check out HEAD
       uses: actions/checkout@v2
 
-    - name: Run cluster endtoend test v9.0.0 (create cluster)
+    - name: Run cluster endtoend test ${{ env.latest_release }} (create cluster)
       timeout-minutes: 5
       run: |
         # By checking out we deleted bin/ directory. We now restore our pre-built v9.0.0 binaries
-        cp -R /tmp/vitess-build-v9.0.0/bin .
+        cp -R /tmp/vitess-build-${{ env.latest_release }}/bin .
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
@@ -84,7 +88,7 @@ jobs:
         mkdir -p /tmp/vitess-build-head/
         cp -R bin /tmp/vitess-build-head/
 
-    - name: Run cluster endtoend test HEAD based on v9.0.0 data (upgrade path)
+    - name: Run cluster endtoend test HEAD based on ${{ env.latest_release }} data (upgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
@@ -105,11 +109,11 @@ jobs:
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
 
-    - name: Run cluster endtoend test v9.0.0 based on HEAD data (downgrade path)
+    - name: Run cluster endtoend test ${{ env.latest_release }} based on HEAD data (downgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
-        cp -R /tmp/vitess-build-v9.0.0/bin .
+        cp -R /tmp/vitess-build-${{ env.latest_release }}/bin .
 
         source build.env
         # We again built manually and there's no need for the test to build.

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -27,7 +27,7 @@ jobs:
             major_and_minor_releases=$(echo -e "$last_major_releases\n$last_minor_release")
           fi
 
-          echo "latest_releases=$(echo "$major_and_minor_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\""$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
+          echo "latest_releases=$(echo "$major_and_minor_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\"v"$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
 
       - name: Set Releases
         id: set-releases

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -26,12 +26,6 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out ${{ env.latest_release }}
       uses: actions/checkout@v2
       with:
@@ -40,7 +34,7 @@ jobs:
     - name: Get dependencies
       run: |
         # This prepares general purpose binary dependencies
-        # as well as v9.0.0 specific go modules
+        # as well as latest version specific go modules
         sudo apt-get update
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
@@ -58,7 +52,7 @@ jobs:
     - name: Building ${{ env.latest_release }} binaries
       timeout-minutes: 10
       run: |
-        # We build v9.0.0 binaries and save them in a temporary location
+        # We build latest version binaries and save them in a temporary location
         source build.env
         make build
         mkdir -p /tmp/vitess-build-${{ env.latest_release }}/
@@ -70,13 +64,13 @@ jobs:
     - name: Run cluster endtoend test ${{ env.latest_release }} (create cluster)
       timeout-minutes: 5
       run: |
-        # By checking out we deleted bin/ directory. We now restore our pre-built v9.0.0 binaries
+        # By checking out we deleted bin/ directory. We now restore our pre-built latest version binaries
         cp -R /tmp/vitess-build-${{ env.latest_release }}/bin .
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
         source build.env
-        # We pass -skip-build so that we use the v9.0.0 binaries, not HEAD binaries
+        # We pass -skip-build so that we use the latest version binaries, not HEAD binaries
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
     - name: Check out HEAD

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -13,6 +13,11 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: Check out to HEAD
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
     - name: Get latest Vitess tag
       run: |
         echo "latest_release=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -2,10 +2,47 @@ name: Cluster (upgrade)
 on: [push, pull_request]
 jobs:
 
+  get_release_matrix:
+    if: github.repository == 'vitessio/vitess'
+    name: Get matrix for endtoend tests on Cluster (upgrade)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-releases.outputs.matrix }}
+
+    steps:
+      - name: Check out to HEAD
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get latest Vitess tag
+        run: |
+          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n3)
+          last_major_release_nb=$(echo "$last_major_releases" | head -n1 | sed 's/.[0-9]*.[0-9]*$//')
+          last_minor_release=$(git show-ref --tags | grep -E "refs/tags/v$last_major_release_nb.[0-9]*.[1-9]*$" | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
+          major_and_minor_releases=$last_major_releases
+
+          if [ "$last_minor_release" != " " ];
+          then
+            major_and_minor_releases=$(echo -e "$last_major_releases\n$last_minor_release")
+          fi
+
+          echo "latest_releases=$(echo "$major_and_minor_releases" | awk ' BEGIN { ORS = ""; print "["; } { print "\/\@{\\\"project\\\":\\\""$0"\\\"}\/\@"; } END { print "]"; }' | sed "s^\/\@\/\@^, ^g;s^\/\@^^g")" >> $GITHUB_ENV
+
+      - name: Set Releases
+        id: set-releases
+        run: |
+          echo "::set-output name=matrix::{\"include\":${{ env.latest_releases }} }"
+
   build:
     if: github.repository == 'vitessio/vitess'
     name: Run endtoend tests on Cluster (upgrade)
     runs-on: ubuntu-latest
+    needs:
+      - get_release_matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJSON(needs.get_release_matrix.outputs.matrix)}}
 
     steps:
     - name: Set up Go
@@ -13,23 +50,14 @@ jobs:
       with:
         go-version: 1.16
 
-    - name: Check out to HEAD
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Get latest Vitess tag
-      run: |
-        echo "latest_release=v$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
-
     - name: Tune the OS
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    - name: Check out ${{ env.latest_release }}
+    - name: Check out ${{ matrix.project }}
       uses: actions/checkout@v2
       with:
-        ref: ${{ env.latest_release }}
+        ref: ${{ matrix.project }}
 
     - name: Get dependencies
       run: |
@@ -49,23 +77,23 @@ jobs:
         sudo apt-get update
         sudo apt-get install percona-xtrabackup-24
 
-    - name: Building ${{ env.latest_release }} binaries
+    - name: Building ${{ matrix.project }} binaries
       timeout-minutes: 10
       run: |
         # We build latest version binaries and save them in a temporary location
         source build.env
         make build
-        mkdir -p /tmp/vitess-build-${{ env.latest_release }}/
-        cp -R bin /tmp/vitess-build-${{ env.latest_release }}/
+        mkdir -p /tmp/vitess-build-${{ matrix.project }}/
+        cp -R bin /tmp/vitess-build-${{ matrix.project }}/
 
     - name: Check out HEAD
       uses: actions/checkout@v2
 
-    - name: Run cluster endtoend test ${{ env.latest_release }} (create cluster)
+    - name: Run cluster endtoend test ${{ matrix.project }} (create cluster)
       timeout-minutes: 5
       run: |
         # By checking out we deleted bin/ directory. We now restore our pre-built latest version binaries
-        cp -R /tmp/vitess-build-${{ env.latest_release }}/bin .
+        cp -R /tmp/vitess-build-${{ matrix.project }}/bin .
         # create the directory where we store test data; ensure it is empty:
         rm -rf /tmp/vtdataroot
         mkdir -p /tmp/vtdataroot
@@ -87,7 +115,7 @@ jobs:
         mkdir -p /tmp/vitess-build-head/
         cp -R bin /tmp/vitess-build-head/
 
-    - name: Run cluster endtoend test HEAD based on ${{ env.latest_release }} data (upgrade path)
+    - name: Run cluster endtoend test HEAD based on ${{ matrix.project }} data (upgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
@@ -108,11 +136,11 @@ jobs:
         eatmydata -- go run test.go -skip-build -keep-data -docker=false -print-log -follow -shard 28
 
 
-    - name: Run cluster endtoend test ${{ env.latest_release }} based on HEAD data (downgrade path)
+    - name: Run cluster endtoend test ${{ matrix.project }} based on HEAD data (downgrade path)
       timeout-minutes: 5
       run: |
         # /tmp/vtdataroot exists from previous test
-        cp -R /tmp/vitess-build-${{ env.latest_release }}/bin .
+        cp -R /tmp/vitess-build-${{ matrix.project }}/bin .
 
         source build.env
         # We again built manually and there's no need for the test to build.

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get latest Vitess tag
       run: |
-        echo "latest_release=v$(git show-ref --tags | grep -e 'refs/tags/v[0-9]' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
+        echo "latest_release=v$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.[0-9]*$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)" >> $GITHUB_ENV
 
     - name: Tune the OS
       run: |


### PR DESCRIPTION
## Description

This pull request changes the `cluster_endtoend_upgrade` workflow (`Cluster (upgrade)`) by dynamically choosing the Vitess tag on which to downgrade/upgrade the cluster.


## Related Issue(s)

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
