### PR TITLE
update MAINTAINERS and CODEOWNERS for deepthi, pH14 and vmg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ bootstrap.sh @deepthi
 /examples/local @rohit-nayak-ps
 /examples/operator @askdba
 /examples/region_sharding @deepthi
-/java/ @harshit-gangal
+/java/ @harshit-gangal @pH14
 /go/cache @vmg
 /go/cmd/vtadmin @ajm188 @doeg
 /go/cmd/vtctldclient @ajm188 @doeg

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,21 +19,21 @@ The following is the full list, alphabetically ordered.
 * Rohit Nayak ([rohit-nayak-ps](https://github.com/rohit-nayak-ps)) rohit@planetscale.com
 * Shlomi Noach ([shlomi-noach](https://github.com/shlomi-noach)) shlomi@planetscale.com
 * Sugu Sougoumarane ([sougou](https://github.com/sougou)) sougou@planetscale.com
-* Vicent Marti ([vmg])(https://github.com/vmg)) vmg@planetscale.com
+* Vicent Marti ([vmg](https://github.com/vmg)) vmg@planetscale.com
 
 ## Areas of expertise
 
 ### General Vitess
-sougou, demmer, rafael, dweitzman, tirsen, askdba, enisoc
+sougou, deepthi, demmer, rafael, dweitzman, tirsen, askdba, enisoc
 
 ### Builds
 dkhenry, shlomi-noach, ajm188, vmg
 
 ### Resharding
-sougou, rafael, tirsen, dweitzman, systay, rohit-nayak-ps
+sougou, rafael, tirsen, dweitzman, systay, rohit-nayak-ps, deepthi
 
 ### Parser
-sougou, dweitzman, deepthi, systay, harshit-gangal
+sougou, dweitzman, systay, harshit-gangal, vmg
 
 ### Performance
 vmg


### PR DESCRIPTION
## Description
Add @deepthi to general vitess and resharding, remove from parser. EDIT: Add @vmg to parser.
Fix link to @vmg's GH profile
Add @ph14 to CODEOWNERS (replacing #6841)

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->