### PR TITLE
Fix for padding in OrderAndCheckPartitions 

### DIFF
--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -242,9 +242,9 @@ func KeyRangeStartEqual(left, right *topodatapb.KeyRange) bool {
 	return bytes.Equal(addPadding(left.Start), addPadding(right.Start))
 }
 
-// KeyRangeIsContiguous returns true if the end of the left key range exactly
+// KeyRangeContiguous returns true if the end of the left key range exactly
 // matches the start of the right key range (i.e they are contigious)
-func KeyRangeIsContiguous(left, right *topodatapb.KeyRange) bool {
+func KeyRangeContiguous(left, right *topodatapb.KeyRange) bool {
 	if left == nil {
 		return right == nil || (len(right.Start) == 0 && len(right.End) == 0)
 	}

--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -242,6 +242,14 @@ func KeyRangeStartEqual(left, right *topodatapb.KeyRange) bool {
 	return bytes.Equal(addPadding(left.Start), addPadding(right.Start))
 }
 
+// KeyRangeIsContiguous returns true if left.End equals right.End (i.e they are contigious)
+func KeyRangeIsContiguous(left, right *topodatapb.KeyRange) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return bytes.Equal(addPadding(left.End), addPadding(right.Start))
+}
+
 // KeyRangeEndEqual returns true if both key ranges have the same end
 func KeyRangeEndEqual(left, right *topodatapb.KeyRange) bool {
 	if left == nil {

--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -242,10 +242,14 @@ func KeyRangeStartEqual(left, right *topodatapb.KeyRange) bool {
 	return bytes.Equal(addPadding(left.Start), addPadding(right.Start))
 }
 
-// KeyRangeIsContiguous returns true if left.End equals right.End (i.e they are contigious)
+// KeyRangeIsContiguous returns true if the end of the left key range exactly
+// matches the start of the right key range (i.e they are contigious)
 func KeyRangeIsContiguous(left, right *topodatapb.KeyRange) bool {
-	if left == nil || right == nil {
-		return false
+	if left == nil {
+		return right == nil || (len(right.Start) == 0 && len(right.End) == 0)
+	}
+	if right == nil {
+		return len(left.Start) == 0 && len(left.End) == 0
 	}
 	return bytes.Equal(addPadding(left.End), addPadding(right.Start))
 }

--- a/go/vt/key/key_test.go
+++ b/go/vt/key/key_test.go
@@ -346,7 +346,7 @@ func TestKeyRangeEqual(t *testing.T) {
 	}
 }
 
-func TestKeyRangeIsContiguous(t *testing.T) {
+func TestKeyRangeContiguous(t *testing.T) {
 	testcases := []struct {
 		first  string
 		second string
@@ -384,9 +384,9 @@ func TestKeyRangeIsContiguous(t *testing.T) {
 	for _, tcase := range testcases {
 		first := stringToKeyRange(tcase.first)
 		second := stringToKeyRange(tcase.second)
-		out := KeyRangeIsContiguous(first, second)
+		out := KeyRangeContiguous(first, second)
 		if out != tcase.out {
-			t.Fatalf("KeyRangeEqual(%q, %q) expected %t, got %t", tcase.first, tcase.second, tcase.out, out)
+			t.Fatalf("KeyRangeContiguous(%q, %q) expected %t, got %t", tcase.first, tcase.second, tcase.out, out)
 		}
 	}
 }

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -680,7 +680,7 @@ func OrderAndCheckPartitions(cell string, srvKeyspace *topodatapb.SrvKeyspace) e
 				// this is the custom sharding case, all KeyRanges must be nil
 				continue
 			}
-			if !key.KeyRangeIsContiguous(currShard.KeyRange, nextShard.KeyRange) {
+			if !key.KeyRangeContiguous(currShard.KeyRange, nextShard.KeyRange) {
 				return fmt.Errorf("non-contiguous KeyRange values for %v in cell %v at shard %v to %v: %v != %v", tabletType, cell, i, i+1, hex.EncodeToString(currShard.KeyRange.End), hex.EncodeToString(nextShard.KeyRange.Start))
 			}
 		}

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -17,7 +17,6 @@ limitations under the License.
 package topo
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 	"path"
@@ -681,7 +680,7 @@ func OrderAndCheckPartitions(cell string, srvKeyspace *topodatapb.SrvKeyspace) e
 				// this is the custom sharding case, all KeyRanges must be nil
 				continue
 			}
-			if !bytes.Equal(currShard.KeyRange.End, nextShard.KeyRange.Start) {
+			if !key.KeyRangeIsContiguous(currShard.KeyRange, nextShard.KeyRange) {
 				return fmt.Errorf("non-contiguous KeyRange values for %v in cell %v at shard %v to %v: %v != %v", tabletType, cell, i, i+1, hex.EncodeToString(currShard.KeyRange.End), hex.EncodeToString(nextShard.KeyRange.Start))
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
We ran into an issue similar to the one in https://github.com/vitessio/vitess/pull/8296. While trying to switch traffic we found the following error:
```
E0922 08:33:05.346443    2565 main.go:67] E0922 15:33:05.346176 traffic_switcher.go:470] switchShardReads failed: partial result: non-contiguous KeyRange values for RDONLY 
```

This PR has three changes:
* adds a new function to the `key` package so it can check for contagious key ranges. It makes sure this function accounts for padding (in the same way as other key ranges comparison functions). 
* Starts using that function in `OrderAndCheckPartitions`.
* Refactors some code duplication in the tests.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
* https://github.com/vitessio/vitess/pull/8296

## Checklist
- [] Should this PR be backported?
I don't know. Maybe?? I think this will only affect Slack. So I don't think there is a big pressure to back port this change. 
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->