### PR TITLE
srvtopo: resilient watcher

### DIFF
--- a/go/vt/srvtopo/query.go
+++ b/go/vt/srvtopo/query.go
@@ -1,0 +1,163 @@
+package srvtopo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/log"
+)
+
+type queryEntry struct {
+	// immutable values
+	rw  *resilientWatcher
+	key fmt.Stringer
+
+	// the mutex protects any access to this structure (read or write)
+	mutex sync.Mutex
+
+	// refreshingChan is used to synchronize requests and avoid hammering
+	// the topo server
+	refreshingChan chan struct{}
+
+	insertionTime time.Time
+	lastQueryTime time.Time
+	value         interface{}
+	lastError     error
+	lastErrorCtx  context.Context
+}
+
+type resilientQuery struct {
+	query func(ctx context.Context, entry *queryEntry) (interface{}, error)
+
+	counts       *stats.CountersWithSingleLabel
+	cacheRefresh time.Duration
+	cacheTTL     time.Duration
+
+	mutex   sync.Mutex
+	entries map[string]*queryEntry
+}
+
+func (q *resilientQuery) getCurrentValue(ctx context.Context, wkey fmt.Stringer, staleOK bool) (interface{}, error) {
+	q.counts.Add(queryCategory, 1)
+
+	// find the entry in the cache, add it if not there
+	key := wkey.String()
+	q.mutex.Lock()
+	entry, ok := q.entries[key]
+	if !ok {
+		entry = &queryEntry{
+			key: wkey,
+		}
+		q.entries[key] = entry
+	}
+	q.mutex.Unlock()
+
+	// Lock the entry, and do everything holding the lock except
+	// querying the underlying topo server.
+	//
+	// This means that even if the topo server is very slow, two concurrent
+	// requests will only issue one underlying query.
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+
+	cacheValid := entry.value != nil && (time.Since(entry.insertionTime) < q.cacheTTL)
+	if !cacheValid && staleOK {
+		// Only allow stale results for a bounded period
+		cacheValid = entry.value != nil && (time.Since(entry.insertionTime) < (q.cacheTTL + 2*q.cacheRefresh))
+	}
+	shouldRefresh := time.Since(entry.lastQueryTime) > q.cacheRefresh
+
+	// If it is not time to check again, then return either the cached
+	// value or the cached error but don't ask topo again.
+	if !shouldRefresh {
+		if cacheValid {
+			return entry.value, nil
+		}
+		return nil, entry.lastError
+	}
+
+	// Refresh the state in a background goroutine if no refresh is already
+	// in progress none is already running. This way queries are not blocked
+	// while the cache is still valid but past the refresh time, and avoids
+	// calling out to the topo service while the lock is held.
+	if entry.refreshingChan == nil {
+		entry.refreshingChan = make(chan struct{})
+		entry.lastQueryTime = time.Now()
+
+		go func() {
+			defer func() {
+				if err := recover(); err != nil {
+					log.Errorf("ResilientQuery uncaught panic, cell :%v, err :%v)", key, err)
+				}
+			}()
+
+			newCtx, cancel := context.WithTimeout(ctx, *srvTopoTimeout)
+			defer cancel()
+
+			result, err := q.query(newCtx, entry)
+
+			entry.mutex.Lock()
+			defer func() {
+				close(entry.refreshingChan)
+				entry.refreshingChan = nil
+				entry.mutex.Unlock()
+			}()
+
+			if err == nil {
+				// save the value we got and the current time in the cache
+				entry.insertionTime = time.Now()
+				// Avoid a tiny race if TTL == refresh time (the default)
+				entry.lastQueryTime = entry.insertionTime
+				entry.value = result
+			} else {
+				q.counts.Add(errorCategory, 1)
+				if entry.insertionTime.IsZero() {
+					log.Errorf("ResilientQuery(%v, %v) failed: %v (no cached value, caching and returning error)", ctx, wkey, err)
+				} else if newCtx.Err() == context.DeadlineExceeded {
+					log.Errorf("ResilientQuery(%v, %v) failed: %v (request timeout), (keeping cached value: %v)", ctx, wkey, err, entry.value)
+				} else if entry.value != nil && time.Since(entry.insertionTime) < q.cacheTTL {
+					q.counts.Add(cachedCategory, 1)
+					log.Warningf("ResilientQuery(%v, %v) failed: %v (keeping cached value: %v)", ctx, wkey, err, entry.value)
+				} else {
+					log.Errorf("ResilientQuery(%v, %v) failed: %v (cached value expired)", ctx, wkey, err)
+					entry.insertionTime = time.Time{}
+					entry.value = nil
+				}
+			}
+
+			entry.lastError = err
+			entry.lastErrorCtx = newCtx
+		}()
+	}
+
+	// If the cached entry is still valid then use it, otherwise wait
+	// for the refresh attempt to complete to get a more up to date
+	// response.
+	//
+	// In the event that the topo service is slow or unresponsive either
+	// on the initial fetch or if the cache TTL expires, then several
+	// requests could be blocked on refreshingCond waiting for the response
+	// to come back.
+	if cacheValid {
+		return entry.value, nil
+	}
+
+	refreshingChan := entry.refreshingChan
+	entry.mutex.Unlock()
+	select {
+	case <-refreshingChan:
+	case <-ctx.Done():
+		entry.mutex.Lock()
+		return nil, fmt.Errorf("timed out waiting for keyspace names")
+	}
+	entry.mutex.Lock()
+
+	if entry.value != nil {
+		return entry.value, nil
+	}
+
+	return nil, entry.lastError
+}

--- a/go/vt/srvtopo/query.go
+++ b/go/vt/srvtopo/query.go
@@ -12,7 +12,6 @@ import (
 
 type queryEntry struct {
 	// immutable values
-	rw  *resilientWatcher
 	key fmt.Stringer
 
 	// the mutex protects any access to this structure (read or write)

--- a/go/vt/srvtopo/query_srvkeyspacenames.go
+++ b/go/vt/srvtopo/query_srvkeyspacenames.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package srvtopo
 
 import (
@@ -19,11 +35,11 @@ func NewSrvKeyspaceNamesQuery(topoServer *topo.Server, counts *stats.CountersWit
 	}
 
 	rq := &resilientQuery{
-		query:        query,
-		counts:       counts,
-		cacheRefresh: cacheRefresh,
-		cacheTTL:     cacheTTL,
-		entries:      make(map[string]*queryEntry),
+		query:                query,
+		counts:               counts,
+		cacheRefreshInterval: cacheRefresh,
+		cacheTTL:             cacheTTL,
+		entries:              make(map[string]*queryEntry),
 	}
 
 	return &SrvKeyspaceNamesQuery{rq}

--- a/go/vt/srvtopo/query_srvkeyspacenames.go
+++ b/go/vt/srvtopo/query_srvkeyspacenames.go
@@ -1,0 +1,56 @@
+package srvtopo
+
+import (
+	"context"
+	"time"
+
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+type SrvKeyspaceNamesQuery struct {
+	*resilientQuery
+}
+
+func NewSrvKeyspaceNamesQuery(topoServer *topo.Server, counts *stats.CountersWithSingleLabel, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceNamesQuery {
+	query := func(ctx context.Context, entry *queryEntry) (interface{}, error) {
+		cell := entry.key.(cellName)
+		return topoServer.GetSrvKeyspaceNames(ctx, string(cell))
+	}
+
+	rq := &resilientQuery{
+		query:        query,
+		counts:       counts,
+		cacheRefresh: cacheRefresh,
+		cacheTTL:     cacheTTL,
+		entries:      make(map[string]*queryEntry),
+	}
+
+	return &SrvKeyspaceNamesQuery{rq}
+}
+
+func (q *SrvKeyspaceNamesQuery) Get(ctx context.Context, cell string, staleOK bool) ([]string, error) {
+	v, err := q.getCurrentValue(ctx, cellName(cell), staleOK)
+	names, _ := v.([]string)
+	return names, err
+}
+
+func (q *SrvKeyspaceNamesQuery) CacheStatus() (result []*SrvKeyspaceNamesCacheStatus) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for _, entry := range q.entries {
+		entry.mutex.Lock()
+		value, _ := entry.value.([]string)
+		result = append(result, &SrvKeyspaceNamesCacheStatus{
+			Cell:           entry.key.String(),
+			Value:          value,
+			ExpirationTime: entry.insertionTime.Add(q.cacheTTL),
+			LastQueryTime:  entry.lastQueryTime,
+			LastError:      entry.lastError,
+			LastErrorCtx:   entry.lastErrorCtx,
+		})
+		entry.mutex.Unlock()
+	}
+	return
+}

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -17,14 +17,13 @@ limitations under the License.
 package srvtopo
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"html/template"
 	"sort"
 	"sync"
 	"time"
-
-	"context"
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -19,9 +19,6 @@ package srvtopo
 import (
 	"context"
 	"flag"
-	"fmt"
-	"html/template"
-	"sort"
 	"sync"
 	"time"
 
@@ -55,61 +52,6 @@ const (
 	queryCategory  = "query"
 	cachedCategory = "cached"
 	errorCategory  = "error"
-
-	// TopoTemplate is the HTML to use to display the
-	// ResilientServerCacheStatus object
-	TopoTemplate = `
-<style>
-  table {
-    border-collapse: collapse;
-  }
-  td, th {
-    border: 1px solid #999;
-    padding: 0.2rem;
-  }
-</style>
-<table>
-  <tr>
-    <th colspan="4">SrvKeyspace Names Cache</th>
-  </tr>
-  <tr>
-    <th>Cell</th>
-    <th>SrvKeyspace Names</th>
-    <th>TTL</th>
-    <th>Error</th>
-  </tr>
-  {{range $i, $skn := .SrvKeyspaceNames}}
-  <tr>
-    <td>{{github_com_vitessio_vitess_vtctld_srv_cell $skn.Cell}}</td>
-    <td>{{range $j, $value := $skn.Value}}{{github_com_vitessio_vitess_vtctld_srv_keyspace $skn.Cell $value}}&nbsp;{{end}}</td>
-    <td>{{github_com_vitessio_vitess_srvtopo_ttl_time $skn.ExpirationTime}}</td>
-    <td>{{if $skn.LastError}}({{github_com_vitessio_vitess_srvtopo_time_since $skn.LastQueryTime}}Ago) {{$skn.LastError}}{{end}}</td>
-  </tr>
-  {{end}}
-</table>
-<br>
-<table>
-  <tr>
-    <th colspan="5">SrvKeyspace Cache</th>
-  </tr>
-  <tr>
-    <th>Cell</th>
-    <th>Keyspace</th>
-    <th>SrvKeyspace</th>
-    <th>TTL</th>
-    <th>Error</th>
-  </tr>
-  {{range $i, $sk := .SrvKeyspaces}}
-  <tr>
-    <td>{{github_com_vitessio_vitess_vtctld_srv_cell $sk.Cell}}</td>
-    <td>{{github_com_vitessio_vitess_vtctld_srv_keyspace $sk.Cell $sk.Keyspace}}</td>
-    <td>{{$sk.StatusAsHTML}}</td>
-    <td>{{github_com_vitessio_vitess_srvtopo_ttl_time $sk.ExpirationTime}}</td>
-    <td>{{if $sk.LastError}}({{github_com_vitessio_vitess_srvtopo_time_since $sk.LastErrorTime}} Ago) {{$sk.LastError}}{{end}}</td>
-  </tr>
-  {{end}}
-</table>
-`
 )
 
 // ResilientServer is an implementation of srvtopo.Server based
@@ -117,18 +59,12 @@ const (
 // - limit the QPS to the underlying topo.Server
 // - return the last known value of the data if there is an error
 type ResilientServer struct {
-	topoServer   *topo.Server
-	cacheTTL     time.Duration
-	cacheRefresh time.Duration
-	counts       *stats.CountersWithSingleLabel
+	topoServer *topo.Server
+	counts     *stats.CountersWithSingleLabel
 
-	// mutex protects the cache map itself, not the individual
-	// values in the cache.
-	mutex                 sync.RWMutex
-	srvKeyspaceNamesCache map[string]*srvKeyspaceNamesEntry
-
-	srvKeyspaceWatcher *SrvKeyspaceWatcher
-	srvVSchemaWatcher  *SrvVSchemaWatcher
+	srvKeyspaceWatcher    *SrvKeyspaceWatcher
+	srvVSchemaWatcher     *SrvVSchemaWatcher
+	srvKeyspaceNamesQuery *SrvKeyspaceNamesQuery
 }
 
 type srvKeyspaceNamesEntry struct {
@@ -149,14 +85,6 @@ type srvKeyspaceNamesEntry struct {
 	lastErrorCtx  context.Context
 }
 
-type watchState int
-
-const (
-	watchStateIdle watchState = iota
-	watchStateStarting
-	watchStateRunning
-)
-
 // NewResilientServer creates a new ResilientServer
 // based on the provided topo.Server.
 func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServer {
@@ -165,7 +93,6 @@ func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServe
 	}
 
 	var metric string
-
 	if counterPrefix == "" {
 		metric = counterPrefix + "Counts"
 	} else {
@@ -174,14 +101,11 @@ func NewResilientServer(base *topo.Server, counterPrefix string) *ResilientServe
 	counts := stats.NewCountersWithSingleLabel(metric, "Resilient srvtopo server operations", "type")
 
 	return &ResilientServer{
-		topoServer:   base,
-		cacheTTL:     *srvTopoCacheTTL,
-		cacheRefresh: *srvTopoCacheRefresh,
-		counts:       counts,
-
-		srvKeyspaceNamesCache: make(map[string]*srvKeyspaceNamesEntry),
+		topoServer:            base,
+		counts:                counts,
 		srvKeyspaceWatcher:    NewSrvKeyspaceWatcher(base, counts, *srvTopoCacheRefresh, *srvTopoCacheTTL),
 		srvVSchemaWatcher:     NewSrvVSchemaWatcher(base, counts, *srvTopoCacheRefresh, *srvTopoCacheTTL),
+		srvKeyspaceNamesQuery: NewSrvKeyspaceNamesQuery(base, counts, *srvTopoCacheRefresh, *srvTopoCacheTTL),
 	}
 }
 
@@ -192,121 +116,7 @@ func (server *ResilientServer) GetTopoServer() (*topo.Server, error) {
 
 // GetSrvKeyspaceNames returns all keyspace names for the given cell.
 func (server *ResilientServer) GetSrvKeyspaceNames(ctx context.Context, cell string, staleOK bool) ([]string, error) {
-	server.counts.Add(queryCategory, 1)
-
-	// find the entry in the cache, add it if not there
-	key := cell
-	server.mutex.Lock()
-	entry, ok := server.srvKeyspaceNamesCache[key]
-	if !ok {
-		entry = &srvKeyspaceNamesEntry{
-			cell: cell,
-		}
-		server.srvKeyspaceNamesCache[key] = entry
-	}
-	server.mutex.Unlock()
-
-	// Lock the entry, and do everything holding the lock except
-	// querying the underlying topo server.
-	//
-	// This means that even if the topo server is very slow, two concurrent
-	// requests will only issue one underlying query.
-	entry.mutex.Lock()
-	defer entry.mutex.Unlock()
-
-	cacheValid := entry.value != nil && (time.Since(entry.insertionTime) < server.cacheTTL)
-	if !cacheValid && staleOK {
-		// Only allow stale results for a bounded period
-		cacheValid = entry.value != nil && (time.Since(entry.insertionTime) < (server.cacheTTL + 2*server.cacheRefresh))
-	}
-	shouldRefresh := time.Since(entry.lastQueryTime) > server.cacheRefresh
-
-	// If it is not time to check again, then return either the cached
-	// value or the cached error but don't ask topo again.
-	if !shouldRefresh {
-		if cacheValid {
-			return entry.value, nil
-		}
-		return nil, entry.lastError
-	}
-
-	// Refresh the state in a background goroutine if no refresh is already
-	// in progress none is already running. This way queries are not blocked
-	// while the cache is still valid but past the refresh time, and avoids
-	// calling out to the topo service while the lock is held.
-	if entry.refreshingChan == nil {
-		entry.refreshingChan = make(chan struct{})
-		entry.lastQueryTime = time.Now()
-		go func() {
-			defer func() {
-				if err := recover(); err != nil {
-					log.Errorf("GetSrvKeyspaceNames uncaught panic, cell :%v, err :%v)", cell, err)
-				}
-			}()
-			newCtx, cancel := context.WithTimeout(ctx, *srvTopoTimeout)
-			defer cancel()
-			result, err := server.topoServer.GetSrvKeyspaceNames(newCtx, cell)
-			entry.mutex.Lock()
-			defer func() {
-				close(entry.refreshingChan)
-				entry.refreshingChan = nil
-				entry.mutex.Unlock()
-			}()
-
-			if err == nil {
-				// save the value we got and the current time in the cache
-				entry.insertionTime = time.Now()
-				// Avoid a tiny race if TTL == refresh time (the default)
-				entry.lastQueryTime = entry.insertionTime
-				entry.value = result
-			} else {
-				server.counts.Add(errorCategory, 1)
-				if entry.insertionTime.IsZero() {
-					log.Errorf("GetSrvKeyspaceNames(%v, %v) failed: %v (no cached value, caching and returning error)", ctx, cell, err)
-				} else if newCtx.Err() == context.DeadlineExceeded {
-					log.Errorf("GetSrvKeyspaceNames(%v, %v) failed: %v (request timeout), (keeping cached value: %v)", ctx, cell, err, entry.value)
-				} else if entry.value != nil && time.Since(entry.insertionTime) < server.cacheTTL {
-					server.counts.Add(cachedCategory, 1)
-					log.Warningf("GetSrvKeyspaceNames(%v, %v) failed: %v (keeping cached value: %v)", ctx, cell, err, entry.value)
-				} else {
-					log.Errorf("GetSrvKeyspaceNames(%v, %v) failed: %v (cached value expired)", ctx, cell, err)
-					entry.insertionTime = time.Time{}
-					entry.value = nil
-				}
-			}
-
-			entry.lastError = err
-			entry.lastErrorCtx = newCtx
-		}()
-	}
-
-	// If the cached entry is still valid then use it, otherwise wait
-	// for the refresh attempt to complete to get a more up to date
-	// response.
-	//
-	// In the onEventLocked that the topo service is slow or unresponsive either
-	// on the initial fetch or if the cache TTL expires, then several
-	// requests could be blocked on refreshingCond waiting for the response
-	// to come back.
-	if cacheValid {
-		return entry.value, nil
-	}
-
-	refreshingChan := entry.refreshingChan
-	entry.mutex.Unlock()
-	select {
-	case <-refreshingChan:
-	case <-ctx.Done():
-		entry.mutex.Lock()
-		return nil, fmt.Errorf("timed out waiting for keyspace names")
-	}
-	entry.mutex.Lock()
-
-	if entry.value != nil {
-		return entry.value, nil
-	}
-
-	return nil, entry.lastError
+	return server.srvKeyspaceNamesQuery.Get(ctx, cell, staleOK)
 }
 
 // GetSrvKeyspace returns SrvKeyspace object for the given cell and keyspace.
@@ -317,152 +127,4 @@ func (server *ResilientServer) GetSrvKeyspace(ctx context.Context, cell, keyspac
 // WatchSrvVSchema is part of the srvtopo.Server interface.
 func (server *ResilientServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
 	server.srvVSchemaWatcher.Watch(ctx, cell, callback)
-}
-
-// The next few structures and methods are used to get a displayable
-// version of the cache in a status page.
-
-// SrvKeyspaceNamesCacheStatus is the current value for SrvKeyspaceNames
-type SrvKeyspaceNamesCacheStatus struct {
-	Cell           string
-	Value          []string
-	ExpirationTime time.Time
-	LastQueryTime  time.Time
-	LastError      error
-	LastErrorCtx   context.Context
-}
-
-// SrvKeyspaceNamesCacheStatusList is used for sorting
-type SrvKeyspaceNamesCacheStatusList []*SrvKeyspaceNamesCacheStatus
-
-// Len is part of sort.Interface
-func (skncsl SrvKeyspaceNamesCacheStatusList) Len() int {
-	return len(skncsl)
-}
-
-// Less is part of sort.Interface
-func (skncsl SrvKeyspaceNamesCacheStatusList) Less(i, j int) bool {
-	return skncsl[i].Cell < skncsl[j].Cell
-}
-
-// Swap is part of sort.Interface
-func (skncsl SrvKeyspaceNamesCacheStatusList) Swap(i, j int) {
-	skncsl[i], skncsl[j] = skncsl[j], skncsl[i]
-}
-
-// SrvKeyspaceCacheStatus is the current value for a SrvKeyspace object
-type SrvKeyspaceCacheStatus struct {
-	Cell           string
-	Keyspace       string
-	Value          *topodatapb.SrvKeyspace
-	ExpirationTime time.Time
-	LastErrorTime  time.Time
-	LastError      error
-	LastErrorCtx   context.Context
-}
-
-// StatusAsHTML returns an HTML version of our status.
-// It works best if there is data in the cache.
-func (st *SrvKeyspaceCacheStatus) StatusAsHTML() template.HTML {
-	if st.Value == nil {
-		return template.HTML("No Data")
-	}
-
-	result := "<b>Partitions:</b><br>"
-	for _, keyspacePartition := range st.Value.Partitions {
-		result += "&nbsp;<b>" + keyspacePartition.ServedType.String() + ":</b>"
-		for _, shard := range keyspacePartition.ShardReferences {
-			result += "&nbsp;" + shard.Name
-		}
-		result += "<br>"
-	}
-
-	if st.Value.ShardingColumnName != "" {
-		result += "<b>ShardingColumnName:</b>&nbsp;" + st.Value.ShardingColumnName + "<br>"
-		result += "<b>ShardingColumnType:</b>&nbsp;" + st.Value.ShardingColumnType.String() + "<br>"
-	}
-
-	if len(st.Value.ServedFrom) > 0 {
-		result += "<b>ServedFrom:</b><br>"
-		for _, sf := range st.Value.ServedFrom {
-			result += "&nbsp;<b>" + sf.TabletType.String() + ":</b>&nbsp;" + sf.Keyspace + "<br>"
-		}
-	}
-
-	return template.HTML(result)
-}
-
-// SrvKeyspaceCacheStatusList is used for sorting
-type SrvKeyspaceCacheStatusList []*SrvKeyspaceCacheStatus
-
-// Len is part of sort.Interface
-func (skcsl SrvKeyspaceCacheStatusList) Len() int {
-	return len(skcsl)
-}
-
-// Less is part of sort.Interface
-func (skcsl SrvKeyspaceCacheStatusList) Less(i, j int) bool {
-	return skcsl[i].Cell+"."+skcsl[i].Keyspace <
-		skcsl[j].Cell+"."+skcsl[j].Keyspace
-}
-
-// Swap is part of sort.Interface
-func (skcsl SrvKeyspaceCacheStatusList) Swap(i, j int) {
-	skcsl[i], skcsl[j] = skcsl[j], skcsl[i]
-}
-
-// ResilientServerCacheStatus has the full status of the cache
-type ResilientServerCacheStatus struct {
-	SrvKeyspaceNames SrvKeyspaceNamesCacheStatusList
-	SrvKeyspaces     SrvKeyspaceCacheStatusList
-}
-
-// CacheStatus returns a displayable version of the cache
-func (server *ResilientServer) CacheStatus() *ResilientServerCacheStatus {
-	result := &ResilientServerCacheStatus{}
-
-	server.mutex.Lock()
-	for _, entry := range server.srvKeyspaceNamesCache {
-		entry.mutex.Lock()
-
-		result.SrvKeyspaceNames = append(result.SrvKeyspaceNames, &SrvKeyspaceNamesCacheStatus{
-			Cell:           entry.cell,
-			Value:          entry.value,
-			ExpirationTime: entry.insertionTime.Add(server.cacheTTL),
-			LastQueryTime:  entry.lastQueryTime,
-			LastError:      entry.lastError,
-			LastErrorCtx:   entry.lastErrorCtx,
-		})
-		entry.mutex.Unlock()
-	}
-	server.mutex.Unlock()
-
-	result.SrvKeyspaces = server.srvKeyspaceWatcher.CacheStatus()
-
-	// do the sorting without the mutex
-	sort.Sort(result.SrvKeyspaceNames)
-	sort.Sort(result.SrvKeyspaces)
-
-	return result
-}
-
-// Returns the ttl for the cached entry or "Expired" if it is in the past
-func ttlTime(expirationTime time.Time) template.HTML {
-	ttl := time.Until(expirationTime).Round(time.Second)
-	if ttl < 0 {
-		return template.HTML("<b>Expired</b>")
-	}
-	return template.HTML(ttl.String())
-}
-
-func timeSince(t time.Time) template.HTML {
-	return template.HTML(time.Since(t).Round(time.Second).String())
-}
-
-// StatusFuncs is required for CacheStatus) to work properly.
-// We don't register them inside servenv directly so we don't introduce
-// a dependency here.
-var StatusFuncs = template.FuncMap{
-	"github_com_vitessio_vitess_srvtopo_ttl_time":   ttlTime,
-	"github_com_vitessio_vitess_srvtopo_time_since": timeSince,
 }

--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -19,7 +19,6 @@ package srvtopo
 import (
 	"context"
 	"flag"
-	"sync"
 	"time"
 
 	"vitess.io/vitess/go/stats"
@@ -65,24 +64,6 @@ type ResilientServer struct {
 	srvKeyspaceWatcher    *SrvKeyspaceWatcher
 	srvVSchemaWatcher     *SrvVSchemaWatcher
 	srvKeyspaceNamesQuery *SrvKeyspaceNamesQuery
-}
-
-type srvKeyspaceNamesEntry struct {
-	// unmutable values
-	cell string
-
-	// the mutex protects any access to this structure (read or write)
-	mutex sync.Mutex
-
-	// refreshingChan is used to synchronize requests and avoid hammering
-	// the topo server
-	refreshingChan chan struct{}
-
-	insertionTime time.Time
-	lastQueryTime time.Time
-	value         []string
-	lastError     error
-	lastErrorCtx  context.Context
 }
 
 // NewResilientServer creates a new ResilientServer

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -342,7 +342,7 @@ func TestSrvKeyspaceCachedError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("First GetSrvKeyspace didn't return an error")
 	}
-	entry := rs.srvKeyspaceWatcher.getEntry(&srvKeyspaceKey{"test_cell", "unknown_ks"})
+	entry := rs.SrvKeyspaceWatcher.rw.getEntry(&srvKeyspaceKey{"test_cell", "unknown_ks"})
 	if err != entry.lastError {
 		t.Errorf("Error wasn't saved properly")
 	}

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -622,9 +622,8 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), *srvTopoCacheRefresh*2) //nolint
 	defer cancel()
 	_, err = rs.GetSrvKeyspaceNames(timeoutCtx, "test_cell", false)
-	wantErr := "timed out waiting for keyspace names"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("expected error '%v', got '%v'", wantErr, err.Error())
+	if err != context.DeadlineExceeded {
+		t.Errorf("expected error '%v', got '%v'", context.DeadlineExceeded, err.Error())
 	}
 	factory.Unlock()
 }

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -441,9 +441,7 @@ func TestWatchSrvVSchema(t *testing.T) {
 	}
 	start := time.Now()
 	for {
-		v, err := get()
-		t.Logf("v = %v err = %v", v, err)
-		if err == nil && proto.Equal(newValue, v) {
+		if v, err := get(); err == nil && proto.Equal(newValue, v) {
 			break
 		}
 		if time.Since(start) > 5*time.Second {

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/vt/status"
@@ -626,4 +628,129 @@ func TestGetSrvKeyspaceNames(t *testing.T) {
 		t.Errorf("expected error '%v', got '%v'", context.DeadlineExceeded, err.Error())
 	}
 	factory.Unlock()
+}
+
+type watched struct {
+	keyspace *topodatapb.SrvKeyspace
+	err      error
+}
+
+func (w *watched) equals(other *watched) bool {
+	if w.keyspace != nil {
+		return other.keyspace != nil && proto.Equal(w.keyspace, other.keyspace)
+	}
+	return w.err == other.err
+}
+
+func TestSrvKeyspaceWatcher(t *testing.T) {
+	ts, factory := memorytopo.NewServerAndFactory("test_cell")
+	*srvTopoCacheTTL = time.Duration(100 * time.Millisecond)
+	*srvTopoCacheRefresh = time.Duration(40 * time.Millisecond)
+	defer func() {
+		*srvTopoCacheTTL = 1 * time.Second
+		*srvTopoCacheRefresh = 1 * time.Second
+	}()
+
+	rs := NewResilientServer(ts, "TestGetSrvKeyspaceWatcher")
+
+	var wmu sync.Mutex
+	var wseen []watched
+
+	allSeen := func() []watched {
+		wmu.Lock()
+		defer wmu.Unlock()
+
+		var result []watched
+		for _, w := range wseen {
+			if len(result) == 0 || !result[len(result)-1].equals(&w) {
+				result = append(result, w)
+			}
+		}
+		return result
+	}
+
+	waitForEntries := func(entryCount int) []watched {
+		var current []watched
+		var expire = time.Now().Add(5 * time.Second)
+
+		for time.Now().Before(expire) {
+			current = allSeen()
+			if len(current) >= entryCount {
+				return current
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		t.Fatalf("Failed to receive %d entries after 5s (got %d entries so far)", entryCount, len(current))
+		return nil
+	}
+
+	rs.WatchSrvKeyspace(context.Background(), "test_cell", "test_ks", func(keyspace *topodatapb.SrvKeyspace, err error) {
+		wmu.Lock()
+		defer wmu.Unlock()
+		wseen = append(wseen, watched{keyspace: keyspace, err: err})
+	})
+
+	seen1 := allSeen()
+	assert.Len(t, seen1, 1)
+	assert.Nil(t, seen1[0].keyspace)
+	assert.True(t, topo.IsErrType(seen1[0].err, topo.NoNode))
+
+	// Set SrvKeyspace with value
+	want := &topodatapb.SrvKeyspace{
+		ShardingColumnName: "id",
+		ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
+	}
+	err := ts.UpdateSrvKeyspace(context.Background(), "test_cell", "test_ks", want)
+	require.NoError(t, err)
+
+	seen2 := waitForEntries(2)
+	assert.Len(t, seen2, 2)
+	assert.NotNil(t, seen2[1].keyspace)
+	assert.Nil(t, seen2[1].err)
+	assert.True(t, proto.Equal(want, seen2[1].keyspace))
+
+	// Now delete the SrvKeyspace, wait until we get the error.
+	err = ts.DeleteSrvKeyspace(context.Background(), "test_cell", "test_ks")
+	require.NoError(t, err)
+
+	seen3 := waitForEntries(3)
+	assert.Len(t, seen3, 3)
+	assert.Nil(t, seen3[2].keyspace)
+	assert.True(t, topo.IsErrType(seen3[2].err, topo.NoNode))
+
+	for i := 0; i < 5; i++ {
+		want = &topodatapb.SrvKeyspace{
+			ShardingColumnName: fmt.Sprintf("updated%d", i),
+			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
+		}
+		err = ts.UpdateSrvKeyspace(context.Background(), "test_cell", "test_ks", want)
+		require.NoError(t, err)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	seen4 := waitForEntries(8)
+	assert.Len(t, seen4, 8)
+
+	for i := 0; i < 5; i++ {
+		w := seen4[3+i]
+		assert.Nil(t, w.err)
+		assert.Equal(t, w.keyspace.ShardingColumnName, fmt.Sprintf("updated%d", i))
+	}
+
+	// Now simulate a topo service error
+	forceErr := topo.NewError(topo.Timeout, "test topo error")
+	factory.SetError(forceErr)
+
+	seen5 := waitForEntries(9)
+	assert.Len(t, seen5, 9)
+	assert.Nil(t, seen5[8].keyspace)
+	assert.True(t, topo.IsErrType(seen5[8].err, topo.Timeout))
+
+	factory.SetError(nil)
+
+	seen6 := waitForEntries(10)
+	assert.Len(t, seen6, 10)
+	assert.Nil(t, seen6[9].err)
+	assert.NotNil(t, seen6[9].keyspace)
+	assert.Equal(t, seen6[9].keyspace.ShardingColumnName, "updated4")
 }

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package srvtopo
 
 import (

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -1,0 +1,195 @@
+package srvtopo
+
+import (
+	"context"
+	"html/template"
+	"sort"
+	"time"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+// TopoTemplate is the HTML to use to display the
+// ResilientServerCacheStatus object
+const TopoTemplate = `
+<style>
+  table {
+    border-collapse: collapse;
+  }
+  td, th {
+    border: 1px solid #999;
+    padding: 0.2rem;
+  }
+</style>
+<table>
+  <tr>
+    <th colspan="4">SrvKeyspace Names Cache</th>
+  </tr>
+  <tr>
+    <th>Cell</th>
+    <th>SrvKeyspace Names</th>
+    <th>TTL</th>
+    <th>Error</th>
+  </tr>
+  {{range $i, $skn := .SrvKeyspaceNames}}
+  <tr>
+    <td>{{github_com_vitessio_vitess_vtctld_srv_cell $skn.Cell}}</td>
+    <td>{{range $j, $value := $skn.Value}}{{github_com_vitessio_vitess_vtctld_srv_keyspace $skn.Cell $value}}&nbsp;{{end}}</td>
+    <td>{{github_com_vitessio_vitess_srvtopo_ttl_time $skn.ExpirationTime}}</td>
+    <td>{{if $skn.LastError}}({{github_com_vitessio_vitess_srvtopo_time_since $skn.LastQueryTime}}Ago) {{$skn.LastError}}{{end}}</td>
+  </tr>
+  {{end}}
+</table>
+<br>
+<table>
+  <tr>
+    <th colspan="5">SrvKeyspace Cache</th>
+  </tr>
+  <tr>
+    <th>Cell</th>
+    <th>Keyspace</th>
+    <th>SrvKeyspace</th>
+    <th>TTL</th>
+    <th>Error</th>
+  </tr>
+  {{range $i, $sk := .SrvKeyspaces}}
+  <tr>
+    <td>{{github_com_vitessio_vitess_vtctld_srv_cell $sk.Cell}}</td>
+    <td>{{github_com_vitessio_vitess_vtctld_srv_keyspace $sk.Cell $sk.Keyspace}}</td>
+    <td>{{$sk.StatusAsHTML}}</td>
+    <td>{{github_com_vitessio_vitess_srvtopo_ttl_time $sk.ExpirationTime}}</td>
+    <td>{{if $sk.LastError}}({{github_com_vitessio_vitess_srvtopo_time_since $sk.LastErrorTime}} Ago) {{$sk.LastError}}{{end}}</td>
+  </tr>
+  {{end}}
+</table>
+`
+
+// The next few structures and methods are used to get a displayable
+// version of the cache in a status page.
+
+// SrvKeyspaceNamesCacheStatus is the current value for SrvKeyspaceNames
+type SrvKeyspaceNamesCacheStatus struct {
+	Cell           string
+	Value          []string
+	ExpirationTime time.Time
+	LastQueryTime  time.Time
+	LastError      error
+	LastErrorCtx   context.Context
+}
+
+// SrvKeyspaceNamesCacheStatusList is used for sorting
+type SrvKeyspaceNamesCacheStatusList []*SrvKeyspaceNamesCacheStatus
+
+// Len is part of sort.Interface
+func (skncsl SrvKeyspaceNamesCacheStatusList) Len() int {
+	return len(skncsl)
+}
+
+// Less is part of sort.Interface
+func (skncsl SrvKeyspaceNamesCacheStatusList) Less(i, j int) bool {
+	return skncsl[i].Cell < skncsl[j].Cell
+}
+
+// Swap is part of sort.Interface
+func (skncsl SrvKeyspaceNamesCacheStatusList) Swap(i, j int) {
+	skncsl[i], skncsl[j] = skncsl[j], skncsl[i]
+}
+
+// SrvKeyspaceCacheStatus is the current value for a SrvKeyspace object
+type SrvKeyspaceCacheStatus struct {
+	Cell           string
+	Keyspace       string
+	Value          *topodatapb.SrvKeyspace
+	ExpirationTime time.Time
+	LastErrorTime  time.Time
+	LastError      error
+	LastErrorCtx   context.Context
+}
+
+// StatusAsHTML returns an HTML version of our status.
+// It works best if there is data in the cache.
+func (st *SrvKeyspaceCacheStatus) StatusAsHTML() template.HTML {
+	if st.Value == nil {
+		return template.HTML("No Data")
+	}
+
+	result := "<b>Partitions:</b><br>"
+	for _, keyspacePartition := range st.Value.Partitions {
+		result += "&nbsp;<b>" + keyspacePartition.ServedType.String() + ":</b>"
+		for _, shard := range keyspacePartition.ShardReferences {
+			result += "&nbsp;" + shard.Name
+		}
+		result += "<br>"
+	}
+
+	if st.Value.ShardingColumnName != "" {
+		result += "<b>ShardingColumnName:</b>&nbsp;" + st.Value.ShardingColumnName + "<br>"
+		result += "<b>ShardingColumnType:</b>&nbsp;" + st.Value.ShardingColumnType.String() + "<br>"
+	}
+
+	if len(st.Value.ServedFrom) > 0 {
+		result += "<b>ServedFrom:</b><br>"
+		for _, sf := range st.Value.ServedFrom {
+			result += "&nbsp;<b>" + sf.TabletType.String() + ":</b>&nbsp;" + sf.Keyspace + "<br>"
+		}
+	}
+
+	return template.HTML(result)
+}
+
+// SrvKeyspaceCacheStatusList is used for sorting
+type SrvKeyspaceCacheStatusList []*SrvKeyspaceCacheStatus
+
+// Len is part of sort.Interface
+func (skcsl SrvKeyspaceCacheStatusList) Len() int {
+	return len(skcsl)
+}
+
+// Less is part of sort.Interface
+func (skcsl SrvKeyspaceCacheStatusList) Less(i, j int) bool {
+	return skcsl[i].Cell+"."+skcsl[i].Keyspace <
+		skcsl[j].Cell+"."+skcsl[j].Keyspace
+}
+
+// Swap is part of sort.Interface
+func (skcsl SrvKeyspaceCacheStatusList) Swap(i, j int) {
+	skcsl[i], skcsl[j] = skcsl[j], skcsl[i]
+}
+
+// ResilientServerCacheStatus has the full status of the cache
+type ResilientServerCacheStatus struct {
+	SrvKeyspaceNames SrvKeyspaceNamesCacheStatusList
+	SrvKeyspaces     SrvKeyspaceCacheStatusList
+}
+
+// CacheStatus returns a displayable version of the cache
+func (server *ResilientServer) CacheStatus() *ResilientServerCacheStatus {
+	result := &ResilientServerCacheStatus{
+		SrvKeyspaceNames: server.srvKeyspaceNamesQuery.CacheStatus(),
+		SrvKeyspaces:     server.srvKeyspaceWatcher.CacheStatus(),
+	}
+	sort.Sort(result.SrvKeyspaceNames)
+	sort.Sort(result.SrvKeyspaces)
+	return result
+}
+
+// Returns the ttl for the cached entry or "Expired" if it is in the past
+func ttlTime(expirationTime time.Time) template.HTML {
+	ttl := time.Until(expirationTime).Round(time.Second)
+	if ttl < 0 {
+		return template.HTML("<b>Expired</b>")
+	}
+	return template.HTML(ttl.String())
+}
+
+func timeSince(t time.Time) template.HTML {
+	return template.HTML(time.Since(t).Round(time.Second).String())
+}
+
+// StatusFuncs is required for CacheStatus) to work properly.
+// We don't register them inside servenv directly so we don't introduce
+// a dependency here.
+var StatusFuncs = template.FuncMap{
+	"github_com_vitessio_vitess_srvtopo_ttl_time":   ttlTime,
+	"github_com_vitessio_vitess_srvtopo_time_since": timeSince,
+}

--- a/go/vt/srvtopo/status.go
+++ b/go/vt/srvtopo/status.go
@@ -165,8 +165,8 @@ type ResilientServerCacheStatus struct {
 // CacheStatus returns a displayable version of the cache
 func (server *ResilientServer) CacheStatus() *ResilientServerCacheStatus {
 	result := &ResilientServerCacheStatus{
-		SrvKeyspaceNames: server.srvKeyspaceNamesQuery.CacheStatus(),
-		SrvKeyspaces:     server.srvKeyspaceWatcher.CacheStatus(),
+		SrvKeyspaceNames: server.srvKeyspaceNamesCacheStatus(),
+		SrvKeyspaces:     server.srvKeyspaceCacheStatus(),
 	}
 	sort.Sort(result.SrvKeyspaceNames)
 	sort.Sort(result.SrvKeyspaces)

--- a/go/vt/srvtopo/watch.go
+++ b/go/vt/srvtopo/watch.go
@@ -11,8 +11,16 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 )
 
+type watchState int
+
+const (
+	watchStateIdle watchState = iota
+	watchStateStarting
+	watchStateRunning
+)
+
 type watchEntry struct {
-	// unmutable values
+	// immutable values
 	rw  *resilientWatcher
 	key fmt.Stringer
 

--- a/go/vt/srvtopo/watch.go
+++ b/go/vt/srvtopo/watch.go
@@ -1,0 +1,192 @@
+package srvtopo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"vitess.io/vitess/go/vt/topo"
+)
+
+type watchEntry struct {
+	// unmutable values
+	watcher *resilientWatcher
+	key     fmt.Stringer
+
+	mutex      sync.RWMutex
+	watchState watchState
+
+	watchStartingChan chan struct{}
+
+	value     interface{}
+	lastError error
+
+	lastValueTime time.Time
+	lastErrorCtx  context.Context
+	lastErrorTime time.Time
+}
+
+type resilientWatcher struct {
+	watch        func(ctx context.Context, entry *watchEntry)
+	cacheRefresh time.Duration
+	cacheTTL     time.Duration
+
+	mutex   sync.Mutex
+	entries map[string]*watchEntry
+}
+
+func (w *resilientWatcher) getEntry(wkey fmt.Stringer) *watchEntry {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	key := wkey.String()
+	entry, ok := w.entries[key]
+	if ok {
+		return entry
+	}
+
+	entry = &watchEntry{
+		watcher: w,
+		key:     wkey,
+	}
+	w.entries[key] = entry
+	return entry
+}
+
+type SrvKeyspaceWatcher struct {
+	w *resilientWatcher
+}
+
+type srvKeyspaceKey struct {
+	cell, keyspace string
+}
+
+func (k *srvKeyspaceKey) String() string {
+	return k.cell + "." + k.keyspace
+}
+
+func NewSrvKeyspaceWatcher(topoServer topo.Server, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceWatcher {
+	watch := func(ctx context.Context, entry *watchEntry) {
+		key := entry.key.(*srvKeyspaceKey)
+		current, changes, cancel := topoServer.WatchSrvKeyspace(context.Background(), key.cell, key.keyspace)
+		if !entry.update(ctx, current.Value, current.Err) {
+			return
+		}
+		defer cancel()
+		for c := range changes {
+			if !entry.update(ctx, c.Value, c.Err) {
+				return
+			}
+		}
+	}
+
+	w := &resilientWatcher{
+		watch:        watch,
+		cacheRefresh: cacheRefresh,
+		cacheTTL:     cacheTTL,
+		entries:      make(map[string]*watchEntry),
+	}
+
+	return &SrvKeyspaceWatcher{w}
+}
+
+func (w *resilientWatcher) GetValue(ctx context.Context, wkey fmt.Stringer) (interface{}, error) {
+	entry := w.getEntry(wkey)
+	return entry.currentValue(ctx)
+}
+
+func (entry *watchEntry) currentValue(ctx context.Context) (interface{}, error) {
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+
+	if entry.watchState == watchStateRunning {
+		return entry.value, entry.lastError
+	}
+
+	shouldRefresh := time.Since(entry.lastErrorTime) > entry.watcher.cacheRefresh
+	if shouldRefresh && (entry.watchState == watchStateIdle) {
+		entry.watchState = watchStateStarting
+		entry.watchStartingChan = make(chan struct{})
+		go entry.watcher.watch(ctx, entry)
+	}
+
+	cacheValid := entry.value != nil && time.Since(entry.lastValueTime) < entry.watcher.cacheTTL
+	if cacheValid {
+		entry.watcher.counts.Add(cachedCategory, 1)
+		return entry.value, nil
+	}
+
+	if entry.watchState == watchStateStarting {
+		watchStartingChan := entry.watchStartingChan
+		entry.mutex.Unlock()
+		select {
+		case <-watchStartingChan:
+		case <-ctx.Done():
+			entry.mutex.Lock()
+			return nil, fmt.Errorf("timed out waiting for keyspace")
+		}
+		entry.mutex.Lock()
+	}
+
+	if entry.value != nil {
+		return entry.value, nil
+	}
+	return nil, entry.lastError
+}
+
+func (entry *watchEntry) update(ctx context.Context, value interface{}, err error) bool {
+	entry.mutex.Lock()
+	defer entry.mutex.Unlock()
+
+	if err != nil {
+		entry.onErrorLocked(ctx, err)
+		return false
+	}
+	entry.onValueLocked(value)
+	return true
+}
+
+func (entry *watchEntry) onValueLocked(value interface{}) {
+	entry.watchState = watchStateRunning
+	if entry.watchStartingChan != nil {
+		close(entry.watchStartingChan)
+		entry.watchStartingChan = nil
+	}
+	entry.value = value
+	entry.lastValueTime = time.Now()
+
+	entry.lastError = nil
+	entry.lastErrorCtx = nil
+	entry.lastErrorTime = time.Time{}
+}
+
+func (entry *watchEntry) onErrorLocked(callerCtx context.Context, err error) {
+	entry.lastError = err
+	entry.lastErrorCtx = callerCtx
+	entry.lastErrorTime = time.Now()
+
+	// if the node disappears, delete the cached value
+	if topo.IsErrType(err, topo.NoNode) {
+		entry.value = nil
+	}
+
+	entry.watcher.counts.Add(errorCategory, 1)
+
+	// This watcher will able to continue to return the last value till it is not able to connect to the topo server even if the cache TTL is reached.
+	// TTL cache is only checked if the error is a known error i.e topo.Error.
+	_, isTopoErr := err.(topo.Error)
+	if isTopoErr && time.Since(entry.lastValueTime) > entry.watcher.cacheTTL {
+		entry.value = nil
+	}
+
+	if entry.watchStartingChan != nil {
+		close(entry.watchStartingChan)
+		entry.watchStartingChan = nil
+	}
+
+	if entry.watchState == watchStateRunning {
+		entry.lastValueTime = time.Now()
+	}
+	entry.watchState = watchStateIdle
+}

--- a/go/vt/srvtopo/watch.go
+++ b/go/vt/srvtopo/watch.go
@@ -198,7 +198,7 @@ func (entry *watchEntry) onErrorLocked(callerCtx context.Context, err error, ini
 			entry.value = nil
 		}
 	} else {
-		entry.lastError = fmt.Errorf("ResilientWatch stream failed for %v: %v", entry.key, err)
+		entry.lastError = fmt.Errorf("ResilientWatch stream failed for %v: %w", entry.key, err)
 		log.Errorf("%v", entry.lastError)
 
 		// Even though we didn't get a new value, update the lastValueTime

--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 )
 
 type SrvKeyspaceWatcher struct {
-	rw *resilientWatcher
+	*resilientWatcher
 }
 
 type srvKeyspaceKey struct {
@@ -20,46 +21,28 @@ func (k *srvKeyspaceKey) String() string {
 	return k.cell + "." + k.keyspace
 }
 
-func NewSrvKeyspaceWatcher(topoServer *topo.Server, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceWatcher {
+func NewSrvKeyspaceWatcher(topoServer *topo.Server, counts *stats.CountersWithSingleLabel, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceWatcher {
 	watch := func(ctx context.Context, entry *watchEntry) {
 		key := entry.key.(*srvKeyspaceKey)
 		current, changes, cancel := topoServer.WatchSrvKeyspace(context.Background(), key.cell, key.keyspace)
 
-		entry.update(ctx, current.Value, current.Err)
+		entry.update(ctx, current.Value, current.Err, true)
 		if current.Err != nil {
 			return
 		}
 
 		defer cancel()
 		for c := range changes {
-			entry.update(ctx, c.Value, c.Err)
+			entry.update(ctx, c.Value, c.Err, false)
 			if c.Err != nil {
 				return
 			}
 		}
 	}
 
-	event := func(entry *watchEntry) {
-		entry.mutex.Lock()
-		defer entry.mutex.Unlock()
-
-		if entry.lastError != nil {
-			return
-		}
-
-		srvkeyspace := entry.value.(*topodata.SrvKeyspace)
-		for watcher := range entry.listeners {
-			ch := watcher.(chan *topodata.SrvKeyspace)
-			select {
-			case ch <- srvkeyspace:
-			default:
-			}
-		}
-	}
-
 	rw := &resilientWatcher{
-		watch:        watch,
-		event:        event,
+		watcher:      watch,
+		counts:       counts,
 		cacheRefresh: cacheRefresh,
 		cacheTTL:     cacheTTL,
 		entries:      make(map[string]*watchEntry),
@@ -70,17 +53,43 @@ func NewSrvKeyspaceWatcher(topoServer *topo.Server, cacheRefresh, cacheTTL time.
 
 func (w *SrvKeyspaceWatcher) Get(ctx context.Context, cell, keyspace string) (*topodata.SrvKeyspace, error) {
 	key := &srvKeyspaceKey{cell, keyspace}
-	v, err := w.rw.getValue(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-	return v.(*topodata.SrvKeyspace), nil
+	v, err := w.getValue(ctx, key)
+	ks, _ := v.(*topodata.SrvKeyspace)
+	return ks, err
 }
 
-func (w *SrvKeyspaceWatcher) Watch(ctx context.Context, cell, keyspace string) chan *topodata.SrvKeyspace {
-	key := &srvKeyspaceKey{cell, keyspace}
-	newChan := make(chan *topodata.SrvKeyspace, 1)
-	entry := w.rw.getEntry(key)
-	entry.addListener(ctx, newChan)
-	return newChan
+func (w *SrvKeyspaceWatcher) Watch(ctx context.Context, cell, keyspace string, callback func(*topodata.SrvKeyspace, error)) {
+	entry := w.getEntry(&srvKeyspaceKey{cell, keyspace})
+	entry.addListener(ctx, func(v interface{}, err error) {
+		srvkeyspace, _ := v.(*topodata.SrvKeyspace)
+		callback(srvkeyspace, err)
+	})
+}
+
+func (w *SrvKeyspaceWatcher) CacheStatus() (result []*SrvKeyspaceCacheStatus) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	for _, entry := range w.entries {
+		entry.mutex.Lock()
+		expirationTime := time.Now().Add(w.cacheTTL)
+		if entry.watchState != watchStateRunning {
+			expirationTime = entry.lastValueTime.Add(w.cacheTTL)
+		}
+
+		key := entry.key.(*srvKeyspaceKey)
+		value, _ := entry.value.(*topodata.SrvKeyspace)
+
+		result = append(result, &SrvKeyspaceCacheStatus{
+			Cell:           key.cell,
+			Keyspace:       key.keyspace,
+			Value:          value,
+			ExpirationTime: expirationTime,
+			LastErrorTime:  entry.lastErrorTime,
+			LastError:      entry.lastError,
+			LastErrorCtx:   entry.lastErrorCtx,
+		})
+		entry.mutex.Unlock()
+	}
+	return
 }

--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -1,0 +1,86 @@
+package srvtopo
+
+import (
+	"context"
+	"time"
+
+	"vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+type SrvKeyspaceWatcher struct {
+	rw *resilientWatcher
+}
+
+type srvKeyspaceKey struct {
+	cell, keyspace string
+}
+
+func (k *srvKeyspaceKey) String() string {
+	return k.cell + "." + k.keyspace
+}
+
+func NewSrvKeyspaceWatcher(topoServer *topo.Server, cacheRefresh, cacheTTL time.Duration) *SrvKeyspaceWatcher {
+	watch := func(ctx context.Context, entry *watchEntry) {
+		key := entry.key.(*srvKeyspaceKey)
+		current, changes, cancel := topoServer.WatchSrvKeyspace(context.Background(), key.cell, key.keyspace)
+
+		entry.update(ctx, current.Value, current.Err)
+		if current.Err != nil {
+			return
+		}
+
+		defer cancel()
+		for c := range changes {
+			entry.update(ctx, c.Value, c.Err)
+			if c.Err != nil {
+				return
+			}
+		}
+	}
+
+	event := func(entry *watchEntry) {
+		entry.mutex.Lock()
+		defer entry.mutex.Unlock()
+
+		if entry.lastError != nil {
+			return
+		}
+
+		srvkeyspace := entry.value.(*topodata.SrvKeyspace)
+		for watcher := range entry.listeners {
+			ch := watcher.(chan *topodata.SrvKeyspace)
+			select {
+			case ch <- srvkeyspace:
+			default:
+			}
+		}
+	}
+
+	rw := &resilientWatcher{
+		watch:        watch,
+		event:        event,
+		cacheRefresh: cacheRefresh,
+		cacheTTL:     cacheTTL,
+		entries:      make(map[string]*watchEntry),
+	}
+
+	return &SrvKeyspaceWatcher{rw}
+}
+
+func (w *SrvKeyspaceWatcher) Get(ctx context.Context, cell, keyspace string) (*topodata.SrvKeyspace, error) {
+	key := &srvKeyspaceKey{cell, keyspace}
+	v, err := w.rw.getValue(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return v.(*topodata.SrvKeyspace), nil
+}
+
+func (w *SrvKeyspaceWatcher) Watch(ctx context.Context, cell, keyspace string) chan *topodata.SrvKeyspace {
+	key := &srvKeyspaceKey{cell, keyspace}
+	newChan := make(chan *topodata.SrvKeyspace, 1)
+	entry := w.rw.getEntry(key)
+	entry.addListener(ctx, newChan)
+	return newChan
+}

--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package srvtopo
 
 import (
@@ -41,11 +57,11 @@ func NewSrvKeyspaceWatcher(topoServer *topo.Server, counts *stats.CountersWithSi
 	}
 
 	rw := &resilientWatcher{
-		watcher:      watch,
-		counts:       counts,
-		cacheRefresh: cacheRefresh,
-		cacheTTL:     cacheTTL,
-		entries:      make(map[string]*watchEntry),
+		watcher:              watch,
+		counts:               counts,
+		cacheRefreshInterval: cacheRefresh,
+		cacheTTL:             cacheTTL,
+		entries:              make(map[string]*watchEntry),
 	}
 
 	return &SrvKeyspaceWatcher{rw}

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SrvVSchemaWatcher struct {
-	*resilientWatcher
+	rw *resilientWatcher
 }
 
 type cellName string
@@ -49,14 +49,14 @@ func NewSrvVSchemaWatcher(topoServer *topo.Server, counts *stats.CountersWithSin
 	return &SrvVSchemaWatcher{rw}
 }
 
-func (w *SrvVSchemaWatcher) Get(ctx context.Context, cell string) (*vschemapb.SrvVSchema, error) {
-	v, err := w.getValue(ctx, cellName(cell))
+func (w *SrvVSchemaWatcher) GetSrvVSchema(ctx context.Context, cell string) (*vschemapb.SrvVSchema, error) {
+	v, err := w.rw.getValue(ctx, cellName(cell))
 	vschema, _ := v.(*vschemapb.SrvVSchema)
 	return vschema, err
 }
 
-func (w *SrvVSchemaWatcher) Watch(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
-	entry := w.getEntry(cellName(cell))
+func (w *SrvVSchemaWatcher) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+	entry := w.rw.getEntry(cellName(cell))
 	entry.addListener(ctx, func(v interface{}, err error) {
 		vschema, _ := v.(*vschemapb.SrvVSchema)
 		callback(vschema, err)

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -1,0 +1,108 @@
+package srvtopo
+
+import (
+	"context"
+	"time"
+
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/topo"
+)
+
+type SrvVSchemaWatcher struct {
+	rw *resilientWatcher
+}
+
+type srvVSchemaKey string
+
+func (k srvVSchemaKey) String() string {
+	return string(k)
+}
+
+func NewSrvVSchemaWatcher(topoServer *topo.Server, cacheRefresh, cacheTTL time.Duration) *SrvVSchemaWatcher {
+	watch := func(ctx context.Context, entry *watchEntry) {
+		key := entry.key.(srvVSchemaKey)
+		current, changes, cancel := topoServer.WatchSrvVSchema(context.Background(), key.String())
+
+		entry.update(ctx, current.Value, current.Err)
+		if current.Err != nil {
+			return
+		}
+
+		defer cancel()
+		for c := range changes {
+			entry.update(ctx, c.Value, c.Err)
+			if c.Err != nil {
+				return
+			}
+		}
+	}
+
+	event := func(entry *watchEntry) {
+		entry.mutex.Lock()
+		defer entry.mutex.Unlock()
+
+		var lastErr error
+		var vschema *vschemapb.SrvVSchema
+
+		if entry.value != nil {
+			vschema = entry.value.(*vschemapb.SrvVSchema)
+		} else {
+			lastErr = entry.lastError
+		}
+
+		for watcher := range entry.listeners {
+			switch w := watcher.(type) {
+			case chan *vschemapb.SrvVSchema:
+				if vschema != nil {
+					select {
+					case w <- vschema:
+					default:
+					}
+				}
+			case *srvVSchemaCallback:
+				w.callback(vschema, lastErr)
+				if w.first != nil {
+					close(w.first)
+					w.first = nil
+				}
+			}
+		}
+	}
+
+	rw := &resilientWatcher{
+		watch:        watch,
+		event:        event,
+		cacheRefresh: cacheRefresh,
+		cacheTTL:     cacheTTL,
+		entries:      make(map[string]*watchEntry),
+	}
+
+	return &SrvVSchemaWatcher{rw}
+}
+
+func (w *SrvVSchemaWatcher) Get(ctx context.Context, cell string) (*vschemapb.SrvVSchema, error) {
+	v, err := w.rw.getValue(ctx, srvVSchemaKey(cell))
+	if err != nil {
+		return nil, err
+	}
+	return v.(*vschemapb.SrvVSchema), nil
+}
+
+func (w *SrvVSchemaWatcher) Watch(ctx context.Context, cell string) chan *vschemapb.SrvVSchema {
+	newChan := make(chan *vschemapb.SrvVSchema, 1)
+	entry := w.rw.getEntry(srvVSchemaKey(cell))
+	entry.addListener(ctx, newChan)
+	return newChan
+}
+
+type srvVSchemaCallback struct {
+	callback func(*vschemapb.SrvVSchema, error)
+	first    chan<- struct{}
+}
+
+func (w *SrvVSchemaWatcher) WatchFunc(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+	first := make(chan struct{})
+	entry := w.rw.getEntry(srvVSchemaKey(cell))
+	entry.addListener(ctx, &srvVSchemaCallback{callback: callback, first: first})
+	<-first
+}

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package srvtopo
 
 import (
@@ -39,11 +55,11 @@ func NewSrvVSchemaWatcher(topoServer *topo.Server, counts *stats.CountersWithSin
 	}
 
 	rw := &resilientWatcher{
-		watcher:      watch,
-		counts:       counts,
-		cacheRefresh: cacheRefresh,
-		cacheTTL:     cacheTTL,
-		entries:      make(map[string]*watchEntry),
+		watcher:              watch,
+		counts:               counts,
+		cacheRefreshInterval: cacheRefresh,
+		cacheTTL:             cacheTTL,
+		entries:              make(map[string]*watchEntry),
 	}
 
 	return &SrvVSchemaWatcher{rw}


### PR DESCRIPTION
## Description

Making progress on https://github.com/vitessio/vitess/issues/8462

After several meetings with the team, we've decided that the only reliable way to detect is whether a failover or a resharding operation is over is by watching _both_ the `SrvKeyspace` and `SrvVSchema` changes in real time.

The current `ResilientServer` design does not allow for this, however.

- `SrvKeyspace` can only be accessed with a getter (i.e. there is no way to subscribe to changes in the keyspace), even though this functionality is actually watching the topology server in its underlying implementation.
- `SrvVSchema` can be subscribed for event changes, however, this is very expensive because the `Watch` call will open a watcher to the underlying topo server for each call, and we already have a couple of those calls in the codebase.

This refactoring fixes these two issues by merging the two implementations into a single `ResilientWatcher` implementation that:

- Keeps an underlying watch open to the topology server, and retries the watch whenever it fails
- Allows accessing the latest value of the watched event with a getter, like the previous implementation
- Allows subscribing to any changes on the watched event in real time using a callback

Although the implementations have been merged, I've taken special care to ensure the functionality remains identical to the previous versions. The unit tests have not been changed.

cc @harshit-gangal @deepthi @rohit-nayak-ps 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->