### PR TITLE
Enable GitHub Actions concurrency feature

### DIFF
--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -2,6 +2,10 @@
 
 name: Cluster (11)
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/cluster_endtoend_11.yml
+++ b/.github/workflows/cluster_endtoend_11.yml
@@ -3,11 +3,10 @@
 name: Cluster (11)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (11)')
   cancel-in-progress: true
 
 jobs:
-
   build:
     name: Run endtoend tests on Cluster (11)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (12)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (12)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -3,7 +3,7 @@
 name: Cluster (12)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (12)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -3,7 +3,7 @@
 name: Cluster (13)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (13)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (13)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (13)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -3,7 +3,7 @@
 name: Cluster (14)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (14)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (14)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (14)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -3,7 +3,7 @@
 name: Cluster (15)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (15)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (15)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (15)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -3,7 +3,7 @@
 name: Cluster (16)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (16)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_16.yml
+++ b/.github/workflows/cluster_endtoend_16.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (16)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (16)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (17)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (17)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_17.yml
+++ b/.github/workflows/cluster_endtoend_17.yml
@@ -3,7 +3,7 @@
 name: Cluster (17)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (17)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (18)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (18)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -3,7 +3,7 @@
 name: Cluster (18)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (18)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -3,7 +3,7 @@
 name: Cluster (19)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (19)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_19.yml
+++ b/.github/workflows/cluster_endtoend_19.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (19)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (19)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (20)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (20)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_20.yml
+++ b/.github/workflows/cluster_endtoend_20.yml
@@ -3,7 +3,7 @@
 name: Cluster (20)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (20)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -3,7 +3,7 @@
 name: Cluster (21)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (21)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (21)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (21)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -3,7 +3,7 @@
 name: Cluster (22)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (22)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_22.yml
+++ b/.github/workflows/cluster_endtoend_22.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (22)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (22)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (23)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (23)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_23.yml
+++ b/.github/workflows/cluster_endtoend_23.yml
@@ -3,7 +3,7 @@
 name: Cluster (23)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (23)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -3,7 +3,7 @@
 name: Cluster (24)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (24)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_24.yml
+++ b/.github/workflows/cluster_endtoend_24.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (24)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (24)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (26)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (26)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_26.yml
+++ b/.github/workflows/cluster_endtoend_26.yml
@@ -3,7 +3,7 @@
 name: Cluster (26)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (26)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (mysql80)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (mysql80)')
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (mysql80)
     runs-on: ubuntu-20.04

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_declarative)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_declarative)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_declarative.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_declarative)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_declarative)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_ghost)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_ghost)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_ghost.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_ghost)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_ghost)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_revert)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_revert)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_revert)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_revert)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_singleton)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_singleton)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_singleton.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_singleton)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_singleton)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_vrepl)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl_stress)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_vrepl_stress)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_stress)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl_stress_suite)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_stress_suite)')
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_stress_suite)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (onlineddl_vrepl_suite)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (onlineddl_vrepl_suite)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -3,7 +3,7 @@
 name: Cluster (onlineddl_vrepl_suite)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (onlineddl_vrepl_suite)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (resharding)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (resharding)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_resharding.yml
+++ b/.github/workflows/cluster_endtoend_resharding.yml
@@ -3,7 +3,7 @@
 name: Cluster (resharding)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (resharding)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -3,7 +3,7 @@
 name: Cluster (resharding_bytes)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (resharding_bytes)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_resharding_bytes.yml
+++ b/.github/workflows/cluster_endtoend_resharding_bytes.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (resharding_bytes)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (resharding_bytes)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -3,7 +3,7 @@
 name: Cluster (tabletmanager_tablegc)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_tablegc)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_tablegc)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_tablegc)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_throttler)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler.yml
@@ -3,7 +3,7 @@
 name: Cluster (tabletmanager_throttler)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_throttler)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -3,7 +3,7 @@
 name: Cluster (tabletmanager_throttler_custom_config)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (tabletmanager_throttler_custom_config)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_custom_config.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (tabletmanager_throttler_custom_config)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (tabletmanager_throttler_custom_config)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -3,7 +3,7 @@
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_basic)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -3,7 +3,7 @@
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_cellalias)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_cellalias)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_cellalias)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -3,7 +3,7 @@
 name: Cluster (vreplication_migrate)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_migrate)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_migrate)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_migrate)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -3,7 +3,7 @@
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_multicell)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_multicell.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multicell.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_multicell)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_multicell)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -3,7 +3,7 @@
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_v2)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_buffer)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_buffer)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_buffer.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_buffer.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_buffer)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_buffer)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_concurrentdml)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_concurrentdml)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_concurrentdml)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_concurrentdml)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_gen4)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_gen4)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_gen4)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_gen4)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_readafterwrite)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_readafterwrite)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_readafterwrite)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_readafterwrite)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_reservedconn)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_reservedconn)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_reservedconn)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_reservedconn)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_schema)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_schema)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_schema)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_schema)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_topo)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_topo)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_topo)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_topo)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_transaction)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_transaction)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_transaction)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_transaction)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_unsharded)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_unsharded)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_unsharded)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_unsharded)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_vindex)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_vindex)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_vindex.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_vindex)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vindex)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtgate_vschema)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtgate_vschema)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtgate_vschema)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtgate_vschema)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -3,7 +3,7 @@
 name: Cluster (vtorc)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtorc)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (vtorc)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
     runs-on: ubuntu-18.04

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -3,7 +3,7 @@
 name: Cluster (xb_recovery)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (xb_recovery)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -2,8 +2,11 @@
 
 name: Cluster (xb_recovery)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on Cluster (xb_recovery)
     runs-on: ubuntu-18.04

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -3,7 +3,7 @@
 name: Unit Test (mariadb102)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Unit Test (mariadb102)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_test_mariadb102.yml
+++ b/.github/workflows/unit_test_mariadb102.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mariadb102)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mariadb103)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mariadb103.yml
+++ b/.github/workflows/unit_test_mariadb103.yml
@@ -3,7 +3,7 @@
 name: Unit Test (mariadb103)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Unit Test (mariadb103)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mysql57)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -3,7 +3,7 @@
 name: Unit Test (mysql57)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Unit Test (mysql57)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -3,7 +3,7 @@
 name: Unit Test (mysql80)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Unit Test (mysql80)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (mysql80)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -3,7 +3,7 @@
 name: Unit Test (percona56)
 on: [push, pull_request]
 concurrency:
-  group: ${{ github.ref }}
+  group: format('{0}-{1}', ${{ github.ref }}, 'Unit Test (percona56)')
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_test_percona56.yml
+++ b/.github/workflows/unit_test_percona56.yml
@@ -2,8 +2,11 @@
 
 name: Unit Test (percona56)
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -1,7 +1,7 @@
 name: {{.Name}}
 on: [push, pull_request]
 concurrency:
-  group: ${{"{{"}} github.ref {{"}}"}}
+  group: format('{0}-{1}', ${{"{{"}} github.ref {{"}}"}}, '{{.Name}}')
   cancel-in-progress: true
 
 jobs:

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -1,7 +1,10 @@
 name: {{.Name}}
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{"{{"}} github.ref {{"}}"}}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Run endtoend tests on {{.Name}}
     {{if .Ubuntu20}}runs-on: ubuntu-20.04{{else}}runs-on: ubuntu-18.04{{end}}

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -1,7 +1,7 @@
 name: {{.Name}}
 on: [push, pull_request]
 concurrency:
-  group: ${{"{{"}} github.ref {{"}}"}}
+  group: format('{0}-{1}', ${{"{{"}} github.ref {{"}}"}}, '{{.Name}}')
   cancel-in-progress: true
 
 jobs:

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -1,7 +1,10 @@
 name: {{.Name}}
 on: [push, pull_request]
-jobs:
+concurrency:
+  group: ${{"{{"}} github.ref {{"}}"}}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-18.04
 


### PR DESCRIPTION
## Description

This pull request is the second attempt at introducing GitHub Actions [concurrency feature](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) into our builds. The goal is to limit the overall number of queued and in-progress builds for this repository.

## How does it work?

When a new commit is added to a pull request, GitHub Actions will add each workflow to groups. Groups are defined like this: `branch_name + workflow_name`, thus every workflow of the pull request's branch will be in their own unique group. GitHub Actions concurrency feature uses these groups to cancel workflow when new workflows (due to a new commit being pushed) are added to the queue. If for a given group there is a more recent workflow in the queue, the older workflows of the same group will be canceled by GitHub Actions, and only the most recent one will be executed.

## Demo

In this pull request commits, the commit 7f3acfb was pushed, and very soon after the empty commit 89ff009 was also pushed. In the build status of 7f3acfb, we can see that most of the builds are marked as canceled, this is due to 89ff009 being pushed.

## Related Issue(s)
#8432 