### PR TITLE
Add `-full_flush` parameter for vtbackup, which performs

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -113,6 +113,7 @@ var (
 
 	initialBackup    = flag.Bool("initial_backup", false, "Instead of restoring from backup, initialize an empty database with the provided init_db_sql_file and upload a backup of that for the shard, if the shard has no backups yet. This can be used to seed a brand new shard with an initial, empty backup. If any backups already exist for the shard, this will be considered a successful no-op. This can only be done before the shard exists in topology (i.e. before any tablets are deployed).")
 	allowFirstBackup = flag.Bool("allow_first_backup", false, "Allow this job to take the first backup of an existing shard.")
+	fullFlush        = flag.Bool("full_flush", false, "Perform a full redo & buffer flush before taking the backup, currently implemented as a clean shutdown and startup. Only makes sense to work around xtrabackup bugs.")
 
 	// vttablet-like flags
 	initDbNameOverride = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet")
@@ -390,6 +391,22 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	log.Infof("Replication caught up to %v", status.Position)
 	if !status.Position.AtLeast(primaryPos) && status.Position.Equal(restorePos) {
 		return fmt.Errorf("not taking backup: replication did not make any progress from restore point: %v", restorePos)
+	}
+
+	if *fullFlush {
+		log.Info("Proceeding with clean MySQL shutdown and startup to flush all buffers.")
+		// Prep for full/clean shutdown (not the default)
+		if err := mysqld.ExecuteSuperQuery(ctx, "SET GLOBAL innodb_fast_shutdown=0"); err != nil {
+			return fmt.Errorf("Could not prep for full shutdown: %v", err)
+		}
+		// Shutdown, waiting for it to finish
+		if err := mysqld.Shutdown(ctx, mycnf, true); err != nil {
+			return fmt.Errorf("Something went wrong during full MySQL shutdown: %v", err)
+		}
+		// Start MySQL, waiting for it to come up
+		if err := mysqld.Start(ctx, mycnf); err != nil {
+			return fmt.Errorf("Could not start MySQL after full shutdown: %v", err)
+		}
 	}
 
 	// Now we can take a new backup.

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -113,7 +113,8 @@ var (
 
 	initialBackup    = flag.Bool("initial_backup", false, "Instead of restoring from backup, initialize an empty database with the provided init_db_sql_file and upload a backup of that for the shard, if the shard has no backups yet. This can be used to seed a brand new shard with an initial, empty backup. If any backups already exist for the shard, this will be considered a successful no-op. This can only be done before the shard exists in topology (i.e. before any tablets are deployed).")
 	allowFirstBackup = flag.Bool("allow_first_backup", false, "Allow this job to take the first backup of an existing shard.")
-	fullFlush        = flag.Bool("full_flush", false, "Perform a full redo & buffer flush before taking the backup, currently implemented as a clean shutdown and startup. Only makes sense to work around xtrabackup bugs.")
+
+	restartBeforeBackup = flag.Bool("restart_before_backup", false, "Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.")
 
 	// vttablet-like flags
 	initDbNameOverride = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet")
@@ -393,9 +394,9 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 		return fmt.Errorf("not taking backup: replication did not make any progress from restore point: %v", restorePos)
 	}
 
-	if *fullFlush {
+	if *restartBeforeBackup {
 		log.Info("Proceeding with clean MySQL shutdown and startup to flush all buffers.")
-		// Prep for full/clean shutdown (not the default)
+		// Prep for full/clean shutdown (not typically the default)
 		if err := mysqld.ExecuteSuperQuery(ctx, "SET GLOBAL innodb_fast_shutdown=0"); err != nil {
 			return fmt.Errorf("Could not prep for full shutdown: %v", err)
 		}

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -55,7 +55,7 @@ func TestTabletInitialBackup(t *testing.T) {
 	//    - list the backups, remove them
 	defer cluster.PanicHandler(t)
 
-	vtBackup(t, true)
+	vtBackup(t, true, false)
 	verifyBackupCount(t, shardKsName, 1)
 
 	// Initialize the tablets
@@ -124,7 +124,7 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 	// backup the replica
 	log.Infof("taking backup %s", time.Now())
-	vtBackup(t, false)
+	vtBackup(t, false, true)
 	log.Infof("done taking backup %s", time.Now())
 
 	// check that the backup shows up in the listing
@@ -163,9 +163,12 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 }
 
-func vtBackup(t *testing.T, initialBackup bool) {
+func vtBackup(t *testing.T, initialBackup bool, fullFlush bool) {
 	// Take the back using vtbackup executable
 	extraArgs := []string{"-allow_first_backup", "-db-credentials-file", dbCredentialFile}
+	if fullFlush {
+		extraArgs = append(extraArgs, "-full_flush")
+	}
 	log.Infof("starting backup tablet %s", time.Now())
 	err := localCluster.StartVtbackup(newInitDBFile, initialBackup, keyspaceName, shardName, cell, extraArgs...)
 	require.Nil(t, err)

--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -163,11 +163,11 @@ func firstBackupTest(t *testing.T, tabletType string) {
 
 }
 
-func vtBackup(t *testing.T, initialBackup bool, fullFlush bool) {
+func vtBackup(t *testing.T, initialBackup bool, restartBeforeBackup bool) {
 	// Take the back using vtbackup executable
 	extraArgs := []string{"-allow_first_backup", "-db-credentials-file", dbCredentialFile}
-	if fullFlush {
-		extraArgs = append(extraArgs, "-full_flush")
+	if restartBeforeBackup {
+		extraArgs = append(extraArgs, "-restart_before_backup")
 	}
 	log.Infof("starting backup tablet %s", time.Now())
 	err := localCluster.StartVtbackup(newInitDBFile, initialBackup, keyspaceName, shardName, cell, extraArgs...)


### PR DESCRIPTION
a clean MySQL shutdown & startup cycle to work around xtrabackup
DDL bugs (see https://jira.percona.com/browse/PXB-2205).  xtrabackup
`-lock-ddl` (which is the default) is not sufficient to fix this, and we
have run into this in real-world scenarios.  See #8610 

Signed-off-by: Jacques Grove <aquarapid@gmail.com>