### PR TITLE
Change local example to use v2 vreplication flows and change default to v2 from v1

### DIFF
--- a/examples/local/202_move_tables.sh
+++ b/examples/local/202_move_tables.sh
@@ -19,4 +19,4 @@
 
 source ./env.sh
 
-vtctlclient MoveTables -workflow=commerce2customer commerce customer '{"customer":{}, "corder":{}}'
+vtctlclient MoveTables -source commerce -tables 'customer,corder' Create customer.commerce2customer

--- a/examples/local/203_switch_reads.sh
+++ b/examples/local/203_switch_reads.sh
@@ -19,5 +19,4 @@
 
 source ./env.sh
 
-vtctlclient SwitchReads -tablet_type=rdonly customer.commerce2customer
-vtctlclient SwitchReads -tablet_type=replica customer.commerce2customer
+vtctlclient MoveTables -tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer

--- a/examples/local/204_switch_writes.sh
+++ b/examples/local/204_switch_writes.sh
@@ -19,4 +19,4 @@
 
 source ./env.sh
 
-vtctlclient SwitchWrites customer.commerce2customer
+vtctlclient MoveTables -tablet_types=master SwitchTraffic customer.commerce2customer

--- a/examples/local/205_clean_commerce.sh
+++ b/examples/local/205_clean_commerce.sh
@@ -19,5 +19,5 @@
 
 source ./env.sh
 
-vtctlclient DropSources customer.commerce2customer
+vtctlclient MoveTables Complete customer.commerce2customer
 

--- a/examples/local/303_reshard.sh
+++ b/examples/local/303_reshard.sh
@@ -19,4 +19,4 @@
 
 source ./env.sh
 
-vtctlclient Reshard customer.cust2cust '0' '-80,80-'
+vtctlclient Reshard -source_shards '0' -target_shards '-80,80-' Create customer.cust2cust

--- a/examples/local/304_switch_reads.sh
+++ b/examples/local/304_switch_reads.sh
@@ -18,5 +18,4 @@
 
 source ./env.sh
 
-vtctlclient SwitchReads -tablet_type=rdonly customer.cust2cust
-vtctlclient SwitchReads -tablet_type=replica customer.cust2cust
+vtctlclient Reshard -tablet_types=rdonly,replica SwitchTraffic customer.cust2cust

--- a/examples/local/305_switch_writes.sh
+++ b/examples/local/305_switch_writes.sh
@@ -18,4 +18,4 @@
 
 source ./env.sh
 
-vtctlclient SwitchWrites customer.cust2cust
+vtctlclient Reshard -tablet_types=master SwitchTraffic customer.cust2cust

--- a/examples/local/306_down_shard_0.sh
+++ b/examples/local/306_down_shard_0.sh
@@ -17,6 +17,8 @@
 
 source ./env.sh
 
+vtctlclient Reshard Complete customer.cust2cust
+
 for i in 200 201 202; do
 	CELL=zone1 TABLET_UID=$i ./scripts/vttablet-down.sh
 	CELL=zone1 TABLET_UID=$i ./scripts/mysqlctl-down.sh

--- a/examples/region_sharding/203_reshard.sh
+++ b/examples/region_sharding/203_reshard.sh
@@ -16,4 +16,4 @@
 
 source ./env.sh
 
-vtctlclient Reshard -tablet_types=MASTER main.main2regions '0' '-40,40-80,80-c0,c0-'
+vtctlclient Reshard -v1 -tablet_types=MASTER main.main2regions '0' '-40,40-80,80-c0,c0-'

--- a/go/test/endtoend/recovery/pitr/shardedpitr_test.go
+++ b/go/test/endtoend/recovery/pitr/shardedpitr_test.go
@@ -299,7 +299,7 @@ func performResharding(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Reshard", "ks.reshardWorkflow", "0", "-80,80-")
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("Reshard", "-v1", "ks.reshardWorkflow", "0", "-80,80-")
 	require.NoError(t, err)
 
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("SwitchReads", "-tablet_type=rdonly", "ks.reshardWorkflow")

--- a/go/test/endtoend/vreplication/helper.go
+++ b/go/test/endtoend/vreplication/helper.go
@@ -167,10 +167,13 @@ func getQueryCount(url string, query string) int {
 func validateDryRunResults(t *testing.T, output string, want []string) {
 	t.Helper()
 	require.NotEmpty(t, output)
-
 	gotDryRun := strings.Split(output, "\n")
 	require.True(t, len(gotDryRun) > 3)
-	gotDryRun = gotDryRun[3 : len(gotDryRun)-1]
+	startRow := 3
+	if strings.Contains(gotDryRun[0], "deprecated") {
+		startRow = 4
+	}
+	gotDryRun = gotDryRun[startRow : len(gotDryRun)-1]
 	if len(want) != len(gotDryRun) {
 		t.Fatalf("want and got: lengths don't match, \nwant\n%s\n\ngot\n%s", strings.Join(want, "\n"), strings.Join(gotDryRun, "\n"))
 	}

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -94,7 +94,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 	} else {
 		args = append(args, "Reshard")
 	}
-	args = append(args, "-v2")
+
 	switch action {
 	case workflowActionCreate:
 		if currentWorkflowType == wrangler.MoveTablesWorkflow {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -477,7 +477,7 @@ func reshard(t *testing.T, ksName string, tableName string, workflow string, sou
 				t.Fatal(err)
 			}
 		}
-		if err := vc.VtctlClient.ExecuteCommand("Reshard", "-cells="+sourceCellOrAlias, "-tablet_types=replica,master", ksWorkflow, sourceShards, targetShards); err != nil {
+		if err := vc.VtctlClient.ExecuteCommand("Reshard", "-v1", "-cells="+sourceCellOrAlias, "-tablet_types=replica,master", ksWorkflow, sourceShards, targetShards); err != nil {
 			t.Fatalf("Reshard command failed with %+v\n", err)
 		}
 		tablets := vc.getVttabletsInKeyspace(t, defaultCell, ksName, "master")
@@ -819,7 +819,7 @@ func catchup(t *testing.T, vttablet *cluster.VttabletProcess, workflow, info str
 }
 
 func moveTables(t *testing.T, cell, workflow, sourceKs, targetKs, tables string) {
-	if err := vc.VtctlClient.ExecuteCommand("MoveTables", "-cells="+cell, "-workflow="+workflow,
+	if err := vc.VtctlClient.ExecuteCommand("MoveTables", "-v1", "-cells="+cell, "-workflow="+workflow,
 		"-tablet_types="+"master,replica,rdonly", sourceKs, targetKs, tables); err != nil {
 		t.Fatalf("MoveTables command failed with %+v\n", err)
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1841,19 +1841,29 @@ func commandValidateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlag
 	return wr.ValidateKeyspace(ctx, keyspace, *pingTablets)
 }
 
-func commandReshard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+func useV1(args []string) bool {
 	for _, arg := range args {
-		if arg == "-v2" {
-			fmt.Println("*** Using Reshard v2 flow ***")
-			return commandVRWorkflow(ctx, wr, subFlags, args, wrangler.ReshardWorkflow)
+		if arg == "-v1" {
+			return true
 		}
 	}
+	return false
+}
+
+func commandReshard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	if !useV1(args) {
+		log.Infof("*** Using Reshard v2 flow ***")
+		return commandVRWorkflow(ctx, wr, subFlags, args, wrangler.ReshardWorkflow)
+	}
+	wr.Logger().Printf("*** The Reshard v1 flow is deprecated, consider using v2 commands instead, see https://vitess.io/docs/reference/vreplication/v2/ ***\n")
+
 	cells := subFlags.String("cells", "", "Cell(s) or CellAlias(es) (comma-separated) to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from.")
 	skipSchemaCopy := subFlags.Bool("skip_schema_copy", false, "Skip copying of schema to targets")
 
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
+	_ = subFlags.Bool("v1", true, "")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -1872,12 +1882,12 @@ func commandReshard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.F
 }
 
 func commandMoveTables(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	for _, arg := range args {
-		if arg == "-v2" {
-			fmt.Println("*** Using MoveTables v2 flow ***")
-			return commandVRWorkflow(ctx, wr, subFlags, args, wrangler.MoveTablesWorkflow)
-		}
+	if !useV1(args) {
+		log.Infof("*** Using MoveTables v2 flow ***")
+		return commandVRWorkflow(ctx, wr, subFlags, args, wrangler.MoveTablesWorkflow)
 	}
+	wr.Logger().Printf("*** The MoveTables v1 flow is deprecated, consider using v2 commands instead, see https://vitess.io/docs/reference/vreplication/v2/ ***\n")
+
 	workflow := subFlags.String("workflow", "", "Workflow name. Can be any descriptive string. Will be used to later migrate traffic via SwitchReads/SwitchWrites.")
 	cells := subFlags.String("cells", "", "Cell(s) or CellAlias(es) (comma-separated) to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from (e.g. master, replica, rdonly). Defaults to -vreplication_tablet_type parameter value for the tablet, which has the default value of replica.")
@@ -1886,6 +1896,7 @@ func commandMoveTables(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 
 	autoStart := subFlags.Bool("auto_start", true, "If false, streams will start in the Stopped state and will need to be explicitly started")
 	stopAfterCopy := subFlags.Bool("stop_after_copy", false, "Streams will be stopped once the copy phase is completed")
+	_ = subFlags.Bool("v1", true, "")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -1941,7 +1952,7 @@ func getSourceKeyspace(clusterKeyspace string) (clusterName string, sourceKeyspa
 }
 
 // commandVRWorkflow is the common entry point for MoveTables/Reshard/Migrate workflows
-// FIXME: this needs a refactor. Also validations for params need to be done per workflow type
+// FIXME: this function needs a refactor. Also validations for params should to be done per workflow type
 func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string,
 	workflowType wrangler.VReplicationWorkflowType) error {
 
@@ -2269,8 +2280,8 @@ func commandVRWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 			return nil
 		}
 	}
-	wr.Logger().Printf("%s was successful\nStart State: %s\nCurrent State: %s\n\n",
-		originalAction, startState, wf.CurrentState())
+	wr.Logger().Printf("%s was successful for workflow %s.%s\nStart State: %s\nCurrent State: %s\n\n",
+		originalAction, vrwp.TargetKeyspace, vrwp.Workflow, startState, wf.CurrentState())
 	return nil
 }
 
@@ -2451,6 +2462,7 @@ func commandMigrateServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandDropSources(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	wr.Logger().Printf("*** DropSources is deprecated. Consider using v2 commands instead, see https://vitess.io/docs/reference/vreplication/v2/ ***\n")
 	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of commandDropSources and only reports the actions to be taken")
 	renameTables := subFlags.Bool("rename_tables", false, "Rename tables instead of dropping them")
 	keepData := subFlags.Bool("keep_data", false, "Do not drop tables or shards (if true, only vreplication artifacts are cleaned up)")
@@ -2483,6 +2495,8 @@ func commandDropSources(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandSwitchReads(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	wr.Logger().Printf("*** SwitchReads is deprecated. Consider using v2 commands instead, see https://vitess.io/docs/reference/vreplication/v2/ ***\n")
+
 	reverse := subFlags.Bool("reverse", false, "Moves the served tablet type backward instead of forward.")
 	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
 	tabletTypes := subFlags.String("tablet_types", "rdonly,replica", "Tablet types to switch one or both or rdonly/replica")
@@ -2536,8 +2550,10 @@ func commandSwitchReads(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandSwitchWrites(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	timeout := subFlags.Duration("timeout", 30*time.Second, "Specifies the maximum time to wait, in seconds, for vreplication to catch up on write migrations. The migration will be cancelled on a timeout.")
-	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "DEPRECATED Specifies the maximum time to wait, in seconds, for vreplication to catch up on write migrations. The migration will be cancelled on a timeout.")
+	wr.Logger().Printf("*** SwitchWrites is deprecated. Consider using v2 commands instead, see https://vitess.io/docs/reference/vreplication/v2/ ***\n")
+
+	timeout := subFlags.Duration("timeout", 30*time.Second, "Specifies the maximum time to wait, in seconds, for vreplication to catch up on primary migrations. The migration will be cancelled on a timeout.")
+	filteredReplicationWaitTime := subFlags.Duration("filtered_replication_wait_time", 30*time.Second, "DEPRECATED Specifies the maximum time to wait, in seconds, for vreplication to catch up on primary migrations. The migration will be cancelled on a timeout.")
 	reverseReplication := subFlags.Bool("reverse_replication", true, "Also reverse the replication")
 	cancel := subFlags.Bool("cancel", false, "Cancel the failed migration and serve from source")
 	reverse := subFlags.Bool("reverse", false, "Reverse a previous SwitchWrites serve from source")

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -81,5 +81,7 @@ sleep 3 # TODO: Required for now!
 mysql --table < ../common/select_customer-80_data.sql
 mysql --table < ../common/select_customer80-_data.sql
 
+./306_down_shard_0.sh
+
 ./401_teardown.sh
 


### PR DESCRIPTION
## Description

This PR 
* makes v2 flows as the default and requires `-v1` to be specified to use the v1 `MoveTables` or `Reshard`
* changes the local examples to use the v2 vreplication CLI UX. 
* The vitess.io documentation has been updated at [https://github.com/vitessio/website/pull/784](https://github.com/vitessio/website/pull/784). It will be merged once 10.0 docs are archived.
* V1 tests have been modified to add the `v1` parameter to the `MoveTables` and `Reshard` vtctl commands
* V2 tests have been modified to remove the `v2` parameter to the vtctl commands
* A deprecation statement is displayed if the v1 commands are used

## Notes 
* The v2 flows have been around for over six months know. Since they are not the default, they have not seen a lot of usage in the field. So we continue to call the v2 flow as experimental and make it the default to push it forward.
* This was first merged  in 11.0. Here we are merging the same commit into main.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
