### PR TITLE
[vtadmin] Fix bad copy-paste in pool config flag parsing

### DIFF
--- a/go/vt/vtadmin/cluster/flags.go
+++ b/go/vt/vtadmin/cluster/flags.go
@@ -172,8 +172,8 @@ func parseOne(cfg *Config, name string, val string) error {
 				return fmt.Errorf("error parsing %s: %w", name, err)
 			}
 		case strings.HasPrefix(name, "schema-read-pool-"):
-			if cfg.BackupReadPoolConfig == nil {
-				cfg.BackupReadPoolConfig = &RPCPoolConfig{
+			if cfg.SchemaReadPoolConfig == nil {
+				cfg.SchemaReadPoolConfig = &RPCPoolConfig{
 					Size:        -1,
 					WaitTimeout: -1,
 				}


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

Oops. I checked the rest of this section and fortunately this seems like the only mistake I made.

## Related Issue(s)


## Checklist
- [ ] Tests were added or are not required -- n/a
- [ ] Documentation was added or is not required -- n/a

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->