### PR TITLE
Allow min TLS version for tablet to mysqld conns

### DIFF
--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -82,6 +82,7 @@ type DBConfigs struct {
 	SslCaPath                  string        `json:"sslCaPath,omitempty"`
 	SslCert                    string        `json:"sslCert,omitempty"`
 	SslKey                     string        `json:"sslKey,omitempty"`
+	TLSMinVersion              string        `json:"tlsMinVersion,omitempty"`
 	ServerName                 string        `json:"serverName,omitempty"`
 	ConnectTimeoutMilliseconds int           `json:"connectTimeoutMilliseconds,omitempty"`
 	DBName                     string        `json:"dbName,omitempty"`
@@ -134,6 +135,7 @@ func registerBaseFlags() {
 	flag.StringVar(&GlobalDBConfigs.SslCaPath, "db_ssl_ca_path", "", "connection ssl ca path")
 	flag.StringVar(&GlobalDBConfigs.SslCert, "db_ssl_cert", "", "connection ssl certificate")
 	flag.StringVar(&GlobalDBConfigs.SslKey, "db_ssl_key", "", "connection ssl key")
+	flag.StringVar(&GlobalDBConfigs.TLSMinVersion, "db_tls_min_version", "", "Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.")
 	flag.StringVar(&GlobalDBConfigs.ServerName, "db_server_name", "", "server name of the DB we are connecting to.")
 	flag.IntVar(&GlobalDBConfigs.ConnectTimeoutMilliseconds, "db_connect_timeout_ms", 0, "connection timeout to mysqld in milliseconds (0 for no timeout)")
 }
@@ -372,6 +374,7 @@ func (dbcfgs *DBConfigs) InitWithSocket(defaultSocketFile string) {
 			cp.SslCaPath = dbcfgs.SslCaPath
 			cp.SslCert = dbcfgs.SslCert
 			cp.SslKey = dbcfgs.SslKey
+			cp.TLSMinVersion = dbcfgs.TLSMinVersion
 			cp.ServerName = dbcfgs.ServerName
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Matt Lord <mattalord@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
When tablets do not connect to mysqld via a unix domain socket, TLS is a concern. And given the version of MySQL involved and the specifics of the key materials used you may need the tablet to [support older ciphers](https://github.com/vitessio/vitess/blob/da96136fe5f430ee8f83b0d447286ba1b9f45341/go/vt/vttls/vttls.go#L33-L59). 

This was seen when using RDS/Aurora instances as the vttablet then uses TCP/IP to communicate with mysqld and you likely want to use TLS to protect that network communication. The [RDS CA bundle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) does not seem to support ECDHE ciphers. And you may simply be using an [older version of MySQL that does not have TLS 1.2 support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport).

Whatever the cause, there may be times where you need to support pre 1.2 TLS for one reason or another and while [vtgate supports that](https://github.com/vitessio/vitess/blob/de7f133dbe2dd6a7910f13c682910a4f5c0ac0df/go/vt/vtgate/plugin_mysql_server.go#L67), vttablet did not. This PR adds a new vttablet flag to support it: `-db_tls_min_version=TLSv1.1`

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->