### PR TITLE
fix parsing of MySQL Server Version flag

### DIFF
--- a/go/vt/sqlparser/parser.go
+++ b/go/vt/sqlparser/parser.go
@@ -47,7 +47,7 @@ var parserPool = sync.Pool{
 var zeroParser yyParserImpl
 
 // MySQLVersion is the version of MySQL that the parser would emulate
-var MySQLVersion string
+var MySQLVersion = "50709" // default version if nothing else is stated
 
 // yyParsePooled is a wrapper around yyParse that pools the parser objects. There isn't a
 // particularly good reason to use yyParse directly, since it immediately discards its parser.
@@ -110,7 +110,6 @@ func Parse2(sql string) (Statement, BindVars, error) {
 func checkParserVersionFlag() {
 	if flag.Parsed() {
 		versionFlagSync.Do(func() {
-			MySQLVersion = "50709" // default version if nothing else is stated
 			if *MySQLServerVersion != "" {
 				convVersion, err := convertMySQLVersionToCommentVersion(*MySQLServerVersion)
 				if err != nil {

--- a/go/vt/sqlparser/parser.go
+++ b/go/vt/sqlparser/parser.go
@@ -110,12 +110,14 @@ func Parse2(sql string) (Statement, BindVars, error) {
 func checkParserVersionFlag() {
 	if flag.Parsed() {
 		versionFlagSync.Do(func() {
-			convVersion, err := convertMySQLVersionToCommentVersion(*MySQLServerVersion)
-			if err != nil {
-				log.Error(err)
-				MySQLVersion = "50709" // default version if nothing else is stated
-			} else {
-				MySQLVersion = convVersion
+			MySQLVersion = "50709" // default version if nothing else is stated
+			if *MySQLServerVersion != "" {
+				convVersion, err := convertMySQLVersionToCommentVersion(*MySQLServerVersion)
+				if err != nil {
+					log.Error(err)
+				} else {
+					MySQLVersion = convVersion
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description
We should only parse the MySQL Server Version flag if it is provided

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->