### PR TITLE
Handle mapping of gRPC packet overflows to `ERTooManyUserConnections` for SELECT cases too

### DIFF
--- a/go/mysql/sql_error.go
+++ b/go/mysql/sql_error.go
@@ -214,7 +214,7 @@ func convertToMysqlError(err error) error {
 	return NewSQLError(mysqlCode.num, mysqlCode.state, err.Error())
 }
 
-var isGRPCOverflowRE = regexp.MustCompile(`.*grpc: received message larger than max \(\d+ vs. \d+\)`)
+var isGRPCOverflowRE = regexp.MustCompile(`.*?grpc: (received|trying to send) message larger than max \(\d+ vs. \d+\)`)
 
 func demuxResourceExhaustedErrors(msg string) int {
 	switch {

--- a/go/mysql/sql_error_test.go
+++ b/go/mysql/sql_error_test.go
@@ -36,6 +36,9 @@ func TestDumuxResourceExhaustedErrors(t *testing.T) {
 		{"grpc: received message larger than max (99282 vs. 1234): trailer", ERNetPacketTooLarge},
 		{"grpc: received message larger than max (1234 vs. 1234)", ERNetPacketTooLarge},
 		{"header: grpc: received message larger than max (1234 vs. 1234)", ERNetPacketTooLarge},
+		{"grpc: trying to send message larger than max (18015277 vs. 16777216)", ERNetPacketTooLarge},
+		{"grpc: trying to send message larger than max (18015277 vs. 16777216): trailer", ERNetPacketTooLarge},
+		{"header: grpc: trying to send message larger than max (18015277 vs. 16777216)", ERNetPacketTooLarge},
 		// This should be explicitly handled by returning ERNetPacketTooLarge from the execturo directly
 		// and therefore shouldn't need to be teased out of another error.
 		{"in-memory row count exceeded allowed limit of 13", ERTooManyUserConnections},


### PR DESCRIPTION
Fixes #8852 

See original PR #6630

This is a potential breaking change for those that depended on the old behavior of `ERTooManyUserConnections` being returned on a too-large `SELECT`, and mapped that to some application-side action.

Not addressed in this PR, but we should probably add an end-to-end test here to catch if/when the upstream gRPC error message is ever changed, since we track upstream gRPC now after having been frozen for years.