### PR TITLE
Addition of known issues to release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,4 +462,4 @@ generate_ci_workflows:
 	cd test && go run ci_workflow_gen.go && cd ..
 
 release-notes:
-	go run ./go/tools/release-notes -from $(FROM) -to $(TO)
+	go run ./go/tools/release-notes -from $(FROM) -to $(TO) -release-branch $(RELEASE_BRANCH)

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -59,10 +59,15 @@ type (
 		Name       string
 		Components []sortedPRComponent
 	}
+
+	knownIssue struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
 )
 
 const (
-	markdownTemplate = `
+	markdownTemplatePR = `
 {{- range $type := . }}
 ## {{ $type.Name }}
 {{- range $component := $type.Components }} 
@@ -74,11 +79,32 @@ const (
 {{- end }}
 `
 
+	markdownTemplateKnownIssues = `
+## Known issues
+{{- range $issue := . }}
+ * {{ $issue.Title }} #{{ $issue.Number }} 
+{{- end }}
+`
+
 	prefixType        = "Type: "
 	prefixComponent   = "Component: "
 	numberOfThreads   = 10
 	lengthOfSingleSHA = 40
 )
+
+func loadKnownIssues(release string) ([]knownIssue, error) {
+	label := fmt.Sprintf("Known issue: %s", release)
+	out, err := execCmd("gh", "issue", "list", "--repo", "vitessio/vitess", "--label", label, "--json", "title,number")
+	if err != nil {
+		return nil, err
+	}
+	var knownIssues []knownIssue
+	err = json.Unmarshal(out, &knownIssues)
+	if err != nil {
+		return nil, err
+	}
+	return knownIssues, nil
+}
 
 func loadMergedPRs(from, to string) (prs []string, authors []string, commitCount int, err error) {
 	// load the git log with "author \t title \t parents"
@@ -351,8 +377,20 @@ func getOutput(fileout string) (*os.File, error) {
 func writePrInfos(writeTo *os.File, prPerType prsByType) (err error) {
 	data := createSortedPrTypeSlice(prPerType)
 
-	t := template.Must(template.New("markdownTemplate").Parse(markdownTemplate))
-	err = t.ExecuteTemplate(writeTo, "markdownTemplate", data)
+	t := template.Must(template.New("markdownTemplatePR").Parse(markdownTemplatePR))
+	err = t.ExecuteTemplate(writeTo, "markdownTemplatePR", data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeKnownIssues(writeTo *os.File, issues []knownIssue) (err error) {
+	if len(issues) == 0 {
+		return nil
+	}
+	t := template.Must(template.New("markdownTemplateKnownIssues").Parse(markdownTemplateKnownIssues))
+	err = t.ExecuteTemplate(writeTo, "markdownTemplateKnownIssues", issues)
 	if err != nil {
 		return err
 	}
@@ -362,6 +400,7 @@ func writePrInfos(writeTo *os.File, prPerType prsByType) (err error) {
 func main() {
 	from := flag.String("from", "", "from sha/tag/branch")
 	to := flag.String("to", "HEAD", "to sha/tag/branch")
+	releaseBranch := flag.String("release-branch", "", "name of the release branch")
 	fileout := flag.String("file", "", "file on which to write release notes, stdout if empty")
 
 	flag.Parse()
@@ -386,6 +425,16 @@ func main() {
 	}()
 
 	err = writePrInfos(out, prPerType)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// known issues
+	knownIssues, err := loadKnownIssues(*releaseBranch)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = writeKnownIssues(out, knownIssues)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Adding a `known issues` section to release notes. Issues can be added to this section by labeling them with `Known issue: <release-branch>`, where `<release-branch>` is the name of the release branch we write the notes for.

A new flag is added to the program to specify the branch name:

```sh
make FROM="v11.0.1" TO="v11.0.2" RELEASE_BRANCH="release-11" release-notes 
```

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
