### PR TITLE
srvtopo: allow unwatching from watch callbacks

### DIFF
--- a/go/vt/srvtopo/keyspace_filtering_server.go
+++ b/go/vt/srvtopo/keyspace_filtering_server.go
@@ -17,9 +17,8 @@ limitations under the License.
 package srvtopo
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -99,9 +98,9 @@ func (ksf keyspaceFilteringServer) GetSrvKeyspace(
 func (ksf keyspaceFilteringServer) WatchSrvVSchema(
 	ctx context.Context,
 	cell string,
-	callback func(*vschemapb.SrvVSchema, error),
+	callback func(*vschemapb.SrvVSchema, error) bool,
 ) {
-	filteringCallback := func(schema *vschemapb.SrvVSchema, err error) {
+	filteringCallback := func(schema *vschemapb.SrvVSchema, err error) bool {
 		if schema != nil {
 			for ks := range schema.Keyspaces {
 				if !ksf.selectKeyspaces[ks] {
@@ -110,7 +109,7 @@ func (ksf keyspaceFilteringServer) WatchSrvVSchema(
 			}
 		}
 
-		callback(schema, err)
+		return callback(schema, err)
 	}
 
 	ksf.server.WatchSrvVSchema(ctx, cell, filteringCallback)

--- a/go/vt/srvtopo/keyspace_filtering_server_test.go
+++ b/go/vt/srvtopo/keyspace_filtering_server_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package srvtopo
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
 	"testing"
-
-	"context"
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -182,7 +181,7 @@ func TestFilteringServerWatchSrvVSchemaFiltersPassthroughSrvVSchema(t *testing.T
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	cb := func(gotSchema *vschemapb.SrvVSchema, gotErr error) {
+	cb := func(gotSchema *vschemapb.SrvVSchema, gotErr error) bool {
 		// ensure that only selected keyspaces made it into the callback
 		for name, ks := range gotSchema.Keyspaces {
 			if !allowed[name] {
@@ -198,6 +197,7 @@ func TestFilteringServerWatchSrvVSchemaFiltersPassthroughSrvVSchema(t *testing.T
 			}
 		}
 		wg.Done()
+		return true
 	}
 
 	f.WatchSrvVSchema(stockCtx, stockCell, cb)
@@ -214,7 +214,7 @@ func TestFilteringServerWatchSrvVSchemaHandlesNilSchema(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	cb := func(gotSchema *vschemapb.SrvVSchema, gotErr error) {
+	cb := func(gotSchema *vschemapb.SrvVSchema, gotErr error) bool {
 		if gotSchema != nil {
 			t.Errorf("Expected nil gotSchema: got %#v", gotSchema)
 		}
@@ -222,6 +222,7 @@ func TestFilteringServerWatchSrvVSchemaHandlesNilSchema(t *testing.T) {
 			t.Errorf("Unexpected error: want %v got %v", wantErr, gotErr)
 		}
 		wg.Done()
+		return true
 	}
 
 	f.WatchSrvVSchema(stockCtx, "other-cell", cb)

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -414,11 +414,12 @@ func TestWatchSrvVSchema(t *testing.T) {
 	mu := sync.Mutex{}
 	var watchValue *vschemapb.SrvVSchema
 	var watchErr error
-	rs.WatchSrvVSchema(ctx, "test_cell", func(v *vschemapb.SrvVSchema, e error) {
+	rs.WatchSrvVSchema(ctx, "test_cell", func(v *vschemapb.SrvVSchema, e error) bool {
 		mu.Lock()
 		defer mu.Unlock()
 		watchValue = v
 		watchErr = e
+		return true
 	})
 	get := func() (*vschemapb.SrvVSchema, error) {
 		mu.Lock()
@@ -684,10 +685,11 @@ func TestSrvKeyspaceWatcher(t *testing.T) {
 		return nil
 	}
 
-	rs.WatchSrvKeyspace(context.Background(), "test_cell", "test_ks", func(keyspace *topodatapb.SrvKeyspace, err error) {
+	rs.WatchSrvKeyspace(context.Background(), "test_cell", "test_ks", func(keyspace *topodatapb.SrvKeyspace, err error) bool {
 		wmu.Lock()
 		defer wmu.Unlock()
 		wseen = append(wseen, watched{keyspace: keyspace, err: err})
+		return true
 	})
 
 	seen1 := allSeen()

--- a/go/vt/srvtopo/server.go
+++ b/go/vt/srvtopo/server.go
@@ -45,5 +45,5 @@ type Server interface {
 	// WatchSrvVSchema starts watching the SrvVSchema object for
 	// the provided cell.  It will call the callback when
 	// a new value or an error occurs.
-	WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error))
+	WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool)
 }

--- a/go/vt/srvtopo/srvtopotest/passthrough.go
+++ b/go/vt/srvtopo/srvtopotest/passthrough.go
@@ -60,6 +60,6 @@ func (srv *PassthroughSrvTopoServer) GetSrvKeyspace(ctx context.Context, cell, k
 }
 
 // WatchSrvVSchema implements srvtopo.Server
-func (srv *PassthroughSrvTopoServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+func (srv *PassthroughSrvTopoServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
 	callback(srv.WatchedSrvVSchema, srv.WatchedSrvVSchemaError)
 }

--- a/go/vt/srvtopo/watch_srvkeyspace.go
+++ b/go/vt/srvtopo/watch_srvkeyspace.go
@@ -74,11 +74,11 @@ func (w *SrvKeyspaceWatcher) GetSrvKeyspace(ctx context.Context, cell, keyspace 
 	return ks, err
 }
 
-func (w *SrvKeyspaceWatcher) WatchSrvKeyspace(ctx context.Context, cell, keyspace string, callback func(*topodata.SrvKeyspace, error)) {
+func (w *SrvKeyspaceWatcher) WatchSrvKeyspace(ctx context.Context, cell, keyspace string, callback func(*topodata.SrvKeyspace, error) bool) {
 	entry := w.rw.getEntry(&srvKeyspaceKey{cell, keyspace})
-	entry.addListener(ctx, func(v interface{}, err error) {
+	entry.addListener(ctx, func(v interface{}, err error) bool {
 		srvkeyspace, _ := v.(*topodata.SrvKeyspace)
-		callback(srvkeyspace, err)
+		return callback(srvkeyspace, err)
 	})
 }
 

--- a/go/vt/srvtopo/watch_srvvschema.go
+++ b/go/vt/srvtopo/watch_srvvschema.go
@@ -71,10 +71,10 @@ func (w *SrvVSchemaWatcher) GetSrvVSchema(ctx context.Context, cell string) (*vs
 	return vschema, err
 }
 
-func (w *SrvVSchemaWatcher) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+func (w *SrvVSchemaWatcher) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
 	entry := w.rw.getEntry(cellName(cell))
-	entry.addListener(ctx, func(v interface{}, err error) {
+	entry.addListener(ctx, func(v interface{}, err error) bool {
 		vschema, _ := v.(*vschemapb.SrvVSchema)
-		callback(vschema, err)
+		return callback(vschema, err)
 	})
 }

--- a/go/vt/vtexplain/vtexplain_topo.go
+++ b/go/vt/vtexplain/vtexplain_topo.go
@@ -17,10 +17,9 @@ limitations under the License.
 package vtexplain
 
 import (
+	"context"
 	"fmt"
 	"sync"
-
-	"context"
 
 	"vitess.io/vitess/go/vt/topo"
 
@@ -115,6 +114,6 @@ func (et *ExplainTopo) GetSrvKeyspace(ctx context.Context, cell, keyspace string
 }
 
 // WatchSrvVSchema is part of the srvtopo.Server interface.
-func (et *ExplainTopo) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+func (et *ExplainTopo) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
 	callback(et.getSrvVSchema(), nil)
 }

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -1224,8 +1224,9 @@ func TestExecutorAlterVSchemaKeyspace(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: "@primary", Autocommit: true})
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 2)
-	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -1251,8 +1252,9 @@ func TestExecutorCreateVindexDDL(t *testing.T) {
 	ks := "TestExecutor"
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -1322,8 +1324,9 @@ func TestExecutorAddDropVschemaTableDDL(t *testing.T) {
 	ks := KsTestUnsharded
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(ctx, "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates

--- a/go/vt/vtgate/executor_vschema_ddl_test.go
+++ b/go/vt/vtgate/executor_vschema_ddl_test.go
@@ -138,8 +138,9 @@ func TestPlanExecutorAlterVSchemaKeyspace(t *testing.T) {
 	session := NewSafeSession(&vtgatepb.Session{TargetString: "@primary", Autocommit: true})
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 2)
-	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -165,8 +166,9 @@ func TestPlanExecutorCreateVindexDDL(t *testing.T) {
 	ks := "TestExecutor"
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -206,8 +208,9 @@ func TestPlanExecutorDropVindexDDL(t *testing.T) {
 	ks := "TestExecutor"
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -274,8 +277,9 @@ func TestPlanExecutorAddDropVschemaTableDDL(t *testing.T) {
 	ks := KsTestUnsharded
 
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates
@@ -390,8 +394,9 @@ func TestExecutorAddDropVindexDDL(t *testing.T) {
 	ks := "TestExecutor"
 	session := NewSafeSession(&vtgatepb.Session{TargetString: ks})
 	vschemaUpdates := make(chan *vschemapb.SrvVSchema, 4)
-	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) {
+	executor.serv.WatchSrvVSchema(context.Background(), "aa", func(vschema *vschemapb.SrvVSchema, err error) bool {
 		vschemaUpdates <- vschema
+		return true
 	})
 
 	vschema := <-vschemaUpdates

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package vtgate
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
-
-	"context"
 
 	"vitess.io/vitess/go/json2"
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -289,7 +288,7 @@ func (sct *sandboxTopo) GetSrvKeyspace(ctx context.Context, cell, keyspace strin
 // If the sandbox was created with a backing topo service, piggy back on it
 // to properly simulate watches, otherwise just immediately call back the
 // caller.
-func (sct *sandboxTopo) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+func (sct *sandboxTopo) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
 	srvVSchema := getSandboxSrvVSchema()
 
 	if sct.topoServer == nil {
@@ -299,11 +298,15 @@ func (sct *sandboxTopo) WatchSrvVSchema(ctx context.Context, cell string, callba
 
 	sct.topoServer.UpdateSrvVSchema(ctx, cell, srvVSchema)
 	current, updateChan, _ := sct.topoServer.WatchSrvVSchema(ctx, cell)
-	callback(current.Value, nil)
+	if !callback(current.Value, nil) {
+		panic("sandboxTopo callback returned false")
+	}
 	go func() {
 		for {
 			update := <-updateChan
-			callback(update.Value, update.Err)
+			if !callback(update.Value, update.Err) {
+				panic("sandboxTopo callback returned false")
+			}
 		}
 	}()
 }

--- a/go/vt/vtgate/vcursor_impl_test.go
+++ b/go/vt/vtgate/vcursor_impl_test.go
@@ -71,7 +71,7 @@ func (f *fakeTopoServer) GetSrvKeyspace(ctx context.Context, cell, keyspace stri
 // WatchSrvVSchema starts watching the SrvVSchema object for
 // the provided cell.  It will call the callback when
 // a new value or an error occurs.
-func (f *fakeTopoServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error)) {
+func (f *fakeTopoServer) WatchSrvVSchema(ctx context.Context, cell string, callback func(*vschemapb.SrvVSchema, error) bool) {
 
 }
 

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -87,8 +87,14 @@ func (vm *VSchemaManager) UpdateVSchema(ctx context.Context, ksName string, vsch
 			log.Errorf("error updating vschema in cell %s: %v", cell, cellErr)
 		}
 	}
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Update all the local copy of VSchema if the topo update is successful.
+	vm.VSchemaUpdate(vschema, err)
+
+	return nil
 }
 
 // VSchemaUpdate builds the VSchema from SrvVschema and call subscribers.

--- a/go/vt/vtgate/vschema_manager.go
+++ b/go/vt/vtgate/vschema_manager.go
@@ -92,7 +92,7 @@ func (vm *VSchemaManager) UpdateVSchema(ctx context.Context, ksName string, vsch
 }
 
 // VSchemaUpdate builds the VSchema from SrvVschema and call subscribers.
-func (vm *VSchemaManager) VSchemaUpdate(v *vschemapb.SrvVSchema, err error) {
+func (vm *VSchemaManager) VSchemaUpdate(v *vschemapb.SrvVSchema, err error) bool {
 	log.Infof("Received vschema update")
 	switch {
 	case err == nil:
@@ -129,6 +129,7 @@ func (vm *VSchemaManager) VSchemaUpdate(v *vschemapb.SrvVSchema, err error) {
 	if vm.subscriber != nil {
 		vm.subscriber(vschema, vSchemaStats(err, vschema))
 	}
+	return true
 }
 
 func vSchemaStats(err error, vschema *vindexes.VSchema) *VSchemaStats {

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -335,7 +335,7 @@ func (vse *Engine) setWatch() {
 	}
 
 	// WatchSrvVSchema does not return until the inner func has been called at least once.
-	vse.ts.WatchSrvVSchema(context.TODO(), vse.cell, func(v *vschemapb.SrvVSchema, err error) {
+	vse.ts.WatchSrvVSchema(context.TODO(), vse.cell, func(v *vschemapb.SrvVSchema, err error) bool {
 		switch {
 		case err == nil:
 			// Build vschema down below.
@@ -344,7 +344,7 @@ func (vse *Engine) setWatch() {
 		default:
 			log.Errorf("Error fetching vschema: %v", err)
 			vse.vschemaErrors.Add(1)
-			return
+			return true
 		}
 		var vschema *vindexes.VSchema
 		if v != nil {
@@ -352,7 +352,7 @@ func (vse *Engine) setWatch() {
 			if err != nil {
 				log.Errorf("Error building vschema: %v", err)
 				vse.vschemaErrors.Add(1)
-				return
+				return true
 			}
 		} else {
 			vschema = &vindexes.VSchema{}
@@ -371,6 +371,7 @@ func (vse *Engine) setWatch() {
 			s.SetVSchema(vse.lvschema)
 		}
 		vse.vschemaUpdates.Add(1)
+		return true
 	})
 }
 


### PR DESCRIPTION
## Description

From @vmg: 
"Here's a feature I forgot to implement in my previous PR. We're gonna need to stop watching specific keyspaces once we detect their cluster event is finished."

cc @deepthi @harshit-gangal @rohit-nayak-ps 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#8462 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->