### PR TITLE
boolean values should not be parenthesised in default clause

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -473,8 +473,9 @@ func (ct *ColumnType) Format(buf *TrackedBuffer) {
 	if ct.Options.Default != nil {
 		buf.astPrintf(ct, " %s", keywordStrings[DEFAULT])
 		_, isLiteral := ct.Options.Default.(*Literal)
+		_, isBool := ct.Options.Default.(BoolVal)
 		_, isNullVal := ct.Options.Default.(*NullVal)
-		if isLiteral || isNullVal || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
+		if isLiteral || isNullVal || isBool || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
 			buf.astPrintf(ct, " %v", ct.Options.Default)
 		} else {
 			buf.astPrintf(ct, " (%v)", ct.Options.Default)

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -673,8 +673,9 @@ func (ct *ColumnType) formatFast(buf *TrackedBuffer) {
 		buf.WriteByte(' ')
 		buf.WriteString(keywordStrings[DEFAULT])
 		_, isLiteral := ct.Options.Default.(*Literal)
+		_, isBool := ct.Options.Default.(BoolVal)
 		_, isNullVal := ct.Options.Default.(*NullVal)
-		if isLiteral || isNullVal || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
+		if isLiteral || isNullVal || isBool || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
 			buf.WriteByte(' ')
 			ct.Options.Default.formatFast(buf)
 		} else {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1179,6 +1179,9 @@ var (
 		input:  "create table function_default3 (x bool DEFAULT (true AND false));",
 		output: "create table function_default3 (\n\tx bool default (true and false)\n)",
 	}, {
+		input:  "create table function_default (x bool DEFAULT true);",
+		output: "create table function_default (\n\tx bool default true\n)",
+	}, {
 		input:  "create table a (\n\t`a` int\n)",
 		output: "create table a (\n\ta int\n)",
 	}, {


### PR DESCRIPTION

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Currently parsing the following query
```sql
create table function_default (x bool DEFAULT true)
```
gives the output
```sql
create table function_default (x bool DEFAULT (true))
```
but this is incorrect and will not work against MySQL5.7. This PR fixes it.

## Related Issues
- Fixes #8501 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
