### PR TITLE
Enhancement of the release notes generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,4 +470,4 @@ generate_ci_workflows:
 	cd test && go run ci_workflow_gen.go && cd ..
 
 release-notes:
-	go run ./go/tools/release-notes -from $(FROM) -to $(TO) -release-branch $(RELEASE_BRANCH)
+	go run ./go/tools/release-notes -from "$(FROM)" -to "$(TO)" -version "$(VERSION)" -summary "$(SUMMARY)"

--- a/doc/internal/ReleaseInstructions.md
+++ b/doc/internal/ReleaseInstructions.md
@@ -117,7 +117,7 @@ The release cutover section is divided in 4 steps:
 
 * Build a Release Notes document using the Makefile: 
     ```shell
-    make RELEASE_BRANCH="release-12" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
+    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
     ```
 
 * Check to make sure all labels and categories set for each PR.
@@ -165,7 +165,7 @@ The release cutover section is divided in 4 steps:
 
 * Build a Release Notes document using the Makefile:
     ```shell
-    make RELEASE_BRANCH="release-12" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
+    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
     ```
 
 * Check to make sure all labels and categories set for each PR.

--- a/go/tools/release-notes/integration/summary.md
+++ b/go/tools/release-notes/integration/summary.md
@@ -1,0 +1,2 @@
+We are shipping the Gen4 planner within this release.
+We reduced the duration of our CI builds by using self-hosted runners.

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -364,6 +365,14 @@ func createSortedPrTypeSlice(prPerType prsByType) []sortedPRType {
 		return data[i].Name < data[j].Name
 	})
 	return data
+}
+
+func releaseSummary(summaryFile string) (string, error) {
+	contentSummary, err := ioutil.ReadFile(summaryFile)
+	if err != nil {
+		return "", err
+	}
+	return string(contentSummary), nil
 }
 
 func getOutput(fileout string) (*os.File, error) {

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -83,7 +83,7 @@ type (
 const (
 	markdownTemplate = `# Release of Vitess {{.Version}}
 
-{{- if .Announcement }}
+{{- if or .Announcement .AddDetails }}
 ## Announcement
 {{ .Announcement }}
 {{- end }}

--- a/go/tools/release-notes/release_notes_test.go
+++ b/go/tools/release-notes/release_notes_test.go
@@ -122,3 +122,33 @@ func TestLoadSummaryReadme(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, str, readmeContent)
 }
+
+func TestGenerateReleaseNotes(t *testing.T) {
+	tcs := []struct {
+		name        string
+		releaseNote releaseNote
+		expectedOut string
+	}{
+		{
+			name:        "empty",
+			releaseNote: releaseNote{},
+			expectedOut: "# Release of Vitess \n",
+		}, {
+			name:        "with version number",
+			releaseNote: releaseNote{Version: "v12.0.0"},
+			expectedOut: "# Release of Vitess v12.0.0\n",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			outFile, err := ioutil.TempFile("", "*.md")
+			require.NoError(t, err)
+			err = tc.releaseNote.generate(outFile)
+			require.NoError(t, err)
+			all, err := ioutil.ReadFile(outFile.Name())
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedOut, string(all))
+		})
+	}
+}

--- a/go/tools/release-notes/release_notes_test.go
+++ b/go/tools/release-notes/release_notes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,4 +104,21 @@ TEST@planetscale.com	docker/lite/install_dependencies.sh:  Upgrade MySQL 8 to 8.
 	assert.Equal(t, prs, []string{"7629", "7831", "7912", "7934", "7943", "7951", "7959", "7964", "7968", "7970"})
 	assert.Equal(t, authorCommits, []string{"385d0b327", "3b744e782", "4a0a943b0", "538709da5", "616f5562c", "6b9a731a2", "e5242a88a", "edac2baf8"})
 	assert.Equal(t, 28, nonMergeCommits)
+}
+
+func TestLoadSummaryReadme(t *testing.T) {
+	readmeFile, err := ioutil.TempFile("", "*.md")
+	require.NoError(t, err)
+
+	readmeContent := `- New Gen4 feature
+- Self hosted runners
+- Bunch of features
+`
+
+	err = ioutil.WriteFile(readmeFile.Name(), []byte(readmeContent), 0644)
+	require.NoError(t, err)
+
+	str, err := releaseSummary(readmeFile.Name())
+	require.NoError(t, err)
+	require.Equal(t, str, readmeContent)
 }

--- a/go/tools/release-notes/release_notes_test.go
+++ b/go/tools/release-notes/release_notes_test.go
@@ -137,6 +137,55 @@ func TestGenerateReleaseNotes(t *testing.T) {
 			name:        "with version number",
 			releaseNote: releaseNote{Version: "v12.0.0"},
 			expectedOut: "# Release of Vitess v12.0.0\n",
+		}, {
+			name:        "with announcement",
+			releaseNote: releaseNote{Announcement: "This is the new release.\n\nNew features got added.", Version: "v12.0.0"},
+			expectedOut: "# Release of Vitess v12.0.0\n" +
+				"## Announcement\n" +
+				"This is the new release.\n\nNew features got added.\n",
+		}, {
+			name:        "with announcement and known issues",
+			releaseNote: releaseNote{Announcement: "This is the new release.\n\nNew features got added.", Version: "v12.0.0", KnownIssues: "* bug 1\n* bug 2\n"},
+			expectedOut: "# Release of Vitess v12.0.0\n" +
+				"## Announcement\n" +
+				"This is the new release.\n\nNew features got added.\n" +
+				"------------\n" +
+				"## Known Issues\n" +
+				"* bug 1\n" +
+				"* bug 2\n\n",
+		}, {
+			name: "with announcement and change log",
+			releaseNote: releaseNote{
+				Announcement:  "This is the new release.\n\nNew features got added.",
+				Version:       "v12.0.0",
+				ChangeLog:     "* PR 1\n* PR 2\n",
+				ChangeMetrics: "optimization is the root of all evil",
+			},
+			expectedOut: "# Release of Vitess v12.0.0\n" +
+				"## Announcement\n" +
+				"This is the new release.\n\nNew features got added.\n" +
+				"------------\n" +
+				"## Changelog\n" +
+				"* PR 1\n" +
+				"* PR 2\n\n" +
+				"optimization is the root of all evil\n",
+		}, {
+			name: "with add details and change log",
+			releaseNote: releaseNote{
+				AddDetails:    "* PR 92\n",
+				Version:       "v12.0.0",
+				ChangeLog:     "* PR 1\n* PR 2\n",
+				ChangeMetrics: "optimization is the root of all evil",
+			},
+			expectedOut: "# Release of Vitess v12.0.0\n" +
+				"## Announcement\n\n" +
+				"> TODO: please detail these pull requests.\n" +
+				"* PR 92\n\n" +
+				"------------\n" +
+				"## Changelog\n" +
+				"* PR 1\n" +
+				"* PR 2\n\n" +
+				"optimization is the root of all evil\n",
 		},
 	}
 


### PR DESCRIPTION
## Description

This pull request improves the content of our release notes by:
- filter the pull requests listed in the changelog, only pull requests labeled with `release-notes` will appear.
- add a new section listing pull requests that need more information (deprecation notice, feature description, etc), this section will be filled manually post-generation.
- add the ability to import a README at the top of the release notes that will be used as the `announcement` section.
- better formating of the release notes document.

----

**Sample output:**

> make release-notes FROM="v11.0.0" TO="upstream/main" VERSION="v12.0.0" SUMMARY="./my/path/file.md"

```txt
# Release of Vitess v12.0.0
## Announcement
We are shipping the Gen4 planner within this release.
We reduced the duration of our CI builds by using self-hosted runners.

> TODO: please detail these pull requests.

### Announcement 
#### Governance
 * add Manan to maintainers #8833

------------
## Changelog

### Bug fixes 
#### Query Serving
 * VtGate schema tracker to use provided user #8857
### Enhancement 
#### Observability
 * Export memstats for statsd backend #8777
### Internal Cleanup 
#### Cluster management
 * Upgrade to k8s 1.18 client #8762


The release includes 1097 commits (excluding merges)

Thanks to all our contributors: [contributor list removed to avoid pinging everyone]
```

---- 
The first two lines were inserted in the document by specifying the `-summary path_to_md_file` option.
> ```
> We are shipping the Gen4 planner within this release.
> We reduced the duration of our CI builds by using self-hosted runners.
> ```

----
What comes below the `> TODO: please detail these pull requests.` is a list of the pull requests that need more details/attention, aka they need human intervention.

## Related Issue(s)

- https://github.com/vitessio/website/pull/835 for documentation

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
