### PR TITLE
Fix passing the wrong cell/cells variable to CreateLookupVindex

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2305,7 +2305,7 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 	if err := json2.Unmarshal([]byte(subFlags.Arg(1)), specs); err != nil {
 		return err
 	}
-	return wr.CreateLookupVindex(ctx, keyspace, specs, *cell, *tabletTypes, *continueAfterCopyWithOwner)
+	return wr.CreateLookupVindex(ctx, keyspace, specs, *cells, *tabletTypes, *continueAfterCopyWithOwner)
 }
 
 func commandExternalizeVindex(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {


### PR DESCRIPTION
Found this by inspection after a user reported an issue.  We are using 
the cells variable as the new usage;  but we were still passing the old
cell variable to the lower code.  As a result, if you pass the `-cells`
directive to CreateLookupVindex, it was effectively ignored. 

Signed-off-by: Jacques Grove <aquarapid@gmail.com>

