### PR TITLE
Return from throttler goroutine if context is cancelled to prevent goroutine leaks

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -271,6 +271,13 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 		for {
 			// check throttler.
 			if !vs.vse.throttlerClient.ThrottleCheckOKOrWait(ctx) {
+				select {
+				// make sure to leave if context is cancelled
+				case <-ctx.Done():
+					return
+				default:
+					// do nothing special
+				}
 				continue
 			}
 			select {


### PR DESCRIPTION
## Description
```
goroutine profile: total 5614
5423 @ 0x43b3c5 0x4059fa 0x405755 0x1346ceb 0x4728e1
#	0x1346cea	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvents.func2+0xaa	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:279
```
There are reports of these leaking goroutines causing OOMs. I have not been able to reproduce it. I think this can only happen if vstreamer is failing to parse events resulting in the context being cancelled, with some events still present in the `throttledEvents` channel. 
In the normal course of events, including errors that I can think of, we should not see this since the binlog streamer will close its channel causing the goroutine to return. So presumably there is an issue with this vreplication workflow causing these errors.

I  have updated the goroutine to look for context cancellations so these goroutines don't leak, hoping that this will fix this issue. I would be happier if we could have reproduced it to ensure the fix works. For now we can try it in the failing workflow.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
