### PR TITLE
Gen4: Move expand star inside the semantic analysis

### DIFF
--- a/go/vt/vtgate/planbuilder/abstract/fuzz.go
+++ b/go/vt/vtgate/planbuilder/abstract/fuzz.go
@@ -50,7 +50,7 @@ func FuzzAnalyse(data []byte) int {
 	}
 	switch stmt := tree.(type) {
 	case *sqlparser.Select:
-		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
+		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{}, semantics.NoRewrite)
 		if err != nil {
 			return 0
 		}

--- a/go/vt/vtgate/planbuilder/abstract/fuzz.go
+++ b/go/vt/vtgate/planbuilder/abstract/fuzz.go
@@ -50,7 +50,7 @@ func FuzzAnalyse(data []byte) int {
 	}
 	switch stmt := tree.(type) {
 	case *sqlparser.Select:
-		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error {return nil})
+		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
 		if err != nil {
 			return 0
 		}

--- a/go/vt/vtgate/planbuilder/abstract/fuzz.go
+++ b/go/vt/vtgate/planbuilder/abstract/fuzz.go
@@ -50,7 +50,7 @@ func FuzzAnalyse(data []byte) int {
 	}
 	switch stmt := tree.(type) {
 	case *sqlparser.Select:
-		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{})
+		semTable, err := semantics.Analyze(stmt, "", &fakeFuzzSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error {return nil})
 		if err != nil {
 			return 0
 		}

--- a/go/vt/vtgate/planbuilder/abstract/operator_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/operator_test.go
@@ -245,7 +245,7 @@ JoinPredicates:
 		t.Run(fmt.Sprintf("%d %s", i, sql), func(t *testing.T) {
 			tree, err := sqlparser.Parse(sql)
 			require.NoError(t, err)
-			semTable, err := semantics.Analyze(tree.(sqlparser.SelectStatement), "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
+			semTable, err := semantics.Analyze(tree.(sqlparser.SelectStatement), "", &semantics.FakeSI{}, semantics.NoRewrite)
 			require.NoError(t, err)
 			optree, err := CreateOperatorFromSelect(tree.(*sqlparser.Select), semTable)
 			require.NoError(t, err)

--- a/go/vt/vtgate/planbuilder/abstract/operator_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/operator_test.go
@@ -245,7 +245,7 @@ JoinPredicates:
 		t.Run(fmt.Sprintf("%d %s", i, sql), func(t *testing.T) {
 			tree, err := sqlparser.Parse(sql)
 			require.NoError(t, err)
-			semTable, err := semantics.Analyze(tree.(sqlparser.SelectStatement), "", &semantics.FakeSI{})
+			semTable, err := semantics.Analyze(tree.(sqlparser.SelectStatement), "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
 			require.NoError(t, err)
 			optree, err := CreateOperatorFromSelect(tree.(*sqlparser.Select), semTable)
 			require.NoError(t, err)

--- a/go/vt/vtgate/planbuilder/abstract/queryprojection_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/queryprojection_test.go
@@ -93,7 +93,7 @@ func TestQP(t *testing.T) {
 			require.NoError(t, err)
 
 			sel := stmt.(*sqlparser.Select)
-			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
+			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, semantics.NoRewrite)
 			require.NoError(t, err)
 
 			qp, err := CreateQPFromSelect(sel)
@@ -200,7 +200,7 @@ func TestQPSimplifiedExpr(t *testing.T) {
 			ast, err := sqlparser.Parse(tc.query)
 			require.NoError(t, err)
 			sel := ast.(*sqlparser.Select)
-			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
+			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, semantics.NoRewrite)
 			require.NoError(t, err)
 
 			qp, err := CreateQPFromSelect(sel)

--- a/go/vt/vtgate/planbuilder/abstract/queryprojection_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/queryprojection_test.go
@@ -93,7 +93,7 @@ func TestQP(t *testing.T) {
 			require.NoError(t, err)
 
 			sel := stmt.(*sqlparser.Select)
-			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{})
+			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
 			require.NoError(t, err)
 
 			qp, err := CreateQPFromSelect(sel)
@@ -200,7 +200,7 @@ func TestQPSimplifiedExpr(t *testing.T) {
 			ast, err := sqlparser.Parse(tc.query)
 			require.NoError(t, err)
 			sel := ast.(*sqlparser.Select)
-			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{})
+			_, err = semantics.Analyze(sel, "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
 			require.NoError(t, err)
 
 			qp, err := CreateQPFromSelect(sel)

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -745,7 +745,7 @@ func exerciseAnalyzer(query, database string, s semantics.SchemaInformation) {
 		return
 	}
 
-	_, _ = semantics.Analyze(sel, database, s)
+	_, _ = semantics.Analyze(sel, database, s, starRewrite)
 }
 
 func BenchmarkSelectVsDML(b *testing.B) {

--- a/go/vt/vtgate/planbuilder/rewrite.go
+++ b/go/vt/vtgate/planbuilder/rewrite.go
@@ -84,11 +84,21 @@ func expandTableColumns(tables []semantics.TableInfo, starExpr *sqlparser.StarEx
 		if err != nil {
 			return false, nil, err
 		}
+
+		withAlias := len(tables) > 1
+		withQualifier := withAlias || !tbl.GetExpr().As.IsEmpty()
 		for _, col := range tbl.GetColumns() {
-			colNames = append(colNames, &sqlparser.AliasedExpr{
-				Expr: sqlparser.NewColNameWithQualifier(col.Name, tblName),
-				As:   sqlparser.NewColIdent(col.Name),
-			})
+			var colName *sqlparser.ColName
+			var alias sqlparser.ColIdent
+			if withQualifier {
+				colName = sqlparser.NewColNameWithQualifier(col.Name, tblName)
+			} else {
+				colName = sqlparser.NewColName(col.Name)
+			}
+			if withAlias {
+				alias = sqlparser.NewColIdent(col.Name)
+			}
+			colNames = append(colNames, &sqlparser.AliasedExpr{Expr: colName, As: alias})
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/rewrite_test.go
@@ -227,7 +227,7 @@ func TestSubqueryRewrite(t *testing.T) {
 			reservedVars := sqlparser.NewReservedVars("vtg", vars)
 			selectStatement, isSelectStatement := ast.(*sqlparser.Select)
 			require.True(t, isSelectStatement, "analyzer expects a select statement")
-			semTable, err := semantics.Analyze(selectStatement, "", &semantics.FakeSI{}, func(statement sqlparser.SelectStatement, semTable *semantics.SemTable) error { return nil })
+			semTable, err := semantics.Analyze(selectStatement, "", &semantics.FakeSI{}, semantics.NoRewrite)
 			require.NoError(t, err)
 			err = subqueryRewrite(selectStatement, semTable, reservedVars)
 			require.NoError(t, err)

--- a/go/vt/vtgate/planbuilder/rewrite_test.go
+++ b/go/vt/vtgate/planbuilder/rewrite_test.go
@@ -73,16 +73,16 @@ func TestExpandStar(t *testing.T) {
 		expErr string
 	}{{
 		sql:    "select * from t1",
-		expSQL: "select t1.a as a, t1.b as b, t1.c as c from t1",
+		expSQL: "select a, b, c from t1",
 	}, {
 		sql:    "select t1.* from t1",
-		expSQL: "select t1.a as a, t1.b as b, t1.c as c from t1",
+		expSQL: "select a, b, c from t1",
 	}, {
 		sql:    "select *, 42, t1.* from t1",
-		expSQL: "select t1.a as a, t1.b as b, t1.c as c, 42, t1.a as a, t1.b as b, t1.c as c from t1",
+		expSQL: "select a, b, c, 42, a, b, c from t1",
 	}, {
 		sql:    "select 42, t1.* from t1",
-		expSQL: "select 42, t1.a as a, t1.b as b, t1.c as c from t1",
+		expSQL: "select 42, a, b, c from t1",
 	}, {
 		sql:    "select * from t1, t2",
 		expSQL: "select t1.a as a, t1.b as b, t1.c as c, t2.c1 as c1, t2.c2 as c2 from t1, t2",
@@ -143,7 +143,7 @@ func TestSemTableDependenciesAfterExpandStar(t *testing.T) {
 		expandedCol int
 	}{{
 		sql:      "select a, * from t1",
-		expSQL:   "select a, t1.a as a from t1",
+		expSQL:   "select a, a from t1",
 		otherTbl: -1, sameTbl: 0, expandedCol: 1,
 	}, {
 		sql:      "select t2.a, t1.a, t1.* from t1, t2",

--- a/go/vt/vtgate/planbuilder/route_planning.go
+++ b/go/vt/vtgate/planbuilder/route_planning.go
@@ -98,12 +98,12 @@ func newBuildSelectPlan(sel *sqlparser.Select, reservedVars *sqlparser.ReservedV
 	if ks, _ := vschema.DefaultKeyspace(); ks != nil {
 		ksName = ks.Name
 	}
-	semTable, err := semantics.Analyze(sel, ksName, vschema)
+	semTable, err := semantics.Analyze(sel, ksName, vschema, starRewrite)
 	if err != nil {
 		return nil, err
 	}
 
-	sel, err = rewrite(sel, semTable, reservedVars)
+	err = subqueryRewrite(sel, semTable, reservedVars)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.txt
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases_no_default_keyspace.txt
@@ -112,7 +112,7 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "Query": "create view view_a as select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative"
+    "Query": "create view view_a as select user_id, col1, col2 from authoritative"
   }
 }
 
@@ -166,7 +166,7 @@ Gen4 plan same as above
       "Name": "user",
       "Sharded": true
     },
-    "Query": "create view view_a as select a.user_id as user_id, a.col1 as col1, a.col2 as col2 from authoritative as a"
+    "Query": "create view view_a as select a.user_id, a.col1, a.col2 from authoritative as a"
   }
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -2190,25 +2190,7 @@ Gen4 plan same as above
     "Vindex": "vindex1"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select * from samecolvin where col = :col",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select samecolvin.col as col from samecolvin where 1 != 1",
-    "Query": "select samecolvin.col as col from samecolvin where col = :col",
-    "Table": "samecolvin",
-    "Values": [
-      ":col"
-    ],
-    "Vindex": "vindex1"
-  }
-}
+Gen4 plan same as above
 
 # non unique predicate on vindex
 "select id from user where user.id > 5"

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -299,23 +299,7 @@ Gen4 plan same as above
     "Table": "authoritative"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select * from authoritative order by user_id",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.user_id) from authoritative where 1 != 1",
-    "OrderBy": "(0|3) ASC",
-    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.user_id) from authoritative order by user_id asc",
-    "ResultColumns": 3,
-    "Table": "authoritative"
-  }
-}
+Gen4 plan same as above
 
 # ORDER BY works for select * from authoritative table
 "select * from authoritative order by col1"
@@ -336,23 +320,7 @@ Gen4 plan same as above
     "Table": "authoritative"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select * from authoritative order by col1",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.col1) from authoritative where 1 != 1",
-    "OrderBy": "(1|3) ASC",
-    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2, weight_string(authoritative.col1) from authoritative order by col1 asc",
-    "ResultColumns": 3,
-    "Table": "authoritative"
-  }
-}
+Gen4 plan same as above
 
 # ORDER BY on scatter with text column
 "select a, textcol1, b from user order by a, textcol1, b"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -272,21 +272,7 @@ Gen4 plan same as above
     "Table": "authoritative"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select * from authoritative",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative where 1 != 1",
-    "Query": "select authoritative.user_id as user_id, authoritative.col1 as col1, authoritative.col2 as col2 from authoritative",
-    "Table": "authoritative"
-  }
-}
+Gen4 plan same as above
 
 # select * from join of authoritative tables
 "select * from authoritative a join authoritative b on a.user_id=b.user_id"
@@ -343,21 +329,7 @@ Gen4 error: Unknown table 'a'
     "Table": "authoritative"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select a.* from authoritative a",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select a.user_id as user_id, a.col1 as col1, a.col2 as col2 from authoritative as a where 1 != 1",
-    "Query": "select a.user_id as user_id, a.col1 as col1, a.col2 as col2 from authoritative as a",
-    "Table": "authoritative"
-  }
-}
+Gen4 plan same as above
 
 # select * from intermixing of authoritative table with non-authoritative results in no expansion
 "select * from authoritative join user on authoritative.user_id=user.id"

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -64,18 +64,7 @@ func Analyze(statement sqlparser.SelectStatement, currentDb string, si SchemaInf
 		return nil, err
 	}
 
-	semTable := &SemTable{
-		ExprBaseTableDeps: analyzer.binder.exprRecursiveDeps,
-		ExprDeps:          analyzer.binder.exprDeps,
-		exprTypes:         analyzer.typer.exprTypes,
-		Tables:            analyzer.tables.Tables,
-		selectScope:       analyzer.scoper.rScope,
-		ProjectionErr:     analyzer.projErr,
-		Comments:          statement.GetComments(),
-		SubqueryMap:       analyzer.binder.subqueryMap,
-		SubqueryRef:       analyzer.binder.subqueryRef,
-		ColumnEqualities:  map[columnName][]sqlparser.Expr{},
-	}
+	semTable := analyzer.newSemTable(statement)
 
 	if err = rewrite(statement, semTable); err != nil {
 		return nil, err
@@ -86,19 +75,23 @@ func Analyze(statement sqlparser.SelectStatement, currentDb string, si SchemaInf
 		return nil, err
 	}
 
-	semTable = &SemTable{
-		ExprBaseTableDeps: analyzer.binder.exprRecursiveDeps,
-		ExprDeps:          analyzer.binder.exprDeps,
-		exprTypes:         analyzer.typer.exprTypes,
-		Tables:            analyzer.tables.Tables,
-		selectScope:       analyzer.scoper.rScope,
-		ProjectionErr:     analyzer.projErr,
+	semTable.ProjectionErr = analyzer.projErr
+	return semTable, nil
+}
+
+func (a analyzer) newSemTable(statement sqlparser.SelectStatement) *SemTable {
+	return &SemTable{
+		ExprBaseTableDeps: a.binder.exprRecursiveDeps,
+		ExprDeps:          a.binder.exprDeps,
+		exprTypes:         a.typer.exprTypes,
+		Tables:            a.tables.Tables,
+		selectScope:       a.scoper.rScope,
+		ProjectionErr:     a.projErr,
 		Comments:          statement.GetComments(),
-		SubqueryMap:       analyzer.binder.subqueryMap,
-		SubqueryRef:       analyzer.binder.subqueryRef,
+		SubqueryMap:       a.binder.subqueryMap,
+		SubqueryRef:       a.binder.subqueryRef,
 		ColumnEqualities:  map[columnName][]sqlparser.Expr{},
 	}
-	return semTable, nil
 }
 
 func (a *analyzer) setError(err error) {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -57,8 +57,15 @@ func newAnalyzer(dbName string, si SchemaInformation) *analyzer {
 	return a
 }
 
+type rewriteFunc = func(statement sqlparser.SelectStatement, semTable *SemTable) error
+
+// NoRewrite is a helper implementation for tests
+var NoRewrite = func(statement sqlparser.SelectStatement, semTable *SemTable) error {
+	return nil
+}
+
 // Analyze analyzes the parsed query.
-func Analyze(statement sqlparser.SelectStatement, currentDb string, si SchemaInformation, rewrite func(statement sqlparser.SelectStatement, semTable *SemTable) error) (*SemTable, error) {
+func Analyze(statement sqlparser.SelectStatement, currentDb string, si SchemaInformation, rewrite rewriteFunc) (*SemTable, error) {
 	analyzer := newAnalyzer(currentDb, si)
 
 	// Analysis for initial scope

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package semantics
 
 import (
-	"strings"
 	"testing"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -402,9 +401,6 @@ func TestNotUniqueTableName(t *testing.T) {
 
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
-			if strings.Contains(query, ") as") {
-				t.Skip("derived tables not implemented")
-			}
 			parse, _ := sqlparser.Parse(query)
 			_, err := Analyze(parse.(sqlparser.SelectStatement), "test", &FakeSI{}, NoRewrite)
 			require.Error(t, err)

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -128,7 +128,7 @@ func TestBindingSingleTableNegative(t *testing.T) {
 		t.Run(query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query)
 			require.NoError(t, err)
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			_, err = Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{}, NoRewrite)
 			require.Error(t, err)
 		})
 	}
@@ -275,7 +275,7 @@ func TestBindingSingleAliasedTable(t *testing.T) {
 					Tables: map[string]*vindexes.Table{
 						"t": {Name: sqlparser.NewTableIdent("t")},
 					},
-				}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+				}, NoRewrite)
 				require.Error(t, err)
 			})
 		}
@@ -375,7 +375,7 @@ func TestBindingMultiTable(t *testing.T) {
 						"tabl": {Name: sqlparser.NewTableIdent("tabl")},
 						"foo":  {Name: sqlparser.NewTableIdent("foo")},
 					},
-				}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+				}, NoRewrite)
 				require.Error(t, err)
 			})
 		}
@@ -406,7 +406,7 @@ func TestNotUniqueTableName(t *testing.T) {
 				t.Skip("derived tables not implemented")
 			}
 			parse, _ := sqlparser.Parse(query)
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "test", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "test", &FakeSI{}, NoRewrite)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "Not unique table/alias")
 		})
@@ -421,7 +421,7 @@ func TestMissingTable(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			parse, _ := sqlparser.Parse(query)
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{}, NoRewrite)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "symbol t.col not found")
 		})
@@ -521,7 +521,7 @@ func TestUnknownColumnMap2(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			si := &FakeSI{Tables: test.schema}
-			tbl, err := Analyze(parse.(sqlparser.SelectStatement), "", si, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			tbl, err := Analyze(parse.(sqlparser.SelectStatement), "", si, NoRewrite)
 			require.NoError(t, err)
 
 			if test.err {
@@ -560,7 +560,7 @@ func TestUnknownPredicate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			si := &FakeSI{Tables: test.schema}
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "", si, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "", si, NoRewrite)
 			if test.err {
 				require.Error(t, err)
 			} else {
@@ -588,7 +588,7 @@ func TestScoping(t *testing.T) {
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
-			}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			}, NoRewrite)
 			if query.errorMessage == "" {
 				require.NoError(t, err)
 			} else {
@@ -652,7 +652,7 @@ func TestScopingWDerivedTables(t *testing.T) {
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
-			}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+			}, NoRewrite)
 			if query.errorMessage != "" {
 				require.EqualError(t, err, query.errorMessage)
 			} else {
@@ -688,7 +688,7 @@ func parseAndAnalyze(t *testing.T, query, dbName string) (sqlparser.Statement, *
 			"t1": {Name: sqlparser.NewTableIdent("t1"), Columns: cols1, ColumnListAuthoritative: true},
 			"t2": {Name: sqlparser.NewTableIdent("t2"), Columns: cols2, ColumnListAuthoritative: true},
 		},
-	}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
+	}, NoRewrite)
 	require.NoError(t, err)
 	return parse, semTable
 }

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -128,7 +128,7 @@ func TestBindingSingleTableNegative(t *testing.T) {
 		t.Run(query, func(t *testing.T) {
 			parse, err := sqlparser.Parse(query)
 			require.NoError(t, err)
-			_, err = Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{})
+			_, err = Analyze(parse.(sqlparser.SelectStatement), "d", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			require.Error(t, err)
 		})
 	}
@@ -275,7 +275,7 @@ func TestBindingSingleAliasedTable(t *testing.T) {
 					Tables: map[string]*vindexes.Table{
 						"t": {Name: sqlparser.NewTableIdent("t")},
 					},
-				})
+				}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 				require.Error(t, err)
 			})
 		}
@@ -375,7 +375,7 @@ func TestBindingMultiTable(t *testing.T) {
 						"tabl": {Name: sqlparser.NewTableIdent("tabl")},
 						"foo":  {Name: sqlparser.NewTableIdent("foo")},
 					},
-				})
+				}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 				require.Error(t, err)
 			})
 		}
@@ -406,7 +406,7 @@ func TestNotUniqueTableName(t *testing.T) {
 				t.Skip("derived tables not implemented")
 			}
 			parse, _ := sqlparser.Parse(query)
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "test", &FakeSI{})
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "test", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "Not unique table/alias")
 		})
@@ -421,7 +421,7 @@ func TestMissingTable(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			parse, _ := sqlparser.Parse(query)
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{})
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "", &FakeSI{}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "symbol t.col not found")
 		})
@@ -521,7 +521,7 @@ func TestUnknownColumnMap2(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			si := &FakeSI{Tables: test.schema}
-			tbl, err := Analyze(parse.(sqlparser.SelectStatement), "", si)
+			tbl, err := Analyze(parse.(sqlparser.SelectStatement), "", si, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			require.NoError(t, err)
 
 			if test.err {
@@ -560,7 +560,7 @@ func TestUnknownPredicate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			si := &FakeSI{Tables: test.schema}
-			_, err := Analyze(parse.(sqlparser.SelectStatement), "", si)
+			_, err := Analyze(parse.(sqlparser.SelectStatement), "", si, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			if test.err {
 				require.Error(t, err)
 			} else {
@@ -588,7 +588,7 @@ func TestScoping(t *testing.T) {
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
-			})
+			}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			if query.errorMessage == "" {
 				require.NoError(t, err)
 			} else {
@@ -652,7 +652,7 @@ func TestScopingWDerivedTables(t *testing.T) {
 				Tables: map[string]*vindexes.Table{
 					"t": {Name: sqlparser.NewTableIdent("t")},
 				},
-			})
+			}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 			if query.errorMessage != "" {
 				require.EqualError(t, err, query.errorMessage)
 			} else {
@@ -688,7 +688,7 @@ func parseAndAnalyze(t *testing.T, query, dbName string) (sqlparser.Statement, *
 			"t1": {Name: sqlparser.NewTableIdent("t1"), Columns: cols1, ColumnListAuthoritative: true},
 			"t2": {Name: sqlparser.NewTableIdent("t2"), Columns: cols2, ColumnListAuthoritative: true},
 		},
-	})
+	}, func(statement sqlparser.SelectStatement, semTable *SemTable) error { return nil })
 	require.NoError(t, err)
 	return parse, semTable
 }

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -16,22 +16,32 @@ limitations under the License.
 
 package semantics
 
-import "vitess.io/vitess/go/vt/sqlparser"
+import (
+	"reflect"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
 
 // scoper is responsible for figuring out the scoping for the query,
 // and keeps the current scope when walking the tree
 type scoper struct {
 	rScope       map[*sqlparser.Select]*scope
 	wScope       map[*sqlparser.Select]*scope
-	sqlNodeScope map[sqlparser.SQLNode]*scope
+	sqlNodeScope map[scopeKey]*scope
 	scopes       []*scope
+}
+
+type scopeKey struct {
+	orderBy bool
+	groupBy bool
+	node    sqlparser.SQLNode
 }
 
 func newScoper() *scoper {
 	return &scoper{
 		rScope:       map[*sqlparser.Select]*scope{},
 		wScope:       map[*sqlparser.Select]*scope{},
-		sqlNodeScope: map[sqlparser.SQLNode]*scope{},
+		sqlNodeScope: map[scopeKey]*scope{},
 	}
 }
 
@@ -46,7 +56,7 @@ func (s *scoper) down(cursor *sqlparser.Cursor) {
 
 		s.rScope[node] = currScope
 		s.wScope[node] = newScope(nil)
-		s.sqlNodeScope[node] = currScope
+		s.sqlNodeScope[scopeKey{node: node}] = currScope
 	case sqlparser.TableExpr:
 		if isParentSelect(cursor) {
 			// when checking the expressions used in JOIN conditions, special rules apply where the ON expression
@@ -56,12 +66,12 @@ func (s *scoper) down(cursor *sqlparser.Cursor) {
 			nScope := newScope(nil)
 			nScope.selectStmt = cursor.Parent().(*sqlparser.Select)
 			s.push(nScope)
-			s.sqlNodeScope[node] = nScope
+			s.sqlNodeScope[scopeKey{node: node}] = nScope
 		}
 	case *sqlparser.Union:
 		scope := newScope(s.currentScope())
 		s.push(scope)
-		s.sqlNodeScope[node] = scope
+		s.sqlNodeScope[scopeKey{node: node}] = scope
 	case sqlparser.SelectExprs:
 		sel, parentIsSelect := cursor.Parent().(*sqlparser.Select)
 		if !parentIsSelect {
@@ -74,29 +84,16 @@ func (s *scoper) down(cursor *sqlparser.Cursor) {
 		}
 
 		wScope.tables = append(wScope.tables, createVTableInfoForExpressions(node))
-	}
-}
-
-func (s *scoper) downPost(cursor *sqlparser.Cursor) {
-	switch node := cursor.Node().(type) {
-	case *sqlparser.Select:
-		s.push(s.sqlNodeScope[node])
-	case sqlparser.TableExpr:
-		if isParentSelect(cursor) {
-			s.push(s.sqlNodeScope[node])
-		}
-	case *sqlparser.Union:
-		s.push(s.sqlNodeScope[node])
-	case sqlparser.OrderBy, sqlparser.GroupBy:
-		// ORDER BY and GROUP BY live in a special scope where they can access the SELECT expressions declared,
-		// but also the tables in the FROM clause
-		s.changeScopeForOrderBy(cursor)
+	case sqlparser.OrderBy:
+		s.changeScopeForOrderBy(cursor, scopeKey{node: cursor.Parent(), orderBy: true})
+	case sqlparser.GroupBy:
+		s.changeScopeForOrderBy(cursor, scopeKey{node: cursor.Parent(), groupBy: true})
 	}
 }
 
 func (s *scoper) up(cursor *sqlparser.Cursor) error {
 	switch cursor.Node().(type) {
-	case *sqlparser.Union, *sqlparser.Select:
+	case sqlparser.SelectStatement, sqlparser.OrderBy, sqlparser.GroupBy:
 		s.popScope()
 	case sqlparser.TableExpr:
 		if isParentSelect(cursor) {
@@ -115,19 +112,51 @@ func (s *scoper) up(cursor *sqlparser.Cursor) error {
 	return nil
 }
 
-func (s *scoper) upPost(cursor *sqlparser.Cursor) error {
-	switch cursor.Node().(type) {
-	case *sqlparser.Union, *sqlparser.Select, sqlparser.OrderBy, sqlparser.GroupBy:
-		s.popScope()
-	case sqlparser.TableExpr:
-		if isParentSelect(cursor) {
-			s.popScope()
+func (s *scoper) downPost(cursor *sqlparser.Cursor) {
+	var scope *scope
+	var found bool
+
+	switch node := cursor.Node().(type) {
+	case sqlparser.OrderBy:
+		scope, found = s.sqlNodeScope[scopeKey{node: cursor.Parent(), orderBy: true}]
+	case sqlparser.GroupBy:
+		scope, found = s.sqlNodeScope[scopeKey{node: cursor.Parent(), groupBy: true}]
+	default:
+		if validAsMapKey(node) {
+			scope, found = s.sqlNodeScope[scopeKey{node: node}]
 		}
+	}
+
+	if found {
+		s.push(scope)
+	}
+}
+
+func validAsMapKey(s sqlparser.SQLNode) bool {
+	return reflect.TypeOf(s).Comparable()
+}
+
+func (s *scoper) upPost(cursor *sqlparser.Cursor) error {
+	var found bool
+
+	switch node := cursor.Node().(type) {
+	case sqlparser.OrderBy:
+		_, found = s.sqlNodeScope[scopeKey{node: cursor.Parent(), orderBy: true}]
+	case sqlparser.GroupBy:
+		_, found = s.sqlNodeScope[scopeKey{node: cursor.Parent(), groupBy: true}]
+	default:
+		if validAsMapKey(node) {
+			_, found = s.sqlNodeScope[scopeKey{node: node}]
+		}
+	}
+
+	if found {
+		s.popScope()
 	}
 	return nil
 }
 
-func (s *scoper) changeScopeForOrderBy(cursor *sqlparser.Cursor) {
+func (s *scoper) changeScopeForOrderBy(cursor *sqlparser.Cursor, k scopeKey) {
 	sel, ok := cursor.Parent().(*sqlparser.Select)
 	if !ok {
 		return
@@ -137,6 +166,7 @@ func (s *scoper) changeScopeForOrderBy(cursor *sqlparser.Cursor) {
 	incomingScope := s.currentScope()
 	nScope := newScope(incomingScope)
 	s.push(nScope)
+	s.sqlNodeScope[k] = nScope
 	wScope := s.wScope[sel]
 	nScope.tables = append(nScope.tables, wScope.tables...)
 	nScope.selectStmt = incomingScope.selectStmt

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -77,7 +77,7 @@ func (s *scoper) down(cursor *sqlparser.Cursor) {
 	}
 }
 
-func (s *scoper) downTwo(cursor *sqlparser.Cursor) {
+func (s *scoper) downPost(cursor *sqlparser.Cursor) {
 	switch node := cursor.Node().(type) {
 	case *sqlparser.Select:
 		s.push(s.sqlNodeScope[node])
@@ -115,7 +115,7 @@ func (s *scoper) up(cursor *sqlparser.Cursor) error {
 	return nil
 }
 
-func (s *scoper) upTwo(cursor *sqlparser.Cursor) error {
+func (s *scoper) upPost(cursor *sqlparser.Cursor) error {
 	switch cursor.Node().(type) {
 	case *sqlparser.Union, *sqlparser.Select, sqlparser.OrderBy, sqlparser.GroupBy:
 		s.popScope()

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -17,8 +17,6 @@ limitations under the License.
 package semantics
 
 import (
-	"reflect"
-
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
@@ -497,7 +495,7 @@ func (d ExprDependencies) Dependencies(expr sqlparser.Expr) TableSet {
 	// that have already set dependencies.
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		expr, ok := node.(sqlparser.Expr)
-		if !ok || !reflect.TypeOf(expr).Comparable() {
+		if !ok || !validAsMapKey(expr) {
 			// if this is not an expression, or it is an expression we can't use as a map-key,
 			// just carry on down the tree
 			return true, nil


### PR DESCRIPTION
## Description

This pull request moves the expand star inside the semantic analysis. Before, we were doing expand star once the semantic analysis was done, which led to the issue #8575.

## Related Issue(s)
Resolves #8575

#7280 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
