### PR TITLE
Backtick DB and table names in RoutingRules

### DIFF
--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -165,16 +165,16 @@ func (wr *Wrangler) MoveTables(ctx context.Context, workflow, sourceKeyspace, ta
 			return err
 		}
 		for _, table := range tables {
-			toSource := []string{sourceKeyspace + "." + table}
-			rules[table] = toSource
-			rules[table+"@replica"] = toSource
-			rules[table+"@rdonly"] = toSource
-			rules[targetKeyspace+"."+table] = toSource
-			rules[targetKeyspace+"."+table+"@replica"] = toSource
-			rules[targetKeyspace+"."+table+"@rdonly"] = toSource
-			rules[targetKeyspace+"."+table] = toSource
-			rules[sourceKeyspace+"."+table+"@replica"] = toSource
-			rules[sourceKeyspace+"."+table+"@rdonly"] = toSource
+			toSource := []string{"`" + sourceKeyspace + "`.`" + table + "`"}
+			rules["`"+table+"`"] = toSource
+			rules["`"+table+"`@replica"] = toSource
+			rules["`"+table+"`@rdonly"] = toSource
+			rules["`"+targetKeyspace+"`.`"+table+"`"] = toSource
+			rules["`"+targetKeyspace+"`.`"+table+"`@replica"] = toSource
+			rules["`"+targetKeyspace+"`.`"+table+"`@rdonly"] = toSource
+			rules["`"+targetKeyspace+"`.`"+table+"`"] = toSource
+			rules["`"+sourceKeyspace+"`.`"+table+"`@replica"] = toSource
+			rules["`"+sourceKeyspace+"`.`"+table+"`@rdonly"] = toSource
 		}
 		if err := topotools.SaveRoutingRules(ctx, wr.ts, rules); err != nil {
 			return err

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -900,16 +900,16 @@ func (ts *trafficSwitcher) switchTableReads(ctx context.Context, cells []string,
 		for _, table := range ts.tables {
 			if direction == workflow.DirectionForward {
 				log.Infof("Route direction forward")
-				toTarget := []string{ts.targetKeyspace + "." + table}
-				rules[table+"@"+tt] = toTarget
-				rules[ts.targetKeyspace+"."+table+"@"+tt] = toTarget
-				rules[ts.sourceKeyspace+"."+table+"@"+tt] = toTarget
+				toTarget := []string{"`" + ts.targetKeyspace + "`.`" + table + "`"}
+				rules["`"+table+"`@"+tt] = toTarget
+				rules["`"+ts.targetKeyspace+"`.`"+table+"`@"+tt] = toTarget
+				rules["`"+ts.sourceKeyspace+"`.`"+table+"`@"+tt] = toTarget
 			} else {
 				log.Infof("Route direction backwards")
-				toSource := []string{ts.sourceKeyspace + "." + table}
-				rules[table+"@"+tt] = toSource
-				rules[ts.targetKeyspace+"."+table+"@"+tt] = toSource
-				rules[ts.sourceKeyspace+"."+table+"@"+tt] = toSource
+				toSource := []string{"`" + ts.sourceKeyspace + "`.`" + table + "`"}
+				rules["`"+table+"`@"+tt] = toSource
+				rules["`"+ts.targetKeyspace+"`.`"+table+"`@"+tt] = toSource
+				rules["`"+ts.sourceKeyspace+"`.`"+table+"`@"+tt] = toSource
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Mark Solters <msolters@gmail.com>

## Description
For some data storage engines, such as Oracle MySQL 8, users will encounter errors if their tables are named after reserved keywords (e.g. `lead`).  This is not an issue if references to these tables are properly escaped.

Currently, the materialize code paths which mutate routing rules do not respect the correct escaping (backticks).  We have independently verified that we get query routing failures when e.g. migrate commands are run, and un-backticked schema/tables are put into RoutingRules.  Manually pulling the RoutingRules as JSON, adding the backticks where appropriate, and manually re-applying fixes these problems.

These changes fix the problem at the source by forcing the Materialize code paths to backtick all database names or table names.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes