### PR TITLE
Removed non-required build directive

### DIFF
--- a/go/vt/vtgate/engine/fuzz_flaky_test.go
+++ b/go/vt/vtgate/engine/fuzz_flaky_test.go
@@ -38,7 +38,6 @@ limitations under the License.
 	continuously by OSS-fuzz. Needless to say, more
 	APIs can be added with ease.
 */
-// +build gofuzz
 
 package engine
 


### PR DESCRIPTION
## Description
Removes a non-required build directive in the fuzzer that was failing `go vet`.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
