### PR TITLE
Handle lock release with SIGHUP in VTGR

### DIFF
--- a/go/vt/vtgr/controller/refresh.go
+++ b/go/vt/vtgr/controller/refresh.go
@@ -63,9 +63,6 @@ type GRTmcClient interface {
 	Ping(ctx context.Context, tablet *topodatapb.Tablet) error
 }
 
-// HostnameGetter is used to get local hostname
-type HostnameGetter func() (string, error)
-
 // GRShard stores the information about a Vitess shard that's running MySQL GR
 type GRShard struct {
 	KeyspaceShard        *topo.KeyspaceShard
@@ -76,6 +73,12 @@ type GRShard struct {
 	ts                   GRTopo
 	tmc                  GRTmcClient
 	dbAgent              db.Agent
+
+	// Every GRShard tracks a unlock function after it grab a topo lock for the shard
+	// VTGR needs to release the topo lock before gracefully shutdown
+	unlock func(*error)
+	// mutex to protect unlock function access
+	unlockMu sync.Mutex
 
 	// configuration
 	minNumReplicas            int
@@ -131,6 +134,7 @@ func NewGRShard(
 		tmc:                       tmc,
 		ts:                        ts,
 		dbAgent:                   dbAgent,
+		unlock:                    nil,
 		sqlGroup:                  NewSQLGroup(config.GroupSize, true, keyspace, shard),
 		minNumReplicas:            config.MinNumReplica,
 		disableReadOnlyProtection: config.DisableReadOnlyProtection,
@@ -200,14 +204,37 @@ func parseTabletInfos(tablets map[string]*topo.TabletInfo) []*grInstance {
 }
 
 // LockShard locks the keyspace-shard on topo server to prevent others from executing conflicting actions.
-func (shard *GRShard) LockShard(ctx context.Context, action string) (context.Context, func(*error), error) {
+func (shard *GRShard) LockShard(ctx context.Context, action string) (context.Context, error) {
 	if shard.KeyspaceShard.Keyspace == "" || shard.KeyspaceShard.Shard == "" {
-		return nil, nil, fmt.Errorf("try to grab lock with incomplete information: %v/%v", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
+		return nil, fmt.Errorf("try to grab lock with incomplete information: %v/%v", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
+	}
+	shard.unlockMu.Lock()
+	defer shard.unlockMu.Unlock()
+	if shard.unlock != nil {
+		return nil, fmt.Errorf("try to grab lock for %s/%s while the shard holds an unlock function", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
 	}
 	start := time.Now()
 	ctx, unlock, err := shard.ts.LockShard(ctx, shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard, fmt.Sprintf("VTGR repairing %s", action))
 	lockShardTimingsMs.Record([]string{action, strconv.FormatBool(err == nil)}, start)
-	return ctx, unlock, err
+	if err != nil {
+		return nil, err
+	}
+	shard.unlock = unlock
+	return ctx, nil
+}
+
+// UnlockShard unlocks the keyspace-shard on topo server
+// and set the unlock function to nil in the container
+func (shard *GRShard) UnlockShard() {
+	shard.unlockMu.Lock()
+	defer shard.unlockMu.Unlock()
+	if shard.unlock == nil {
+		log.Warningf("Shard %s/%s does not hold a lock", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
+		return
+	}
+	var err error
+	shard.unlock(&err)
+	shard.unlock = nil
 }
 
 func (shard *GRShard) findTabletByHostAndPort(host string, port int) *grInstance {
@@ -243,6 +270,13 @@ func (shard *GRShard) GetCurrentShardStatuses() ShardStatus {
 	status := *collector.status
 	shard.Unlock()
 	return status
+}
+
+// GetUnlock returns the unlock function for the shard for testing
+func (shard *GRShard) GetUnlock() func(*error) {
+	shard.unlockMu.Lock()
+	defer shard.unlockMu.Unlock()
+	return shard.unlock
 }
 
 func (collector *shardStatusCollector) isUnreachable(instance *grInstance) bool {

--- a/go/vt/vtgr/controller/repair.go
+++ b/go/vt/vtgr/controller/repair.go
@@ -91,12 +91,12 @@ func (shard *GRShard) Repair(ctx context.Context, status DiagnoseType) (RepairRe
 }
 
 func (shard *GRShard) repairShardHasNoGroup(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairShardHasNoGroup")
+	ctx, err := shard.LockShard(ctx, "repairShardHasNoGroup")
 	if err != nil {
 		log.Warningf("repairShardHasNoPrimaryTablet fails to grab lock for the shard %v: %v", shard.KeyspaceShard, err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	// Diagnose() will call shardAgreedGroup as the first thing
 	// which will update mysqlGroup stored in the shard
@@ -169,12 +169,12 @@ func (shard *GRShard) repairShardHasNoGroupAction(ctx context.Context) error {
 }
 
 func (shard *GRShard) repairShardHasInactiveGroup(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairShardHasInactiveGroup")
+	ctx, err := shard.LockShard(ctx, "repairShardHasInactiveGroup")
 	if err != nil {
 		log.Warningf("repairShardHasInactiveGroup fails to grab lock for the shard %v: %v", shard.KeyspaceShard, err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	// Diagnose() will call shardAgreedGroup as the first thing
 	// which will update mysqlGroup stored in the shard
@@ -200,12 +200,12 @@ func (shard *GRShard) repairShardHasInactiveGroup(ctx context.Context) (RepairRe
 }
 
 func (shard *GRShard) repairBackoffError(ctx context.Context, diagnose DiagnoseType) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairBackoffError")
+	ctx, err := shard.LockShard(ctx, "repairBackoffError")
 	if err != nil {
 		log.Warningf("repairBackoffError fails to grab lock for the shard %v: %v", shard.KeyspaceShard, err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	status, err := shard.diagnoseLocked(ctx)
 	if err != nil {
@@ -416,12 +416,12 @@ func (shard *GRShard) findFailoverCandidate(ctx context.Context) (*grInstance, e
 }
 
 func (shard *GRShard) repairWrongPrimaryTablet(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairWrongPrimaryTablet")
+	ctx, err := shard.LockShard(ctx, "repairWrongPrimaryTablet")
 	if err != nil {
 		log.Warningf("repairWrongPrimaryTablet fails to grab lock for the shard %v: %v", shard.KeyspaceShard, err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	// We grab shard level lock and check again if there is no primary
 	// to avoid race conditions
 	shard.refreshTabletsInShardLocked(ctx)
@@ -469,12 +469,12 @@ func (shard *GRShard) fixPrimaryTabletLocked(ctx context.Context) error {
 // repairUnconnectedReplica usually handle the case when there is a DiagnoseTypeHealthy tablet and
 // it is not connected to mysql primary node
 func (shard *GRShard) repairUnconnectedReplica(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairUnconnectedReplica")
+	ctx, err := shard.LockShard(ctx, "repairUnconnectedReplica")
 	if err != nil {
 		log.Warningf("repairUnconnectedReplica fails to grab lock for the shard %v: %v", formatKeyspaceShard(shard.KeyspaceShard), err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	status, err := shard.diagnoseLocked(ctx)
 	if err != nil {
@@ -526,12 +526,12 @@ func (shard *GRShard) repairUnconnectedReplicaAction(ctx context.Context) error 
 }
 
 func (shard *GRShard) repairUnreachablePrimary(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairUnreachablePrimary")
+	ctx, err := shard.LockShard(ctx, "repairUnreachablePrimary")
 	if err != nil {
 		log.Warningf("repairUnreachablePrimary fails to grab lock for the shard %v: %v", formatKeyspaceShard(shard.KeyspaceShard), err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	status, err := shard.diagnoseLocked(ctx)
 	if err != nil {
@@ -559,12 +559,12 @@ func (shard *GRShard) repairUnreachablePrimary(ctx context.Context) (RepairResul
 }
 
 func (shard *GRShard) repairInsufficientGroupSize(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairInsufficientGroupSize")
+	ctx, err := shard.LockShard(ctx, "repairInsufficientGroupSize")
 	if err != nil {
 		log.Warningf("repairInsufficientGroupSize fails to grab lock for the shard %v: %v", formatKeyspaceShard(shard.KeyspaceShard), err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	status, err := shard.diagnoseLocked(ctx)
 	if err != nil {
@@ -594,12 +594,12 @@ func (shard *GRShard) repairInsufficientGroupSize(ctx context.Context) (RepairRe
 }
 
 func (shard *GRShard) repairReadOnlyShard(ctx context.Context) (RepairResultCode, error) {
-	ctx, unlock, err := shard.LockShard(ctx, "repairReadOnlyShard")
+	ctx, err := shard.LockShard(ctx, "repairReadOnlyShard")
 	if err != nil {
 		log.Warningf("repairReadOnlyShard fails to grab lock for the shard %v: %v", formatKeyspaceShard(shard.KeyspaceShard), err)
 		return Noop, err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	status, err := shard.diagnoseLocked(ctx)
 	if err != nil {
@@ -625,12 +625,12 @@ func (shard *GRShard) repairReadOnlyShard(ctx context.Context) (RepairResultCode
 
 // Failover takes a shard and find an node with largest GTID as the mysql primary of the group
 func (shard *GRShard) Failover(ctx context.Context) error {
-	ctx, unlock, err := shard.LockShard(ctx, "Failover")
+	ctx, err := shard.LockShard(ctx, "Failover")
 	if err != nil {
 		log.Warningf("Failover fails to grab lock for the shard %v: %v", formatKeyspaceShard(shard.KeyspaceShard), err)
 		return err
 	}
-	defer unlock(&err)
+	defer shard.UnlockShard()
 	shard.refreshTabletsInShardLocked(ctx)
 	return shard.failoverLocked(ctx)
 }

--- a/go/vt/vtgr/vtgr_test.go
+++ b/go/vt/vtgr/vtgr_test.go
@@ -1,0 +1,53 @@
+package vtgr
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vtgr/config"
+	"vitess.io/vitess/go/vt/vtgr/controller"
+	"vitess.io/vitess/go/vt/vtgr/db"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSighupHandle(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	defer ts.Close()
+	ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{})
+	ts.CreateShard(ctx, "ks", "0")
+	vtgr := newVTGR(
+		ctx,
+		ts,
+		tmclient.NewTabletManagerClient(),
+	)
+	var shards []*controller.GRShard
+	config := &config.VTGRConfig{
+		DisableReadOnlyProtection:   false,
+		GroupSize:                   5,
+		MinNumReplica:               3,
+		BackoffErrorWaitTimeSeconds: 10,
+		BootstrapWaitTimeSeconds:    10 * 60,
+	}
+	shards = append(shards, controller.NewGRShard("ks", "0", nil, vtgr.tmc, vtgr.topo, db.NewVTGRSqlAgent(), config, *localDbPort))
+	vtgr.Shards = shards
+	shard := vtgr.Shards[0]
+	shard.LockShard(ctx, "test")
+	res := 0
+	vtgr.handleSignal(func(i int) {
+		res = i
+	})
+	assert.NotNil(t, shard.GetUnlock())
+	assert.False(t, vtgr.stopped.Get())
+	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, res)
+	assert.Nil(t, shard.GetUnlock())
+	assert.True(t, vtgr.stopped.Get())
+}


### PR DESCRIPTION
Signed-off-by: crowu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
VTGR relies on the lock from topo server. Most of the topo lock uses health-check of session to determine if a process is still holding the lock. This is not ideal for lock release process during a restart with SIGHUP. Take consul as an example, the session check by default uses serfHealth, which is a health check on the node level - even if the process restart because the node is healthy, consul will think the lock is still being held until the TTL. As a result, during a deploy, there could be TTL period of time that VTGR cannot grab the lock and fix the cluster.

This PR handle the SIGHUP signal by explicitly release the lock that was held to avoid the situation above.


## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/issues/8386

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->