### PR TITLE
throttler: don't allocate any resources unless it is actually enabled

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -165,34 +165,34 @@ func NewThrottler(env tabletenv.Env, ts *topo.Server, tabletTypeFunc func() topo
 			Size:               2,
 			IdleTimeoutSeconds: env.Config().OltpReadPool.IdleTimeoutSeconds,
 		}),
-
-		mysqlThrottleMetricChan: make(chan *mysql.MySQLThrottleMetric),
-
-		mysqlInventoryChan:     make(chan *mysql.Inventory, 1),
-		mysqlClusterProbesChan: make(chan *mysql.ClusterProbes),
-		mysqlInventory:         mysql.NewInventory(),
-
-		metricsQuery:     replicationLagQuery,
-		MetricsThreshold: sync2.NewAtomicFloat64(throttleThreshold.Seconds()),
-
-		throttledApps:          cache.New(cache.NoExpiration, 10*time.Second),
-		mysqlClusterThresholds: cache.New(cache.NoExpiration, 0),
-		aggregatedMetrics:      cache.New(aggregatedMetricsExpiration, aggregatedMetricsCleanup),
-		recentApps:             cache.New(recentAppsExpiration, time.Minute),
-		metricsHealth:          cache.New(cache.NoExpiration, 0),
-
-		tickers: [](*timer.SuspendableTicker){},
-
-		nonLowPriorityAppRequestsThrottled: cache.New(nonDeprioritizedAppMapExpiration, nonDeprioritizedAppMapInterval),
-
-		httpClient: base.SetupHTTPClient(0),
 	}
-	throttler.initThrottleTabletTypes()
-	throttler.ThrottleApp("abusing-app", time.Now().Add(time.Hour*24*365*10), defaultThrottleRatio)
-	throttler.check = NewThrottlerCheck(throttler)
-	throttler.initConfig("")
-	throttler.check.SelfChecks(context.Background())
 
+	if env.Config().EnableLagThrottler {
+		throttler.mysqlThrottleMetricChan = make(chan *mysql.MySQLThrottleMetric)
+
+		throttler.mysqlInventoryChan = make(chan *mysql.Inventory, 1)
+		throttler.mysqlClusterProbesChan = make(chan *mysql.ClusterProbes)
+		throttler.mysqlInventory = mysql.NewInventory()
+
+		throttler.metricsQuery = replicationLagQuery
+		throttler.MetricsThreshold = sync2.NewAtomicFloat64(throttleThreshold.Seconds())
+
+		throttler.throttledApps = cache.New(cache.NoExpiration, 10*time.Second)
+		throttler.mysqlClusterThresholds = cache.New(cache.NoExpiration, 0)
+		throttler.aggregatedMetrics = cache.New(aggregatedMetricsExpiration, aggregatedMetricsCleanup)
+		throttler.recentApps = cache.New(recentAppsExpiration, time.Minute)
+		throttler.metricsHealth = cache.New(cache.NoExpiration, 0)
+
+		throttler.tickers = [](*timer.SuspendableTicker){}
+		throttler.nonLowPriorityAppRequestsThrottled = cache.New(nonDeprioritizedAppMapExpiration, nonDeprioritizedAppMapInterval)
+
+		throttler.httpClient = base.SetupHTTPClient(0)
+		throttler.initThrottleTabletTypes()
+		throttler.ThrottleApp("abusing-app", time.Now().Add(time.Hour*24*365*10), defaultThrottleRatio)
+		throttler.check = NewThrottlerCheck(throttler)
+		throttler.initConfig("")
+		throttler.check.SelfChecks(context.Background())
+	}
 	return throttler
 }
 


### PR DESCRIPTION
## Description
Even when `-enable_lag_throttler` is not set, various caches are created and checked at intervals.
Specifically `nonLowPriorityAppRequestsThrottled` is checked every 100ms. This is wasteful. 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->