### PR TITLE
Improve deterministic of bootstrap

### DIFF
--- a/go/vt/vtgr/controller/repair.go
+++ b/go/vt/vtgr/controller/repair.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -144,6 +145,9 @@ func (shard *GRShard) repairShardHasNoGroupAction(ctx context.Context) error {
 		return errors.New("unsafe to bootstrap group")
 	}
 	var candidate *grInstance
+	sort.SliceStable(replicas, func(i, j int) bool {
+		return replicas[i].alias < replicas[j].alias
+	})
 	for _, replica := range replicas {
 		if !shard.shardStatusCollector.isUnreachable(replica) {
 			candidate = replica
@@ -291,7 +295,11 @@ func (shard *GRShard) stopAndRebootstrap(ctx context.Context) error {
 	if err := shard.checkShardLocked(ctx); err != nil {
 		return err
 	}
-	return shard.dbAgent.BootstrapGroupLocked(candidate.instanceKey)
+	uuid := shard.sqlGroup.GetGroupName()
+	if uuid == "" {
+		return errors.New("trying to rebootstrap without uuid")
+	}
+	return shard.dbAgent.RebootstrapGroupLocked(candidate.instanceKey, uuid)
 }
 
 func (shard *GRShard) getGTIDSetFromAll(skipPrimary bool) (*groupGTIDRecorder, *concurrency.AllErrorRecorder, error) {

--- a/go/vt/vtgr/db/mock_mysql.go
+++ b/go/vt/vtgr/db/mock_mysql.go
@@ -63,6 +63,20 @@ func (mr *MockAgentMockRecorder) BootstrapGroupLocked(instanceKey interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapGroupLocked", reflect.TypeOf((*MockAgent)(nil).BootstrapGroupLocked), instanceKey)
 }
 
+// RebootstrapGroupLocked mocks base method
+func (m *MockAgent) RebootstrapGroupLocked(instanceKey *inst.InstanceKey, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RebootstrapGroupLocked", instanceKey, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RebootstrapGroupLocked indicates an expected call of RebootstrapGroupLocked
+func (mr *MockAgentMockRecorder) RebootstrapGroupLocked(instanceKey, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebootstrapGroupLocked", reflect.TypeOf((*MockAgent)(nil).RebootstrapGroupLocked), instanceKey, name)
+}
+
 // StopGroupLocked mocks base method
 func (m *MockAgent) StopGroupLocked(instanceKey *inst.InstanceKey) error {
 	m.ctrl.T.Helper()
@@ -99,8 +113,8 @@ func (m *MockAgent) SetReadOnly(instanceKey *inst.InstanceKey, readOnly bool) er
 	return ret0
 }
 
-// SetSuperReadOnly indicates an expected call of SetSuperReadOnly
-func (mr *MockAgentMockRecorder) SetSuperReadOnly(instanceKey, readOnly interface{}) *gomock.Call {
+// SetReadOnly indicates an expected call of SetReadOnly
+func (mr *MockAgentMockRecorder) SetReadOnly(instanceKey, readOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadOnly", reflect.TypeOf((*MockAgent)(nil).SetReadOnly), instanceKey, readOnly)
 }


### PR DESCRIPTION
Signed-off-by: Yang Wu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR improves the deterministic of the bootstrap logic. Specifically:

- when we bootstrap, instead of picking a random node, we do a sort so that every time we are using the same node
- on rebootstrap, we pass in the group name instead of checking local group_replication_group_name, which can be empty if the bootstrap failed earlier

After this fix, we should only generate group name in bootstrap and it is only executed when there are 5 nodes in group without a group name

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->