### PR TITLE
Handle subquery merging with references correctly

### DIFF
--- a/go/vt/vtgate/planbuilder/route_test.go
+++ b/go/vt/vtgate/planbuilder/route_test.go
@@ -80,9 +80,9 @@ func TestSubqueryCanMerge(t *testing.T) {
 		{false, false, false, false, false, false, false, true, false},
 		{false, false, false, false, false, false, false, true, false},
 		{false, false, false, false, false, false, false, true, false},
-		{false, false, false, false, false, false, false, false, false},
-		{false, false, false, false, false, false, true, true, false},
 		{false, false, false, false, false, false, false, true, false},
+		{false, false, false, false, false, false, true, true, false},
+		{true, true, true, true, true, true, true, true, true},
 		{false, false, false, false, false, false, false, true, false},
 	}
 

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2214,3 +2214,21 @@
     "Table": "user_extra"
   }
 }
+
+"INSERT INTO main.user_privacy_consents (user_id, accepted_at)  SELECT user_id, accepted_at FROM (SELECT 1 as user_id, 1629194864 as accepted_at) AS tmp WHERE NOT EXISTS (SELECT user_id FROM main.user_privacy_consents WHERE user_id = 1)"
+{
+  "QueryType": "INSERT",
+  "Original": "INSERT INTO main.user_privacy_consents (user_id, accepted_at)  SELECT user_id, accepted_at FROM (SELECT 1 as user_id, 1629194864 as accepted_at) AS tmp WHERE NOT EXISTS (SELECT user_id FROM main.user_privacy_consents WHERE user_id = 1)",
+  "Instructions": {
+    "OperatorType": "Insert",
+    "Variant": "Unsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetTabletType": "MASTER",
+    "MultiShardAutocommit": false,
+    "Query": "insert into user_privacy_consents(user_id, accepted_at) select user_id, accepted_at from (select 1 as user_id, 1629194864 as accepted_at from dual) as tmp where not exists (select user_id from user_privacy_consents where user_id = 1)",
+    "TableName": "user_privacy_consents"
+  }
+}


### PR DESCRIPTION
## Description

Make sure to merge subqueries where either the inner or the outer are reference tables.

## Related Issue(s)
Fixes #8638


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required