### PR TITLE
naming: deprecate old flags and create new ones (master->primary)

### DIFF
--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -66,7 +66,7 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Allows backups to be taken on master. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup.")
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use -allow_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -96,7 +96,7 @@ func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Whether to use master tablet for backup. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup.")
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use -allow_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -40,7 +40,7 @@ func init() {
 	addCommand("Shards", command{
 		"BackupShard",
 		commandBackupShard,
-		"[-allow_master=false] <keyspace/shard>",
+		"[-allow_primary=false] <keyspace/shard>",
 		"Chooses a tablet and creates a backup for a shard."})
 	addCommand("Shards", command{
 		"RemoveBackup",
@@ -51,7 +51,7 @@ func init() {
 	addCommand("Tablets", command{
 		"Backup",
 		commandBackup,
-		"[-concurrency=4] [-allow_master=false] <tablet alias>",
+		"[-concurrency=4] [-allow_primary=false] <tablet alias>",
 		"Stops mysqld and uses the BackupStorage service to store a new backup. This function also remembers if the tablet was replicating so that it can restore the same state after the backup completes."})
 	addCommand("Tablets", command{
 		"RestoreFromBackup",
@@ -62,7 +62,11 @@ func init() {
 
 func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 4, "Specifies the number of compression/checksum jobs to run simultaneously")
-	allowMaster := subFlags.Bool("allow_master", false, "Allows backups to be taken on master. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup ")
+	allowPrimary := subFlags.Bool("allow_primary", false, "Allows backups to be taken on primary. Warning!! If you are using the builtin backup engine, this will shutdown your primary mysql for as long as it takes to create a backup.")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Allows backups to be taken on master. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup.")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -79,13 +83,20 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	if err != nil {
 		return err
 	}
+	if *deprecatedAllowMaster {
+		*allowPrimary = *deprecatedAllowMaster
+	}
 
-	return execBackup(ctx, wr, tabletInfo.Tablet, *concurrency, *allowMaster)
+	return execBackup(ctx, wr, tabletInfo.Tablet, *concurrency, *allowPrimary)
 }
 
 func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 4, "Specifies the number of compression/checksum jobs to run simultaneously")
-	allowMaster := subFlags.Bool("allow_master", false, "Whether to use master tablet for backup. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup ")
+	allowPrimary := subFlags.Bool("allow_primary", false, "Whether to use primary tablet for backup. Warning!! If you are using the builtin backup engine, this will shutdown your primary mysql for as long as it takes to create a backup.")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Whether to use master tablet for backup. Warning!! If you are using the builtin backup engine, this will shutdown your master mysql for as long as it takes to create a backup.")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -128,15 +139,15 @@ func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		}
 	}
 
-	// if no other tablet is available and allowMaster is set to true
-	if tabletForBackup == nil && *allowMaster {
-	ChooseMaster:
+	// if no other tablet is available and allowPrimary is set to true
+	if tabletForBackup == nil && *allowPrimary {
+	ChooseTablet:
 		for i := range tablets {
 			switch tablets[i].Type {
 			case topodatapb.TabletType_MASTER:
 				tabletForBackup = tablets[i].Tablet
 				secondsBehind = 0 //nolint
-				break ChooseMaster
+				break ChooseTablet
 			default:
 				continue
 			}
@@ -147,12 +158,16 @@ func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return errors.New("no tablet available for backup")
 	}
 
-	return execBackup(ctx, wr, tabletForBackup, *concurrency, *allowMaster)
+	if *deprecatedAllowMaster {
+		*allowPrimary = *deprecatedAllowMaster
+	}
+
+	return execBackup(ctx, wr, tabletForBackup, *concurrency, *allowPrimary)
 }
 
 // execBackup is shared by Backup and BackupShard
-func execBackup(ctx context.Context, wr *wrangler.Wrangler, tablet *topodatapb.Tablet, concurrency int, allowMaster bool) error {
-	stream, err := wr.TabletManagerClient().Backup(ctx, tablet, concurrency, allowMaster)
+func execBackup(ctx context.Context, wr *wrangler.Wrangler, tablet *topodatapb.Tablet, concurrency int, allowPrimary bool) error {
+	stream, err := wr.TabletManagerClient().Backup(ctx, tablet, concurrency, allowPrimary)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -35,7 +35,7 @@ func init() {
 		"ReparentTablet",
 		commandReparentTablet,
 		"<tablet alias>",
-		"Reparent a tablet to the current master in the shard. This only works if the current replica position matches the last known reparent action."})
+		"Reparent a tablet to the current primary in the shard. This only works if the current replication position matches the last known reparent action."})
 	addCommand("Shards", command{
 		"InitShardPrimary",
 		commandInitShardPrimary,
@@ -49,18 +49,18 @@ func init() {
 	addCommand("Shards", command{
 		"PlannedReparentShard",
 		commandPlannedReparentShard,
-		"-keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-avoid_master=<tablet alias>] [-wait_replicas_timeout=<duration>]",
-		"Reparents the shard to the new master, or away from old master. Both old and new master need to be up and running."})
+		"-keyspace_shard=<keyspace/shard> [-new_primary=<tablet alias>] [-avoid_tablet=<tablet alias>] [-wait_replicas_timeout=<duration>]",
+		"Reparents the shard to the new primary, or away from old primary. Both old and new primary need to be up and running."})
 	addCommand("Shards", command{
 		"EmergencyReparentShard",
 		commandEmergencyReparentShard,
-		"-keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-wait_replicas_timeout=<duration>] [-ignore_replicas=<tablet alias list>]",
-		"Reparents the shard to the new master. Assumes the old master is dead and not responding."})
+		"-keyspace_shard=<keyspace/shard> [-new_primary=<tablet alias>] [-wait_replicas_timeout=<duration>] [-ignore_replicas=<tablet alias list>]",
+		"Reparents the shard to the new primary. Assumes the old primary is dead and not responding."})
 	addCommand("Shards", command{
 		"TabletExternallyReparented",
 		commandTabletExternallyReparented,
 		"<tablet alias>",
-		"Changes metadata in the topology server to acknowledge a shard master change performed by an external tool. See the Reparenting guide for more information:" +
+		"Changes metadata in the topology server to acknowledge a shard primary change performed by an external tool. See the Reparenting guide for more information:" +
 			"https://vitess.io/docs/user-guides/reparenting/#external-reparenting"})
 }
 
@@ -87,7 +87,7 @@ func commandInitShardPrimary(ctx context.Context, wr *wrangler.Wrangler, subFlag
 		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
-	force := subFlags.Bool("force", false, "will force the reparent even if the provided tablet is not a master or the shard master")
+	force := subFlags.Bool("force", false, "will force the reparent even if the provided tablet is not writable or the shard primary")
 	waitReplicasTimeout := subFlags.Duration("wait_replicas_timeout", *topo.RemoteOperationTimeout, "time to wait for replicas to catch up in reparenting")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -113,40 +113,52 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 
 	waitReplicasTimeout := subFlags.Duration("wait_replicas_timeout", *topo.RemoteOperationTimeout, "time to wait for replicas to catch up on replication before and after reparenting")
 	keyspaceShard := subFlags.String("keyspace_shard", "", "keyspace/shard of the shard that needs to be reparented")
-	newMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
-	avoidMaster := subFlags.String("avoid_master", "", "alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master")
+	newPrimary := subFlags.String("new_primary", "", "alias of a tablet that should be the new primary")
+	avoidTablet := subFlags.String("avoid_tablet", "", "alias of a tablet that should not be the primary, i.e. reparent to any other tablet if this one is the primary")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedNewMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
+	deprecatedAvoidMaster := subFlags.String("avoid_master", "", "alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() == 2 {
 		// Legacy syntax: "<keyspace/shard> <tablet alias>".
-		if *keyspaceShard != "" || *newMaster != "" {
-			return fmt.Errorf("cannot use legacy syntax and flags -keyspace_shard and -new_master for action PlannedReparentShard at the same time")
+		if *keyspaceShard != "" || *newPrimary != "" {
+			return fmt.Errorf("cannot use legacy syntax and flags -keyspace_shard and -new_master/-new_primary for action PlannedReparentShard at the same time")
 		}
 		*keyspaceShard = subFlags.Arg(0)
-		*newMaster = subFlags.Arg(1)
+		*newPrimary = subFlags.Arg(1)
 	} else if subFlags.NArg() != 0 {
-		return fmt.Errorf("action PlannedReparentShard requires -keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-avoid_master=<tablet alias>]")
+		return fmt.Errorf("action PlannedReparentShard requires -keyspace_shard=<keyspace/shard> [-new_primary=<tablet alias>] [-avoid_tablet=<tablet alias>]")
 	}
 
+	if *deprecatedNewMaster != "" {
+		newPrimary = deprecatedNewMaster
+	}
+	if *deprecatedAvoidMaster != "" {
+		avoidTablet = deprecatedAvoidMaster
+	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(*keyspaceShard)
 	if err != nil {
 		return err
 	}
-	var newMasterAlias, avoidMasterAlias *topodatapb.TabletAlias
-	if *newMaster != "" {
-		newMasterAlias, err = topoproto.ParseTabletAlias(*newMaster)
+	var newPrimaryAlias, avoidTabletAlias *topodatapb.TabletAlias
+	if *newPrimary != "" {
+		newPrimaryAlias, err = topoproto.ParseTabletAlias(*newPrimary)
 		if err != nil {
 			return err
 		}
 	}
-	if *avoidMaster != "" {
-		avoidMasterAlias, err = topoproto.ParseTabletAlias(*avoidMaster)
+	if *avoidTablet != "" {
+		avoidTabletAlias, err = topoproto.ParseTabletAlias(*avoidTablet)
 		if err != nil {
 			return err
 		}
 	}
-	return wr.PlannedReparentShard(ctx, keyspace, shard, newMasterAlias, avoidMasterAlias, *waitReplicasTimeout)
+	return wr.PlannedReparentShard(ctx, keyspace, shard, newPrimaryAlias, avoidTabletAlias, *waitReplicasTimeout)
 }
 
 func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -156,20 +168,29 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 
 	waitReplicasTimeout := subFlags.Duration("wait_replicas_timeout", *topo.RemoteOperationTimeout, "time to wait for replicas to catch up in reparenting")
 	keyspaceShard := subFlags.String("keyspace_shard", "", "keyspace/shard of the shard that needs to be reparented")
-	newMaster := subFlags.String("new_master", "", "optional alias of a tablet that should be the new master. If not specified, Vitess will select the best candidate")
+	newPrimary := subFlags.String("new_primary", "", "optional alias of a tablet that should be the new primary. If not specified, Vitess will select the best candidate")
 	ignoreReplicasList := subFlags.String("ignore_replicas", "", "comma-separated list of replica tablet aliases to ignore during emergency reparent")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedNewMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master. If not specified, Vitess will select the best candidate")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() == 2 {
 		// Legacy syntax: "<keyspace/shard> <tablet alias>".
-		if *newMaster != "" {
-			return fmt.Errorf("cannot use legacy syntax and flag -new_master for action EmergencyReparentShard at the same time")
+		if *newPrimary != "" {
+			return fmt.Errorf("cannot use legacy syntax and flag -new_master/-new_primary for action EmergencyReparentShard at the same time")
 		}
 		*keyspaceShard = subFlags.Arg(0)
-		*newMaster = subFlags.Arg(1)
+		*newPrimary = subFlags.Arg(1)
 	} else if subFlags.NArg() != 0 {
 		return fmt.Errorf("action EmergencyReparentShard requires -keyspace_shard=<keyspace/shard>")
+	}
+
+	if *deprecatedNewMaster != "" {
+		newPrimary = deprecatedNewMaster
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(*keyspaceShard)
@@ -177,8 +198,8 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 		return err
 	}
 	var tabletAlias *topodatapb.TabletAlias
-	if *newMaster != "" {
-		tabletAlias, err = topoproto.ParseTabletAlias(*newMaster)
+	if *newPrimary != "" {
+		tabletAlias, err = topoproto.ParseTabletAlias(*newPrimary)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -44,8 +44,8 @@ func init() {
 	addCommand("Shards", command{
 		"InitShardMaster",
 		commandInitShardPrimary,
-		"DEPRECATED [-force] [-wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>",
-		"Sets the initial master for a shard. Will make all other tablets in the shard replicas of the provided master. WARNING: this could cause data loss on an already replicating shard. PlannedReparentShard or EmergencyReparentShard should be used instead."})
+		"[-force] [-wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>",
+		"DEPRECATED. Use InitShardPrimary instead."})
 	addCommand("Shards", command{
 		"PlannedReparentShard",
 		commandPlannedReparentShard,
@@ -118,8 +118,8 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedNewMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master")
-	deprecatedAvoidMaster := subFlags.String("avoid_master", "", "alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master")
+	deprecatedNewMaster := subFlags.String("new_master", "", "DEPRECATED. Use -new_primary instead")
+	deprecatedAvoidMaster := subFlags.String("avoid_master", "", "DEPRECATED. Use -avoid_tablet instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -173,7 +173,7 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedNewMaster := subFlags.String("new_master", "", "alias of a tablet that should be the new master. If not specified, Vitess will select the best candidate")
+	deprecatedNewMaster := subFlags.String("new_master", "", "DEPRECATED. Use -new_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -149,7 +149,7 @@ func (pr *PlannedReparenter) preflightChecks(
 
 	if opts.NewPrimaryAlias == nil {
 		if !topoproto.TabletAliasEqual(opts.AvoidPrimaryAlias, ev.ShardInfo.MasterAlias) {
-			event.DispatchUpdate(ev, "current primary is different than AvoidPrimary, nothing to do")
+			event.DispatchUpdate(ev, "current primary is different than tablet to avoid, nothing to do")
 			return true, nil
 		}
 

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -240,7 +240,7 @@ var commands = []commandGroup{
 				"Add or remove a shard from serving. This is meant as an emergency function. It does not rebuild any serving graph i.e. does not run 'RebuildKeyspaceGraph'."},
 			{"SetShardIsMasterServing", commandSetShardIsPrimaryServing,
 				"<keyspace/shard> <is_master_serving>",
-				"DEPRECATED Add or remove a shard from serving. This is meant as an emergency function. It does not rebuild any serving graph i.e. does not run 'RebuildKeyspaceGraph'."},
+				"DEPRECATED. Use SetShardIsPrimaryServing instead."},
 			{"SetShardTabletControl", commandSetShardTabletControl,
 				"[--cells=c1,c2,...] [--blacklisted_tables=t1,t2,...] [--remove] [--disable_query_service] <keyspace/shard> <tablet type>",
 				"Sets the TabletControl record for a shard and type. Only use this for an emergency fix or after a finished vertical split. The *MigrateServedFrom* and *MigrateServedType* commands set this field appropriately already. Always specify the blacklisted_tables flag for vertical splits, but never for horizontal splits.\n" +
@@ -781,7 +781,7 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Allows for the master tablet of a shard to be deleted. Use with caution.")
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use allow_primary instead.")
 	allowPrimary := subFlags.Bool("allow_primary", false, "Allows for the primary tablet of a shard to be deleted. Use with caution.")
 
 	if err := subFlags.Parse(args); err != nil {
@@ -2767,7 +2767,7 @@ func commandReloadSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFla
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "Include the master tablet")
+	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "DEPRECATED. Use -include_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -2793,7 +2793,7 @@ func commandReloadSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, sub
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "Include the master tablet(s)")
+	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "DEPRECATED. Use -include_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -2838,7 +2838,7 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 
 	// handle deprecated flags
 	// should be deleted in a future release
-	deprecatedSkipNoMaster := subFlags.Bool("skip-no-master", false, "Skip shards that don't have master when performing validation")
+	deprecatedSkipNoMaster := subFlags.Bool("skip-no-master", false, "DEPRECATED. Use -skip-no-primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -69,15 +69,15 @@ COMMAND ARGUMENT DEFINITIONS
   -- experimental: A replica copy of data that is ready but not serving query
                    traffic. The value indicates a special characteristic of
                    the tablet that indicates the tablet should not be
-                   considered a potential master. Vitess also does not
+                   considered a potential primary. Vitess also does not
                    worry about lag for experimental tablets when reparenting.
   -- master: A primary copy of data
   -- rdonly: A replica copy of data for OLAP load patterns
-  -- replica: A replica copy of data ready to be promoted to master
+  -- replica: A replica copy of data ready to be promoted to primary
   -- restore: A tablet that is restoring from a snapshot. Typically, this
               happens at tablet startup, then it goes to its right state.
   -- spare: A replica copy of data that is ready but not serving query traffic.
-            The data could be a potential master tablet.
+            The data could be a potential primary tablet.
 */
 
 import (
@@ -167,7 +167,7 @@ var commands = []commandGroup{
 				"[-hostname <hostname>] [-ip-addr <ip addr>] [-mysql-port <mysql port>] [-vt-port <vt port>] [-grpc-port <grpc port>] <tablet alias> ",
 				"Updates the IP address and port numbers of a tablet."},
 			{"DeleteTablet", commandDeleteTablet,
-				"[-allow_master] <tablet alias> ...",
+				"[-allow_primary] <tablet alias> ...",
 				"Deletes tablet(s) from the topology."},
 			{"SetReadOnly", commandSetReadOnly,
 				"<tablet alias>",
@@ -231,12 +231,12 @@ var commands = []commandGroup{
 				"Validates that all nodes that are reachable from this shard are consistent."},
 			{"ShardReplicationPositions", commandShardReplicationPositions,
 				"<keyspace/shard>",
-				"Shows the replication status of each replica machine in the shard graph. In this case, the status refers to the replication lag between the master vttablet and the replica vttablet. In Vitess, data is always written to the master vttablet first and then replicated to all replica vttablets. Output is sorted by tablet type, then replication position. Use ctrl-C to interrupt command and see partial result if needed."},
+				"Shows the replication status of each replica in the shard graph. In this case, the status refers to the replication lag between the primary vttablet and the replica vttablet. In Vitess, data is always written to the primary vttablet first and then replicated to all replica vttablets. Output is sorted by tablet type, then replication position. Use ctrl-C to interrupt command and see partial result if needed."},
 			{"ListShardTablets", commandListShardTablets,
 				"<keyspace/shard>",
 				"Lists all tablets in the specified shard."},
 			{"SetShardIsPrimaryServing", commandSetShardIsPrimaryServing,
-				"<keyspace/shard> <true/false>",
+				"<keyspace/shard> <is_serving>",
 				"Add or remove a shard from serving. This is meant as an emergency function. It does not rebuild any serving graph i.e. does not run 'RebuildKeyspaceGraph'."},
 			{"SetShardIsMasterServing", commandSetShardIsPrimaryServing,
 				"<keyspace/shard> <is_master_serving>",
@@ -252,10 +252,10 @@ var commands = []commandGroup{
 				"Updates KeyspaceGraph partition for a shard and type. Only use this for an emergency fix during an horizontal shard split. The *MigrateServedType* commands set this field appropriately already. Specify the remove flag, if you want the shard to be removed from the desired partition."},
 			{"SourceShardDelete", commandSourceShardDelete,
 				"<keyspace/shard> <uid>",
-				"Deletes the SourceShard record with the provided index. This is meant as an emergency cleanup function. It does not call RefreshState for the shard master."},
+				"Deletes the SourceShard record with the provided index. This is meant as an emergency cleanup function. It does not call RefreshState for the shard primary."},
 			{"SourceShardAdd", commandSourceShardAdd,
 				"[--key_range=<keyrange>] [--tables=<table1,table2,...>] <keyspace/shard> <uid> <source keyspace/shard>",
-				"Adds the SourceShard record with the provided index. This is meant as an emergency function. It does not call RefreshState for the shard master."},
+				"Adds the SourceShard record with the provided index. This is meant as an emergency function. It does not call RefreshState for the shard primary."},
 			{"ShardReplicationAdd", commandShardReplicationAdd,
 				"<keyspace/shard> <tablet alias> <parent tablet alias>",
 				"HIDDEN Adds an entry to the replication graph in the given cell."},
@@ -394,23 +394,23 @@ var commands = []commandGroup{
 				"<tablet alias>",
 				"Reloads the schema on a remote tablet."},
 			{"ReloadSchemaShard", commandReloadSchemaShard,
-				"[-concurrency=10] [-include_master=false] <keyspace/shard>",
+				"[-concurrency=10] [-include_primary=false] <keyspace/shard>",
 				"Reloads the schema on all the tablets in a shard."},
 			{"ReloadSchemaKeyspace", commandReloadSchemaKeyspace,
-				"[-concurrency=10] [-include_master=false] <keyspace>",
+				"[-concurrency=10] [-include_primary=false] <keyspace>",
 				"Reloads the schema on all the tablets in a keyspace."},
 			{"ValidateSchemaShard", commandValidateSchemaShard,
 				"[-exclude_tables=''] [-include-views] [-include-vschema] <keyspace/shard>",
-				"Validates that the master schema matches all of the replicas."},
+				"Validates that the schema on primary tablet matches all of the replica tablets."},
 			{"ValidateSchemaKeyspace", commandValidateSchemaKeyspace,
-				"[-exclude_tables=''] [-include-views] [-skip-no-master] [-include-vschema] <keyspace name>",
-				"Validates that the master schema from shard 0 matches the schema on all of the other tablets in the keyspace."},
+				"[-exclude_tables=''] [-include-views] [-skip-no-primary] [-include-vschema] <keyspace name>",
+				"Validates that the schema on the primary tablet for shard 0 matches the schema on all of the other tablets in the keyspace."},
 			{"ApplySchema", commandApplySchema,
 				"[-allow_long_unavailability] [-wait_replicas_timeout=10s] [-ddl_strategy=<ddl_strategy>] [-request_context=<unique-request-context>] [-skip_preflight] {-sql=<sql> || -sql-file=<filename>} <keyspace>",
-				"Applies the schema change to the specified keyspace on every master, running in parallel on all shards. The changes are then propagated to replicas via replication. If -allow_long_unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected. -ddl_strategy is used to intruct migrations via vreplication, gh-ost or pt-osc with optional parameters. -request_context allows the user to specify a custom request context for online DDL migrations. If -skip_preflight, SQL goes directly to shards without going through sanity checks"},
+				"Applies the schema change to the specified keyspace on every primary, running in parallel on all shards. The changes are then propagated to replicas via replication. If -allow_long_unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected. -ddl_strategy is used to intruct migrations via vreplication, gh-ost or pt-osc with optional parameters. -request_context allows the user to specify a custom request context for online DDL migrations. If -skip_preflight, SQL goes directly to shards without going through sanity checks"},
 			{"CopySchemaShard", commandCopySchemaShard,
 				"[-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] [-skip-verify] [-wait_replicas_timeout=10s] {<source keyspace/shard> || <source tablet alias>} <destination keyspace/shard>",
-				"Copies the schema from a source shard's master (or a specific tablet) to a destination shard. The schema is applied directly on the master of the destination shard, and it is propagated to the replicas through binlogs."},
+				"Copies the schema from a source shard's primary (or a specific tablet) to a destination shard. The schema is applied directly on the primary of the destination shard, and it is propagated to the replicas through binlogs."},
 			{"OnlineDDL", commandOnlineDDL,
 				"<keyspace> <command> [<migration_uuid>]",
 				"Operates on online DDL (migrations). Examples:" +
@@ -425,20 +425,20 @@ var commands = []commandGroup{
 
 			{"ValidateVersionShard", commandValidateVersionShard,
 				"<keyspace/shard>",
-				"Validates that the master version matches all of the replicas."},
+				"Validates that the version on primary matches all of the replicas."},
 			{"ValidateVersionKeyspace", commandValidateVersionKeyspace,
 				"<keyspace name>",
-				"Validates that the master version from shard 0 matches all of the other tablets in the keyspace."},
+				"Validates that the version on primary of shard 0 matches all of the other tablets in the keyspace."},
 
 			{"GetPermissions", commandGetPermissions,
 				"<tablet alias>",
 				"Displays the permissions for a tablet."},
 			{"ValidatePermissionsShard", commandValidatePermissionsShard,
 				"<keyspace/shard>",
-				"Validates that the master permissions match all the replicas."},
+				"Validates that the permissions on primary match all the replicas."},
 			{"ValidatePermissionsKeyspace", commandValidatePermissionsKeyspace,
 				"<keyspace name>",
-				"Validates that the master permissions from shard 0 match those of all of the other tablets in the keyspace."},
+				"Validates that the permissions on primary of shard 0 match those of all of the other tablets in the keyspace."},
 
 			{"GetVSchema", commandGetVSchema,
 				"<keyspace>",
@@ -548,7 +548,7 @@ func fmtTabletAwkable(ti *topo.TabletInfo) string {
 		shard = "<null>"
 	}
 	mtst := "<null>"
-	// special case for old master that hasn't updated topo yet
+	// special case for old primary that hasn't updated topo yet
 	if ti.MasterTermStartTime != nil && ti.MasterTermStartTime.Seconds > 0 {
 		mtst = logutil.ProtoToTime(ti.MasterTermStartTime).Format(time.RFC3339)
 	}
@@ -781,7 +781,9 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	allowMaster := subFlags.Bool("allow_master", false, "Allows for the master tablet of a shard to be deleted. Use with caution.")
+	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "Allows for the master tablet of a shard to be deleted. Use with caution.")
+	allowPrimary := subFlags.Bool("allow_primary", false, "Allows for the primary tablet of a shard to be deleted. Use with caution.")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -793,8 +795,13 @@ func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 	if err != nil {
 		return err
 	}
+	// deprecated flags
+	// delete in a future release
+	if *deprecatedAllowMaster {
+		allowPrimary = deprecatedAllowMaster
+	}
 	for _, tabletAlias := range tabletAliases {
-		if err := wr.DeleteTablet(ctx, tabletAlias, *allowMaster); err != nil {
+		if err := wr.DeleteTablet(ctx, tabletAlias, *allowPrimary); err != nil {
 			return err
 		}
 	}
@@ -1308,7 +1315,7 @@ func commandSetShardIsPrimaryServing(ctx context.Context, wr *wrangler.Wrangler,
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("the <keyspace/shard> <is_master_serving> arguments are both required for the SetShardIsPrimaryServing command")
+		return fmt.Errorf("the <keyspace/shard> <is_serving> arguments are both required for the SetShardIsPrimaryServing command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -2529,8 +2536,8 @@ func commandSwitchReads(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandSwitchWrites(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	timeout := subFlags.Duration("timeout", 30*time.Second, "Specifies the maximum time to wait, in seconds, for vreplication to catch up on master migrations. The migration will be cancelled on a timeout.")
-	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "DEPRECATED Specifies the maximum time to wait, in seconds, for vreplication to catch up on master migrations. The migration will be cancelled on a timeout.")
+	timeout := subFlags.Duration("timeout", 30*time.Second, "Specifies the maximum time to wait, in seconds, for vreplication to catch up on write migrations. The migration will be cancelled on a timeout.")
+	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "DEPRECATED Specifies the maximum time to wait, in seconds, for vreplication to catch up on write migrations. The migration will be cancelled on a timeout.")
 	reverseReplication := subFlags.Bool("reverse_replication", true, "Also reverse the replication")
 	cancel := subFlags.Bool("cancel", false, "Cancel the failed migration and serve from source")
 	reverse := subFlags.Bool("reverse", false, "Reverse a previous SwitchWrites serve from source")
@@ -2756,7 +2763,12 @@ func commandReloadSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 
 func commandReloadSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 10, "How many tablets to reload in parallel")
-	includeMaster := subFlags.Bool("include_master", true, "Include the master tablet")
+	includePrimary := subFlags.Bool("include_primary", true, "Include the primary tablet")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "Include the master tablet")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2767,22 +2779,33 @@ func commandReloadSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFla
 	if err != nil {
 		return err
 	}
+	if *deprecatedIncludeMaster {
+		includePrimary = deprecatedIncludeMaster
+	}
 	sema := sync2.NewSemaphore(*concurrency, 0)
-	wr.ReloadSchemaShard(ctx, keyspace, shard, "" /* waitPosition */, sema, *includeMaster)
+	wr.ReloadSchemaShard(ctx, keyspace, shard, "" /* waitPosition */, sema, *includePrimary)
 	return nil
 }
 
 func commandReloadSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 10, "How many tablets to reload in parallel")
-	includeMaster := subFlags.Bool("include_master", true, "Include the master tablet(s)")
+	includePrimary := subFlags.Bool("include_primary", true, "Include the primary tablet(s)")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "Include the master tablet(s)")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 1 {
 		return fmt.Errorf("the <keyspace> argument is required for the ReloadSchemaKeyspace command")
 	}
+	if *deprecatedIncludeMaster {
+		includePrimary = deprecatedIncludeMaster
+	}
 	sema := sync2.NewSemaphore(*concurrency, 0)
-	return wr.ReloadSchemaKeyspace(ctx, subFlags.Arg(0), sema, *includeMaster)
+	return wr.ReloadSchemaKeyspace(ctx, subFlags.Arg(0), sema, *includePrimary)
 }
 
 func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -2810,8 +2833,13 @@ func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subF
 func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the validation")
-	skipNoMaster := subFlags.Bool("skip-no-master", false, "Skip shards that don't have master when performing validation")
+	skipNoPrimary := subFlags.Bool("skip-no-primary", true, "Skip shards that don't have primary when performing validation")
 	includeVSchema := subFlags.Bool("include-vschema", false, "Validate schemas against the vschema")
+
+	// handle deprecated flags
+	// should be deleted in a future release
+	deprecatedSkipNoMaster := subFlags.Bool("skip-no-master", false, "Skip shards that don't have master when performing validation")
+
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2819,12 +2847,15 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 		return fmt.Errorf("the <keyspace name> argument is required for the ValidateSchemaKeyspace command")
 	}
 
+	if *deprecatedSkipNoMaster {
+		skipNoPrimary = deprecatedSkipNoMaster
+	}
 	keyspace := subFlags.Arg(0)
 	var excludeTableArray []string
 	if *excludeTables != "" {
 		excludeTableArray = strings.Split(*excludeTables, ",")
 	}
-	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews, *skipNoMaster, *includeVSchema)
+	return wr.ValidateSchemaKeyspace(ctx, keyspace, excludeTableArray, *includeViews, *skipNoPrimary, *includeVSchema)
 }
 
 func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
@@ -3455,7 +3486,7 @@ func commandVExec(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fla
 	log.Warningf(deprecationMessage)
 
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
-	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of VExec and only reports the final query and list of masters on which it will be applied")
+	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of VExec and only reports the final query and list of tablets on which it will be applied")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -3490,7 +3521,7 @@ func commandVExec(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fla
 }
 
 func commandWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of Workflow and only reports the final query and list of masters on which the operation will be applied")
+	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of Workflow and only reports the final query and list of tablets on which the operation will be applied")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}

--- a/go/vt/vtctld/vtctld.go
+++ b/go/vt/vtctld/vtctld.go
@@ -60,7 +60,7 @@ func InitVtctld(ts *topo.Server) {
 
 	actionRepo.RegisterKeyspaceAction("ValidateSchemaKeyspace",
 		func(ctx context.Context, wr *wrangler.Wrangler, keyspace string) (string, error) {
-			return "", wr.ValidateSchemaKeyspace(ctx, keyspace, nil /*excludeTables*/, false /*includeViews*/, false /*skipNoMaster*/, false /*includeVSchema*/)
+			return "", wr.ValidateSchemaKeyspace(ctx, keyspace, nil /*excludeTables*/, false /*includeViews*/, false /*skipNoPrimary*/, false /*includeVSchema*/)
 		})
 
 	actionRepo.RegisterKeyspaceAction("ValidateVersionKeyspace",

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -193,7 +193,7 @@ func (wr *Wrangler) ValidateSchemaShard(ctx context.Context, keyspace, shard str
 
 // ValidateSchemaKeyspace will diff the schema from all the tablets in
 // the keyspace.
-func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews, skipNoMaster bool, includeVSchema bool) error {
+func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string, excludeTables []string, includeViews, skipNoPrimary bool, includeVSchema bool) error {
 	// find all the shards
 	shards, err := wr.ts.GetShardNames(ctx, keyspace)
 	if err != nil {
@@ -234,7 +234,7 @@ func (wr *Wrangler) ValidateSchemaKeyspace(ctx context.Context, keyspace string,
 		}
 
 		if !si.HasMaster() {
-			if !skipNoMaster {
+			if !skipNoPrimary {
 				er.RecordError(fmt.Errorf("no master in shard %v/%v", keyspace, shard))
 			}
 			continue

--- a/go/vt/wrangler/schema_test.go
+++ b/go/vt/wrangler/schema_test.go
@@ -125,10 +125,10 @@ func TestValidateSchemaKeyspace(t *testing.T) {
 	}
 
 	// Schema Checks
-	err := tmePass.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoMaster*/, true /*includeVSchema*/)
+	err := tmePass.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoPrimary*/, true /*includeVSchema*/)
 	require.NoError(t, err)
-	err = tmePass.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoMaster*/, false /*includeVSchema*/)
+	err = tmePass.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoPrimary*/, false /*includeVSchema*/)
 	require.NoError(t, err)
-	shouldErr := tmeDiffs.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoMaster*/, true /*includeVSchema*/)
+	shouldErr := tmeDiffs.wr.ValidateSchemaKeyspace(ctx, "ks", nil /*excludeTables*/, true /*includeViews*/, true /*skipNoPrimary*/, true /*includeVSchema*/)
 	require.Error(t, shouldErr)
 }

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -106,7 +106,7 @@ func (wr *Wrangler) InitTablet(ctx context.Context, tablet *topodatapb.Tablet, a
 // DeleteTablet removes a tablet from a shard.
 // - if allowMaster is set, we can Delete a master tablet (and clear
 // its record from the Shard record if it was the master).
-func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.TabletAlias, allowMaster bool) (err error) {
+func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.TabletAlias, allowPrimary bool) (err error) {
 	// load the tablet, see if we'll need to rebuild
 	ti, err := wr.ts.GetTablet(ctx, tabletAlias)
 	if err != nil {
@@ -118,7 +118,7 @@ func (wr *Wrangler) DeleteTablet(ctx context.Context, tabletAlias *topodatapb.Ta
 		return err
 	}
 
-	if wasMaster && !allowMaster {
+	if wasMaster && !allowPrimary {
 		return fmt.Errorf("cannot delete tablet %v as it is a master, use allow_master flag", topoproto.TabletAliasString(tabletAlias))
 	}
 

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -98,11 +98,11 @@ func TestBackupRestore(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
-	// create a master tablet, set its master position
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// create a primary tablet, set its primary position
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -112,12 +112,12 @@ func TestBackupRestore(t *testing.T) {
 		},
 	}
 
-	// start master so that replica can fetch master position from it
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	// start primary so that replica can fetch primary position from it
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// create a single tablet, set it up so we can do backups
-	// set its position same as that of master so that backup doesn't wait for catchup
+	// set its position same as that of primary so that backup doesn't wait for catchup
 	sourceTablet := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
@@ -175,7 +175,7 @@ func TestBackupRestore(t *testing.T) {
 		"SHOW DATABASES": {},
 	}
 	destTablet.FakeMysqlDaemon.SetReplicationPositionPos = sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition
-	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 
 	destTablet.StartActionLoop(t, wr)
 	defer destTablet.StopActionLoop(t)
@@ -197,23 +197,23 @@ func TestBackupRestore(t *testing.T) {
 	assert.True(t, destTablet.FakeMysqlDaemon.Running)
 
 	// Initialize mycnf, required for restore
-	masterInnodbDataDir := path.Join(root, "master_innodb_data")
-	masterInnodbLogDir := path.Join(root, "master_innodb_log")
-	masterDataDir := path.Join(root, "master_data")
-	master.TM.Cnf = &mysqlctl.Mycnf{
-		DataDir:               masterDataDir,
-		InnodbDataHomeDir:     masterInnodbDataDir,
-		InnodbLogGroupHomeDir: masterInnodbLogDir,
+	primaryInnodbDataDir := path.Join(root, "primary_innodb_data")
+	primaryInnodbLogDir := path.Join(root, "primary_innodb_log")
+	primaryDataDir := path.Join(root, "primary_data")
+	primary.TM.Cnf = &mysqlctl.Mycnf{
+		DataDir:               primaryDataDir,
+		InnodbDataHomeDir:     primaryInnodbDataDir,
+		InnodbLogGroupHomeDir: primaryInnodbLogDir,
 		BinLogPath:            path.Join(root, "bin-logs/filename_prefix"),
 		RelayLogPath:          path.Join(root, "relay-logs/filename_prefix"),
 		RelayLogIndexPath:     path.Join(root, "relay-log.index"),
 		RelayLogInfoPath:      path.Join(root, "relay-log.info"),
 	}
 
-	master.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
+	primary.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SHOW DATABASES": {},
 	}
-	master.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	primary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"RESET SLAVE ALL",
 		"FAKE SET SLAVE POSITION",
@@ -221,28 +221,28 @@ func TestBackupRestore(t *testing.T) {
 		"START SLAVE",
 	}
 
-	master.FakeMysqlDaemon.SetReplicationPositionPos = master.FakeMysqlDaemon.CurrentPrimaryPosition
+	primary.FakeMysqlDaemon.SetReplicationPositionPos = primary.FakeMysqlDaemon.CurrentPrimaryPosition
 
-	// restore master from backup
-	require.NoError(t, master.TM.RestoreData(ctx, logutil.NewConsoleLogger(), 0 /* waitForBackupInterval */, false /* deleteBeforeRestore */), "RestoreData failed")
+	// restore primary from backup
+	require.NoError(t, primary.TM.RestoreData(ctx, logutil.NewConsoleLogger(), 0 /* waitForBackupInterval */, false /* deleteBeforeRestore */), "RestoreData failed")
 	// tablet was created as MASTER, so it's baseTabletType is MASTER
-	assert.Equal(t, topodatapb.TabletType_MASTER, master.Tablet.Type)
-	assert.False(t, master.FakeMysqlDaemon.Replicating)
-	assert.True(t, master.FakeMysqlDaemon.Running)
+	assert.Equal(t, topodatapb.TabletType_MASTER, primary.Tablet.Type)
+	assert.False(t, primary.FakeMysqlDaemon.Replicating)
+	assert.True(t, primary.FakeMysqlDaemon.Running)
 
-	// restore master when database already exists
+	// restore primary when database already exists
 	// checkNoDb should return false
 	// so fake the necessary queries
-	master.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
+	primary.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SHOW DATABASES":                      {Rows: [][]sqltypes.Value{{sqltypes.NewVarBinary("vt_test_keyspace")}}},
 		"SHOW TABLES FROM `vt_test_keyspace`": {Rows: [][]sqltypes.Value{{sqltypes.NewVarBinary("a")}}},
 	}
 
-	require.NoError(t, master.TM.RestoreData(ctx, logutil.NewConsoleLogger(), 0 /* waitForBackupInterval */, false /* deleteBeforeRestore */), "RestoreData failed")
+	require.NoError(t, primary.TM.RestoreData(ctx, logutil.NewConsoleLogger(), 0 /* waitForBackupInterval */, false /* deleteBeforeRestore */), "RestoreData failed")
 	// Tablet type should not change
-	assert.Equal(t, topodatapb.TabletType_MASTER, master.Tablet.Type)
-	assert.False(t, master.FakeMysqlDaemon.Replicating)
-	assert.True(t, master.FakeMysqlDaemon.Running)
+	assert.Equal(t, topodatapb.TabletType_MASTER, primary.Tablet.Type)
+	assert.False(t, primary.FakeMysqlDaemon.Replicating)
+	assert.True(t, primary.FakeMysqlDaemon.Running)
 }
 
 // TestBackupRestoreLagged tests the changes made in https://github.com/vitessio/vitess/pull/5000
@@ -299,11 +299,11 @@ func TestBackupRestoreLagged(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
-	// create a master tablet, set its master position
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// create a primary tablet, set its position
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -313,12 +313,12 @@ func TestBackupRestoreLagged(t *testing.T) {
 		},
 	}
 
-	// start master so that replica can fetch master position from it
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	// start primary so that replica can fetch primary position from it
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// create a single tablet, set it up so we can do backups
-	// set its position same as that of master so that backup doesn't wait for catchup
+	// set its position same as that of primary so that backup doesn't wait for catchup
 	sourceTablet := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
@@ -370,7 +370,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 		require.NoError(t, sourceTablet.FakeMysqlDaemon.CheckSuperQueryList())
 		assert.True(t, sourceTablet.FakeMysqlDaemon.Replicating)
 		assert.True(t, sourceTablet.FakeMysqlDaemon.Running)
-		assert.Equal(t, master.FakeMysqlDaemon.CurrentPrimaryPosition, sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition)
+		assert.Equal(t, primary.FakeMysqlDaemon.CurrentPrimaryPosition, sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition)
 	case <-timer2.C:
 		require.FailNow(t, "Backup timed out")
 	}
@@ -399,7 +399,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 		"SHOW DATABASES": {},
 	}
 	destTablet.FakeMysqlDaemon.SetReplicationPositionPos = destTablet.FakeMysqlDaemon.CurrentPrimaryPosition
-	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 
 	destTablet.StartActionLoop(t, wr)
 	defer destTablet.StopActionLoop(t)
@@ -439,7 +439,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 		require.NoError(t, destTablet.FakeMysqlDaemon.CheckSuperQueryList(), "destTablet.FakeMysqlDaemon.CheckSuperQueryList failed")
 		assert.True(t, destTablet.FakeMysqlDaemon.Replicating)
 		assert.True(t, destTablet.FakeMysqlDaemon.Running)
-		assert.Equal(t, master.FakeMysqlDaemon.CurrentPrimaryPosition, destTablet.FakeMysqlDaemon.CurrentPrimaryPosition)
+		assert.Equal(t, primary.FakeMysqlDaemon.CurrentPrimaryPosition, destTablet.FakeMysqlDaemon.CurrentPrimaryPosition)
 	case <-timer2.C:
 		require.FailNow(t, "Restore timed out")
 	}
@@ -496,11 +496,11 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
-	// create a master tablet, set its master position
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// create a primary tablet, set its primary position
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -510,11 +510,11 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 		},
 	}
 
-	// start master so that replica can fetch master position from it
-	master.StartActionLoop(t, wr)
+	// start primary so that replica can fetch primary position from it
+	primary.StartActionLoop(t, wr)
 
 	// create a single tablet, set it up so we can do backups
-	// set its position same as that of master so that backup doesn't wait for catchup
+	// set its position same as that of primary so that backup doesn't wait for catchup
 	sourceTablet := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
@@ -567,7 +567,7 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 		"SHOW DATABASES": {},
 	}
 	destTablet.FakeMysqlDaemon.SetReplicationPositionPos = sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition
-	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 
 	destTablet.StartActionLoop(t, wr)
 	defer destTablet.StopActionLoop(t)
@@ -582,8 +582,8 @@ func TestRestoreUnreachableMaster(t *testing.T) {
 		RelayLogInfoPath:      path.Join(root, "relay-log.info"),
 	}
 
-	// stop master so that it is unreachable
-	master.StopActionLoop(t)
+	// stop primary so that it is unreachable
+	primary.StopActionLoop(t)
 
 	// set a short timeout so that we don't have to wait 30 seconds
 	*topo.RemoteOperationTimeout = 2 * time.Second
@@ -649,11 +649,11 @@ func TestDisableActiveReparents(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
 	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
-	// create a master tablet, set its master position
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// create a primary tablet, set its primary position
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -663,12 +663,12 @@ func TestDisableActiveReparents(t *testing.T) {
 		},
 	}
 
-	// start master so that replica can fetch master position from it
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	// start primary so that replica can fetch primary position from it
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// create a single tablet, set it up so we can do backups
-	// set its position same as that of master so that backup doesn't wait for catchup
+	// set its position same as that of primary so that backup doesn't wait for catchup
 	sourceTablet := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
 	sourceTablet.FakeMysqlDaemon.ReadOnly = true
 	sourceTablet.FakeMysqlDaemon.Replicating = true
@@ -724,7 +724,7 @@ func TestDisableActiveReparents(t *testing.T) {
 		"SHOW DATABASES": {},
 	}
 	destTablet.FakeMysqlDaemon.SetReplicationPositionPos = sourceTablet.FakeMysqlDaemon.CurrentPrimaryPosition
-	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	destTablet.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 
 	destTablet.StartActionLoop(t, wr)
 	defer destTablet.StopActionLoop(t)

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -65,22 +65,22 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 		t.Fatalf("CreateKeyspace failed: %v", err)
 	}
 
-	sourceMasterDb := fakesqldb.New(t).SetName("sourceMasterDb")
-	defer sourceMasterDb.Close()
-	sourceMaster := NewFakeTablet(t, wr, "cell1", 0,
-		topodatapb.TabletType_MASTER, sourceMasterDb, TabletKeyspaceShard(t, "ks", "-80"))
+	sourcePrimaryDb := fakesqldb.New(t).SetName("sourcePrimaryDb")
+	defer sourcePrimaryDb.Close()
+	sourcePrimary := NewFakeTablet(t, wr, "cell1", 0,
+		topodatapb.TabletType_MASTER, sourcePrimaryDb, TabletKeyspaceShard(t, "ks", "-80"))
 
 	sourceRdonlyDb := fakesqldb.New(t).SetName("sourceRdonlyDb")
 	defer sourceRdonlyDb.Close()
 	sourceRdonly := NewFakeTablet(t, wr, "cell1", 1,
 		topodatapb.TabletType_RDONLY, sourceRdonlyDb, TabletKeyspaceShard(t, "ks", "-80"))
 
-	destinationMasterDb := fakesqldb.New(t).SetName("destinationMasterDb")
-	defer destinationMasterDb.Close()
-	destinationMaster := NewFakeTablet(t, wr, "cell1", 10,
-		topodatapb.TabletType_MASTER, destinationMasterDb, TabletKeyspaceShard(t, "ks", "-40"))
+	destinationPrimaryDb := fakesqldb.New(t).SetName("destinationPrimaryDb")
+	defer destinationPrimaryDb.Close()
+	destinationPrimary := NewFakeTablet(t, wr, "cell1", 10,
+		topodatapb.TabletType_MASTER, destinationPrimaryDb, TabletKeyspaceShard(t, "ks", "-40"))
 
-	for _, ft := range []*FakeTablet{sourceMaster, sourceRdonly, destinationMaster} {
+	for _, ft := range []*FakeTablet{sourcePrimary, sourceRdonly, destinationPrimary} {
 		ft.StartActionLoop(t, wr)
 		defer ft.StopActionLoop(t)
 	}
@@ -104,7 +104,7 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 		DatabaseSchema:   "CREATE DATABASE `{{.DatabaseName}}` /*!40100 DEFAULT CHARACTER SET utf8 */",
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{},
 	}
-	sourceMaster.FakeMysqlDaemon.Schema = schema
+	sourcePrimary.FakeMysqlDaemon.Schema = schema
 	sourceRdonly.FakeMysqlDaemon.Schema = schema
 
 	changeToDb := "USE `vt_ks`"
@@ -127,10 +127,10 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	selectShardMetadata := "SELECT db_name, name, value FROM _vt.shard_metadata"
 
 	// The source table is asked about its schema.
-	// It may be the master or the rdonly.
+	// It may be the primary or the rdonly.
 	sourceDb := sourceRdonlyDb
 	if useShardAsSource {
-		sourceDb = sourceMasterDb
+		sourceDb = sourcePrimaryDb
 	}
 	sourceDb.AddQuery(changeToDb, &sqltypes.Result{})
 	sourceDb.AddQuery(selectInformationSchema, &sqltypes.Result{
@@ -148,13 +148,13 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	sourceDb.AddQuery(selectShardMetadata, &sqltypes.Result{})
 
 	// The destination table is asked to create the new schema.
-	destinationMasterDb.AddQuery(changeToDb, &sqltypes.Result{})
-	destinationMasterDb.AddQuery(createDb, &sqltypes.Result{})
-	destinationMasterDb.AddQuery(createTable, &sqltypes.Result{})
-	destinationMasterDb.AddQuery(createTableView, &sqltypes.Result{})
+	destinationPrimaryDb.AddQuery(changeToDb, &sqltypes.Result{})
+	destinationPrimaryDb.AddQuery(createDb, &sqltypes.Result{})
+	destinationPrimaryDb.AddQuery(createTable, &sqltypes.Result{})
+	destinationPrimaryDb.AddQuery(createTableView, &sqltypes.Result{})
 
-	destinationMaster.FakeMysqlDaemon.SchemaFunc = func() (*tabletmanagerdatapb.SchemaDefinition, error) {
-		if destinationMasterDb.GetQueryCalledNum(createTableView) == 1 {
+	destinationPrimary.FakeMysqlDaemon.SchemaFunc = func() (*tabletmanagerdatapb.SchemaDefinition, error) {
+		if destinationPrimaryDb.GetQueryCalledNum(createTableView) == 1 {
 			return schema, nil
 		}
 		return schemaEmptyDb, nil
@@ -179,14 +179,14 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 		t.Errorf("CopySchemaShard did not select data from _vt.shard_metadata exactly once. Query count: %v", count)
 	}
 
-	// Check call count on destinationMasterDb
-	if count := destinationMasterDb.GetQueryCalledNum(createDb); count != 1 {
+	// Check call count on destinationPrimaryDb
+	if count := destinationPrimaryDb.GetQueryCalledNum(createDb); count != 1 {
 		t.Errorf("CopySchemaShard did not create the db exactly once. Query count: %v", count)
 	}
-	if count := destinationMasterDb.GetQueryCalledNum(createTable); count != 1 {
+	if count := destinationPrimaryDb.GetQueryCalledNum(createTable); count != 1 {
 		t.Errorf("CopySchemaShard did not create the table exactly once. Query count: %v", count)
 	}
-	if count := destinationMasterDb.GetQueryCalledNum(createTableView); count != 1 {
+	if count := destinationPrimaryDb.GetQueryCalledNum(createTableView); count != 1 {
 		t.Errorf("CopySchemaShard did not create the table view exactly once. Query count: %v", count)
 	}
 }

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -49,14 +49,14 @@ func TestEmergencyReparentShard(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -65,15 +65,15 @@ func TestEmergencyReparentShard(t *testing.T) {
 			},
 		},
 	}
-	currentMasterFilePosition, _ := mysql.ParseFilePosGTIDSet("mariadb-bin.000010:456")
-	oldMaster.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
-		GTIDSet: currentMasterFilePosition,
+	currentPrimaryFilePosition, _ := mysql.ParseFilePosGTIDSet("mariadb-bin.000010:456")
+	oldPrimary.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
+		GTIDSet: currentPrimaryFilePosition,
 	}
 
-	// new master
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
-	newMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// new primary
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
+	newPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -82,18 +82,18 @@ func TestEmergencyReparentShard(t *testing.T) {
 			},
 		},
 	}
-	newMasterRelayLogPos, _ := mysql.ParseFilePosGTIDSet("relay-bin.000004:456")
-	newMaster.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
-		GTIDSet: newMasterRelayLogPos,
+	newPrimaryRelayLogPos, _ := mysql.ParseFilePosGTIDSet("relay-bin.000004:456")
+	newPrimary.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
+		GTIDSet: newPrimaryRelayLogPos,
 	}
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = newMaster.FakeMysqlDaemon.CurrentSourceFilePosition
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = newPrimary.FakeMysqlDaemon.CurrentSourceFilePosition
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE IO_THREAD",
 		"CREATE DATABASE IF NOT EXISTS _vt",
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -102,18 +102,18 @@ func TestEmergencyReparentShard(t *testing.T) {
 			},
 		},
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master, will be scrapped
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary, will be scrapped
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
@@ -132,7 +132,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 		GTIDSet: goodReplica1RelayLogPos,
 	}
 	goodReplica1.FakeMysqlDaemon.WaitPrimaryPosition = goodReplica1.FakeMysqlDaemon.CurrentSourceFilePosition
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE IO_THREAD",
 		"STOP SLAVE",
@@ -159,7 +159,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 		GTIDSet: goodReplica2RelayLogPos,
 	}
 	goodReplica2.FakeMysqlDaemon.WaitPrimaryPosition = goodReplica2.FakeMysqlDaemon.CurrentSourceFilePosition
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -169,20 +169,20 @@ func TestEmergencyReparentShard(t *testing.T) {
 	// run EmergencyReparentShard
 	// using deprecated flag until it is removed completely. at that time this should be replaced with -wait_replicas_timeout
 	waitReplicaTimeout := time.Second * 2
-	err := vp.Run([]string{"EmergencyReparentShard", "-wait_replicas_timeout", waitReplicaTimeout.String(), newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard,
-		topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	err := vp.Run([]string{"EmergencyReparentShard", "-wait_replicas_timeout", waitReplicaTimeout.String(), newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard,
+		topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	require.NoError(t, err)
 	// check what was run
-	err = newMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = newPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	assert.False(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly set")
-	checkSemiSyncEnabled(t, true, true, newMaster)
+	assert.False(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly set")
+	checkSemiSyncEnabled(t, true, true, newPrimary)
 }
 
-// TestEmergencyReparentShardMasterElectNotBest tries to emergency reparent
+// TestEmergencyReparentShardPrimaryElectNotBest tries to emergency reparent
 // to a host that is not the latest in replication position.
-func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
+func TestEmergencyReparentShardPrimaryElectNotBest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -195,15 +195,15 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	moreAdvancedReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.Replicating = true
+	// new primary
+	newPrimary.FakeMysqlDaemon.Replicating = true
 	// this server has executed upto 455, which is the highest among replicas
-	newMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	newPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -214,7 +214,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	}
 	// It has more transactions in its relay log, but not as many as
 	// moreAdvancedReplica
-	newMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	newPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
 				Domain:   2,
@@ -223,25 +223,25 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 			},
 		},
 	}
-	newMasterRelayLogPos, _ := mysql.ParseFilePosGTIDSet("relay-bin.000004:456")
-	newMaster.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
-		GTIDSet: newMasterRelayLogPos,
+	newPrimaryRelayLogPos, _ := mysql.ParseFilePosGTIDSet("relay-bin.000004:456")
+	newPrimary.FakeMysqlDaemon.CurrentSourceFilePosition = mysql.Position{
+		GTIDSet: newPrimaryRelayLogPos,
 	}
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = newMaster.FakeMysqlDaemon.CurrentSourceFilePosition
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = newPrimary.FakeMysqlDaemon.CurrentSourceFilePosition
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE IO_THREAD",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master, will be scrapped
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	// old primary, will be scrapped
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
 	// more advanced replica
 	moreAdvancedReplica.FakeMysqlDaemon.Replicating = true
-	// position up to which this replica has executed is behind desired new master
+	// position up to which this replica has executed is behind desired new primary
 	moreAdvancedReplica.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
@@ -251,7 +251,7 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 			},
 		},
 	}
-	// relay log position is more advanced than desired new master
+	// relay log position is more advanced than desired new primary
 	moreAdvancedReplica.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			2: mysql.MariadbGTID{
@@ -273,15 +273,15 @@ func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	defer moreAdvancedReplica.StopActionLoop(t)
 
 	// run EmergencyReparentShard
-	err := wr.EmergencyReparentShard(ctx, newMaster.Tablet.Keyspace, newMaster.Tablet.Shard, newMaster.Tablet.Alias, 10*time.Second, sets.NewString())
+	err := wr.EmergencyReparentShard(ctx, newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard, newPrimary.Tablet.Alias, 10*time.Second, sets.NewString())
 	cancel()
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "is not fully caught up")
 	// check what was run
-	err = newMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = newPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
-	err = oldMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = oldPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 	err = moreAdvancedReplica.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)

--- a/go/vt/wrangler/testlib/external_reparent_test.go
+++ b/go/vt/wrangler/testlib/external_reparent_test.go
@@ -54,76 +54,76 @@ func TestTabletExternallyReparentedBasic(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create an old master, a new master, two good replicas, one bad replica
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create an old primary, a new primary, two good replicas, one bad replica
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
 
-	// On the elected master, we will respond to
+	// On the elected primary, we will respond to
 	// TabletActionReplicaWasPromoted
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// On the old master, we will only respond to
+	// On the old primary, we will only respond to
 	// TabletActionReplicaWasRestarted.
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
-	// First test: reparent to the same master, make sure it works
+	// First test: reparent to the same primary, make sure it works
 	// as expected.
-	if err := vp.Run([]string{"TabletExternallyReparented", topoproto.TabletAliasString(oldMaster.Tablet.Alias)}); err != nil {
-		t.Fatalf("TabletExternallyReparented(same master) should have worked: %v", err)
+	if err := vp.Run([]string{"TabletExternallyReparented", topoproto.TabletAliasString(oldPrimary.Tablet.Alias)}); err != nil {
+		t.Fatalf("TabletExternallyReparented(same primary) should have worked: %v", err)
 	}
 
-	// check the old master is still master
-	tablet, err := ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+	// check the old primary is still primary
+	tablet, err := ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("old master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("old primary should be MASTER but is: %v", tablet.Type)
 	}
 
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
 	}
 
 	// This tests the good case, where everything works as planned
-	t.Logf("TabletExternallyReparented(new master) expecting success")
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	t.Logf("TabletExternallyReparented(new primary) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
 
-	// check the new master is master
-	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check the new primary is primary
+	tablet, err = ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 
 	// We have to wait for shard sync to do its magic in the background
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be replica but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_REPLICA {
 			break
@@ -144,65 +144,65 @@ func TestTabletExternallyReparentedToReplica(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master, a new master, two good replicas, one bad replica
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
+	// Create an old primary, a new primary, two good replicas, one bad replica
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(ctx, logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
 
-	// On the elected master, we will respond to
+	// On the elected primary, we will respond to
 	// TabletActionReplicaWasPromoted
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// On the old master, we will only respond to
+	// On the old primary, we will only respond to
 	// TabletActionReplicaWasRestarted.
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
 	// Second test: reparent to a replica, and pretend the old
-	// master is still good to go.
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// primary is still good to go.
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
 	}
 
-	// This tests a bad case: the new designated master is a replica at mysql level,
+	// This tests a bad case: the new designated primary is a replica at mysql level,
 	// but we should do what we're told anyway.
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) error: %v", err)
 	}
 
-	// check that newMaster is master
-	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check that newPrimary is primary
+	tablet, err := ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 
 	// We have to wait for shard sync to do its magic in the background
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be replica but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_REPLICA {
 			break
@@ -213,7 +213,7 @@ func TestTabletExternallyReparentedToReplica(t *testing.T) {
 }
 
 // TestTabletExternallyReparentedWithDifferentMysqlPort makes sure
-// that if mysql is restarted on the master-elect tablet and has a different
+// that if mysql is restarted on the primary-elect tablet and has a different
 // port, we pick it up correctly.
 func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
@@ -226,35 +226,35 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master, a new master, two good replicas, one bad replica
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create an old primary, a new primary, two good replicas, one bad replica
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
 	// Now we're restarting mysql on a different port, 3301->3303
 	// but without updating the Tablet record in topology.
 
-	// On the elected master, we will respond to
+	// On the elected primary, we will respond to
 	// TabletActionReplicaWasPromoted, so we need a MysqlDaemon
-	// that returns no master, and the new port (as returned by mysql)
-	newMaster.FakeMysqlDaemon.MysqlPort.Set(3303)
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	// that returns no primary, and the new port (as returned by mysql)
+	newPrimary.FakeMysqlDaemon.MysqlPort.Set(3303)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
 	}
-	// On the old master, we will only respond to
+	// On the old primary, we will only respond to
 	// TabletActionReplicaWasRestarted and point to the new mysql port
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
 	// On the good replicas, we will respond to
 	// TabletActionReplicaWasRestarted and point to the new mysql port
@@ -262,33 +262,33 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	defer goodReplica.StopActionLoop(t)
 
 	// This tests the good case, where everything works as planned
-	t.Logf("TabletExternallyReparented(new master) expecting success")
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	t.Logf("TabletExternallyReparented(new primary) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
-	// check the new master is master
-	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check the new primary is primary
+	tablet, err := ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 
 	// We have to wait for shard sync to do its magic in the background
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be replica but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_REPLICA {
 			break
@@ -298,9 +298,9 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 	}
 }
 
-// TestTabletExternallyReparentedContinueOnUnexpectedMaster makes sure
-// that we ignore mysql's master if the flag is set
-func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
+// TestTabletExternallyReparentedContinueOnUnexpectedPrimary makes sure
+// that we ignore mysql's primary if the flag is set
+func TestTabletExternallyReparentedContinueOnUnexpectedPrimary(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -311,31 +311,31 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master, a new master, two good replicas, one bad replica
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create an old primary, a new primary, two good replicas, one bad replica
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
-	// On the elected master, we will respond to
+	// On the elected primary, we will respond to
 	// TabletActionReplicaWasPromoted, so we need a MysqlDaemon
-	// that returns no master, and the new port (as returned by mysql)
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	// that returns no primary, and the new port (as returned by mysql)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
 	}
-	// On the old master, we will only respond to
+	// On the old primary, we will only respond to
 	// TabletActionReplicaWasRestarted and point to a bad host
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
 	// On the good replica, we will respond to
 	// TabletActionReplicaWasRestarted and point to a bad host
@@ -343,32 +343,32 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 	defer goodReplica.StopActionLoop(t)
 
 	// This tests the good case, where everything works as planned
-	t.Logf("TabletExternallyReparented(new master) expecting success")
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	t.Logf("TabletExternallyReparented(new primary) expecting success")
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
-	// check the new master is master
-	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check the new primary is primary
+	tablet, err := ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 	// We have to wait for shard sync to do its magic in the background
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be replica but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_REPLICA {
 			break
@@ -389,65 +389,65 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master, a new master, and a good replica.
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create an old primary, a new primary, and a good replica.
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
-	// On the elected master, we will respond to
+	// On the elected primary, we will respond to
 	// TabletActionReplicaWasPromoted.
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START Replica",
 	}
-	// On the old master, we will only respond to
+	// On the old primary, we will only respond to
 	// TabletActionReplicaWasRestarted.
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
 
-	goodReplica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	// On the good replica, we will respond to
 	// TabletActionReplicaWasRestarted.
 	goodReplica.StartActionLoop(t, wr)
 	defer goodReplica.StopActionLoop(t)
 
 	// The reparent should work as expected here
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
 
-	// check the new master is master
-	tablet, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check the new primary is primary
+	tablet, err := ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 
 	// We have to wait for shard sync to do its magic in the background
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be replica but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be replica but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err = ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err = ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_REPLICA {
 			break
@@ -456,23 +456,23 @@ func TestTabletExternallyReparentedRerun(t *testing.T) {
 		}
 	}
 
-	// run TER again and make sure the master is still correct
-	if err := wr.TabletExternallyReparented(ctx, newMaster.Tablet.Alias); err != nil {
+	// run TER again and make sure the primary is still correct
+	if err := wr.TabletExternallyReparented(ctx, newPrimary.Tablet.Alias); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
 	}
 
-	// check the new master is still master
-	tablet, err = ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// check the new primary is still primary
+	tablet, err = ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
-		t.Fatalf("GetTablet(%v) failed: %v", newMaster.Tablet.Alias, err)
+		t.Fatalf("GetTablet(%v) failed: %v", newPrimary.Tablet.Alias, err)
 	}
 	if tablet.Type != topodatapb.TabletType_MASTER {
-		t.Fatalf("new master should be MASTER but is: %v", tablet.Type)
+		t.Fatalf("new primary should be MASTER but is: %v", tablet.Type)
 	}
 
 }
 
-func TestRPCTabletExternallyReparentedDemotesMasterToConfiguredTabletType(t *testing.T) {
+func TestRPCTabletExternallyReparentedDemotesPrimaryToConfiguredTabletType(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -486,21 +486,21 @@ func TestRPCTabletExternallyReparentedDemotesMasterToConfiguredTabletType(t *tes
 	ts := memorytopo.NewServer("cell1")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master and a new master
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_SPARE, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_SPARE, nil)
+	// Create an old primary and a new primary
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_SPARE, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_SPARE, nil)
 
-	oldMaster.StartActionLoop(t, wr)
-	newMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	defer newMaster.StopActionLoop(t)
+	oldPrimary.StartActionLoop(t, wr)
+	newPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	defer newPrimary.StopActionLoop(t)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1"}, false)
 	assert.NoError(t, err, "RebuildKeyspaceLocked failed: %v", err)
 
-	// Reparent to new master
-	ti, err := ts.GetTablet(ctx, newMaster.Tablet.Alias)
+	// Reparent to new primary
+	ti, err := ts.GetTablet(ctx, newPrimary.Tablet.Alias)
 	if err != nil {
 		t.Fatalf("GetTablet failed: %v", err)
 	}
@@ -513,16 +513,16 @@ func TestRPCTabletExternallyReparentedDemotesMasterToConfiguredTabletType(t *tes
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > 10*time.Second /* timeout */ {
-			tablet, err := ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+			tablet, err := ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 			if err != nil {
-				t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+				t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 			}
-			t.Fatalf("old master (%v) should be spare but is: %v", topoproto.TabletAliasString(oldMaster.Tablet.Alias), tablet.Type)
+			t.Fatalf("old primary (%v) should be spare but is: %v", topoproto.TabletAliasString(oldPrimary.Tablet.Alias), tablet.Type)
 		}
-		// check the old master was converted to replica
-		tablet, err := ts.GetTablet(ctx, oldMaster.Tablet.Alias)
+		// check the old primary was converted to replica
+		tablet, err := ts.GetTablet(ctx, oldPrimary.Tablet.Alias)
 		if err != nil {
-			t.Fatalf("GetTablet(%v) failed: %v", oldMaster.Tablet.Alias, err)
+			t.Fatalf("GetTablet(%v) failed: %v", oldPrimary.Tablet.Alias, err)
 		}
 		if tablet.Type == topodatapb.TabletType_SPARE {
 			break
@@ -531,9 +531,9 @@ func TestRPCTabletExternallyReparentedDemotesMasterToConfiguredTabletType(t *tes
 		}
 	}
 
-	shardInfo, err := ts.GetShard(context.Background(), newMaster.Tablet.Keyspace, newMaster.Tablet.Shard)
+	shardInfo, err := ts.GetShard(context.Background(), newPrimary.Tablet.Keyspace, newPrimary.Tablet.Shard)
 	assert.NoError(t, err)
 
-	assert.True(t, topoproto.TabletAliasEqual(newMaster.Tablet.Alias, shardInfo.MasterAlias))
-	assert.Equal(t, topodatapb.TabletType_MASTER, newMaster.TM.Tablet().Type)
+	assert.True(t, topoproto.TabletAliasEqual(newPrimary.Tablet.Alias, shardInfo.MasterAlias))
+	assert.Equal(t, topodatapb.TabletType_MASTER, newPrimary.TM.Tablet().Type)
 }

--- a/go/vt/wrangler/testlib/find_tablet_test.go
+++ b/go/vt/wrangler/testlib/find_tablet_test.go
@@ -37,13 +37,13 @@ func TestFindTablet(t *testing.T) {
 	ts := memorytopo.NewServer("cell1", "cell2")
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
-	// Create an old master, two good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	// Create an old primary, two good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldMaster.Tablet.Keyspace, []string{"cell1", "cell2"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, oldPrimary.Tablet.Keyspace, []string{"cell1", "cell2"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
@@ -54,24 +54,24 @@ func TestFindTablet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTabletMapForShardByCell should have worked but got: %v", err)
 	}
-	master, err := topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
-	if err != nil || !topoproto.TabletAliasEqual(master, oldMaster.Tablet.Alias) {
-		t.Fatalf("FindTabletByHostAndPort(master) failed: %v %v", err, master)
+	primary, err := topotools.FindTabletByHostAndPort(tabletMap, oldPrimary.Tablet.Hostname, "vt", oldPrimary.Tablet.PortMap["vt"])
+	if err != nil || !topoproto.TabletAliasEqual(primary, oldPrimary.Tablet.Alias) {
+		t.Fatalf("FindTabletByHostAndPort(primary) failed: %v %v", err, primary)
 	}
 	replica1, err := topotools.FindTabletByHostAndPort(tabletMap, goodReplica1.Tablet.Hostname, "vt", goodReplica1.Tablet.PortMap["vt"])
 	if err != nil || !topoproto.TabletAliasEqual(replica1, goodReplica1.Tablet.Alias) {
-		t.Fatalf("FindTabletByHostAndPort(replica1) failed: %v %v", err, master)
+		t.Fatalf("FindTabletByHostAndPort(replica1) failed: %v %v", err, primary)
 	}
 	replica2, err := topotools.FindTabletByHostAndPort(tabletMap, goodReplica2.Tablet.Hostname, "vt", goodReplica2.Tablet.PortMap["vt"])
 	if !topo.IsErrType(err, topo.NoNode) {
 		t.Fatalf("FindTabletByHostAndPort(replica2) worked: %v %v", err, replica2)
 	}
 
-	// Make sure the master is not exported in other cells
+	// Make sure the primary is not exported in other cells
 	tabletMap, _ = ts.GetTabletMapForShardByCell(ctx, "test_keyspace", "0", []string{"cell2"})
-	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
+	primary, err = topotools.FindTabletByHostAndPort(tabletMap, oldPrimary.Tablet.Hostname, "vt", oldPrimary.Tablet.PortMap["vt"])
 	if !topo.IsErrType(err, topo.NoNode) {
-		t.Fatalf("FindTabletByHostAndPort(master) worked in cell2: %v %v", err, master)
+		t.Fatalf("FindTabletByHostAndPort(primary) worked in cell2: %v %v", err, primary)
 	}
 
 	// Get tablet map for all cells.  If there were to be failures talking to local cells, this will return the tablet map
@@ -80,9 +80,9 @@ func TestFindTablet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTabletMapForShard should nil but got: %v", err)
 	}
-	master, err = topotools.FindTabletByHostAndPort(tabletMap, oldMaster.Tablet.Hostname, "vt", oldMaster.Tablet.PortMap["vt"])
-	if err != nil || !topoproto.TabletAliasEqual(master, oldMaster.Tablet.Alias) {
-		t.Fatalf("FindTabletByHostAndPort(master) failed: %v %v", err, master)
+	primary, err = topotools.FindTabletByHostAndPort(tabletMap, oldPrimary.Tablet.Hostname, "vt", oldPrimary.Tablet.PortMap["vt"])
+	if err != nil || !topoproto.TabletAliasEqual(primary, oldPrimary.Tablet.Alias) {
+		t.Fatalf("FindTabletByHostAndPort(primary) failed: %v %v", err, primary)
 	}
 
 }

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -87,7 +87,7 @@ func TestMigrateServedTypes(t *testing.T) {
 	}
 
 	// create the source shard
-	sourceMaster := NewFakeTablet(t, wr, "cell1", 10, topodatapb.TabletType_MASTER, nil,
+	sourcePrimary := NewFakeTablet(t, wr, "cell1", 10, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "0"))
 	sourceReplica := NewFakeTablet(t, wr, "cell1", 11, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "0"))
@@ -95,7 +95,7 @@ func TestMigrateServedTypes(t *testing.T) {
 		TabletKeyspaceShard(t, "ks", "0"))
 
 	// create the first destination shard
-	dest1Master := NewFakeTablet(t, wr, "cell1", 20, topodatapb.TabletType_MASTER, nil,
+	dest1Primary := NewFakeTablet(t, wr, "cell1", 20, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "-80"))
 	dest1Replica := NewFakeTablet(t, wr, "cell1", 21, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "-80"))
@@ -103,7 +103,7 @@ func TestMigrateServedTypes(t *testing.T) {
 		TabletKeyspaceShard(t, "ks", "-80"))
 
 	// create the second destination shard
-	dest2Master := NewFakeTablet(t, wr, "cell1", 30, topodatapb.TabletType_MASTER, nil,
+	dest2Primary := NewFakeTablet(t, wr, "cell1", 30, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "80-"))
 	dest2Replica := NewFakeTablet(t, wr, "cell1", 31, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "80-"))
@@ -128,9 +128,9 @@ func TestMigrateServedTypes(t *testing.T) {
 	sourceReplica.StartActionLoop(t, wr)
 	defer sourceReplica.StopActionLoop(t)
 
-	// sourceMaster will see the refresh, and has to respond to it
+	// sourcePrimary will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	sourceMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	sourcePrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -139,8 +139,8 @@ func TestMigrateServedTypes(t *testing.T) {
 			},
 		},
 	}
-	sourceMaster.StartActionLoop(t, wr)
-	defer sourceMaster.StopActionLoop(t)
+	sourcePrimary.StartActionLoop(t, wr)
+	defer sourcePrimary.StopActionLoop(t)
 
 	// dest1Rdonly will see the refresh
 	dest1Rdonly.StartActionLoop(t, wr)
@@ -150,16 +150,16 @@ func TestMigrateServedTypes(t *testing.T) {
 	dest1Replica.StartActionLoop(t, wr)
 	defer dest1Replica.StopActionLoop(t)
 
-	dest1Master.StartActionLoop(t, wr)
-	defer dest1Master.StopActionLoop(t)
+	dest1Primary.StartActionLoop(t, wr)
+	defer dest1Primary.StopActionLoop(t)
 
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient1 := binlogplayer.NewMockDBClient(t)
 	dbClientFactory1 := func() binlogplayer.DBClient { return dbClient1 }
-	dest1Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest1Master.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, dbClient1.DBName(), nil)
+	dest1Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest1Primary.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, dbClient1.DBName(), nil)
 	// select * from _vt.vreplication during Open
 	dbClient1.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest1Master.TM.VREngine.Open(context.Background())
+	dest1Primary.TM.VREngine.Open(context.Background())
 	// select pos, state, message from _vt.vreplication
 	dbClient1.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
 		sqltypes.NewVarBinary("MariaDB/5-456-892"),
@@ -176,16 +176,16 @@ func TestMigrateServedTypes(t *testing.T) {
 	dest2Replica.StartActionLoop(t, wr)
 	defer dest2Replica.StopActionLoop(t)
 
-	dest2Master.StartActionLoop(t, wr)
-	defer dest2Master.StopActionLoop(t)
+	dest2Primary.StartActionLoop(t, wr)
+	defer dest2Primary.StopActionLoop(t)
 
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient2 := binlogplayer.NewMockDBClient(t)
 	dbClientFactory2 := func() binlogplayer.DBClient { return dbClient2 }
-	dest2Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest2Master.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, dbClient2.DBName(), nil)
+	dest2Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest2Primary.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, dbClient2.DBName(), nil)
 	// select * from _vt.vreplication during Open
 	dbClient2.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest2Master.TM.VREngine.Open(context.Background())
+	dest2Primary.TM.VREngine.Open(context.Background())
 	// select pos, state, message from _vt.vreplication
 	dbClient2.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
 		sqltypes.NewVarBinary("MariaDB/5-456-892"),
@@ -234,7 +234,7 @@ func TestMigrateServedTypes(t *testing.T) {
 	checkShardSourceShards(t, ts, "-80", 1)
 	checkShardSourceShards(t, ts, "80-", 1)
 
-	// migrate master over
+	// migrate primary over
 	if err := vp.Run([]string{"MigrateServedTypes", "ks/0", "master"}); err != nil {
 		t.Fatalf("MigrateServedType(master) failed: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	}
 
 	// create the first source shard
-	source1Master := NewFakeTablet(t, wr, "cell1", 20, topodatapb.TabletType_MASTER, nil,
+	source1Primary := NewFakeTablet(t, wr, "cell1", 20, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "-80"))
 	source1Replica := NewFakeTablet(t, wr, "cell1", 21, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "-80"))
@@ -279,14 +279,14 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 		TabletKeyspaceShard(t, "ks", "-80"))
 
 	// create the second source shard
-	source2Master := NewFakeTablet(t, wr, "cell1", 30, topodatapb.TabletType_MASTER, nil,
+	source2Primary := NewFakeTablet(t, wr, "cell1", 30, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "80-"))
 	source2Replica := NewFakeTablet(t, wr, "cell1", 31, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "80-"))
 	source2Rdonly := NewFakeTablet(t, wr, "cell1", 32, topodatapb.TabletType_RDONLY, nil,
 		TabletKeyspaceShard(t, "ks", "80-"))
 
-	dest1Master := NewFakeTablet(t, wr, "cell1", 40, topodatapb.TabletType_MASTER, nil,
+	dest1Primary := NewFakeTablet(t, wr, "cell1", 40, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "-40"))
 	dest1Replica := NewFakeTablet(t, wr, "cell1", 41, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "-40"))
@@ -294,14 +294,14 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 		TabletKeyspaceShard(t, "ks", "-40"))
 
 	//	create the second source shard
-	dest2Master := NewFakeTablet(t, wr, "cell1", 50, topodatapb.TabletType_MASTER, nil,
+	dest2Primary := NewFakeTablet(t, wr, "cell1", 50, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "40-80"))
 	dest2Replica := NewFakeTablet(t, wr, "cell1", 51, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "40-80"))
 	dest2Rdonly := NewFakeTablet(t, wr, "cell1", 52, topodatapb.TabletType_RDONLY, nil,
 		TabletKeyspaceShard(t, "ks", "40-80"))
 
-	dest3Master := NewFakeTablet(t, wr, "cell1", 60, topodatapb.TabletType_MASTER, nil,
+	dest3Primary := NewFakeTablet(t, wr, "cell1", 60, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "80-c0"))
 	dest3Replica := NewFakeTablet(t, wr, "cell1", 61, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "80-c0"))
@@ -309,7 +309,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 		TabletKeyspaceShard(t, "ks", "80-c0"))
 
 	// create the second source shard
-	dest4Master := NewFakeTablet(t, wr, "cell1", 70, topodatapb.TabletType_MASTER, nil,
+	dest4Primary := NewFakeTablet(t, wr, "cell1", 70, topodatapb.TabletType_MASTER, nil,
 		TabletKeyspaceShard(t, "ks", "c0-"))
 	dest4Replica := NewFakeTablet(t, wr, "cell1", 71, topodatapb.TabletType_REPLICA, nil,
 		TabletKeyspaceShard(t, "ks", "c0-"))
@@ -337,9 +337,9 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	source1Replica.StartActionLoop(t, wr)
 	defer source1Replica.StopActionLoop(t)
 
-	// source1Master will see the refresh, and has to respond to it
+	// source1Primary will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	source1Master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	source1Primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -348,8 +348,8 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 			},
 		},
 	}
-	source1Master.StartActionLoop(t, wr)
-	defer source1Master.StopActionLoop(t)
+	source1Primary.StartActionLoop(t, wr)
+	defer source1Primary.StopActionLoop(t)
 
 	// // dest1Rdonly will see the refresh
 	dest1Rdonly.StartActionLoop(t, wr)
@@ -359,8 +359,8 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	dest1Replica.StartActionLoop(t, wr)
 	defer dest1Replica.StopActionLoop(t)
 
-	dest1Master.StartActionLoop(t, wr)
-	defer dest1Master.StopActionLoop(t)
+	dest1Primary.StartActionLoop(t, wr)
+	defer dest1Primary.StopActionLoop(t)
 
 	// // dest2Rdonly will see the refresh
 	dest2Rdonly.StartActionLoop(t, wr)
@@ -370,8 +370,8 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	dest2Replica.StartActionLoop(t, wr)
 	defer dest2Replica.StopActionLoop(t)
 
-	dest2Master.StartActionLoop(t, wr)
-	defer dest2Master.StopActionLoop(t)
+	dest2Primary.StartActionLoop(t, wr)
+	defer dest2Primary.StopActionLoop(t)
 
 	// Now let's kick off the process for the second shard.
 
@@ -383,9 +383,9 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	source2Replica.StartActionLoop(t, wr)
 	defer source2Replica.StopActionLoop(t)
 
-	// sourceMaster will see the refresh, and has to respond to it
+	// source2Primary will see the refresh, and has to respond to it
 	// also will be asked about its replication position.
-	source2Master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	source2Primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -394,8 +394,8 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 			},
 		},
 	}
-	source2Master.StartActionLoop(t, wr)
-	defer source2Master.StopActionLoop(t)
+	source2Primary.StartActionLoop(t, wr)
+	defer source2Primary.StopActionLoop(t)
 
 	// dest3Rdonly will see the refresh
 	dest3Rdonly.StartActionLoop(t, wr)
@@ -405,8 +405,8 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	dest3Replica.StartActionLoop(t, wr)
 	defer dest3Replica.StopActionLoop(t)
 
-	dest3Master.StartActionLoop(t, wr)
-	defer dest3Master.StopActionLoop(t)
+	dest3Primary.StartActionLoop(t, wr)
+	defer dest3Primary.StopActionLoop(t)
 
 	// dest4Rdonly will see the refresh
 	dest4Rdonly.StartActionLoop(t, wr)
@@ -416,16 +416,16 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	dest4Replica.StartActionLoop(t, wr)
 	defer dest4Replica.StopActionLoop(t)
 
-	dest4Master.StartActionLoop(t, wr)
-	defer dest4Master.StopActionLoop(t)
+	dest4Primary.StartActionLoop(t, wr)
+	defer dest4Primary.StopActionLoop(t)
 
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient1 := binlogplayer.NewMockDBClient(t)
 	dbClientFactory1 := func() binlogplayer.DBClient { return dbClient1 }
-	dest1Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest1Master.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, "db", nil)
+	dest1Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest1Primary.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, "db", nil)
 	// select * from _vt.vreplication during Open
 	dbClient1.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest1Master.TM.VREngine.Open(context.Background())
+	dest1Primary.TM.VREngine.Open(context.Background())
 	// select pos, state, message from _vt.vreplication
 	dbClient1.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
 		sqltypes.NewVarBinary("MariaDB/5-456-892"),
@@ -437,10 +437,10 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient2 := binlogplayer.NewMockDBClient(t)
 	dbClientFactory2 := func() binlogplayer.DBClient { return dbClient2 }
-	dest2Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest2Master.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, "db", nil)
+	dest2Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest2Primary.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, "db", nil)
 	// select * from _vt.vreplication during Open
 	dbClient2.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest2Master.TM.VREngine.Open(context.Background())
+	dest2Primary.TM.VREngine.Open(context.Background())
 
 	// select pos, state, message from _vt.vreplication
 	dbClient2.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
@@ -490,7 +490,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	checkShardSourceShards(t, ts, "-40", 1)
 	checkShardSourceShards(t, ts, "40-80", 1)
 
-	// migrate master over
+	// migrate primary over
 	if err := vp.Run([]string{"MigrateServedTypes", "ks/-80", "master"}); err != nil {
 		t.Fatalf("MigrateServedType(master) failed: %v", err)
 	}
@@ -506,10 +506,10 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient1 = binlogplayer.NewMockDBClient(t)
 	dbClientFactory1 = func() binlogplayer.DBClient { return dbClient1 }
-	dest3Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest3Master.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, "db", nil)
+	dest3Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest3Primary.FakeMysqlDaemon, dbClientFactory1, dbClientFactory1, "db", nil)
 	// select * from _vt.vreplication during Open
 	dbClient1.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest3Master.TM.VREngine.Open(context.Background())
+	dest3Primary.TM.VREngine.Open(context.Background())
 	// select pos, state, message from _vt.vreplication
 	dbClient1.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
 		sqltypes.NewVarBinary("MariaDB/5-456-892"),
@@ -521,10 +521,10 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	// Override with a fake VREngine after TM is initialized in action loop.
 	dbClient2 = binlogplayer.NewMockDBClient(t)
 	dbClientFactory2 = func() binlogplayer.DBClient { return dbClient2 }
-	dest4Master.TM.VREngine = vreplication.NewTestEngine(ts, "", dest4Master.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, "db", nil)
+	dest4Primary.TM.VREngine = vreplication.NewTestEngine(ts, "", dest4Primary.FakeMysqlDaemon, dbClientFactory2, dbClientFactory2, "db", nil)
 	// select * from _vt.vreplication during Open
 	dbClient2.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
-	dest4Master.TM.VREngine.Open(context.Background())
+	dest4Primary.TM.VREngine.Open(context.Background())
 
 	// select pos, state, message from _vt.vreplication
 	dbClient2.ExpectRequest("select pos, state, message from _vt.vreplication where id=1", &sqltypes.Result{Rows: [][]sqltypes.Value{{
@@ -568,7 +568,7 @@ func TestMultiShardMigrateServedTypes(t *testing.T) {
 	checkShardSourceShards(t, ts, "80-c0", 1)
 	checkShardSourceShards(t, ts, "c0-", 1)
 
-	// // migrate master over
+	// // migrate primary over
 	if err := vp.Run([]string{"MigrateServedTypes", "ks/80-", "master"}); err != nil {
 		t.Fatalf("MigrateServedType(master) failed: %v", err)
 	}

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -50,20 +50,20 @@ func TestPermissions(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	replica := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 
-	// mark the master inside the shard
-	_, err := ts.UpdateShardFields(ctx, master.Tablet.Keyspace, master.Tablet.Shard, func(si *topo.ShardInfo) error {
-		si.MasterAlias = master.Tablet.Alias
+	// mark the primary inside the shard
+	_, err := ts.UpdateShardFields(ctx, primary.Tablet.Keyspace, primary.Tablet.Shard, func(si *topo.ShardInfo) error {
+		si.MasterAlias = primary.Tablet.Alias
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("UpdateShardFields failed: %v", err)
 	}
 
-	// master will be asked for permissions
-	master.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
+	// primary will be asked for permissions
+	primary.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SELECT * FROM mysql.user ORDER BY host, user": {
 			Fields: []*querypb.Field{
 				{
@@ -549,17 +549,17 @@ func TestPermissions(t *testing.T) {
 			},
 		},
 	}
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// Make a two-level-deep copy, so we can make them diverge later.
-	user := *master.FakeMysqlDaemon.FetchSuperQueryMap["SELECT * FROM mysql.user ORDER BY host, user"]
+	user := *primary.FakeMysqlDaemon.FetchSuperQueryMap["SELECT * FROM mysql.user ORDER BY host, user"]
 	user.Fields = append([]*querypb.Field{}, user.Fields...)
 
 	// replica will be asked for permissions
 	replica.FakeMysqlDaemon.FetchSuperQueryMap = map[string]*sqltypes.Result{
 		"SELECT * FROM mysql.user ORDER BY host, user":   &user,
-		"SELECT * FROM mysql.db ORDER BY host, db, user": master.FakeMysqlDaemon.FetchSuperQueryMap["SELECT * FROM mysql.db ORDER BY host, db, user"],
+		"SELECT * FROM mysql.db ORDER BY host, db, user": primary.FakeMysqlDaemon.FetchSuperQueryMap["SELECT * FROM mysql.db ORDER BY host, db, user"],
 	}
 	replica.StartActionLoop(t, wr)
 	defer replica.StopActionLoop(t)
@@ -571,7 +571,7 @@ func TestPermissions(t *testing.T) {
 	}
 
 	// run ValidatePermissionsKeyspace, this should work
-	if err := vp.Run([]string{"ValidatePermissionsKeyspace", master.Tablet.Keyspace}); err != nil {
+	if err := vp.Run([]string{"ValidatePermissionsKeyspace", primary.Tablet.Keyspace}); err != nil {
 		t.Fatalf("ValidatePermissionsKeyspace failed: %v", err)
 	}
 
@@ -582,7 +582,7 @@ func TestPermissions(t *testing.T) {
 	}
 
 	// run ValidatePermissionsKeyspace again, this should now fail
-	if err := vp.Run([]string{"ValidatePermissionsKeyspace", master.Tablet.Keyspace}); err == nil || !strings.Contains(err.Error(), "has an extra user") {
+	if err := vp.Run([]string{"ValidatePermissionsKeyspace", primary.Tablet.Keyspace}); err == nil || !strings.Contains(err.Error(), "has an extra user") {
 		t.Fatalf("ValidatePermissionsKeyspace has unexpected err: %v", err)
 	}
 

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -38,7 +38,7 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
+func TestPlannedReparentShardNoPrimaryProvided(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -50,15 +50,15 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell2", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
+	// new primary
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -67,7 +67,7 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -76,7 +76,7 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -84,33 +84,33 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = newMaster.FakeMysqlDaemon.WaitPrimaryPosition
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = newPrimary.FakeMysqlDaemon.WaitPrimaryPosition
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
-		// we end up calling SetMaster twice on the old master
+		// we end up calling SetReplicationSource twice on the old primary
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
-	// SetMaster is called on new master to make sure it's replicating before reparenting.
-	newMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	// SetReplicationSource is called on new primary to make sure it's replicating before reparenting.
+	newPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -121,30 +121,30 @@ func TestPlannedReparentShardNoMasterProvided(t *testing.T) {
 
 	// run PlannedReparentShard
 	// using deprecated flag until it is removed completely. at that time this should be replaced with -wait_replicas_timeout
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard})
 	require.NoError(t, err)
 
 	// check what was run
-	err = newMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = newPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	err = oldMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = oldPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
 	err = goodReplica1.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	assert.False(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly is set")
-	assert.True(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly not set")
+	assert.False(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly is set")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly not set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.ReadOnly, "goodReplica1.FakeMysqlDaemon.ReadOnly not set")
-	assert.True(t, oldMaster.TM.QueryServiceControl.IsServing(), "oldMaster...QueryServiceControl not serving")
+	assert.True(t, oldPrimary.TM.QueryServiceControl.IsServing(), "oldPrimary...QueryServiceControl not serving")
 
-	// verify the old master was told to start replicating (and not
+	// verify the old primary was told to start replicating (and not
 	// the replica that wasn't replicating in the first place)
-	assert.True(t, oldMaster.FakeMysqlDaemon.Replicating, "oldMaster.FakeMysqlDaemon.Replicating not set")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.Replicating, "oldPrimary.FakeMysqlDaemon.Replicating not set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.Replicating, "goodReplica1.FakeMysqlDaemon.Replicating not set")
-	checkSemiSyncEnabled(t, true, true, newMaster)
-	checkSemiSyncEnabled(t, false, true, goodReplica1, oldMaster)
+	checkSemiSyncEnabled(t, true, true, newPrimary)
+	checkSemiSyncEnabled(t, false, true, goodReplica1, oldPrimary)
 }
 
 func TestPlannedReparentShardNoError(t *testing.T) {
@@ -159,16 +159,16 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
+	// new primary
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -177,7 +177,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -186,7 +186,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -194,33 +194,33 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = newMaster.FakeMysqlDaemon.WaitPrimaryPosition
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = newPrimary.FakeMysqlDaemon.WaitPrimaryPosition
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
-		// we end up calling SetMaster twice on the old master
+		// we end up calling SetReplicationSource twice on the old primary
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
-	// SetMaster is called on new master to make sure it's replicating before reparenting.
-	newMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	// SetReplicationSource is called on new primary to make sure it's replicating before reparenting.
+	newPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 
 	// goodReplica1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -232,7 +232,7 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	// goodReplica2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
 	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -240,38 +240,38 @@ func TestPlannedReparentShardNoError(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master",
-		topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_primary",
+		topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	require.NoError(t, err)
 
 	// check what was run
-	err = newMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = newPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
-	err = oldMaster.FakeMysqlDaemon.CheckSuperQueryList()
+	err = oldPrimary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 	err = goodReplica1.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 	err = goodReplica2.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	assert.False(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly set")
-	assert.True(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly not set")
+	assert.False(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly set")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly not set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.ReadOnly, "goodReplica1.FakeMysqlDaemon.ReadOnly not set")
 
 	assert.True(t, goodReplica2.FakeMysqlDaemon.ReadOnly, "goodReplica2.FakeMysqlDaemon.ReadOnly not set")
-	assert.True(t, oldMaster.TM.QueryServiceControl.IsServing(), "oldMaster...QueryServiceControl not serving")
+	assert.True(t, oldPrimary.TM.QueryServiceControl.IsServing(), "oldPrimary...QueryServiceControl not serving")
 
-	// verify the old master was told to start replicating (and not
+	// verify the old primary was told to start replicating (and not
 	// the replica that wasn't replicating in the first place)
-	assert.True(t, oldMaster.FakeMysqlDaemon.Replicating, "oldMaster.FakeMysqlDaemon.Replicating not set")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.Replicating, "oldPrimary.FakeMysqlDaemon.Replicating not set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.Replicating, "goodReplica1.FakeMysqlDaemon.Replicating not set")
 	assert.False(t, goodReplica2.FakeMysqlDaemon.Replicating, "goodReplica2.FakeMysqlDaemon.Replicating set")
 
-	checkSemiSyncEnabled(t, true, true, newMaster)
-	checkSemiSyncEnabled(t, false, true, goodReplica1, goodReplica2, oldMaster)
+	checkSemiSyncEnabled(t, true, true, newPrimary)
+	checkSemiSyncEnabled(t, false, true, goodReplica1, goodReplica2, oldPrimary)
 }
 
-func TestPlannedReparentNoMaster(t *testing.T) {
+func TestPlannedReparentNoPrimary(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -288,13 +288,14 @@ func TestPlannedReparentNoMaster(t *testing.T) {
 	NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
+	// use deprecated flag new_master to ensure coverage
 	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", replica1.Tablet.Keyspace + "/" + replica1.Tablet.Shard, "-new_master", topoproto.TabletAliasString(replica1.Tablet.Alias)})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "the shard has no current primary")
 }
 
 // TestPlannedReparentShardWaitForPositionFail simulates a failure of the WaitForPosition call
-// on the desired new master tablet
+// on the desired new primary tablet
 func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
@@ -307,16 +308,16 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
+	// new primary
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -325,7 +326,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -334,7 +335,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -342,29 +343,29 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	// set to incorrect value to make promote fail on WaitForMasterPos
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = newMaster.FakeMysqlDaemon.PromoteResult
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	// set to incorrect value to make promote fail on WaitForReplicationPos
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = newPrimary.FakeMysqlDaemon.PromoteResult
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
-	// SetMaster is called on new master to make sure it's replicating before reparenting.
-	newMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	// SetReplicationSource is called on new primary to make sure it's replicating before reparenting.
+	newPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -376,7 +377,7 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
 	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -384,17 +385,17 @@ func TestPlannedReparentShardWaitForPositionFail(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "replication on primary-elect cell1-0000000001 did not catch up in time")
 
-	// now check that DemoteMaster was undone and old master is still master
-	assert.True(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly not set")
-	assert.False(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly set")
+	// now check that DemotePrimary was undone and old primary is still primary
+	assert.True(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly not set")
+	assert.False(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly set")
 }
 
 // TestPlannedReparentShardWaitForPositionTimeout simulates a context timeout
-// during the WaitForPosition call to the desired new master
+// during the WaitForPosition call to the desired new primary
 func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
@@ -407,17 +408,17 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.TimeoutHook = func() error { return context.DeadlineExceeded }
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
+	// new primary
+	newPrimary.FakeMysqlDaemon.TimeoutHook = func() error { return context.DeadlineExceeded }
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -426,7 +427,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -435,7 +436,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -443,28 +444,28 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = newMaster.FakeMysqlDaemon.WaitPrimaryPosition
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = newPrimary.FakeMysqlDaemon.WaitPrimaryPosition
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
-	// SetMaster is called on new master to make sure it's replicating before reparenting.
-	newMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	// SetReplicationSource is called on new primary to make sure it's replicating before reparenting.
+	newPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -476,7 +477,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
 	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -484,13 +485,14 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	// use deprecated flag new_master to ensure coverage
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "replication on primary-elect cell1-0000000001 did not catch up in time")
 
-	// now check that DemoteMaster was undone and old master is still master
-	assert.True(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly not set")
-	assert.False(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly set")
+	// now check that DemotePrimary was undone and old primary is still primary
+	assert.True(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly not set")
+	assert.False(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly set")
 }
 
 func TestPlannedReparentShardRelayLogError(t *testing.T) {
@@ -505,15 +507,15 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	// Create a primary, a couple good replicas
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// old master
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// old primary
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -522,19 +524,19 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 			},
 		},
 	}
-	master.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	primary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"CREATE DATABASE IF NOT EXISTS _vt",
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
-	master.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
+	primary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
 	// goodReplica1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 	// simulate error that will trigger a call to RestartReplication
 	goodReplica1.FakeMysqlDaemon.SetReplicationSourceError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -546,20 +548,20 @@ func TestPlannedReparentShardRelayLogError(t *testing.T) {
 	defer goodReplica1.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", master.Tablet.Keyspace + "/" + master.Tablet.Shard, "-new_master",
-		topoproto.TabletAliasString(master.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", primary.Tablet.Keyspace + "/" + primary.Tablet.Shard, "-new_primary",
+		topoproto.TabletAliasString(primary.Tablet.Alias)})
 	require.NoError(t, err)
 	// check what was run
-	err = master.FakeMysqlDaemon.CheckSuperQueryList()
+	err = primary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 	err = goodReplica1.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	assert.False(t, master.FakeMysqlDaemon.ReadOnly, "master.FakeMysqlDaemon.ReadOnly set")
+	assert.False(t, primary.FakeMysqlDaemon.ReadOnly, "primary.FakeMysqlDaemon.ReadOnly set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.ReadOnly, "goodReplica1.FakeMysqlDaemon.ReadOnly not set")
-	assert.True(t, master.TM.QueryServiceControl.IsServing(), "master...QueryServiceControl not serving")
+	assert.True(t, primary.TM.QueryServiceControl.IsServing(), "primary...QueryServiceControl not serving")
 
-	// verify the old master was told to start replicating (and not
+	// verify the old primary was told to start replicating (and not
 	// the replica that wasn't replicating in the first place)
 	assert.True(t, goodReplica1.FakeMysqlDaemon.Replicating, "goodReplica1.FakeMysqlDaemon.Replicating not set")
 }
@@ -580,15 +582,15 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	// Create a primary, a couple good replicas
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// old master
-	master.FakeMysqlDaemon.ReadOnly = false
-	master.FakeMysqlDaemon.Replicating = false
-	master.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// old primary
+	primary.FakeMysqlDaemon.ReadOnly = false
+	primary.FakeMysqlDaemon.Replicating = false
+	primary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -597,22 +599,22 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 			},
 		},
 	}
-	master.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	primary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"CREATE DATABASE IF NOT EXISTS _vt",
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
-	master.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
+	primary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
 	// goodReplica1 is not replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
 	goodReplica1.FakeMysqlDaemon.IOThreadRunning = false
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
-	goodReplica1.FakeMysqlDaemon.CurrentSourceHost = master.Tablet.MysqlHostname
-	goodReplica1.FakeMysqlDaemon.CurrentSourcePort = int(master.Tablet.MysqlPort)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
+	goodReplica1.FakeMysqlDaemon.CurrentSourceHost = primary.Tablet.MysqlHostname
+	goodReplica1.FakeMysqlDaemon.CurrentSourcePort = int(primary.Tablet.MysqlPort)
 	// simulate error that will trigger a call to RestartReplication
 	goodReplica1.FakeMysqlDaemon.StartReplicationError = errors.New("Slave failed to initialize relay log info structure from the repository")
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
@@ -624,26 +626,27 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	defer goodReplica1.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", master.Tablet.Keyspace + "/" + master.Tablet.Shard, "-new_master",
-		topoproto.TabletAliasString(master.Tablet.Alias)})
+	// use deprecated flag new_master to ensure coverage
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", primary.Tablet.Keyspace + "/" + primary.Tablet.Shard, "-new_master",
+		topoproto.TabletAliasString(primary.Tablet.Alias)})
 	require.NoError(t, err)
 	// check what was run
-	err = master.FakeMysqlDaemon.CheckSuperQueryList()
+	err = primary.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 	err = goodReplica1.FakeMysqlDaemon.CheckSuperQueryList()
 	require.NoError(t, err)
 
-	assert.False(t, master.FakeMysqlDaemon.ReadOnly, "master.FakeMysqlDaemon.ReadOnly set")
+	assert.False(t, primary.FakeMysqlDaemon.ReadOnly, "primary.FakeMysqlDaemon.ReadOnly set")
 	assert.True(t, goodReplica1.FakeMysqlDaemon.ReadOnly, "goodReplica1.FakeMysqlDaemon.ReadOnly not set")
-	assert.True(t, master.TM.QueryServiceControl.IsServing(), "master...QueryServiceControl not serving")
+	assert.True(t, primary.TM.QueryServiceControl.IsServing(), "primary...QueryServiceControl not serving")
 
-	// verify the old master was told to start replicating (and not
+	// verify the old primary was told to start replicating (and not
 	// the replica that wasn't replicating in the first place)
 	assert.True(t, goodReplica1.FakeMysqlDaemon.Replicating, "goodReplica1.FakeMysqlDaemon.Replicating not set")
 }
 
 // TestPlannedReparentShardPromoteReplicaFail simulates a failure of the PromoteReplica call
-// on the desired new master tablet
+// on the desired new primary tablet
 func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
@@ -656,18 +659,18 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
-	newMaster := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	newPrimary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	// new master
-	newMaster.FakeMysqlDaemon.ReadOnly = true
-	newMaster.FakeMysqlDaemon.Replicating = true
+	// new primary
+	newPrimary.FakeMysqlDaemon.ReadOnly = true
+	newPrimary.FakeMysqlDaemon.Replicating = true
 	// make promote fail
-	newMaster.FakeMysqlDaemon.PromoteError = errors.New("some error")
-	newMaster.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteError = errors.New("some error")
+	newPrimary.FakeMysqlDaemon.WaitPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -676,7 +679,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.PromoteResult = mysql.Position{
+	newPrimary.FakeMysqlDaemon.PromoteResult = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -685,7 +688,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 			},
 		},
 	}
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -693,29 +696,29 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	newMaster.StartActionLoop(t, wr)
-	defer newMaster.StopActionLoop(t)
+	newPrimary.StartActionLoop(t, wr)
+	defer newPrimary.StopActionLoop(t)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = false
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = newMaster.FakeMysqlDaemon.WaitPrimaryPosition
-	oldMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = false
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = newPrimary.FakeMysqlDaemon.WaitPrimaryPosition
+	oldPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
-	// SetMaster is called on new master to make sure it's replicating before reparenting.
-	newMaster.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	// SetReplicationSource is called on new primary to make sure it's replicating before reparenting.
+	newPrimary.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -727,7 +730,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	// good replica 2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
 	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(newPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -735,18 +738,18 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "some error")
 
-	// when promote fails, we don't call UndoDemoteMaster, so the old master should be read-only
-	assert.True(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly")
-	assert.True(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly")
+	// when promote fails, we don't call UndoDemotePrimary, so the old primary should be read-only
+	assert.True(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly")
 
 	// retrying should work
-	newMaster.FakeMysqlDaemon.PromoteError = nil
-	newMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	newPrimary.FakeMysqlDaemon.PromoteError = nil
+	newPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
 		"START SLAVE",
@@ -758,7 +761,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
 		"START SLAVE",
 		// extra commands because of retry
@@ -767,18 +770,19 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	}
 
 	// run PlannedReparentShard
-	err = vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newMaster.Tablet.Alias)})
+	// use deprecated flag new_master to ensure coverage
+	err = vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	require.NoError(t, err)
 
-	// check that mastership changed correctly
-	assert.False(t, newMaster.FakeMysqlDaemon.ReadOnly, "newMaster.FakeMysqlDaemon.ReadOnly")
-	assert.True(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly")
+	// check that primary changed correctly
+	assert.False(t, newPrimary.FakeMysqlDaemon.ReadOnly, "newPrimary.FakeMysqlDaemon.ReadOnly")
+	assert.True(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly")
 }
 
-// TestPlannedReparentShardSameMaster tests PRS with oldMaster works correctly
-// Simulate failure of previous PRS and oldMaster is ReadOnly
-// Verify that master correctly gets set to ReadWrite
-func TestPlannedReparentShardSameMaster(t *testing.T) {
+// TestPlannedReparentShardSamePrimary tests PRS with oldPrimary works correctly
+// Simulate failure of previous PRS and oldPrimary is ReadOnly
+// Verify that primary correctly gets set to ReadWrite
+func TestPlannedReparentShardSamePrimary(t *testing.T) {
 	delay := discovery.GetTabletPickerRetryDelay()
 	defer func() {
 		discovery.SetTabletPickerRetryDelay(delay)
@@ -790,16 +794,16 @@ func TestPlannedReparentShardSameMaster(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	// Create a primary, a couple good replicas
+	oldPrimary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	goodReplica1 := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 	goodReplica2 := NewFakeTablet(t, wr, "cell2", 3, topodatapb.TabletType_REPLICA, nil)
 
-	// old master
-	oldMaster.FakeMysqlDaemon.ReadOnly = true
-	oldMaster.FakeMysqlDaemon.Replicating = false
-	oldMaster.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
-	oldMaster.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// old primary
+	oldPrimary.FakeMysqlDaemon.ReadOnly = true
+	oldPrimary.FakeMysqlDaemon.Replicating = false
+	oldPrimary.FakeMysqlDaemon.ReplicationStatusError = mysql.ErrNotReplica
+	oldPrimary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			7: mysql.MariadbGTID{
 				Domain:   7,
@@ -808,19 +812,19 @@ func TestPlannedReparentShardSameMaster(t *testing.T) {
 			},
 		},
 	}
-	oldMaster.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+	oldPrimary.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"CREATE DATABASE IF NOT EXISTS _vt",
 		"SUBCREATE TABLE IF NOT EXISTS _vt.reparent_journal",
 		"SUBINSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES",
 	}
-	oldMaster.StartActionLoop(t, wr)
-	defer oldMaster.StopActionLoop(t)
-	oldMaster.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+	oldPrimary.StartActionLoop(t, wr)
+	defer oldPrimary.StopActionLoop(t)
+	oldPrimary.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
 
 	// good replica 1 is replicating
 	goodReplica1.FakeMysqlDaemon.ReadOnly = true
 	goodReplica1.FakeMysqlDaemon.Replicating = true
-	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	goodReplica1.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 	goodReplica1.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",
@@ -832,7 +836,7 @@ func TestPlannedReparentShardSameMaster(t *testing.T) {
 	// goodReplica2 is not replicating
 	goodReplica2.FakeMysqlDaemon.ReadOnly = true
 	goodReplica2.FakeMysqlDaemon.Replicating = false
-	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldMaster.Tablet)
+	goodReplica2.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(oldPrimary.Tablet)
 	goodReplica2.StartActionLoop(t, wr)
 	goodReplica2.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"FAKE SET MASTER",
@@ -840,7 +844,7 @@ func TestPlannedReparentShardSameMaster(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", oldMaster.Tablet.Keyspace + "/" + oldMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(oldMaster.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", oldPrimary.Tablet.Keyspace + "/" + oldPrimary.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(oldPrimary.Tablet.Alias)})
 	require.NoError(t, err)
-	assert.False(t, oldMaster.FakeMysqlDaemon.ReadOnly, "oldMaster.FakeMysqlDaemon.ReadOnly")
+	assert.False(t, oldPrimary.FakeMysqlDaemon.ReadOnly, "oldPrimary.FakeMysqlDaemon.ReadOnly")
 }

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -50,19 +50,19 @@ func TestShardReplicationStatuses(t *testing.T) {
 	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
 		t.Fatalf("GetOrCreateShard failed: %v", err)
 	}
-	master := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)
+	primary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)
 	replica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// mark the master inside the shard
+	// mark the primary inside the shard
 	if _, err := ts.UpdateShardFields(ctx, "test_keyspace", "0", func(si *topo.ShardInfo) error {
-		si.MasterAlias = master.Tablet.Alias
+		si.MasterAlias = primary.Tablet.Alias
 		return nil
 	}); err != nil {
 		t.Fatalf("UpdateShardFields failed: %v", err)
 	}
 
-	// master action loop (to initialize host and port)
-	master.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
+	// primary action loop (to initialize host and port)
+	primary.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
 		GTIDSet: mysql.MariadbGTIDSet{
 			5: mysql.MariadbGTID{
 				Domain:   5,
@@ -71,8 +71,8 @@ func TestShardReplicationStatuses(t *testing.T) {
 			},
 		},
 	}
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// replica loop
 	replica.FakeMysqlDaemon.CurrentPrimaryPosition = mysql.Position{
@@ -84,8 +84,8 @@ func TestShardReplicationStatuses(t *testing.T) {
 			},
 		},
 	}
-	replica.FakeMysqlDaemon.CurrentSourceHost = master.Tablet.MysqlHostname
-	replica.FakeMysqlDaemon.CurrentSourcePort = int(master.Tablet.MysqlPort)
+	replica.FakeMysqlDaemon.CurrentSourceHost = primary.Tablet.MysqlHostname
+	replica.FakeMysqlDaemon.CurrentSourcePort = int(primary.Tablet.MysqlPort)
 	replica.StartActionLoop(t, wr)
 	defer replica.StopActionLoop(t)
 
@@ -95,7 +95,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 		t.Fatalf("ShardReplicationStatuses failed: %v", err)
 	}
 
-	// check result (make master first in the array)
+	// check result (make primary first in the array)
 	if len(ti) != 2 || len(rs) != 2 {
 		t.Fatalf("ShardReplicationStatuses returned wrong results: %v %v", ti, rs)
 	}
@@ -103,10 +103,10 @@ func TestShardReplicationStatuses(t *testing.T) {
 		ti[0], ti[1] = ti[1], ti[0]
 		rs[0], rs[1] = rs[1], rs[0]
 	}
-	if !topoproto.TabletAliasEqual(ti[0].Alias, master.Tablet.Alias) ||
+	if !topoproto.TabletAliasEqual(ti[0].Alias, primary.Tablet.Alias) ||
 		!topoproto.TabletAliasEqual(ti[1].Alias, replica.Tablet.Alias) ||
 		rs[0].SourceHost != "" ||
-		rs[1].SourceHost != master.Tablet.Hostname {
+		rs[1].SourceHost != primary.Tablet.Hostname {
 		t.Fatalf("ShardReplicationStatuses returend wrong results: %v %v", ti, rs)
 	}
 }
@@ -126,20 +126,20 @@ func TestReparentTablet(t *testing.T) {
 	if _, err := ts.GetOrCreateShard(ctx, "test_keyspace", "0"); err != nil {
 		t.Fatalf("CreateShard failed: %v", err)
 	}
-	master := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)
+	primary := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_MASTER, nil)
 	replica := NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// mark the master inside the shard
+	// mark the primary inside the shard
 	if _, err := ts.UpdateShardFields(ctx, "test_keyspace", "0", func(si *topo.ShardInfo) error {
-		si.MasterAlias = master.Tablet.Alias
+		si.MasterAlias = primary.Tablet.Alias
 		return nil
 	}); err != nil {
 		t.Fatalf("UpdateShardFields failed: %v", err)
 	}
 
-	// master action loop (to initialize host and port)
-	master.StartActionLoop(t, wr)
-	defer master.StopActionLoop(t)
+	// primary action loop (to initialize host and port)
+	primary.StartActionLoop(t, wr)
+	defer primary.StopActionLoop(t)
 
 	// replica loop
 	// We have to set the settings as replicating. Otherwise,
@@ -147,7 +147,7 @@ func TestReparentTablet(t *testing.T) {
 	// which ends up making this test unpredictable.
 	replica.FakeMysqlDaemon.Replicating = true
 	replica.FakeMysqlDaemon.IOThreadRunning = true
-	replica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(master.Tablet)
+	replica.FakeMysqlDaemon.SetReplicationSourceInput = topoproto.MysqlAddr(primary.Tablet)
 	replica.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
 		"STOP SLAVE",
 		"FAKE SET MASTER",

--- a/go/vt/wrangler/testlib/shard_test.go
+++ b/go/vt/wrangler/testlib/shard_test.go
@@ -39,13 +39,13 @@ func TestDeleteShardCleanup(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	// Create a master, a couple good replicas
-	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
+	// Create a primary, a couple good replicas
+	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, nil)
 	replica := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	remoteReplica := NewFakeTablet(t, wr, "cell2", 2, topodatapb.TabletType_REPLICA, nil)
 
 	// Build keyspace graph
-	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, master.Tablet.Keyspace, []string{"cell1", "cell2"}, false)
+	err := topotools.RebuildKeyspace(context.Background(), logutil.NewConsoleLogger(), ts, primary.Tablet.Keyspace, []string{"cell1", "cell2"}, false)
 	if err != nil {
 		t.Fatalf("RebuildKeyspaceLocked failed: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestDeleteShardCleanup(t *testing.T) {
 	// recursive flag, should fail on serving check first.
 	if err := vp.Run([]string{
 		"DeleteShard",
-		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+		primary.Tablet.Keyspace + "/" + primary.Tablet.Shard,
 	}); err == nil || !strings.Contains(err.Error(), "is still serving, cannot delete it") {
 		t.Fatalf("DeleteShard() returned wrong error: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestDeleteShardCleanup(t *testing.T) {
 	if err := vp.Run([]string{
 		"DeleteShard",
 		"-even_if_serving",
-		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+		primary.Tablet.Keyspace + "/" + primary.Tablet.Shard,
 	}); err == nil || !strings.Contains(err.Error(), "use -recursive or remove them manually") {
 		t.Fatalf("DeleteShard(evenIfServing=true) returned wrong error: %v", err)
 	}
@@ -80,20 +80,20 @@ func TestDeleteShardCleanup(t *testing.T) {
 		"DeleteShard",
 		"-recursive",
 		"-even_if_serving",
-		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+		primary.Tablet.Keyspace + "/" + primary.Tablet.Shard,
 	}); err != nil {
 		t.Fatalf("DeleteShard(recursive=true, evenIfServing=true) should have worked but returned: %v", err)
 	}
 
 	// Make sure all tablets are gone.
-	for _, ft := range []*FakeTablet{master, replica, remoteReplica} {
+	for _, ft := range []*FakeTablet{primary, replica, remoteReplica} {
 		if _, err := ts.GetTablet(ctx, ft.Tablet.Alias); !topo.IsErrType(err, topo.NoNode) {
 			t.Errorf("tablet %v is still in topo: %v", ft.Tablet.Alias, err)
 		}
 	}
 
 	// Make sure the shard is gone.
-	if _, err := ts.GetShard(ctx, master.Tablet.Keyspace, master.Tablet.Shard); !topo.IsErrType(err, topo.NoNode) {
-		t.Errorf("shard %v/%v is still in topo: %v", master.Tablet.Keyspace, master.Tablet.Shard, err)
+	if _, err := ts.GetShard(ctx, primary.Tablet.Keyspace, primary.Tablet.Shard); !topo.IsErrType(err, topo.NoNode) {
+		t.Errorf("shard %v/%v is still in topo: %v", primary.Tablet.Keyspace, primary.Tablet.Shard, err)
 	}
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Deprecate vtctl command flags that contain `master` and introduce replacements that use `primary` instead.
Full list is documented in linked issue.
Along the way I needed to make changes in `wranger/testlib` so I went through and cleaned up all references in that package.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#7114 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required (will be added to https://github.com/vitessio/website/pull/786)

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
All changes are fully backwards-compatible and will remain so in release 12. Old flags will be removed in release 13, so users are advised to change their scripts and tooling before then.