### PR TITLE
support grpc reflection on APIs

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/reflection"
 
 	"context"
 
@@ -212,6 +213,9 @@ func serveGRPC() {
 	if GRPCPort == nil || *GRPCPort == 0 {
 		return
 	}
+
+	// register reflection to support list calls :)
+	reflection.Register(GRPCServer)
 
 	// listen on the port
 	log.Infof("Listening for gRPC calls on port %v", *GRPCPort)


### PR DESCRIPTION
Signed-off-by: Josh Chorlton <choo@stripe.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Just registers the grpc server in `servenv` as part of the [reflection API](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md). This should allow us to run `grpcurl ... list`.

It's just a nice-to-have convenience thing. It's more useful as vitess combines servers into a single entrypoint with servers activated by flag, so we can trivially tell what RPCs are available without digging through source.

## Related Issue(s)
N/A

## Checklist
- [ x] Tests were added or are not required
- [ x] Documentation was added or is not required

## Deployment Notes
I'd appreciate some help testing this. I tried to get a quick vitess server up and running just to make sure it didn't crash on boot. I couldn't find instructions, and couldn't find a grpc server that was trivial to start without e.g. a valid topo-srv running. Is there a good way to test this without hacking about in docker compose or other and getting the whole stack running?