### PR TITLE
engine: add support for finding a plan's affected shards

### DIFF
--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -22,6 +22,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
@@ -54,6 +55,16 @@ func (c *Concatenate) GetTableName() string {
 		res = formatTwoOptionsNicely(res, c.Sources[i].GetTableName())
 	}
 	return res
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (c *Concatenate) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	for _, src := range c.Sources {
+		if err := src.GetExecShards(vcursor, bindVars, each); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func formatTwoOptionsNicely(a, b string) string {

--- a/go/vt/vtgate/engine/dbddl.go
+++ b/go/vt/vtgate/engine/dbddl.go
@@ -94,6 +94,12 @@ func (c *DBDDL) GetTableName() string {
 	return ""
 }
 
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (c *DBDDL) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// The DBDDL primitive is not shard-aware, it acts globally on the cluster
+	return nil
+}
+
 // Execute implements the Primitive interface
 func (c *DBDDL) Execute(vcursor VCursor, _ map[string]*querypb.BindVariable, _ bool) (*sqltypes.Result, error) {
 	name := vcursor.GetDBDDLPluginName()

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
@@ -152,6 +153,11 @@ func (d *Distinct) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (d *Distinct) GetTableName() string {
 	return d.Source.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (d *Distinct) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return d.Source.GetExecShards(vcursor, bindVars, each)
 }
 
 // GetFields implements the Primitive interface

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/srvtopo"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -61,6 +62,10 @@ func (f *fakePrimitive) GetKeyspaceName() string {
 
 func (f *fakePrimitive) GetTableName() string {
 	return "fakeTable"
+}
+
+func (f *fakePrimitive) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return nil
 }
 
 func (f *fakePrimitive) Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -22,6 +22,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 )
 
 var _ Primitive = (*Join)(nil)
@@ -166,6 +167,17 @@ func (jn *Join) GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVari
 	}
 	result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
 	return result, nil
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (jn *Join) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	if err := jn.Left.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	if err := jn.Right.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Inputs returns the input primitives for this join

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -49,6 +50,11 @@ func (l *Limit) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (l *Limit) GetTableName() string {
 	return l.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (l *Limit) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return l.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // Execute satisfies the Primtive interface.

--- a/go/vt/vtgate/engine/memory_sort.go
+++ b/go/vt/vtgate/engine/memory_sort.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -57,6 +58,11 @@ func (ms *MemorySort) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (ms *MemorySort) GetTableName() string {
 	return ms.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (ms *MemorySort) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return ms.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // SetTruncateColumnCount sets the truncate column count.

--- a/go/vt/vtgate/engine/mstream.go
+++ b/go/vt/vtgate/engine/mstream.go
@@ -21,6 +21,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
@@ -56,6 +57,18 @@ func (m *MStream) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (m *MStream) GetTableName() string {
 	return m.TableName
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (m *MStream) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	rss, _, err := vcursor.ResolveDestinations(m.Keyspace.Name, nil, []key.Destination{m.TargetDestination})
+	if err != nil {
+		return err
+	}
+	for _, rs := range rss {
+		each(rs)
+	}
+	return nil
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/srvtopo"
 
 	"google.golang.org/protobuf/proto"
 
@@ -180,6 +181,11 @@ func (oa *OrderedAggregate) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (oa *OrderedAggregate) GetTableName() string {
 	return oa.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (oa *OrderedAggregate) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return oa.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // SetTruncateColumnCount sets the truncate column count.

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -186,6 +186,7 @@ type (
 		RouteType() string
 		GetKeyspaceName() string
 		GetTableName() string
+		GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(*srvtopo.ResolvedShard)) error
 		Execute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error)
 		StreamExecute(vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error
 		GetFields(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/projection.go
+++ b/go/vt/vtgate/engine/projection.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
@@ -29,6 +30,11 @@ func (p *Projection) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (p *Projection) GetTableName() string {
 	return p.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (p *Projection) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return p.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/pullout_subquery.go
+++ b/go/vt/vtgate/engine/pullout_subquery.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -59,6 +60,17 @@ func (ps *PulloutSubquery) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (ps *PulloutSubquery) GetTableName() string {
 	return ps.Underlying.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (ps *PulloutSubquery) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	if err := ps.Subquery.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	if err := ps.Underlying.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Execute satisfies the Primitive interface.

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -20,6 +20,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
@@ -58,6 +59,11 @@ func (r *RenameFields) GetKeyspaceName() string {
 // GetTableName implements the primitive interface
 func (r *RenameFields) GetTableName() string {
 	return r.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (r *RenameFields) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return r.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // Execute implements the primitive interface

--- a/go/vt/vtgate/engine/replace_variables.go
+++ b/go/vt/vtgate/engine/replace_variables.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 )
 
 var _ Primitive = (*ReplaceVariables)(nil)
@@ -47,6 +48,11 @@ func (r *ReplaceVariables) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (r *ReplaceVariables) GetTableName() string {
 	return r.Input.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (r *ReplaceVariables) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return r.Input.GetExecShards(vcursor, bindVars, each)
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/revert_migration.go
+++ b/go/vt/vtgate/engine/revert_migration.go
@@ -26,6 +26,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
@@ -67,6 +68,17 @@ func (v *RevertMigration) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (v *RevertMigration) GetTableName() string {
 	return ""
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (v *RevertMigration) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// In Vitess 12, IsSkipTopo() is always true for all strategies
+	rss, _, err := vcursor.ResolveDestinations(v.Keyspace.Name, nil, []key.Destination{v.TargetDestination})
+	if err != nil {
+		return err
+	}
+	each(rss[0])
+	return nil
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/rows.go
+++ b/go/vt/vtgate/engine/rows.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 )
 
 var _ Primitive = (*Rows)(nil)
@@ -50,6 +51,12 @@ func (r *Rows) GetKeyspaceName() string {
 //GetTableName implements the Primitive interface
 func (r *Rows) GetTableName() string {
 	return ""
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (r *Rows) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// No shards are accessed
+	return nil
 }
 
 //Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/session_primitive.go
+++ b/go/vt/vtgate/engine/session_primitive.go
@@ -20,6 +20,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
@@ -56,6 +57,13 @@ func (s *SessionPrimitive) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (s *SessionPrimitive) GetTableName() string {
 	return ""
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (s *SessionPrimitive) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// the SessionPrimitive only changes the state on the current Session, it
+	// does not reach out to any shards
+	return nil
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/singlerow.go
+++ b/go/vt/vtgate/engine/singlerow.go
@@ -19,6 +19,8 @@ package engine
 import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/proto/query"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/srvtopo"
 )
 
 var _ Primitive = (*SingleRow)(nil)
@@ -42,6 +44,10 @@ func (s *SingleRow) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (s *SingleRow) GetTableName() string {
 	return ""
+}
+
+func (s *SingleRow) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	return nil
 }
 
 // Execute performs a non-streaming exec.

--- a/go/vt/vtgate/engine/sql_calc_found_rows.go
+++ b/go/vt/vtgate/engine/sql_calc_found_rows.go
@@ -20,6 +20,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
@@ -45,6 +46,17 @@ func (s SQLCalcFoundRows) GetKeyspaceName() string {
 //GetTableName implements the Primitive interface
 func (s SQLCalcFoundRows) GetTableName() string {
 	return s.LimitPrimitive.GetTableName()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (s SQLCalcFoundRows) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	if err := s.LimitPrimitive.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	if err := s.CountPrimitive.GetExecShards(vcursor, bindVars, each); err != nil {
+		return err
+	}
+	return nil
 }
 
 //Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/update_target.go
+++ b/go/vt/vtgate/engine/update_target.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -56,6 +57,11 @@ func (updTarget *UpdateTarget) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (updTarget *UpdateTarget) GetTableName() string {
 	return ""
+}
+
+func (updTarget *UpdateTarget) GetExecShards(vcursor VCursor, bindVars map[string]*query.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// This is a memory-only operation
+	return nil
 }
 
 // Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -83,6 +84,12 @@ func (vf *VindexFunc) GetKeyspaceName() string {
 // GetTableName specifies the table that this primitive routes to.
 func (vf *VindexFunc) GetTableName() string {
 	return ""
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (vf *VindexFunc) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// This Vindex query is resolved without accessing any shards
+	return nil
 }
 
 // Execute performs a non-streaming exec.

--- a/go/vt/vtgate/engine/vschema_ddl.go
+++ b/go/vt/vtgate/engine/vschema_ddl.go
@@ -21,6 +21,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
@@ -61,6 +62,12 @@ func (v *AlterVSchema) GetKeyspaceName() string {
 //GetTableName implements the Primitive interface
 func (v *AlterVSchema) GetTableName() string {
 	return v.AlterVschemaDDL.Table.Name.String()
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (v *AlterVSchema) GetExecShards(vcursor VCursor, bindVars map[string]*query.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	// AlterVSchema is a topo operation so it doesn't reach out to any shards
+	return nil
 }
 
 //Execute implements the Primitive interface

--- a/go/vt/vtgate/engine/vstream.go
+++ b/go/vt/vtgate/engine/vstream.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -58,6 +59,18 @@ func (v *VStream) GetKeyspaceName() string {
 // GetTableName implements the Primitive interface
 func (v *VStream) GetTableName() string {
 	return v.TableName
+}
+
+// GetExecShards lists all the shards that would be accessed by this primitive
+func (v *VStream) GetExecShards(vcursor VCursor, bindVars map[string]*querypb.BindVariable, each func(rs *srvtopo.ResolvedShard)) error {
+	rss, _, err := vcursor.ResolveDestinations(v.Keyspace.Name, nil, []key.Destination{v.TargetDestination})
+	if err != nil {
+		return err
+	}
+	for _, rs := range rss {
+		each(rs)
+	}
+	return nil
 }
 
 // Execute implements the Primitive interface


### PR DESCRIPTION
## Description

I just had a very productive unproductive morning! After discussing the next steps for our buffering work with @harshit-gangal, he suggested that I implement a `GetExecShards` method on all our plan `Primitive` types: this would allow us to figure out all the shards that would be affected by executing a given plan, so the new buffering code knows whether a given plan would require buffering because a given shard is currently undergoing a disruption event.

After implementing the whole logic for all our primitive types, I quickly noticed that this is not a feasible step forward: for many of the most common primitives, figuring out the reachable shards for the plan is essentially as expensive as actually executing the plan itself (in fact, for some primitives, we need to _actually execute parts of the plan_ in order to accurately gather the reachable shards for the full execution).

I'm opening this PR nonetheless for further discussion, and as a future reference. Although the functionality is complete and working, I'm not sure there's a compelling reason to have it merged.

cc @harshit-gangal @deepthi

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/8462


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->