### PR TITLE
Apply goimports in `asthelpergen`

### DIFF
--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -34,6 +34,7 @@ jobs:
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
+        go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
       run: |

--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -25,6 +25,8 @@ import (
 	"path"
 	"strings"
 
+	"vitess.io/vitess/go/tools/goimports"
+
 	"vitess.io/vitess/go/tools/common"
 
 	"github.com/dave/jennifer/jen"
@@ -182,13 +184,13 @@ func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 			continue
 		}
 
-		var buf bytes.Buffer
-		if err := file.Render(&buf); err != nil {
-			errors = append(errors, fmt.Errorf("render error for '%s': %w", fullPath, err))
+		genFile, err := goimports.FormatJenFile(file)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("goimport error: %w", err))
 			continue
 		}
 
-		if !bytes.Equal(existing, buf.Bytes()) {
+		if !bytes.Equal(existing, genFile) {
 			errors = append(errors, fmt.Errorf("'%s' has changed", fullPath))
 			continue
 		}

--- a/go/tools/asthelpergen/main/main.go
+++ b/go/tools/asthelpergen/main/main.go
@@ -18,7 +18,10 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
+
+	"vitess.io/vitess/go/tools/goimports"
 
 	. "vitess.io/vitess/go/tools/asthelpergen"
 )
@@ -46,7 +49,12 @@ func main() {
 		log.Printf("%d files OK", len(result))
 	} else {
 		for fullPath, file := range result {
-			if err := file.Save(fullPath); err != nil {
+			content, err := goimports.FormatJenFile(file)
+			if err != nil {
+				log.Fatalf("failed to apply goimport to '%s': %v", fullPath, err)
+			}
+			err = ioutil.WriteFile(fullPath, content, 0664)
+			if err != nil {
 				log.Fatalf("failed to save file to '%s': %v", fullPath, err)
 			}
 			log.Printf("saved '%s'", fullPath)

--- a/go/tools/goimports/goimports.go
+++ b/go/tools/goimports/goimports.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goimports
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/dave/jennifer/jen"
+)
+
+// FormatJenFile formats the given *jen.File with goimports and return a slice
+// of byte corresponding to the formatted file.
+func FormatJenFile(file *jen.File) ([]byte, error) {
+	tempFile, err := ioutil.TempFile("/tmp", "*.go")
+	if err != nil {
+		return nil, err
+	}
+
+	err = file.Save(tempFile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("goimports", "-local", "vitess.io/vitess", "-w", tempFile.Name())
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadFile(tempFile.Name())
+}

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -23,11 +23,11 @@ import (
 	"go/types"
 	"io/ioutil"
 	"log"
-	"os"
-	"os/exec"
 	"path"
 	"sort"
 	"strings"
+
+	"vitess.io/vitess/go/tools/goimports"
 
 	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/tools/common"
@@ -475,7 +475,7 @@ func main() {
 		log.Printf("%d files OK", len(result))
 	} else {
 		for fullPath, file := range result {
-			content, err := getFileInGoimportFormat(file)
+			content, err := goimports.FormatJenFile(file)
 			if err != nil {
 				log.Fatalf("failed to apply goimport to '%s': %v", fullPath, err)
 			}
@@ -499,7 +499,7 @@ func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 			continue
 		}
 
-		genFile, err := getFileInGoimportFormat(file)
+		genFile, err := goimports.FormatJenFile(file)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("goimport error: %w", err))
 			continue
@@ -564,24 +564,4 @@ func GenerateSizeHelpers(packagePatterns []string, typePatterns []string) (map[s
 	}
 
 	return sizegen.finalize(), nil
-}
-
-func getFileInGoimportFormat(file *jen.File) ([]byte, error) {
-	tempFile, err := ioutil.TempFile("/tmp", "*.go")
-	if err != nil {
-		return nil, err
-	}
-
-	err = file.Save(tempFile.Name())
-	if err != nil {
-		return nil, err
-	}
-
-	cmd := exec.Command("goimports", "-local", "vitess.io/vitess", "-w", tempFile.Name())
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	if err != nil {
-		return nil, err
-	}
-	return ioutil.ReadFile(tempFile.Name())
 }


### PR DESCRIPTION
## Description

This pull request fixes a similar issue as the one solved by #8828. The `asthelpergen` generates files that are not formatted using `goimports`, which ultimately makes `TestFullGeneration` fail with the following output when local files are formatted correctly:
```
--- FAIL: TestFullGeneration (1.76s)
    asthelpergen_test.go:32: 
        	Error Trace:	asthelpergen_test.go:32
        	Error:      	Should be empty, but was ['/home/runner/work/vitess/vitess/go/tools/asthelpergen/integration/ast_clone.go' has changed]
        	Test:       	TestFullGeneration
FAIL
FAIL	vitess.io/vitess/go/tools/asthelpergen	1.769s
```

In this pull request, I have taken what was done in #8828 and applied it to the `asthelpergen`.

## Related Issue(s)

- #8828 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
