### PR TITLE
servenv: add `--onclose_timeout` flag

### DIFF
--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -69,7 +69,7 @@ func Run(port int) {
 	}
 
 	log.Info("Shutting down gracefully")
-	Close()
+	fireOnCloseHooks(*onCloseTimeout)
 }
 
 // Close runs any registered exit hooks in parallel.

--- a/go/vt/servenv/servenv_test.go
+++ b/go/vt/servenv/servenv_test.go
@@ -57,3 +57,17 @@ func TestFireOnTermSyncHooksTimeout(t *testing.T) {
 		t.Errorf("finished = %v, want %v", finished, want)
 	}
 }
+
+func TestFireOnCloseHooksTimeout(t *testing.T) {
+	onCloseHooks = event.Hooks{}
+
+	OnClose(func() {
+		time.Sleep(1 * time.Second)
+	})
+
+	// we deliberatly test the flag to make sure it's not accidently set to a
+	// high value.
+	if finished, want := fireOnCloseHooks(*onCloseTimeout), false; finished != want {
+		t.Errorf("finished = %v, want %v", finished, want)
+	}
+}


### PR DESCRIPTION
This PR adds a new `--onclose_timeout` flag that adds a timeout for
`onClose` hooks. It's very similar to the existing `--onterm_timeout`
flag.

The flag will be helpful for services that use the `--lameduck-period` flag
in conjunction with `onClose` hooks. In this scenario, a service can't add 
timeouts to `onClose` hooks; hence blocking the service shutdown.
