### PR TITLE
Fix vreplication error metric

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -329,7 +329,7 @@ func (st *vrStats) register() {
 	stats.NewCountersFuncWithMultiLabels(
 		"VReplicationErrors",
 		"Errors during vreplication",
-		[]string{"workflow", "type"},
+		[]string{"workflow", "id", "type"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()


### PR DESCRIPTION
## Description
Metric was setup incorrectly with two dimensions instead of three causing Prometheus errors.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

