### PR TITLE
onlineddl Executor: build schema with DBA user

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -227,14 +227,14 @@ func (e *Executor) initSchema(ctx context.Context) error {
 
 	defer e.env.LogError()
 
-	conn, err := e.pool.Get(ctx)
+	conn, err := dbconnpool.NewDBConnection(ctx, e.env.Config().DB.DbaConnector())
 	if err != nil {
 		return err
 	}
-	defer conn.Recycle()
+	defer conn.Close()
 
 	for _, ddl := range ApplyDDL {
-		_, err := conn.Exec(ctx, ddl, math.MaxInt32, false)
+		_, err := conn.ExecuteFetch(ddl, math.MaxInt32, false)
 		if mysql.IsSchemaApplyError(err) {
 			continue
 		}


### PR DESCRIPTION
## Description
Fixes https://github.com/vitessio/vitess/issues/8621

Using DBA account to creating `_vt.*` schema (namely `_vt.schema_migrations`)
DBA account is privileged, as opposed to `app` account which may not have the privileges to create the schema.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required


cc @aquarapid 
