### PR TITLE
Fixed filename for the configuration file in Vttestserver

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -22,7 +22,7 @@
 if [[ -z $MYSQL_MAX_CONNECTIONS ]]; then
   MYSQL_MAX_CONNECTIONS=1000
 fi
-echo "max_connections = $MYSQL_MAX_CONNECTIONS" >> /vt/config/mycnf/default-fast.cnf
+echo "max_connections = $MYSQL_MAX_CONNECTIONS" >> /vt/config/mycnf/test-suite.cnf
 
 # Delete socket files before running mysqlctld if exists.
 # This is the primary reason for unhealthy state on restart.


### PR DESCRIPTION
## Description
Fixed filename for the configuration file in Vttestserver docker file. Earlier, we rewrote `default-fast.cnf` to `test-suite.cnf`. This PR fixes one remaining reference

# Related Issues
- Fixes #8808 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
