### PR TITLE
[vtctl] Add missing call to `flag.Parse` in `commandGetRoutingRules`

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3183,6 +3183,10 @@ func commandGetVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 }
 
 func commandGetRoutingRules(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	if err := subFlags.Parse(args); err != nil {
+		return err
+	}
+
 	resp, err := wr.VtctldServer().GetRoutingRules(ctx, &vtctldatapb.GetRoutingRulesRequest{})
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

## Description

Noticed this the other day.

Before:

```
❯ vtctlclient -server ":15999" GetRoutingRules -h
{}
```

After:

```
❯ vtctlclient -server ":15999" GetRoutingRules -h
Usage: GetRoutingRules 

Displays the VSchema routing rules.

```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? - **No**
- [x] Tests were added or are not required - **N/A**
- [x] Documentation was added or is not required - **N/A**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->