### PR TITLE
Gen4: SQL_CALC_FOUND_ROWS support

### DIFF
--- a/go/vt/sqlparser/rewriter_api.go
+++ b/go/vt/sqlparser/rewriter_api.go
@@ -52,7 +52,7 @@ func Rewrite(node SQLNode, pre, post ApplyFunc) (result SQLNode) {
 	return parent.SQLNode
 }
 
-// RootNode is the root node of the AST. It is the first element of the tree.
+// RootNode is the root node of the AST when rewriting. It is the first element of the tree.
 type RootNode struct {
 	SQLNode
 }

--- a/go/vt/vtgate/planbuilder/gen4_planner.go
+++ b/go/vt/vtgate/planbuilder/gen4_planner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2021 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -173,13 +173,6 @@ func planLimit(limit *sqlparser.Limit, plan logicalPlan) (logicalPlan, error) {
 		return nil, err
 	}
 	return lPlan, nil
-}
-
-func checkUnsupportedConstructs(sel *sqlparser.Select) error {
-	if sel.SQLCalcFoundRows {
-		return semantics.Gen4NotSupportedF("sql_calc_found_rows")
-	}
-	return nil
 }
 
 func planHorizon(ctx *planningContext, plan logicalPlan, in sqlparser.SelectStatement) (logicalPlan, error) {

--- a/go/vt/vtgate/planbuilder/horizon_planning.go
+++ b/go/vt/vtgate/planbuilder/horizon_planning.go
@@ -39,10 +39,6 @@ type horizonPlanning struct {
 }
 
 func (hp *horizonPlanning) planHorizon(ctx *planningContext, plan logicalPlan) (logicalPlan, error) {
-	if err := checkUnsupportedConstructs(hp.sel); err != nil {
-		return nil, err
-	}
-
 	rb, isRoute := plan.(*route)
 	if !isRoute && ctx.semTable.ProjectionErr != nil {
 		return nil, ctx.semTable.ProjectionErr

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -238,7 +238,7 @@ func setMiscFunc(in logicalPlan, sel *sqlparser.Select) error {
 }
 
 func buildSQLCalcFoundRowsPlan(
-	query string,
+	originalQuery string,
 	sel *sqlparser.Select,
 	reservedVars *sqlparser.ReservedVars,
 	vschema ContextVSchema,
@@ -249,7 +249,7 @@ func buildSQLCalcFoundRowsPlan(
 		return nil, err
 	}
 
-	statement2, reserved2, err := sqlparser.Parse2(query)
+	statement2, reserved2, err := sqlparser.Parse2(originalQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/sql_calc_found_rows.go
+++ b/go/vt/vtgate/planbuilder/sql_calc_found_rows.go
@@ -28,7 +28,9 @@ var _ logicalPlan = (*sqlCalcFoundRows)(nil)
 
 type sqlCalcFoundRows struct {
 	LimitQuery, CountQuery logicalPlan
-	ljt, cjt               *jointab
+
+	// only used by WireUp for V3c
+	ljt, cjt *jointab
 }
 
 //Wireup implements the logicalPlan interface

--- a/go/vt/vtgate/planbuilder/sql_calc_found_rows.go
+++ b/go/vt/vtgate/planbuilder/sql_calc_found_rows.go
@@ -29,11 +29,11 @@ var _ logicalPlan = (*sqlCalcFoundRows)(nil)
 type sqlCalcFoundRows struct {
 	LimitQuery, CountQuery logicalPlan
 
-	// only used by WireUp for V3c
+	// only used by WireUp for V3
 	ljt, cjt *jointab
 }
 
-//Wireup implements the logicalPlan interface
+// Wireup implements the logicalPlan interface
 func (s *sqlCalcFoundRows) Wireup(logicalPlan, *jointab) error {
 	err := s.LimitQuery.Wireup(s.LimitQuery, s.ljt)
 	if err != nil {
@@ -42,7 +42,7 @@ func (s *sqlCalcFoundRows) Wireup(logicalPlan, *jointab) error {
 	return s.CountQuery.Wireup(s.CountQuery, s.cjt)
 }
 
-//Wireup2 implements the logicalPlan interface
+// WireupGen4 implements the logicalPlan interface
 func (s *sqlCalcFoundRows) WireupGen4(semTable *semantics.SemTable) error {
 	err := s.LimitQuery.WireupGen4(semTable)
 	if err != nil {
@@ -51,7 +51,7 @@ func (s *sqlCalcFoundRows) WireupGen4(semTable *semantics.SemTable) error {
 	return s.CountQuery.WireupGen4(semTable)
 }
 
-// Solves implements the logicalPlan interface
+// ContainsTables implements the logicalPlan interface
 func (s *sqlCalcFoundRows) ContainsTables() semantics.TableSet {
 	return s.LimitQuery.ContainsTables()
 }
@@ -66,32 +66,32 @@ func (s *sqlCalcFoundRows) Primitive() engine.Primitive {
 
 // All the methods below are not implemented. They should not be called on a sqlCalcFoundRows plan
 
-//Order implements the logicalPlan interface
+// Order implements the logicalPlan interface
 func (s *sqlCalcFoundRows) Order() int {
 	return s.LimitQuery.Order()
 }
 
-//ResultColumns implements the logicalPlan interface
+// ResultColumns implements the logicalPlan interface
 func (s *sqlCalcFoundRows) ResultColumns() []*resultColumn {
 	return s.LimitQuery.ResultColumns()
 }
 
-//Reorder implements the logicalPlan interface
+// Reorder implements the logicalPlan interface
 func (s *sqlCalcFoundRows) Reorder(order int) {
 	s.LimitQuery.Reorder(order)
 }
 
-//SupplyVar implements the logicalPlan interface
+// SupplyVar implements the logicalPlan interface
 func (s *sqlCalcFoundRows) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
 	s.LimitQuery.SupplyVar(from, to, col, varname)
 }
 
-//SupplyCol implements the logicalPlan interface
+// SupplyCol implements the logicalPlan interface
 func (s *sqlCalcFoundRows) SupplyCol(col *sqlparser.ColName) (*resultColumn, int) {
 	return s.LimitQuery.SupplyCol(col)
 }
 
-//SupplyWeightString implements the logicalPlan interface
+// SupplyWeightString implements the logicalPlan interface
 func (s *sqlCalcFoundRows) SupplyWeightString(int, bool) (weightcolNumber int, err error) {
 	return 0, UnsupportedSupplyWeightString{Type: "sqlCalcFoundRows"}
 }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -1656,6 +1656,50 @@ Gen4 plan same as above
     ]
   }
 }
+{
+  "QueryType": "SELECT",
+  "Original": "select sql_calc_found_rows * from music limit 100",
+  "Instructions": {
+    "OperatorType": "SQL_CALC_FOUND_ROWS",
+    "Inputs": [
+      {
+        "OperatorType": "Limit",
+        "Count": 100,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "SelectScatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select * from music where 1 != 1",
+            "Query": "select * from music limit :__upper_limit",
+            "Table": "music"
+          }
+        ]
+      },
+      {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "count(0) AS count(*)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "SelectScatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(*) from music where 1 != 1",
+            "Query": "select count(*) from music",
+            "Table": "music"
+          }
+        ]
+      }
+    ]
+  }
+}
 
 # sql_calc_found_rows with SelectEqualUnique plans
 "select sql_calc_found_rows * from music where user_id = 1 limit 2"
@@ -1698,6 +1742,7 @@ Gen4 plan same as above
     ]
   }
 }
+Gen4 plan same as above
 
 # sql_calc_found_rows with group by and having
 "select sql_calc_found_rows user_id, count(id) from music group by user_id having count(user_id) = 1 order by user_id limit 2"
@@ -1747,14 +1792,62 @@ Gen4 plan same as above
     ]
   }
 }
+{
+  "QueryType": "SELECT",
+  "Original": "select sql_calc_found_rows user_id, count(id) from music group by user_id having count(user_id) = 1 order by user_id limit 2",
+  "Instructions": {
+    "OperatorType": "SQL_CALC_FOUND_ROWS",
+    "Inputs": [
+      {
+        "OperatorType": "Limit",
+        "Count": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "SelectScatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select user_id, count(id), weight_string(user_id) from music where 1 != 1 group by user_id",
+            "OrderBy": "(0|2) ASC",
+            "Query": "select user_id, count(id), weight_string(user_id) from music group by user_id having count(user_id) = 1 order by user_id asc limit :__upper_limit",
+            "ResultColumns": 2,
+            "Table": "music"
+          }
+        ]
+      },
+      {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "count(0) AS count(*)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "SelectScatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(*) from (select user_id, count(id) from music where 1 != 1 group by user_id) as t where 1 != 1",
+            "Query": "select count(*) from (select user_id, count(id) from music group by user_id having count(user_id) = 1) as t",
+            "Table": "music"
+          }
+        ]
+      }
+    ]
+  }
+}
 
 # sql_calc_found_rows in sub queries
 "select * from music where user_id IN (select sql_calc_found_rows * from music limit 10)"
 "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'"
+Gen4 plan same as above
 
 # sql_calc_found_rows in derived table
 "select sql_calc_found_rows * from (select sql_calc_found_rows * from music limit 10) t limit 1"
 "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'"
+Gen4 plan same as above
 
 # select from unsharded keyspace into dumpfile
 "select * from main.unsharded into Dumpfile 'x.txt'"

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -1608,6 +1608,7 @@ Gen4 plan same as above
     "Vindex": "user_index"
   }
 }
+Gen4 plan same as above
 
 # sql_calc_found_rows with limit
 "select sql_calc_found_rows * from music limit 100"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -386,6 +386,7 @@ Gen4 plan same as above
 # union with SQL_CALC_FOUND_ROWS 
 "(select sql_calc_found_rows id from user where id = 1 limit 1) union select id from user where id = 1"
 "SQL_CALC_FOUND_ROWS not supported with union"
+Gen4 plan same as above
 
 # set with DEFAULT - vitess aware
 "set workload = default"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -425,10 +425,12 @@ Gen4 plan same as above
 # create view with sql_calc_found_rows with limit
 "create view user.view_a as select sql_calc_found_rows * from music limit 100"
 "Complex select queries are not supported in create or alter view statements"
+Gen4 plan same as above
 
 # create view with sql_calc_found_rows with group by and having
 "create view user.view_a as select sql_calc_found_rows user_id, count(id) from music group by user_id having count(user_id) = 1 order by user_id limit 2"
 "Complex select queries are not supported in create or alter view statements"
+Gen4 plan same as above
 
 # create view with incompatible keyspaces
 "create view main.view_a as select * from user.user_extra"

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -268,8 +268,9 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 	switch node := cursor.Node().(type) {
 	case *sqlparser.Select:
-		if a.scoper.currentScope() == nil {
-			return nil
+		parent := cursor.Parent()
+		if _, isRoot := parent.(*sqlparser.RootNode); !isRoot && node.SQLCalcFoundRows {
+			return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "SQL_CALC_FOUND_ROWS only supported in single SELECT queries")
 		}
 		errMsg := "INTO"
 		nextVal := false

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -269,8 +269,11 @@ func (a *analyzer) checkForInvalidConstructs(cursor *sqlparser.Cursor) error {
 	switch node := cursor.Node().(type) {
 	case *sqlparser.Select:
 		parent := cursor.Parent()
+		if _, isUnion := parent.(*sqlparser.Union); isUnion && node.SQLCalcFoundRows {
+			return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "SQL_CALC_FOUND_ROWS not supported with union")
+		}
 		if _, isRoot := parent.(*sqlparser.RootNode); !isRoot && node.SQLCalcFoundRows {
-			return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "SQL_CALC_FOUND_ROWS only supported in single SELECT queries")
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'")
 		}
 		errMsg := "INTO"
 		nextVal := false

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -787,13 +787,13 @@ func TestInvalidQueries(t *testing.T) {
 		err: "Column 'id' in field list is ambiguous",
 	}, {
 		sql: "select sql_calc_found_rows id from a union select 1 limit 109",
-		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
+		err: "SQL_CALC_FOUND_ROWS not supported with union",
 	}, {
 		sql: "select * from (select sql_calc_found_rows id from a) as t",
-		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
+		err: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
 	}, {
 		sql: "select (select sql_calc_found_rows id from a) as t",
-		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
+		err: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
 	}}
 	for _, tc := range tcases {
 		t.Run(tc.sql, func(t *testing.T) {

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -763,7 +763,7 @@ func TestUnionOrderByRewrite(t *testing.T) {
 	assert.Equal(t, "select tabl1.id from tabl1 union select 1 from dual order by id asc", sqlparser.String(stmt))
 }
 
-func TestInvalidUnion(t *testing.T) {
+func TestInvalidQueries(t *testing.T) {
 	tcases := []struct {
 		sql string
 		err string
@@ -785,6 +785,15 @@ func TestInvalidUnion(t *testing.T) {
 	}, {
 		sql: "select a.id, b.id from a, b union select 1, 2 order by id",
 		err: "Column 'id' in field list is ambiguous",
+	}, {
+		sql: "select sql_calc_found_rows id from a union select 1 limit 109",
+		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
+	}, {
+		sql: "select * from (select sql_calc_found_rows id from a) as t",
+		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
+	}, {
+		sql: "select (select sql_calc_found_rows id from a) as t",
+		err: "SQL_CALC_FOUND_ROWS only supported in single SELECT queries",
 	}}
 	for _, tc := range tcases {
 		t.Run(tc.sql, func(t *testing.T) {


### PR DESCRIPTION
## Description
Adds support in the gen4 planner for SQL_CALC_FOUND_ROWS.
It does this by sharing most of the logic from the V3 planner.

## Related Issue(s)
#7280 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
