### PR TITLE
Gen4: unskipped TestFoundRows test since it is supported in Gen4

### DIFF
--- a/go/test/endtoend/vtgate/found_rows_test.go
+++ b/go/test/endtoend/vtgate/found_rows_test.go
@@ -36,8 +36,6 @@ func TestFoundRows(t *testing.T) {
 	require.Nil(t, err)
 	defer conn.Close()
 
-	t.Skipf("This test uses `SQL_CALC_FOUND_ROWS`, which is currently unsupported by Gen4. Remove this once it is supported.")
-
 	exec(t, conn, "delete from t2")
 	defer exec(t, conn, "delete from t2")
 
@@ -45,10 +43,10 @@ func TestFoundRows(t *testing.T) {
 
 	runTests := func(workload string) {
 		assertFoundRowsValue(t, conn, "select * from t2", workload, 5)
-		assertFoundRowsValue(t, conn, "select * from t2 limit 2", workload, 2)
-		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 limit 2", workload, 5)
-		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 where id3 = 4 limit 2", workload, 1)
-		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 where id4 = 3 limit 2", workload, 3)
+		assertFoundRowsValue(t, conn, "select * from t2 order by id3 limit 2", workload, 2)
+		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 order by id3 limit 2", workload, 5)
+		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 where id3 = 4 order by id3 limit 2", workload, 1)
+		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS * from t2 where id4 = 3 order by id3 limit 2", workload, 3)
 		assertFoundRowsValue(t, conn, "select SQL_CALC_FOUND_ROWS id4, count(id3) from t2 where id3 = 3 group by id4 limit 1", workload, 1)
 	}
 


### PR DESCRIPTION
## Description

This pull request remove the `t.Skip` in the end-to-end test `TestFoundRows` since this feature got supported by Gen4 through PR https://github.com/vitessio/vitess/pull/8878. The test was originally skipped with the addition of `Gen4CompareV3` (https://github.com/vitessio/vitess/pull/8858).

Since we are doing select on a sharded keyspace with a limit, `order by`'s got added to ensure the results are always in the same order between Gen4 and V3 executions.

## Related Issue(s)

- #7280 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
