### PR TITLE
Proper handling of CHAR columns with binary collations

### DIFF
--- a/go/test/endtoend/vreplication/config.go
+++ b/go/test/endtoend/vreplication/config.go
@@ -10,7 +10,7 @@ create table orders(oid int, cid int, pid int, mname varchar(128), price int, qt
 create table order_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 create table customer2(cid int, name varbinary(128), typ enum('individual','soho','enterprise'), sport set('football','cricket','baseball'),ts timestamp not null default current_timestamp, primary key(cid));
 create table customer_seq2(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
-create table tenant(tenant_id binary(16), name varbinary(16), primary key (tenant_id));
+create table tenant(tenant_id binary(16), name varbinary(16), country_code char(3) collate utf8mb4_bin, primary key (tenant_id));
 `
 
 	initialProductVSchema = `

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -12,6 +12,6 @@ insert into customer2(cid, name, typ, sport) values(1, 'john',1,'football,baseba
 insert into customer2(cid, name, typ, sport) values(2, 'paul','soho','cricket');
 insert into customer2(cid, name, typ, sport) values(3, 'ringo','enterprise','');
 -- for testing edge case where inserted binary value is 15 bytes, field is 16, mysql adds a null while storing but binlog returns 15 bytes
-insert into tenant(tenant_id, name) values (x'02BD00987932461E8820C908E84BAE', 'abc');
+insert into tenant(tenant_id, name, country_code) values (x'02BD00987932461E8820C908E84BAE', 'abc', 'USA');
 
 


### PR DESCRIPTION
Make any necessary test and code fixes.

Signed-off-by: Matt Lord <mattalord@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
The work in https://github.com/vitessio/vitess/pull/8137 seems to have introduced a bug in how we vreplicate CHAR columns that are using a binary collation. If we e.g. have a column defined as `foo CHAR(3) COLLATE UTF8MB4_BIN` then the column gets padded to the maximum **byte** length / display width of 12 -- `utf8mb4` is 1-4 bytes per character -- which causes the SQL statement to fail as we're then trying to insert 12 characters into a 3 character column:
```
Error applying event: Data too long for column 'foo' at row 1 (errno 1406) (sqlstate 22001)
during query: update t1 set ... foo='TWD\0\0\0\0\0\0\0\0\0' ...
``` 

### Test Case
```
# git clone git@github.com:vitessio/vitess.git && cd vitess

git checkout main && git pull

make docker_local

./docker/local/run.sh

vtctlclient -server localhost:15999 ApplySchema -sql "ALTER TABLE customer ADD country_code CHAR(3) DEFAULT 'USA' COLLATE UTF8MB4_BIN" commerce

mysql -h 127.0.0.1 -P 15306 commerce -e "insert into customer values (1, 'test1@testing.com', 'USA')"

./201_customer_tablets.sh

./202_move_tables.sh

mysql -h 127.0.0.1 -P 15306 commerce -e "insert into customer values (2, 'test2@testing.com', 'CAN')"

vtctlclient -server localhost:15999 Workflow customer.commerce2customer show
```

**Final results:**
```
{
        "Workflow": "commerce2customer",
        "SourceLocation": {
                "Keyspace": "commerce",
                "Shards": [
                        "0"
                ]
        },
        "TargetLocation": {
                "Keyspace": "customer",
                "Shards": [
                        "0"
                ]
        },
        "MaxVReplicationLag": 5,
        "ShardStatuses": {
                "0/zone1-0000000200": {
                        "PrimaryReplicationStatuses": [
                                {
                                        "Shard": "0",
                                        "Tablet": "zone1-0000000200",
                                        "ID": 1,
                                        "Bls": {
                                                "keyspace": "commerce",
                                                "shard": "0",
                                                "filter": {
                                                        "rules": [
                                                                {
                                                                        "match": "customer",
                                                                        "filter": "select * from customer"
                                                                },
                                                                {
                                                                        "match": "corder",
                                                                        "filter": "select * from corder"
                                                                }
                                                        ]
                                                }
                                        },
                                        "Pos": "971ac708-09c6-11ec-9caa-0242ac110002:1-42",
                                        "StopPos": "",
                                        "State": "Running",
                                        "DBName": "vt_customer",
                                        "TransactionTimestamp": 0,
                                        "TimeUpdated": 1630351445,
                                        "Message": "Data too long for column 'country_code' at row 1 (errno 1406) (sqlstate 22001) during query: insert into customer(customer_id,email,country_code) values (2,'test2@testing.com','CAN\\0\\0\\0\\0\\0\\0\\0\\0\\0')",
                                        "Tags": "",
                                        "CopyState": null
                                }
                        ],
                        "TabletControls": null,
                        "PrimaryIsServing": true
                }
        }
}
```

**Originating Binlog events:**
```
mysqlbinlog -vvv --base64-output=decode-rows /vt/vtdataroot/vt_0000000100/bin-logs/vt-0000000100-bin.000001
...
# at 11487
#210830 19:43:25 server id 386181494  end_log_pos 11552 CRC32 0x5f219419 	GTID	last_committed=40	sequence_number=41	rbr_only=yes
/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
SET @@SESSION.GTID_NEXT= '717b62d4-09ca-11ec-acb3-0242ac110002:41'/*!*/;
# at 11552
#210830 19:43:25 server id 386181494  end_log_pos 11631 CRC32 0x357d0a9c 	Query	thread_id=77	exec_time=0	error_code=0
SET TIMESTAMP=1630352605/*!*/;
BEGIN
/*!*/;
# at 11631
#210830 19:43:25 server id 386181494  end_log_pos 11695 CRC32 0xcf4ba969 	Table_map: `vt_commerce`.`customer` mapped to number 143
# at 11695
#210830 19:43:25 server id 386181494  end_log_pos 11761 CRC32 0x0babe28e 	Write_rows: table id 143 flags: STMT_END_F
### INSERT INTO `vt_commerce`.`customer`
### SET
###   @1=2 /* LONGINT meta=0 nullable=0 is_null=0 */
###   @2='test2@testing.com' /* VARSTRING(128) meta=128 nullable=1 is_null=0 */
###   @3='CAN' /* STRING(12) meta=65036 nullable=1 is_null=0 */
# at 11761
#210830 19:43:25 server id 386181494  end_log_pos 11792 CRC32 0xbaed4e55 	Xid = 495
COMMIT/*!*/;
...
```

It's the max length you see there of 12 bytes that is the issue. We have to take the max-bytes-per-character into account when padding the byte array with null bytes (`\0`s). So in this case we have a max of 4 bytes per character with `utf8mb4` and we should be calculating this to map the max bytes to max chars when padding with null bytes: 12 / 4 = 3. In effect, we need to make the same kind of adjustment done [here](https://github.com/mysql/mysql-server/blob/8.0/sql/sql_show.cc#L5468-L5482) and [here](https://github.com/mysql/mysql-server/blob/8.0/sql/field.cc#L6410-L6440) in MySQL. I don't yet see where we have character set info available here in Vitess though... 

## Related Issue(s)
https://github.com/vitessio/vitess/issues/8743

## Checklist
- [x] Should this PR be backported? Yes
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->