### PR TITLE
schema engine: reset table size stats when a table is dropped

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -373,6 +373,10 @@ func (se *Engine) reload(ctx context.Context) error {
 		if !curTables[tableName] {
 			dropped = append(dropped, tableName)
 			delete(se.tables, tableName)
+			// We can't actually delete the label from the stats, but we can set it to 0.
+			// Many monitoring tools will drop zero-valued metrics.
+			se.tableFileSizeGauge.Reset(tableName)
+			se.tableAllocatedSizeGauge.Reset(tableName)
 		}
 	}
 

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -84,6 +84,8 @@ func TestOpenAndReload(t *testing.T) {
 
 	want := initialSchema()
 	mustMatch(t, want, se.GetSchema())
+	assert.Equal(t, int64(100), se.tableFileSizeGauge.Counts()["msg"])
+	assert.Equal(t, int64(150), se.tableAllocatedSizeGauge.Counts()["msg"])
 
 	// Advance time some more.
 	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
@@ -195,6 +197,8 @@ func TestOpenAndReload(t *testing.T) {
 	}
 	delete(want, "msg")
 	assert.Equal(t, want, se.GetSchema())
+	assert.Equal(t, int64(0), se.tableAllocatedSizeGauge.Counts()["msg"])
+	assert.Equal(t, int64(0), se.tableFileSizeGauge.Counts()["msg"])
 
 	//ReloadAt tests
 	pos1, err := mysql.DecodePosition("MariaDB/0-41983-20")


### PR DESCRIPTION
## Description
Schema engine tracks `file_size` and `allocated_size` stats for each table. However, when a table is dropped, the stats are not reset.

## Related Issue(s)

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->