### PR TITLE
CI: Move cluster and unit tests to docker to see if they run more reliably than in the native CI VM

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 11
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 11
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 11

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 12
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 12
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 12

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 13
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 13
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 13

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 14
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 14
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 14

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 15
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 15
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 15

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 16
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 16
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 16

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 17
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 17
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 17

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -51,4 +51,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 18
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 18
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 18

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 19
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 19
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 19

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 20
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 20
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 20

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 21
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 21
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 21

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 22
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 22
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 22

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 23
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 23
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 23

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -51,4 +51,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 24
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 24
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 24

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard 26
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard 26
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard 26

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_declarative
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_declarative
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_declarative

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_ghost
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_ghost
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_ghost

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_revert
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_revert
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_revert

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_singleton
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_singleton
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_singleton

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_vrepl

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_stress
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_stress
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_vrepl_stress

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_stress_suite
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_stress_suite
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_vrepl_stress_suite

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_suite
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard onlineddl_vrepl_suite
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard onlineddl_vrepl_suite

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard resharding
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard resharding
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard resharding

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard resharding_bytes
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard resharding_bytes
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard resharding_bytes

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_tablegc
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_tablegc
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard tabletmanager_tablegc

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_throttler
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_throttler
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard tabletmanager_throttler

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_throttler_custom_config
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard tabletmanager_throttler_custom_config
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard tabletmanager_throttler_custom_config

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_basic
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_basic
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vreplication_basic

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_cellalias
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_cellalias
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vreplication_cellalias

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_migrate
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_migrate
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vreplication_migrate

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_multicell
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_multicell
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vreplication_multicell

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_v2
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vreplication_v2
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vreplication_v2

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_buffer
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_buffer
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_buffer

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_concurrentdml
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_concurrentdml
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_concurrentdml

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_gen4
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_gen4
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_gen4

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_readafterwrite
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_readafterwrite
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_readafterwrite

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_reservedconn
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_reservedconn
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_reservedconn

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_schema
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_schema
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_schema

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_topo
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_topo
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_topo

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_transaction
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_transaction
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_transaction

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_unsharded
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_unsharded
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_unsharded

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_vindex
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_vindex
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_vindex

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_vschema
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtgate_vschema
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtgate_vschema

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard vtorc
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard vtorc
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard vtorc

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -47,4 +47,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard xb_recovery
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard xb_recovery
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard xb_recovery

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -69,6 +69,6 @@ jobs:
       timeout-minutes: 30
       run: |
         # Run native
-        # eatmydata -- make unit_test
+        eatmydata -- make unit_test
         # Run in a docker container
-        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb102 unit
+        # eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb102 unit

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -68,4 +68,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb102 unit

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -68,4 +68,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mariadb103 unit

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -53,4 +53,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mysql57 unit

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -68,4 +68,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=mysql80 unit

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -69,4 +69,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor=percona56 unit

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -57,4 +57,7 @@ jobs:
       timeout-minutes: 30
       run: |
         source build.env
-        eatmydata -- go run test.go -docker=false -print-log -follow -shard {{.Shard}}
+        # Run native
+        # eatmydata -- go run test.go -docker=false -print-log -follow -shard {{.Shard}}
+        # Run in a docker container
+        eatmydata -- go run test.go -print-log -follow -retry=1 -shard {{.Shard}}

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -124,4 +124,7 @@ jobs:
     - name: Run test
       timeout-minutes: 30
       run: |
-        eatmydata -- make unit_test
+        # Run native
+        # eatmydata -- make unit_test
+        # Run in a docker container
+        eatmydata -- go run test.go -retry=1 -print-log -follow -flavor={{.Platform}} unit


### PR DESCRIPTION


Signed-off-by: Rohit Nayak <rohit@planetscale.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->