### PR TITLE
Add isActive flag to vtgr to support multi-cell topology

### DIFF
--- a/go/vt/vtgr/controller/diagnose.go
+++ b/go/vt/vtgr/controller/diagnose.go
@@ -376,16 +376,16 @@ func (shard *GRShard) instanceReachable(ctx context.Context, instance *grInstanc
 // findShardPrimaryTablet iterates through the replicas stored in grShard and returns
 // the one that's marked as primary
 func (shard *GRShard) findShardPrimaryTablet() *grInstance {
-	var latestMasterTimestamp time.Time
+	var latestPrimaryTimestamp time.Time
 	var primaryInstance *grInstance
 	foundPrimary := false
 	for _, instance := range shard.instances {
-		if instance.tablet.Type == topodatapb.TabletType_MASTER {
+		if instance.tablet.Type == topodatapb.TabletType_PRIMARY {
 			foundPrimary = true
-			// It is possible that there are more than one master in topo server
+			// It is possible that there are more than one primary in topo server
 			// we should compare timestamp to pick the latest one
-			if latestMasterTimestamp.Before(instance.masterTimeStamp) {
-				latestMasterTimestamp = instance.masterTimeStamp
+			if latestPrimaryTimestamp.Before(instance.primaryTimeStamp) {
+				latestPrimaryTimestamp = instance.primaryTimeStamp
 				primaryInstance = instance
 			}
 		}
@@ -420,9 +420,9 @@ func (shard *GRShard) disconnectedInstance() (*grInstance, error) {
 		shard.instances[i], shard.instances[j] = shard.instances[j], shard.instances[i]
 	})
 	for _, instance := range shard.instances {
-		// Skip master because VTGR always join group and then update tablet type
-		// which means if a tablet has type master then it should have a group already
-		if instance.tablet.Type == topodatapb.TabletType_MASTER {
+		// Skip primary because VTGR always join group and then update tablet type
+		// which means if a tablet has type primary then it should have a group already
+		if instance.tablet.Type == topodatapb.TabletType_PRIMARY {
 			continue
 		}
 		// Skip instance without hostname because they are not up and running

--- a/go/vt/vtgr/controller/diagnose_test.go
+++ b/go/vt/vtgr/controller/diagnose_test.go
@@ -31,7 +31,6 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/orchestrator/inst"
-
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"

--- a/go/vt/vtgr/controller/group_test.go
+++ b/go/vt/vtgr/controller/group_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/vt/orchestrator/inst"
-
 	"vitess.io/vitess/go/vt/vtgr/db"
 
 	"github.com/stretchr/testify/assert"

--- a/go/vt/vtgr/controller/refresh.go
+++ b/go/vt/vtgr/controller/refresh.go
@@ -22,19 +22,17 @@ import (
 	"sync"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtgr/config"
-
-	"vitess.io/vitess/go/vt/vtgr/db"
-
-	"vitess.io/vitess/go/stats"
-
 	"golang.org/x/net/context"
 
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/orchestrator/inst"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtgr/config"
+	"vitess.io/vitess/go/vt/vtgr/db"
 )
 
 var (
@@ -44,10 +42,10 @@ var (
 // grInstance represents an instance that's running MySQL GR
 // it wraps a InstanceKey plus some tablet related information
 type grInstance struct {
-	instanceKey      *inst.InstanceKey
-	tablet           *topodatapb.Tablet
-	primaryTimeStamp time.Time
-	alias            string
+	instanceKey     *inst.InstanceKey
+	tablet          *topodatapb.Tablet
+	masterTimeStamp time.Time
+	alias           string
 }
 
 // GRTopo is VTGR wrapper for topo server
@@ -91,6 +89,8 @@ type GRShard struct {
 	lastDiagnoseResult DiagnoseType
 	lastDiagnoseSince  time.Time
 
+	isActive sync2.AtomicBool
+
 	// lock prevents multiple go routine fights with each other
 	sync.Mutex
 }
@@ -126,8 +126,9 @@ func NewGRShard(
 	ts GRTopo,
 	dbAgent db.Agent,
 	config *config.VTGRConfig,
-	localDbPort int) *GRShard {
-	return &GRShard{
+	localDbPort int,
+	isActive bool) *GRShard {
+	grShard := &GRShard{
 		KeyspaceShard:             &topo.KeyspaceShard{Keyspace: keyspace, Shard: shard},
 		cells:                     cells,
 		shardStatusCollector:      newShardStatusCollector(keyspace, shard),
@@ -142,6 +143,8 @@ func NewGRShard(
 		transientErrorWaitTime:    time.Duration(config.BackoffErrorWaitTimeSeconds) * time.Second,
 		bootstrapWaitTime:         time.Duration(config.BootstrapWaitTimeSeconds) * time.Second,
 	}
+	grShard.isActive.Set(isActive)
+	return grShard
 }
 
 // refreshTabletsInShardLocked is called by repair to get a fresh view of the shard
@@ -182,7 +185,7 @@ func parseTabletInfos(tablets map[string]*topo.TabletInfo) []*grInstance {
 	var newReplicas []*grInstance
 	for alias, tabletInfo := range tablets {
 		tablet := tabletInfo.Tablet
-		// Only monitor primary, replica and ronly tablet types
+		// Only monitor master, replica and ronly tablet types
 		switch tablet.Type {
 		case topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY:
 			// mysql hostname and port might be empty here if tablet is not running
@@ -192,10 +195,10 @@ func parseTabletInfos(tablets map[string]*topo.TabletInfo) []*grInstance {
 				Port:     int(tablet.MysqlPort),
 			}
 			grInstance := grInstance{
-				instanceKey:      &instanceKey,
-				tablet:           tablet,
-				primaryTimeStamp: logutil.ProtoToTime(tablet.PrimaryTermStartTime),
-				alias:            alias,
+				instanceKey:     &instanceKey,
+				tablet:          tablet,
+				masterTimeStamp: logutil.ProtoToTime(tablet.PrimaryTermStartTime),
+				alias:           alias,
 			}
 			newReplicas = append(newReplicas, &grInstance)
 		}
@@ -277,6 +280,12 @@ func (shard *GRShard) GetUnlock() func(*error) {
 	shard.unlockMu.Lock()
 	defer shard.unlockMu.Unlock()
 	return shard.unlock
+}
+
+// SetIsActive sets isActive for the shard
+func (shard *GRShard) SetIsActive(isActive bool) {
+	log.Infof("Setting is active to %v", isActive)
+	shard.isActive.Set(isActive)
 }
 
 func (collector *shardStatusCollector) isUnreachable(instance *grInstance) bool {

--- a/go/vt/vtgr/controller/refresh.go
+++ b/go/vt/vtgr/controller/refresh.go
@@ -42,10 +42,10 @@ var (
 // grInstance represents an instance that's running MySQL GR
 // it wraps a InstanceKey plus some tablet related information
 type grInstance struct {
-	instanceKey     *inst.InstanceKey
-	tablet          *topodatapb.Tablet
-	masterTimeStamp time.Time
-	alias           string
+	instanceKey      *inst.InstanceKey
+	tablet           *topodatapb.Tablet
+	primaryTimeStamp time.Time
+	alias            string
 }
 
 // GRTopo is VTGR wrapper for topo server
@@ -185,7 +185,7 @@ func parseTabletInfos(tablets map[string]*topo.TabletInfo) []*grInstance {
 	var newReplicas []*grInstance
 	for alias, tabletInfo := range tablets {
 		tablet := tabletInfo.Tablet
-		// Only monitor master, replica and ronly tablet types
+		// Only monitor primary, replica and ronly tablet types
 		switch tablet.Type {
 		case topodatapb.TabletType_PRIMARY, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY:
 			// mysql hostname and port might be empty here if tablet is not running
@@ -195,10 +195,10 @@ func parseTabletInfos(tablets map[string]*topo.TabletInfo) []*grInstance {
 				Port:     int(tablet.MysqlPort),
 			}
 			grInstance := grInstance{
-				instanceKey:     &instanceKey,
-				tablet:          tablet,
-				masterTimeStamp: logutil.ProtoToTime(tablet.PrimaryTermStartTime),
-				alias:           alias,
+				instanceKey:      &instanceKey,
+				tablet:           tablet,
+				primaryTimeStamp: logutil.ProtoToTime(tablet.PrimaryTermStartTime),
+				alias:            alias,
 			}
 			newReplicas = append(newReplicas, &grInstance)
 		}

--- a/go/vt/vtgr/controller/refresh_test.go
+++ b/go/vt/vtgr/controller/refresh_test.go
@@ -49,7 +49,7 @@ func TestRefreshTabletsInShard(t *testing.T) {
 	testutil.AddTablet(ctx, t, ts, tablet2.Tablet, nil)
 	testutil.AddTablet(ctx, t, ts, tablet3.Tablet, nil)
 	cfg := &config.VTGRConfig{GroupSize: 3, MinNumReplica: 0, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0)
+	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0, true)
 	assert.Equal(t, "ks", shard.shardStatusCollector.status.Keyspace)
 	assert.Equal(t, "0", shard.shardStatusCollector.status.Shard)
 	shard.refreshTabletsInShardLocked(context.Background())
@@ -61,7 +61,7 @@ func TestRefreshTabletsInShard(t *testing.T) {
 	})
 	assert.Equal(t, testHost, instances[0].tablet.Hostname)
 	assert.Equal(t, int32(testPort0), instances[0].tablet.MysqlPort)
-	assert.Equal(t, topodatapb.TabletType_PRIMARY, instances[0].tablet.Type)
+	assert.Equal(t, topodatapb.TabletType_MASTER, instances[0].tablet.Type)
 	// host 3 is missing mysql host but we still put it in the instances list here
 	assert.Equal(t, testHost, instances[1].instanceKey.Hostname)
 	assert.Equal(t, int32(0), instances[1].tablet.MysqlPort)
@@ -81,7 +81,7 @@ func TestRefreshWithCells(t *testing.T) {
 	testutil.AddTablet(ctx, t, ts, tablet2.Tablet, nil)
 	testutil.AddTablet(ctx, t, ts, tablet3.Tablet, nil)
 	cfg := &config.VTGRConfig{GroupSize: 3, MinNumReplica: 0, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-	shard := NewGRShard("ks", "0", []string{"cell1", "cell3"}, nil, ts, nil, cfg, testPort0)
+	shard := NewGRShard("ks", "0", []string{"cell1", "cell3"}, nil, ts, nil, cfg, testPort0, true)
 	shard.refreshTabletsInShardLocked(context.Background())
 	instances := shard.instances
 	// only have 2 instances here because we are not watching cell2
@@ -106,7 +106,7 @@ func TestRefreshWithEmptyCells(t *testing.T) {
 	testutil.AddTablet(ctx, t, ts, tablet2.Tablet, nil)
 	testutil.AddTablet(ctx, t, ts, tablet3.Tablet, nil)
 	cfg := &config.VTGRConfig{GroupSize: 3, MinNumReplica: 0, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0)
+	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0, true)
 	shard.refreshTabletsInShardLocked(context.Background())
 	instances := shard.instances
 	// nil cell will return everything
@@ -126,7 +126,7 @@ func TestLockRelease(t *testing.T) {
 	ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{})
 	ts.CreateShard(ctx, "ks", "0")
 	cfg := &config.VTGRConfig{GroupSize: 3, MinNumReplica: 0, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0)
+	shard := NewGRShard("ks", "0", nil, nil, ts, nil, cfg, testPort0, true)
 	ctx, err := shard.LockShard(ctx, "")
 	assert.NoError(t, err)
 	// make sure we get the lock
@@ -139,11 +139,11 @@ func TestLockRelease(t *testing.T) {
 	assert.EqualError(t, err, "lost topology lock; aborting: shard ks/0 is not locked (no lockInfo in map)")
 }
 
-func buildTabletInfo(id uint32, host string, mysqlPort int, ttype topodatapb.TabletType, primaryTermTime time.Time) *topo.TabletInfo {
-	return buildTabletInfoWithCell(id, host, "test_cell", mysqlPort, ttype, primaryTermTime)
+func buildTabletInfo(id uint32, host string, mysqlPort int, ttype topodatapb.TabletType, masterTermTime time.Time) *topo.TabletInfo {
+	return buildTabletInfoWithCell(id, host, "test_cell", mysqlPort, ttype, masterTermTime)
 }
 
-func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype topodatapb.TabletType, primaryTermTime time.Time) *topo.TabletInfo {
+func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype topodatapb.TabletType, masterTermTime time.Time) *topo.TabletInfo {
 	alias := &topodatapb.TabletAlias{Cell: cell, Uid: id}
 	return &topo.TabletInfo{Tablet: &topodatapb.Tablet{
 		Alias:                alias,
@@ -153,7 +153,7 @@ func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype 
 		Keyspace:             "ks",
 		Shard:                "0",
 		Type:                 ttype,
-		PrimaryTermStartTime: logutil.TimeToProto(primaryTermTime),
+		PrimaryTermStartTime: logutil.TimeToProto(masterTermTime),
 		Tags:                 map[string]string{"hostname": fmt.Sprintf("host_%d", id)},
 	}}
 }

--- a/go/vt/vtgr/controller/refresh_test.go
+++ b/go/vt/vtgr/controller/refresh_test.go
@@ -61,7 +61,7 @@ func TestRefreshTabletsInShard(t *testing.T) {
 	})
 	assert.Equal(t, testHost, instances[0].tablet.Hostname)
 	assert.Equal(t, int32(testPort0), instances[0].tablet.MysqlPort)
-	assert.Equal(t, topodatapb.TabletType_MASTER, instances[0].tablet.Type)
+	assert.Equal(t, topodatapb.TabletType_PRIMARY, instances[0].tablet.Type)
 	// host 3 is missing mysql host but we still put it in the instances list here
 	assert.Equal(t, testHost, instances[1].instanceKey.Hostname)
 	assert.Equal(t, int32(0), instances[1].tablet.MysqlPort)
@@ -139,11 +139,11 @@ func TestLockRelease(t *testing.T) {
 	assert.EqualError(t, err, "lost topology lock; aborting: shard ks/0 is not locked (no lockInfo in map)")
 }
 
-func buildTabletInfo(id uint32, host string, mysqlPort int, ttype topodatapb.TabletType, masterTermTime time.Time) *topo.TabletInfo {
-	return buildTabletInfoWithCell(id, host, "test_cell", mysqlPort, ttype, masterTermTime)
+func buildTabletInfo(id uint32, host string, mysqlPort int, ttype topodatapb.TabletType, primaryTermTime time.Time) *topo.TabletInfo {
+	return buildTabletInfoWithCell(id, host, "test_cell", mysqlPort, ttype, primaryTermTime)
 }
 
-func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype topodatapb.TabletType, masterTermTime time.Time) *topo.TabletInfo {
+func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype topodatapb.TabletType, primaryTermTime time.Time) *topo.TabletInfo {
 	alias := &topodatapb.TabletAlias{Cell: cell, Uid: id}
 	return &topo.TabletInfo{Tablet: &topodatapb.Tablet{
 		Alias:                alias,
@@ -153,7 +153,7 @@ func buildTabletInfoWithCell(id uint32, host, cell string, mysqlPort int, ttype 
 		Keyspace:             "ks",
 		Shard:                "0",
 		Type:                 ttype,
-		PrimaryTermStartTime: logutil.TimeToProto(masterTermTime),
+		PrimaryTermStartTime: logutil.TimeToProto(primaryTermTime),
 		Tags:                 map[string]string{"hostname": fmt.Sprintf("host_%d", id)},
 	}}
 }

--- a/go/vt/vtgr/controller/repair.go
+++ b/go/vt/vtgr/controller/repair.go
@@ -308,7 +308,7 @@ func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *
 	primary := shard.findShardPrimaryTablet()
 	var mysqlPrimaryHost string
 	var mysqlPrimaryPort int
-	// skipMaster is true when we manual failover or if there is a unreachalbe primary tablet
+	// skipPrimary is true when we manual failover or if there is a unreachalbe primary tablet
 	// in both case, there should be a reconciled primary tablet
 	if skipPrimary && primary != nil {
 		status := shard.sqlGroup.GetStatus(primary.instanceKey)

--- a/go/vt/vtgr/controller/repair.go
+++ b/go/vt/vtgr/controller/repair.go
@@ -294,7 +294,7 @@ func (shard *GRShard) stopAndRebootstrap(ctx context.Context) error {
 	return shard.dbAgent.BootstrapGroupLocked(candidate.instanceKey)
 }
 
-func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *concurrency.AllErrorRecorder, error) {
+func (shard *GRShard) getGTIDSetFromAll(skipMaster bool) (*groupGTIDRecorder, *concurrency.AllErrorRecorder, error) {
 	if len(shard.instances) == 0 {
 		return nil, nil, fmt.Errorf("%v has 0 instance", formatKeyspaceShard(shard.KeyspaceShard))
 	}
@@ -308,9 +308,9 @@ func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *
 	primary := shard.findShardPrimaryTablet()
 	var mysqlPrimaryHost string
 	var mysqlPrimaryPort int
-	// skipPrimary is true when we manual failover or if there is a unreachalbe primary tablet
+	// skipMaster is true when we manual failover or if there is a unreachalbe primary tablet
 	// in both case, there should be a reconciled primary tablet
-	if skipPrimary && primary != nil {
+	if skipMaster && primary != nil {
 		status := shard.sqlGroup.GetStatus(primary.instanceKey)
 		mysqlPrimaryHost, mysqlPrimaryPort = status.HostName, status.Port
 		log.Infof("Found primary instance from MySQL on %v", mysqlPrimaryHost)
@@ -321,7 +321,7 @@ func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *
 	// that is unreachable
 	errorRecorder := shard.forAllInstances(func(instance *grInstance, wg *sync.WaitGroup, er concurrency.ErrorRecorder) {
 		defer wg.Done()
-		if skipPrimary && instance.instanceKey.Hostname == mysqlPrimaryHost && instance.instanceKey.Port == mysqlPrimaryPort {
+		if skipMaster && instance.instanceKey.Hostname == mysqlPrimaryHost && instance.instanceKey.Port == mysqlPrimaryPort {
 			log.Infof("Skip %v to failover to a non-primary node", mysqlPrimaryHost)
 			return
 		}
@@ -397,15 +397,10 @@ func (shard *GRShard) findFailoverCandidate(ctx context.Context) (*grInstance, e
 	})
 	var candidate *grInstance
 	candidate, err = shard.findFailoverCandidateFromRecorder(ctx, gtidRecorder, func(c context.Context, instance *grInstance) bool {
-		for _, unreachable := range shard.shardStatusCollector.status.Unreachables {
-			if unreachable == instance.alias {
-				return false
-			}
-		}
-		return true
+		return !shard.shardStatusCollector.isUnreachable(instance)
 	})
 	if err != nil {
-		log.Errorf("Failed to find failover candidate by GTID after forAllInstances: %v", err)
+		log.Errorf("Failed to find failover candidate by GTID after fanout: %v", err)
 		return nil, err
 	}
 	if candidate == nil {
@@ -458,9 +453,9 @@ func (shard *GRShard) fixPrimaryTabletLocked(ctx context.Context) error {
 	if err := shard.checkShardLocked(ctx); err != nil {
 		return err
 	}
-	err := shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_PRIMARY)
+	err := shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_MASTER)
 	if err != nil {
-		return fmt.Errorf("failed to change type to primary on %v: %v", candidate.alias, err)
+		return fmt.Errorf("failed to change type to master on %v: %v", candidate.alias, err)
 	}
 	log.Infof("Successfully make %v the primary tablet", candidate.alias)
 	return nil
@@ -655,7 +650,7 @@ func (shard *GRShard) failoverLocked(ctx context.Context) error {
 	if err := shard.checkShardLocked(ctx); err != nil {
 		return err
 	}
-	err = shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_PRIMARY)
+	err = shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_MASTER)
 	if err != nil {
 		log.Errorf("Failed to failover Vitess %v", candidate.alias)
 		return err

--- a/go/vt/vtgr/controller/repair.go
+++ b/go/vt/vtgr/controller/repair.go
@@ -294,7 +294,7 @@ func (shard *GRShard) stopAndRebootstrap(ctx context.Context) error {
 	return shard.dbAgent.BootstrapGroupLocked(candidate.instanceKey)
 }
 
-func (shard *GRShard) getGTIDSetFromAll(skipMaster bool) (*groupGTIDRecorder, *concurrency.AllErrorRecorder, error) {
+func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *concurrency.AllErrorRecorder, error) {
 	if len(shard.instances) == 0 {
 		return nil, nil, fmt.Errorf("%v has 0 instance", formatKeyspaceShard(shard.KeyspaceShard))
 	}
@@ -310,7 +310,7 @@ func (shard *GRShard) getGTIDSetFromAll(skipMaster bool) (*groupGTIDRecorder, *c
 	var mysqlPrimaryPort int
 	// skipMaster is true when we manual failover or if there is a unreachalbe primary tablet
 	// in both case, there should be a reconciled primary tablet
-	if skipMaster && primary != nil {
+	if skipPrimary && primary != nil {
 		status := shard.sqlGroup.GetStatus(primary.instanceKey)
 		mysqlPrimaryHost, mysqlPrimaryPort = status.HostName, status.Port
 		log.Infof("Found primary instance from MySQL on %v", mysqlPrimaryHost)
@@ -321,7 +321,7 @@ func (shard *GRShard) getGTIDSetFromAll(skipMaster bool) (*groupGTIDRecorder, *c
 	// that is unreachable
 	errorRecorder := shard.forAllInstances(func(instance *grInstance, wg *sync.WaitGroup, er concurrency.ErrorRecorder) {
 		defer wg.Done()
-		if skipMaster && instance.instanceKey.Hostname == mysqlPrimaryHost && instance.instanceKey.Port == mysqlPrimaryPort {
+		if skipPrimary && instance.instanceKey.Hostname == mysqlPrimaryHost && instance.instanceKey.Port == mysqlPrimaryPort {
 			log.Infof("Skip %v to failover to a non-primary node", mysqlPrimaryHost)
 			return
 		}
@@ -400,7 +400,7 @@ func (shard *GRShard) findFailoverCandidate(ctx context.Context) (*grInstance, e
 		return !shard.shardStatusCollector.isUnreachable(instance)
 	})
 	if err != nil {
-		log.Errorf("Failed to find failover candidate by GTID after fanout: %v", err)
+		log.Errorf("Failed to find failover candidate by GTID after forAllInstances: %v", err)
 		return nil, err
 	}
 	if candidate == nil {
@@ -453,9 +453,9 @@ func (shard *GRShard) fixPrimaryTabletLocked(ctx context.Context) error {
 	if err := shard.checkShardLocked(ctx); err != nil {
 		return err
 	}
-	err := shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_MASTER)
+	err := shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_PRIMARY)
 	if err != nil {
-		return fmt.Errorf("failed to change type to master on %v: %v", candidate.alias, err)
+		return fmt.Errorf("failed to change type to primary on %v: %v", candidate.alias, err)
 	}
 	log.Infof("Successfully make %v the primary tablet", candidate.alias)
 	return nil
@@ -650,7 +650,7 @@ func (shard *GRShard) failoverLocked(ctx context.Context) error {
 	if err := shard.checkShardLocked(ctx); err != nil {
 		return err
 	}
-	err = shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_MASTER)
+	err = shard.tmc.ChangeType(ctx, candidate.tablet, topodatapb.TabletType_PRIMARY)
 	if err != nil {
 		log.Errorf("Failed to failover Vitess %v", candidate.alias)
 		return err

--- a/go/vt/vtgr/controller/repair_test.go
+++ b/go/vt/vtgr/controller/repair_test.go
@@ -74,7 +74,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testHost, testPort1, "group", true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -193,7 +193,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 				Return(nil).
 				AnyTimes()
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			shard.UpdateTabletsInShardWithLock(ctx)
 			_, err := shard.Repair(ctx, DiagnoseTypeShardHasNoGroup)
 			if tt.errorMsg == "" {
@@ -229,7 +229,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 			}, true, getMysql56GTIDSet(sid1, "1-10"), topodatapb.TabletType_REPLICA},
 			{alias1, testHost, testPort1, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
-			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_PRIMARY},
+			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_MASTER},
 			{alias2, testHost, testPort2, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_REPLICA},
@@ -240,7 +240,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 			}, false, getMysql56GTIDSet(sid1, "1-10"), topodatapb.TabletType_REPLICA},
 			{alias1, testHost, testPort1, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
-			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_PRIMARY},
+			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_MASTER},
 			{alias2, testHost, testPort2, "group", []db.TestGroupState{
 				{MemberHost: "", MemberPort: "NULL", MemberState: "OFFLINE", MemberRole: ""},
 			}, true, getMysql56GTIDSet(sid1, "1-9"), topodatapb.TabletType_REPLICA},
@@ -434,7 +434,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeShardHasInactiveGroup)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -488,7 +488,7 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias2, testPort2, "group", []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -505,7 +505,7 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias2, testPort2, "group", []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
@@ -519,7 +519,7 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 			}, topodatapb.TabletType_REPLICA},
 			{alias1, testPort1, "group", []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias2, testPort2, "group", []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "UNREACHABLE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -531,12 +531,12 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias1, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_PRIMARY},
+			{alias1, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_MASTER},
 			{alias2, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
 		}},
 		{"raise error if all nodes failed", "", 0, []data{ // diagnose as DiagnoseTypeShardNetworkPartition
 			{alias0, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
-			{alias1, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_PRIMARY},
+			{alias1, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_MASTER},
 			{alias2, 0, "group", []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
 		}},
 	}
@@ -592,12 +592,12 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 			if candidate != nil {
 				tmc.
 					EXPECT().
-					ChangeType(gomock.Any(), gomock.Any(), topodatapb.TabletType_PRIMARY).
+					ChangeType(gomock.Any(), gomock.Any(), topodatapb.TabletType_MASTER).
 					Return(nil).
 					Times(expectedCalls)
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeWrongPrimaryTablet)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -628,7 +628,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 			{alias0, testPort0, "group", false, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, "group", true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -641,7 +641,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 			{alias0, testPort0, "group", true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "PRIMARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, "group", false, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "PRIMARY"},
@@ -654,7 +654,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 			{alias0, testPort0, "group", false, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, "group", true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -666,7 +666,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 		{"fix replica with two nodes in ERROR state", "", 0, []data{ // InsufficientGroupSize
 			{alias0, testPort0, "group", false, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, "group", true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
@@ -731,7 +731,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeUnconnectedReplica)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -758,22 +758,22 @@ func TestRepairUnreachablePrimary(t *testing.T) {
 		inputs                []data
 	}{
 		{"primary is unreachable", "", testPort1, []data{
-			{testPort0, false, getMysql56GTIDSet(sid, "1-11"), topodatapb.TabletType_PRIMARY},
+			{testPort0, false, getMysql56GTIDSet(sid, "1-11"), topodatapb.TabletType_MASTER},
 			{testPort1, true, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_REPLICA},
 			{testPort2, true, getMysql56GTIDSet(sid, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
 		{"failover to reachable node when primary is unreachable", "", testPort2, []data{
-			{testPort0, false, getMysql56GTIDSet(sid, "1-11"), topodatapb.TabletType_PRIMARY},
+			{testPort0, false, getMysql56GTIDSet(sid, "1-11"), topodatapb.TabletType_MASTER},
 			{testPort1, false, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_REPLICA},
 			{testPort2, true, getMysql56GTIDSet(sid, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
 		{"do nothing if replica is unreachable", "", 0, []data{
-			{testPort0, true, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_PRIMARY},
+			{testPort0, true, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_MASTER},
 			{testPort1, false, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_REPLICA},
 			{testPort2, false, getMysql56GTIDSet(sid, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
 		{"raise error if gtid divergence", "vtgr repair: found more than one failover candidates by GTID set for ks/0", 0, []data{
-			{testPort0, false, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_PRIMARY},
+			{testPort0, false, getMysql56GTIDSet(sid, "1-10"), topodatapb.TabletType_MASTER},
 			{testPort1, true, getMysql56GTIDSet("264a8230-67d2-11eb-acdd-0a8d91f24125", "1-10"), topodatapb.TabletType_REPLICA},
 			{testPort2, true, getMysql56GTIDSet(sid, "1-9"), topodatapb.TabletType_REPLICA},
 		}},
@@ -811,7 +811,7 @@ func TestRepairUnreachablePrimary(t *testing.T) {
 				Times(expectedCalls)
 			tmc.
 				EXPECT().
-				ChangeType(gomock.Any(), gomock.Any(), topodatapb.TabletType_PRIMARY).
+				ChangeType(gomock.Any(), gomock.Any(), topodatapb.TabletType_MASTER).
 				Return(nil).
 				Times(expectedCalls)
 			status := make(map[int32]struct {
@@ -850,7 +850,7 @@ func TestRepairUnreachablePrimary(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeUnreachablePrimary)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -880,7 +880,7 @@ func TestRepairInsufficientGroupSize(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
@@ -942,7 +942,7 @@ func TestRepairInsufficientGroupSize(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeInsufficientGroupSize)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -973,7 +973,7 @@ func TestRepairReadOnlyShard(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -990,7 +990,7 @@ func TestRepairReadOnlyShard(t *testing.T) {
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
-			}, topodatapb.TabletType_PRIMARY},
+			}, topodatapb.TabletType_MASTER},
 			{alias1, testPort1, true, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -1052,7 +1052,7 @@ func TestRepairReadOnlyShard(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			_, err := shard.Repair(ctx, DiagnoseTypeReadOnlyShard)
 			if tt.errorMsg == "" {
 				assert.NoError(t, err)
@@ -1215,7 +1215,7 @@ func TestRepairBackoffError(t *testing.T) {
 					AnyTimes()
 			}
 			cfg := &config.VTGRConfig{GroupSize: repairGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
-			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0)
+			shard := NewGRShard("ks", "0", nil, tmc, ts, dbAgent, cfg, testPort0, true)
 			shard.lastDiagnoseResult = tt.diagnose
 			_, err := shard.Repair(ctx, tt.diagnose)
 			if tt.errorMsg == "" {

--- a/go/vt/vtgr/vtgr_test.go
+++ b/go/vt/vtgr/vtgr_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/sync2"
+	"github.com/stretchr/testify/assert"
 
+	"vitess.io/vitess/go/sync2"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vtgr/config"
 	"vitess.io/vitess/go/vt/vtgr/controller"
 	"vitess.io/vitess/go/vt/vtgr/db"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSighupHandle(t *testing.T) {
@@ -37,7 +36,7 @@ func TestSighupHandle(t *testing.T) {
 		BackoffErrorWaitTimeSeconds: 10,
 		BootstrapWaitTimeSeconds:    10 * 60,
 	}
-	shards = append(shards, controller.NewGRShard("ks", "0", nil, vtgr.tmc, vtgr.topo, db.NewVTGRSqlAgent(), config, *localDbPort))
+	shards = append(shards, controller.NewGRShard("ks", "0", nil, vtgr.tmc, vtgr.topo, db.NewVTGRSqlAgent(), config, *localDbPort, true))
 	vtgr.Shards = shards
 	shard := vtgr.Shards[0]
 	shard.LockShard(ctx, "test")


### PR DESCRIPTION
Signed-off-by: Yang Wu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When we deploy VTGR in more than one region, we usually deploy one mysql group per region to avoid cross-region paxos round. 

Because of that, we need to define an "active" region for VTGR: only VTGR in the active region will do the `tmc.ChangeType` call. VTGR in the inactive region will just maintain the mysql group without modifying vttablet records in topo server

See the diagram in #8779 for more illustration

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Resolves https://github.com/vitessio/vitess/issues/8779

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->