### PR TITLE
Fixing a panic in vtgate with OLAP mode

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -730,7 +730,8 @@ func TestRenameFieldsOnOLAP(t *testing.T) {
 	}()
 
 	qr := exec(t, conn, "show tables")
-	assert.Equal(t, `[[VARCHAR("aggr_test")] [VARCHAR("t1")] [VARCHAR("t1_id2_idx")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t3")] [VARCHAR("t3_id7_idx")] [VARCHAR("t4")] [VARCHAR("t4_id2_idx")] [VARCHAR("t5_null_vindex")] [VARCHAR("t6")] [VARCHAR("t6_id2_idx")] [VARCHAR("t7_fk")] [VARCHAR("t7_xxhash")] [VARCHAR("t7_xxhash_idx")] [VARCHAR("t8")] [VARCHAR("vstream_test")]]`, fmt.Sprintf("%v", qr.Rows))
+	require.Equal(t, 1, len(qr.Fields))
+	assert.Equal(t, `Tables_in_ks`, fmt.Sprintf("%v", qr.Fields[0].Name))
 	_ = exec(t, conn, "use mysql")
 	qr = exec(t, conn, "select @@workload")
 	assert.Equal(t, `[[VARBINARY("OLAP")]]`, fmt.Sprintf("%v", qr.Rows))

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -717,6 +717,25 @@ func TestSubqueryInINClause(t *testing.T) {
 	assertMatches(t, conn, `SELECT id2 FROM t1 WHERE id1 IN (SELECT 1 FROM dual)`, `[[INT64(1)]]`)
 }
 
+func TestRenameFieldsOnOLAP(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_ = exec(t, conn, "set workload = olap")
+	defer func() {
+		exec(t, conn, "set workload = oltp")
+	}()
+
+	qr := exec(t, conn, "show tables")
+	assert.Equal(t, `[[VARCHAR("aggr_test")] [VARCHAR("t1")] [VARCHAR("t1_id2_idx")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("t3")] [VARCHAR("t3_id7_idx")] [VARCHAR("t4")] [VARCHAR("t4_id2_idx")] [VARCHAR("t5_null_vindex")] [VARCHAR("t6")] [VARCHAR("t6_id2_idx")] [VARCHAR("t7_fk")] [VARCHAR("t7_xxhash")] [VARCHAR("t7_xxhash_idx")] [VARCHAR("t8")] [VARCHAR("vstream_test")]]`, fmt.Sprintf("%v", qr.Rows))
+	_ = exec(t, conn, "use mysql")
+	qr = exec(t, conn, "select @@workload")
+	assert.Equal(t, `[[VARBINARY("OLAP")]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
 func assertMatches(t *testing.T, conn *mysql.Conn, query, expected string) {
 	t.Helper()
 	qr := exec(t, conn, query)

--- a/go/vt/vtgate/endtoend/misc_test.go
+++ b/go/vt/vtgate/endtoend/misc_test.go
@@ -69,14 +69,3 @@ func TestCreateAndDropDatabase(t *testing.T) {
 		})
 	}
 }
-
-func TestRenameFieldsOnOLAP(t *testing.T) {
-	// note that this is testing vttest and not vtgate
-	conn, err := mysql.Connect(ctx, &vtParams)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	_ = exec(t, conn, "set workload = olap")
-	qr := exec(t, conn, "show tables")
-	assert.Equal(t, `[[VARCHAR("aggr_test")] [VARCHAR("t1")] [VARCHAR("t1_id2_idx")] [VARCHAR("t1_last_insert_id")] [VARCHAR("t1_row_count")] [VARCHAR("t1_sharded")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("vstream_test")]]`, fmt.Sprintf("%v", qr.Rows))
-}

--- a/go/vt/vtgate/endtoend/misc_test.go
+++ b/go/vt/vtgate/endtoend/misc_test.go
@@ -69,3 +69,14 @@ func TestCreateAndDropDatabase(t *testing.T) {
 		})
 	}
 }
+
+func TestRenameFieldsOnOLAP(t *testing.T) {
+	// note that this is testing vttest and not vtgate
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_ = exec(t, conn, "set workload = olap")
+	qr := exec(t, conn, "show tables")
+	assert.Equal(t, `[[VARCHAR("aggr_test")] [VARCHAR("t1")] [VARCHAR("t1_id2_idx")] [VARCHAR("t1_last_insert_id")] [VARCHAR("t1_row_count")] [VARCHAR("t1_sharded")] [VARCHAR("t2")] [VARCHAR("t2_id4_idx")] [VARCHAR("vstream_test")]]`, fmt.Sprintf("%v", qr.Rows))
+}

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -73,12 +73,9 @@ func (r *RenameFields) Execute(vcursor VCursor, bindVars map[string]*querypb.Bin
 }
 
 func (r *RenameFields) renameFields(qr *sqltypes.Result) {
-	if len(r.Indices) != len(qr.Fields) {
-		return
-	}
-	for ind, index := range r.Indices {
-		colName := r.Cols[ind]
-		qr.Fields[index].Name = colName
+	for i := 0; i < len(r.Indices) && i < len(qr.Fields); i++ {
+		colName := r.Cols[r.Indices[i]]
+		qr.Fields[i].Name = colName
 	}
 }
 

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -87,7 +87,11 @@ func (r *RenameFields) StreamExecute(vcursor VCursor, bindVars map[string]*query
 	if wantfields {
 		innerCallback := callback
 		callback = func(result *sqltypes.Result) error {
-			r.renameFields(result)
+			// Only the first callback will contain the fields.
+			// This check is to avoid going over the RenameFields indices when no fields are present in the result set.
+			if len(result.Fields) != 0 {
+				r.renameFields(result)
+			}
 			return innerCallback(result)
 		}
 	}

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -73,6 +73,9 @@ func (r *RenameFields) Execute(vcursor VCursor, bindVars map[string]*querypb.Bin
 }
 
 func (r *RenameFields) renameFields(qr *sqltypes.Result) {
+	if len(r.Indices) != len(qr.Fields) {
+		return
+	}
 	for ind, index := range r.Indices {
 		colName := r.Cols[ind]
 		qr.Fields[index].Name = colName

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -74,8 +74,8 @@ func (r *RenameFields) Execute(vcursor VCursor, bindVars map[string]*querypb.Bin
 
 func (r *RenameFields) renameFields(qr *sqltypes.Result) {
 	for ind, index := range r.Indices {
-		if ind == len(qr.Fields) {
-			break
+		if index >= len(qr.Fields) {
+			continue
 		}
 		colName := r.Cols[ind]
 		qr.Fields[index].Name = colName

--- a/go/vt/vtgate/engine/rename_fields.go
+++ b/go/vt/vtgate/engine/rename_fields.go
@@ -73,9 +73,12 @@ func (r *RenameFields) Execute(vcursor VCursor, bindVars map[string]*querypb.Bin
 }
 
 func (r *RenameFields) renameFields(qr *sqltypes.Result) {
-	for i := 0; i < len(r.Indices) && i < len(qr.Fields); i++ {
-		colName := r.Cols[r.Indices[i]]
-		qr.Fields[i].Name = colName
+	for ind, index := range r.Indices {
+		if ind == len(qr.Fields) {
+			break
+		}
+		colName := r.Cols[ind]
+		qr.Fields[index].Name = colName
 	}
 }
 


### PR DESCRIPTION
## Description

This pull request fixes a panic in vtgate that happens when a `show tables` or a `use <database>` query is sent to Vitess after entering `olap` mode.

## Related Issue(s)
Fixes #8694 

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
