### PR TITLE
Fixes subquery rewrite when it is part of IN clause

### DIFF
--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -176,8 +176,11 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT a.col, b.col FROM A JOIN B USING (id)",
 		expected: "SELECT a.col, b.col FROM A JOIN B ON A.id = B.id",
 	}, {
-		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual)",
 		expected: "SELECT * FROM tbl WHERE id IN (1)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
 	}, {
 		in:       "SELECT a.col, b.col FROM A JOIN B USING (id1,id2,id3)",
 		expected: "SELECT a.col, b.col FROM A JOIN B ON A.id1 = B.id1 AND A.id2 = B.id2 AND A.id3 = B.id3",

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -176,6 +176,9 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT a.col, b.col FROM A JOIN B USING (id)",
 		expected: "SELECT a.col, b.col FROM A JOIN B ON A.id = B.id",
 	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
+		expected: "SELECT * FROM tbl WHERE id IN (1)",
+	}, {
 		in:       "SELECT a.col, b.col FROM A JOIN B USING (id1,id2,id3)",
 		expected: "SELECT a.col, b.col FROM A JOIN B ON A.id1 = B.id1 AND A.id2 = B.id2 AND A.id3 = B.id3",
 	}, {

--- a/go/vt/sqlparser/ast_rewriting_test.go
+++ b/go/vt/sqlparser/ast_rewriting_test.go
@@ -179,8 +179,30 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual)",
 		expected: "SELECT * FROM tbl WHERE id IN (1)",
 	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT last_insert_id() FROM dual)",
+		expected: "SELECT * FROM tbl WHERE id IN (:__lastInsertId)",
+		liid:     true,
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT (SELECT 1 FROM dual WHERE 1 = 0) FROM dual)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
+	}, {
 		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
 		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual WHERE 1 = 0)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1,2 FROM dual)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1,2 FROM dual)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual ORDER BY 1)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual ORDER BY 1)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT id FROM user GROUP BY id)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT id FROM user GROUP BY id)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual, user)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual, user)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual limit 1)",
+		expected: "SELECT * FROM tbl WHERE id IN (SELECT 1 FROM dual limit 1)",
 	}, {
 		in:       "SELECT a.col, b.col FROM A JOIN B USING (id1,id2,id3)",
 		expected: "SELECT a.col, b.col FROM A JOIN B ON A.id1 = B.id1 AND A.id2 = B.id2 AND A.id3 = B.id3",


### PR DESCRIPTION
## Description
Currently our rewriter, incorrectly rewrites a subquery which is part of an IN clause
For example, consider the following query - 
```sql
SELECT id FROM user WHERE id IN (SELECT 1 FROM DUAL)
```
This query is rewritten to -
```sql
SELECT id FROM user WHERE id IN 1
```
but this is syntactically wrong. Instead we must rewrite it to - 
```sql
SELECT id FROM user WHERE id IN (1)
```

This PR fixes this problem

## Related Issue(s)
-  #8522


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
