### PR TITLE
naming: deprecate funcs and add new ones in TabletManagerClient interface

### DIFF
--- a/go/vt/vtcombo/tablet_map.go
+++ b/go/vt/vtcombo/tablet_map.go
@@ -731,7 +731,15 @@ func (itmc *internalTabletManagerClient) MasterStatus(ctx context.Context, table
 	return nil, fmt.Errorf("not implemented in vtcombo")
 }
 
+func (itmc *internalTabletManagerClient) PrimaryStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	return nil, fmt.Errorf("not implemented in vtcombo")
+}
+
 func (itmc *internalTabletManagerClient) MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
+	return "", fmt.Errorf("not implemented in vtcombo")
+}
+
+func (itmc *internalTabletManagerClient) PrimaryPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
 	return "", fmt.Errorf("not implemented in vtcombo")
 }
 
@@ -759,6 +767,10 @@ func (itmc *internalTabletManagerClient) InitMaster(ctx context.Context, tablet 
 	return "", fmt.Errorf("not implemented in vtcombo")
 }
 
+func (itmc *internalTabletManagerClient) InitPrimary(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
+	return "", fmt.Errorf("not implemented in vtcombo")
+}
+
 func (itmc *internalTabletManagerClient) PopulateReparentJournal(ctx context.Context, tablet *topodatapb.Tablet, timeCreatedNS int64, actionName string, masterAlias *topodatapb.TabletAlias, pos string) error {
 	return fmt.Errorf("not implemented in vtcombo")
 }
@@ -771,7 +783,19 @@ func (itmc *internalTabletManagerClient) UndoDemoteMaster(ctx context.Context, t
 	return fmt.Errorf("not implemented in vtcombo")
 }
 
+func (itmc *internalTabletManagerClient) DemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	return nil, fmt.Errorf("not implemented in vtcombo")
+}
+
+func (itmc *internalTabletManagerClient) UndoDemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) error {
+	return fmt.Errorf("not implemented in vtcombo")
+}
+
 func (itmc *internalTabletManagerClient) SetMaster(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartSlave bool) error {
+	return fmt.Errorf("not implemented in vtcombo")
+}
+
+func (itmc *internalTabletManagerClient) SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartSlave bool) error {
 	return fmt.Errorf("not implemented in vtcombo")
 }
 

--- a/go/vt/vttablet/faketmclient/fake_client.go
+++ b/go/vt/vttablet/faketmclient/fake_client.go
@@ -196,6 +196,11 @@ func (client *FakeTabletManagerClient) MasterStatus(ctx context.Context, tablet 
 	return &replicationdatapb.PrimaryStatus{}, nil
 }
 
+// PrimaryStatus is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) PrimaryStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	return &replicationdatapb.PrimaryStatus{}, nil
+}
+
 // StartReplication is part of the tmclient.TabletManagerClient interface.
 func (client *FakeTabletManagerClient) StartReplication(ctx context.Context, tablet *topodatapb.Tablet) error {
 	return nil
@@ -228,6 +233,11 @@ func (client *FakeTabletManagerClient) ReplicaWasRestarted(ctx context.Context, 
 
 // MasterPosition is part of the tmclient.TabletManagerClient interface.
 func (client *FakeTabletManagerClient) MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
+	return "", nil
+}
+
+// PrimaryPosition is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) PrimaryPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
 	return "", nil
 }
 
@@ -275,6 +285,11 @@ func (client *FakeTabletManagerClient) InitMaster(ctx context.Context, tablet *t
 	return "", nil
 }
 
+// InitPrimary is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) InitPrimary(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
+	return "", nil
+}
+
 // PopulateReparentJournal is part of the tmclient.TabletManagerClient interface.
 func (client *FakeTabletManagerClient) PopulateReparentJournal(ctx context.Context, tablet *topodatapb.Tablet, timeCreatedNS int64, actionName string, masterAlias *topodatapb.TabletAlias, position string) error {
 	return nil
@@ -290,8 +305,23 @@ func (client *FakeTabletManagerClient) UndoDemoteMaster(ctx context.Context, tab
 	return nil
 }
 
+// DemotePrimary is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) DemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	return nil, nil
+}
+
+// UndoDemotePrimary is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) UndoDemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) error {
+	return nil
+}
+
 // SetMaster is part of the tmclient.TabletManagerClient interface.
 func (client *FakeTabletManagerClient) SetMaster(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
+	return nil
+}
+
+// SetReplicationSource is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
 	return nil
 }
 

--- a/go/vt/vttablet/tmclient/rpc_client_api.go
+++ b/go/vt/vttablet/tmclient/rpc_client_api.go
@@ -112,8 +112,11 @@ type TabletManagerClient interface {
 	// Replication related methods
 	//
 
-	// MasterStatus returns the tablet's mysql master status.
+	// Deprecated MasterStatus returns the tablet's mysql master status.
 	MasterStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error)
+
+	// PrimaryStatus returns the tablet's mysql master status.
+	PrimaryStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error)
 
 	// ReplicationStatus returns the tablet's mysql replication status.
 	ReplicationStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.Status, error)
@@ -134,8 +137,11 @@ type TabletManagerClient interface {
 	// GetReplicas returns the addresses of the replicas
 	GetReplicas(ctx context.Context, tablet *topodatapb.Tablet) ([]string, error)
 
-	// MasterPosition returns the tablet's master position
+	// Deprecated MasterPosition returns the tablet's master position
 	MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error)
+
+	// PrimaryPosition returns the tablet's master position
+	PrimaryPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error)
 
 	// WaitForPosition waits for the position to be reached
 	WaitForPosition(ctx context.Context, tablet *topodatapb.Tablet, pos string) error
@@ -156,10 +162,15 @@ type TabletManagerClient interface {
 	// replication positions are reset.
 	ResetReplication(ctx context.Context, tablet *topodatapb.Tablet) error
 
-	// InitMaster tells a tablet to make itself the new master,
+	// Deprecated InitMaster tells a tablet to make itself the new master,
 	// and return the replication position the replicas should use to
 	// reparent to it.
 	InitMaster(ctx context.Context, tablet *topodatapb.Tablet) (string, error)
+
+	// InitPrimary tells a tablet to make itself the new primary,
+	// and return the replication position the replicas should use to
+	// reparent to it.
+	InitPrimary(ctx context.Context, tablet *topodatapb.Tablet) (string, error)
 
 	// PopulateReparentJournal asks the master to insert a row in
 	// its reparent_journal table.
@@ -170,21 +181,34 @@ type TabletManagerClient interface {
 	// reparent_journal table.
 	InitReplica(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, replicationPosition string, timeCreatedNS int64) error
 
-	// DemoteMaster tells the soon-to-be-former master it's going to change,
+	// Deprecated DemoteMaster tells the soon-to-be-former master it's going to change,
 	// and it should go read-only and return its current position.
 	DemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error)
 
-	// UndoDemoteMaster reverts all changes made by DemoteMaster
+	// Deprecated UndoDemoteMaster reverts all changes made by DemoteMaster
 	// To be used if we are unable to promote the chosen new master
 	UndoDemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) error
+
+	// DemotePrimary tells the soon-to-be-former primary it's going to change,
+	// and it should go read-only and return its current position.
+	DemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error)
+
+	// UndoDemotePrimary reverts all changes made by DemotePrimary
+	// To be used if we are unable to promote the chosen new primary
+	UndoDemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) error
 
 	// ReplicaWasPromoted tells the remote tablet it is now the master
 	ReplicaWasPromoted(ctx context.Context, tablet *topodatapb.Tablet) error
 
-	// SetMaster tells a tablet to start replicating from the
+	// Deprecated SetMaster tells a tablet to start replicating from the
 	// passed in master tablet alias, and wait for the row in the
 	// reparent_journal table (if timeCreatedNS is non-zero).
 	SetMaster(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error
+
+	// SetReplicationSource tells a tablet to start replicating from the
+	// passed in tablet alias, and wait for the row in the
+	// reparent_journal table (if timeCreatedNS is non-zero).
+	SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error
 
 	// ReplicaWasRestarted tells the replica tablet its master has changed
 	ReplicaWasRestarted(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias) error


### PR DESCRIPTION
## Description
Since we introduced new RPCs in #8473, #8512, #8513 and #8520 we need corresponding functions in the client interface.

## Related Issue(s)
#7114

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
