### PR TITLE
Backport: Fixing multiple issues related to onlineddl/lifecycle

### DIFF
--- a/go/vt/schema/tablegc_test.go
+++ b/go/vt/schema/tablegc_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsGCTableName(t *testing.T) {
@@ -151,4 +152,17 @@ func TestParseGCLifecycle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateRenameStatementWithUUID(t *testing.T) {
+	uuid := "997342e3_e91d_11eb_aaae_0a43f95f28a3"
+	tableName := "mytbl"
+	countIterations := 5
+	toTableNames := map[string]bool{}
+	for i := 0; i < countIterations; i++ {
+		_, toTableName, err := GenerateRenameStatementWithUUID(tableName, PurgeTableGCState, OnlineDDLToGCUUID(uuid), time.Now().Add(time.Duration(i)*time.Second).UTC())
+		require.NoError(t, err)
+		toTableNames[toTableName] = true
+	}
+	assert.Equal(t, countIterations, len(toTableNames))
 }


### PR DESCRIPTION
Backport suggested by @deepthi in https://github.com/vitessio/vitess/pull/8500#issuecomment-884360924

## Description

Fixes #8498
Fixes #8499 (possibly)

- stale migration analysis did not update completed_timestamp. As result lifecycle would not run. Now that's fixed.
- retroactively updating completed_timestamp for existing NULL entries
- liveness_timestamp now always set with started_timestamp, so that it is never NULL even if migration didn't report liveness. This is essential for detecting and marking stale migrations
- when garbage collecting artifacts, RENAME statement would create collissions between artifacts of same migration. This is now solved by assigning distinct timestamps to artifacts of same migration
- on the safe side, though there is no evidence this ever happened, whenever an artifact is added, we set cleanup_timestamp to be NULL


## Related Issue(s)
- #8498 
- #8499 
- #6926 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
