### PR TITLE
Increase replication pos column size

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -541,7 +541,7 @@ func CreateVReplicationTable() []string {
   id INT AUTO_INCREMENT,
   workflow VARBINARY(1000),
   source VARBINARY(10000) NOT NULL,
-  pos VARBINARY(10000) NOT NULL,
+  pos BLOB NOT NULL,
   stop_pos VARBINARY(10000) DEFAULT NULL,
   max_tps BIGINT(20) NOT NULL,
   max_replication_lag BIGINT(20) NOT NULL,

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -42,7 +42,7 @@ import (
 const createSidecarDB = "CREATE DATABASE IF NOT EXISTS _vt"
 const createSchemaTrackingTable = `CREATE TABLE IF NOT EXISTS _vt.schema_version (
 		 id INT AUTO_INCREMENT,
-		  pos VARBINARY(10000) NOT NULL,
+		  pos BLOB NOT NULL,
 		  time_updated BIGINT(20) NOT NULL,
 		  ddl VARBINARY(1000) DEFAULT NULL,
 		  schemax BLOB NOT NULL,

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -258,7 +258,7 @@ func TestVersion(t *testing.T) {
 	defer engine.Close()
 
 	execStatements(t, []string{
-		"create table _vt.schema_version(id int, pos varbinary(10000), time_updated bigint(20), ddl varchar(10000), schemax blob, primary key(id))",
+		"create table _vt.schema_version(id int, pos blob, time_updated bigint(20), ddl varchar(10000), schemax blob, primary key(id))",
 	})
 	defer execStatements(t, []string{
 		"drop table _vt.schema_version",


### PR DESCRIPTION
## Description

This change fixes errors using vreplication when the gtid_executed set is very large.  

This can happen as part of normal MySQL server operation if there simply happens to be many changes in primary instances in a cluster.  There doesn't seem to be any defined maximum size on the string values returned so it's critical that larger values are handled.  The column type has been changed from varbinary to blob because larger varbinary values cause an error when the maximum row size for the table exceeds 64k


## Related Issue(s)
https://github.com/vitessio/vitess/issues/8612


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
