### PR TITLE
Fix how we identify MySQL generated columns

### DIFF
--- a/go/vt/vttablet/onlineddl/vrepl.go
+++ b/go/vt/vttablet/onlineddl/vrepl.go
@@ -268,7 +268,7 @@ func (v *VRepl) readTableColumns(ctx context.Context, conn *dbconnpool.DBConnect
 		columnNames = append(columnNames, columnName)
 
 		extra := row.AsString("Extra", "")
-		if strings.Contains(extra, "VIRTUAL") || strings.Contains(extra, "GENERATED") {
+		if strings.Contains(extra, "STORED GENERATED") || strings.Contains(extra, "VIRTUAL GENERATED") {
 			virtualColumnNames = append(virtualColumnNames, columnName)
 		}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -296,7 +296,7 @@ func (vr *vreplicator) buildColInfoMap(ctx context.Context) (map[string][]*Colum
 				}
 			}
 			extra := strings.ToLower(row[5].ToString())
-			if strings.Contains(extra, "generated") || strings.Contains(extra, "virtual") {
+			if strings.Contains(extra, "stored generated") || strings.Contains(extra, "virtual generated") {
 				isGenerated = true
 			}
 			colInfo = append(colInfo, &ColumnInfo{


### PR DESCRIPTION
## Description
This PR is trying to fix problem mentioned in Issue #8759 (caused by PR #8129 )

For the same create table statement in MySQL5.6/5.7 & MySQL8 will write different `Extra` table metadata.
This lead to a misjudgment on how we identify a generated column,  especially on `DEFAULT CURRENT_TIMESTAMP` columns (additional metadata added in I_S in MySQL 8).

```sql
CREATE TABLE toki_test4 (
	id int AUTO_INCREMENT,
	org_value INTEGER,
        doubled_value INTEGER AS (`org_value` * 2) STORED, -- NOTE: generated column is not supported in MySQL5.6
        doubled_value_virtual INTEGER AS (`org_value` * 2),  -- NOTE: generated column is not supported in MySQL5.6
	created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
	PRIMARY KEY (`id`)
);
```

MySQL5.6
```sql
desc toki_test4;

+-----------+-----------+------+-----+-------------------+----------------+
| Field     | Type      | Null | Key | Default           | Extra          |
+-----------+-----------+------+-----+-------------------+----------------+
| id        | int(11)   | NO   | PRI | NULL              | auto_increment |
| org_value | int(11)   | YES  |     | NULL              |                |
| created   | timestamp | NO   |     | CURRENT_TIMESTAMP |                |
+-----------+-----------+------+-----+-------------------+----------------+
```

MySQL8
```sql
desc toki_test4;
+-----------------------+-----------+------+-----+-------------------+-------------------+
| Field                 | Type      | Null | Key | Default           | Extra             |
+-----------------------+-----------+------+-----+-------------------+-------------------+
| id                    | int       | NO   | PRI | NULL              | auto_increment    |
| org_value             | int       | YES  |     | NULL              |                   |
| doubled_value         | int       | YES  |     | NULL              | STORED GENERATED  |
| doubled_value_virtual | int       | YES  |     | NULL              | VIRTUAL GENERATED |
| created               | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED |
+-----------------------+-----------+------+-----+-------------------+-------------------+
```

## Related Issue(s)
#8759 

## Checklist
- [x] Should this PR be backported? (Only versions after PR #8129 has this bug)
- [ ] Tests were added or are not required (TBD)
- [X] Documentation was added or is not required