### PR TITLE
increase conn killer check to double the tx timeout value

### DIFF
--- a/go/vt/vttablet/endtoend/connkilling/connkiller_test.go
+++ b/go/vt/vttablet/endtoend/connkilling/connkiller_test.go
@@ -35,7 +35,7 @@ func TestTxKillerKillsTransactionsInReservedConnections(t *testing.T) {
 	_, err := client.ReserveBeginExecute("select 42", nil, nil)
 	require.NoError(t, err)
 
-	assertIsKilledWithin5Seconds(t, client)
+	assertIsKilledWithin6Seconds(t, client)
 }
 
 func TestTxKillerDoesNotKillReservedConnectionsInUse(t *testing.T) {
@@ -73,7 +73,7 @@ func TestTxKillerCountsTimeFromTxStartedNotStatefulConnCreated(t *testing.T) {
 	_, err = client.Execute("select 43", nil)
 	require.NoError(t, err)
 
-	assertIsKilledWithin5Seconds(t, client)
+	assertIsKilledWithin6Seconds(t, client)
 }
 
 func TestTxKillerKillsTransactionThreeSecondsAfterCreation(t *testing.T) {
@@ -83,7 +83,7 @@ func TestTxKillerKillsTransactionThreeSecondsAfterCreation(t *testing.T) {
 	_, err := client.BeginExecute("select 42", nil, nil)
 	require.NoError(t, err)
 
-	assertIsKilledWithin5Seconds(t, client)
+	assertIsKilledWithin6Seconds(t, client)
 }
 
 func assertIsNotKilledOver5Second(t *testing.T, client *framework.QueryClient) {
@@ -94,10 +94,10 @@ func assertIsNotKilledOver5Second(t *testing.T, client *framework.QueryClient) {
 	}
 }
 
-func assertIsKilledWithin5Seconds(t *testing.T, client *framework.QueryClient) {
+func assertIsKilledWithin6Seconds(t *testing.T, client *framework.QueryClient) {
 	var err error
 	// when it is used once per second
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 6; i++ {
 		_, err = client.Execute("select 43", nil)
 		if err != nil {
 			break


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Updated the assert checking for tx killer to double the time for tx timeout value to cover up any delayed case.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->