### PR TITLE
Fixes for reparent endtoend test flakiness

### DIFF
--- a/go/test/endtoend/reparent/reparent_test.go
+++ b/go/test/endtoend/reparent/reparent_test.go
@@ -111,7 +111,7 @@ func TestReparentNoChoiceDownPrimary(t *testing.T) {
 	require.NotEqual(t, newPrimary.Alias, tab1.Alias)
 
 	// Check new primary has latest transaction.
-	err = checkInsertedValues(ctx, t, newPrimary, 2)
+	err = checkInsertedValues(ctx, t, newPrimary, insertVal)
 	require.NoError(t, err)
 
 	// bring back the old primary as a replica, check that it catches up
@@ -152,7 +152,7 @@ func TestReparentIgnoreReplicas(t *testing.T) {
 
 	newPrimary := getNewPrimary(t)
 	// Check new primary has latest transaction.
-	err = checkInsertedValues(ctx, t, newPrimary, 2)
+	err = checkInsertedValues(ctx, t, newPrimary, insertVal)
 	require.Nil(t, err)
 
 	// bring back the old primary as a replica, check that it catches up
@@ -343,9 +343,13 @@ func TestReparentWithDownReplica(t *testing.T) {
 
 	ctx := context.Background()
 
+	confirmReplication(t, tab1, []*cluster.Vttablet{tab2, tab3, tab4})
+
 	// Stop replica mysql Process
 	err := tab3.MysqlctlProcess.Stop()
 	require.NoError(t, err)
+
+	confirmReplication(t, tab1, []*cluster.Vttablet{tab2, tab4})
 
 	// Perform a graceful reparent operation. It will fail as one tablet is down.
 	out, err := prs(t, tab2)
@@ -365,7 +369,7 @@ func TestReparentWithDownReplica(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait until it gets the data
-	err = checkInsertedValues(ctx, t, tab3, 2)
+	err = checkInsertedValues(ctx, t, tab3, insertVal)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Extended timeout for replication restoration, which sometimes seems to
take a while in CI.

Additionally made test insert rows truly unique, which I'm not sure
fixed anything but makes it much easier to check the state of
replication.

Signed-off-by: Aaron Young <young@squareup.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->