### PR TITLE
Backports of #8403 #8483 #8489 #8401 #8521 #8396 from main into release 11.0

### DIFF
--- a/go/test/endtoend/cluster/vtctl_process.go
+++ b/go/test/endtoend/cluster/vtctl_process.go
@@ -58,19 +58,11 @@ func (vtctl *VtctlProcess) AddCellInfo(Cell string) (err error) {
 
 // CreateKeyspace executes vtctl command to create keyspace
 func (vtctl *VtctlProcess) CreateKeyspace(keyspace string) (err error) {
-	tmpProcess := exec.Command(
-		vtctl.Binary,
-		"-topo_implementation", vtctl.TopoImplementation,
-		"-topo_global_server_address", vtctl.TopoGlobalAddress,
-		"-topo_global_root", vtctl.TopoGlobalRoot,
-	)
-	if *isCoverage {
-		tmpProcess.Args = append(tmpProcess.Args, "-test.coverprofile="+getCoveragePath("vtctl-create-ks.out"))
+	output, err := vtctl.ExecuteCommandWithOutput("CreateKeyspace", keyspace)
+	if err != nil {
+		log.Errorf("CreateKeyspace returned err: %s, output: %s", err, output)
 	}
-	tmpProcess.Args = append(tmpProcess.Args,
-		"CreateKeyspace", keyspace)
-	log.Infof("Running CreateKeyspace with command: %v", strings.Join(tmpProcess.Args, " "))
-	return tmpProcess.Run()
+	return err
 }
 
 // ExecuteCommandWithOutput executes any vtctlclient command and returns output

--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -3,7 +3,7 @@ package vreplication
 var (
 	initialProductSchema = `
 create table product(pid int, description varbinary(128), primary key(pid));
-create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, primary key(cid))  CHARSET=utf8mb4;
+create table customer(cid int, name varbinary(128), meta json default null, typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, bits bit(2) default b'11', primary key(cid))  CHARSET=utf8mb4;
 create table customer_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table merchant(mname varchar(128), category varchar(128), primary key(mname)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table orders(oid int, cid int, pid int, mname varchar(128), price int, qty int, total int as (qty * price), total2 int as (qty * price) stored, primary key(oid));

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -695,10 +695,7 @@ func DeleteVReplication(uid uint32) string {
 // MessageTruncate truncates the message string to a safe length.
 func MessageTruncate(msg string) string {
 	// message length is 1000 bytes.
-	if len(msg) > 950 {
-		return msg[:950] + "..."
-	}
-	return msg
+	return LimitString(msg, 950)
 }
 
 func encodeString(in string) string {

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -74,7 +74,7 @@ func (dc *dbClientImpl) Connect() error {
 func (dc *dbClientImpl) Begin() error {
 	_, err := dc.dbConn.ExecuteFetch("begin", 1, false)
 	if err != nil {
-		log.Errorf("BEGIN failed w/ error %v", err)
+		LogError("BEGIN failed w/ error", err)
 		dc.handleError(err)
 	}
 	return err
@@ -83,7 +83,7 @@ func (dc *dbClientImpl) Begin() error {
 func (dc *dbClientImpl) Commit() error {
 	_, err := dc.dbConn.ExecuteFetch("commit", 1, false)
 	if err != nil {
-		log.Errorf("COMMIT failed w/ error %v", err)
+		LogError("COMMIT failed w/ error", err)
 		dc.dbConn.Close()
 	}
 	return err
@@ -92,7 +92,7 @@ func (dc *dbClientImpl) Commit() error {
 func (dc *dbClientImpl) Rollback() error {
 	_, err := dc.dbConn.ExecuteFetch("rollback", 1, false)
 	if err != nil {
-		log.Errorf("ROLLBACK failed w/ error %v", err)
+		LogError("ROLLBACK failed w/ error", err)
 		dc.dbConn.Close()
 	}
 	return err
@@ -102,10 +102,22 @@ func (dc *dbClientImpl) Close() {
 	dc.dbConn.Close()
 }
 
+// LogError logs a message after truncating it to avoid spamming logs
+func LogError(msg string, err error) {
+	log.Errorf("%s: %s", msg, MessageTruncate(err.Error()))
+}
+
+// LimitString truncates string to specified size
+func LimitString(s string, limit int) string {
+	if len(s) > limit {
+		return s[:limit]
+	}
+	return s
+}
+
 func (dc *dbClientImpl) ExecuteFetch(query string, maxrows int) (*sqltypes.Result, error) {
 	mqr, err := dc.dbConn.ExecuteFetch(query, maxrows, true)
 	if err != nil {
-		log.Errorf("ExecuteFetch failed w/ error %v", err)
 		dc.handleError(err)
 		return nil, err
 	}

--- a/go/vt/binlog/binlogplayer/fake_dbclient.go
+++ b/go/vt/binlog/binlogplayer/fake_dbclient.go
@@ -68,10 +68,10 @@ func (dc *fakeDBClient) ExecuteFetch(query string, maxrows int) (qr *sqltypes.Re
 		if strings.Contains(query, "where") {
 			return sqltypes.MakeTestResult(
 				sqltypes.MakeTestFields(
-					"id|state|source",
-					"int64|varchar|varchar",
+					"id|state|source|message",
+					"int64|varchar|varchar|varchar",
 				),
-				`1|Running|keyspace:"ks" shard:"0" key_range:<end:"\200" > `,
+				`1|Running|keyspace:"ks" shard:"0" key_range:<end:"\200" > |`,
 			), nil
 		}
 		return &sqltypes.Result{}, nil

--- a/go/vt/discovery/tablet_picker.go
+++ b/go/vt/discovery/tablet_picker.go
@@ -114,8 +114,8 @@ func (tp *TabletPicker) PickForStreaming(ctx context.Context) (*topodatapb.Table
 		if len(candidates) == 0 {
 			// if no candidates were found, sleep and try again
 			tp.incNoTabletFoundStat()
-			log.Infof("No tablet found for streaming, shard %s.%s, cells %v, tabletTypes %v, sleeping for %d seconds",
-				tp.keyspace, tp.shard, tp.cells, tp.tabletTypes, int(GetTabletPickerRetryDelay()/1e9))
+			log.Infof("No tablet found for streaming, shard %s.%s, cells %v, tabletTypes %v, sleeping for %.3f seconds",
+				tp.keyspace, tp.shard, tp.cells, tp.tabletTypes, float64(GetTabletPickerRetryDelay().Milliseconds())/1000.0)
 			timer := time.NewTimer(GetTabletPickerRetryDelay())
 			select {
 			case <-ctx.Done():

--- a/go/vt/discovery/tablet_picker_test.go
+++ b/go/vt/discovery/tablet_picker_test.go
@@ -329,6 +329,7 @@ func TestPickError(t *testing.T) {
 	defer cancel()
 	_, err = tp.PickForStreaming(ctx)
 	require.EqualError(t, err, "context has expired")
+	require.Greater(t, globalTPStats.noTabletFoundError.Counts()["cell.ks.0.replica"], int64(0))
 }
 
 type pickerTestEnv struct {

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -243,7 +243,7 @@ func isByteComparable(v sqltypes.Value) bool {
 		return true
 	}
 	switch v.Type() {
-	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set, sqltypes.TypeJSON:
+	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Time, sqltypes.Datetime, sqltypes.Enum, sqltypes.Set, sqltypes.TypeJSON, sqltypes.Bit:
 		return true
 	}
 	return false

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -567,6 +567,21 @@ func TestNullsafeCompare(t *testing.T) {
 		v1:  TestValue(querypb.Type_DATETIME, "1000-01-01 00:00:00"),
 		v2:  TestValue(querypb.Type_BINARY, "2000-01-01 00:00:00"),
 		out: -1,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "101"),
+		v2:  TestValue(querypb.Type_BIT, "101"),
+		out: 0,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "1"),
+		v2:  TestValue(querypb.Type_BIT, "0"),
+		out: 1,
+	}, {
+		// Date/Time types
+		v1:  TestValue(querypb.Type_BIT, "0"),
+		v2:  TestValue(querypb.Type_BIT, "1"),
+		out: -1,
 	}}
 	for _, tcase := range tcases {
 		got, err := NullsafeCompare(tcase.v1, tcase.v2)

--- a/go/vt/vtgate/vindexes/consistent_lookup_test.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup_test.go
@@ -451,7 +451,6 @@ func TestConsistentLookupUpdateBecauseUncomparableTypes(t *testing.T) {
 		{querypb.Type_TEXT, "some string"},
 		{querypb.Type_VARCHAR, "some string"},
 		{querypb.Type_CHAR, "some string"},
-		{querypb.Type_BIT, "some string"},
 		{querypb.Type_GEOMETRY, "some string"},
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/controller.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller.go
@@ -160,7 +160,7 @@ func (ct *controller) run(ctx context.Context) {
 			return
 		default:
 		}
-		log.Errorf("stream %v: %v, retrying after %v", ct.id, err, *retryDelay)
+		binlogplayer.LogError(fmt.Sprintf("error in stream %v, retrying after %v", ct.id, *retryDelay), err)
 		ct.blpStats.ErrorCounts.Add([]string{"Stream Error"}, 1)
 		timer := time.NewTimer(*retryDelay)
 		select {

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -329,7 +329,7 @@ func (st *vrStats) register() {
 	stats.NewCountersFuncWithMultiLabels(
 		"VReplicationErrors",
 		"Errors during vreplication",
-		[]string{"workflow", "type"},
+		[]string{"workflow", "id", "type"},
 		func() map[string]int64 {
 			st.mu.Lock()
 			defer st.mu.Unlock()

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
+	"vitess.io/vitess/go/vt/sqlparser"
 
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -68,41 +71,43 @@ const (
 	LogError = "Error"
 )
 
-func getLastLog(dbClient *vdbClient, vreplID uint32) (int64, string, string, string, error) {
+func getLastLog(dbClient *vdbClient, vreplID uint32) (id int64, typ, state, message string, err error) {
 	var qr *sqltypes.Result
-	var err error
 	query := fmt.Sprintf("select id, type, state, message from _vt.vreplication_log where vrepl_id = %d order by id desc limit 1", vreplID)
 	if qr, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch); err != nil {
 		return 0, "", "", "", err
 	}
-	if len(qr.Rows) != 1 || len(qr.Rows[0]) != 4 {
+	if len(qr.Rows) != 1 {
 		return 0, "", "", "", nil
 	}
 	row := qr.Rows[0]
-	id, _ := evalengine.ToInt64(row[0])
-	typ := row[1].ToString()
-	state := row[2].ToString()
-	message := row[3].ToString()
+	id, _ = evalengine.ToInt64(row[0])
+	typ = row[1].ToString()
+	state = row[2].ToString()
+	message = row[3].ToString()
 	return id, typ, state, message, nil
 }
 
 func insertLog(dbClient *vdbClient, typ string, vreplID uint32, state, message string) error {
-	var query string
-
-	// getLastLog returns the last log for a stream. During insertion, if the id/type/state/message match we do not insert
+	// getLastLog returns the last log for a stream. During insertion, if the type/state/message match we do not insert
 	// a new log but increment the count. This prevents spamming of the log table in case the same message is logged continuously.
-	id, currentType, currentState, currentMessage, err := getLastLog(dbClient, vreplID)
+	id, _, lastLogState, lastLogMessage, err := getLastLog(dbClient, vreplID)
 	if err != nil {
 		return err
 	}
-
-	if id > 0 && typ == currentType && state == currentState && message == currentMessage {
+	if typ == LogStateChange && state == lastLogState {
+		// handles case where current state is Running, controller restarts after an error and initializes the state Running
+		return nil
+	}
+	var query string
+	if id > 0 && message == lastLogMessage {
 		query = fmt.Sprintf("update _vt.vreplication_log set count = count + 1 where id = %d", id)
 	} else {
-		query = `insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%d, '%s', '%s', %s)`
-		query = fmt.Sprintf(query, vreplID, typ, state, encodeString(message))
+		buf := sqlparser.NewTrackedBuffer(nil)
+		buf.Myprintf("insert into _vt.vreplication_log(vrepl_id, type, state, message) values(%s, %s, %s, %s)",
+			strconv.Itoa(int(vreplID)), encodeString(typ), encodeString(state), encodeString(message))
+		query = buf.ParsedQuery().Query
 	}
-
 	if _, err = withDDL.Exec(context.Background(), query, dbClient.ExecuteFetch); err != nil {
 		return fmt.Errorf("could not insert into log table: %v: %v", query, err)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -484,8 +484,8 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		if sql == "" {
 			sql = event.Dml
 		}
-		// If the event is for one of the AWS RDS "special" tables, we skip
-		if !strings.Contains(sql, " mysql.rds_") {
+		// If the event is for one of the AWS RDS "special" or pt-table-checksum tables, we skip
+		if !strings.Contains(sql, " mysql.rds_") && !strings.Contains(sql, " percona.checksums") {
 			// This is a player using statement based replication
 			if err := vp.vr.dbClient.Begin(); err != nil {
 				return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -410,7 +410,7 @@ func TestPlayerStatementModeWithFilter(t *testing.T) {
 	output := []string{
 		"begin",
 		"rollback",
-		"/update _vt.vreplication set message='Error: filter rules are not supported for SBR",
+		"/update _vt.vreplication set message='filter rules are not supported for SBR",
 	}
 
 	execStatements(t, input)
@@ -1568,7 +1568,7 @@ func TestPlayerDDL(t *testing.T) {
 	execStatements(t, []string{"alter table t1 add column val2 varchar(128)"})
 	expectDBClientQueries(t, []string{
 		"alter table t1 add column val2 varchar(128)",
-		"/update _vt.vreplication set message='Error: Duplicate",
+		"/update _vt.vreplication set message='Duplicate",
 	})
 	cancel()
 
@@ -2362,7 +2362,7 @@ func TestRestartOnVStreamEnd(t *testing.T) {
 
 	streamerEngine.Close()
 	expectDBClientQueries(t, []string{
-		"/update _vt.vreplication set message='Error: vstream ended'",
+		"/update _vt.vreplication set message='vstream ended'",
 	})
 	streamerEngine.Open()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -19,8 +19,11 @@ package vreplication
 import (
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+
+	"vitess.io/vitess/go/vt/sqlparser"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 
@@ -145,9 +148,8 @@ func newVReplicator(id uint32, source *binlogdatapb.BinlogSource, sourceVStreame
 func (vr *vreplicator) Replicate(ctx context.Context) error {
 	err := vr.replicate(ctx)
 	if err != nil {
-		log.Errorf("Replicate error: %s", err.Error())
-		if err := vr.setMessage(fmt.Sprintf("Error: %s", err.Error())); err != nil {
-			log.Errorf("Failed to set error state: %v", err)
+		if err := vr.setMessage(err.Error()); err != nil {
+			binlogplayer.LogError("Failed to set error state", err)
 		}
 	}
 	return err
@@ -333,11 +335,14 @@ func (vr *vreplicator) readSettings(ctx context.Context) (settings binlogplayer.
 }
 
 func (vr *vreplicator) setMessage(message string) error {
+	message = binlogplayer.MessageTruncate(message)
 	vr.stats.History.Add(&binlogplayer.StatsHistoryRecord{
 		Time:    time.Now(),
 		Message: message,
 	})
-	query := fmt.Sprintf("update _vt.vreplication set message=%v where id=%v", encodeString(binlogplayer.MessageTruncate(message)), vr.id)
+	buf := sqlparser.NewTrackedBuffer(nil)
+	buf.Myprintf("update _vt.vreplication set message=%s where id=%s", encodeString(message), strconv.Itoa(int(vr.id)))
+	query := buf.ParsedQuery().Query
 	if _, err := vr.dbClient.Execute(query); err != nil {
 		return fmt.Errorf("could not set message: %v: %v", query, err)
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -271,6 +271,13 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 		for {
 			// check throttler.
 			if !vs.vse.throttlerClient.ThrottleCheckOKOrWait(ctx) {
+				select {
+				// make sure to leave if context is cancelled
+				case <-ctx.Done():
+					return
+				default:
+					// do nothing special
+				}
 				continue
 			}
 			select {

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -253,10 +253,10 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 		}
 		// Perform the diff of source and target streams.
 		dr, err := td.diff(ctx, df.ts.wr, &rowsToCompare, debug, onlyPks)
-		dr.TableName = table
 		if err != nil {
 			return nil, vterrors.Wrap(err, "diff")
 		}
+		dr.TableName = table
 		diffReports[table] = dr
 	}
 	if format == "json" {


### PR DESCRIPTION
## Description
Backport of the following PRs from main into release 11.0:

* https://github.com/vitessio/vitess/pull/8403
Tablet Picker: add metric to record lack of available tablets

* https://github.com/vitessio/vitess/pull/8396
Ignore SBR statements from pt-table-checksum

* https://github.com/vitessio/vitess/pull/8483
Fix vreplication error metric

* https://github.com/vitessio/vitess/pull/8489
Return from throttler goroutine if context is cancelled to prevent goroutine leaks

* https://github.com/vitessio/vitess/pull/8401
VDiff: Add BIT datatype to list of byte comparable types 

* https://github.com/vitessio/vitess/pull/8521
Fix VReplication logging to file and db


