### PR TITLE
Updated Makefile do_release script to include godoc steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ endif
 	git add --all
 	git commit -n -s -m "Release commit for $(RELEASE_VERSION)" 
 	git tag -m Version\ $(RELEASE_VERSION) v$(RELEASE_VERSION)
+	git tag -a v$(GODOC_RELEASE_VERSION) -m "Tagging $(RELEASE_VERSION) also as $(GODOC_RELEASE_VERSION) for godoc/go modules"
 	cd java && mvn versions:set -DnewVersion=$(DEV_VERSION)
 	echo package servenv > go/vt/servenv/version.go
 	echo  >> go/vt/servenv/version.go
@@ -357,8 +358,8 @@ endif
 	git add --all
 	git commit -n -s -m "Back to dev mode"
 	echo "Release preparations successful" 
-	echo "A git tag was created, you can push it with:"
-	echo "   git push upstream v$(RELEASE_VERSION)"
+	echo "Two git tags were created, you can push them with:"
+	echo "   git push upstream v$(RELEASE_VERSION) && git push upstream v$(GODOC_RELEASE_VERSION)"
 	echo "The git branch has also been updated. You need to push it and get it merged"
 
 tools:


### PR DESCRIPTION
## Description

This pull request modifies the `do_release` target of the Makefile to include the steps to create the godoc / go modules tags.

The `do_release` must be called as followed: 

```
make RELEASE_VERSION="11.0.1" GODOC_RELEASE_VERSION="0.11.1" DEV_VERSION="11.0.2-SNAPSHOT" do_release
```

The process google docs has been updated accordingly.

cc @systay @askdba 