### PR TITLE
default to primary tablet if not set in VStream api

### DIFF
--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -228,8 +228,15 @@ func (vtg *VTGate) ResolveTransaction(ctx context.Context, request *vtgatepb.Res
 func (vtg *VTGate) VStream(request *vtgatepb.VStreamRequest, stream vtgateservicepb.Vitess_VStreamServer) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx := withCallerIDContext(stream.Context(), request.CallerId)
+
+	// For backward compatibility.
+	// The mysql query equivalent has logic to use topodatapb.TabletType_PRIMARY if tablet_type is not set.
+	tabletType := request.TabletType
+	if tabletType == topodatapb.TabletType_UNKNOWN {
+		tabletType = topodatapb.TabletType_PRIMARY
+	}
 	vtgErr := vtg.server.VStream(ctx,
-		request.TabletType,
+		tabletType,
 		request.Vgtid,
 		request.Filter,
 		request.Flags,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Now the underlying streamExecute uses plan builder to build and execute the query.
The VStream API pass on the tablet type received from the request. 

Earlier it was hardcoded to use a PRIMARY tablet but now it uses what the user has passed in the request.
For query-based streaming through MySQL protocol, it is already handled for cases when tablet type is not set.

For direct VStream API calls, the fallback logic is added to use PRIMARY tablet type if not provided.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes #8676 

## Checklist
- [X] Should this PR be backported?
- [] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->