### PR TITLE
Trivial:  fix the GenerateShardRanges vtctl[client] help

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -378,7 +378,7 @@ var commands = []commandGroup{
 				"<tablet alias> ...",
 				"Lists specified tablets in an awk-friendly way."},
 			{"GenerateShardRanges", commandGenerateShardRanges,
-				"<num shards>",
+				"-num_shards N",
 				"Generates shard ranges assuming a keyspace with N shards."},
 			{"Panic", commandPanic,
 				"",


### PR DESCRIPTION
This was incorrect;  if you just pass a number (without `-num_shards`), you get the default 2 shard ranges printed.

Signed-off-by: Jacques Grove <aquarapid@gmail.com>

