### PR TITLE
Gen4: Removed default case when dealing with weird/non-unique vindex predicate

### DIFF
--- a/go/vt/vtgate/planbuilder/jointree.go
+++ b/go/vt/vtgate/planbuilder/jointree.go
@@ -437,9 +437,6 @@ func (rp *routeTree) searchForNewVindexes(predicates []sqlparser.Expr) (bool, er
 					return false, err
 				}
 				newVindexFound = newVindexFound || found
-
-			default:
-				return false, semantics.Gen4NotSupportedF("%s", sqlparser.String(filter))
 			}
 		case *sqlparser.IsExpr:
 			found, err := rp.planIsExpr(node)

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2091,3 +2091,22 @@ Gen4 plan same as above
     "Vindex": "vindex1"
   }
 }
+
+# non unique predicate on vindex
+"select id from user where user.id > 5"
+{
+  "QueryType": "SELECT",
+  "Original": "select id from user where user.id \u003e 5",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select id from `user` where 1 != 1",
+    "Query": "select id from `user` where `user`.id \u003e 5",
+    "Table": "`user`"
+  }
+}
+Gen4 plan same as above


### PR DESCRIPTION
## Description
This pull request removes the `Gen4 unsupported error` when dealing with vindex predicates other than `equal`, `in`, `not in`, `like`.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
