### PR TITLE
Improve the Docker local and compose examples

### DIFF
--- a/examples/compose/client.sh
+++ b/examples/compose/client.sh
@@ -25,4 +25,4 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 # This is a convenience script to run the client.go script
-exec $tty docker-compose exec ${CS:-vtgate} go run ${script:-/script/client.go} -server=vtgate:15999
+exec $tty docker-compose exec -u root "${CS:-vtgate}" go run "${script:-/script/client.go}" -server=vtgate:15999

--- a/examples/local/201_newkeyspace_tablets.sh
+++ b/examples/local/201_newkeyspace_tablets.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -eEo pipefail
+
+# Copyright 2020 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script creates a primary, replica, and rdonly tablet in the given
+# keyspace and initializes them.
+
+# Let's allow this to be run from anywhere
+pushd "$(dirname "${0}")" >/dev/null
+
+source ./env.sh
+
+KEYSPACE=${1:-test}
+BASETABLETNUM=${2:-2}
+SHARD=${3:-"-"}
+
+for i in ${BASETABLETNUM}00 ${BASETABLETNUM}01 ${BASETABLETNUM}02; do
+        CELL=zone1 TABLET_UID="${i}" ./scripts/mysqlctl-up.sh
+        SHARD=${SHARD} CELL=zone1 KEYSPACE=${KEYSPACE} TABLET_UID=$i ./scripts/vttablet-up.sh
+done
+
+vtctldclient InitShardPrimary --force "${KEYSPACE}/${SHARD}" "zone1-${BASETABLETNUM}00"
+
+# Go back to the original ${PWD} in the parent shell
+popd >/dev/null


### PR DESCRIPTION
## Description
`Vitess/base` is built using `root` and `pkg/cache` is mostly `root`, but the default user is later changed to `vitess` so using the example `client.go` fails on `/go/pkg/cache` permissions. This fixes that without changing docker image and keeping it localized just to the shell script.

Adding a script I find useful for adding additional arbitrary keyspaces in the `docker_local` container.

Signed-off-by: Matt Lord <mattalord@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
https://github.com/vitessio/vitess/pull/5863
h/t to @dartov for the compose part -- carrying his PR forward.


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required