### PR TITLE
Prefix logger with keyspace/shard

### DIFF
--- a/go/vt/vtgr/controller/refresh.go
+++ b/go/vt/vtgr/controller/refresh.go
@@ -26,13 +26,13 @@ import (
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/sync2"
-	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/orchestrator/inst"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtgr/config"
 	"vitess.io/vitess/go/vt/vtgr/db"
+	"vitess.io/vitess/go/vt/vtgr/log"
 )
 
 var (
@@ -91,6 +91,8 @@ type GRShard struct {
 
 	isActive sync2.AtomicBool
 
+	logger *log.Logger
+
 	// lock prevents multiple go routine fights with each other
 	sync.Mutex
 }
@@ -140,6 +142,7 @@ func NewGRShard(
 		minNumReplicas:            config.MinNumReplica,
 		disableReadOnlyProtection: config.DisableReadOnlyProtection,
 		localDbPort:               localDbPort,
+		logger:                    log.NewVTGRLogger(keyspace, shard),
 		transientErrorWaitTime:    time.Duration(config.BackoffErrorWaitTimeSeconds) * time.Second,
 		bootstrapWaitTime:         time.Duration(config.BootstrapWaitTimeSeconds) * time.Second,
 	}
@@ -172,7 +175,7 @@ func (shard *GRShard) refreshTabletsInShardInternal(ctx context.Context) ([]*grI
 	keyspace, shardName := shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard
 	tablets, err := shard.ts.GetTabletMapForShardByCell(ctx, keyspace, shardName, shard.cells)
 	if err != nil {
-		log.Errorf("Error fetching tablets for keyspace/shardName %v/%v: %v", keyspace, shardName, err)
+		shard.logger.Errorf("Error fetching tablets for keyspace/shardName %v/%v: %v", keyspace, shardName, err)
 		return nil, err
 	}
 	return parseTabletInfos(tablets), nil
@@ -232,7 +235,7 @@ func (shard *GRShard) UnlockShard() {
 	shard.unlockMu.Lock()
 	defer shard.unlockMu.Unlock()
 	if shard.unlock == nil {
-		log.Warningf("Shard %s/%s does not hold a lock", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
+		shard.logger.Warningf("Shard %s/%s does not hold a lock", shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard)
 		return
 	}
 	var err error
@@ -284,7 +287,7 @@ func (shard *GRShard) GetUnlock() func(*error) {
 
 // SetIsActive sets isActive for the shard
 func (shard *GRShard) SetIsActive(isActive bool) {
-	log.Infof("Setting is active to %v", isActive)
+	shard.logger.Infof("Setting is active to %v", isActive)
 	shard.isActive.Set(isActive)
 }
 

--- a/go/vt/vtgr/log/log.go
+++ b/go/vt/vtgr/log/log.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+// Logger is a wrapper that prefix loglines with keyspace/shard
+type Logger struct {
+	prefix string
+}
+
+// NewVTGRLogger creates a new logger
+func NewVTGRLogger(keyspace, shard string) *Logger {
+	return &Logger{
+		prefix: fmt.Sprintf("%s/%s", keyspace, shard),
+	}
+}
+
+// Info formats arguments like fmt.Print
+func (logger *Logger) Info(msg string) {
+	log.Info(logger.annotate(msg))
+}
+
+// Infof formats arguments like fmt.Printf.
+func (logger *Logger) Infof(format string, args ...interface{}) {
+	log.Info(logger.annotate(fmt.Sprintf(format, args...)))
+}
+
+// Warning formats arguments like fmt.Print
+func (logger *Logger) Warning(msg string) {
+	log.Warning(logger.annotate(msg))
+}
+
+// Warningf formats arguments like fmt.Printf.
+func (logger *Logger) Warningf(format string, args ...interface{}) {
+	log.Warning(logger.annotate(fmt.Sprintf(format, args...)))
+}
+
+// Error formats arguments like fmt.Print
+func (logger *Logger) Error(msg string) {
+	log.Error(logger.annotate(msg))
+}
+
+// Errorf formats arguments like fmt.Printf.
+func (logger *Logger) Errorf(format string, args ...interface{}) {
+	log.Error(logger.annotate(fmt.Sprintf(format, args...)))
+}
+
+func (logger *Logger) annotate(input string) string {
+	return fmt.Sprintf("shard=%s %s", logger.prefix, input)
+}

--- a/go/vt/vtgr/log/log_test.go
+++ b/go/vt/vtgr/log/log_test.go
@@ -1,0 +1,16 @@
+package log
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVTGRLogger(t *testing.T) {
+	logger := NewVTGRLogger("ks", "0")
+	s1 := logger.annotate("abc")
+	assert.Equal(t, "shard=ks/0 abc", s1)
+	s2 := fmt.Sprintf(logger.annotate("abc %s"), "def")
+	assert.Equal(t, "shard=ks/0 abc def", s2)
+}


### PR DESCRIPTION
Signed-off-by: Yang Wu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
VTGR logs can be pretty hard to find the right one for a given shard. Often the time, we need know the host name and then grab logs from it.

This PR prefix all the VTGR logs with `shard=ks/shard` so that it is easier to search.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
^

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->