### PR TITLE
mysql/server: abort connection if secure transport is required

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -370,6 +370,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	} else {
 		if l.RequireSecureTransport {
 			c.writeErrorPacketFromError(vterrors.Errorf(vtrpc.Code_UNAVAILABLE, "server does not allow insecure connections, client must use SSL/TLS"))
+			return
 		}
 		connCountByTLSVer.Add(versionNoTLS, 1)
 		defer connCountByTLSVer.Add(versionNoTLS, -1)


### PR DESCRIPTION
## Description

Found while reviewing https://github.com/vitessio/vitess/pull/8503 (by @dbussink). This is an actual error in the auth code, that should abort right away if TLS is required and the connection doesn't have it. The logic error has been there for a while.

I'm thinking this is probably worth a backport just for safety, even though it may not be exploitable. cc @deepthi 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->