### PR TITLE
Fixing vtorc naming convention - Functions and Variables

### DIFF
--- a/go/vt/orchestrator/app/cli.go
+++ b/go/vt/orchestrator/app/cli.go
@@ -280,7 +280,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.MasterKey.DisplayString())
+			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.PrimaryKey.DisplayString())
 		}
 	case registerCliCommand("move-up-replicas", "Classic file:pos relocation", `Moves replicas of the given instance one level up the topology`):
 		{
@@ -321,7 +321,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.MasterKey.DisplayString())
+			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.PrimaryKey.DisplayString())
 		}
 	case registerCliCommand("repoint-replicas", "Classic file:pos relocation", `Repoint all replicas of given instance to replicate back from the instance. Use with care`):
 		{
@@ -344,7 +344,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instanceKey == nil {
 				log.Fatal("Cannot deduce instance:", instance)
 			}
-			_, err := inst.TakeMaster(instanceKey, false)
+			_, err := inst.TakePrimary(instanceKey, false)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -353,7 +353,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("make-co-master", "Classic file:pos relocation", `Create a master-master replication. Given instance is a replica which replicates directly from a master.`):
 		{
 			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
-			_, err := inst.MakeCoMaster(instanceKey)
+			_, err := inst.MakeCoPrimary(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -475,7 +475,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("gtid-errant-reset-master", "Replication, general", `Reset master on instance, remove GTID errant transactions`):
 		{
 			instanceKey, _ = inst.FigureInstanceKey(instanceKey, thisInstanceKey)
-			_, err := inst.ErrantGTIDResetMaster(instanceKey)
+			_, err := inst.ErrantGTIDResetPrimary(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -532,7 +532,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instanceKey == nil {
 				log.Fatal("Cannot deduce instance:", instance)
 			}
-			_, err := inst.DetachReplicaMasterHost(instanceKey)
+			_, err := inst.DetachReplicaPrimaryHost(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -544,7 +544,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instanceKey == nil {
 				log.Fatal("Cannot deduce instance:", instance)
 			}
-			_, err := inst.ReattachReplicaMasterHost(instanceKey)
+			_, err := inst.ReattachReplicaPrimaryHost(instanceKey)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -568,7 +568,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if binlogCoordinates, err = inst.ParseBinlogCoordinates(*config.RuntimeCLIFlags.BinlogFile); err != nil {
 				log.Fatalf("Expecing --binlog argument as file:pos")
 			}
-			_, err = inst.MasterPosWait(instanceKey, binlogCoordinates)
+			_, err = inst.PrimaryPosWait(instanceKey, binlogCoordinates)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -772,7 +772,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		}
 	case registerCliCommand("all-clusters-masters", "Information", `List of writeable masters, one per cluster`):
 		{
-			instances, err := inst.ReadWriteableClustersMasters()
+			instances, err := inst.ReadWriteableClustersPrimaries()
 			if err != nil {
 				log.Fatale(err)
 			} else {
@@ -863,7 +863,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("which-cluster-master", "Information", `Output the name of the master in a given cluster`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)
-			masters, err := inst.ReadClusterMaster(clusterName)
+			masters, err := inst.ReadClusterPrimary(clusterName)
 			if err != nil {
 				log.Fatale(err)
 			}
@@ -912,8 +912,8 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Unable to get master: unresolved instance")
 			}
 			instance := validateInstanceIsFound(instanceKey)
-			if instance.MasterKey.IsValid() {
-				fmt.Println(instance.MasterKey.DisplayString())
+			if instance.PrimaryKey.IsValid() {
+				fmt.Println(instance.PrimaryKey.DisplayString())
 			}
 		}
 	case registerCliCommand("which-downtimed-instances", "Information", `List instances currently downtimed, potentially filtered by cluster`):

--- a/go/vt/orchestrator/app/cli.go
+++ b/go/vt/orchestrator/app/cli.go
@@ -280,7 +280,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.PrimaryKey.DisplayString())
+			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.SourceKey.DisplayString())
 		}
 	case registerCliCommand("move-up-replicas", "Classic file:pos relocation", `Moves replicas of the given instance one level up the topology`):
 		{
@@ -321,7 +321,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if err != nil {
 				log.Fatale(err)
 			}
-			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.PrimaryKey.DisplayString())
+			fmt.Printf("%s<%s\n", instanceKey.DisplayString(), instance.SourceKey.DisplayString())
 		}
 	case registerCliCommand("repoint-replicas", "Classic file:pos relocation", `Repoint all replicas of given instance to replicate back from the instance. Use with care`):
 		{
@@ -912,8 +912,8 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("Unable to get master: unresolved instance")
 			}
 			instance := validateInstanceIsFound(instanceKey)
-			if instance.PrimaryKey.IsValid() {
-				fmt.Println(instance.PrimaryKey.DisplayString())
+			if instance.SourceKey.IsValid() {
+				fmt.Println(instance.SourceKey.DisplayString())
 			}
 		}
 	case registerCliCommand("which-downtimed-instances", "Information", `List instances currently downtimed, potentially filtered by cluster`):

--- a/go/vt/orchestrator/http/api.go
+++ b/go/vt/orchestrator/http/api.go
@@ -521,13 +521,13 @@ func (this *HttpAPI) MoveUpReplicas(params martini.Params, r render.Render, req 
 		return
 	}
 
-	replicas, newMaster, err, errs := inst.MoveUpReplicas(&instanceKey, req.URL.Query().Get("pattern"))
+	replicas, newPrimary, err, errs := inst.MoveUpReplicas(&instanceKey, req.URL.Query().Get("pattern"))
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
 
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Moved up %d replicas of %+v below %+v; %d errors: %+v", len(replicas), instanceKey, newMaster.Key, len(errs), errs), Details: replicas})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Moved up %d replicas of %+v below %+v; %d errors: %+v", len(replicas), instanceKey, newPrimary.Key, len(errs), errs), Details: replicas})
 }
 
 // Repoint positiones a replica under another (or same) primary with exact same coordinates.
@@ -578,8 +578,8 @@ func (this *HttpAPI) RepointReplicas(params martini.Params, r render.Render, req
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Repointed %d replicas of %+v", len(replicas), instanceKey), Details: replicas})
 }
 
-// MakeCoMaster attempts to make an instance co-primary with its own primary
-func (this *HttpAPI) MakeCoMaster(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+// MakeCoPrimary attempts to make an instance co-primary with its own primary
+func (this *HttpAPI) MakeCoPrimary(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -620,9 +620,9 @@ func (this *HttpAPI) ResetReplication(params martini.Params, r render.Render, re
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Replica reset on %+v", instance.Key), Details: instance})
 }
 
-// DetachReplicaMasterHost detaches a replica from its primary by setting an invalid
+// DetachReplicaPrimaryHost detaches a replica from its primary by setting an invalid
 // (yet revertible) host name
-func (this *HttpAPI) DetachReplicaMasterHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+func (this *HttpAPI) DetachReplicaPrimaryHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -642,9 +642,9 @@ func (this *HttpAPI) DetachReplicaMasterHost(params martini.Params, r render.Ren
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Replica detached: %+v", instance.Key), Details: instance})
 }
 
-// ReattachReplicaMasterHost reverts a detachReplicaMasterHost command
+// ReattachReplicaPrimaryHost reverts a detachReplicaMasterHost command
 // by resetting the original primary hostname in CHANGE MASTER TO
-func (this *HttpAPI) ReattachReplicaMasterHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+func (this *HttpAPI) ReattachReplicaPrimaryHost(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -722,8 +722,8 @@ func (this *HttpAPI) LocateErrantGTID(params martini.Params, r render.Render, re
 	Respond(r, &APIResponse{Code: OK, Message: "located errant GTID", Details: errantBinlogs})
 }
 
-// ErrantGTIDResetMaster removes errant transactions on a server by way of RESET MASTER
-func (this *HttpAPI) ErrantGTIDResetMaster(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+// ErrantGTIDResetPrimary removes errant transactions on a server by way of RESET MASTER
+func (this *HttpAPI) ErrantGTIDResetPrimary(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -755,13 +755,13 @@ func (this *HttpAPI) ErrantGTIDInjectEmpty(params martini.Params, r render.Rende
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	instance, clusterMaster, countInjectedTransactions, err := inst.ErrantGTIDInjectEmpty(&instanceKey)
+	instance, clusterPrimary, countInjectedTransactions, err := inst.ErrantGTIDInjectEmpty(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
 
-	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Have injected %+v transactions on cluster master %+v", countInjectedTransactions, clusterMaster.Key), Details: instance})
+	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Have injected %+v transactions on cluster master %+v", countInjectedTransactions, clusterPrimary.Key), Details: instance})
 }
 
 // MoveBelow attempts to move an instance below its supposed sibling
@@ -863,8 +863,8 @@ func (this *HttpAPI) TakeSiblings(params martini.Params, r render.Render, req *h
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Took %d siblings of %+v", count, instanceKey), Details: instance})
 }
 
-// TakeMaster
-func (this *HttpAPI) TakeMaster(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+// TakePrimary
+func (this *HttpAPI) TakePrimary(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -1637,10 +1637,10 @@ func (this *HttpAPI) UntagAll(params martini.Params, r render.Render, req *http.
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("%s removed from %+v instances", tag.TagName, len(*untagged)), Details: untagged.GetInstanceKeys()})
 }
 
-// SubmitMastersToKvStores writes a cluster's primary (or all clusters primaries) to kv stores.
+// SubmitPrimariesToKvStores writes a cluster's primary (or all clusters primaries) to kv stores.
 // This should generally only happen once in a lifetime of a cluster. Otherwise KV
 // stores are updated via failovers.
-func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Render, req *http.Request) {
+func (this *HttpAPI) SubmitPrimariesToKvStores(params martini.Params, r render.Render, req *http.Request) {
 	clusterName, err := getClusterNameIfExists(params)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
@@ -1655,7 +1655,7 @@ func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Ren
 }
 
 // Clusters provides list of known primaries
-func (this *HttpAPI) Masters(params martini.Params, r render.Render, req *http.Request) {
+func (this *HttpAPI) Primaries(params martini.Params, r render.Render, req *http.Request) {
 	instances, err := inst.ReadWriteableClustersPrimaries()
 
 	if err != nil {
@@ -1666,25 +1666,25 @@ func (this *HttpAPI) Masters(params martini.Params, r render.Render, req *http.R
 	r.JSON(http.StatusOK, instances)
 }
 
-// ClusterMaster returns the writable primary of a given cluster
-func (this *HttpAPI) ClusterMaster(params martini.Params, r render.Render, req *http.Request) {
+// ClusterPrimary returns the writable primary of a given cluster
+func (this *HttpAPI) ClusterPrimary(params martini.Params, r render.Render, req *http.Request) {
 	clusterName, err := figureClusterName(getClusterHint(params))
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
 
-	masters, err := inst.ReadClusterPrimary(clusterName)
+	primaries, err := inst.ReadClusterPrimary(clusterName)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
-	if len(masters) == 0 {
-		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("No masters found for %+v", clusterName)})
+	if len(primaries) == 0 {
+		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("No primaries found for %+v", clusterName)})
 		return
 	}
 
-	r.JSON(http.StatusOK, masters[0])
+	r.JSON(http.StatusOK, primaries[0])
 }
 
 // Downtimed lists downtimed instances, potentially filtered by cluster
@@ -2304,8 +2304,8 @@ func (this *HttpAPI) Recover(params martini.Params, r render.Render, req *http.R
 	Respond(r, &APIResponse{Code: OK, Message: fmt.Sprintf("Recovery executed on %+v", instanceKey), Details: *promotedInstanceKey})
 }
 
-// GracefulMasterTakeover gracefully fails over a primary onto its single replica.
-func (this *HttpAPI) gracefulMasterTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User, auto bool) {
+// GracefulPrimaryTakeover gracefully fails over a primary onto its single replica.
+func (this *HttpAPI) gracefulPrimaryTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User, auto bool) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -2329,20 +2329,20 @@ func (this *HttpAPI) gracefulMasterTakeover(params martini.Params, r render.Rend
 	Respond(r, &APIResponse{Code: OK, Message: "graceful-master-takeover: successor promoted", Details: topologyRecovery})
 }
 
-// GracefulMasterTakeover gracefully fails over a primary, either:
+// GracefulPrimaryTakeover gracefully fails over a primary, either:
 // - onto its single replica, or
 // - onto a replica indicated by the user
-func (this *HttpAPI) GracefulMasterTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
-	this.gracefulMasterTakeover(params, r, req, user, false)
+func (this *HttpAPI) GracefulPrimaryTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	this.gracefulPrimaryTakeover(params, r, req, user, false)
 }
 
-// GracefulMasterTakeoverAuto gracefully fails over a primary onto a replica of orchestrator's choosing
-func (this *HttpAPI) GracefulMasterTakeoverAuto(params martini.Params, r render.Render, req *http.Request, user auth.User) {
-	this.gracefulMasterTakeover(params, r, req, user, true)
+// GracefulPrimaryTakeoverAuto gracefully fails over a primary onto a replica of orchestrator's choosing
+func (this *HttpAPI) GracefulPrimaryTakeoverAuto(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	this.gracefulPrimaryTakeover(params, r, req, user, true)
 }
 
-// ForceMasterFailover fails over a primary (even if there's no particular problem with the primary)
-func (this *HttpAPI) ForceMasterFailover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+// ForcePrimaryFailover fails over a primary (even if there's no particular problem with the primary)
+func (this *HttpAPI) ForcePrimaryFailover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -2364,8 +2364,8 @@ func (this *HttpAPI) ForceMasterFailover(params martini.Params, r render.Render,
 	}
 }
 
-// ForceMasterTakeover fails over a primary (even if there's no particular problem with the primary)
-func (this *HttpAPI) ForceMasterTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+// ForcePrimaryTakeover fails over a primary (even if there's no particular problem with the primary)
+func (this *HttpAPI) ForcePrimaryTakeover(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		Respond(r, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
@@ -2839,9 +2839,9 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "move-below/:host/:port/:siblingHost/:siblingPort", this.MoveBelow)
 	this.registerAPIRequest(m, "repoint/:host/:port/:belowHost/:belowPort", this.Repoint)
 	this.registerAPIRequest(m, "repoint-slaves/:host/:port", this.RepointReplicas)
-	this.registerAPIRequest(m, "make-co-master/:host/:port", this.MakeCoMaster)
+	this.registerAPIRequest(m, "make-co-master/:host/:port", this.MakeCoPrimary)
 	this.registerAPIRequest(m, "enslave-siblings/:host/:port", this.TakeSiblings)
-	this.registerAPIRequest(m, "enslave-master/:host/:port", this.TakeMaster)
+	this.registerAPIRequest(m, "enslave-master/:host/:port", this.TakePrimary)
 
 	// Binlog server relocation:
 	this.registerAPIRequest(m, "regroup-slaves-bls/:host/:port", this.RegroupReplicasBinlogServers)
@@ -2855,7 +2855,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "enable-gtid/:host/:port", this.EnableGTID)
 	this.registerAPIRequest(m, "disable-gtid/:host/:port", this.DisableGTID)
 	this.registerAPIRequest(m, "locate-gtid-errant/:host/:port", this.LocateErrantGTID)
-	this.registerAPIRequest(m, "gtid-errant-reset-master/:host/:port", this.ErrantGTIDResetMaster)
+	this.registerAPIRequest(m, "gtid-errant-reset-master/:host/:port", this.ErrantGTIDResetPrimary)
 	this.registerAPIRequest(m, "gtid-errant-inject-empty/:host/:port", this.ErrantGTIDInjectEmpty)
 	this.registerAPIRequest(m, "skip-query/:host/:port", this.SkipQuery)
 	this.registerAPIRequest(m, "start-slave/:host/:port", this.StartReplication)
@@ -2863,10 +2863,10 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "stop-slave/:host/:port", this.StopReplication)
 	this.registerAPIRequest(m, "stop-slave-nice/:host/:port", this.StopReplicationNicely)
 	this.registerAPIRequest(m, "reset-slave/:host/:port", this.ResetReplication)
-	this.registerAPIRequest(m, "detach-slave/:host/:port", this.DetachReplicaMasterHost)
-	this.registerAPIRequest(m, "reattach-slave/:host/:port", this.ReattachReplicaMasterHost)
-	this.registerAPIRequest(m, "detach-slave-master-host/:host/:port", this.DetachReplicaMasterHost)
-	this.registerAPIRequest(m, "reattach-slave-master-host/:host/:port", this.ReattachReplicaMasterHost)
+	this.registerAPIRequest(m, "detach-slave/:host/:port", this.DetachReplicaPrimaryHost)
+	this.registerAPIRequest(m, "reattach-slave/:host/:port", this.ReattachReplicaPrimaryHost)
+	this.registerAPIRequest(m, "detach-slave-master-host/:host/:port", this.DetachReplicaPrimaryHost)
+	this.registerAPIRequest(m, "reattach-slave-master-host/:host/:port", this.ReattachReplicaPrimaryHost)
 	this.registerAPIRequest(m, "flush-binary-logs/:host/:port", this.FlushBinaryLogs)
 	this.registerAPIRequest(m, "purge-binary-logs/:host/:port/:logFile", this.PurgeBinaryLogs)
 	this.registerAPIRequest(m, "restart-slave-statements/:host/:port", this.RestartReplicationStatements)
@@ -2904,8 +2904,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "clusters", this.Clusters)
 	this.registerAPIRequest(m, "clusters-info", this.ClustersInfo)
 
-	this.registerAPIRequest(m, "masters", this.Masters)
-	this.registerAPIRequest(m, "master/:clusterHint", this.ClusterMaster)
+	this.registerAPIRequest(m, "masters", this.Primaries)
+	this.registerAPIRequest(m, "master/:clusterHint", this.ClusterPrimary)
 	this.registerAPIRequest(m, "instance-replicas/:host/:port", this.InstanceReplicas)
 	this.registerAPIRequest(m, "all-instances", this.AllInstances)
 	this.registerAPIRequest(m, "downtimed", this.Downtimed)
@@ -2919,8 +2919,8 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "snapshot-topologies", this.SnapshotTopologies)
 
 	// Key-value:
-	this.registerAPIRequest(m, "submit-masters-to-kv-stores", this.SubmitMastersToKvStores)
-	this.registerAPIRequest(m, "submit-masters-to-kv-stores/:clusterHint", this.SubmitMastersToKvStores)
+	this.registerAPIRequest(m, "submit-masters-to-kv-stores", this.SubmitPrimariesToKvStores)
+	this.registerAPIRequest(m, "submit-masters-to-kv-stores/:clusterHint", this.SubmitPrimariesToKvStores)
 
 	// Tags:
 	this.registerAPIRequest(m, "tagged", this.Tagged)
@@ -2958,18 +2958,18 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	this.registerAPIRequest(m, "recover/:host/:port/:candidateHost/:candidatePort", this.Recover)
 	this.registerAPIRequest(m, "recover-lite/:host/:port", this.RecoverLite)
 	this.registerAPIRequest(m, "recover-lite/:host/:port/:candidateHost/:candidatePort", this.RecoverLite)
-	this.registerAPIRequest(m, "graceful-master-takeover/:host/:port", this.GracefulMasterTakeover)
-	this.registerAPIRequest(m, "graceful-master-takeover/:host/:port/:designatedHost/:designatedPort", this.GracefulMasterTakeover)
-	this.registerAPIRequest(m, "graceful-master-takeover/:clusterHint", this.GracefulMasterTakeover)
-	this.registerAPIRequest(m, "graceful-master-takeover/:clusterHint/:designatedHost/:designatedPort", this.GracefulMasterTakeover)
-	this.registerAPIRequest(m, "graceful-master-takeover-auto/:host/:port", this.GracefulMasterTakeoverAuto)
-	this.registerAPIRequest(m, "graceful-master-takeover-auto/:host/:port/:designatedHost/:designatedPort", this.GracefulMasterTakeoverAuto)
-	this.registerAPIRequest(m, "graceful-master-takeover-auto/:clusterHint", this.GracefulMasterTakeoverAuto)
-	this.registerAPIRequest(m, "graceful-master-takeover-auto/:clusterHint/:designatedHost/:designatedPort", this.GracefulMasterTakeoverAuto)
-	this.registerAPIRequest(m, "force-master-failover/:host/:port", this.ForceMasterFailover)
-	this.registerAPIRequest(m, "force-master-failover/:clusterHint", this.ForceMasterFailover)
-	this.registerAPIRequest(m, "force-master-takeover/:clusterHint/:designatedHost/:designatedPort", this.ForceMasterTakeover)
-	this.registerAPIRequest(m, "force-master-takeover/:host/:port/:designatedHost/:designatedPort", this.ForceMasterTakeover)
+	this.registerAPIRequest(m, "graceful-master-takeover/:host/:port", this.GracefulPrimaryTakeover)
+	this.registerAPIRequest(m, "graceful-master-takeover/:host/:port/:designatedHost/:designatedPort", this.GracefulPrimaryTakeover)
+	this.registerAPIRequest(m, "graceful-master-takeover/:clusterHint", this.GracefulPrimaryTakeover)
+	this.registerAPIRequest(m, "graceful-master-takeover/:clusterHint/:designatedHost/:designatedPort", this.GracefulPrimaryTakeover)
+	this.registerAPIRequest(m, "graceful-master-takeover-auto/:host/:port", this.GracefulPrimaryTakeoverAuto)
+	this.registerAPIRequest(m, "graceful-master-takeover-auto/:host/:port/:designatedHost/:designatedPort", this.GracefulPrimaryTakeoverAuto)
+	this.registerAPIRequest(m, "graceful-master-takeover-auto/:clusterHint", this.GracefulPrimaryTakeoverAuto)
+	this.registerAPIRequest(m, "graceful-master-takeover-auto/:clusterHint/:designatedHost/:designatedPort", this.GracefulPrimaryTakeoverAuto)
+	this.registerAPIRequest(m, "force-master-failover/:host/:port", this.ForcePrimaryFailover)
+	this.registerAPIRequest(m, "force-master-failover/:clusterHint", this.ForcePrimaryFailover)
+	this.registerAPIRequest(m, "force-master-takeover/:clusterHint/:designatedHost/:designatedPort", this.ForcePrimaryTakeover)
+	this.registerAPIRequest(m, "force-master-takeover/:host/:port/:designatedHost/:designatedPort", this.ForcePrimaryTakeover)
 	this.registerAPIRequest(m, "register-candidate/:host/:port/:promotionRule", this.RegisterCandidate)
 	this.registerAPIRequest(m, "automated-recovery-filters", this.AutomatedRecoveryFilters)
 	this.registerAPIRequest(m, "audit-failure-detection", this.AuditFailureDetection)

--- a/go/vt/orchestrator/http/api.go
+++ b/go/vt/orchestrator/http/api.go
@@ -1646,7 +1646,7 @@ func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Ren
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
 	}
-	kvPairs, submittedCount, err := logic.SubmitMastersToKvStores(clusterName, true)
+	kvPairs, submittedCount, err := logic.SubmitPrimariesToKvStores(clusterName, true)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return
@@ -2317,7 +2317,7 @@ func (this *HttpAPI) gracefulMasterTakeover(params martini.Params, r render.Rend
 	}
 	designatedKey, _ := this.getInstanceKey(params["designatedHost"], params["designatedPort"])
 	// designatedKey may be empty/invalid
-	topologyRecovery, _, err := logic.GracefulMasterTakeover(clusterName, &designatedKey, auto)
+	topologyRecovery, _, err := logic.GracefulPrimaryTakeover(clusterName, &designatedKey, auto)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error(), Details: topologyRecovery})
 		return
@@ -2352,7 +2352,7 @@ func (this *HttpAPI) ForceMasterFailover(params martini.Params, r render.Render,
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	topologyRecovery, err := logic.ForceMasterFailover(clusterName)
+	topologyRecovery, err := logic.ForcePrimaryFailover(clusterName)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -2386,7 +2386,7 @@ func (this *HttpAPI) ForceMasterTakeover(params martini.Params, r render.Render,
 		return
 	}
 
-	topologyRecovery, err := logic.ForceMasterTakeover(clusterName, designatedInstance)
+	topologyRecovery, err := logic.ForcePrimaryTakeover(clusterName, designatedInstance)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/vt/orchestrator/http/api.go
+++ b/go/vt/orchestrator/http/api.go
@@ -590,7 +590,7 @@ func (this *HttpAPI) MakeCoMaster(params martini.Params, r render.Render, req *h
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	instance, err := inst.MakeCoMaster(&instanceKey)
+	instance, err := inst.MakeCoPrimary(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -633,7 +633,7 @@ func (this *HttpAPI) DetachReplicaMasterHost(params martini.Params, r render.Ren
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	instance, err := inst.DetachReplicaMasterHost(&instanceKey)
+	instance, err := inst.DetachReplicaPrimaryHost(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -655,7 +655,7 @@ func (this *HttpAPI) ReattachReplicaMasterHost(params martini.Params, r render.R
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	instance, err := inst.ReattachReplicaMasterHost(&instanceKey)
+	instance, err := inst.ReattachReplicaPrimaryHost(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -734,7 +734,7 @@ func (this *HttpAPI) ErrantGTIDResetMaster(params martini.Params, r render.Rende
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	instance, err := inst.ErrantGTIDResetMaster(&instanceKey)
+	instance, err := inst.ErrantGTIDResetPrimary(&instanceKey)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -875,7 +875,7 @@ func (this *HttpAPI) TakeMaster(params martini.Params, r render.Render, req *htt
 		return
 	}
 
-	instance, err := inst.TakeMaster(&instanceKey, false)
+	instance, err := inst.TakePrimary(&instanceKey, false)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -1656,7 +1656,7 @@ func (this *HttpAPI) SubmitMastersToKvStores(params martini.Params, r render.Ren
 
 // Clusters provides list of known primaries
 func (this *HttpAPI) Masters(params martini.Params, r render.Render, req *http.Request) {
-	instances, err := inst.ReadWriteableClustersMasters()
+	instances, err := inst.ReadWriteableClustersPrimaries()
 
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
@@ -1674,7 +1674,7 @@ func (this *HttpAPI) ClusterMaster(params martini.Params, r render.Render, req *
 		return
 	}
 
-	masters, err := inst.ReadClusterMaster(clusterName)
+	masters, err := inst.ReadClusterPrimary(clusterName)
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
 		return

--- a/go/vt/orchestrator/inst/analysis.go
+++ b/go/vt/orchestrator/inst/analysis.go
@@ -30,46 +30,46 @@ type AnalysisCode string
 type StructureAnalysisCode string
 
 const (
-	NoProblem                                               AnalysisCode = "NoProblem"
-	ClusterHasNoMaster                                      AnalysisCode = "ClusterHasNoMaster"
-	DeadMasterWithoutReplicas                               AnalysisCode = "DeadMasterWithoutReplicas"
-	DeadMaster                                              AnalysisCode = "DeadMaster"
-	DeadMasterAndReplicas                                   AnalysisCode = "DeadMasterAndReplicas"
-	DeadMasterAndSomeReplicas                               AnalysisCode = "DeadMasterAndSomeReplicas"
-	MasterHasMaster                                         AnalysisCode = "MasterHasMaster"
-	MasterIsReadOnly                                        AnalysisCode = "MasterIsReadOnly"
-	MasterSemiSyncMustBeSet                                 AnalysisCode = "MasterSemiSyncMustBeSet"
-	MasterSemiSyncMustNotBeSet                              AnalysisCode = "MasterSemiSyncMustNotBeSet"
-	ReplicaIsWritable                                       AnalysisCode = "ReplicaIsWritable"
-	NotConnectedToMaster                                    AnalysisCode = "NotConnectedToMaster"
-	ConnectedToWrongMaster                                  AnalysisCode = "ConnectedToWrongMaster"
-	ReplicationStopped                                      AnalysisCode = "ReplicationStopped"
-	ReplicaSemiSyncMustBeSet                                AnalysisCode = "ReplicaSemiSyncMustBeSet"
-	ReplicaSemiSyncMustNotBeSet                             AnalysisCode = "ReplicaSemiSyncMustNotBeSet"
-	UnreachableMasterWithLaggingReplicas                    AnalysisCode = "UnreachableMasterWithLaggingReplicas"
-	UnreachableMaster                                       AnalysisCode = "UnreachableMaster"
-	MasterSingleReplicaNotReplicating                       AnalysisCode = "MasterSingleReplicaNotReplicating"
-	MasterSingleReplicaDead                                 AnalysisCode = "MasterSingleReplicaDead"
-	AllMasterReplicasNotReplicating                         AnalysisCode = "AllMasterReplicasNotReplicating"
-	AllMasterReplicasNotReplicatingOrDead                   AnalysisCode = "AllMasterReplicasNotReplicatingOrDead"
-	LockedSemiSyncMasterHypothesis                          AnalysisCode = "LockedSemiSyncMasterHypothesis"
-	LockedSemiSyncMaster                                    AnalysisCode = "LockedSemiSyncMaster"
-	MasterWithoutReplicas                                   AnalysisCode = "MasterWithoutReplicas"
-	DeadCoMaster                                            AnalysisCode = "DeadCoMaster"
-	DeadCoMasterAndSomeReplicas                             AnalysisCode = "DeadCoMasterAndSomeReplicas"
-	UnreachableCoMaster                                     AnalysisCode = "UnreachableCoMaster"
-	AllCoMasterReplicasNotReplicating                       AnalysisCode = "AllCoMasterReplicasNotReplicating"
-	DeadIntermediateMaster                                  AnalysisCode = "DeadIntermediateMaster"
-	DeadIntermediateMasterWithSingleReplica                 AnalysisCode = "DeadIntermediateMasterWithSingleReplica"
-	DeadIntermediateMasterWithSingleReplicaFailingToConnect AnalysisCode = "DeadIntermediateMasterWithSingleReplicaFailingToConnect"
-	DeadIntermediateMasterAndSomeReplicas                   AnalysisCode = "DeadIntermediateMasterAndSomeReplicas"
-	DeadIntermediateMasterAndReplicas                       AnalysisCode = "DeadIntermediateMasterAndReplicas"
-	UnreachableIntermediateMasterWithLaggingReplicas        AnalysisCode = "UnreachableIntermediateMasterWithLaggingReplicas"
-	UnreachableIntermediateMaster                           AnalysisCode = "UnreachableIntermediateMaster"
-	AllIntermediateMasterReplicasFailingToConnectOrDead     AnalysisCode = "AllIntermediateMasterReplicasFailingToConnectOrDead"
-	AllIntermediateMasterReplicasNotReplicating             AnalysisCode = "AllIntermediateMasterReplicasNotReplicating"
-	FirstTierReplicaFailingToConnectToMaster                AnalysisCode = "FirstTierReplicaFailingToConnectToMaster"
-	BinlogServerFailingToConnectToMaster                    AnalysisCode = "BinlogServerFailingToConnectToMaster"
+	NoProblem                                                AnalysisCode = "NoProblem"
+	ClusterHasNoPrimary                                      AnalysisCode = "ClusterHasNoMaster"
+	DeadPrimaryWithoutReplicas                               AnalysisCode = "DeadMasterWithoutReplicas"
+	DeadPrimary                                              AnalysisCode = "DeadMaster"
+	DeadPrimaryAndReplicas                                   AnalysisCode = "DeadMasterAndReplicas"
+	DeadPrimaryAndSomeReplicas                               AnalysisCode = "DeadMasterAndSomeReplicas"
+	PrimaryHasPrimary                                        AnalysisCode = "MasterHasMaster"
+	PrimaryIsReadOnly                                        AnalysisCode = "MasterIsReadOnly"
+	PrimarySemiSyncMustBeSet                                 AnalysisCode = "MasterSemiSyncMustBeSet"
+	PrimarySemiSyncMustNotBeSet                              AnalysisCode = "MasterSemiSyncMustNotBeSet"
+	ReplicaIsWritable                                        AnalysisCode = "ReplicaIsWritable"
+	NotConnectedToPrimary                                    AnalysisCode = "NotConnectedToMaster"
+	ConnectedToWrongPrimary                                  AnalysisCode = "ConnectedToWrongMaster"
+	ReplicationStopped                                       AnalysisCode = "ReplicationStopped"
+	ReplicaSemiSyncMustBeSet                                 AnalysisCode = "ReplicaSemiSyncMustBeSet"
+	ReplicaSemiSyncMustNotBeSet                              AnalysisCode = "ReplicaSemiSyncMustNotBeSet"
+	UnreachablePrimaryWithLaggingReplicas                    AnalysisCode = "UnreachableMasterWithLaggingReplicas"
+	UnreachablePrimary                                       AnalysisCode = "UnreachableMaster"
+	PrimarySingleReplicaNotReplicating                       AnalysisCode = "MasterSingleReplicaNotReplicating"
+	PrimarySingleReplicaDead                                 AnalysisCode = "MasterSingleReplicaDead"
+	AllPrimaryReplicasNotReplicating                         AnalysisCode = "AllMasterReplicasNotReplicating"
+	AllPrimaryReplicasNotReplicatingOrDead                   AnalysisCode = "AllMasterReplicasNotReplicatingOrDead"
+	LockedSemiSyncPrimaryHypothesis                          AnalysisCode = "LockedSemiSyncMasterHypothesis"
+	LockedSemiSyncPrimary                                    AnalysisCode = "LockedSemiSyncMaster"
+	PrimaryWithoutReplicas                                   AnalysisCode = "MasterWithoutReplicas"
+	DeadCoPrimary                                            AnalysisCode = "DeadCoMaster"
+	DeadCoPrimaryAndSomeReplicas                             AnalysisCode = "DeadCoMasterAndSomeReplicas"
+	UnreachableCoPrimary                                     AnalysisCode = "UnreachableCoMaster"
+	AllCoPrimaryReplicasNotReplicating                       AnalysisCode = "AllCoMasterReplicasNotReplicating"
+	DeadIntermediatePrimary                                  AnalysisCode = "DeadIntermediateMaster"
+	DeadIntermediatePrimaryWithSingleReplica                 AnalysisCode = "DeadIntermediateMasterWithSingleReplica"
+	DeadIntermediatePrimaryWithSingleReplicaFailingToConnect AnalysisCode = "DeadIntermediateMasterWithSingleReplicaFailingToConnect"
+	DeadIntermediatePrimaryAndSomeReplicas                   AnalysisCode = "DeadIntermediateMasterAndSomeReplicas"
+	DeadIntermediatePrimaryAndReplicas                       AnalysisCode = "DeadIntermediateMasterAndReplicas"
+	UnreachableIntermediatePrimaryWithLaggingReplicas        AnalysisCode = "UnreachableIntermediateMasterWithLaggingReplicas"
+	UnreachableIntermediatePrimary                           AnalysisCode = "UnreachableIntermediateMaster"
+	AllIntermediatePrimaryReplicasFailingToConnectOrDead     AnalysisCode = "AllIntermediateMasterReplicasFailingToConnectOrDead"
+	AllIntermediatePrimaryReplicasNotReplicating             AnalysisCode = "AllIntermediateMasterReplicasNotReplicating"
+	FirstTierReplicaFailingToConnectToPrimary                AnalysisCode = "FirstTierReplicaFailingToConnectToMaster"
+	BinlogServerFailingToConnectToPrimary                    AnalysisCode = "BinlogServerFailingToConnectToMaster"
 )
 
 const (
@@ -81,7 +81,7 @@ const (
 	DifferentGTIDModesStructureWarning                   StructureAnalysisCode = "DifferentGTIDModesStructureWarning"
 	ErrantGTIDStructureWarning                           StructureAnalysisCode = "ErrantGTIDStructureWarning"
 	NoFailoverSupportStructureWarning                    StructureAnalysisCode = "NoFailoverSupportStructureWarning"
-	NoWriteableMasterStructureWarning                    StructureAnalysisCode = "NoWriteableMasterStructureWarning"
+	NoWriteablePrimaryStructureWarning                   StructureAnalysisCode = "NoWriteableMasterStructureWarning"
 	NotEnoughValidSemiSyncReplicasStructureWarning       StructureAnalysisCode = "NotEnoughValidSemiSyncReplicasStructureWarning"
 )
 
@@ -112,61 +112,61 @@ type ReplicationAnalysisHints struct {
 }
 
 const (
-	ForceMasterFailoverCommandHint    string = "force-master-failover"
-	ForceMasterTakeoverCommandHint    string = "force-master-takeover"
-	GracefulMasterTakeoverCommandHint string = "graceful-master-takeover"
+	ForcePrimaryFailoverCommandHint    string = "force-master-failover"
+	ForcePrimaryTakeoverCommandHint    string = "force-master-takeover"
+	GracefulPrimaryTakeoverCommandHint string = "graceful-master-takeover"
 )
 
 type AnalysisInstanceType string
 
 const (
-	AnalysisInstanceTypeMaster             AnalysisInstanceType = "master"
-	AnalysisInstanceTypeCoMaster           AnalysisInstanceType = "co-master"
-	AnalysisInstanceTypeIntermediateMaster AnalysisInstanceType = "intermediate-master"
+	AnalysisInstanceTypePrimary             AnalysisInstanceType = "master"
+	AnalysisInstanceTypeCoPrimary           AnalysisInstanceType = "co-master"
+	AnalysisInstanceTypeIntermediatePrimary AnalysisInstanceType = "intermediate-master"
 )
 
 // ReplicationAnalysis notes analysis on replication chain status, per instance
 type ReplicationAnalysis struct {
 	AnalyzedInstanceKey                       InstanceKey
-	AnalyzedInstanceMasterKey                 InstanceKey
+	AnalyzedInstancePrimaryKey                InstanceKey
 	TabletType                                topodatapb.TabletType
-	MasterTimeStamp                           time.Time
+	PrimaryTimeStamp                          time.Time
 	SuggestedClusterAlias                     string
 	ClusterDetails                            ClusterInfo
 	AnalyzedInstanceDataCenter                string
 	AnalyzedInstanceRegion                    string
 	AnalyzedInstancePhysicalEnvironment       string
 	AnalyzedInstanceBinlogCoordinates         BinlogCoordinates
-	IsMaster                                  bool
-	IsClusterMaster                           bool
-	IsCoMaster                                bool
+	IsPrimary                                 bool
+	IsClusterPrimary                          bool
+	IsCoPrimary                               bool
 	LastCheckValid                            bool
 	LastCheckPartialSuccess                   bool
 	CountReplicas                             uint
 	CountValidReplicas                        uint
 	CountValidReplicatingReplicas             uint
-	CountReplicasFailingToConnectToMaster     uint
+	CountReplicasFailingToConnectToPrimary    uint
 	CountDowntimedReplicas                    uint
 	ReplicationDepth                          uint
 	Replicas                                  InstanceKeyMap
 	SlaveHosts                                InstanceKeyMap // for backwards compatibility. Equals `Replicas`
-	IsFailingToConnectToMaster                bool
+	IsFailingToConnectToPrimary               bool
 	ReplicationStopped                        bool
 	Analysis                                  AnalysisCode
 	Description                               string
 	StructureAnalysis                         []StructureAnalysisCode
 	IsDowntimed                               bool
-	IsReplicasDowntimed                       bool // as good as downtimed because all replicas are downtimed AND analysis is all about the replicas (e.e. AllMasterReplicasNotReplicating)
+	IsReplicasDowntimed                       bool // as good as downtimed because all replicas are downtimed AND analysis is all about the replicas (e.e. AllPrimaryReplicasNotReplicating)
 	DowntimeEndTimestamp                      string
 	DowntimeRemainingSeconds                  int
 	IsBinlogServer                            bool
 	OracleGTIDImmediateTopology               bool
 	MariaDBGTIDImmediateTopology              bool
 	BinlogServerImmediateTopology             bool
-	SemiSyncMasterEnabled                     bool
-	SemiSyncMasterStatus                      bool
-	SemiSyncMasterWaitForReplicaCount         uint
-	SemiSyncMasterClients                     uint
+	SemiSyncPrimaryEnabled                    bool
+	SemiSyncPrimaryStatus                     bool
+	SemiSyncPrimaryWaitForReplicaCount        uint
+	SemiSyncPrimaryClients                    uint
 	SemiSyncReplicaEnabled                    bool
 	CountSemiSyncReplicasEnabled              uint
 	CountLoggingReplicas                      uint
@@ -228,13 +228,13 @@ func (this *ReplicationAnalysis) AnalysisString() string {
 
 // Get a string description of the analyzed instance type (primary? co-primary? intermediate-primary?)
 func (this *ReplicationAnalysis) GetAnalysisInstanceType() AnalysisInstanceType {
-	if this.IsCoMaster {
-		return AnalysisInstanceTypeCoMaster
+	if this.IsCoPrimary {
+		return AnalysisInstanceTypeCoPrimary
 	}
-	if this.IsMaster {
-		return AnalysisInstanceTypeMaster
+	if this.IsPrimary {
+		return AnalysisInstanceTypePrimary
 	}
-	return AnalysisInstanceTypeIntermediateMaster
+	return AnalysisInstanceTypeIntermediatePrimary
 }
 
 // ValidSecondsFromSeenToLastAttemptedCheck returns the maximum allowed elapsed time

--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -57,7 +57,7 @@ func initializeAnalysisDaoPostConfiguration() {
 
 type clusterAnalysis struct {
 	hasClusterwideAction bool
-	masterKey            *InstanceKey
+	primaryKey           *InstanceKey
 }
 
 // GetReplicationAnalysis will check for replication problems (dead primary; unreachable primary; etc)
@@ -375,22 +375,22 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			return nil
 		}
 
-		masterTablet := &topodatapb.Tablet{}
+		primaryTablet := &topodatapb.Tablet{}
 		if str := m.GetString("master_tablet_info"); str != "" {
-			if err := prototext.Unmarshal([]byte(str), masterTablet); err != nil {
+			if err := prototext.Unmarshal([]byte(str), primaryTablet); err != nil {
 				log.Errorf("could not read tablet %v: %v", str, err)
 				return nil
 			}
 		}
 
 		a.TabletType = tablet.Type
-		a.MasterTimeStamp = m.GetTime("master_timestamp")
+		a.PrimaryTimeStamp = m.GetTime("master_timestamp")
 
-		a.IsMaster = m.GetBool("is_master")
-		countCoMasterReplicas := m.GetUint("count_co_master_replicas")
-		a.IsCoMaster = m.GetBool("is_co_master") || (countCoMasterReplicas > 0)
+		a.IsPrimary = m.GetBool("is_master")
+		countCoPrimaryReplicas := m.GetUint("count_co_master_replicas")
+		a.IsCoPrimary = m.GetBool("is_co_master") || (countCoPrimaryReplicas > 0)
 		a.AnalyzedInstanceKey = InstanceKey{Hostname: m.GetString("hostname"), Port: m.GetInt("port")}
-		a.AnalyzedInstanceMasterKey = InstanceKey{Hostname: m.GetString("master_host"), Port: m.GetInt("master_port")}
+		a.AnalyzedInstancePrimaryKey = InstanceKey{Hostname: m.GetString("master_host"), Port: m.GetInt("master_port")}
 		a.AnalyzedInstanceDataCenter = m.GetString("data_center")
 		a.AnalyzedInstanceRegion = m.GetString("region")
 		a.AnalyzedInstancePhysicalEnvironment = m.GetString("physical_environment")
@@ -410,10 +410,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.CountReplicas = m.GetUint("count_replicas")
 		a.CountValidReplicas = m.GetUint("count_valid_replicas")
 		a.CountValidReplicatingReplicas = m.GetUint("count_valid_replicating_replicas")
-		a.CountReplicasFailingToConnectToMaster = m.GetUint("count_replicas_failing_to_connect_to_master")
+		a.CountReplicasFailingToConnectToPrimary = m.GetUint("count_replicas_failing_to_connect_to_master")
 		a.CountDowntimedReplicas = m.GetUint("count_downtimed_replicas")
 		a.ReplicationDepth = m.GetUint("replication_depth")
-		a.IsFailingToConnectToMaster = m.GetBool("is_failing_to_connect_to_master")
+		a.IsFailingToConnectToPrimary = m.GetBool("is_failing_to_connect_to_master")
 		a.ReplicationStopped = m.GetBool("replication_stopped")
 		a.IsDowntimed = m.GetBool("is_downtimed")
 		a.DowntimeEndTimestamp = m.GetString("downtime_end_timestamp")
@@ -430,13 +430,13 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.MariaDBGTIDImmediateTopology = countValidMariaDBGTIDReplicas == a.CountValidReplicas && a.CountValidReplicas > 0
 		countValidBinlogServerReplicas := m.GetUint("count_valid_binlog_server_replicas")
 		a.BinlogServerImmediateTopology = countValidBinlogServerReplicas == a.CountValidReplicas && a.CountValidReplicas > 0
-		a.SemiSyncMasterEnabled = m.GetBool("semi_sync_master_enabled")
-		a.SemiSyncMasterStatus = m.GetBool("semi_sync_master_status")
+		a.SemiSyncPrimaryEnabled = m.GetBool("semi_sync_master_enabled")
+		a.SemiSyncPrimaryStatus = m.GetBool("semi_sync_master_status")
 		a.SemiSyncReplicaEnabled = m.GetBool("semi_sync_replica_enabled")
 		a.CountSemiSyncReplicasEnabled = m.GetUint("count_semi_sync_replicas")
 		// countValidSemiSyncReplicasEnabled := m.GetUint("count_valid_semi_sync_replicas")
-		a.SemiSyncMasterWaitForReplicaCount = m.GetUint("semi_sync_master_wait_for_slave_count")
-		a.SemiSyncMasterClients = m.GetUint("semi_sync_master_clients")
+		a.SemiSyncPrimaryWaitForReplicaCount = m.GetUint("semi_sync_master_wait_for_slave_count")
+		a.SemiSyncPrimaryClients = m.GetUint("semi_sync_master_clients")
 
 		a.MinReplicaGTIDMode = m.GetString("min_replica_gtid_mode")
 		a.MaxReplicaGTIDMode = m.GetString("max_replica_gtid_mode")
@@ -454,8 +454,8 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		a.IsReadOnly = m.GetUint("read_only") == 1
 
 		if !a.LastCheckValid {
-			analysisMessage := fmt.Sprintf("analysis: ClusterName: %+v, IsMaster: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v, CountReplicasFailingToConnectToMaster: %+v",
-				a.ClusterDetails.ClusterName, a.IsMaster, a.LastCheckValid, a.LastCheckPartialSuccess, a.CountReplicas, a.CountValidReplicas, a.CountValidReplicatingReplicas, a.CountLaggingReplicas, a.CountDelayedReplicas, a.CountReplicasFailingToConnectToMaster,
+			analysisMessage := fmt.Sprintf("analysis: ClusterName: %+v, IsPrimary: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v, CountReplicasFailingToConnectToMaster: %+v",
+				a.ClusterDetails.ClusterName, a.IsPrimary, a.LastCheckValid, a.LastCheckPartialSuccess, a.CountReplicas, a.CountValidReplicas, a.CountValidReplicatingReplicas, a.CountLaggingReplicas, a.CountDelayedReplicas, a.CountReplicasFailingToConnectToPrimary,
 			)
 			if util.ClearToLog("analysis_dao", analysisMessage) {
 				log.Debugf(analysisMessage)
@@ -464,8 +464,8 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		if clusters[a.SuggestedClusterAlias] == nil {
 			clusters[a.SuggestedClusterAlias] = &clusterAnalysis{}
 			if a.TabletType == topodatapb.TabletType_PRIMARY {
-				a.IsClusterMaster = true
-				clusters[a.SuggestedClusterAlias].masterKey = &a.AnalyzedInstanceKey
+				a.IsClusterPrimary = true
+				clusters[a.SuggestedClusterAlias].primaryKey = &a.AnalyzedInstanceKey
 			}
 		}
 		// ca has clusterwide info
@@ -474,177 +474,177 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			// We can only take one cluster level action at a time.
 			return nil
 		}
-		if a.IsClusterMaster && !a.LastCheckValid && a.CountReplicas == 0 {
-			a.Analysis = DeadMasterWithoutReplicas
+		if a.IsClusterPrimary && !a.LastCheckValid && a.CountReplicas == 0 {
+			a.Analysis = DeadPrimaryWithoutReplicas
 			a.Description = "Master cannot be reached by orchestrator and has no replica"
 			ca.hasClusterwideAction = true
 			//
-		} else if a.IsClusterMaster && !a.LastCheckValid && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadMaster
+		} else if a.IsClusterPrimary && !a.LastCheckValid && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadPrimary
 			a.Description = "Master cannot be reached by orchestrator and none of its replicas is replicating"
 			ca.hasClusterwideAction = true
 			//
-		} else if a.IsClusterMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadMasterAndReplicas
+		} else if a.IsClusterPrimary && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadPrimaryAndReplicas
 			a.Description = "Master cannot be reached by orchestrator and none of its replicas is replicating"
 			ca.hasClusterwideAction = true
 			//
-		} else if a.IsClusterMaster && !a.LastCheckValid && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadMasterAndSomeReplicas
+		} else if a.IsClusterPrimary && !a.LastCheckValid && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadPrimaryAndSomeReplicas
 			a.Description = "Master cannot be reached by orchestrator; some of its replicas are unreachable and none of its reachable replicas is replicating"
 			ca.hasClusterwideAction = true
 			//
-		} else if a.IsClusterMaster && !a.IsMaster {
-			a.Analysis = MasterHasMaster
+		} else if a.IsClusterPrimary && !a.IsPrimary {
+			a.Analysis = PrimaryHasPrimary
 			a.Description = "Master is replicating from somewhere else"
 			ca.hasClusterwideAction = true
 			//
-		} else if a.IsClusterMaster && a.IsReadOnly {
-			a.Analysis = MasterIsReadOnly
+		} else if a.IsClusterPrimary && a.IsReadOnly {
+			a.Analysis = PrimaryIsReadOnly
 			a.Description = "Master is read-only"
 			//
-		} else if a.IsClusterMaster && MasterSemiSync(a.AnalyzedInstanceKey) != 0 && !a.SemiSyncMasterEnabled {
-			a.Analysis = MasterSemiSyncMustBeSet
+		} else if a.IsClusterPrimary && PrimarySemiSync(a.AnalyzedInstanceKey) != 0 && !a.SemiSyncPrimaryEnabled {
+			a.Analysis = PrimarySemiSyncMustBeSet
 			a.Description = "Master semi-sync must be set"
 			//
-		} else if a.IsClusterMaster && MasterSemiSync(a.AnalyzedInstanceKey) == 0 && a.SemiSyncMasterEnabled {
-			a.Analysis = MasterSemiSyncMustNotBeSet
+		} else if a.IsClusterPrimary && PrimarySemiSync(a.AnalyzedInstanceKey) == 0 && a.SemiSyncPrimaryEnabled {
+			a.Analysis = PrimarySemiSyncMustNotBeSet
 			a.Description = "Master semi-sync must not be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && ca.masterKey == nil {
-			a.Analysis = ClusterHasNoMaster
+		} else if topo.IsReplicaType(a.TabletType) && ca.primaryKey == nil {
+			a.Analysis = ClusterHasNoPrimary
 			a.Description = "Cluster has no master"
 			ca.hasClusterwideAction = true
 		} else if topo.IsReplicaType(a.TabletType) && !a.IsReadOnly {
 			a.Analysis = ReplicaIsWritable
 			a.Description = "Replica is writable"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && a.IsMaster {
-			a.Analysis = NotConnectedToMaster
+		} else if topo.IsReplicaType(a.TabletType) && a.IsPrimary {
+			a.Analysis = NotConnectedToPrimary
 			a.Description = "Not connected to the master"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsMaster && ca.masterKey != nil && a.AnalyzedInstanceMasterKey != *ca.masterKey {
-			a.Analysis = ConnectedToWrongMaster
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && ca.primaryKey != nil && a.AnalyzedInstancePrimaryKey != *ca.primaryKey {
+			a.Analysis = ConnectedToWrongPrimary
 			a.Description = "Connected to wrong master"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsMaster && a.ReplicationStopped {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && a.ReplicationStopped {
 			a.Analysis = ReplicationStopped
 			a.Description = "Replication is stopped"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsMaster && ReplicaSemiSyncFromTablet(masterTablet, tablet) && !a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && ReplicaSemiSyncFromTablet(primaryTablet, tablet) && !a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustBeSet
 			a.Description = "Replica semi-sync must be set"
 			//
-		} else if topo.IsReplicaType(a.TabletType) && !a.IsMaster && !ReplicaSemiSyncFromTablet(masterTablet, tablet) && a.SemiSyncReplicaEnabled {
+		} else if topo.IsReplicaType(a.TabletType) && !a.IsPrimary && !ReplicaSemiSyncFromTablet(primaryTablet, tablet) && a.SemiSyncReplicaEnabled {
 			a.Analysis = ReplicaSemiSyncMustNotBeSet
 			a.Description = "Replica semi-sync must not be set"
 			//
 			// TODO(sougou): Events below here are either ignored or not possible.
-		} else if a.IsMaster && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = UnreachableMasterWithLaggingReplicas
+		} else if a.IsPrimary && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
+			a.Analysis = UnreachablePrimaryWithLaggingReplicas
 			a.Description = "Master cannot be reached by orchestrator and all of its replicas are lagging"
 			//
-		} else if a.IsMaster && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+		} else if a.IsPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
 			// partial success is here to redice noise
-			a.Analysis = UnreachableMaster
+			a.Analysis = UnreachablePrimary
 			a.Description = "Master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//
-		} else if a.IsMaster && !a.LastCheckValid && a.LastCheckPartialSuccess && a.CountReplicasFailingToConnectToMaster > 0 && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+		} else if a.IsPrimary && !a.LastCheckValid && a.LastCheckPartialSuccess && a.CountReplicasFailingToConnectToPrimary > 0 && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
 			// there's partial success, but also at least one replica is failing to connect to primary
-			a.Analysis = UnreachableMaster
+			a.Analysis = UnreachablePrimary
 			a.Description = "Master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//
-		} else if a.IsMaster && a.SemiSyncMasterEnabled && a.SemiSyncMasterStatus && a.SemiSyncMasterWaitForReplicaCount > 0 && a.SemiSyncMasterClients < a.SemiSyncMasterWaitForReplicaCount {
+		} else if a.IsPrimary && a.SemiSyncPrimaryEnabled && a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount {
 			if isStaleBinlogCoordinates {
-				a.Analysis = LockedSemiSyncMaster
+				a.Analysis = LockedSemiSyncPrimary
 				a.Description = "Semi sync master is locked since it doesn't get enough replica acknowledgements"
 			} else {
-				a.Analysis = LockedSemiSyncMasterHypothesis
+				a.Analysis = LockedSemiSyncPrimaryHypothesis
 				a.Description = "Semi sync master seems to be locked, more samplings needed to validate"
 			}
 			//
-		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = MasterSingleReplicaNotReplicating
+		} else if a.IsPrimary && a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = PrimarySingleReplicaNotReplicating
 			a.Description = "Master is reachable but its single replica is not replicating"
-		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == 0 {
-			a.Analysis = MasterSingleReplicaDead
+		} else if a.IsPrimary && a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == 0 {
+			a.Analysis = PrimarySingleReplicaDead
 			a.Description = "Master is reachable but its single replica is dead"
 			//
-		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = AllMasterReplicasNotReplicating
+		} else if a.IsPrimary && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = AllPrimaryReplicasNotReplicating
 			a.Description = "Master is reachable but none of its replicas is replicating"
 			//
-		} else if a.IsMaster && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = AllMasterReplicasNotReplicatingOrDead
+		} else if a.IsPrimary && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = AllPrimaryReplicasNotReplicatingOrDead
 			a.Description = "Master is reachable but none of its replicas is replicating"
 			//
-		} else /* co-master */ if a.IsCoMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadCoMaster
+		} else /* co-master */ if a.IsCoPrimary && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadCoPrimary
 			a.Description = "Co-master cannot be reached by orchestrator and none of its replicas is replicating"
 			//
-		} else if a.IsCoMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadCoMasterAndSomeReplicas
+		} else if a.IsCoPrimary && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadCoPrimaryAndSomeReplicas
 			a.Description = "Co-master cannot be reached by orchestrator; some of its replicas are unreachable and none of its reachable replicas is replicating"
 			//
-		} else if a.IsCoMaster && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = UnreachableCoMaster
+		} else if a.IsCoPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+			a.Analysis = UnreachableCoPrimary
 			a.Description = "Co-master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//
-		} else if a.IsCoMaster && a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = AllCoMasterReplicasNotReplicating
+		} else if a.IsCoPrimary && a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = AllCoPrimaryReplicasNotReplicating
 			a.Description = "Co-master is reachable but none of its replicas is replicating"
 			//
-		} else /* intermediate-master */ if !a.IsMaster && !a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountReplicasFailingToConnectToMaster == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadIntermediateMasterWithSingleReplicaFailingToConnect
+		} else /* intermediate-master */ if !a.IsPrimary && !a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountReplicasFailingToConnectToPrimary == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadIntermediatePrimaryWithSingleReplicaFailingToConnect
 			a.Description = "Intermediate master cannot be reached by orchestrator and its (single) replica is failing to connect"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadIntermediateMasterWithSingleReplica
+		} else if !a.IsPrimary && !a.LastCheckValid && a.CountReplicas == 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadIntermediatePrimaryWithSingleReplica
 			a.Description = "Intermediate master cannot be reached by orchestrator and its (single) replica is not replicating"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadIntermediateMaster
+		} else if !a.IsPrimary && !a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicas == a.CountReplicas && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadIntermediatePrimary
 			a.Description = "Intermediate master cannot be reached by orchestrator and none of its replicas is replicating"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = DeadIntermediateMasterAndSomeReplicas
+		} else if !a.IsPrimary && !a.LastCheckValid && a.CountValidReplicas < a.CountReplicas && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = DeadIntermediatePrimaryAndSomeReplicas
 			a.Description = "Intermediate master cannot be reached by orchestrator; some of its replicas are unreachable and none of its reachable replicas is replicating"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == 0 {
-			a.Analysis = DeadIntermediateMasterAndReplicas
+		} else if !a.IsPrimary && !a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicas == 0 {
+			a.Analysis = DeadIntermediatePrimaryAndReplicas
 			a.Description = "Intermediate master cannot be reached by orchestrator and all of its replicas are unreachable"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = UnreachableIntermediateMasterWithLaggingReplicas
+		} else if !a.IsPrimary && !a.LastCheckValid && a.CountLaggingReplicas == a.CountReplicas && a.CountDelayedReplicas < a.CountReplicas && a.CountValidReplicatingReplicas > 0 {
+			a.Analysis = UnreachableIntermediatePrimaryWithLaggingReplicas
 			a.Description = "Intermediate master cannot be reached by orchestrator and all of its replicas are lagging"
 			//
-		} else if !a.IsMaster && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
-			a.Analysis = UnreachableIntermediateMaster
+		} else if !a.IsPrimary && !a.LastCheckValid && !a.LastCheckPartialSuccess && a.CountValidReplicas > 0 && a.CountValidReplicatingReplicas > 0 {
+			a.Analysis = UnreachableIntermediatePrimary
 			a.Description = "Intermediate master cannot be reached by orchestrator but it has replicating replicas; possibly a network/host issue"
 			//
-		} else if !a.IsMaster && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicatingReplicas == 0 &&
-			a.CountReplicasFailingToConnectToMaster > 0 && a.CountReplicasFailingToConnectToMaster == a.CountValidReplicas {
+		} else if !a.IsPrimary && a.LastCheckValid && a.CountReplicas > 1 && a.CountValidReplicatingReplicas == 0 &&
+			a.CountReplicasFailingToConnectToPrimary > 0 && a.CountReplicasFailingToConnectToPrimary == a.CountValidReplicas {
 			// All replicas are either failing to connect to primary (and at least one of these have to exist)
 			// or completely dead.
 			// Must have at least two replicas to reach such conclusion -- do note that the intermediate primary is still
 			// reachable to orchestrator, so we base our conclusion on replicas only at this point.
-			a.Analysis = AllIntermediateMasterReplicasFailingToConnectOrDead
+			a.Analysis = AllIntermediatePrimaryReplicasFailingToConnectOrDead
 			a.Description = "Intermediate master is reachable but all of its replicas are failing to connect"
 			//
-		} else if !a.IsMaster && a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
-			a.Analysis = AllIntermediateMasterReplicasNotReplicating
+		} else if !a.IsPrimary && a.LastCheckValid && a.CountReplicas > 0 && a.CountValidReplicatingReplicas == 0 {
+			a.Analysis = AllIntermediatePrimaryReplicasNotReplicating
 			a.Description = "Intermediate master is reachable but none of its replicas is replicating"
 			//
-		} else if a.IsBinlogServer && a.IsFailingToConnectToMaster {
-			a.Analysis = BinlogServerFailingToConnectToMaster
+		} else if a.IsBinlogServer && a.IsFailingToConnectToPrimary {
+			a.Analysis = BinlogServerFailingToConnectToPrimary
 			a.Description = "Binlog server is unable to connect to its master"
 			//
-		} else if a.ReplicationDepth == 1 && a.IsFailingToConnectToMaster {
-			a.Analysis = FirstTierReplicaFailingToConnectToMaster
+		} else if a.ReplicationDepth == 1 && a.IsFailingToConnectToPrimary {
+			a.Analysis = FirstTierReplicaFailingToConnectToPrimary
 			a.Description = "1st tier replica (directly replicating from topology master) is unable to connect to the master"
 			//
 		}
-		//		 else if a.IsMaster && a.CountReplicas == 0 {
+		//		 else if a.IsPrimary && a.CountReplicas == 0 {
 		//			a.Analysis = MasterWithoutReplicas
 		//			a.Description = "Master has no replicas"
 		//		}
@@ -663,16 +663,16 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 			}
 			if a.CountReplicas == a.CountDowntimedReplicas {
 				switch a.Analysis {
-				case AllMasterReplicasNotReplicating,
-					AllMasterReplicasNotReplicatingOrDead,
-					MasterSingleReplicaDead,
-					AllCoMasterReplicasNotReplicating,
-					DeadIntermediateMasterWithSingleReplica,
-					DeadIntermediateMasterWithSingleReplicaFailingToConnect,
-					DeadIntermediateMasterAndReplicas,
-					DeadIntermediateMasterAndSomeReplicas,
-					AllIntermediateMasterReplicasFailingToConnectOrDead,
-					AllIntermediateMasterReplicasNotReplicating:
+				case AllPrimaryReplicasNotReplicating,
+					AllPrimaryReplicasNotReplicatingOrDead,
+					PrimarySingleReplicaDead,
+					AllCoPrimaryReplicasNotReplicating,
+					DeadIntermediatePrimaryWithSingleReplica,
+					DeadIntermediatePrimaryWithSingleReplicaFailingToConnect,
+					DeadIntermediatePrimaryAndReplicas,
+					DeadIntermediatePrimaryAndSomeReplicas,
+					AllIntermediatePrimaryReplicasFailingToConnectOrDead,
+					AllIntermediatePrimaryReplicasNotReplicating:
 					a.IsReplicasDowntimed = true
 					a.SkippableDueToDowntime = true
 				}
@@ -686,25 +686,25 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		{
 			// Moving on to structure analysis
 			// We also do structural checks. See if there's potential danger in promotions
-			if a.IsMaster && a.CountLoggingReplicas == 0 && a.CountReplicas > 1 {
+			if a.IsPrimary && a.CountLoggingReplicas == 0 && a.CountReplicas > 1 {
 				a.StructureAnalysis = append(a.StructureAnalysis, NoLoggingReplicasStructureWarning)
 			}
-			if a.IsMaster && a.CountReplicas > 1 &&
+			if a.IsPrimary && a.CountReplicas > 1 &&
 				!a.OracleGTIDImmediateTopology &&
 				!a.MariaDBGTIDImmediateTopology &&
 				!a.BinlogServerImmediateTopology {
 				a.StructureAnalysis = append(a.StructureAnalysis, NoFailoverSupportStructureWarning)
 			}
-			if a.IsMaster && a.CountStatementBasedLoggingReplicas > 0 && a.CountMixedBasedLoggingReplicas > 0 {
+			if a.IsPrimary && a.CountStatementBasedLoggingReplicas > 0 && a.CountMixedBasedLoggingReplicas > 0 {
 				a.StructureAnalysis = append(a.StructureAnalysis, StatementAndMixedLoggingReplicasStructureWarning)
 			}
-			if a.IsMaster && a.CountStatementBasedLoggingReplicas > 0 && a.CountRowBasedLoggingReplicas > 0 {
+			if a.IsPrimary && a.CountStatementBasedLoggingReplicas > 0 && a.CountRowBasedLoggingReplicas > 0 {
 				a.StructureAnalysis = append(a.StructureAnalysis, StatementAndRowLoggingReplicasStructureWarning)
 			}
-			if a.IsMaster && a.CountMixedBasedLoggingReplicas > 0 && a.CountRowBasedLoggingReplicas > 0 {
+			if a.IsPrimary && a.CountMixedBasedLoggingReplicas > 0 && a.CountRowBasedLoggingReplicas > 0 {
 				a.StructureAnalysis = append(a.StructureAnalysis, MixedAndRowLoggingReplicasStructureWarning)
 			}
-			if a.IsMaster && a.CountDistinctMajorVersionsLoggingReplicas > 1 {
+			if a.IsPrimary && a.CountDistinctMajorVersionsLoggingReplicas > 1 {
 				a.StructureAnalysis = append(a.StructureAnalysis, MultipleMajorVersionsLoggingReplicasStructureWarning)
 			}
 
@@ -715,11 +715,11 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 				a.StructureAnalysis = append(a.StructureAnalysis, ErrantGTIDStructureWarning)
 			}
 
-			if a.IsMaster && a.IsReadOnly {
-				a.StructureAnalysis = append(a.StructureAnalysis, NoWriteableMasterStructureWarning)
+			if a.IsPrimary && a.IsReadOnly {
+				a.StructureAnalysis = append(a.StructureAnalysis, NoWriteablePrimaryStructureWarning)
 			}
 
-			if a.IsMaster && a.SemiSyncMasterEnabled && !a.SemiSyncMasterStatus && a.SemiSyncMasterWaitForReplicaCount > 0 && a.SemiSyncMasterClients < a.SemiSyncMasterWaitForReplicaCount {
+			if a.IsPrimary && a.SemiSyncPrimaryEnabled && !a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount {
 				a.StructureAnalysis = append(a.StructureAnalysis, NotEnoughValidSemiSyncReplicasStructureWarning)
 			}
 		}

--- a/go/vt/orchestrator/inst/analysis_test.go
+++ b/go/vt/orchestrator/inst/analysis_test.go
@@ -36,15 +36,15 @@ func TestGetAnalysisInstanceType(t *testing.T) {
 		test.S(t).ExpectEquals(string(analysis.GetAnalysisInstanceType()), "intermediate-master")
 	}
 	{
-		analysis := &ReplicationAnalysis{IsMaster: true}
+		analysis := &ReplicationAnalysis{IsPrimary: true}
 		test.S(t).ExpectEquals(string(analysis.GetAnalysisInstanceType()), "master")
 	}
 	{
-		analysis := &ReplicationAnalysis{IsCoMaster: true}
+		analysis := &ReplicationAnalysis{IsCoPrimary: true}
 		test.S(t).ExpectEquals(string(analysis.GetAnalysisInstanceType()), "co-master")
 	}
 	{
-		analysis := &ReplicationAnalysis{IsMaster: true, IsCoMaster: true}
+		analysis := &ReplicationAnalysis{IsPrimary: true, IsCoPrimary: true}
 		test.S(t).ExpectEquals(string(analysis.GetAnalysisInstanceType()), "co-master")
 	}
 }

--- a/go/vt/orchestrator/inst/cluster.go
+++ b/go/vt/orchestrator/inst/cluster.go
@@ -25,37 +25,37 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/kv"
 )
 
-func GetClusterMasterKVKey(clusterAlias string) string {
+func GetClusterPrimaryKVKey(clusterAlias string) string {
 	return fmt.Sprintf("%s%s", config.Config.KVClusterMasterPrefix, clusterAlias)
 }
 
-func getClusterMasterKVPair(clusterAlias string, masterKey *InstanceKey) *kv.KVPair {
+func getClusterPrimaryKVPair(clusterAlias string, primaryKey *InstanceKey) *kv.KVPair {
 	if clusterAlias == "" {
 		return nil
 	}
-	if masterKey == nil {
+	if primaryKey == nil {
 		return nil
 	}
-	return kv.NewKVPair(GetClusterMasterKVKey(clusterAlias), masterKey.StringCode())
+	return kv.NewKVPair(GetClusterPrimaryKVKey(clusterAlias), primaryKey.StringCode())
 }
 
-// GetClusterMasterKVPairs returns all KV pairs associated with a primary. This includes the
+// GetClusterPrimaryKVPairs returns all KV pairs associated with a primary. This includes the
 // full identity of the primary as well as a breakdown by hostname, port, ipv4, ipv6
-func GetClusterMasterKVPairs(clusterAlias string, masterKey *InstanceKey) (kvPairs [](*kv.KVPair)) {
-	masterKVPair := getClusterMasterKVPair(clusterAlias, masterKey)
-	if masterKVPair == nil {
+func GetClusterPrimaryKVPairs(clusterAlias string, primaryKey *InstanceKey) (kvPairs [](*kv.KVPair)) {
+	primaryKVPair := getClusterPrimaryKVPair(clusterAlias, primaryKey)
+	if primaryKVPair == nil {
 		return kvPairs
 	}
-	kvPairs = append(kvPairs, masterKVPair)
+	kvPairs = append(kvPairs, primaryKVPair)
 
 	addPair := func(keySuffix, value string) {
-		key := fmt.Sprintf("%s/%s", masterKVPair.Key, keySuffix)
+		key := fmt.Sprintf("%s/%s", primaryKVPair.Key, keySuffix)
 		kvPairs = append(kvPairs, kv.NewKVPair(key, value))
 	}
 
-	addPair("hostname", masterKey.Hostname)
-	addPair("port", fmt.Sprintf("%d", masterKey.Port))
-	if ipv4, ipv6, err := readHostnameIPs(masterKey.Hostname); err == nil {
+	addPair("hostname", primaryKey.Hostname)
+	addPair("port", fmt.Sprintf("%d", primaryKey.Port))
+	if ipv4, ipv6, err := readHostnameIPs(primaryKey.Hostname); err == nil {
 		addPair("ipv4", ipv4)
 		addPair("ipv6", ipv6)
 	}
@@ -79,19 +79,19 @@ func mappedClusterNameToAlias(clusterName string) string {
 
 // ClusterInfo makes for a cluster status/info summary
 type ClusterInfo struct {
-	ClusterName                            string
-	ClusterAlias                           string // Human friendly alias
-	ClusterDomain                          string // CNAME/VIP/A-record/whatever of the primary of this cluster
-	CountInstances                         uint
-	HeuristicLag                           int64
-	HasAutomatedMasterRecovery             bool
-	HasAutomatedIntermediateMasterRecovery bool
+	ClusterName                             string
+	ClusterAlias                            string // Human friendly alias
+	ClusterDomain                           string // CNAME/VIP/A-record/whatever of the primary of this cluster
+	CountInstances                          uint
+	HeuristicLag                            int64
+	HasAutomatedPrimaryRecovery             bool
+	HasAutomatedIntermediatePrimaryRecovery bool
 }
 
 // ReadRecoveryInfo
 func (this *ClusterInfo) ReadRecoveryInfo() {
-	this.HasAutomatedMasterRecovery = this.filtersMatchCluster(config.Config.RecoverMasterClusterFilters)
-	this.HasAutomatedIntermediateMasterRecovery = this.filtersMatchCluster(config.Config.RecoverIntermediateMasterClusterFilters)
+	this.HasAutomatedPrimaryRecovery = this.filtersMatchCluster(config.Config.RecoverMasterClusterFilters)
+	this.HasAutomatedIntermediatePrimaryRecovery = this.filtersMatchCluster(config.Config.RecoverIntermediateMasterClusterFilters)
 }
 
 // filtersMatchCluster will see whether the given filters match the given cluster details

--- a/go/vt/orchestrator/inst/cluster_test.go
+++ b/go/vt/orchestrator/inst/cluster_test.go
@@ -38,29 +38,29 @@ func init() {
 }
 
 func TestGetClusterMasterKVKey(t *testing.T) {
-	kvKey := GetClusterMasterKVKey("foo")
+	kvKey := GetClusterPrimaryKVKey("foo")
 	test.S(t).ExpectEquals(kvKey, "test/master/foo")
 }
 
 func TestGetClusterMasterKVPair(t *testing.T) {
 	{
-		kvPair := getClusterMasterKVPair("myalias", &masterKey)
+		kvPair := getClusterPrimaryKVPair("myalias", &masterKey)
 		test.S(t).ExpectNotNil(kvPair)
 		test.S(t).ExpectEquals(kvPair.Key, "test/master/myalias")
 		test.S(t).ExpectEquals(kvPair.Value, masterKey.StringCode())
 	}
 	{
-		kvPair := getClusterMasterKVPair("", &masterKey)
+		kvPair := getClusterPrimaryKVPair("", &masterKey)
 		test.S(t).ExpectTrue(kvPair == nil)
 	}
 	{
-		kvPair := getClusterMasterKVPair("myalias", nil)
+		kvPair := getClusterPrimaryKVPair("myalias", nil)
 		test.S(t).ExpectTrue(kvPair == nil)
 	}
 }
 
 func TestGetClusterMasterKVPairs(t *testing.T) {
-	kvPairs := GetClusterMasterKVPairs("myalias", &masterKey)
+	kvPairs := GetClusterPrimaryKVPairs("myalias", &masterKey)
 	test.S(t).ExpectTrue(len(kvPairs) >= 2)
 
 	{
@@ -81,6 +81,6 @@ func TestGetClusterMasterKVPairs(t *testing.T) {
 }
 
 func TestGetClusterMasterKVPairs2(t *testing.T) {
-	kvPairs := GetClusterMasterKVPairs("", &masterKey)
+	kvPairs := GetClusterPrimaryKVPairs("", &masterKey)
 	test.S(t).ExpectEquals(len(kvPairs), 0)
 }

--- a/go/vt/orchestrator/inst/durability.go
+++ b/go/vt/orchestrator/inst/durability.go
@@ -56,8 +56,8 @@ func init() {
 // durabler is the interface which is used to get the promotion rules for candidates and the semi sync setup
 type durabler interface {
 	promotionRule(*topodatapb.Tablet) CandidatePromotionRule
-	masterSemiSync(InstanceKey) int
-	replicaSemiSync(master, replica *topodatapb.Tablet) bool
+	primarySemiSync(InstanceKey) int
+	replicaSemiSync(primary, replica *topodatapb.Tablet) bool
 }
 
 func registerDurability(name string, newDurablerFunc newDurabler) {
@@ -85,15 +85,15 @@ func PromotionRule(tablet *topodatapb.Tablet) CandidatePromotionRule {
 	return curDurabilityPolicy.promotionRule(tablet)
 }
 
-// MasterSemiSync returns the primary semi-sync setting for the instance.
+// PrimarySemiSync returns the primary semi-sync setting for the instance.
 // 0 means none. Non-zero specifies the number of required ackers.
-func MasterSemiSync(instanceKey InstanceKey) int {
-	return curDurabilityPolicy.masterSemiSync(instanceKey)
+func PrimarySemiSync(instanceKey InstanceKey) int {
+	return curDurabilityPolicy.primarySemiSync(instanceKey)
 }
 
 // ReplicaSemiSync returns the replica semi-sync setting for the instance.
-func ReplicaSemiSync(masterKey, replicaKey InstanceKey) bool {
-	master, err := ReadTablet(masterKey)
+func ReplicaSemiSync(primaryKey, replicaKey InstanceKey) bool {
+	primary, err := ReadTablet(primaryKey)
 	if err != nil {
 		return false
 	}
@@ -101,13 +101,13 @@ func ReplicaSemiSync(masterKey, replicaKey InstanceKey) bool {
 	if err != nil {
 		return false
 	}
-	return curDurabilityPolicy.replicaSemiSync(master, replica)
+	return curDurabilityPolicy.replicaSemiSync(primary, replica)
 }
 
 // ReplicaSemiSyncFromTablet returns the replica semi-sync setting from the tablet record.
 // Prefer using this function if tablet record is available.
-func ReplicaSemiSyncFromTablet(master, replica *topodatapb.Tablet) bool {
-	return curDurabilityPolicy.replicaSemiSync(master, replica)
+func ReplicaSemiSyncFromTablet(primary, replica *topodatapb.Tablet) bool {
+	return curDurabilityPolicy.replicaSemiSync(primary, replica)
 }
 
 //=======================================================================
@@ -123,11 +123,11 @@ func (d *durabilityNone) promotionRule(tablet *topodatapb.Tablet) CandidatePromo
 	return MustNotPromoteRule
 }
 
-func (d *durabilityNone) masterSemiSync(instanceKey InstanceKey) int {
+func (d *durabilityNone) primarySemiSync(instanceKey InstanceKey) int {
 	return 0
 }
 
-func (d *durabilityNone) replicaSemiSync(master, replica *topodatapb.Tablet) bool {
+func (d *durabilityNone) replicaSemiSync(primary, replica *topodatapb.Tablet) bool {
 	return false
 }
 
@@ -145,11 +145,11 @@ func (d *durabilitySemiSync) promotionRule(tablet *topodatapb.Tablet) CandidateP
 	return MustNotPromoteRule
 }
 
-func (d *durabilitySemiSync) masterSemiSync(instanceKey InstanceKey) int {
+func (d *durabilitySemiSync) primarySemiSync(instanceKey InstanceKey) int {
 	return 1
 }
 
-func (d *durabilitySemiSync) replicaSemiSync(master, replica *topodatapb.Tablet) bool {
+func (d *durabilitySemiSync) replicaSemiSync(primary, replica *topodatapb.Tablet) bool {
 	switch replica.Type {
 	case topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA:
 		return true
@@ -172,18 +172,18 @@ func (d *durabilityCrossCell) promotionRule(tablet *topodatapb.Tablet) Candidate
 	return MustNotPromoteRule
 }
 
-func (d *durabilityCrossCell) masterSemiSync(instanceKey InstanceKey) int {
+func (d *durabilityCrossCell) primarySemiSync(instanceKey InstanceKey) int {
 	return 1
 }
 
-func (d *durabilityCrossCell) replicaSemiSync(master, replica *topodatapb.Tablet) bool {
+func (d *durabilityCrossCell) replicaSemiSync(primary, replica *topodatapb.Tablet) bool {
 	// Prevent panics.
-	if master.Alias == nil || replica.Alias == nil {
+	if primary.Alias == nil || replica.Alias == nil {
 		return false
 	}
 	switch replica.Type {
 	case topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA:
-		return master.Alias.Cell != replica.Alias.Cell
+		return primary.Alias.Cell != replica.Alias.Cell
 	}
 	return false
 }
@@ -209,11 +209,11 @@ func (d *durabilitySpecified) promotionRule(tablet *topodatapb.Tablet) Candidate
 	return MustNotPromoteRule
 }
 
-func (d *durabilitySpecified) masterSemiSync(instanceKey InstanceKey) int {
+func (d *durabilitySpecified) primarySemiSync(instanceKey InstanceKey) int {
 	return 0
 }
 
-func (d *durabilitySpecified) replicaSemiSync(master, replica *topodatapb.Tablet) bool {
+func (d *durabilitySpecified) replicaSemiSync(primary, replica *topodatapb.Tablet) bool {
 	return false
 }
 

--- a/go/vt/orchestrator/inst/instance.go
+++ b/go/vt/orchestrator/inst/instance.go
@@ -48,10 +48,10 @@ type Instance struct {
 	LogSlaveUpdatesEnabled       bool // for API backwards compatibility. Equals `LogReplicationUpdatesEnabled`
 	LogReplicationUpdatesEnabled bool
 	SelfBinlogCoordinates        BinlogCoordinates
-	MasterKey                    InstanceKey
-	MasterUUID                   string
+	PrimaryKey                   InstanceKey
+	PrimaryUUID                  string
 	AncestryUUID                 string
-	IsDetachedMaster             bool
+	IsDetachedPrimary            bool
 
 	Slave_SQL_Running          bool // for API backwards compatibility. Equals `ReplicationSQLThreadRuning`
 	ReplicationSQLThreadRuning bool
@@ -72,36 +72,36 @@ type Instance struct {
 	RelaylogCoordinates   BinlogCoordinates
 	LastSQLError          string
 	LastIOError           string
-	SecondsBehindMaster   sql.NullInt64
+	SecondsBehindPrimary  sql.NullInt64
 	SQLDelay              uint
 	ExecutedGtidSet       string
 	GtidPurged            string
 	GtidErrant            string
 
-	masterExecutedGtidSet string // Not exported
+	primaryExecutedGtidSet string // Not exported
 
-	SlaveLagSeconds                   sql.NullInt64 // for API backwards compatibility. Equals `ReplicationLagSeconds`
-	ReplicationLagSeconds             sql.NullInt64
-	SlaveHosts                        InstanceKeyMap // for API backwards compatibility. Equals `Replicas`
-	Replicas                          InstanceKeyMap
-	ClusterName                       string
-	SuggestedClusterAlias             string
-	DataCenter                        string
-	Region                            string
-	PhysicalEnvironment               string
-	ReplicationDepth                  uint
-	IsCoMaster                        bool
-	HasReplicationCredentials         bool
-	ReplicationCredentialsAvailable   bool
-	SemiSyncAvailable                 bool // when both semi sync plugins (primary & replica) are loaded
-	SemiSyncEnforced                  bool
-	SemiSyncMasterEnabled             bool
-	SemiSyncReplicaEnabled            bool
-	SemiSyncMasterTimeout             uint64
-	SemiSyncMasterWaitForReplicaCount uint
-	SemiSyncMasterStatus              bool
-	SemiSyncMasterClients             uint
-	SemiSyncReplicaStatus             bool
+	SlaveLagSeconds                    sql.NullInt64 // for API backwards compatibility. Equals `ReplicationLagSeconds`
+	ReplicationLagSeconds              sql.NullInt64
+	SlaveHosts                         InstanceKeyMap // for API backwards compatibility. Equals `Replicas`
+	Replicas                           InstanceKeyMap
+	ClusterName                        string
+	SuggestedClusterAlias              string
+	DataCenter                         string
+	Region                             string
+	PhysicalEnvironment                string
+	ReplicationDepth                   uint
+	IsCoPrimary                        bool
+	HasReplicationCredentials          bool
+	ReplicationCredentialsAvailable    bool
+	SemiSyncAvailable                  bool // when both semi sync plugins (primary & replica) are loaded
+	SemiSyncEnforced                   bool
+	SemiSyncPrimaryEnabled             bool
+	SemiSyncReplicaEnabled             bool
+	SemiSyncPrimaryTimeout             uint64
+	SemiSyncPrimaryWaitForReplicaCount uint
+	SemiSyncPrimaryStatus              bool
+	SemiSyncPrimaryClients             uint
+	SemiSyncReplicaStatus              bool
 
 	LastSeenTimestamp    string
 	IsLastCheckValid     bool
@@ -311,12 +311,12 @@ func (this *Instance) FlavorNameAndMajorVersion() string {
 
 // IsReplica makes simple heuristics to decide whether this instance is a replica of another instance
 func (this *Instance) IsReplica() bool {
-	return this.MasterKey.Hostname != "" && this.MasterKey.Hostname != "_" && this.MasterKey.Port != 0 && (this.ReadBinlogCoordinates.LogFile != "" || this.UsingGTID())
+	return this.PrimaryKey.Hostname != "" && this.PrimaryKey.Hostname != "_" && this.PrimaryKey.Port != 0 && (this.ReadBinlogCoordinates.LogFile != "" || this.UsingGTID())
 }
 
-// IsMaster makes simple heuristics to decide whether this instance is a primary (not replicating from any other server),
+// IsPrimary makes simple heuristics to decide whether this instance is a primary (not replicating from any other server),
 // either via traditional async/semisync replication or group replication
-func (this *Instance) IsMaster() bool {
+func (this *Instance) IsPrimary() bool {
 	// If traditional replication is configured, it is for sure not a primary
 	if this.IsReplica() {
 		return false
@@ -374,9 +374,9 @@ func (this *Instance) NextGTID() (string, error) {
 		return tokens[len(tokens)-1]
 	}
 	// executed GTID set: 4f6d62ed-df65-11e3-b395-60672090eb04:1,b9b4712a-df64-11e3-b391-60672090eb04:1-6
-	executedGTIDsFromMaster := lastToken(this.ExecutedGtidSet, ",")
-	// executedGTIDsFromMaster: b9b4712a-df64-11e3-b391-60672090eb04:1-6
-	executedRange := lastToken(executedGTIDsFromMaster, ":")
+	executedGTIDsFromPrimary := lastToken(this.ExecutedGtidSet, ",")
+	// executedGTIDsFromPrimary: b9b4712a-df64-11e3-b391-60672090eb04:1-6
+	executedRange := lastToken(executedGTIDsFromPrimary, ":")
 	// executedRange: 1-6
 	lastExecutedNumberToken := lastToken(executedRange, "-")
 	// lastExecutedNumber: 6
@@ -385,7 +385,7 @@ func (this *Instance) NextGTID() (string, error) {
 		return "", err
 	}
 	nextNumber := lastExecutedNumber + 1
-	nextGTID := fmt.Sprintf("%s:%d", firstToken(executedGTIDsFromMaster, ":"), nextNumber)
+	nextGTID := fmt.Sprintf("%s:%d", firstToken(executedGTIDsFromPrimary, ":"), nextNumber)
 	return nextGTID, nil
 }
 
@@ -408,12 +408,12 @@ func (this *Instance) GetNextBinaryLog(binlogCoordinates BinlogCoordinates) (Bin
 }
 
 // IsReplicaOf returns true if this instance claims to replicate from given primary
-func (this *Instance) IsReplicaOf(master *Instance) bool {
-	return this.MasterKey.Equals(&master.Key)
+func (this *Instance) IsReplicaOf(primary *Instance) bool {
+	return this.PrimaryKey.Equals(&primary.Key)
 }
 
 // IsReplicaOf returns true if this i supposed primary of given replica
-func (this *Instance) IsMasterOf(replica *Instance) bool {
+func (this *Instance) IsPrimaryOf(replica *Instance) bool {
 	return replica.IsReplicaOf(this)
 }
 
@@ -472,9 +472,9 @@ func (this *Instance) CanReplicateFrom(other *Instance) (bool, error) {
 func (this *Instance) HasReasonableMaintenanceReplicationLag() bool {
 	// replicas with SQLDelay are a special case
 	if this.SQLDelay > 0 {
-		return math.AbsInt64(this.SecondsBehindMaster.Int64-int64(this.SQLDelay)) <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
+		return math.AbsInt64(this.SecondsBehindPrimary.Int64-int64(this.SQLDelay)) <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
 	}
-	return this.SecondsBehindMaster.Int64 <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
+	return this.SecondsBehindPrimary.Int64 <= int64(config.Config.ReasonableMaintenanceReplicationLagSeconds)
 }
 
 // CanMove returns true if this instance's state allows it to be repositioned. For example,
@@ -492,7 +492,7 @@ func (this *Instance) CanMove() (bool, error) {
 	if !this.ReplicationIOThreadState.IsRunning() {
 		return false, fmt.Errorf("%+v: instance is not replicating", this.Key)
 	}
-	if !this.SecondsBehindMaster.Valid {
+	if !this.SecondsBehindPrimary.Valid {
 		return false, fmt.Errorf("%+v: cannot determine replication lag", this.Key)
 	}
 	if !this.HasReasonableMaintenanceReplicationLag() {
@@ -501,8 +501,8 @@ func (this *Instance) CanMove() (bool, error) {
 	return true, nil
 }
 
-// CanMoveAsCoMaster returns true if this instance's state allows it to be repositioned.
-func (this *Instance) CanMoveAsCoMaster() (bool, error) {
+// CanMoveAsCoPrimary returns true if this instance's state allows it to be repositioned.
+func (this *Instance) CanMoveAsCoPrimary() (bool, error) {
 	if !this.IsLastCheckValid {
 		return false, fmt.Errorf("%+v: last check invalid", this.Key)
 	}
@@ -543,7 +543,7 @@ func (this *Instance) LagStatusString() string {
 	if this.IsReplica() && !this.ReplicaRunning() {
 		return "null"
 	}
-	if this.IsReplica() && !this.SecondsBehindMaster.Valid {
+	if this.IsReplica() && !this.SecondsBehindPrimary.Valid {
 		return "null"
 	}
 	if this.IsReplica() && this.ReplicationLagSeconds.Int64 > int64(config.Config.ReasonableMaintenanceReplicationLagSeconds) {
@@ -578,7 +578,7 @@ func (this *Instance) descriptionTokens() (tokens []string) {
 			}
 			extraTokens = append(extraTokens, token)
 		}
-		if this.SemiSyncMasterStatus {
+		if this.SemiSyncPrimaryStatus {
 			extraTokens = append(extraTokens, "semi:master")
 		}
 		if this.SemiSyncReplicaStatus {

--- a/go/vt/orchestrator/inst/instance.go
+++ b/go/vt/orchestrator/inst/instance.go
@@ -48,8 +48,8 @@ type Instance struct {
 	LogSlaveUpdatesEnabled       bool // for API backwards compatibility. Equals `LogReplicationUpdatesEnabled`
 	LogReplicationUpdatesEnabled bool
 	SelfBinlogCoordinates        BinlogCoordinates
-	PrimaryKey                   InstanceKey
-	PrimaryUUID                  string
+	SourceKey                    InstanceKey
+	SourceUUID                   string
 	AncestryUUID                 string
 	IsDetachedPrimary            bool
 
@@ -311,7 +311,7 @@ func (this *Instance) FlavorNameAndMajorVersion() string {
 
 // IsReplica makes simple heuristics to decide whether this instance is a replica of another instance
 func (this *Instance) IsReplica() bool {
-	return this.PrimaryKey.Hostname != "" && this.PrimaryKey.Hostname != "_" && this.PrimaryKey.Port != 0 && (this.ReadBinlogCoordinates.LogFile != "" || this.UsingGTID())
+	return this.SourceKey.Hostname != "" && this.SourceKey.Hostname != "_" && this.SourceKey.Port != 0 && (this.ReadBinlogCoordinates.LogFile != "" || this.UsingGTID())
 }
 
 // IsPrimary makes simple heuristics to decide whether this instance is a primary (not replicating from any other server),
@@ -409,7 +409,7 @@ func (this *Instance) GetNextBinaryLog(binlogCoordinates BinlogCoordinates) (Bin
 
 // IsReplicaOf returns true if this instance claims to replicate from given primary
 func (this *Instance) IsReplicaOf(primary *Instance) bool {
-	return this.PrimaryKey.Equals(&primary.Key)
+	return this.SourceKey.Equals(&primary.Key)
 }
 
 // IsReplicaOf returns true if this i supposed primary of given replica

--- a/go/vt/orchestrator/inst/instance_topology.go
+++ b/go/vt/orchestrator/inst/instance_topology.go
@@ -53,7 +53,7 @@ func getASCIITopologyEntry(depth int, instance *Instance, replicationMap map[*In
 	if instance == nil {
 		return []string{}
 	}
-	if instance.IsCoMaster && depth > 1 {
+	if instance.IsCoPrimary && depth > 1 {
 		return []string{}
 	}
 	prefix := ""
@@ -113,28 +113,28 @@ func ASCIITopology(clusterName string, historyTimestampPattern string, tabulated
 	}
 
 	replicationMap := make(map[*Instance]([]*Instance))
-	var masterInstance *Instance
+	var primaryInstance *Instance
 	// Investigate replicas:
 	for _, instance := range instances {
-		master, ok := instancesMap[instance.MasterKey]
+		primary, ok := instancesMap[instance.PrimaryKey]
 		if ok {
-			if _, ok := replicationMap[master]; !ok {
-				replicationMap[master] = [](*Instance){}
+			if _, ok := replicationMap[primary]; !ok {
+				replicationMap[primary] = [](*Instance){}
 			}
-			replicationMap[master] = append(replicationMap[master], instance)
+			replicationMap[primary] = append(replicationMap[primary], instance)
 		} else {
-			masterInstance = instance
+			primaryInstance = instance
 		}
 	}
 	// Get entries:
 	var entries []string
-	if masterInstance != nil {
+	if primaryInstance != nil {
 		// Single primary
-		entries = getASCIITopologyEntry(0, masterInstance, replicationMap, historyTimestampPattern == "", fillerCharacter, tabulated, printTags)
+		entries = getASCIITopologyEntry(0, primaryInstance, replicationMap, historyTimestampPattern == "", fillerCharacter, tabulated, printTags)
 	} else {
 		// Co-primaries? For visualization we put each in its own branch while ignoring its other co-primaries.
 		for _, instance := range instances {
-			if instance.IsCoMaster {
+			if instance.IsCoPrimary {
 				entries = append(entries, getASCIITopologyEntry(1, instance, replicationMap, historyTimestampPattern == "", fillerCharacter, tabulated, printTags)...)
 			}
 		}
@@ -178,11 +178,11 @@ func shouldPostponeRelocatingReplica(replica *Instance, postponedFunctionsContai
 	return false
 }
 
-// GetInstanceMaster synchronously reaches into the replication topology
+// GetInstancePrimary synchronously reaches into the replication topology
 // and retrieves primary's data
-func GetInstanceMaster(instance *Instance) (*Instance, error) {
-	master, err := ReadTopologyInstance(&instance.MasterKey)
-	return master, err
+func GetInstancePrimary(instance *Instance) (*Instance, error) {
+	primary, err := ReadTopologyInstance(&instance.PrimaryKey)
+	return primary, err
 }
 
 // InstancesAreSiblings checks whether both instances are replicating from same primary
@@ -197,19 +197,19 @@ func InstancesAreSiblings(instance0, instance1 *Instance) bool {
 		// same instance...
 		return false
 	}
-	return instance0.MasterKey.Equals(&instance1.MasterKey)
+	return instance0.PrimaryKey.Equals(&instance1.PrimaryKey)
 }
 
-// InstanceIsMasterOf checks whether an instance is the primary of another
-func InstanceIsMasterOf(allegedMaster, allegedReplica *Instance) bool {
+// InstanceIsPrimaryOf checks whether an instance is the primary of another
+func InstanceIsPrimaryOf(allegedPrimary, allegedReplica *Instance) bool {
 	if !allegedReplica.IsReplica() {
 		return false
 	}
-	if allegedMaster.Key.Equals(&allegedReplica.Key) {
+	if allegedPrimary.Key.Equals(&allegedReplica.Key) {
 		// same instance...
 		return false
 	}
-	return allegedMaster.Key.Equals(&allegedReplica.MasterKey)
+	return allegedPrimary.Key.Equals(&allegedReplica.PrimaryKey)
 }
 
 // MoveUp will attempt moving instance indicated by instanceKey up the topology hierarchy.
@@ -227,21 +227,21 @@ func MoveUp(instanceKey *InstanceKey) (*Instance, error) {
 	if canMove, merr := rinstance.CanMove(); !canMove {
 		return instance, merr
 	}
-	master, err := GetInstanceMaster(instance)
+	primary, err := GetInstancePrimary(instance)
 	if err != nil {
-		return instance, log.Errorf("Cannot GetInstanceMaster() for %+v. error=%+v", instance.Key, err)
+		return instance, log.Errorf("Cannot GetInstancePrimary() for %+v. error=%+v", instance.Key, err)
 	}
 
-	if !master.IsReplica() {
-		return instance, fmt.Errorf("master is not a replica itself: %+v", master.Key)
+	if !primary.IsReplica() {
+		return instance, fmt.Errorf("master is not a replica itself: %+v", primary.Key)
 	}
 
-	if canReplicate, err := instance.CanReplicateFrom(master); !canReplicate {
+	if canReplicate, err := instance.CanReplicateFrom(primary); !canReplicate {
 		return instance, err
 	}
-	if master.IsBinlogServer() {
+	if primary.IsBinlogServer() {
 		// Quick solution via binlog servers
-		return Repoint(instanceKey, &master.MasterKey, GTIDHintDeny)
+		return Repoint(instanceKey, &primary.PrimaryKey, GTIDHintDeny)
 	}
 
 	log.Infof("Will move %+v up the topology", *instanceKey)
@@ -252,15 +252,15 @@ func MoveUp(instanceKey *InstanceKey) (*Instance, error) {
 	} else {
 		defer EndMaintenance(maintenanceToken)
 	}
-	if maintenanceToken, merr := BeginMaintenance(&master.Key, GetMaintenanceOwner(), fmt.Sprintf("child %+v moves up", *instanceKey)); merr != nil {
-		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", master.Key, merr)
+	if maintenanceToken, merr := BeginMaintenance(&primary.Key, GetMaintenanceOwner(), fmt.Sprintf("child %+v moves up", *instanceKey)); merr != nil {
+		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", primary.Key, merr)
 		goto Cleanup
 	} else {
 		defer EndMaintenance(maintenanceToken)
 	}
 
 	if !instance.UsingMariaDBGTID {
-		master, err = StopReplication(&master.Key)
+		primary, err = StopReplication(&primary.Key)
 		if err != nil {
 			goto Cleanup
 		}
@@ -272,14 +272,14 @@ func MoveUp(instanceKey *InstanceKey) (*Instance, error) {
 	}
 
 	if !instance.UsingMariaDBGTID {
-		_, err = StartReplicationUntilMasterCoordinates(instanceKey, &master.SelfBinlogCoordinates)
+		_, err = StartReplicationUntilPrimaryCoordinates(instanceKey, &primary.SelfBinlogCoordinates)
 		if err != nil {
 			goto Cleanup
 		}
 	}
 
 	// We can skip hostname unresolve; we just copy+paste whatever our primary thinks of its primary.
-	_, err = ChangeMasterTo(instanceKey, &master.MasterKey, &master.ExecBinlogCoordinates, true, GTIDHintDeny)
+	_, err = ChangePrimaryTo(instanceKey, &primary.PrimaryKey, &primary.ExecBinlogCoordinates, true, GTIDHintDeny)
 	if err != nil {
 		goto Cleanup
 	}
@@ -287,13 +287,13 @@ func MoveUp(instanceKey *InstanceKey) (*Instance, error) {
 Cleanup:
 	instance, _ = StartReplication(instanceKey)
 	if !instance.UsingMariaDBGTID {
-		master, _ = StartReplication(&master.Key)
+		primary, _ = StartReplication(&primary.Key)
 	}
 	if err != nil {
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("move-up", instanceKey, fmt.Sprintf("moved up %+v. Previous master: %+v", *instanceKey, master.Key))
+	AuditOperation("move-up", instanceKey, fmt.Sprintf("moved up %+v. Previous master: %+v", *instanceKey, primary.Key))
 
 	return instance, err
 }
@@ -314,13 +314,13 @@ func MoveUpReplicas(instanceKey *InstanceKey, pattern string) ([](*Instance), *I
 	if !instance.IsReplica() {
 		return res, instance, fmt.Errorf("instance is not a replica: %+v", instanceKey), errs
 	}
-	_, err = GetInstanceMaster(instance)
+	_, err = GetInstancePrimary(instance)
 	if err != nil {
-		return res, instance, log.Errorf("Cannot GetInstanceMaster() for %+v. error=%+v", instance.Key, err), errs
+		return res, instance, log.Errorf("Cannot GetInstancePrimary() for %+v. error=%+v", instance.Key, err), errs
 	}
 
 	if instance.IsBinlogServer() {
-		replicas, err, errors := RepointReplicasTo(instanceKey, pattern, &instance.MasterKey)
+		replicas, err, errors := RepointReplicasTo(instanceKey, pattern, &instance.PrimaryKey)
 		// Bail out!
 		return replicas, instance, err, errors
 	}
@@ -384,13 +384,13 @@ func MoveUpReplicas(instanceKey *InstanceKey, pattern string) ([](*Instance), *I
 						replicaErr = err
 						return
 					}
-					replica, err = StartReplicationUntilMasterCoordinates(&replica.Key, &instance.SelfBinlogCoordinates)
+					replica, err = StartReplicationUntilPrimaryCoordinates(&replica.Key, &instance.SelfBinlogCoordinates)
 					if err != nil {
 						replicaErr = err
 						return
 					}
 
-					replica, err = ChangeMasterTo(&replica.Key, &instance.MasterKey, &instance.ExecBinlogCoordinates, false, GTIDHintDeny)
+					replica, err = ChangePrimaryTo(&replica.Key, &instance.PrimaryKey, &instance.ExecBinlogCoordinates, false, GTIDHintDeny)
 					if err != nil {
 						replicaErr = err
 						return
@@ -422,7 +422,7 @@ Cleanup:
 		// All returned with error
 		return res, instance, log.Error("Error on all operations"), errs
 	}
-	AuditOperation("move-up-replicas", instanceKey, fmt.Sprintf("moved up %d/%d replicas of %+v. New master: %+v", len(res), len(replicas), *instanceKey, instance.MasterKey))
+	AuditOperation("move-up-replicas", instanceKey, fmt.Sprintf("moved up %d/%d replicas of %+v. New master: %+v", len(res), len(replicas), *instanceKey, instance.PrimaryKey))
 
 	return res, instance, err, errs
 }
@@ -492,19 +492,19 @@ func MoveBelow(instanceKey, siblingKey *InstanceKey) (*Instance, error) {
 		goto Cleanup
 	}
 	if instance.ExecBinlogCoordinates.SmallerThan(&sibling.ExecBinlogCoordinates) {
-		_, err = StartReplicationUntilMasterCoordinates(instanceKey, &sibling.ExecBinlogCoordinates)
+		_, err = StartReplicationUntilPrimaryCoordinates(instanceKey, &sibling.ExecBinlogCoordinates)
 		if err != nil {
 			goto Cleanup
 		}
 	} else if sibling.ExecBinlogCoordinates.SmallerThan(&instance.ExecBinlogCoordinates) {
-		sibling, err = StartReplicationUntilMasterCoordinates(siblingKey, &instance.ExecBinlogCoordinates)
+		sibling, err = StartReplicationUntilPrimaryCoordinates(siblingKey, &instance.ExecBinlogCoordinates)
 		if err != nil {
 			goto Cleanup
 		}
 	}
 	// At this point both siblings have executed exact same statements and are identical
 
-	_, err = ChangeMasterTo(instanceKey, &sibling.Key, &sibling.SelfBinlogCoordinates, false, GTIDHintDeny)
+	_, err = ChangePrimaryTo(instanceKey, &sibling.Key, &sibling.SelfBinlogCoordinates, false, GTIDHintDeny)
 	if err != nil {
 		goto Cleanup
 	}
@@ -522,8 +522,8 @@ Cleanup:
 	return instance, err
 }
 
-func canReplicateAssumingOracleGTID(instance, masterInstance *Instance) (canReplicate bool, err error) {
-	subtract, err := GTIDSubtract(&instance.Key, masterInstance.GtidPurged, instance.ExecutedGtidSet)
+func canReplicateAssumingOracleGTID(instance, primaryInstance *Instance) (canReplicate bool, err error) {
+	subtract, err := GTIDSubtract(&instance.Key, primaryInstance.GtidPurged, instance.ExecutedGtidSet)
 	if err != nil {
 		return false, err
 	}
@@ -585,7 +585,7 @@ func moveInstanceBelowViaGTID(instance, otherInstance *Instance) (*Instance, err
 		goto Cleanup
 	}
 
-	_, err = ChangeMasterTo(instanceKey, &otherInstance.Key, &otherInstance.SelfBinlogCoordinates, false, GTIDHintForce)
+	_, err = ChangePrimaryTo(instanceKey, &otherInstance.Key, &otherInstance.SelfBinlogCoordinates, false, GTIDHintForce)
 	if err != nil {
 		goto Cleanup
 	}
@@ -687,7 +687,7 @@ func moveReplicasViaGTID(replicas [](*Instance), other *Instance, postponedFunct
 }
 
 // MoveReplicasGTID will (attempt to) move all replicas of given primary below given instance.
-func MoveReplicasGTID(masterKey *InstanceKey, belowKey *InstanceKey, pattern string) (movedReplicas [](*Instance), unmovedReplicas [](*Instance), err error, errs []error) {
+func MoveReplicasGTID(primaryKey *InstanceKey, belowKey *InstanceKey, pattern string) (movedReplicas [](*Instance), unmovedReplicas [](*Instance), err error, errs []error) {
 	belowInstance, err := ReadTopologyInstance(belowKey)
 	if err != nil {
 		// Can't access "below" ==> can't move replicas beneath it
@@ -695,7 +695,7 @@ func MoveReplicasGTID(masterKey *InstanceKey, belowKey *InstanceKey, pattern str
 	}
 
 	// replicas involved
-	replicas, err := ReadReplicaInstancesIncludingBinlogServerSubReplicas(masterKey)
+	replicas, err := ReadReplicaInstancesIncludingBinlogServerSubReplicas(primaryKey)
 	if err != nil {
 		return movedReplicas, unmovedReplicas, err, errs
 	}
@@ -706,18 +706,18 @@ func MoveReplicasGTID(masterKey *InstanceKey, belowKey *InstanceKey, pattern str
 	}
 
 	if len(unmovedReplicas) > 0 {
-		err = fmt.Errorf("MoveReplicasGTID: only moved %d out of %d replicas of %+v; error is: %+v", len(movedReplicas), len(replicas), *masterKey, err)
+		err = fmt.Errorf("MoveReplicasGTID: only moved %d out of %d replicas of %+v; error is: %+v", len(movedReplicas), len(replicas), *primaryKey, err)
 	}
 
 	return movedReplicas, unmovedReplicas, err, errs
 }
 
 // Repoint connects a replica to a primary using its exact same executing coordinates.
-// The given masterKey can be null, in which case the existing primary is used.
+// The given primaryKey can be null, in which case the existing primary is used.
 // Two use cases:
-// - masterKey is nil: use case is corrupted relay logs on replica
-// - masterKey is not nil: using Binlog servers (coordinates remain the same)
-func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gtidHint OperationGTIDHint) (*Instance, error) {
+// - primaryKey is nil: use case is corrupted relay logs on replica
+// - primaryKey is not nil: using Binlog servers (coordinates remain the same)
+func Repoint(instanceKey *InstanceKey, primaryKey *InstanceKey, gtidHint OperationGTIDHint) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -730,33 +730,33 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gtidHint Operatio
 	if instance.IsReplicationGroupSecondary() {
 		return instance, fmt.Errorf("repoint: %+v is a secondary replication group member, hence, it cannot be relocated", instance.Key)
 	}
-	if masterKey == nil {
-		masterKey = &instance.MasterKey
+	if primaryKey == nil {
+		primaryKey = &instance.PrimaryKey
 	}
 	// With repoint we *prefer* the primary to be alive, but we don't strictly require it.
 	// The use case for the primary being alive is with hostname-resolve or hostname-unresolve: asking the replica
 	// to reconnect to its same primary while changing the MASTER_HOST in CHANGE MASTER TO due to DNS changes etc.
-	master, err := ReadTopologyInstance(masterKey)
-	masterIsAccessible := (err == nil)
-	if !masterIsAccessible {
-		master, _, err = ReadInstance(masterKey)
-		if master == nil || err != nil {
+	primary, err := ReadTopologyInstance(primaryKey)
+	primaryIsAccessible := (err == nil)
+	if !primaryIsAccessible {
+		primary, _, err = ReadInstance(primaryKey)
+		if primary == nil || err != nil {
 			return instance, err
 		}
 	}
-	if canReplicate, err := instance.CanReplicateFrom(master); !canReplicate {
+	if canReplicate, err := instance.CanReplicateFrom(primary); !canReplicate {
 		return instance, err
 	}
 
 	// if a binlog server check it is sufficiently up to date
-	if master.IsBinlogServer() {
+	if primary.IsBinlogServer() {
 		// "Repoint" operation trusts the user. But only so much. Repoiting to a binlog server which is not yet there is strictly wrong.
-		if !instance.ExecBinlogCoordinates.SmallerThanOrEquals(&master.SelfBinlogCoordinates) {
-			return instance, fmt.Errorf("repoint: binlog server %+v is not sufficiently up to date to repoint %+v below it", *masterKey, *instanceKey)
+		if !instance.ExecBinlogCoordinates.SmallerThanOrEquals(&primary.SelfBinlogCoordinates) {
+			return instance, fmt.Errorf("repoint: binlog server %+v is not sufficiently up to date to repoint %+v below it", *primaryKey, *instanceKey)
 		}
 	}
 
-	log.Infof("Will repoint %+v to master %+v", *instanceKey, *masterKey)
+	log.Infof("Will repoint %+v to master %+v", *instanceKey, *primaryKey)
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "repoint"); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", *instanceKey, merr)
@@ -772,11 +772,11 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gtidHint Operatio
 
 	// See above, we are relaxed about the primary being accessible/inaccessible.
 	// If accessible, we wish to do hostname-unresolve. If inaccessible, we can skip the test and not fail the
-	// ChangeMasterTo operation. This is why we pass "!masterIsAccessible" below.
+	// ChangePrimaryTo operation. This is why we pass "!primaryIsAccessible" below.
 	if instance.ExecBinlogCoordinates.IsEmpty() {
 		instance.ExecBinlogCoordinates.LogFile = "orchestrator-unknown-log-file"
 	}
-	_, err = ChangeMasterTo(instanceKey, masterKey, &instance.ExecBinlogCoordinates, !masterIsAccessible, gtidHint)
+	_, err = ChangePrimaryTo(instanceKey, primaryKey, &instance.ExecBinlogCoordinates, !primaryIsAccessible, gtidHint)
 	if err != nil {
 		goto Cleanup
 	}
@@ -787,7 +787,7 @@ Cleanup:
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v repointed to master: %+v", *instanceKey, *masterKey))
+	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v repointed to master: %+v", *instanceKey, *primaryKey))
 
 	return instance, err
 
@@ -864,7 +864,7 @@ func RepointReplicasTo(instanceKey *InstanceKey, pattern string, belowKey *Insta
 	}
 	if belowKey == nil {
 		// Default to existing primary. All replicas are of the same primary, hence just pick one.
-		belowKey = &replicas[0].MasterKey
+		belowKey = &replicas[0].PrimaryKey
 	}
 	log.Infof("Will repoint replicas of %+v to %+v", *instanceKey, *belowKey)
 	return RepointTo(replicas, belowKey)
@@ -875,9 +875,9 @@ func RepointReplicas(instanceKey *InstanceKey, pattern string) ([](*Instance), e
 	return RepointReplicasTo(instanceKey, pattern, nil)
 }
 
-// MakeCoMaster will attempt to make an instance co-primary with its primary, by making its primary a replica of its own.
+// MakeCoPrimary will attempt to make an instance co-primary with its primary, by making its primary a replica of its own.
 // This only works out if the primary is not replicating; the primary does not have a known primary (it may have an unknown primary).
-func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
+func MakeCoPrimary(instanceKey *InstanceKey) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -885,26 +885,26 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 	if canMove, merr := instance.CanMove(); !canMove {
 		return instance, merr
 	}
-	master, err := GetInstanceMaster(instance)
+	primary, err := GetInstancePrimary(instance)
 	if err != nil {
 		return instance, err
 	}
 	// Relocation of group secondaries makes no sense, group secondaries, by definition, always replicate from the group
 	// primary
 	if instance.IsReplicationGroupSecondary() {
-		return instance, fmt.Errorf("MakeCoMaster: %+v is a secondary replication group member, hence, it cannot be relocated", instance.Key)
+		return instance, fmt.Errorf("MakeCoPrimary: %+v is a secondary replication group member, hence, it cannot be relocated", instance.Key)
 	}
-	log.Debugf("Will check whether %+v's master (%+v) can become its co-master", instance.Key, master.Key)
-	if canMove, merr := master.CanMoveAsCoMaster(); !canMove {
+	log.Debugf("Will check whether %+v's master (%+v) can become its co-master", instance.Key, primary.Key)
+	if canMove, merr := primary.CanMoveAsCoPrimary(); !canMove {
 		return instance, merr
 	}
-	if instanceKey.Equals(&master.MasterKey) {
-		return instance, fmt.Errorf("instance %+v is already co master of %+v", instance.Key, master.Key)
+	if instanceKey.Equals(&primary.PrimaryKey) {
+		return instance, fmt.Errorf("instance %+v is already co master of %+v", instance.Key, primary.Key)
 	}
 	if !instance.ReadOnly {
 		return instance, fmt.Errorf("instance %+v is not read-only; first make it read-only before making it co-master", instance.Key)
 	}
-	if master.IsCoMaster {
+	if primary.IsCoPrimary {
 		// We allow breaking of an existing co-primary replication. Here's the breakdown:
 		// Ideally, this would not eb allowed, and we would first require the user to RESET SLAVE on 'master'
 		// prior to making it participate as co-primary with our 'instance'.
@@ -915,28 +915,28 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 		// - M2 is read-only or is unreachable/invalid
 		// - S  is read-only
 		// And so we will be replacing one read-only co-primary with another.
-		otherCoMaster, found, _ := ReadInstance(&master.MasterKey)
-		if found && otherCoMaster.IsLastCheckValid && !otherCoMaster.ReadOnly {
-			return instance, fmt.Errorf("master %+v is already co-master with %+v, and %+v is alive, and not read-only; cowardly refusing to demote it. Please set it as read-only beforehand", master.Key, otherCoMaster.Key, otherCoMaster.Key)
+		otherCoPrimary, found, _ := ReadInstance(&primary.PrimaryKey)
+		if found && otherCoPrimary.IsLastCheckValid && !otherCoPrimary.ReadOnly {
+			return instance, fmt.Errorf("master %+v is already co-master with %+v, and %+v is alive, and not read-only; cowardly refusing to demote it. Please set it as read-only beforehand", primary.Key, otherCoPrimary.Key, otherCoPrimary.Key)
 		}
 		// OK, good to go.
-	} else if _, found, _ := ReadInstance(&master.MasterKey); found {
-		return instance, fmt.Errorf("%+v is not a real master; it replicates from: %+v", master.Key, master.MasterKey)
+	} else if _, found, _ := ReadInstance(&primary.PrimaryKey); found {
+		return instance, fmt.Errorf("%+v is not a real master; it replicates from: %+v", primary.Key, primary.PrimaryKey)
 	}
-	if canReplicate, err := master.CanReplicateFrom(instance); !canReplicate {
+	if canReplicate, err := primary.CanReplicateFrom(instance); !canReplicate {
 		return instance, err
 	}
-	log.Infof("Will make %+v co-master of %+v", instanceKey, master.Key)
+	log.Infof("Will make %+v co-master of %+v", instanceKey, primary.Key)
 
 	var gitHint OperationGTIDHint = GTIDHintNeutral
-	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), fmt.Sprintf("make co-master of %+v", master.Key)); merr != nil {
+	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), fmt.Sprintf("make co-master of %+v", primary.Key)); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", *instanceKey, merr)
 		goto Cleanup
 	} else {
 		defer EndMaintenance(maintenanceToken)
 	}
-	if maintenanceToken, merr := BeginMaintenance(&master.Key, GetMaintenanceOwner(), fmt.Sprintf("%+v turns into co-master of this", *instanceKey)); merr != nil {
-		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", master.Key, merr)
+	if maintenanceToken, merr := BeginMaintenance(&primary.Key, GetMaintenanceOwner(), fmt.Sprintf("%+v turns into co-master of this", *instanceKey)); merr != nil {
+		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", primary.Key, merr)
 		goto Cleanup
 	} else {
 		defer EndMaintenance(maintenanceToken)
@@ -944,10 +944,10 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 
 	// the coMaster used to be merely a replica. Just point primary into *some* position
 	// within coMaster...
-	if master.IsReplica() {
+	if primary.IsReplica() {
 		// this is the case of a co-primary. For primaries, the StopReplication operation throws an error, and
 		// there's really no point in doing it.
-		master, err = StopReplication(&master.Key)
+		primary, err = StopReplication(&primary.Key)
 		if err != nil {
 			goto Cleanup
 		}
@@ -955,7 +955,7 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 
 	if instance.AllowTLS {
 		log.Debugf("Enabling SSL replication")
-		_, err = EnableMasterSSL(&master.Key)
+		_, err = EnablePrimarySSL(&primary.Key)
 		if err != nil {
 			goto Cleanup
 		}
@@ -964,18 +964,18 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 	if instance.UsingOracleGTID {
 		gitHint = GTIDHintForce
 	}
-	master, err = ChangeMasterTo(&master.Key, instanceKey, &instance.SelfBinlogCoordinates, false, gitHint)
+	primary, err = ChangePrimaryTo(&primary.Key, instanceKey, &instance.SelfBinlogCoordinates, false, gitHint)
 	if err != nil {
 		goto Cleanup
 	}
 
 Cleanup:
-	master, _ = StartReplication(&master.Key)
+	primary, _ = StartReplication(&primary.Key)
 	if err != nil {
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("make-co-master", instanceKey, fmt.Sprintf("%+v made co-master of %+v", *instanceKey, master.Key))
+	AuditOperation("make-co-master", instanceKey, fmt.Sprintf("%+v made co-master of %+v", *instanceKey, primary.Key))
 
 	return instance, err
 }
@@ -1021,8 +1021,8 @@ Cleanup:
 	return instance, err
 }
 
-// DetachReplicaMasterHost detaches a replica from its primary by corrupting the Master_Host (in such way that is reversible)
-func DetachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
+// DetachReplicaPrimaryHost detaches a replica from its primary by corrupting the Master_Host (in such way that is reversible)
+func DetachReplicaPrimaryHost(instanceKey *InstanceKey) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -1030,12 +1030,12 @@ func DetachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
 	if !instance.IsReplica() {
 		return instance, fmt.Errorf("instance is not a replica: %+v", *instanceKey)
 	}
-	if instance.MasterKey.IsDetached() {
+	if instance.PrimaryKey.IsDetached() {
 		return instance, fmt.Errorf("instance already detached: %+v", *instanceKey)
 	}
-	detachedMasterKey := instance.MasterKey.DetachedKey()
+	detachedPrimaryKey := instance.PrimaryKey.DetachedKey()
 
-	log.Infof("Will detach master host on %+v. Detached key is %+v", *instanceKey, *detachedMasterKey)
+	log.Infof("Will detach master host on %+v. Detached key is %+v", *instanceKey, *detachedPrimaryKey)
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "detach-replica-master-host"); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", *instanceKey, merr)
@@ -1049,7 +1049,7 @@ func DetachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
 		goto Cleanup
 	}
 
-	_, err = ChangeMasterTo(instanceKey, detachedMasterKey, &instance.ExecBinlogCoordinates, true, GTIDHintNeutral)
+	_, err = ChangePrimaryTo(instanceKey, detachedPrimaryKey, &instance.ExecBinlogCoordinates, true, GTIDHintNeutral)
 	if err != nil {
 		goto Cleanup
 	}
@@ -1060,13 +1060,13 @@ Cleanup:
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v detached from master into %+v", *instanceKey, *detachedMasterKey))
+	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v detached from master into %+v", *instanceKey, *detachedPrimaryKey))
 
 	return instance, err
 }
 
-// ReattachReplicaMasterHost reattaches a replica back onto its primary by undoing a DetachReplicaMasterHost operation
-func ReattachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
+// ReattachReplicaPrimaryHost reattaches a replica back onto its primary by undoing a DetachReplicaPrimaryHost operation
+func ReattachReplicaPrimaryHost(instanceKey *InstanceKey) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -1074,13 +1074,13 @@ func ReattachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
 	if !instance.IsReplica() {
 		return instance, fmt.Errorf("instance is not a replica: %+v", *instanceKey)
 	}
-	if !instance.MasterKey.IsDetached() {
+	if !instance.PrimaryKey.IsDetached() {
 		return instance, fmt.Errorf("instance does not seem to be detached: %+v", *instanceKey)
 	}
 
-	reattachedMasterKey := instance.MasterKey.ReattachedKey()
+	reattachedPrimaryKey := instance.PrimaryKey.ReattachedKey()
 
-	log.Infof("Will reattach master host on %+v. Reattached key is %+v", *instanceKey, *reattachedMasterKey)
+	log.Infof("Will reattach master host on %+v. Reattached key is %+v", *instanceKey, *reattachedPrimaryKey)
 
 	if maintenanceToken, merr := BeginMaintenance(instanceKey, GetMaintenanceOwner(), "reattach-replica-master-host"); merr != nil {
 		err = fmt.Errorf("Cannot begin maintenance on %+v: %v", *instanceKey, merr)
@@ -1094,12 +1094,12 @@ func ReattachReplicaMasterHost(instanceKey *InstanceKey) (*Instance, error) {
 		goto Cleanup
 	}
 
-	_, err = ChangeMasterTo(instanceKey, reattachedMasterKey, &instance.ExecBinlogCoordinates, true, GTIDHintNeutral)
+	_, err = ChangePrimaryTo(instanceKey, reattachedPrimaryKey, &instance.ExecBinlogCoordinates, true, GTIDHintNeutral)
 	if err != nil {
 		goto Cleanup
 	}
 	// Just in case this instance used to be a primary:
-	ReplaceAliasClusterName(instanceKey.StringCode(), reattachedMasterKey.StringCode())
+	ReplaceAliasClusterName(instanceKey.StringCode(), reattachedPrimaryKey.StringCode())
 
 Cleanup:
 	instance, _ = StartReplication(instanceKey)
@@ -1107,7 +1107,7 @@ Cleanup:
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v reattached to master %+v", *instanceKey, *reattachedMasterKey))
+	AuditOperation("repoint", instanceKey, fmt.Sprintf("replica %+v reattached to master %+v", *instanceKey, *reattachedPrimaryKey))
 
 	return instance, err
 }
@@ -1213,11 +1213,11 @@ func LocateErrantGTID(instanceKey *InstanceKey) (errantBinlogs []string, err err
 	return errantBinlogs, err
 }
 
-// ErrantGTIDResetMaster will issue a safe RESET MASTER on a replica that replicates via GTID:
+// ErrantGTIDResetPrimary will issue a safe RESET MASTER on a replica that replicates via GTID:
 // It will make sure the gtid_purged set matches the executed set value as read just before the RESET.
 // this will enable new replicas to be attached to given instance without complaints about missing/purged entries.
 // This function requires that the instance does not have replicas.
-func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err error) {
+func ErrantGTIDResetPrimary(instanceKey *InstanceKey) (instance *Instance, err error) {
 	instance, err = ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -1234,7 +1234,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 
 	gtidSubtract := ""
 	executedGtidSet := ""
-	masterStatusFound := false
+	primaryStatusFound := false
 	replicationStopped := false
 	waitInterval := time.Second * 5
 
@@ -1269,7 +1269,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 	// The replica will be left in a broken state.
 	// This is why we allow multiple attempts at the following:
 	for i := 0; i < countRetries; i++ {
-		instance, err = ResetMaster(instanceKey)
+		instance, err = ResetPrimary(instanceKey)
 		if err == nil {
 			break
 		}
@@ -1280,12 +1280,12 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 		goto Cleanup
 	}
 
-	masterStatusFound, executedGtidSet, err = ShowMasterStatus(instanceKey)
+	primaryStatusFound, executedGtidSet, err = ShowPrimaryStatus(instanceKey)
 	if err != nil {
 		err = fmt.Errorf("gtid-errant-reset-master: error getting master status on %+v, after which intended to set gtid_purged to: %s. Error was: %+v", instance.Key, gtidSubtract, err)
 		goto Cleanup
 	}
-	if !masterStatusFound {
+	if !primaryStatusFound {
 		err = fmt.Errorf("gtid-errant-reset-master: cannot get master status on %+v, after which intended to set gtid_purged to: %s.", instance.Key, gtidSubtract)
 		goto Cleanup
 	}
@@ -1324,48 +1324,48 @@ Cleanup:
 
 // ErrantGTIDInjectEmpty will inject an empty transaction on the primary of an instance's cluster in order to get rid
 // of an errant transaction observed on the instance.
-func ErrantGTIDInjectEmpty(instanceKey *InstanceKey) (instance *Instance, clusterMaster *Instance, countInjectedTransactions int64, err error) {
+func ErrantGTIDInjectEmpty(instanceKey *InstanceKey) (instance *Instance, clusterPrimary *Instance, countInjectedTransactions int64, err error) {
 	instance, err = ReadTopologyInstance(instanceKey)
 	if err != nil {
-		return instance, clusterMaster, countInjectedTransactions, err
+		return instance, clusterPrimary, countInjectedTransactions, err
 	}
 	if instance.GtidErrant == "" {
-		return instance, clusterMaster, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty will not operate on %+v because no errant GTID is found", *instanceKey)
+		return instance, clusterPrimary, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty will not operate on %+v because no errant GTID is found", *instanceKey)
 	}
 	if !instance.SupportsOracleGTID {
-		return instance, clusterMaster, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty requested for %+v but it does not support oracle-gtid", *instanceKey)
+		return instance, clusterPrimary, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty requested for %+v but it does not support oracle-gtid", *instanceKey)
 	}
 
-	masters, err := ReadClusterWriteableMaster(instance.ClusterName)
+	primaries, err := ReadClusterWriteablePrimary(instance.ClusterName)
 	if err != nil {
-		return instance, clusterMaster, countInjectedTransactions, err
+		return instance, clusterPrimary, countInjectedTransactions, err
 	}
-	if len(masters) == 0 {
-		return instance, clusterMaster, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty found no writabel master for %+v cluster", instance.ClusterName)
+	if len(primaries) == 0 {
+		return instance, clusterPrimary, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty found no writabel master for %+v cluster", instance.ClusterName)
 	}
-	clusterMaster = masters[0]
+	clusterPrimary = primaries[0]
 
-	if !clusterMaster.SupportsOracleGTID {
-		return instance, clusterMaster, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty requested for %+v but the cluster's master %+v does not support oracle-gtid", *instanceKey, clusterMaster.Key)
+	if !clusterPrimary.SupportsOracleGTID {
+		return instance, clusterPrimary, countInjectedTransactions, log.Errorf("gtid-errant-inject-empty requested for %+v but the cluster's master %+v does not support oracle-gtid", *instanceKey, clusterPrimary.Key)
 	}
 
 	gtidSet, err := NewOracleGtidSet(instance.GtidErrant)
 	if err != nil {
-		return instance, clusterMaster, countInjectedTransactions, err
+		return instance, clusterPrimary, countInjectedTransactions, err
 	}
 	explodedEntries := gtidSet.Explode()
-	log.Infof("gtid-errant-inject-empty: about to inject %+v empty transactions %+v on cluster master %+v", len(explodedEntries), gtidSet.String(), clusterMaster.Key)
+	log.Infof("gtid-errant-inject-empty: about to inject %+v empty transactions %+v on cluster master %+v", len(explodedEntries), gtidSet.String(), clusterPrimary.Key)
 	for _, entry := range explodedEntries {
-		if err := injectEmptyGTIDTransaction(&clusterMaster.Key, entry); err != nil {
-			return instance, clusterMaster, countInjectedTransactions, err
+		if err := injectEmptyGTIDTransaction(&clusterPrimary.Key, entry); err != nil {
+			return instance, clusterPrimary, countInjectedTransactions, err
 		}
 		countInjectedTransactions++
 	}
 
 	// and we're done (pending deferred functions)
-	AuditOperation("gtid-errant-inject-empty", instanceKey, fmt.Sprintf("injected %+v empty transactions on %+v", countInjectedTransactions, clusterMaster.Key))
+	AuditOperation("gtid-errant-inject-empty", instanceKey, fmt.Sprintf("injected %+v empty transactions on %+v", countInjectedTransactions, clusterPrimary.Key))
 
-	return instance, clusterMaster, countInjectedTransactions, err
+	return instance, clusterPrimary, countInjectedTransactions, err
 }
 
 // TakeSiblings is a convenience method for turning siblings of a replica to be its subordinates.
@@ -1379,13 +1379,13 @@ func TakeSiblings(instanceKey *InstanceKey) (instance *Instance, takenSiblings i
 	if !instance.IsReplica() {
 		return instance, takenSiblings, log.Errorf("take-siblings: instance %+v is not a replica.", *instanceKey)
 	}
-	relocatedReplicas, _, err, _ := RelocateReplicas(&instance.MasterKey, instanceKey, "")
+	relocatedReplicas, _, err, _ := RelocateReplicas(&instance.PrimaryKey, instanceKey, "")
 
 	return instance, len(relocatedReplicas), err
 }
 
-// Created this function to allow a hook to be called after a successful TakeMaster event
-func TakeMasterHook(successor *Instance, demoted *Instance) {
+// Created this function to allow a hook to be called after a successful TakePrimary event
+func TakePrimaryHook(successor *Instance, demoted *Instance) {
 	if demoted == nil {
 		return
 	}
@@ -1418,12 +1418,12 @@ func TakeMasterHook(successor *Instance, demoted *Instance) {
 
 }
 
-// TakeMaster will move an instance up the chain and cause its primary to become its replica.
+// TakePrimary will move an instance up the chain and cause its primary to become its replica.
 // It's almost a role change, just that other replicas of either 'instance' or its primary are currently unaffected
 // (they continue replicate without change)
 // Note that the primary must itself be a replica; however the grandparent does not necessarily have to be reachable
 // and can in fact be dead.
-func TakeMaster(instanceKey *InstanceKey, allowTakingCoMaster bool) (*Instance, error) {
+func TakePrimary(instanceKey *InstanceKey, allowTakingCoPrimary bool) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -1433,20 +1433,20 @@ func TakeMaster(instanceKey *InstanceKey, allowTakingCoMaster bool) (*Instance, 
 	if instance.IsReplicationGroupSecondary() {
 		return instance, fmt.Errorf("takeMaster: %+v is a secondary replication group member, hence, it cannot be relocated", instance.Key)
 	}
-	masterInstance, found, err := ReadInstance(&instance.MasterKey)
+	primaryInstance, found, err := ReadInstance(&instance.PrimaryKey)
 	if err != nil || !found {
 		return instance, err
 	}
-	if masterInstance.IsCoMaster && !allowTakingCoMaster {
-		return instance, fmt.Errorf("%+v is co-master. Cannot take it.", masterInstance.Key)
+	if primaryInstance.IsCoPrimary && !allowTakingCoPrimary {
+		return instance, fmt.Errorf("%+v is co-master. Cannot take it.", primaryInstance.Key)
 	}
-	log.Debugf("TakeMaster: will attempt making %+v take its master %+v, now resolved as %+v", *instanceKey, instance.MasterKey, masterInstance.Key)
+	log.Debugf("TakePrimary: will attempt making %+v take its master %+v, now resolved as %+v", *instanceKey, instance.PrimaryKey, primaryInstance.Key)
 
-	if canReplicate, err := masterInstance.CanReplicateFrom(instance); !canReplicate {
+	if canReplicate, err := primaryInstance.CanReplicateFrom(instance); !canReplicate {
 		return instance, err
 	}
 	// We begin
-	masterInstance, err = StopReplication(&masterInstance.Key)
+	primaryInstance, err = StopReplication(&primaryInstance.Key)
 	if err != nil {
 		goto Cleanup
 	}
@@ -1455,27 +1455,27 @@ func TakeMaster(instanceKey *InstanceKey, allowTakingCoMaster bool) (*Instance, 
 		goto Cleanup
 	}
 
-	instance, err = StartReplicationUntilMasterCoordinates(&instance.Key, &masterInstance.SelfBinlogCoordinates)
+	instance, err = StartReplicationUntilPrimaryCoordinates(&instance.Key, &primaryInstance.SelfBinlogCoordinates)
 	if err != nil {
 		goto Cleanup
 	}
 
-	// instance and masterInstance are equal
+	// instance and primaryInstance are equal
 	// We skip name unresolve. It is OK if the primary's primary is dead, unreachable, does not resolve properly.
 	// We just copy+paste info from the primary.
 	// In particular, this is commonly calledin DeadMaster recovery
-	instance, err = ChangeMasterTo(&instance.Key, &masterInstance.MasterKey, &masterInstance.ExecBinlogCoordinates, true, GTIDHintNeutral)
+	instance, err = ChangePrimaryTo(&instance.Key, &primaryInstance.PrimaryKey, &primaryInstance.ExecBinlogCoordinates, true, GTIDHintNeutral)
 	if err != nil {
 		goto Cleanup
 	}
 	// instance is now sibling of primary
-	masterInstance, err = ChangeMasterTo(&masterInstance.Key, &instance.Key, &instance.SelfBinlogCoordinates, false, GTIDHintNeutral)
+	primaryInstance, err = ChangePrimaryTo(&primaryInstance.Key, &instance.Key, &instance.SelfBinlogCoordinates, false, GTIDHintNeutral)
 	if err != nil {
 		goto Cleanup
 	}
 	// swap is done!
 	// we make it official by now writing the results in topo server and changing the types for the tablets
-	err = SwitchMaster(instance.Key, masterInstance.Key)
+	err = SwitchPrimary(instance.Key, primaryInstance.Key)
 	if err != nil {
 		goto Cleanup
 	}
@@ -1484,20 +1484,20 @@ Cleanup:
 	if instance != nil {
 		instance, _ = StartReplication(&instance.Key)
 	}
-	if masterInstance != nil {
-		masterInstance, _ = StartReplication(&masterInstance.Key)
+	if primaryInstance != nil {
+		primaryInstance, _ = StartReplication(&primaryInstance.Key)
 	}
 	if err != nil {
 		return instance, err
 	}
-	AuditOperation("take-master", instanceKey, fmt.Sprintf("took master: %+v", masterInstance.Key))
+	AuditOperation("take-master", instanceKey, fmt.Sprintf("took master: %+v", primaryInstance.Key))
 
-	// Created this to enable a custom hook to be called after a TakeMaster success.
+	// Created this to enable a custom hook to be called after a TakePrimary success.
 	// This only runs if there is a hook configured in orchestrator.conf.json
-	demoted := masterInstance
+	demoted := primaryInstance
 	successor := instance
 	if config.Config.PostTakeMasterProcesses != nil {
-		TakeMasterHook(successor, demoted)
+		TakePrimaryHook(successor, demoted)
 	}
 
 	return instance, err
@@ -1514,11 +1514,11 @@ func sortInstances(instances [](*Instance)) {
 }
 
 // getReplicasForSorting returns a list of replicas of a given primary potentially for candidate choosing
-func getReplicasForSorting(masterKey *InstanceKey, includeBinlogServerSubReplicas bool) (replicas [](*Instance), err error) {
+func getReplicasForSorting(primaryKey *InstanceKey, includeBinlogServerSubReplicas bool) (replicas [](*Instance), err error) {
 	if includeBinlogServerSubReplicas {
-		replicas, err = ReadReplicaInstancesIncludingBinlogServerSubReplicas(masterKey)
+		replicas, err = ReadReplicaInstancesIncludingBinlogServerSubReplicas(primaryKey)
 	} else {
-		replicas, err = ReadReplicaInstances(masterKey)
+		replicas, err = ReadReplicaInstances(primaryKey)
 	}
 	return replicas, err
 }
@@ -1548,13 +1548,13 @@ func sortedReplicasDataCenterHint(replicas [](*Instance), stopReplicationMethod 
 
 // GetSortedReplicas reads list of replicas of a given primary, and returns them sorted by exec coordinates
 // (most up-to-date replica first).
-func GetSortedReplicas(masterKey *InstanceKey, stopReplicationMethod StopReplicationMethod) (replicas [](*Instance), err error) {
-	if replicas, err = getReplicasForSorting(masterKey, false); err != nil {
+func GetSortedReplicas(primaryKey *InstanceKey, stopReplicationMethod StopReplicationMethod) (replicas [](*Instance), err error) {
+	if replicas, err = getReplicasForSorting(primaryKey, false); err != nil {
 		return replicas, err
 	}
 	replicas = sortedReplicas(replicas, stopReplicationMethod)
 	if len(replicas) == 0 {
-		return replicas, fmt.Errorf("No replicas found for %+v", *masterKey)
+		return replicas, fmt.Errorf("No replicas found for %+v", *primaryKey)
 	}
 	return replicas, err
 }
@@ -1587,9 +1587,9 @@ func isGenerallyValidAsCandidateReplica(replica *Instance) bool {
 	return true
 }
 
-// isValidAsCandidateMasterInBinlogServerTopology let's us know whether a given replica is generally
+// isValidAsCandidatePrimaryInBinlogServerTopology let's us know whether a given replica is generally
 // valid to promote to be primary.
-func isValidAsCandidateMasterInBinlogServerTopology(replica *Instance) bool {
+func isValidAsCandidatePrimaryInBinlogServerTopology(replica *Instance) bool {
 	if !replica.IsLastCheckValid {
 		// something wrong with this replica right now. We shouldn't hope to be able to promote it
 		return false
@@ -1716,7 +1716,7 @@ func chooseCandidateReplica(replicas [](*Instance)) (candidateReplica *Instance,
 }
 
 // GetCandidateReplica chooses the best replica to promote given a (possibly dead) primary
-func GetCandidateReplica(masterKey *InstanceKey, forRematchPurposes bool) (*Instance, [](*Instance), [](*Instance), [](*Instance), [](*Instance), error) {
+func GetCandidateReplica(primaryKey *InstanceKey, forRematchPurposes bool) (*Instance, [](*Instance), [](*Instance), [](*Instance), [](*Instance), error) {
 	var candidateReplica *Instance
 	aheadReplicas := [](*Instance){}
 	equalReplicas := [](*Instance){}
@@ -1724,10 +1724,10 @@ func GetCandidateReplica(masterKey *InstanceKey, forRematchPurposes bool) (*Inst
 	cannotReplicateReplicas := [](*Instance){}
 
 	dataCenterHint := ""
-	if master, _, _ := ReadInstance(masterKey); master != nil {
-		dataCenterHint = master.DataCenter
+	if primary, _, _ := ReadInstance(primaryKey); primary != nil {
+		dataCenterHint = primary.DataCenter
 	}
-	replicas, err := getReplicasForSorting(masterKey, false)
+	replicas, err := getReplicasForSorting(primaryKey, false)
 	if err != nil {
 		return candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err
 	}
@@ -1740,7 +1740,7 @@ func GetCandidateReplica(masterKey *InstanceKey, forRematchPurposes bool) (*Inst
 		return candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err
 	}
 	if len(replicas) == 0 {
-		return candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, fmt.Errorf("No replicas found for %+v", *masterKey)
+		return candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, fmt.Errorf("No replicas found for %+v", *primaryKey)
 	}
 	candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err = chooseCandidateReplica(replicas)
 	if err != nil {
@@ -1757,35 +1757,35 @@ func GetCandidateReplica(masterKey *InstanceKey, forRematchPurposes bool) (*Inst
 }
 
 // GetCandidateReplicaOfBinlogServerTopology chooses the best replica to promote given a (possibly dead) primary
-func GetCandidateReplicaOfBinlogServerTopology(masterKey *InstanceKey) (candidateReplica *Instance, err error) {
-	replicas, err := getReplicasForSorting(masterKey, true)
+func GetCandidateReplicaOfBinlogServerTopology(primaryKey *InstanceKey) (candidateReplica *Instance, err error) {
+	replicas, err := getReplicasForSorting(primaryKey, true)
 	if err != nil {
 		return candidateReplica, err
 	}
 	replicas = sortedReplicas(replicas, NoStopReplication)
 	if len(replicas) == 0 {
-		return candidateReplica, fmt.Errorf("No replicas found for %+v", *masterKey)
+		return candidateReplica, fmt.Errorf("No replicas found for %+v", *primaryKey)
 	}
 	for _, replica := range replicas {
 		replica := replica
 		if candidateReplica != nil {
 			break
 		}
-		if isValidAsCandidateMasterInBinlogServerTopology(replica) && !IsBannedFromBeingCandidateReplica(replica) {
+		if isValidAsCandidatePrimaryInBinlogServerTopology(replica) && !IsBannedFromBeingCandidateReplica(replica) {
 			// this is the one
 			candidateReplica = replica
 		}
 	}
 	if candidateReplica != nil {
-		log.Debugf("GetCandidateReplicaOfBinlogServerTopology: returning %+v as candidate replica for %+v", candidateReplica.Key, *masterKey)
+		log.Debugf("GetCandidateReplicaOfBinlogServerTopology: returning %+v as candidate replica for %+v", candidateReplica.Key, *primaryKey)
 	} else {
-		log.Debugf("GetCandidateReplicaOfBinlogServerTopology: no candidate replica found for %+v", *masterKey)
+		log.Debugf("GetCandidateReplicaOfBinlogServerTopology: no candidate replica found for %+v", *primaryKey)
 	}
 	return candidateReplica, err
 }
 
-func getMostUpToDateActiveBinlogServer(masterKey *InstanceKey) (mostAdvancedBinlogServer *Instance, binlogServerReplicas [](*Instance), err error) {
-	if binlogServerReplicas, err = ReadBinlogServerReplicaInstances(masterKey); err == nil && len(binlogServerReplicas) > 0 {
+func getMostUpToDateActiveBinlogServer(primaryKey *InstanceKey) (mostAdvancedBinlogServer *Instance, binlogServerReplicas [](*Instance), err error) {
+	if binlogServerReplicas, err = ReadBinlogServerReplicaInstances(primaryKey); err == nil && len(binlogServerReplicas) > 0 {
 		// Pick the most advanced binlog sever that is good to go
 		for _, binlogServer := range binlogServerReplicas {
 			if binlogServer.IsLastCheckValid {
@@ -1803,7 +1803,7 @@ func getMostUpToDateActiveBinlogServer(masterKey *InstanceKey) (mostAdvancedBinl
 
 // RegroupReplicasGTID will choose a candidate replica of a given instance, and take its siblings using GTID
 func RegroupReplicasGTID(
-	masterKey *InstanceKey,
+	primaryKey *InstanceKey,
 	returnReplicaEvenOnFailureToRegroup bool,
 	onCandidateReplicaChosen func(*Instance),
 	postponedFunctionsContainer *PostponedFunctionsContainer,
@@ -1817,7 +1817,7 @@ func RegroupReplicasGTID(
 ) {
 	var emptyReplicas [](*Instance)
 	var unmovedReplicas [](*Instance)
-	candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := GetCandidateReplica(masterKey, true)
+	candidateReplica, aheadReplicas, equalReplicas, laterReplicas, cannotReplicateReplicas, err := GetCandidateReplica(primaryKey, true)
 	if err != nil {
 		if !returnReplicaEvenOnFailureToRegroup {
 			candidateReplica = nil
@@ -1838,7 +1838,7 @@ func RegroupReplicasGTID(
 		}
 	}
 
-	if err := SwitchMaster(candidateReplica.Key, *masterKey); err != nil {
+	if err := SwitchPrimary(candidateReplica.Key, *primaryKey); err != nil {
 		return emptyReplicas, emptyReplicas, emptyReplicas, candidateReplica, err
 	}
 
@@ -1858,15 +1858,15 @@ func RegroupReplicasGTID(
 	StartReplication(&candidateReplica.Key)
 
 	log.Debugf("RegroupReplicasGTID: done")
-	AuditOperation("regroup-replicas-gtid", masterKey, fmt.Sprintf("regrouped replicas of %+v via GTID; promoted %+v", *masterKey, candidateReplica.Key))
+	AuditOperation("regroup-replicas-gtid", primaryKey, fmt.Sprintf("regrouped replicas of %+v via GTID; promoted %+v", *primaryKey, candidateReplica.Key))
 	return unmovedReplicas, movedReplicas, cannotReplicateReplicas, candidateReplica, err
 }
 
 // RegroupReplicasBinlogServers works on a binlog-servers topology. It picks the most up-to-date BLS and repoints all other
 // BLS below it
-func RegroupReplicasBinlogServers(masterKey *InstanceKey, returnReplicaEvenOnFailureToRegroup bool) (repointedBinlogServers [](*Instance), promotedBinlogServer *Instance, err error) {
+func RegroupReplicasBinlogServers(primaryKey *InstanceKey, returnReplicaEvenOnFailureToRegroup bool) (repointedBinlogServers [](*Instance), promotedBinlogServer *Instance, err error) {
 	var binlogServerReplicas [](*Instance)
-	promotedBinlogServer, binlogServerReplicas, err = getMostUpToDateActiveBinlogServer(masterKey)
+	promotedBinlogServer, binlogServerReplicas, err = getMostUpToDateActiveBinlogServer(primaryKey)
 
 	resultOnError := func(err error) ([](*Instance), *Instance, error) {
 		if !returnReplicaEvenOnFailureToRegroup {
@@ -1884,13 +1884,13 @@ func RegroupReplicasBinlogServers(masterKey *InstanceKey, returnReplicaEvenOnFai
 	if err != nil {
 		return resultOnError(err)
 	}
-	AuditOperation("regroup-replicas-bls", masterKey, fmt.Sprintf("regrouped binlog server replicas of %+v; promoted %+v", *masterKey, promotedBinlogServer.Key))
+	AuditOperation("regroup-replicas-bls", primaryKey, fmt.Sprintf("regrouped binlog server replicas of %+v; promoted %+v", *primaryKey, promotedBinlogServer.Key))
 	return repointedBinlogServers, promotedBinlogServer, nil
 }
 
 // RegroupReplicas is a "smart" method of promoting one replica over the others ("promoting" it on top of its siblings)
 // This method decides which strategy to use: GTID, Binlog Servers.
-func RegroupReplicas(masterKey *InstanceKey, returnReplicaEvenOnFailureToRegroup bool,
+func RegroupReplicas(primaryKey *InstanceKey, returnReplicaEvenOnFailureToRegroup bool,
 	onCandidateReplicaChosen func(*Instance),
 	postponedFunctionsContainer *PostponedFunctionsContainer) (
 
@@ -1904,7 +1904,7 @@ func RegroupReplicas(masterKey *InstanceKey, returnReplicaEvenOnFailureToRegroup
 	//
 	var emptyReplicas [](*Instance)
 
-	replicas, err := ReadReplicaInstances(masterKey)
+	replicas, err := ReadReplicaInstances(primaryKey)
 	if err != nil {
 		return emptyReplicas, emptyReplicas, emptyReplicas, emptyReplicas, instance, err
 	}
@@ -1925,13 +1925,13 @@ func RegroupReplicas(masterKey *InstanceKey, returnReplicaEvenOnFailureToRegroup
 		}
 	}
 	if allGTID {
-		log.Debugf("RegroupReplicas: using GTID to regroup replicas of %+v", *masterKey)
-		unmovedReplicas, movedReplicas, cannotReplicateReplicas, candidateReplica, err := RegroupReplicasGTID(masterKey, returnReplicaEvenOnFailureToRegroup, onCandidateReplicaChosen, nil, nil)
+		log.Debugf("RegroupReplicas: using GTID to regroup replicas of %+v", *primaryKey)
+		unmovedReplicas, movedReplicas, cannotReplicateReplicas, candidateReplica, err := RegroupReplicasGTID(primaryKey, returnReplicaEvenOnFailureToRegroup, onCandidateReplicaChosen, nil, nil)
 		return unmovedReplicas, emptyReplicas, movedReplicas, cannotReplicateReplicas, candidateReplica, err
 	}
 	if allBinlogServers {
-		log.Debugf("RegroupReplicas: using binlog servers to regroup replicas of %+v", *masterKey)
-		movedReplicas, candidateReplica, err := RegroupReplicasBinlogServers(masterKey, returnReplicaEvenOnFailureToRegroup)
+		log.Debugf("RegroupReplicas: using binlog servers to regroup replicas of %+v", *primaryKey)
+		movedReplicas, candidateReplica, err := RegroupReplicasBinlogServers(primaryKey, returnReplicaEvenOnFailureToRegroup)
 		return emptyReplicas, emptyReplicas, movedReplicas, cannotReplicateReplicas, candidateReplica, err
 	}
 	return emptyReplicas, emptyReplicas, emptyReplicas, emptyReplicas, instance, log.Errorf("No solution path found for RegroupReplicas")
@@ -1945,7 +1945,7 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 		return instance, log.Errorf("%+v cannot replicate from %+v. Reason: %+v", instance.Key, other.Key, err)
 	}
 	// simplest:
-	if InstanceIsMasterOf(other, instance) {
+	if InstanceIsPrimaryOf(other, instance) {
 		// already the desired setup.
 		return Repoint(&instance.Key, &other.Key, GTIDHintNeutral)
 	}
@@ -1954,34 +1954,34 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 	if InstancesAreSiblings(instance, other) && other.IsBinlogServer() {
 		return MoveBelow(&instance.Key, &other.Key)
 	}
-	instanceMaster, _, err := ReadInstance(&instance.MasterKey)
+	instancePrimary, _, err := ReadInstance(&instance.PrimaryKey)
 	if err != nil {
 		return instance, err
 	}
-	if instanceMaster != nil && instanceMaster.MasterKey.Equals(&other.Key) && instanceMaster.IsBinlogServer() {
+	if instancePrimary != nil && instancePrimary.PrimaryKey.Equals(&other.Key) && instancePrimary.IsBinlogServer() {
 		// Moving to grandparent via binlog server
-		return Repoint(&instance.Key, &instanceMaster.MasterKey, GTIDHintDeny)
+		return Repoint(&instance.Key, &instancePrimary.PrimaryKey, GTIDHintDeny)
 	}
 	if other.IsBinlogServer() {
-		if instanceMaster != nil && instanceMaster.IsBinlogServer() && InstancesAreSiblings(instanceMaster, other) {
+		if instancePrimary != nil && instancePrimary.IsBinlogServer() && InstancesAreSiblings(instancePrimary, other) {
 			// Special case: this is a binlog server family; we move under the uncle, in one single step
 			return Repoint(&instance.Key, &other.Key, GTIDHintDeny)
 		}
 
 		// Relocate to its primary, then repoint to the binlog server
-		otherMaster, found, err := ReadInstance(&other.MasterKey)
+		otherPrimary, found, err := ReadInstance(&other.PrimaryKey)
 		if err != nil {
 			return instance, err
 		}
 		if !found {
-			return instance, log.Errorf("Cannot find master %+v", other.MasterKey)
+			return instance, log.Errorf("Cannot find master %+v", other.PrimaryKey)
 		}
 		if !other.IsLastCheckValid {
 			return instance, log.Errorf("Binlog server %+v is not reachable. It would take two steps to relocate %+v below it, and I won't even do the first step.", other.Key, instance.Key)
 		}
 
-		log.Debugf("Relocating to a binlog server; will first attempt to relocate to the binlog server's master: %+v, and then repoint down", otherMaster.Key)
-		if _, err := relocateBelowInternal(instance, otherMaster); err != nil {
+		log.Debugf("Relocating to a binlog server; will first attempt to relocate to the binlog server's master: %+v, and then repoint down", otherPrimary.Key)
+		if _, err := relocateBelowInternal(instance, otherPrimary); err != nil {
 			return instance, err
 		}
 		return Repoint(&instance.Key, &other.Key, GTIDHintDeny)
@@ -2000,16 +2000,16 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 	// Check simple binlog file/pos operations:
 	if InstancesAreSiblings(instance, other) {
 		// If comastering, only move below if it's read-only
-		if !other.IsCoMaster || other.ReadOnly {
+		if !other.IsCoPrimary || other.ReadOnly {
 			return MoveBelow(&instance.Key, &other.Key)
 		}
 	}
 	// See if we need to MoveUp
-	if instanceMaster != nil && instanceMaster.MasterKey.Equals(&other.Key) {
+	if instancePrimary != nil && instancePrimary.PrimaryKey.Equals(&other.Key) {
 		// Moving to grandparent--handles co-primary writable case
 		return MoveUp(&instance.Key)
 	}
-	if instanceMaster != nil && instanceMaster.IsBinlogServer() {
+	if instancePrimary != nil && instancePrimary.IsBinlogServer() {
 		// Break operation into two: move (repoint) up, then continue
 		if _, err := MoveUp(&instance.Key); err != nil {
 			return instance, err
@@ -2063,11 +2063,11 @@ func relocateReplicasInternal(replicas [](*Instance), instance, other *Instance)
 		return RepointTo(replicas, &other.Key)
 	}
 	// Try and take advantage of binlog servers:
-	if InstanceIsMasterOf(other, instance) && instance.IsBinlogServer() {
+	if InstanceIsPrimaryOf(other, instance) && instance.IsBinlogServer() {
 		// Up from a binlog server
 		return RepointTo(replicas, &other.Key)
 	}
-	if InstanceIsMasterOf(instance, other) && other.IsBinlogServer() {
+	if InstanceIsPrimaryOf(instance, other) && other.IsBinlogServer() {
 		// Down under a binlog server
 		return RepointTo(replicas, &other.Key)
 	}
@@ -2077,11 +2077,11 @@ func relocateReplicasInternal(replicas [](*Instance), instance, other *Instance)
 	}
 	if other.IsBinlogServer() {
 		// Relocate to binlog server's parent (recursive call), then repoint down
-		otherMaster, found, err := ReadInstance(&other.MasterKey)
+		otherPrimary, found, err := ReadInstance(&other.PrimaryKey)
 		if err != nil || !found {
 			return nil, err, errs
 		}
-		replicas, err, errs = relocateReplicasInternal(replicas, instance, otherMaster)
+		replicas, err, errs = relocateReplicasInternal(replicas, instance, otherPrimary)
 		if err != nil {
 			return replicas, err, errs
 		}

--- a/go/vt/orchestrator/inst/instance_topology_dao.go
+++ b/go/vt/orchestrator/inst/instance_topology_dao.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	Error1201CouldnotInitializeMasterInfoStructure = "Error 1201:"
+	Error1201CouldnotInitializePrimaryInfoStructure = "Error 1201:"
 )
 
 // ExecInstance executes a given query on the given MySQL topology instance
@@ -207,8 +207,8 @@ func purgeBinaryLogsTo(instanceKey *InstanceKey, logFile string) (*Instance, err
 }
 
 // TODO(sougou): implement count
-func SetSemiSyncMaster(instanceKey *InstanceKey, enableMaster bool) error {
-	if _, err := ExecInstance(instanceKey, `set global rpl_semi_sync_master_enabled = ?, global rpl_semi_sync_slave_enabled = ?`, enableMaster, false); err != nil {
+func SetSemiSyncPrimary(instanceKey *InstanceKey, enablePrimary bool) error {
+	if _, err := ExecInstance(instanceKey, `set global rpl_semi_sync_master_enabled = ?, global rpl_semi_sync_slave_enabled = ?`, enablePrimary, false); err != nil {
 		return log.Errore(err)
 	}
 	return nil
@@ -482,8 +482,8 @@ func WaitForExecBinlogCoordinatesToReach(instanceKey *InstanceKey, coordinates *
 	}
 }
 
-// StartReplicationUntilMasterCoordinates issuesa START SLAVE UNTIL... statement on given instance
-func StartReplicationUntilMasterCoordinates(instanceKey *InstanceKey, masterCoordinates *BinlogCoordinates) (*Instance, error) {
+// StartReplicationUntilPrimaryCoordinates issuesa START SLAVE UNTIL... statement on given instance
+func StartReplicationUntilPrimaryCoordinates(instanceKey *InstanceKey, primaryCoordinates *BinlogCoordinates) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, log.Errore(err)
@@ -496,18 +496,18 @@ func StartReplicationUntilMasterCoordinates(instanceKey *InstanceKey, masterCoor
 		return instance, fmt.Errorf("replication threads are not stopped: %+v", instanceKey)
 	}
 
-	log.Infof("Will start replication on %+v until coordinates: %+v", instanceKey, masterCoordinates)
+	log.Infof("Will start replication on %+v until coordinates: %+v", instanceKey, primaryCoordinates)
 
 	// MariaDB has a bug: a CHANGE MASTER TO statement does not work properly with prepared statement... :P
 	// See https://mariadb.atlassian.net/browse/MDEV-7640
 	// This is the reason for ExecInstance
 	_, err = ExecInstance(instanceKey, "start slave until master_log_file=?, master_log_pos=?",
-		masterCoordinates.LogFile, masterCoordinates.LogPos)
+		primaryCoordinates.LogFile, primaryCoordinates.LogPos)
 	if err != nil {
 		return instance, log.Errore(err)
 	}
 
-	instance, exactMatch, err := WaitForExecBinlogCoordinatesToReach(instanceKey, masterCoordinates, 0)
+	instance, exactMatch, err := WaitForExecBinlogCoordinatesToReach(instanceKey, primaryCoordinates, 0)
 	if err != nil {
 		return instance, log.Errore(err)
 	}
@@ -523,17 +523,17 @@ func StartReplicationUntilMasterCoordinates(instanceKey *InstanceKey, masterCoor
 	return instance, err
 }
 
-// EnableMasterSSL issues CHANGE MASTER TO MASTER_SSL=1
-func EnableMasterSSL(instanceKey *InstanceKey) (*Instance, error) {
+// EnablePrimarySSL issues CHANGE MASTER TO MASTER_SSL=1
+func EnablePrimarySSL(instanceKey *InstanceKey) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, log.Errore(err)
 	}
 
 	if instance.ReplicationThreadsExist() && !instance.ReplicationThreadsStopped() {
-		return instance, fmt.Errorf("EnableMasterSSL: Cannot enable SSL replication on %+v because replication threads are not stopped", *instanceKey)
+		return instance, fmt.Errorf("EnablePrimarySSL: Cannot enable SSL replication on %+v because replication threads are not stopped", *instanceKey)
 	}
-	log.Debugf("EnableMasterSSL: Will attempt enabling SSL replication on %+v", *instanceKey)
+	log.Debugf("EnablePrimarySSL: Will attempt enabling SSL replication on %+v", *instanceKey)
 
 	if *config.RuntimeCLIFlags.Noop {
 		return instance, fmt.Errorf("noop: aborting CHANGE MASTER TO MASTER_SSL=1 operation on %+v; signaling error but nothing went wrong.", *instanceKey)
@@ -544,7 +544,7 @@ func EnableMasterSSL(instanceKey *InstanceKey) (*Instance, error) {
 		return instance, log.Errore(err)
 	}
 
-	log.Infof("EnableMasterSSL: Enabled SSL replication on %+v", *instanceKey)
+	log.Infof("EnablePrimarySSL: Enabled SSL replication on %+v", *instanceKey)
 
 	instance, err = ReadTopologyInstance(instanceKey)
 	return instance, err
@@ -566,9 +566,9 @@ func workaroundBug83713(instanceKey *InstanceKey) {
 	}
 }
 
-// ChangeMasterTo changes the given instance's primary according to given input.
+// ChangePrimaryTo changes the given instance's primary according to given input.
 // TODO(sougou): deprecate ReplicationCredentialsQuery, and all other credential discovery.
-func ChangeMasterTo(instanceKey *InstanceKey, masterKey *InstanceKey, masterBinlogCoordinates *BinlogCoordinates, skipUnresolve bool, gtidHint OperationGTIDHint) (*Instance, error) {
+func ChangePrimaryTo(instanceKey *InstanceKey, primaryKey *InstanceKey, primaryBinlogCoordinates *BinlogCoordinates, skipUnresolve bool, gtidHint OperationGTIDHint) (*Instance, error) {
 	user, password := config.Config.MySQLReplicaUser, config.Config.MySQLReplicaPassword
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
@@ -576,41 +576,41 @@ func ChangeMasterTo(instanceKey *InstanceKey, masterKey *InstanceKey, masterBinl
 	}
 
 	if instance.ReplicationThreadsExist() && !instance.ReplicationThreadsStopped() {
-		return instance, fmt.Errorf("ChangeMasterTo: Cannot change master on: %+v because replication threads are not stopped", *instanceKey)
+		return instance, fmt.Errorf("ChangePrimaryTo: Cannot change master on: %+v because replication threads are not stopped", *instanceKey)
 	}
-	log.Debugf("ChangeMasterTo: will attempt changing master on %+v to %+v, %+v", *instanceKey, *masterKey, *masterBinlogCoordinates)
-	changeToMasterKey := masterKey
+	log.Debugf("ChangePrimaryTo: will attempt changing master on %+v to %+v, %+v", *instanceKey, *primaryKey, *primaryBinlogCoordinates)
+	changeToPrimaryKey := primaryKey
 	if !skipUnresolve {
-		unresolvedMasterKey, nameUnresolved, err := UnresolveHostname(masterKey)
+		unresolvedPrimaryKey, nameUnresolved, err := UnresolveHostname(primaryKey)
 		if err != nil {
-			log.Debugf("ChangeMasterTo: aborting operation on %+v due to resolving error on %+v: %+v", *instanceKey, *masterKey, err)
+			log.Debugf("ChangePrimaryTo: aborting operation on %+v due to resolving error on %+v: %+v", *instanceKey, *primaryKey, err)
 			return instance, err
 		}
 		if nameUnresolved {
-			log.Debugf("ChangeMasterTo: Unresolved %+v into %+v", *masterKey, unresolvedMasterKey)
+			log.Debugf("ChangePrimaryTo: Unresolved %+v into %+v", *primaryKey, unresolvedPrimaryKey)
 		}
-		changeToMasterKey = &unresolvedMasterKey
+		changeToPrimaryKey = &unresolvedPrimaryKey
 	}
 
 	if *config.RuntimeCLIFlags.Noop {
 		return instance, fmt.Errorf("noop: aborting CHANGE MASTER TO operation on %+v; signalling error but nothing went wrong.", *instanceKey)
 	}
 
-	var changeMasterFunc func() error
+	var changePrimaryFunc func() error
 	changedViaGTID := false
 	if instance.UsingMariaDBGTID && gtidHint != GTIDHintDeny {
 		// Keep on using GTID
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err := ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port)
 			return err
 		}
 		changedViaGTID = true
 	} else if instance.UsingMariaDBGTID && gtidHint == GTIDHintDeny {
 		// Make sure to not use GTID
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?, master_log_file=?, master_log_pos=?, master_use_gtid=no",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port, masterBinlogCoordinates.LogFile, masterBinlogCoordinates.LogPos)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port, primaryBinlogCoordinates.LogFile, primaryBinlogCoordinates.LogPos)
 			return err
 		}
 	} else if instance.IsMariaDB() && gtidHint == GTIDHintForce {
@@ -624,61 +624,61 @@ func ChangeMasterTo(instanceKey *InstanceKey, masterKey *InstanceKey, masterBinl
 			// - https://dba.stackexchange.com/a/234323
 			mariadbGTIDHint = "current_pos"
 		}
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, fmt.Sprintf("change master to master_user=?, master_password=?, master_host=?, master_port=?, master_use_gtid=%s", mariadbGTIDHint),
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port)
 			return err
 		}
 		changedViaGTID = true
 	} else if instance.UsingOracleGTID && gtidHint != GTIDHintDeny {
 		// Is Oracle; already uses GTID; keep using it.
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port)
 			return err
 		}
 		changedViaGTID = true
 	} else if instance.UsingOracleGTID && gtidHint == GTIDHintDeny {
 		// Is Oracle; already uses GTID
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?, master_log_file=?, master_log_pos=?, master_auto_position=0",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port, masterBinlogCoordinates.LogFile, masterBinlogCoordinates.LogPos)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port, primaryBinlogCoordinates.LogFile, primaryBinlogCoordinates.LogPos)
 			return err
 		}
 	} else if instance.SupportsOracleGTID && gtidHint == GTIDHintForce {
 		// Is Oracle; not using GTID right now; turn into GTID
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?, master_auto_position=1",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port)
 			return err
 		}
 		changedViaGTID = true
 	} else {
 		// Normal binlog file:pos
-		changeMasterFunc = func() error {
+		changePrimaryFunc = func() error {
 			_, err = ExecInstance(instanceKey, "change master to master_user=?, master_password=?, master_host=?, master_port=?, master_log_file=?, master_log_pos=?",
-				user, password, changeToMasterKey.Hostname, changeToMasterKey.Port, masterBinlogCoordinates.LogFile, masterBinlogCoordinates.LogPos)
+				user, password, changeToPrimaryKey.Hostname, changeToPrimaryKey.Port, primaryBinlogCoordinates.LogFile, primaryBinlogCoordinates.LogPos)
 			return err
 		}
 	}
-	err = changeMasterFunc()
-	if err != nil && instance.UsingOracleGTID && strings.Contains(err.Error(), Error1201CouldnotInitializeMasterInfoStructure) {
-		log.Debugf("ChangeMasterTo: got %+v", err)
+	err = changePrimaryFunc()
+	if err != nil && instance.UsingOracleGTID && strings.Contains(err.Error(), Error1201CouldnotInitializePrimaryInfoStructure) {
+		log.Debugf("ChangePrimaryTo: got %+v", err)
 		workaroundBug83713(instanceKey)
-		err = changeMasterFunc()
+		err = changePrimaryFunc()
 	}
 	if err != nil {
 		return instance, log.Errore(err)
 	}
 
-	semiSync := ReplicaSemiSync(*masterKey, *instanceKey)
+	semiSync := ReplicaSemiSync(*primaryKey, *instanceKey)
 	if _, err := ExecInstance(instanceKey, `set global rpl_semi_sync_master_enabled = ?, global rpl_semi_sync_slave_enabled = ?`, false, semiSync); err != nil {
 		return instance, log.Errore(err)
 	}
 
 	ResetInstanceRelaylogCoordinatesHistory(instanceKey)
 
-	log.Infof("ChangeMasterTo: Changed master on %+v to: %+v, %+v. GTID: %+v", *instanceKey, masterKey, masterBinlogCoordinates, changedViaGTID)
+	log.Infof("ChangePrimaryTo: Changed master on %+v to: %+v, %+v. GTID: %+v", *instanceKey, primaryKey, primaryBinlogCoordinates, changedViaGTID)
 
 	instance, err = ReadTopologyInstance(instanceKey)
 	return instance, err
@@ -700,7 +700,7 @@ func SkipToNextBinaryLog(instanceKey *InstanceKey) (*Instance, error) {
 	nextFileCoordinates.LogPos = 4
 	log.Debugf("Will skip replication on %+v to next binary log: %+v", instance.Key, nextFileCoordinates.LogFile)
 
-	instance, err = ChangeMasterTo(&instance.Key, &instance.MasterKey, &nextFileCoordinates, false, GTIDHintNeutral)
+	instance, err = ChangePrimaryTo(&instance.Key, &instance.PrimaryKey, &nextFileCoordinates, false, GTIDHintNeutral)
 	if err != nil {
 		return instance, log.Errore(err)
 	}
@@ -732,7 +732,7 @@ func ResetReplication(instanceKey *InstanceKey) (*Instance, error) {
 		return instance, log.Errore(err)
 	}
 	_, err = ExecInstance(instanceKey, `reset slave /*!50603 all */`)
-	if err != nil && strings.Contains(err.Error(), Error1201CouldnotInitializeMasterInfoStructure) {
+	if err != nil && strings.Contains(err.Error(), Error1201CouldnotInitializePrimaryInfoStructure) {
 		log.Debugf("ResetReplication: got %+v", err)
 		workaroundBug83713(instanceKey)
 		_, err = ExecInstance(instanceKey, `reset slave /*!50603 all */`)
@@ -746,8 +746,8 @@ func ResetReplication(instanceKey *InstanceKey) (*Instance, error) {
 	return instance, err
 }
 
-// ResetMaster issues a RESET MASTER statement on given instance. Use with extreme care!
-func ResetMaster(instanceKey *InstanceKey) (*Instance, error) {
+// ResetPrimary issues a RESET MASTER statement on given instance. Use with extreme care!
+func ResetPrimary(instanceKey *InstanceKey) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, log.Errore(err)
@@ -874,8 +874,8 @@ func SkipQuery(instanceKey *InstanceKey) (*Instance, error) {
 	return StartReplication(instanceKey)
 }
 
-// MasterPosWait issues a MASTER_POS_WAIT() an given instance according to given coordinates.
-func MasterPosWait(instanceKey *InstanceKey, binlogCoordinates *BinlogCoordinates) (*Instance, error) {
+// PrimaryPosWait issues a MASTER_POS_WAIT() an given instance according to given coordinates.
+func PrimaryPosWait(instanceKey *InstanceKey, binlogCoordinates *BinlogCoordinates) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, log.Errore(err)
@@ -957,17 +957,17 @@ func GTIDSubtract(instanceKey *InstanceKey, gtidSet string, gtidSubset string) (
 	return gtidSubtract, err
 }
 
-func ShowMasterStatus(instanceKey *InstanceKey) (masterStatusFound bool, executedGtidSet string, err error) {
+func ShowPrimaryStatus(instanceKey *InstanceKey) (primaryStatusFound bool, executedGtidSet string, err error) {
 	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
-		return masterStatusFound, executedGtidSet, err
+		return primaryStatusFound, executedGtidSet, err
 	}
 	err = sqlutils.QueryRowsMap(db, "show master status", func(m sqlutils.RowMap) error {
-		masterStatusFound = true
+		primaryStatusFound = true
 		executedGtidSet = m.GetStringD("Executed_Gtid_Set", "")
 		return nil
 	})
-	return masterStatusFound, executedGtidSet, err
+	return primaryStatusFound, executedGtidSet, err
 }
 
 func ShowBinaryLogs(instanceKey *InstanceKey) (binlogs []string, err error) {

--- a/go/vt/orchestrator/inst/instance_topology_dao.go
+++ b/go/vt/orchestrator/inst/instance_topology_dao.go
@@ -700,7 +700,7 @@ func SkipToNextBinaryLog(instanceKey *InstanceKey) (*Instance, error) {
 	nextFileCoordinates.LogPos = 4
 	log.Debugf("Will skip replication on %+v to next binary log: %+v", instance.Key, nextFileCoordinates.LogFile)
 
-	instance, err = ChangePrimaryTo(&instance.Key, &instance.PrimaryKey, &nextFileCoordinates, false, GTIDHintNeutral)
+	instance, err = ChangePrimaryTo(&instance.Key, &instance.SourceKey, &nextFileCoordinates, false, GTIDHintNeutral)
 	if err != nil {
 		return instance, log.Errore(err)
 	}

--- a/go/vt/orchestrator/inst/minimal_instance.go
+++ b/go/vt/orchestrator/inst/minimal_instance.go
@@ -9,7 +9,7 @@ type MinimalInstance struct {
 func (this *MinimalInstance) ToInstance() *Instance {
 	return &Instance{
 		Key:         this.Key,
-		PrimaryKey:  this.PrimaryKey,
+		SourceKey:   this.PrimaryKey,
 		ClusterName: this.ClusterName,
 	}
 }

--- a/go/vt/orchestrator/inst/minimal_instance.go
+++ b/go/vt/orchestrator/inst/minimal_instance.go
@@ -2,14 +2,14 @@ package inst
 
 type MinimalInstance struct {
 	Key         InstanceKey
-	MasterKey   InstanceKey
+	PrimaryKey  InstanceKey
 	ClusterName string
 }
 
 func (this *MinimalInstance) ToInstance() *Instance {
 	return &Instance{
 		Key:         this.Key,
-		MasterKey:   this.MasterKey,
+		PrimaryKey:  this.PrimaryKey,
 		ClusterName: this.ClusterName,
 	}
 }

--- a/go/vt/orchestrator/inst/tablet_dao.go
+++ b/go/vt/orchestrator/inst/tablet_dao.go
@@ -40,39 +40,39 @@ var TopoServ *topo.Server
 // ErrTabletAliasNil is a fixed error message.
 var ErrTabletAliasNil = errors.New("tablet alias is nil")
 
-// SwitchMaster makes the new tablet the primary and proactively performs
+// SwitchPrimary makes the new tablet the primary and proactively performs
 // the necessary propagation to the old primary. The propagation is best
 // effort. If it fails, the tablet's shard sync will eventually converge.
 // The proactive propagation allows a competing Orchestrator from discovering
 // the successful action of a previous one, which reduces churn.
-func SwitchMaster(newMasterKey, oldMasterKey InstanceKey) error {
-	newMasterTablet, err := ChangeTabletType(newMasterKey, topodatapb.TabletType_PRIMARY)
+func SwitchPrimary(newPrimaryKey, oldPrimaryKey InstanceKey) error {
+	newPrimaryTablet, err := ChangeTabletType(newPrimaryKey, topodatapb.TabletType_PRIMARY)
 	if err != nil {
 		return err
 	}
 	// The following operations are best effort.
-	if newMasterTablet.Type != topodatapb.TabletType_PRIMARY {
-		log.Errorf("Unexpected: tablet type did not change to master: %v", newMasterTablet.Type)
+	if newPrimaryTablet.Type != topodatapb.TabletType_PRIMARY {
+		log.Errorf("Unexpected: tablet type did not change to master: %v", newPrimaryTablet.Type)
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
 	defer cancel()
-	_, err = TopoServ.UpdateShardFields(ctx, newMasterTablet.Keyspace, newMasterTablet.Shard, func(si *topo.ShardInfo) error {
-		if proto.Equal(si.PrimaryAlias, newMasterTablet.Alias) && proto.Equal(si.PrimaryTermStartTime, newMasterTablet.PrimaryTermStartTime) {
+	_, err = TopoServ.UpdateShardFields(ctx, newPrimaryTablet.Keyspace, newPrimaryTablet.Shard, func(si *topo.ShardInfo) error {
+		if proto.Equal(si.PrimaryAlias, newPrimaryTablet.Alias) && proto.Equal(si.PrimaryTermStartTime, newPrimaryTablet.PrimaryTermStartTime) {
 			return topo.NewError(topo.NoUpdateNeeded, "")
 		}
 
 		// We just successfully reparented. We should check timestamps, but always overwrite.
 		lastTerm := si.GetPrimaryTermStartTime()
-		newTerm := logutil.ProtoToTime(newMasterTablet.PrimaryTermStartTime)
+		newTerm := logutil.ProtoToTime(newPrimaryTablet.PrimaryTermStartTime)
 		if !newTerm.After(lastTerm) {
 			log.Errorf("Possible clock skew. New master start time is before previous one: %v vs %v", newTerm, lastTerm)
 		}
 
-		aliasStr := topoproto.TabletAliasString(newMasterTablet.Alias)
+		aliasStr := topoproto.TabletAliasString(newPrimaryTablet.Alias)
 		log.Infof("Updating shard record: master_alias=%v, primary_term_start_time=%v", aliasStr, newTerm)
-		si.PrimaryAlias = newMasterTablet.Alias
-		si.PrimaryTermStartTime = newMasterTablet.PrimaryTermStartTime
+		si.PrimaryAlias = newPrimaryTablet.Alias
+		si.PrimaryTermStartTime = newPrimaryTablet.PrimaryTermStartTime
 		return nil
 	})
 	// Don't proceed if shard record could not be updated.
@@ -80,7 +80,7 @@ func SwitchMaster(newMasterKey, oldMasterKey InstanceKey) error {
 		log.Errore(err)
 		return nil
 	}
-	if _, err := ChangeTabletType(oldMasterKey, topodatapb.TabletType_REPLICA); err != nil {
+	if _, err := ChangeTabletType(oldPrimaryKey, topodatapb.TabletType_REPLICA); err != nil {
 		// This is best effort.
 		log.Errore(err)
 	}

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -328,7 +328,7 @@ func onHealthTick() {
 // This should generally only happen once in a lifetime of a cluster. Otherwise KV
 // stores are updated via failovers.
 func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVPair), submittedCount int, err error) {
-	kvPairs, err = inst.GetMastersKVPairs(clusterName)
+	kvPairs, err = inst.GetPrimariesKVPairs(clusterName)
 	log.Debugf("kv.SubmitMastersToKvStores, clusterName: %s, force: %+v: numPairs: %+v", clusterName, force, len(kvPairs))
 	if err != nil {
 		return kvPairs, submittedCount, log.Errore(err)
@@ -442,13 +442,13 @@ func ContinuousDiscovery() {
 			go func() {
 				if IsLeaderOrActive() {
 					go inst.ReviewUnseenInstances()
-					go inst.InjectUnseenMasters()
+					go inst.InjectUnseenPrimaries()
 
 					go inst.ForgetLongUnseenInstances()
 					go inst.ForgetUnseenInstancesDifferentlyResolved()
 					go inst.ForgetExpiredHostnameResolves()
 					go inst.DeleteInvalidHostnameResolves()
-					go inst.ResolveUnknownMasterHostnameResolves()
+					go inst.ResolveUnknownPrimaryHostnameResolves()
 					go inst.ExpireMaintenance()
 					go inst.ExpireCandidateInstances()
 					go inst.ExpireHostnameUnresolve()

--- a/go/vt/orchestrator/logic/orchestrator.go
+++ b/go/vt/orchestrator/logic/orchestrator.go
@@ -324,12 +324,12 @@ func onHealthTick() {
 	}
 }
 
-// SubmitMastersToKvStores records a cluster's primary (or all clusters primaries) to kv stores.
+// SubmitPrimariesToKvStores records a cluster's primary (or all clusters primaries) to kv stores.
 // This should generally only happen once in a lifetime of a cluster. Otherwise KV
 // stores are updated via failovers.
-func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVPair), submittedCount int, err error) {
+func SubmitPrimariesToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVPair), submittedCount int, err error) {
 	kvPairs, err = inst.GetPrimariesKVPairs(clusterName)
-	log.Debugf("kv.SubmitMastersToKvStores, clusterName: %s, force: %+v: numPairs: %+v", clusterName, force, len(kvPairs))
+	log.Debugf("kv.SubmitPrimariesToKvStores, clusterName: %s, force: %+v: numPairs: %+v", clusterName, force, len(kvPairs))
 	if err != nil {
 		return kvPairs, submittedCount, log.Errore(err)
 	}
@@ -352,7 +352,7 @@ func SubmitMastersToKvStores(clusterName string, force bool) (kvPairs [](*kv.KVP
 		}
 		submitKvPairs = append(submitKvPairs, kvPair)
 	}
-	log.Debugf("kv.SubmitMastersToKvStores: submitKvPairs: %+v", len(submitKvPairs))
+	log.Debugf("kv.SubmitPrimariesToKvStores: submitKvPairs: %+v", len(submitKvPairs))
 	for _, kvPair := range submitKvPairs {
 		err := kv.PutKVPair(kvPair)
 		if err == nil {
@@ -465,7 +465,7 @@ func ContinuousDiscovery() {
 					go ExpireTopologyRecoveryStepsHistory()
 
 					if runCheckAndRecoverOperationsTimeRipe() && IsLeader() {
-						go SubmitMastersToKvStores("", false)
+						go SubmitPrimariesToKvStores("", false)
 					}
 				} else {
 					// Take this opportunity to refresh yourself

--- a/go/vt/orchestrator/logic/tablet_discovery.go
+++ b/go/vt/orchestrator/logic/tablet_discovery.go
@@ -284,17 +284,17 @@ func TabletRefresh(instanceKey inst.InstanceKey) (*topodatapb.Tablet, error) {
 	return ti.Tablet, nil
 }
 
-// TabletDemoteMaster requests the primary tablet to stop accepting transactions.
-func TabletDemoteMaster(instanceKey inst.InstanceKey) error {
-	return tabletDemoteMaster(instanceKey, true)
+// TabletDemotePrimary requests the primary tablet to stop accepting transactions.
+func TabletDemotePrimary(instanceKey inst.InstanceKey) error {
+	return tabletDemotePrimary(instanceKey, true)
 }
 
-// TabletUndoDemoteMaster requests the primary tablet to undo the demote.
-func TabletUndoDemoteMaster(instanceKey inst.InstanceKey) error {
-	return tabletDemoteMaster(instanceKey, false)
+// TabletUndoDemotePrimary requests the primary tablet to undo the demote.
+func TabletUndoDemotePrimary(instanceKey inst.InstanceKey) error {
+	return tabletDemotePrimary(instanceKey, false)
 }
 
-func tabletDemoteMaster(instanceKey inst.InstanceKey, forward bool) error {
+func tabletDemotePrimary(instanceKey inst.InstanceKey, forward bool) error {
 	if instanceKey.Hostname == "" {
 		return errors.New("Can't demote/undo master: instance is unspecified")
 	}
@@ -308,14 +308,14 @@ func tabletDemoteMaster(instanceKey inst.InstanceKey, forward bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	if forward {
-		_, err = tmc.DemoteMaster(ctx, tablet)
+		_, err = tmc.DemotePrimary(ctx, tablet)
 	} else {
-		err = tmc.UndoDemoteMaster(ctx, tablet)
+		err = tmc.UndoDemotePrimary(ctx, tablet)
 	}
 	return err
 }
 
-func ShardMaster(instanceKey *inst.InstanceKey) (masterKey *inst.InstanceKey, err error) {
+func ShardPrimary(instanceKey *inst.InstanceKey) (primaryKey *inst.InstanceKey, err error) {
 	tablet, err := inst.ReadTablet(*instanceKey)
 	if err != nil {
 		return nil, err
@@ -331,12 +331,12 @@ func ShardMaster(instanceKey *inst.InstanceKey) (masterKey *inst.InstanceKey, er
 	}
 	tCtx, tCancel := context.WithTimeout(context.Background(), *topo.RemoteOperationTimeout)
 	defer tCancel()
-	master, err := ts.GetTablet(tCtx, si.PrimaryAlias)
+	primary, err := ts.GetTablet(tCtx, si.PrimaryAlias)
 	if err != nil {
 		return nil, err
 	}
 	return &inst.InstanceKey{
-		Hostname: master.MysqlHostname,
-		Port:     int(master.MysqlPort),
+		Hostname: primary.MysqlHostname,
+		Port:     int(primary.MysqlPort),
 	}, nil
 }

--- a/go/vt/orchestrator/logic/topology_recovery.go
+++ b/go/vt/orchestrator/logic/topology_recovery.go
@@ -46,9 +46,9 @@ var countPendingRecoveries int64
 type RecoveryType string
 
 const (
-	MasterRecovery             RecoveryType = "MasterRecovery"
-	CoMasterRecovery           RecoveryType = "CoMasterRecovery"
-	IntermediateMasterRecovery RecoveryType = "IntermediateMasterRecovery"
+	PrimaryRecovery             RecoveryType = "MasterRecovery"
+	CoPrimaryRecovery           RecoveryType = "CoMasterRecovery"
+	IntermediatePrimaryRecovery RecoveryType = "IntermediateMasterRecovery"
 )
 
 type RecoveryAcknowledgement struct {
@@ -113,7 +113,7 @@ type TopologyRecovery struct {
 	LastDetectionId           int64
 	RelatedRecoveryId         int64
 	Type                      RecoveryType
-	RecoveryType              MasterRecoveryType
+	RecoveryType              PrimaryRecoveryType
 }
 
 func NewTopologyRecovery(replicationAnalysis inst.ReplicationAnalysis) *TopologyRecovery {
@@ -124,7 +124,7 @@ func NewTopologyRecovery(replicationAnalysis inst.ReplicationAnalysis) *Topology
 	topologyRecovery.LostReplicas = *inst.NewInstanceKeyMap()
 	topologyRecovery.ParticipatingInstanceKeys = *inst.NewInstanceKeyMap()
 	topologyRecovery.AllErrors = []string{}
-	topologyRecovery.RecoveryType = NotMasterRecovery
+	topologyRecovery.RecoveryType = NotPrimaryRecovery
 	return topologyRecovery
 }
 
@@ -155,13 +155,13 @@ func NewTopologyRecoveryStep(uid string, message string) *TopologyRecoveryStep {
 	}
 }
 
-type MasterRecoveryType string
+type PrimaryRecoveryType string
 
 const (
-	NotMasterRecovery          MasterRecoveryType = "NotMasterRecovery"
-	MasterRecoveryGTID         MasterRecoveryType = "MasterRecoveryGTID"
-	MasterRecoveryBinlogServer MasterRecoveryType = "MasterRecoveryBinlogServer"
-	MasterRecoveryUnknown      MasterRecoveryType = "MasterRecoveryUnknown"
+	NotPrimaryRecovery          PrimaryRecoveryType = "NotMasterRecovery"
+	PrimaryRecoveryGTID         PrimaryRecoveryType = "MasterRecoveryGTID"
+	PrimaryRecoveryBinlogServer PrimaryRecoveryType = "MasterRecoveryBinlogServer"
+	PrimaryRecoveryUnknown      PrimaryRecoveryType = "MasterRecoveryUnknown"
 )
 
 var emergencyReadTopologyInstanceMap *cache.Cache
@@ -181,27 +181,27 @@ func (this InstancesByCountReplicas) Less(i, j int) bool {
 	return len(this[i].Replicas) < len(this[j].Replicas)
 }
 
-var recoverDeadMasterCounter = metrics.NewCounter()
-var recoverDeadMasterSuccessCounter = metrics.NewCounter()
-var recoverDeadMasterFailureCounter = metrics.NewCounter()
-var recoverDeadIntermediateMasterCounter = metrics.NewCounter()
-var recoverDeadIntermediateMasterSuccessCounter = metrics.NewCounter()
-var recoverDeadIntermediateMasterFailureCounter = metrics.NewCounter()
-var recoverDeadCoMasterCounter = metrics.NewCounter()
-var recoverDeadCoMasterSuccessCounter = metrics.NewCounter()
-var recoverDeadCoMasterFailureCounter = metrics.NewCounter()
+var recoverDeadPrimaryCounter = metrics.NewCounter()
+var recoverDeadPrimarySuccessCounter = metrics.NewCounter()
+var recoverDeadPrimaryFailureCounter = metrics.NewCounter()
+var recoverDeadIntermediatePrimaryCounter = metrics.NewCounter()
+var recoverDeadIntermediatePrimarySuccessCounter = metrics.NewCounter()
+var recoverDeadIntermediatePrimaryFailureCounter = metrics.NewCounter()
+var recoverDeadCoPrimaryCounter = metrics.NewCounter()
+var recoverDeadCoPrimarySuccessCounter = metrics.NewCounter()
+var recoverDeadCoPrimaryFailureCounter = metrics.NewCounter()
 var countPendingRecoveriesGauge = metrics.NewGauge()
 
 func init() {
-	metrics.Register("recover.dead_master.start", recoverDeadMasterCounter)
-	metrics.Register("recover.dead_master.success", recoverDeadMasterSuccessCounter)
-	metrics.Register("recover.dead_master.fail", recoverDeadMasterFailureCounter)
-	metrics.Register("recover.dead_intermediate_master.start", recoverDeadIntermediateMasterCounter)
-	metrics.Register("recover.dead_intermediate_master.success", recoverDeadIntermediateMasterSuccessCounter)
-	metrics.Register("recover.dead_intermediate_master.fail", recoverDeadIntermediateMasterFailureCounter)
-	metrics.Register("recover.dead_co_master.start", recoverDeadCoMasterCounter)
-	metrics.Register("recover.dead_co_master.success", recoverDeadCoMasterSuccessCounter)
-	metrics.Register("recover.dead_co_master.fail", recoverDeadCoMasterFailureCounter)
+	metrics.Register("recover.dead_master.start", recoverDeadPrimaryCounter)
+	metrics.Register("recover.dead_master.success", recoverDeadPrimarySuccessCounter)
+	metrics.Register("recover.dead_master.fail", recoverDeadPrimaryFailureCounter)
+	metrics.Register("recover.dead_intermediate_master.start", recoverDeadIntermediatePrimaryCounter)
+	metrics.Register("recover.dead_intermediate_master.success", recoverDeadIntermediatePrimarySuccessCounter)
+	metrics.Register("recover.dead_intermediate_master.fail", recoverDeadIntermediatePrimaryFailureCounter)
+	metrics.Register("recover.dead_co_master.start", recoverDeadCoPrimaryCounter)
+	metrics.Register("recover.dead_co_master.success", recoverDeadCoPrimarySuccessCounter)
+	metrics.Register("recover.dead_co_master.fail", recoverDeadCoPrimaryFailureCounter)
 	metrics.Register("recover.pending", countPendingRecoveriesGauge)
 
 	go initializeTopologyRecoveryPostConfiguration()
@@ -375,12 +375,12 @@ func executeProcesses(processes []string, description string, topologyRecovery *
 	return err
 }
 
-func recoverDeadMasterInBinlogServerTopology(topologyRecovery *TopologyRecovery) (promotedReplica *inst.Instance, err error) {
-	failedMasterKey := &topologyRecovery.AnalysisEntry.AnalyzedInstanceKey
+func recoverDeadPrimaryInBinlogServerTopology(topologyRecovery *TopologyRecovery) (promotedReplica *inst.Instance, err error) {
+	failedPrimaryKey := &topologyRecovery.AnalysisEntry.AnalyzedInstanceKey
 
 	var promotedBinlogServer *inst.Instance
 
-	_, promotedBinlogServer, err = inst.RegroupReplicasBinlogServers(failedMasterKey, true)
+	_, promotedBinlogServer, err = inst.RegroupReplicasBinlogServers(failedPrimaryKey, true)
 	if err != nil {
 		return nil, log.Errore(err)
 	}
@@ -463,26 +463,26 @@ func recoverDeadMasterInBinlogServerTopology(topologyRecovery *TopologyRecovery)
 				_, err = inst.Repoint(&binlogServerReplica.Key, &promotedReplica.Key, inst.GTIDHintDeny)
 				return err
 			}
-			topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("recoverDeadMasterInBinlogServerTopology, moving binlog server %+v", binlogServerReplica.Key))
+			topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("recoverDeadPrimaryInBinlogServerTopology, moving binlog server %+v", binlogServerReplica.Key))
 		}
 	}()
 
 	return promotedReplica, err
 }
 
-func GetMasterRecoveryType(analysisEntry *inst.ReplicationAnalysis) (masterRecoveryType MasterRecoveryType) {
-	masterRecoveryType = MasterRecoveryUnknown
+func GetPrimaryRecoveryType(analysisEntry *inst.ReplicationAnalysis) (primaryRecoveryType PrimaryRecoveryType) {
+	primaryRecoveryType = PrimaryRecoveryUnknown
 	if analysisEntry.OracleGTIDImmediateTopology || analysisEntry.MariaDBGTIDImmediateTopology {
-		masterRecoveryType = MasterRecoveryGTID
+		primaryRecoveryType = PrimaryRecoveryGTID
 	} else if analysisEntry.BinlogServerImmediateTopology {
-		masterRecoveryType = MasterRecoveryBinlogServer
+		primaryRecoveryType = PrimaryRecoveryBinlogServer
 	}
-	return masterRecoveryType
+	return primaryRecoveryType
 }
 
-// recoverDeadMaster recovers a dead primary, complete logic inside
-func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey *inst.InstanceKey, skipProcesses bool) (recoveryAttempted bool, promotedReplica *inst.Instance, lostReplicas [](*inst.Instance), err error) {
-	topologyRecovery.Type = MasterRecovery
+// recoverDeadPrimary recovers a dead primary, complete logic inside
+func recoverDeadPrimary(topologyRecovery *TopologyRecovery, candidateInstanceKey *inst.InstanceKey, skipProcesses bool) (recoveryAttempted bool, promotedReplica *inst.Instance, lostReplicas [](*inst.Instance), err error) {
+	topologyRecovery.Type = PrimaryRecovery
 	analysisEntry := &topologyRecovery.AnalysisEntry
 	failedInstanceKey := &analysisEntry.AnalyzedInstanceKey
 	var cannotReplicateReplicas [](*inst.Instance)
@@ -497,10 +497,10 @@ func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey 
 
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: will recover %+v", *failedInstanceKey))
 
-	err = TabletDemoteMaster(*failedInstanceKey)
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: TabletDemoteMaster: %v", err))
+	err = TabletDemotePrimary(*failedInstanceKey)
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: TabletDemotePrimary: %v", err))
 
-	topologyRecovery.RecoveryType = GetMasterRecoveryType(analysisEntry)
+	topologyRecovery.RecoveryType = GetPrimaryRecoveryType(analysisEntry)
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: masterRecoveryType=%+v", topologyRecovery.RecoveryType))
 
 	promotedReplicaIsIdeal := func(promoted *inst.Instance, hasBestPromotionRule bool) bool {
@@ -523,19 +523,19 @@ func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey 
 		return false
 	}
 	switch topologyRecovery.RecoveryType {
-	case MasterRecoveryUnknown:
+	case PrimaryRecoveryUnknown:
 		{
 			return false, nil, lostReplicas, topologyRecovery.AddError(log.Errorf("RecoveryType unknown/unsupported"))
 		}
-	case MasterRecoveryGTID:
+	case PrimaryRecoveryGTID:
 		{
 			AuditTopologyRecovery(topologyRecovery, "RecoverDeadMaster: regrouping replicas via GTID")
 			lostReplicas, _, cannotReplicateReplicas, promotedReplica, err = inst.RegroupReplicasGTID(failedInstanceKey, true, nil, &topologyRecovery.PostponedFunctionsContainer, promotedReplicaIsIdeal)
 		}
-	case MasterRecoveryBinlogServer:
+	case PrimaryRecoveryBinlogServer:
 		{
 			AuditTopologyRecovery(topologyRecovery, "RecoverDeadMaster: recovering via binlog servers")
-			promotedReplica, err = recoverDeadMasterInBinlogServerTopology(topologyRecovery)
+			promotedReplica, err = recoverDeadPrimaryInBinlogServerTopology(topologyRecovery)
 		}
 	}
 	topologyRecovery.AddError(err)
@@ -575,8 +575,8 @@ func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey 
 	}
 
 	if promotedReplica == nil {
-		err := TabletUndoDemoteMaster(*failedInstanceKey)
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: TabletUndoDemoteMaster: %v", err))
+		err := TabletUndoDemotePrimary(*failedInstanceKey)
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: TabletUndoDemotePrimary: %v", err))
 		message := "Failure: no replica promoted."
 		AuditTopologyRecovery(topologyRecovery, message)
 		inst.AuditOperation("recover-dead-master", failedInstanceKey, message)
@@ -589,7 +589,7 @@ func recoverDeadMaster(topologyRecovery *TopologyRecovery, candidateInstanceKey 
 	return true, promotedReplica, lostReplicas, err
 }
 
-func MasterFailoverGeographicConstraintSatisfied(analysisEntry *inst.ReplicationAnalysis, suggestedInstance *inst.Instance) (satisfied bool, dissatisfiedReason string) {
+func PrimaryFailoverGeographicConstraintSatisfied(analysisEntry *inst.ReplicationAnalysis, suggestedInstance *inst.Instance) (satisfied bool, dissatisfiedReason string) {
 	if config.Config.PreventCrossDataCenterMasterFailover {
 		if suggestedInstance.DataCenter != analysisEntry.AnalyzedInstanceDataCenter {
 			return false, fmt.Sprintf("PreventCrossDataCenterMasterFailover: will not promote server in %s when failed server in %s", suggestedInstance.DataCenter, analysisEntry.AnalyzedInstanceDataCenter)
@@ -640,7 +640,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 		AuditTopologyRecovery(topologyRecovery, "+ searching for an ideal candidate")
 		if deadInstance != nil {
 			for _, candidateReplica := range candidateReplicas {
-				if canTakeOverPromotedServerAsMaster(candidateReplica, promotedReplica) &&
+				if canTakeOverPromotedServerAsPrimary(candidateReplica, promotedReplica) &&
 					candidateReplica.DataCenter == deadInstance.DataCenter &&
 					candidateReplica.PhysicalEnvironment == deadInstance.PhysicalEnvironment {
 					// This would make a great candidate
@@ -656,7 +656,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 		for _, candidateReplica := range candidateReplicas {
 			if promotedReplica.Key.Equals(&candidateReplica.Key) {
 				// Seems like we promoted a candidate replica (though not in same DC and ENV as dead primary)
-				if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, candidateReplica); satisfied {
+				if satisfied, reason := PrimaryFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, candidateReplica); satisfied {
 					// Good enough. No further action required.
 					AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("promoted replica %+v is a good candidate", promotedReplica.Key))
 					return promotedReplica, false, nil
@@ -671,7 +671,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 		// Try a candidate replica that is in same DC & env as the promoted replica (our promoted replica is not an "is_candidate")
 		AuditTopologyRecovery(topologyRecovery, "+ searching for a candidate")
 		for _, candidateReplica := range candidateReplicas {
-			if canTakeOverPromotedServerAsMaster(candidateReplica, promotedReplica) &&
+			if canTakeOverPromotedServerAsPrimary(candidateReplica, promotedReplica) &&
 				promotedReplica.DataCenter == candidateReplica.DataCenter &&
 				promotedReplica.PhysicalEnvironment == candidateReplica.PhysicalEnvironment {
 				// OK, better than nothing
@@ -685,8 +685,8 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 		// Try a candidate replica (our promoted replica is not an "is_candidate")
 		AuditTopologyRecovery(topologyRecovery, "+ searching for a candidate")
 		for _, candidateReplica := range candidateReplicas {
-			if canTakeOverPromotedServerAsMaster(candidateReplica, promotedReplica) {
-				if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, candidateReplica); satisfied {
+			if canTakeOverPromotedServerAsPrimary(candidateReplica, promotedReplica) {
+				if satisfied, reason := PrimaryFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, candidateReplica); satisfied {
 					// OK, better than nothing
 					candidateInstanceKey = &candidateReplica.Key
 					AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("no candidate was offered for %+v but orchestrator picks %+v as candidate replacement", promotedReplica.Key, candidateReplica.Key))
@@ -698,7 +698,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 	}
 
 	keepSearchingHint := ""
-	if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, promotedReplica); !satisfied {
+	if satisfied, reason := PrimaryFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, promotedReplica); !satisfied {
 		keepSearchingHint = fmt.Sprintf("Will keep searching; %s", reason)
 	} else if promotedReplica.PromotionRule == inst.PreferNotPromoteRule {
 		keepSearchingHint = fmt.Sprintf("Will keep searching because we have promoted a server with prefer_not rule: %+v", promotedReplica.Key)
@@ -712,7 +712,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 			// find neutral instance in same dv&env as dead primary
 			AuditTopologyRecovery(topologyRecovery, "+ searching for a neutral server to replace promoted server, in same DC and env as dead master")
 			for _, neutralReplica := range neutralReplicas {
-				if canTakeOverPromotedServerAsMaster(neutralReplica, promotedReplica) &&
+				if canTakeOverPromotedServerAsPrimary(neutralReplica, promotedReplica) &&
 					deadInstance.DataCenter == neutralReplica.DataCenter &&
 					deadInstance.PhysicalEnvironment == neutralReplica.PhysicalEnvironment {
 					candidateInstanceKey = &neutralReplica.Key
@@ -724,7 +724,7 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 			// find neutral instance in same dv&env as promoted replica
 			AuditTopologyRecovery(topologyRecovery, "+ searching for a neutral server to replace promoted server, in same DC and env as promoted replica")
 			for _, neutralReplica := range neutralReplicas {
-				if canTakeOverPromotedServerAsMaster(neutralReplica, promotedReplica) &&
+				if canTakeOverPromotedServerAsPrimary(neutralReplica, promotedReplica) &&
 					promotedReplica.DataCenter == neutralReplica.DataCenter &&
 					promotedReplica.PhysicalEnvironment == neutralReplica.PhysicalEnvironment {
 					candidateInstanceKey = &neutralReplica.Key
@@ -735,8 +735,8 @@ func SuggestReplacementForPromotedReplica(topologyRecovery *TopologyRecovery, de
 		if candidateInstanceKey == nil {
 			AuditTopologyRecovery(topologyRecovery, "+ searching for a neutral server to replace a prefer_not")
 			for _, neutralReplica := range neutralReplicas {
-				if canTakeOverPromotedServerAsMaster(neutralReplica, promotedReplica) {
-					if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, neutralReplica); satisfied {
+				if canTakeOverPromotedServerAsPrimary(neutralReplica, promotedReplica) {
+					if satisfied, reason := PrimaryFailoverGeographicConstraintSatisfied(&topologyRecovery.AnalysisEntry, neutralReplica); satisfied {
 						// OK, better than nothing
 						candidateInstanceKey = &neutralReplica.Key
 						AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("no candidate was offered for %+v but orchestrator picks %+v as candidate replacement, based on promoted instance having prefer_not promotion rule", promotedReplica.Key, neutralReplica.Key))
@@ -783,7 +783,7 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 
 	if candidateInstance.PrimaryKey.Equals(&promotedReplica.Key) {
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("replace-promoted-replica-with-candidate: suggested candidate %+v is replica of promoted instance %+v. Will try and take its master", candidateInstance.Key, promotedReplica.Key))
-		candidateInstance, err = inst.TakePrimary(&candidateInstance.Key, topologyRecovery.Type == CoMasterRecovery)
+		candidateInstance, err = inst.TakePrimary(&candidateInstance.Key, topologyRecovery.Type == CoPrimaryRecovery)
 		if err != nil {
 			return promotedReplica, log.Errore(err)
 		}
@@ -812,9 +812,9 @@ func replacePromotedReplicaWithCandidate(topologyRecovery *TopologyRecovery, dea
 	return promotedReplica, nil
 }
 
-// checkAndRecoverDeadMaster checks a given analysis, decides whether to take action, and possibly takes action
+// checkAndRecoverDeadPrimary checks a given analysis, decides whether to take action, and possibly takes action
 // Returns true when action was taken.
-func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
+func checkAndRecoverDeadPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
 	if !(forceInstanceRecovery || analysisEntry.ClusterDetails.HasAutomatedPrimaryRecovery) {
 		return false, nil, nil
 	}
@@ -848,8 +848,8 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 	}
 
 	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("will handle DeadMaster event on %+v", analysisEntry.ClusterDetails.ClusterName))
-	recoverDeadMasterCounter.Inc(1)
-	recoveryAttempted, promotedReplica, lostReplicas, err := recoverDeadMaster(topologyRecovery, candidateInstanceKey, skipProcesses)
+	recoverDeadPrimaryCounter.Inc(1)
+	recoveryAttempted, promotedReplica, lostReplicas, err := recoverDeadPrimary(topologyRecovery, candidateInstanceKey, skipProcesses)
 	if err != nil {
 		AuditTopologyRecovery(topologyRecovery, err.Error())
 	}
@@ -858,13 +858,13 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		return false, topologyRecovery, err
 	}
 
-	overrideMasterPromotion := func() (*inst.Instance, error) {
+	overridePrimaryPromotion := func() (*inst.Instance, error) {
 		if promotedReplica == nil {
 			// No promotion; nothing to override.
 			return promotedReplica, err
 		}
 		// Scenarios where we might cancel the promotion.
-		if satisfied, reason := MasterFailoverGeographicConstraintSatisfied(&analysisEntry, promotedReplica); !satisfied {
+		if satisfied, reason := PrimaryFailoverGeographicConstraintSatisfied(&analysisEntry, promotedReplica); !satisfied {
 			return nil, fmt.Errorf("RecoverDeadMaster: failed %+v promotion; %s", promotedReplica.Key, reason)
 		}
 		if config.Config.FailMasterPromotionOnLagMinutes > 0 &&
@@ -885,7 +885,7 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 		// All seems well. No override done.
 		return promotedReplica, err
 	}
-	if promotedReplica, err = overrideMasterPromotion(); err != nil {
+	if promotedReplica, err = overridePrimaryPromotion(); err != nil {
 		AuditTopologyRecovery(topologyRecovery, err.Error())
 	}
 	// And this is the end; whether successful or not, we're done.
@@ -893,7 +893,7 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 	// Now, see whether we are successful or not. From this point there's no going back.
 	if promotedReplica != nil {
 		// Success!
-		recoverDeadMasterSuccessCounter.Inc(1)
+		recoverDeadPrimarySuccessCounter.Inc(1)
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadMaster: successfully promoted %+v", promotedReplica.Key))
 		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadMaster: promoted server coordinates: %+v", promotedReplica.SelfBinlogCoordinates))
 
@@ -965,14 +965,14 @@ func checkAndRecoverDeadMaster(analysisEntry inst.ReplicationAnalysis, candidate
 			executeProcesses(config.Config.PostMasterFailoverProcesses, "PostMasterFailoverProcesses", topologyRecovery, false)
 		}
 	} else {
-		recoverDeadMasterFailureCounter.Inc(1)
+		recoverDeadPrimaryFailureCounter.Inc(1)
 	}
 
 	return true, topologyRecovery, err
 }
 
-// isGenerallyValidAsCandidateSiblingOfIntermediateMaster sees that basic server configuration and state are valid
-func isGenerallyValidAsCandidateSiblingOfIntermediateMaster(sibling *inst.Instance) bool {
+// isGenerallyValidAsCandidateSiblingOfIntermediatePrimary sees that basic server configuration and state are valid
+func isGenerallyValidAsCandidateSiblingOfIntermediatePrimary(sibling *inst.Instance) bool {
 	if !sibling.LogBinEnabled {
 		return false
 	}
@@ -988,33 +988,33 @@ func isGenerallyValidAsCandidateSiblingOfIntermediateMaster(sibling *inst.Instan
 	return true
 }
 
-// isValidAsCandidateSiblingOfIntermediateMaster checks to see that the given sibling is capable to take over instance's replicas
-func isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance *inst.Instance, sibling *inst.Instance) bool {
-	if sibling.Key.Equals(&intermediateMasterInstance.Key) {
+// isValidAsCandidateSiblingOfIntermediatePrimary checks to see that the given sibling is capable to take over instance's replicas
+func isValidAsCandidateSiblingOfIntermediatePrimary(intermediatePrimaryInstance *inst.Instance, sibling *inst.Instance) bool {
+	if sibling.Key.Equals(&intermediatePrimaryInstance.Key) {
 		// same instance
 		return false
 	}
-	if !isGenerallyValidAsCandidateSiblingOfIntermediateMaster(sibling) {
+	if !isGenerallyValidAsCandidateSiblingOfIntermediatePrimary(sibling) {
 		return false
 	}
 	if inst.IsBannedFromBeingCandidateReplica(sibling) {
 		return false
 	}
-	if sibling.HasReplicationFilters != intermediateMasterInstance.HasReplicationFilters {
+	if sibling.HasReplicationFilters != intermediatePrimaryInstance.HasReplicationFilters {
 		return false
 	}
-	if sibling.IsBinlogServer() != intermediateMasterInstance.IsBinlogServer() {
+	if sibling.IsBinlogServer() != intermediatePrimaryInstance.IsBinlogServer() {
 		// When both are binlog servers, failover is trivial.
 		// When failed IM is binlog server, its sibling is still valid, but we catually prefer to just repoint the replica up -- simplest!
 		return false
 	}
-	if sibling.ExecBinlogCoordinates.SmallerThan(&intermediateMasterInstance.ExecBinlogCoordinates) {
+	if sibling.ExecBinlogCoordinates.SmallerThan(&intermediatePrimaryInstance.ExecBinlogCoordinates) {
 		return false
 	}
 	return true
 }
 
-func isGenerallyValidAsWouldBeMaster(replica *inst.Instance, requireLogReplicationUpdates bool) bool {
+func isGenerallyValidAsWouldBePrimary(replica *inst.Instance, requireLogReplicationUpdates bool) bool {
 	if !replica.IsLastCheckValid {
 		// something wrong with this replica right now. We shouldn't hope to be able to promote it
 		return false
@@ -1035,8 +1035,8 @@ func isGenerallyValidAsWouldBeMaster(replica *inst.Instance, requireLogReplicati
 	return true
 }
 
-func canTakeOverPromotedServerAsMaster(wantToTakeOver *inst.Instance, toBeTakenOver *inst.Instance) bool {
-	if !isGenerallyValidAsWouldBeMaster(wantToTakeOver, true) {
+func canTakeOverPromotedServerAsPrimary(wantToTakeOver *inst.Instance, toBeTakenOver *inst.Instance) bool {
+	if !isGenerallyValidAsWouldBePrimary(wantToTakeOver, true) {
 		return false
 	}
 	if !wantToTakeOver.PrimaryKey.Equals(&toBeTakenOver.Key) {
@@ -1048,16 +1048,16 @@ func canTakeOverPromotedServerAsMaster(wantToTakeOver *inst.Instance, toBeTakenO
 	return true
 }
 
-// GetCandidateSiblingOfIntermediateMaster chooses the best sibling of a dead intermediate primary
+// GetCandidateSiblingOfIntermediatePrimary chooses the best sibling of a dead intermediate primary
 // to whom the IM's replicas can be moved.
-func GetCandidateSiblingOfIntermediateMaster(topologyRecovery *TopologyRecovery, intermediateMasterInstance *inst.Instance) (*inst.Instance, error) {
+func GetCandidateSiblingOfIntermediatePrimary(topologyRecovery *TopologyRecovery, intermediatePrimaryInstance *inst.Instance) (*inst.Instance, error) {
 
-	siblings, err := inst.ReadReplicaInstances(&intermediateMasterInstance.PrimaryKey)
+	siblings, err := inst.ReadReplicaInstances(&intermediatePrimaryInstance.PrimaryKey)
 	if err != nil {
 		return nil, err
 	}
 	if len(siblings) <= 1 {
-		return nil, log.Errorf("topology_recovery: no siblings found for %+v", intermediateMasterInstance.Key)
+		return nil, log.Errorf("topology_recovery: no siblings found for %+v", intermediatePrimaryInstance.Key)
 	}
 
 	sort.Sort(sort.Reverse(InstancesByCountReplicas(siblings)))
@@ -1067,13 +1067,13 @@ func GetCandidateSiblingOfIntermediateMaster(topologyRecovery *TopologyRecovery,
 	// this has small likelihood in the general case, and, well, it's an attempt. It's a Plan A, but we have Plan B & C if this fails.
 
 	// At first, we try to return an "is_candidate" server in same dc & env
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("searching for the best candidate sibling of dead intermediate master %+v", intermediateMasterInstance.Key))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("searching for the best candidate sibling of dead intermediate master %+v", intermediatePrimaryInstance.Key))
 	for _, sibling := range siblings {
 		sibling := sibling
-		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) &&
+		if isValidAsCandidateSiblingOfIntermediatePrimary(intermediatePrimaryInstance, sibling) &&
 			sibling.IsCandidate &&
-			sibling.DataCenter == intermediateMasterInstance.DataCenter &&
-			sibling.PhysicalEnvironment == intermediateMasterInstance.PhysicalEnvironment {
+			sibling.DataCenter == intermediatePrimaryInstance.DataCenter &&
+			sibling.PhysicalEnvironment == intermediatePrimaryInstance.PhysicalEnvironment {
 			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as the ideal candidate", sibling.Key))
 			return sibling, nil
 		}
@@ -1081,35 +1081,35 @@ func GetCandidateSiblingOfIntermediateMaster(topologyRecovery *TopologyRecovery,
 	// No candidate in same DC & env, let's search for a candidate anywhere
 	for _, sibling := range siblings {
 		sibling := sibling
-		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) && sibling.IsCandidate {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [candidate sibling]", sibling.Key, intermediateMasterInstance.Key))
+		if isValidAsCandidateSiblingOfIntermediatePrimary(intermediatePrimaryInstance, sibling) && sibling.IsCandidate {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [candidate sibling]", sibling.Key, intermediatePrimaryInstance.Key))
 			return sibling, nil
 		}
 	}
 	// Go for some valid in the same DC & ENV
 	for _, sibling := range siblings {
 		sibling := sibling
-		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) &&
-			sibling.DataCenter == intermediateMasterInstance.DataCenter &&
-			sibling.PhysicalEnvironment == intermediateMasterInstance.PhysicalEnvironment {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [same dc & environment]", sibling.Key, intermediateMasterInstance.Key))
+		if isValidAsCandidateSiblingOfIntermediatePrimary(intermediatePrimaryInstance, sibling) &&
+			sibling.DataCenter == intermediatePrimaryInstance.DataCenter &&
+			sibling.PhysicalEnvironment == intermediatePrimaryInstance.PhysicalEnvironment {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [same dc & environment]", sibling.Key, intermediatePrimaryInstance.Key))
 			return sibling, nil
 		}
 	}
 	// Just whatever is valid.
 	for _, sibling := range siblings {
 		sibling := sibling
-		if isValidAsCandidateSiblingOfIntermediateMaster(intermediateMasterInstance, sibling) {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [any sibling]", sibling.Key, intermediateMasterInstance.Key))
+		if isValidAsCandidateSiblingOfIntermediatePrimary(intermediatePrimaryInstance, sibling) {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found %+v as a replacement for %+v [any sibling]", sibling.Key, intermediatePrimaryInstance.Key))
 			return sibling, nil
 		}
 	}
-	return nil, log.Errorf("topology_recovery: cannot find candidate sibling of %+v", intermediateMasterInstance.Key)
+	return nil, log.Errorf("topology_recovery: cannot find candidate sibling of %+v", intermediatePrimaryInstance.Key)
 }
 
-// RecoverDeadIntermediateMaster performs intermediate primary recovery; complete logic inside
-func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (successorInstance *inst.Instance, err error) {
-	topologyRecovery.Type = IntermediateMasterRecovery
+// RecoverDeadIntermediatePrimary performs intermediate primary recovery; complete logic inside
+func RecoverDeadIntermediatePrimary(topologyRecovery *TopologyRecovery, skipProcesses bool) (successorInstance *inst.Instance, err error) {
+	topologyRecovery.Type = IntermediatePrimaryRecovery
 	analysisEntry := &topologyRecovery.AnalysisEntry
 	failedInstanceKey := &analysisEntry.AnalyzedInstanceKey
 	recoveryResolved := false
@@ -1121,28 +1121,28 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		}
 	}
 
-	intermediateMasterInstance, _, err := inst.ReadInstance(failedInstanceKey)
+	intermediatePrimaryInstance, _, err := inst.ReadInstance(failedInstanceKey)
 	if err != nil {
 		return nil, topologyRecovery.AddError(err)
 	}
 	// Find possible candidate
-	candidateSiblingOfIntermediateMaster, _ := GetCandidateSiblingOfIntermediateMaster(topologyRecovery, intermediateMasterInstance)
+	candidateSiblingOfIntermediatePrimary, _ := GetCandidateSiblingOfIntermediatePrimary(topologyRecovery, intermediatePrimaryInstance)
 	relocateReplicasToCandidateSibling := func() {
-		if candidateSiblingOfIntermediateMaster == nil {
+		if candidateSiblingOfIntermediatePrimary == nil {
 			return
 		}
 		// We have a candidate
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will attempt a candidate intermediate master: %+v", candidateSiblingOfIntermediateMaster.Key))
-		relocatedReplicas, candidateSibling, err, errs := inst.RelocateReplicas(failedInstanceKey, &candidateSiblingOfIntermediateMaster.Key, "")
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: will attempt a candidate intermediate master: %+v", candidateSiblingOfIntermediatePrimary.Key))
+		relocatedReplicas, candidateSibling, err, errs := inst.RelocateReplicas(failedInstanceKey, &candidateSiblingOfIntermediatePrimary.Key, "")
 		topologyRecovery.AddErrors(errs)
-		topologyRecovery.ParticipatingInstanceKeys.AddKey(candidateSiblingOfIntermediateMaster.Key)
+		topologyRecovery.ParticipatingInstanceKeys.AddKey(candidateSiblingOfIntermediatePrimary.Key)
 
 		if len(relocatedReplicas) == 0 {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: failed to move any replica to candidate intermediate master (%+v)", candidateSibling.Key))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: failed to move any replica to candidate intermediate master (%+v)", candidateSibling.Key))
 			return
 		}
 		if err != nil || len(errs) > 0 {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: move to candidate intermediate master (%+v) did not complete: err: %+v, errs: %+v", candidateSibling.Key, err, errs))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: move to candidate intermediate master (%+v) did not complete: err: %+v, errs: %+v", candidateSibling.Key, err, errs))
 			return
 		}
 		if err == nil {
@@ -1153,19 +1153,19 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		}
 	}
 	// Plan A: find a replacement intermediate primary in same Data Center
-	if candidateSiblingOfIntermediateMaster != nil && candidateSiblingOfIntermediateMaster.DataCenter == intermediateMasterInstance.DataCenter {
+	if candidateSiblingOfIntermediatePrimary != nil && candidateSiblingOfIntermediatePrimary.DataCenter == intermediatePrimaryInstance.DataCenter {
 		relocateReplicasToCandidateSibling()
 	}
 	if !recoveryResolved {
-		AuditTopologyRecovery(topologyRecovery, "- RecoverDeadIntermediateMaster: will next attempt regrouping of replicas")
+		AuditTopologyRecovery(topologyRecovery, "- RecoverDeadIntermediatePrimary: will next attempt regrouping of replicas")
 		// Plan B: regroup (we wish to reduce cross-DC replication streams)
 		lostReplicas, _, _, _, regroupPromotedReplica, regroupError := inst.RegroupReplicas(failedInstanceKey, true, nil, nil)
 		if regroupError != nil {
 			topologyRecovery.AddError(regroupError)
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: regroup failed on: %+v", regroupError))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: regroup failed on: %+v", regroupError))
 		}
 		if regroupPromotedReplica != nil {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: regrouped under %+v, with %d lost replicas", regroupPromotedReplica.Key, len(lostReplicas)))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: regrouped under %+v, with %d lost replicas", regroupPromotedReplica.Key, len(lostReplicas)))
 			topologyRecovery.ParticipatingInstanceKeys.AddKey(regroupPromotedReplica.Key)
 			if len(lostReplicas) == 0 && regroupError == nil {
 				// Seems like the regroup worked flawlessly. The local replica took over all of its siblings.
@@ -1174,8 +1174,8 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 			}
 		}
 		// Plan C: try replacement intermediate primary in other DC...
-		if candidateSiblingOfIntermediateMaster != nil && candidateSiblingOfIntermediateMaster.DataCenter != intermediateMasterInstance.DataCenter {
-			AuditTopologyRecovery(topologyRecovery, "- RecoverDeadIntermediateMaster: will next attempt relocating to another DC server")
+		if candidateSiblingOfIntermediatePrimary != nil && candidateSiblingOfIntermediatePrimary.DataCenter != intermediatePrimaryInstance.DataCenter {
+			AuditTopologyRecovery(topologyRecovery, "- RecoverDeadIntermediatePrimary: will next attempt relocating to another DC server")
 			relocateReplicasToCandidateSibling()
 		}
 	}
@@ -1186,9 +1186,9 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 		// one replica, but the operation is still valid if regroup partially/completely failed. We just promote anything
 		// not regrouped.
 		// So, match up all that's left, plan D
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: will next attempt to relocate up from %+v", *failedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: will next attempt to relocate up from %+v", *failedInstanceKey))
 
-		relocatedReplicas, masterInstance, _, errs := inst.RelocateReplicas(failedInstanceKey, &analysisEntry.AnalyzedInstancePrimaryKey, "")
+		relocatedReplicas, primaryInstance, _, errs := inst.RelocateReplicas(failedInstanceKey, &analysisEntry.AnalyzedInstancePrimaryKey, "")
 		topologyRecovery.AddErrors(errs)
 		topologyRecovery.ParticipatingInstanceKeys.AddKey(analysisEntry.AnalyzedInstancePrimaryKey)
 
@@ -1196,11 +1196,11 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 			recoveryResolved = true
 			if successorInstance == nil {
 				// There could have been a local replica taking over its siblings. We'd like to consider that one as successor.
-				successorInstance = masterInstance
+				successorInstance = primaryInstance
 			}
 			inst.AuditOperation("recover-dead-intermediate-master", failedInstanceKey, fmt.Sprintf("Relocated replicas under: %+v %d errors: %+v", successorInstance.Key, len(errs), errs))
 		} else {
-			err = log.Errorf("topology_recovery: RecoverDeadIntermediateMaster failed to match up any replica from %+v", *failedInstanceKey)
+			err = log.Errorf("topology_recovery: RecoverDeadIntermediatePrimary failed to match up any replica from %+v", *failedInstanceKey)
 			topologyRecovery.AddError(err)
 		}
 	}
@@ -1211,24 +1211,24 @@ func RecoverDeadIntermediateMaster(topologyRecovery *TopologyRecovery, skipProce
 	return successorInstance, err
 }
 
-// checkAndRecoverDeadIntermediateMaster checks a given analysis, decides whether to take action, and possibly takes action
+// checkAndRecoverDeadIntermediatePrimary checks a given analysis, decides whether to take action, and possibly takes action
 // Returns true when action was taken.
-func checkAndRecoverDeadIntermediateMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (bool, *TopologyRecovery, error) {
+func checkAndRecoverDeadIntermediatePrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (bool, *TopologyRecovery, error) {
 	if !(forceInstanceRecovery || analysisEntry.ClusterDetails.HasAutomatedIntermediatePrimaryRecovery) {
 		return false, nil, nil
 	}
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediateMaster: found an active or recent recovery on %+v. Will not issue another RecoverDeadIntermediateMaster.", analysisEntry.AnalyzedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadIntermediatePrimary: found an active or recent recovery on %+v. Will not issue another RecoverDeadIntermediatePrimary.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 
 	// That's it! We must do recovery!
-	recoverDeadIntermediateMasterCounter.Inc(1)
-	promotedReplica, err := RecoverDeadIntermediateMaster(topologyRecovery, skipProcesses)
+	recoverDeadIntermediatePrimaryCounter.Inc(1)
+	promotedReplica, err := RecoverDeadIntermediatePrimary(topologyRecovery, skipProcesses)
 	if promotedReplica != nil {
 		// success
-		recoverDeadIntermediateMasterSuccessCounter.Inc(1)
+		recoverDeadIntermediatePrimarySuccessCounter.Inc(1)
 
 		if !skipProcesses {
 			// Execute post intermediate-master-failover processes
@@ -1237,20 +1237,20 @@ func checkAndRecoverDeadIntermediateMaster(analysisEntry inst.ReplicationAnalysi
 			executeProcesses(config.Config.PostIntermediateMasterFailoverProcesses, "PostIntermediateMasterFailoverProcesses", topologyRecovery, false)
 		}
 	} else {
-		recoverDeadIntermediateMasterFailureCounter.Inc(1)
+		recoverDeadIntermediatePrimaryFailureCounter.Inc(1)
 	}
 	return true, topologyRecovery, err
 }
 
-// RecoverDeadCoMaster recovers a dead co-primary, complete logic inside
-func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool) (promotedReplica *inst.Instance, lostReplicas [](*inst.Instance), err error) {
-	topologyRecovery.Type = CoMasterRecovery
+// RecoverDeadCoPrimary recovers a dead co-primary, complete logic inside
+func RecoverDeadCoPrimary(topologyRecovery *TopologyRecovery, skipProcesses bool) (promotedReplica *inst.Instance, lostReplicas [](*inst.Instance), err error) {
+	topologyRecovery.Type = CoPrimaryRecovery
 	analysisEntry := &topologyRecovery.AnalysisEntry
 	failedInstanceKey := &analysisEntry.AnalyzedInstanceKey
-	otherCoMasterKey := &analysisEntry.AnalyzedInstancePrimaryKey
-	otherCoMaster, found, _ := inst.ReadInstance(otherCoMasterKey)
-	if otherCoMaster == nil || !found {
-		return nil, lostReplicas, topologyRecovery.AddError(log.Errorf("RecoverDeadCoMaster: could not read info for co-master %+v of %+v", *otherCoMasterKey, *failedInstanceKey))
+	otherCoPrimaryKey := &analysisEntry.AnalyzedInstancePrimaryKey
+	otherCoPrimary, found, _ := inst.ReadInstance(otherCoPrimaryKey)
+	if otherCoPrimary == nil || !found {
+		return nil, lostReplicas, topologyRecovery.AddError(log.Errorf("RecoverDeadCoPrimary: could not read info for co-master %+v of %+v", *otherCoPrimaryKey, *failedInstanceKey))
 	}
 	inst.AuditOperation("recover-dead-co-master", failedInstanceKey, "problem found; will recover")
 	if !skipProcesses {
@@ -1259,22 +1259,22 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 		}
 	}
 
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: will recover %+v", *failedInstanceKey))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoPrimary: will recover %+v", *failedInstanceKey))
 
-	var coMasterRecoveryType MasterRecoveryType = MasterRecoveryUnknown
+	var coPrimaryRecoveryType PrimaryRecoveryType = PrimaryRecoveryUnknown
 	if analysisEntry.OracleGTIDImmediateTopology || analysisEntry.MariaDBGTIDImmediateTopology {
-		coMasterRecoveryType = MasterRecoveryGTID
+		coPrimaryRecoveryType = PrimaryRecoveryGTID
 	}
 
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: coMasterRecoveryType=%+v", coMasterRecoveryType))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoPrimary: coPrimaryRecoveryType=%+v", coPrimaryRecoveryType))
 
 	var cannotReplicateReplicas [](*inst.Instance)
-	switch coMasterRecoveryType {
-	case MasterRecoveryUnknown:
+	switch coPrimaryRecoveryType {
+	case PrimaryRecoveryUnknown:
 		{
-			return nil, lostReplicas, topologyRecovery.AddError(log.Errorf("RecoverDeadCoMaster: RecoveryType unknown/unsupported"))
+			return nil, lostReplicas, topologyRecovery.AddError(log.Errorf("RecoverDeadCoPrimary: RecoveryType unknown/unsupported"))
 		}
-	case MasterRecoveryGTID:
+	case PrimaryRecoveryGTID:
 		{
 			lostReplicas, _, cannotReplicateReplicas, promotedReplica, err = inst.RegroupReplicasGTID(failedInstanceKey, true, nil, &topologyRecovery.PostponedFunctionsContainer, nil)
 		}
@@ -1282,18 +1282,18 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 	topologyRecovery.AddError(err)
 	lostReplicas = append(lostReplicas, cannotReplicateReplicas...)
 
-	mustPromoteOtherCoMaster := config.Config.CoMasterRecoveryMustPromoteOtherCoMaster
-	if !otherCoMaster.ReadOnly {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: other co-master %+v is writeable hence has to be promoted", otherCoMaster.Key))
-		mustPromoteOtherCoMaster = true
+	mustPromoteOtherCoPrimary := config.Config.CoMasterRecoveryMustPromoteOtherCoMaster
+	if !otherCoPrimary.ReadOnly {
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoPrimary: other co-master %+v is writeable hence has to be promoted", otherCoPrimary.Key))
+		mustPromoteOtherCoPrimary = true
 	}
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster? %+v", mustPromoteOtherCoMaster))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoPrimary: mustPromoteOtherCoPrimary? %+v", mustPromoteOtherCoPrimary))
 
 	if promotedReplica != nil {
 		topologyRecovery.ParticipatingInstanceKeys.AddKey(promotedReplica.Key)
-		if mustPromoteOtherCoMaster {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoMaster: mustPromoteOtherCoMaster. Verifying that %+v is/can be promoted", *otherCoMasterKey))
-			promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, otherCoMasterKey)
+		if mustPromoteOtherCoPrimary {
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("RecoverDeadCoPrimary: mustPromoteOtherCoPrimary. Verifying that %+v is/can be promoted", *otherCoPrimaryKey))
+			promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, otherCoPrimaryKey)
 		} else {
 			// We are allowed to promote any server
 			promotedReplica, err = replacePromotedReplicaWithCandidate(topologyRecovery, failedInstanceKey, promotedReplica, nil)
@@ -1301,8 +1301,8 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 		topologyRecovery.AddError(err)
 	}
 	if promotedReplica != nil {
-		if mustPromoteOtherCoMaster && !promotedReplica.Key.Equals(otherCoMasterKey) {
-			topologyRecovery.AddError(log.Errorf("RecoverDeadCoMaster: could not manage to promote other-co-master %+v; was only able to promote %+v; mustPromoteOtherCoMaster is true (either CoMasterRecoveryMustPromoteOtherCoMaster is true, or co-master is writeable), therefore failing", *otherCoMasterKey, promotedReplica.Key))
+		if mustPromoteOtherCoPrimary && !promotedReplica.Key.Equals(otherCoPrimaryKey) {
+			topologyRecovery.AddError(log.Errorf("RecoverDeadCoPrimary: could not manage to promote other-co-master %+v; was only able to promote %+v; mustPromoteOtherCoPrimary is true (either CoMasterRecoveryMustPromoteOtherCoMaster is true, or co-master is writeable), therefore failing", *otherCoPrimaryKey, promotedReplica.Key))
 			promotedReplica = nil
 		}
 	}
@@ -1331,21 +1331,21 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 	// config.Config.ApplyMySQLPromotionAfterMasterFailover, if true, will cause it to break, because we would RESET SLAVE on S1
 	// but we want to make sure the circle is broken no matter what.
 	// So in the case we promoted not-the-other-co-primary, we issue a detach-replica-master-host, which is a reversible operation
-	if promotedReplica != nil && !promotedReplica.Key.Equals(otherCoMasterKey) {
+	if promotedReplica != nil && !promotedReplica.Key.Equals(otherCoPrimaryKey) {
 		_, err = inst.DetachReplicaPrimaryHost(&promotedReplica.Key)
 		topologyRecovery.AddError(log.Errore(err))
 	}
 
 	if promotedReplica != nil && len(lostReplicas) > 0 && config.Config.DetachLostReplicasAfterMasterFailover {
 		postponedFunction := func() error {
-			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadCoMaster: lost %+v replicas during recovery process; detaching them", len(lostReplicas)))
+			AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- RecoverDeadCoPrimary: lost %+v replicas during recovery process; detaching them", len(lostReplicas)))
 			for _, replica := range lostReplicas {
 				replica := replica
 				inst.DetachReplicaPrimaryHost(&replica.Key)
 			}
 			return nil
 		}
-		topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("RecoverDeadCoMaster, detaching %+v replicas", len(lostReplicas)))
+		topologyRecovery.AddPostponedFunction(postponedFunction, fmt.Sprintf("RecoverDeadCoPrimary, detaching %+v replicas", len(lostReplicas)))
 	}
 
 	func() error {
@@ -1361,22 +1361,22 @@ func RecoverDeadCoMaster(topologyRecovery *TopologyRecovery, skipProcesses bool)
 	return promotedReplica, lostReplicas, err
 }
 
-// checkAndRecoverDeadCoMaster checks a given analysis, decides whether to take action, and possibly takes action
+// checkAndRecoverDeadCoPrimary checks a given analysis, decides whether to take action, and possibly takes action
 // Returns true when action was taken.
-func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (bool, *TopologyRecovery, error) {
+func checkAndRecoverDeadCoPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (bool, *TopologyRecovery, error) {
 	failedInstanceKey := &analysisEntry.AnalyzedInstanceKey
 	if !(forceInstanceRecovery || analysisEntry.ClusterDetails.HasAutomatedPrimaryRecovery) {
 		return false, nil, nil
 	}
 	topologyRecovery, err := AttemptRecoveryRegistration(&analysisEntry, !forceInstanceRecovery, !forceInstanceRecovery)
 	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another RecoverDeadCoMaster.", analysisEntry.AnalyzedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another RecoverDeadCoPrimary.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 
 	// That's it! We must do recovery!
-	recoverDeadCoMasterCounter.Inc(1)
-	promotedReplica, lostReplicas, err := RecoverDeadCoMaster(topologyRecovery, skipProcesses)
+	recoverDeadCoPrimaryCounter.Inc(1)
+	promotedReplica, lostReplicas, err := RecoverDeadCoPrimary(topologyRecovery, skipProcesses)
 	resolveRecovery(topologyRecovery, promotedReplica)
 	if promotedReplica == nil {
 		inst.AuditOperation("recover-dead-co-master", failedInstanceKey, "Failure: no replica promoted.")
@@ -1389,7 +1389,7 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 			return false, nil, log.Errorf("Promoted replica %+v: sql thread is not up to date (relay logs still unapplied). Aborting promotion", promotedReplica.Key)
 		}
 		// success
-		recoverDeadCoMasterSuccessCounter.Inc(1)
+		recoverDeadCoPrimarySuccessCounter.Inc(1)
 
 		if config.Config.ApplyMySQLPromotionAfterMasterFailover {
 			AuditTopologyRecovery(topologyRecovery, "- RecoverDeadMaster: will apply MySQL changes to promoted master")
@@ -1402,13 +1402,13 @@ func checkAndRecoverDeadCoMaster(analysisEntry inst.ReplicationAnalysis, candida
 			executeProcesses(config.Config.PostMasterFailoverProcesses, "PostMasterFailoverProcesses", topologyRecovery, false)
 		}
 	} else {
-		recoverDeadCoMasterFailureCounter.Inc(1)
+		recoverDeadCoPrimaryFailureCounter.Inc(1)
 	}
 	return true, topologyRecovery, err
 }
 
 // checkAndRecoverGenericProblem is a general-purpose recovery function
-func checkAndRecoverLockedSemiSyncMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
+func checkAndRecoverLockedSemiSyncPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
 
 	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, true, true)
 	if topologyRecovery == nil {
@@ -1525,40 +1525,40 @@ func getCheckAndRecoverFunction(analysisCode inst.AnalysisCode, analyzedInstance
 		if isInEmergencyOperationGracefulPeriod(analyzedInstanceKey) {
 			return checkAndRecoverGenericProblem, false
 		} else {
-			return checkAndRecoverDeadMaster, true
+			return checkAndRecoverDeadPrimary, true
 		}
 	case inst.LockedSemiSyncPrimary:
 		if isInEmergencyOperationGracefulPeriod(analyzedInstanceKey) {
 			return checkAndRecoverGenericProblem, false
 		} else {
-			return checkAndRecoverLockedSemiSyncMaster, true
+			return checkAndRecoverLockedSemiSyncPrimary, true
 		}
 	// topo
 	case inst.ClusterHasNoPrimary:
-		return electNewMaster, true
+		return electNewPrimary, true
 	case inst.PrimaryHasPrimary:
-		return fixClusterAndMaster, true
+		return fixClusterAndPrimary, true
 	case inst.PrimaryIsReadOnly, inst.PrimarySemiSyncMustBeSet, inst.PrimarySemiSyncMustNotBeSet:
-		return fixMaster, true
+		return fixPrimary, true
 	case inst.NotConnectedToPrimary, inst.ConnectedToWrongPrimary, inst.ReplicationStopped, inst.ReplicaIsWritable,
 		inst.ReplicaSemiSyncMustBeSet, inst.ReplicaSemiSyncMustNotBeSet:
 		return fixReplica, false
 	// intermediate primary
 	case inst.DeadIntermediatePrimary:
-		return checkAndRecoverDeadIntermediateMaster, true
+		return checkAndRecoverDeadIntermediatePrimary, true
 	case inst.DeadIntermediatePrimaryAndSomeReplicas:
-		return checkAndRecoverDeadIntermediateMaster, true
+		return checkAndRecoverDeadIntermediatePrimary, true
 	case inst.DeadIntermediatePrimaryWithSingleReplicaFailingToConnect:
-		return checkAndRecoverDeadIntermediateMaster, true
+		return checkAndRecoverDeadIntermediatePrimary, true
 	case inst.AllIntermediatePrimaryReplicasFailingToConnectOrDead:
-		return checkAndRecoverDeadIntermediateMaster, true
+		return checkAndRecoverDeadIntermediatePrimary, true
 	case inst.DeadIntermediatePrimaryAndReplicas:
 		return checkAndRecoverGenericProblem, false
 	// co-primary
 	case inst.DeadCoPrimary:
-		return checkAndRecoverDeadCoMaster, true
+		return checkAndRecoverDeadCoPrimary, true
 	case inst.DeadCoPrimaryAndSomeReplicas:
-		return checkAndRecoverDeadCoMaster, true
+		return checkAndRecoverDeadCoPrimary, true
 	// primary, non actionable
 	case inst.DeadPrimaryAndReplicas:
 		return checkAndRecoverGenericProblem, false
@@ -1771,16 +1771,16 @@ func ForceExecuteRecovery(analysisEntry inst.ReplicationAnalysis, candidateInsta
 
 // ForcePrimaryFailover *trusts* primary of given cluster is dead and initiates a failover
 func ForcePrimaryFailover(clusterName string) (topologyRecovery *TopologyRecovery, err error) {
-	clusterMasters, err := inst.ReadClusterPrimary(clusterName)
+	clusterPrimaries, err := inst.ReadClusterPrimary(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
 	}
-	if len(clusterMasters) != 1 {
+	if len(clusterPrimaries) != 1 {
 		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
 	}
-	clusterMaster := clusterMasters[0]
+	clusterPrimary := clusterPrimaries[0]
 
-	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.ForcePrimaryFailoverCommandHint, &clusterMaster.Key)
+	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.ForcePrimaryFailoverCommandHint, &clusterPrimary.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -1803,21 +1803,21 @@ func ForcePrimaryFailover(clusterName string) (topologyRecovery *TopologyRecover
 // ForcePrimaryTakeover *trusts* primary of given cluster is dead and fails over to designated instance,
 // which has to be its direct child.
 func ForcePrimaryTakeover(clusterName string, destination *inst.Instance) (topologyRecovery *TopologyRecovery, err error) {
-	clusterMasters, err := inst.ReadClusterWriteablePrimary(clusterName)
+	clusterPrimaries, err := inst.ReadClusterWriteablePrimary(clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
 	}
-	if len(clusterMasters) != 1 {
+	if len(clusterPrimaries) != 1 {
 		return nil, fmt.Errorf("Cannot deduce cluster master for %+v", clusterName)
 	}
-	clusterMaster := clusterMasters[0]
+	clusterPrimary := clusterPrimaries[0]
 
-	if !destination.PrimaryKey.Equals(&clusterMaster.Key) {
-		return nil, fmt.Errorf("You may only promote a direct child of the master %+v. The master of %+v is %+v.", clusterMaster.Key, destination.Key, destination.PrimaryKey)
+	if !destination.PrimaryKey.Equals(&clusterPrimary.Key) {
+		return nil, fmt.Errorf("You may only promote a direct child of the master %+v. The master of %+v is %+v.", clusterPrimary.Key, destination.Key, destination.PrimaryKey)
 	}
-	log.Infof("Will demote %+v and promote %+v instead", clusterMaster.Key, destination.Key)
+	log.Infof("Will demote %+v and promote %+v instead", clusterPrimary.Key, destination.Key)
 
-	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.ForcePrimaryTakeoverCommandHint, &clusterMaster.Key)
+	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.ForcePrimaryTakeoverCommandHint, &clusterPrimary.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -1837,21 +1837,21 @@ func ForcePrimaryTakeover(clusterName string, destination *inst.Instance) (topol
 	return topologyRecovery, nil
 }
 
-func getGracefulMasterTakeoverDesignatedInstance(clusterMasterKey *inst.InstanceKey, designatedKey *inst.InstanceKey, clusterMasterDirectReplicas [](*inst.Instance), auto bool) (designatedInstance *inst.Instance, err error) {
+func getGracefulPrimaryTakeoverDesignatedInstance(clusterPrimaryKey *inst.InstanceKey, designatedKey *inst.InstanceKey, clusterPrimaryDirectReplicas [](*inst.Instance), auto bool) (designatedInstance *inst.Instance, err error) {
 	if designatedKey == nil {
 		// User did not specify a replica to promote
-		if len(clusterMasterDirectReplicas) == 1 {
+		if len(clusterPrimaryDirectReplicas) == 1 {
 			// Single replica. That's the one we'll promote
-			return clusterMasterDirectReplicas[0], nil
+			return clusterPrimaryDirectReplicas[0], nil
 		}
 		// More than one replica.
 		if !auto {
-			return nil, fmt.Errorf("GracefulPrimaryTakeover: target instance not indicated, auto=false, and master %+v has %+v replicas. orchestrator cannot choose where to failover to. Aborting", *clusterMasterKey, len(clusterMasterDirectReplicas))
+			return nil, fmt.Errorf("GracefulPrimaryTakeover: target instance not indicated, auto=false, and master %+v has %+v replicas. orchestrator cannot choose where to failover to. Aborting", *clusterPrimaryKey, len(clusterPrimaryDirectReplicas))
 		}
-		log.Debugf("GracefulPrimaryTakeover: request takeover for master %+v, no designated replica indicated. orchestrator will attempt to auto deduce replica.", *clusterMasterKey)
-		designatedInstance, _, _, _, _, err = inst.GetCandidateReplica(clusterMasterKey, false)
+		log.Debugf("GracefulPrimaryTakeover: request takeover for master %+v, no designated replica indicated. orchestrator will attempt to auto deduce replica.", *clusterPrimaryKey)
+		designatedInstance, _, _, _, _, err = inst.GetCandidateReplica(clusterPrimaryKey, false)
 		if err != nil || designatedInstance == nil {
-			return nil, fmt.Errorf("GracefulPrimaryTakeover: no target instance indicated, failed to auto-detect candidate replica for master %+v. Aborting", *clusterMasterKey)
+			return nil, fmt.Errorf("GracefulPrimaryTakeover: no target instance indicated, failed to auto-detect candidate replica for master %+v. Aborting", *clusterPrimaryKey)
 		}
 		log.Debugf("GracefulPrimaryTakeover: candidateReplica=%+v", designatedInstance.Key)
 		if _, err := inst.StartReplication(&designatedInstance.Key); err != nil {
@@ -1862,13 +1862,13 @@ func getGracefulMasterTakeoverDesignatedInstance(clusterMasterKey *inst.Instance
 	}
 
 	// Verify designated instance is a direct replica of primary
-	for _, directReplica := range clusterMasterDirectReplicas {
+	for _, directReplica := range clusterPrimaryDirectReplicas {
 		if directReplica.Key.Equals(designatedKey) {
 			designatedInstance = directReplica
 		}
 	}
 	if designatedInstance == nil {
-		return nil, fmt.Errorf("GracefulPrimaryTakeover: indicated designated instance %+v must be directly replicating from the master %+v", *designatedKey, *clusterMasterKey)
+		return nil, fmt.Errorf("GracefulPrimaryTakeover: indicated designated instance %+v must be directly replicating from the master %+v", *designatedKey, *clusterPrimaryKey)
 	}
 	log.Infof("GracefulPrimaryTakeover: designated master instructed to be %+v", designatedInstance.Key)
 	return designatedInstance, nil
@@ -1880,30 +1880,30 @@ func getGracefulMasterTakeoverDesignatedInstance(clusterMasterKey *inst.Instance
 // This function is graceful in that it will first lock down the primary, then wait
 // for the designated replica to catch up with last position.
 // It will point old primary at the newly promoted primary at the correct coordinates.
-func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey, auto bool) (topologyRecovery *TopologyRecovery, promotedMasterCoordinates *inst.BinlogCoordinates, err error) {
-	clusterMasters, err := inst.ReadClusterPrimary(clusterName)
+func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey, auto bool) (topologyRecovery *TopologyRecovery, promotedPrimaryCoordinates *inst.BinlogCoordinates, err error) {
+	clusterPrimaries, err := inst.ReadClusterPrimary(clusterName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot deduce cluster master for %+v; error: %+v", clusterName, err)
 	}
-	if len(clusterMasters) != 1 {
-		return nil, nil, fmt.Errorf("Cannot deduce cluster master for %+v. Found %+v potential masters", clusterName, len(clusterMasters))
+	if len(clusterPrimaries) != 1 {
+		return nil, nil, fmt.Errorf("Cannot deduce cluster master for %+v. Found %+v potential masters", clusterName, len(clusterPrimaries))
 	}
-	clusterMaster := clusterMasters[0]
+	clusterPrimary := clusterPrimaries[0]
 
-	clusterMasterDirectReplicas, err := inst.ReadReplicaInstances(&clusterMaster.Key)
+	clusterPrimaryDirectReplicas, err := inst.ReadReplicaInstances(&clusterPrimary.Key)
 	if err != nil {
 		return nil, nil, log.Errore(err)
 	}
 
-	if len(clusterMasterDirectReplicas) == 0 {
-		return nil, nil, fmt.Errorf("Master %+v doesn't seem to have replicas", clusterMaster.Key)
+	if len(clusterPrimaryDirectReplicas) == 0 {
+		return nil, nil, fmt.Errorf("Master %+v doesn't seem to have replicas", clusterPrimary.Key)
 	}
 
 	if designatedKey != nil && !designatedKey.IsValid() {
 		// An empty or invalid key is as good as no key
 		designatedKey = nil
 	}
-	designatedInstance, err := getGracefulMasterTakeoverDesignatedInstance(&clusterMaster.Key, designatedKey, clusterMasterDirectReplicas, auto)
+	designatedInstance, err := getGracefulPrimaryTakeoverDesignatedInstance(&clusterPrimary.Key, designatedKey, clusterPrimaryDirectReplicas, auto)
 	if err != nil {
 		return nil, nil, log.Errore(err)
 	}
@@ -1912,26 +1912,26 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 		return nil, nil, fmt.Errorf("GracefulPrimaryTakeover: designated instance %+v cannot be promoted due to promotion rule or it is explicitly ignored in PromotionIgnoreHostnameFilters configuration", designatedInstance.Key)
 	}
 
-	masterOfDesignatedInstance, err := inst.GetInstancePrimary(designatedInstance)
+	primaryOfDesignatedInstance, err := inst.GetInstancePrimary(designatedInstance)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !masterOfDesignatedInstance.Key.Equals(&clusterMaster.Key) {
-		return nil, nil, fmt.Errorf("Sanity check failure. It seems like the designated instance %+v does not replicate from the master %+v (designated instance's master key is %+v). This error is strange. Panicking", designatedInstance.Key, clusterMaster.Key, designatedInstance.PrimaryKey)
+	if !primaryOfDesignatedInstance.Key.Equals(&clusterPrimary.Key) {
+		return nil, nil, fmt.Errorf("Sanity check failure. It seems like the designated instance %+v does not replicate from the master %+v (designated instance's master key is %+v). This error is strange. Panicking", designatedInstance.Key, clusterPrimary.Key, designatedInstance.PrimaryKey)
 	}
 	if !designatedInstance.HasReasonableMaintenanceReplicationLag() {
 		return nil, nil, fmt.Errorf("Desginated instance %+v seems to be lagging to much for thie operation. Aborting.", designatedInstance.Key)
 	}
 
-	if len(clusterMasterDirectReplicas) > 1 {
+	if len(clusterPrimaryDirectReplicas) > 1 {
 		log.Infof("GracefulPrimaryTakeover: Will let %+v take over its siblings", designatedInstance.Key)
-		relocatedReplicas, _, err, _ := inst.RelocateReplicas(&clusterMaster.Key, &designatedInstance.Key, "")
-		if len(relocatedReplicas) != len(clusterMasterDirectReplicas)-1 {
+		relocatedReplicas, _, err, _ := inst.RelocateReplicas(&clusterPrimary.Key, &designatedInstance.Key, "")
+		if len(relocatedReplicas) != len(clusterPrimaryDirectReplicas)-1 {
 			// We are unable to make designated instance primary of all its siblings
 			relocatedReplicasKeyMap := inst.NewInstanceKeyMap()
 			relocatedReplicasKeyMap.AddInstances(relocatedReplicas)
 			// Let's see which replicas have not been relocated
-			for _, directReplica := range clusterMasterDirectReplicas {
+			for _, directReplica := range clusterPrimaryDirectReplicas {
 				if relocatedReplicasKeyMap.HasKey(directReplica.Key) {
 					// relocated, good
 					continue
@@ -1949,9 +1949,9 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 			}
 		}
 	}
-	log.Infof("GracefulPrimaryTakeover: Will demote %+v and promote %+v instead", clusterMaster.Key, designatedInstance.Key)
+	log.Infof("GracefulPrimaryTakeover: Will demote %+v and promote %+v instead", clusterPrimary.Key, designatedInstance.Key)
 
-	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.GracefulPrimaryTakeoverCommandHint, &clusterMaster.Key)
+	analysisEntry, err := forceAnalysisEntry(clusterName, inst.DeadPrimary, inst.GracefulPrimaryTakeoverCommandHint, &clusterPrimary.Key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1962,12 +1962,12 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 	if err := executeProcesses(config.Config.PreGracefulTakeoverProcesses, "PreGracefulTakeoverProcesses", preGracefulTakeoverTopologyRecovery, true); err != nil {
 		return nil, nil, fmt.Errorf("Failed running PreGracefulTakeoverProcesses: %+v", err)
 	}
-	demotedMasterSelfBinlogCoordinates := &clusterMaster.SelfBinlogCoordinates
-	log.Infof("GracefulPrimaryTakeover: Will wait for %+v to reach master coordinates %+v", designatedInstance.Key, *demotedMasterSelfBinlogCoordinates)
-	if designatedInstance, _, err = inst.WaitForExecBinlogCoordinatesToReach(&designatedInstance.Key, demotedMasterSelfBinlogCoordinates, time.Duration(config.Config.ReasonableMaintenanceReplicationLagSeconds)*time.Second); err != nil {
+	demotedPrimarySelfBinlogCoordinates := &clusterPrimary.SelfBinlogCoordinates
+	log.Infof("GracefulPrimaryTakeover: Will wait for %+v to reach master coordinates %+v", designatedInstance.Key, *demotedPrimarySelfBinlogCoordinates)
+	if designatedInstance, _, err = inst.WaitForExecBinlogCoordinatesToReach(&designatedInstance.Key, demotedPrimarySelfBinlogCoordinates, time.Duration(config.Config.ReasonableMaintenanceReplicationLagSeconds)*time.Second); err != nil {
 		return nil, nil, err
 	}
-	promotedMasterCoordinates = &designatedInstance.SelfBinlogCoordinates
+	promotedPrimaryCoordinates = &designatedInstance.SelfBinlogCoordinates
 
 	log.Infof("GracefulPrimaryTakeover: attempting recovery")
 	recoveryAttempted, topologyRecovery, err := ForceExecuteRecovery(analysisEntry, &designatedInstance.Key, false)
@@ -1981,35 +1981,35 @@ func GracefulPrimaryTakeover(clusterName string, designatedKey *inst.InstanceKey
 		return nil, nil, fmt.Errorf("GracefulPrimaryTakeover: recovery attempted but with no results. This should not happen")
 	}
 	var gtidHint inst.OperationGTIDHint = inst.GTIDHintNeutral
-	if topologyRecovery.RecoveryType == MasterRecoveryGTID {
+	if topologyRecovery.RecoveryType == PrimaryRecoveryGTID {
 		gtidHint = inst.GTIDHintForce
 	}
-	clusterMaster, err = inst.ChangePrimaryTo(&clusterMaster.Key, &designatedInstance.Key, promotedMasterCoordinates, false, gtidHint)
-	if !clusterMaster.SelfBinlogCoordinates.Equals(demotedMasterSelfBinlogCoordinates) {
-		log.Errorf("GracefulPrimaryTakeover: sanity problem. Demoted master's coordinates changed from %+v to %+v while supposed to have been frozen", *demotedMasterSelfBinlogCoordinates, clusterMaster.SelfBinlogCoordinates)
+	clusterPrimary, err = inst.ChangePrimaryTo(&clusterPrimary.Key, &designatedInstance.Key, promotedPrimaryCoordinates, false, gtidHint)
+	if !clusterPrimary.SelfBinlogCoordinates.Equals(demotedPrimarySelfBinlogCoordinates) {
+		log.Errorf("GracefulPrimaryTakeover: sanity problem. Demoted master's coordinates changed from %+v to %+v while supposed to have been frozen", *demotedPrimarySelfBinlogCoordinates, clusterPrimary.SelfBinlogCoordinates)
 	}
-	_, startReplicationErr := inst.StartReplication(&clusterMaster.Key)
+	_, startReplicationErr := inst.StartReplication(&clusterPrimary.Key)
 	if err == nil {
 		err = startReplicationErr
 	}
 
 	if designatedInstance.AllowTLS {
-		_, enableSSLErr := inst.EnablePrimarySSL(&clusterMaster.Key)
+		_, enableSSLErr := inst.EnablePrimarySSL(&clusterPrimary.Key)
 		if err == nil {
 			err = enableSSLErr
 		}
 	}
 	executeProcesses(config.Config.PostGracefulTakeoverProcesses, "PostGracefulTakeoverProcesses", topologyRecovery, false)
 
-	return topologyRecovery, promotedMasterCoordinates, err
+	return topologyRecovery, promotedPrimaryCoordinates, err
 }
 
-// electNewMaster elects a new primary while none were present before.
-// TODO(sougou): this should be mreged with recoverDeadMaster
-func electNewMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
+// electNewPrimary elects a new primary while none were present before.
+// TODO(sougou): this should be mreged with recoverDeadPrimary
+func electNewPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
 	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, false, true)
 	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another electNewMaster.", analysisEntry.AnalyzedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another electNewPrimary.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will elect a new master: %v", analysisEntry.Analysis, analysisEntry.SuggestedClusterAlias)
@@ -2082,23 +2082,23 @@ func electNewMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey
 	}
 	count := inst.PrimarySemiSync(candidate.Key)
 	err = inst.SetSemiSyncPrimary(&candidate.Key, count > 0)
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- electNewMaster: applying semi-sync %v: success=%t", count > 0, (err == nil)))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- electNewPrimary: applying semi-sync %v: success=%t", count > 0, (err == nil)))
 	if err != nil {
 		return false, topologyRecovery, err
 	}
 	_, err = inst.SetReadOnly(&candidate.Key, false)
-	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- electNewMaster: set read-only false: success=%t", (err == nil)))
+	AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- electNewPrimary: set read-only false: success=%t", (err == nil)))
 	if err != nil {
 		return false, topologyRecovery, err
 	}
 	return true, topologyRecovery, nil
 }
 
-// fixClusterAndMaster performs a traditional vitess PlannedReparentShard.
-func fixClusterAndMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
+// fixClusterAndPrimary performs a traditional vitess PlannedReparentShard.
+func fixClusterAndPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
 	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, false, true)
 	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another fixClusterAndMaster.", analysisEntry.AnalyzedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another fixClusterAndPrimary.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will fix incorrect mastership %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
@@ -2124,11 +2124,11 @@ func fixClusterAndMaster(analysisEntry inst.ReplicationAnalysis, candidateInstan
 	return recoveryAttempted, topologyRecovery, err
 }
 
-// fixMaster sets the primary as read-write.
-func fixMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
+// fixPrimary sets the primary as read-write.
+func fixPrimary(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *inst.InstanceKey, forceInstanceRecovery bool, skipProcesses bool) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
 	topologyRecovery, err = AttemptRecoveryRegistration(&analysisEntry, false, true)
 	if topologyRecovery == nil {
-		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another fixMaster.", analysisEntry.AnalyzedInstanceKey))
+		AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("found an active or recent recovery on %+v. Will not issue another fixPrimary.", analysisEntry.AnalyzedInstanceKey))
 		return false, nil, err
 	}
 	log.Infof("Analysis: %v, will fix master to read-write %+v", analysisEntry.Analysis, analysisEntry.AnalyzedInstanceKey)
@@ -2145,12 +2145,12 @@ func fixMaster(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *ins
 	// TODO(sougou): this code pattern has reached DRY limits. Reuse.
 	count := inst.PrimarySemiSync(analysisEntry.AnalyzedInstanceKey)
 	err = inst.SetSemiSyncPrimary(&analysisEntry.AnalyzedInstanceKey, count > 0)
-	//AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- fixMaster: applying semi-sync %v: success=%t", count > 0, (err == nil)))
+	//AuditTopologyRecovery(topologyRecovery, fmt.Sprintf("- fixPrimary: applying semi-sync %v: success=%t", count > 0, (err == nil)))
 	if err != nil {
 		return false, topologyRecovery, err
 	}
 
-	if err := TabletUndoDemoteMaster(analysisEntry.AnalyzedInstanceKey); err != nil {
+	if err := TabletUndoDemotePrimary(analysisEntry.AnalyzedInstanceKey); err != nil {
 		return false, topologyRecovery, err
 	}
 	return true, topologyRecovery, nil
@@ -2178,12 +2178,12 @@ func fixReplica(analysisEntry inst.ReplicationAnalysis, candidateInstanceKey *in
 		return false, topologyRecovery, err
 	}
 
-	masterKey, err := ShardMaster(&analysisEntry.AnalyzedInstanceKey)
+	primaryKey, err := ShardPrimary(&analysisEntry.AnalyzedInstanceKey)
 	if err != nil {
 		log.Info("Could not compute master for %+v", analysisEntry.AnalyzedInstanceKey)
 		return false, topologyRecovery, err
 	}
-	if _, err := inst.MoveBelowGTID(&analysisEntry.AnalyzedInstanceKey, masterKey); err != nil {
+	if _, err := inst.MoveBelowGTID(&analysisEntry.AnalyzedInstanceKey, primaryKey); err != nil {
 		return false, topologyRecovery, err
 	}
 	return true, topologyRecovery, nil

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -83,7 +83,7 @@ func IsRunningQueryService(tt topodatapb.TabletType) bool {
 // non-serving state through its health check. then vtgate will catch
 // that non-serving state, and stop sending queries.
 //
-// Masters are not subject to lameduck, as we usually want to transition
+// Primaries are not subject to lameduck, as we usually want to transition
 // them as fast as possible.
 //
 // Replica and rdonly will use lameduck when going from healthy to


### PR DESCRIPTION
## Description
Cleanup references to master and slave in `vt/orchestrator` in functions and variables 


## Related Issue(s)
- Fixes #7110

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required