### PR TITLE
Clear only the current shard's schemacopy rows  during schema reload

### DIFF
--- a/go/mysql/endtoend/schema_change_test.go
+++ b/go/mysql/endtoend/schema_change_test.go
@@ -123,7 +123,7 @@ func TestChangeSchemaIsNoticed(t *testing.T) {
 				tables = append(tables, "table_name = "+sqlparser.String(apa))
 			}
 			tableNamePredicates := strings.Join(tables, " OR ")
-			del := fmt.Sprintf("%s WHERE %s", mysql.ClearSchemaCopy, tableNamePredicates)
+			del := fmt.Sprintf("%s AND %s", mysql.ClearSchemaCopy, tableNamePredicates)
 			upd := fmt.Sprintf("%s AND %s", mysql.InsertIntoSchemaCopy, tableNamePredicates)
 
 			_, err = conn.ExecuteFetch(del, 1000, true)

--- a/go/mysql/schema.go
+++ b/go/mysql/schema.go
@@ -89,7 +89,7 @@ where c.table_schema = database() AND ISC.table_schema is null`
 	DetectSchemaChange = detectChangeColumns + " UNION " + detectNewColumns + " UNION " + detectRemoveColumns
 
 	// ClearSchemaCopy query clears the schemacopy table.
-	ClearSchemaCopy = `delete from _vt.schemacopy`
+	ClearSchemaCopy = `delete from _vt.schemacopy where table_schema = database()`
 
 	// InsertIntoSchemaCopy query copies over the schema information from information_schema.columns table.
 	InsertIntoSchemaCopy = `insert _vt.schemacopy 

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -61,12 +61,6 @@ create table t8(
 	testId bigint,
 	primary key(id8)
 ) Engine=InnoDB;
-
-create table t9(
-	id9 bigint,
-	testId bigint,
-	primary key(id9)
-) Engine=InnoDB;
 `
 
 	VSchema = `
@@ -190,13 +184,16 @@ func TestNewTable(t *testing.T) {
 	defer connShard2.Close()
 
 	_ = exec(t, conn, "create table test_table (id bigint, name varchar(100))")
-	defer exec(t, conn, "drop table test_table")
 
 	time.Sleep(2 * time.Second)
 
 	assertMatches(t, conn, "select * from test_table", `[]`)
 	assertMatches(t, connShard1, "select * from test_table", `[]`)
 	assertMatches(t, connShard2, "select * from test_table", `[]`)
+
+	exec(t, conn, "drop table test_table")
+
+	time.Sleep(2 * time.Second)
 }
 
 func TestAmbiguousColumnJoin(t *testing.T) {

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -190,6 +190,7 @@ func TestNewTable(t *testing.T) {
 	defer connShard2.Close()
 
 	_ = exec(t, conn, "create table test_table (id bigint, name varchar(100))")
+	defer exec(t, conn, "drop table test_table")
 
 	time.Sleep(2 * time.Second)
 

--- a/go/vt/vttablet/tabletserver/health_streamer.go
+++ b/go/vt/vttablet/tabletserver/health_streamer.go
@@ -359,7 +359,7 @@ func (hs *healthStreamer) reload() error {
 	}
 
 	tableNamePredicate := fmt.Sprintf("table_name IN (%s)", strings.Join(tableNames, ", "))
-	del := fmt.Sprintf("%s WHERE %s", mysql.ClearSchemaCopy, tableNamePredicate)
+	del := fmt.Sprintf("%s AND %s", mysql.ClearSchemaCopy, tableNamePredicate)
 	upd := fmt.Sprintf("%s AND %s", mysql.InsertIntoSchemaCopy, tableNamePredicate)
 
 	// Reload the schema in a transaction.


### PR DESCRIPTION
## Description

This pull request makes VTTablet clear only the rows that match the current database name and the updated tables in `schemacopy` ; instead of clearing all the rows that match the updated tables. This will be useful for @GuptaManan100 when testing the Rails guide against a sharded cluster. 

VTTestServer uses a single MySQL instance where the different shards are suffixed in the `table_schema` column by their name (`-80`, `80-`, etc). Removing all the rows from the `schemacopy` tables was making the shards not agreeing and made them repetitively send schema updates to VTGate.

After testing VTTestServer with schema tracking enabled: it is preferable to lower the schema update interval in the VTTablets or add multiple timeouts in the Rails test suite. 

## Related Issue(s)

Resolves #8510


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
