### PR TITLE
add question on backporting back to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 
 
 ## Checklist
+- [ ] Should this PR be backported?
 - [ ] Tests were added or are not required
 - [ ] Documentation was added or is not required
 


### PR DESCRIPTION
## Description
We used to have a question on the PR template asking whether the PR needed to be backported.
Adding that back because we have gone back to doing backports instead of forward merges.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
