### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"regexp"
@@ -220,7 +219,7 @@ func main() {
 }
 
 func applyFilePatch(dockerYaml []byte, patchFile string) []byte {
-	yamlPatch, err := ioutil.ReadFile(patchFile)
+	yamlPatch, err := os.ReadFile(patchFile)
 	if err != nil {
 		log.Fatalf("reading yaml patch file %s: %s", patchFile, err)
 	}
@@ -272,7 +271,7 @@ func createFile(filePath string) *os.File {
 }
 
 func readFile(filePath string) []byte {
-	file, err := ioutil.ReadFile(filePath)
+	file, err := os.ReadFile(filePath)
 
 	if err != nil {
 		log.Fatalf("reading %s: %s", filePath, err)
@@ -296,7 +295,7 @@ func handleError(err error) {
 
 func appendToSqlFile(schemaFileNames []string, f *os.File) {
 	for _, file := range schemaFileNames {
-		data, err := ioutil.ReadFile(tablesPath + file)
+		data, err := os.ReadFile(tablesPath + file)
 		if err != nil {
 			log.Fatalf("reading %s: %s", tablesPath+file, err)
 		}
@@ -313,7 +312,7 @@ func appendToSqlFile(schemaFileNames []string, f *os.File) {
 }
 
 func getTableName(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -325,7 +324,7 @@ func getTableName(sqlFile string) string {
 }
 
 func getPrimaryKey(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -337,7 +336,7 @@ func getPrimaryKey(sqlFile string) string {
 }
 
 func getKeyColumns(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -404,7 +403,7 @@ func writeVschemaFile(file []byte, fileName string) {
 }
 
 func writeFile(file []byte, fileName string) {
-	err := ioutil.WriteFile(fileName, file, 0644)
+	err := os.WriteFile(fileName, file, 0644)
 	if err != nil {
 		log.Fatalf("writing %s %s", fileName, err)
 	}

--- a/go/cmd/rulesctl/common/common.go
+++ b/go/cmd/rulesctl/common/common.go
@@ -3,8 +3,8 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	vtfcr "vitess.io/vitess/go/vt/vttablet/customrule/filecustomrule"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
@@ -32,7 +32,7 @@ func MustWriteJSON(obj interface{}, path string) {
 		log.Fatalf("Unable to marshal object: %v", err)
 	}
 
-	err = ioutil.WriteFile(path, enc, 0400)
+	err = os.WriteFile(path, enc, 0400)
 	if err != nil {
 		log.Fatalf("Unable to save new JSON: %v", err)
 	}

--- a/go/cmd/vtctldclient/command/routing_rules.go
+++ b/go/cmd/vtctldclient/command/routing_rules.go
@@ -19,7 +19,7 @@ package command
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -71,7 +71,7 @@ func commandApplyRoutingRules(cmd *cobra.Command, args []string) error {
 
 	var rulesBytes []byte
 	if applyRoutingRulesOptions.RulesFilePath != "" {
-		data, err := ioutil.ReadFile(applyRoutingRulesOptions.RulesFilePath)
+		data, err := os.ReadFile(applyRoutingRulesOptions.RulesFilePath)
 		if err != nil {
 			return err
 		}

--- a/go/cmd/vtctldclient/command/vschemas.go
+++ b/go/cmd/vtctldclient/command/vschemas.go
@@ -18,7 +18,7 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -78,7 +78,7 @@ func commandApplyVSchema(cmd *cobra.Command, args []string) error {
 	var err error
 	if sqlMode {
 		if applyVSchemaOptions.SQLFile != "" {
-			sqlBytes, err := ioutil.ReadFile(applyVSchemaOptions.SQLFile)
+			sqlBytes, err := os.ReadFile(applyVSchemaOptions.SQLFile)
 			if err != nil {
 				return err
 			}
@@ -89,7 +89,7 @@ func commandApplyVSchema(cmd *cobra.Command, args []string) error {
 	} else { // jsonMode
 		var schema []byte
 		if applyVSchemaOptions.VSchemaFile != "" {
-			schema, err = ioutil.ReadFile(applyVSchemaOptions.VSchemaFile)
+			schema, err = os.ReadFile(applyVSchemaOptions.VSchemaFile)
 			if err != nil {
 				return err
 			}

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/vt/log"
@@ -123,7 +123,7 @@ func getFileParam(flag, flagFile, name string, required bool) (string, error) {
 
 		return "", nil
 	}
-	data, err := ioutil.ReadFile(flagFile)
+	data, err := os.ReadFile(flagFile)
 	if err != nil {
 		return "", fmt.Errorf("cannot read file %v: %v", flagFile, err)
 	}

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -20,7 +20,7 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"context"
 
@@ -130,7 +130,7 @@ func initConfig(tabletAlias *topodatapb.TabletAlias) (*tabletenv.TabletConfig, *
 	}
 
 	if *tabletConfig != "" {
-		bytes, err := ioutil.ReadFile(*tabletConfig)
+		bytes, err := os.ReadFile(*tabletConfig)
 		if err != nil {
 			log.Exitf("error reading config file %s: %v", *tabletConfig, err)
 		}
@@ -181,10 +181,10 @@ func extractOnlineDDL() error {
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(binaryFileName, ghostBinary, 0755); err != nil {
+		if err := os.WriteFile(binaryFileName, ghostBinary, 0755); err != nil {
 			// One possibility of failure is that gh-ost is up and running. In that case,
 			// let's pause and check if the running gh-ost is exact same binary as the one we wish to extract.
-			foundBytes, _ := ioutil.ReadFile(binaryFileName)
+			foundBytes, _ := os.ReadFile(binaryFileName)
 			if bytes.Equal(ghostBinary, foundBytes) {
 				// OK, it's the same binary, there is no need to extract the file anyway
 				return nil

--- a/go/cmd/vttestserver/vttestserver_test.go
+++ b/go/cmd/vttestserver/vttestserver_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -76,7 +75,7 @@ func TestPersistentMode(t *testing.T) {
 	conf := config
 	defer resetFlags(args, conf)
 
-	dir, err := ioutil.TempDir("/tmp", "vttestserver_persistent_mode_")
+	dir, err := os.MkdirTemp("/tmp", "vttestserver_persistent_mode_")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -230,7 +229,7 @@ func TestMtlsAuth(t *testing.T) {
 	defer resetFlags(args, conf)
 
 	// Our test root.
-	root, err := ioutil.TempDir("", "tlstest")
+	root, err := os.MkdirTemp("", "tlstest")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -273,7 +272,7 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 	defer resetFlags(args, conf)
 
 	// Our test root.
-	root, err := ioutil.TempDir("", "tlstest")
+	root, err := os.MkdirTemp("", "tlstest")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -607,7 +607,7 @@ func cmdEdit(ctx context.Context, subFlags *flag.FlagSet, args []string) error {
 		return fmt.Errorf("edit: cannot start $EDITOR: %v", err)
 	}
 
-	fileData, err := ioutil.ReadFile(tmpPath)
+	fileData, err := os.ReadFile(tmpPath)
 	if err != nil {
 		os.Remove(tmpPath)
 		return fmt.Errorf("edit: cannot read file %v", err)
@@ -784,7 +784,7 @@ func getPathData(ctx context.Context, filePath string) ([]byte, error) {
 	var err error
 	file, err := os.Open(filePath)
 	if err == nil {
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err == nil {
 			return data, err
 		}
@@ -800,7 +800,7 @@ func setPathData(ctx context.Context, filePath string, data []byte) error {
 		}
 		return err
 	}
-	return ioutil.WriteFile(filePath, []byte(data), 0666)
+	return os.WriteFile(filePath, []byte(data), 0666)
 }
 
 func fileCp(ctx context.Context, srcPath, dstPath string) error {
@@ -954,7 +954,7 @@ func cmdUnzip(ctx context.Context, subFlags *flag.FlagSet, args []string) error 
 		if err != nil {
 			return fmt.Errorf("unzip: error %v", err)
 		}
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			return fmt.Errorf("unzip: failed reading archive: %v", err)
 		}

--- a/go/ioutil2/ioutil.go
+++ b/go/ioutil2/ioutil.go
@@ -18,7 +18,6 @@ limitations under the License.
 package ioutil2
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -26,7 +25,7 @@ import (
 // WriteFileAtomic writes the data to a temp file and atomically move if everything else succeeds.
 func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 	dir, name := path.Split(filename)
-	f, err := ioutil.TempFile(dir, name)
+	f, err := os.CreateTemp(dir, name)
 	if err != nil {
 		return err
 	}

--- a/go/ioutil2/ioutil_test.go
+++ b/go/ioutil2/ioutil_test.go
@@ -19,7 +19,6 @@ package ioutil2
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -32,7 +31,7 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rData, err := ioutil.ReadFile(fname)
+	rData, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/mysql/auth_server_clientcert_test.go
+++ b/go/mysql/auth_server_clientcert_test.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -47,7 +46,7 @@ func TestValidCert(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestSSLConnection")
+	root, err := os.MkdirTemp("", "TestSSLConnection")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -130,7 +129,7 @@ func TestNoCert(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestSSLConnection")
+	root, err := os.MkdirTemp("", "TestSSLConnection")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -249,7 +248,7 @@ func (a *AuthServerStatic) DefaultAuthMethodDescription() AuthMethodDescription 
 func (a *AuthServerStatic) reload() {
 	jsonBytes := []byte(a.jsonConfig)
 	if a.file != "" {
-		data, err := ioutil.ReadFile(a.file)
+		data, err := os.ReadFile(a.file)
 		if err != nil {
 			log.Errorf("Failed to read mysql_auth_server_static_file file: %v", err)
 			return

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -18,7 +18,6 @@ package mysql
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"syscall"
@@ -128,7 +127,7 @@ func TestHostMatcher(t *testing.T) {
 }
 
 func TestStaticConfigHUP(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "mysql_auth_server_static_file.json")
+	tmpFile, err := os.CreateTemp("", "mysql_auth_server_static_file.json")
 	if err != nil {
 		t.Fatalf("couldn't create temp file: %v", err)
 	}
@@ -136,7 +135,7 @@ func TestStaticConfigHUP(t *testing.T) {
 
 	oldStr := "str5"
 	jsonConfig := fmt.Sprintf("{\"%s\":[{\"Password\":\"%s\"}]}", oldStr, oldStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 
@@ -159,7 +158,7 @@ func TestStaticConfigHUP(t *testing.T) {
 }
 
 func TestStaticConfigHUPWithRotation(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "mysql_auth_server_static_file.json")
+	tmpFile, err := os.CreateTemp("", "mysql_auth_server_static_file.json")
 	if err != nil {
 		t.Fatalf("couldn't create temp file: %v", err)
 	}
@@ -167,7 +166,7 @@ func TestStaticConfigHUPWithRotation(t *testing.T) {
 
 	oldStr := "str1"
 	jsonConfig := fmt.Sprintf("{\"%s\":[{\"Password\":\"%s\"}]}", oldStr, oldStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 
@@ -184,7 +183,7 @@ func TestStaticConfigHUPWithRotation(t *testing.T) {
 
 func hupTest(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.File, oldStr, newStr string) {
 	jsonConfig := fmt.Sprintf("{\"%s\":[{\"Password\":\"%s\"}]}", newStr, newStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't overwrite temp file: %v", err)
 	}
 
@@ -205,7 +204,7 @@ func hupTest(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.File, oldStr, 
 
 func hupTestWithRotation(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.File, oldStr, newStr string) {
 	jsonConfig := fmt.Sprintf("{\"%s\":[{\"Password\":\"%s\"}]}", newStr, newStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't overwrite temp file: %v", err)
 	}
 

--- a/go/mysql/auth_server_vault.go
+++ b/go/mysql/auth_server_vault.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -277,7 +276,7 @@ func readFromFile(filePath string) (string, error) {
 	if filePath == "" {
 		return "", nil
 	}
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Errorf("Could not read file: %s", filePath)
 		return "", err

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -139,7 +138,7 @@ func TestConnectTimeout(t *testing.T) {
 	// Tests a connection where Dial to a unix socket fails
 	// properly returns the right error. To simulate exactly the
 	// right failure, try to dial a Unix socket that's just a temp file.
-	fd, err := ioutil.TempFile("", "mysql")
+	fd, err := os.CreateTemp("", "mysql")
 	if err != nil {
 		t.Fatalf("cannot create TemFile: %v", err)
 	}
@@ -175,7 +174,7 @@ func TestTLSClientDisabled(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
@@ -248,7 +247,7 @@ func TestTLSClientPreferredDefault(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
@@ -369,7 +368,7 @@ func TestTLSClientVerifyCA(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
@@ -453,7 +452,7 @@ func TestTLSClientVerifyIdentity(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)

--- a/go/mysql/endtoend/main_test.go
+++ b/go/mysql/endtoend/main_test.go
@@ -19,7 +19,6 @@ package endtoend
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -174,7 +173,7 @@ func TestMain(m *testing.M) {
 
 	exitCode := func() int {
 		// Create the certs.
-		root, err := ioutil.TempDir("", "TestTLSServer")
+		root, err := os.MkdirTemp("", "TestTLSServer")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "TempDir failed: %v", err)
 			return 1
@@ -191,16 +190,16 @@ ssl-cert=%v/server-cert.pem
 ssl-key=%v/server-key.pem
 `, root, root, root)
 		extraMyCnf := path.Join(root, "ssl_my.cnf")
-		if err := ioutil.WriteFile(extraMyCnf, []byte(cnf), os.ModePerm); err != nil {
-			fmt.Fprintf(os.Stderr, "ioutil.WriteFile(%v) failed: %v", extraMyCnf, err)
+		if err := os.WriteFile(extraMyCnf, []byte(cnf), os.ModePerm); err != nil {
+			fmt.Fprintf(os.Stderr, "os.WriteFile(%v) failed: %v", extraMyCnf, err)
 			return 1
 		}
 
 		// For LargeQuery tests
 		cnf = "max_allowed_packet=100M\n"
 		maxPacketMyCnf := path.Join(root, "max_packet.cnf")
-		if err := ioutil.WriteFile(maxPacketMyCnf, []byte(cnf), os.ModePerm); err != nil {
-			fmt.Fprintf(os.Stderr, "ioutil.WriteFile(%v) failed: %v", maxPacketMyCnf, err)
+		if err := os.WriteFile(maxPacketMyCnf, []byte(cnf), os.ModePerm); err != nil {
+			fmt.Fprintf(os.Stderr, "os.WriteFile(%v) failed: %v", maxPacketMyCnf, err)
 			return 1
 		}
 

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -20,7 +20,6 @@ package fakesqldb
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -153,9 +152,9 @@ type ExpectedExecuteFetch struct {
 // New creates a server, and starts listening.
 func New(t testing.TB) *DB {
 	// Pick a path for our socket.
-	socketDir, err := ioutil.TempDir("", "fakesqldb")
+	socketDir, err := os.MkdirTemp("", "fakesqldb")
 	if err != nil {
-		t.Fatalf("ioutil.TempDir failed: %v", err)
+		t.Fatalf("os.MkdirTemp failed: %v", err)
 	}
 	socketFile := path.Join(socketDir, "fakesqldb.sock")
 

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -18,7 +18,6 @@ package mysql
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -112,7 +111,7 @@ func TestSSLConnection(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestSSLConnection")
+	root, err := os.MkdirTemp("", "TestSSLConnection")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -75,7 +75,7 @@ func Init() {
 	data := []byte(*ldapAuthConfigString)
 	if *ldapAuthConfigFile != "" {
 		var err error
-		data, err = ioutil.ReadFile(*ldapAuthConfigFile)
+		data, err = os.ReadFile(*ldapAuthConfigFile)
 		if err != nil {
 			log.Exitf("Failed to read mysql_ldap_auth_config_file: %v", err)
 		}

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -344,7 +343,7 @@ func FuzzTLSServer(data []byte) int {
 
 	host := l.Addr().(*net.TCPAddr).IP.String()
 	port := l.Addr().(*net.TCPAddr).Port
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	if err != nil {
 		return -1
 	}

--- a/go/mysql/mysql_fuzzer_test.go
+++ b/go/mysql/mysql_fuzzer_test.go
@@ -20,7 +20,7 @@ limitations under the License.
 package mysql
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime/debug"
 	"testing"
@@ -30,7 +30,7 @@ import (
 
 func TestFuzzHandleNextCommandFromFile(t *testing.T) {
 	directoryName := "fuzzdata"
-	files, err := ioutil.ReadDir(directoryName)
+	files, err := os.ReadDir(directoryName)
 	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file.Name(), func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestFuzzHandleNextCommandFromFile(t *testing.T) {
 					t.Fatal(string(debug.Stack()))
 				}
 			}()
-			testcase, err := ioutil.ReadFile(path.Join(directoryName, file.Name()))
+			testcase, err := os.ReadFile(path.Join(directoryName, file.Name()))
 			require.NoError(t, err)
 			FuzzHandleNextCommand(testcase)
 		})

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -388,7 +387,7 @@ func TestConnectionUnixSocket(t *testing.T) {
 	}
 	defer authServer.close()
 
-	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	unixSocket, err := os.CreateTemp("", "mysql_vitess_test.sock")
 	require.NoError(t, err, "Failed to create temp file")
 
 	os.Remove(unixSocket.Name())
@@ -821,7 +820,7 @@ func TestTLSServer(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSServer")
+	root, err := os.MkdirTemp("", "TestTLSServer")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
@@ -920,7 +919,7 @@ func TestTLSRequired(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestTLSRequired")
+	root, err := os.MkdirTemp("", "TestTLSRequired")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 	tlstest.CreateCA(root)
@@ -999,7 +998,7 @@ func TestCachingSha2PasswordAuthWithTLS(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestSSLConnection")
+	root, err := os.MkdirTemp("", "TestSSLConnection")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -194,7 +193,7 @@ func TestChannel(t *testing.T) {
 func TestFile(t *testing.T) {
 	logger := New("logger", 10)
 
-	dir, err := ioutil.TempDir("", "streamlog_file")
+	dir, err := os.MkdirTemp("", "streamlog_file")
 	if err != nil {
 		t.Fatalf("error getting tempdir: %v", err)
 	}
@@ -213,7 +212,7 @@ func TestFile(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	want := "test 1\ntest 2\n"
-	contents, _ := ioutil.ReadFile(logPath)
+	contents, _ := os.ReadFile(logPath)
 	got := string(contents)
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)
@@ -227,7 +226,7 @@ func TestFile(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	want = "test 1\ntest 2\ntest 3\n"
-	contents, _ = ioutil.ReadFile(rotatedPath)
+	contents, _ = os.ReadFile(rotatedPath)
 	got = string(contents)
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)
@@ -244,14 +243,14 @@ func TestFile(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	want = "test 1\ntest 2\ntest 3\n"
-	contents, _ = ioutil.ReadFile(rotatedPath)
+	contents, _ = os.ReadFile(rotatedPath)
 	got = string(contents)
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)
 	}
 
 	want = "test 4\n"
-	contents, _ = ioutil.ReadFile(logPath)
+	contents, _ = os.ReadFile(logPath)
 	got = string(contents)
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)

--- a/go/tb/error.go
+++ b/go/tb/error.go
@@ -28,7 +28,7 @@ package tb
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 )
 
@@ -96,7 +96,7 @@ func stack(calldepth int) []byte {
 		// Print this much at least.  If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
 		if file != lastFile {
-			data, err := ioutil.ReadFile(file)
+			data, err := os.ReadFile(file)
 			if err != nil {
 				continue
 			}

--- a/go/test/endtoend/backup/transform/backup_transform_utils.go
+++ b/go/test/endtoend/backup/transform/backup_transform_utils.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -89,11 +88,11 @@ func TestMainSetup(m *testing.M, useMysqlctld bool) {
 		shard := &localCluster.Keyspaces[0].Shards[0]
 		// changing password for mysql user
 		dbCredentialFile = initialsharding.WriteDbCredentialToTmp(localCluster.TmpDirectory)
-		initDb, _ := ioutil.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
+		initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 		sql := string(initDb)
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 		sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
-		ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
+		os.WriteFile(newInitDBFile, []byte(sql), 0666)
 
 		extraArgs := []string{"-db-credentials-file", dbCredentialFile}
 		commonTabletArg = append(commonTabletArg, "-db-credentials-file", dbCredentialFile)
@@ -303,7 +302,7 @@ func TestBackupTransformErrorImpl(t *testing.T) {
 func validateManifestFile(t *testing.T, backupLocation string) {
 
 	// reading manifest
-	data, err := ioutil.ReadFile(backupLocation + "/MANIFEST")
+	data, err := os.ReadFile(backupLocation + "/MANIFEST")
 	require.Nilf(t, err, "error while reading MANIFEST %v", err)
 	manifest := make(map[string]interface{})
 

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -19,7 +19,6 @@ package vtbackup
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -84,11 +83,11 @@ func TestMain(m *testing.M) {
 		// Create a new init_db.sql file that sets up passwords for all users.
 		// Then we use a db-credentials-file with the passwords.
 		dbCredentialFile = initialsharding.WriteDbCredentialToTmp(localCluster.TmpDirectory)
-		initDb, _ := ioutil.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
+		initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 		sql := string(initDb)
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 		sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
-		err = ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
+		err = os.WriteFile(newInitDBFile, []byte(sql), 0666)
 		if err != nil {
 			return 1, err
 		}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -105,11 +104,11 @@ func LaunchCluster(setupType int, streamMode string, stripes int) (int, error) {
 	shard := &localCluster.Keyspaces[0].Shards[0]
 
 	dbCredentialFile = initialsharding.WriteDbCredentialToTmp(localCluster.TmpDirectory)
-	initDb, _ := ioutil.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
+	initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 	sql := string(initDb)
 	newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 	sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
-	err = ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
+	err = os.WriteFile(newInitDBFile, []byte(sql), 0666)
 	if err != nil {
 		return 1, err
 	}

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -670,14 +669,14 @@ func getPort() int {
 	if _, err := os.Stat(tmpPortFileName); os.IsNotExist(err) {
 		port = getVtStartPort()
 	} else {
-		result, _ := ioutil.ReadFile(tmpPortFileName)
+		result, _ := os.ReadFile(tmpPortFileName)
 		cport, err := strconv.Atoi(string(result))
 		if err != nil || cport > 60000 || cport == 0 {
 			cport = getVtStartPort()
 		}
 		port = cport
 	}
-	ioutil.WriteFile(tmpPortFileName, []byte(fmt.Sprintf("%d", port+200)), 0666)
+	os.WriteFile(tmpPortFileName, []byte(fmt.Sprintf("%d", port+200)), 0666)
 	return port
 }
 

--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -196,7 +195,7 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 		return
 	}
 
-	err = ioutil.WriteFile(configFile, config, 0666)
+	err = os.WriteFile(configFile, config, 0666)
 	if err != nil {
 		return
 	}

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -157,7 +157,7 @@ func (vtgate *VtgateProcess) GetStatusForTabletOfShard(name string, endPointsCou
 	}
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]interface{})
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
 			panic(err)
@@ -263,7 +263,7 @@ func (vtgate *VtgateProcess) GetVars() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("error getting response from %s", vtgate.VerifyURL)
 	}
 	if resp.StatusCode == 200 {
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
 			return nil, fmt.Errorf("not able to parse response body")

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -145,7 +144,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 
 	if vttablet.ServingStatus != "" {
 		if err = vttablet.WaitForTabletStatus(vttablet.ServingStatus); err != nil {
-			errFileContent, _ := ioutil.ReadFile(fname)
+			errFileContent, _ := os.ReadFile(fname)
 			if errFileContent != nil {
 				log.Infof("vttablet error:\n%s\n", string(errFileContent))
 			}
@@ -163,7 +162,7 @@ func (vttablet *VttabletProcess) GetStatus() string {
 		return ""
 	}
 	if resp.StatusCode == 200 {
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		return string(respByte)
 	}
@@ -178,7 +177,7 @@ func (vttablet *VttabletProcess) GetVars() map[string]interface{} {
 	}
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]interface{})
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
 			return nil
@@ -194,7 +193,7 @@ func (vttablet *VttabletProcess) GetStatusDetails() string {
 	if err != nil {
 		return fmt.Sprintf("Status details failed: %v", err.Error())
 	}
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	return string(respByte)
 }
 
@@ -478,7 +477,7 @@ func (vttablet *VttabletProcess) WaitForVReplicationToCatchup(t testing.TB, work
 
 // BulkLoad performs a bulk load of rows into a given vttablet.
 func (vttablet *VttabletProcess) BulkLoad(t testing.TB, db, table string, bulkInsert func(io.Writer)) {
-	tmpbulk, err := ioutil.TempFile(path.Join(vttablet.Directory, "tmp"), "bulk_load")
+	tmpbulk, err := os.CreateTemp(path.Join(vttablet.Directory, "tmp"), "bulk_load")
 	if err != nil {
 		t.Fatalf("failed to create tmp file for loading: %v", err)
 	}

--- a/go/test/endtoend/cluster/vtworker_process.go
+++ b/go/test/endtoend/cluster/vtworker_process.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -222,7 +222,7 @@ func (vtworker *VtworkerProcess) GetVars() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("error getting response from %s", vtworker.VerifyURL)
 	}
 	if resp.StatusCode == 200 {
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
 			return nil, fmt.Errorf("not able to parse response body")

--- a/go/test/endtoend/clustertest/vtctld_test.go
+++ b/go/test/endtoend/clustertest/vtctld_test.go
@@ -20,7 +20,7 @@ package clustertest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -66,7 +66,7 @@ func testTopoDataAPI(t *testing.T, url string) {
 	assert.Equal(t, resp.StatusCode, 200)
 
 	resultMap := make(map[string]interface{})
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(respByte, &resultMap)
 	require.Nil(t, err)
 
@@ -101,7 +101,7 @@ func testListAllTablets(t *testing.T) {
 func testTabletStatus(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://%s:%d", clusterInstance.Hostname, clusterInstance.Keyspaces[0].Shards[0].Vttablets[0].HTTPPort))
 	require.Nil(t, err)
-	respByte, err := ioutil.ReadAll(resp.Body)
+	respByte, err := io.ReadAll(resp.Body)
 	require.Nil(t, err)
 	result := string(respByte)
 	log.Infof("Tablet status response: %v", result)

--- a/go/test/endtoend/clustertest/vtgate_test.go
+++ b/go/test/endtoend/clustertest/vtgate_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -54,7 +54,7 @@ func verifyVtgateVariables(t *testing.T, url string) {
 	resp, _ := http.Get(url)
 	if resp != nil && resp.StatusCode == 200 {
 		resultMap := make(map[string]interface{})
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		require.Nil(t, err)
 		if resultMap["VtgateVSchemaCounts"] == nil {

--- a/go/test/endtoend/clustertest/vttablet_test.go
+++ b/go/test/endtoend/clustertest/vttablet_test.go
@@ -20,7 +20,7 @@ package clustertest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -35,7 +35,7 @@ func TestVttabletProcess(t *testing.T) {
 	testURL(t, fmt.Sprintf("http://localhost:%d/debug/vars/", firstTabletPort), "tablet debug var url")
 	resp, _ := http.Get(fmt.Sprintf("http://localhost:%d/debug/vars", firstTabletPort))
 	resultMap := make(map[string]interface{})
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	err := json.Unmarshal(respByte, &resultMap)
 	if err != nil {
 		panic(err)

--- a/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
+++ b/go/test/endtoend/encryption/encryptedtransport/encrypted_transport_test.go
@@ -56,7 +56,7 @@ package encryptedtransport
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -389,12 +389,12 @@ func getVitessClient(addr string) (vtgateservicepb.VitessClient, error) {
 func setCreds(t *testing.T, name string, ca string) {
 	f1, err := os.Open(path.Join(certDirectory, "ca-cert.pem"))
 	require.NoError(t, err)
-	b1, err := ioutil.ReadAll(f1)
+	b1, err := io.ReadAll(f1)
 	require.NoError(t, err)
 
 	f2, err := os.Open(path.Join(certDirectory, ca+"-cert.pem"))
 	require.NoError(t, err)
-	b2, err := ioutil.ReadAll(f2)
+	b2, err := io.ReadAll(f2)
 	require.NoError(t, err)
 
 	caContent := append(b1, b2...)

--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -541,7 +541,7 @@ func getVar(vttablet *cluster.Vttablet) (map[string]interface{}, error) {
 	}
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]interface{})
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		return resultMap, err
 	}

--- a/go/test/endtoend/migration/migration_test.go
+++ b/go/test/endtoend/migration/migration_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -245,7 +245,7 @@ func startCluster(t *testing.T) string {
 	tabletConfig := fmt.Sprintf(connFormat, productSocket, customerSocket)
 	fmt.Printf("tablet_config:\n%s\n", tabletConfig)
 	yamlFile := path.Join(clusterInstance.TmpDirectory, "external.yaml")
-	err = ioutil.WriteFile(yamlFile, []byte(tabletConfig), 0644)
+	err = os.WriteFile(yamlFile, []byte(tabletConfig), 0644)
 	require.NoError(t, err)
 	return yamlFile
 }

--- a/go/test/endtoend/onlineddl/exec_util.go
+++ b/go/test/endtoend/onlineddl/exec_util.go
@@ -18,7 +18,7 @@ package onlineddl
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -31,7 +31,7 @@ import (
 
 // CreateTempScript creates a script in the temporary directory with given content
 func CreateTempScript(t *testing.T, content string) (fileName string) {
-	f, err := ioutil.TempFile("", "onlineddl-test-")
+	f, err := os.CreateTemp("", "onlineddl-test-")
 	require.NoError(t, err)
 
 	_, err = f.WriteString(content)

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -19,7 +19,7 @@ package vrepl
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -223,7 +223,7 @@ func throttleResponse(tablet *cluster.Vttablet, path string) (resp *http.Respons
 	if err != nil {
 		return resp, respBody, err
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
 	return resp, respBody, err
 }

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -136,7 +135,7 @@ func TestSchemaChange(t *testing.T) {
 	shards := clusterInstance.Keyspaces[0].Shards
 	require.Equal(t, 1, len(shards))
 
-	files, err := ioutil.ReadDir(testDataPath)
+	files, err := os.ReadDir(testDataPath)
 	require.NoError(t, err)
 	for _, f := range files {
 		if !f.IsDir() {
@@ -156,7 +155,7 @@ func readTestFile(t *testing.T, testName string, fileName string) (content strin
 		return "", false
 	}
 	require.NoError(t, err)
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	require.NoError(t, err)
 	return strings.TrimSpace(string(b)), true
 }

--- a/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
+++ b/go/test/endtoend/recovery/pitrtls/shardedpitr_tls_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -526,7 +525,7 @@ func tlsLaunchRecoveryTablet(t *testing.T, tablet *cluster.Vttablet, tabletForBi
 }
 
 func getCNFromCertPEM(filename string) string {
-	pemBytes, _ := ioutil.ReadFile(filename)
+	pemBytes, _ := os.ReadFile(filename)
 	block, _ := pem.Decode(pemBytes)
 	cert, _ := x509.ParseCertificate(block.Bytes)
 	rdn := cert.Subject.ToRDNSequence()[0][0]

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -96,7 +95,7 @@ func TestMainImpl(m *testing.M) {
 		localCluster.Keyspaces = append(localCluster.Keyspaces, *keyspace)
 
 		dbCredentialFile = initialsharding.WriteDbCredentialToTmp(localCluster.TmpDirectory)
-		initDb, _ := ioutil.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
+		initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 		sql := string(initDb)
 		newInitDBFile = path.Join(localCluster.TmpDirectory, "init_db_with_passwords.sql")
 		sql = sql + initialsharding.GetPasswordUpdateSQL(localCluster)
@@ -105,7 +104,7 @@ func TestMainImpl(m *testing.M) {
 SET GLOBAL old_alter_table = ON;
 `
 		sql = sql + oldAlterTableMode
-		ioutil.WriteFile(newInitDBFile, []byte(sql), 0666)
+		os.WriteFile(newInitDBFile, []byte(sql), 0666)
 
 		extraArgs := []string{"-db-credentials-file", dbCredentialFile}
 		commonTabletArg = append(commonTabletArg, "-db-credentials-file", dbCredentialFile)

--- a/go/test/endtoend/sharding/initialsharding/sharding_util.go
+++ b/go/test/endtoend/sharding/initialsharding/sharding_util.go
@@ -18,7 +18,6 @@ package initialsharding
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -630,7 +629,7 @@ func checkSrvKeyspaceForSharding(t *testing.T, ksName string, expectedPartitions
 // Create a new init_db.sql file that sets up passwords for all users.
 // Then we use a db-credentials-file with the passwords.
 func writeInitDBFile() {
-	initDb, _ := ioutil.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
+	initDb, _ := os.ReadFile(path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"))
 	sql := string(initDb)
 	newInitDbFile = path.Join(ClusterInstance.TmpDirectory, "init_db_with_passwords.sql")
 	sql = sql + GetPasswordUpdateSQL(ClusterInstance) + `
@@ -664,7 +663,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   ON *.* TO 'vt_filtered'@'127.0.0.1';
 FLUSH PRIVILEGES;
 `
-	ioutil.WriteFile(newInitDbFile, []byte(sql), 0666)
+	os.WriteFile(newInitDbFile, []byte(sql), 0666)
 
 }
 
@@ -678,7 +677,7 @@ func WriteDbCredentialToTmp(tmpDir string) string {
         "vt_filtered": ["VtFilteredPass"]
     	}`)
 	dbCredentialFile = path.Join(tmpDir, "db_credentials.json")
-	ioutil.WriteFile(dbCredentialFile, data, 0666)
+	os.WriteFile(dbCredentialFile, data, 0666)
 	return dbCredentialFile
 }
 

--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -32,7 +32,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -360,7 +360,7 @@ func (bt *BufferingTest) Test(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode)
 
 	var metadata VTGateBufferingStats
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(respByte, &metadata)
 	require.NoError(t, err)
 

--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -73,7 +73,7 @@ func verifyVtgateVariables(t *testing.T, url string) {
 	require.Equal(t, 200, resp.StatusCode, "Vtgate api url response not found")
 
 	resultMap := make(map[string]interface{})
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(respByte, &resultMap)
 	require.NoError(t, err)
 	assert.Contains(t, resultMap, "VtgateVSchemaCounts", "Vschema count should be present in variables")

--- a/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
+++ b/go/test/endtoend/tabletmanager/custom_rule_topo_test.go
@@ -18,7 +18,7 @@ package tabletmanager
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -50,7 +50,7 @@ func TestTopoCustomRule(t *testing.T) {
 	topoCustomRuleFile := "/tmp/rules.json"
 	topoCustomRulePath := "/keyspaces/ks/configs/CustomRules"
 	data := []byte("[]\n")
-	err = ioutil.WriteFile(topoCustomRuleFile, data, 0777)
+	err = os.WriteFile(topoCustomRuleFile, data, 0777)
 	require.NoError(t, err)
 
 	// Copy config file into topo.
@@ -93,7 +93,7 @@ func TestTopoCustomRule(t *testing.T) {
 		"TableNames" : ["t1"],
 		"Query" : "(select)|(SELECT)"
 	  }]`)
-	err = ioutil.WriteFile(topoCustomRuleFile, data, 0777)
+	err = os.WriteFile(topoCustomRuleFile, data, 0777)
 	require.NoError(t, err)
 
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("TopoCp", "-to_topo", topoCustomRuleFile, topoCustomRulePath)

--- a/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_security_policy_test.go
@@ -18,7 +18,7 @@ package tabletmanager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -64,7 +64,7 @@ func assertNotAllowedURLTest(t *testing.T, url string) {
 	resp, err := http.Get(url)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -76,7 +76,7 @@ func assertAllowedURLTest(t *testing.T, url string) {
 	resp, err := http.Get(url)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/go/test/endtoend/vault/vault_server.go
+++ b/go/test/endtoend/vault/vault_server.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -83,14 +82,14 @@ func (vs *VaultServer) start() error {
 	}
 
 	hclFile := path.Join(os.Getenv("PWD"), vaultConfigFileName)
-	hcl, _ := ioutil.ReadFile(hclFile)
+	hcl, _ := os.ReadFile(hclFile)
 	// Replace variable parts in Vault config file
 	hcl = bytes.Replace(hcl, []byte("$server"), []byte(vs.address), 1)
 	hcl = bytes.Replace(hcl, []byte("$port"), []byte(fmt.Sprintf("%d", vs.port1)), 1)
 	hcl = bytes.Replace(hcl, []byte("$cert"), []byte(path.Join(os.Getenv("PWD"), vaultCertFileName)), 1)
 	hcl = bytes.Replace(hcl, []byte("$key"), []byte(path.Join(os.Getenv("PWD"), vaultKeyFileName)), 1)
 	newHclFile := path.Join(vs.logDir, vaultConfigFileName)
-	err = ioutil.WriteFile(newHclFile, hcl, 0700)
+	err = os.WriteFile(newHclFile, hcl, 0700)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -154,7 +153,7 @@ func downloadExecFile(path string, url string) error {
 	}
 	defer resp.Body.Close()
 
-	err = ioutil.WriteFile(path, []byte(""), 0700)
+	err = os.WriteFile(path, []byte(""), 0700)
 	if err != nil {
 		return err
 	}

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -151,7 +150,7 @@ func TestVaultAuth(t *testing.T) {
 	time.Sleep(30 * time.Second)
 	// Check the log for the Vault token renewal message
 	//   If we don't see it, that is a test failure
-	logContents, _ := ioutil.ReadFile(path.Join(clusterInstance.TmpDirectory, vttabletLogFileName))
+	logContents, _ := os.ReadFile(path.Join(clusterInstance.TmpDirectory, vttabletLogFileName))
 	require.True(t, bytes.Contains(logContents, []byte(tokenRenewalString)))
 }
 

--- a/go/test/endtoend/vreplication/helper.go
+++ b/go/test/endtoend/vreplication/helper.go
@@ -3,7 +3,7 @@ package vreplication
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -108,7 +108,7 @@ func getQueryCount(url string, query string) int {
 		fmt.Printf("http Get returns status %d\n", resp.StatusCode)
 		return 0
 	}
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	body := string(respByte)
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(body))

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -19,8 +19,9 @@ package vreplication
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -60,7 +61,7 @@ func throttleResponse(tablet *cluster.VttabletProcess, path string) (resp *http.
 	if err != nil {
 		return resp, respBody, err
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
 	return resp, respBody, err
 }
@@ -79,7 +80,7 @@ func throttlerCheckSelf(tablet *cluster.VttabletProcess, app string) (resp *http
 	if err != nil {
 		return resp, respBody, err
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	respBody = string(b)
 	return resp, respBody, err
 }
@@ -198,7 +199,7 @@ func TestCellAliasVreplicationWorkflow(t *testing.T) {
 func insertInitialData(t *testing.T) {
 	t.Run("insertInitialData", func(t *testing.T) {
 		log.Infof("Inserting initial data")
-		lines, _ := ioutil.ReadFile("unsharded_init_data.sql")
+		lines, _ := os.ReadFile("unsharded_init_data.sql")
 		execMultipleQueries(t, vtgateConn, "product:0", string(lines))
 		execVtgateQuery(t, vtgateConn, "product:0", "insert into customer_seq(id, next_id, cache) values(0, 100, 100);")
 		execVtgateQuery(t, vtgateConn, "product:0", "insert into order_seq(id, next_id, cache) values(0, 100, 100);")

--- a/go/test/endtoend/vtcombo/vttest_sample_test.go
+++ b/go/test/endtoend/vtcombo/vttest_sample_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -105,7 +105,7 @@ func TestStandalone(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	resultMap := make(map[string]interface{})
-	respByte, _ := ioutil.ReadAll(resp.Body)
+	respByte, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(respByte, &resultMap)
 	require.Nil(t, err)
 	cmd := resultMap["cmdline"]

--- a/go/test/endtoend/vtgate/buffer/buffer_test.go
+++ b/go/test/endtoend/vtgate/buffer/buffer_test.go
@@ -32,7 +32,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -305,7 +305,7 @@ func testBufferBase(t *testing.T, isExternalParent bool) {
 	bufferingStops := 0
 	if resp.StatusCode == 200 {
 		resultMap := make(map[string]interface{})
-		respByte, _ := ioutil.ReadAll(resp.Body)
+		respByte, _ := io.ReadAll(resp.Body)
 		err := json.Unmarshal(respByte, &resultMap)
 		if err != nil {
 			panic(err)

--- a/go/test/endtoend/vtgate/schema/schema_test.go
+++ b/go/test/endtoend/vtgate/schema/schema_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -167,7 +166,7 @@ func testWithAutoSchemaFromChangeDir(t *testing.T) {
 	_ = os.Mkdir(path.Join(schemaChangeDirectory, keyspaceName), 0700)
 	_ = os.Mkdir(path.Join(schemaChangeDirectory, keyspaceName, "input"), 0700)
 	sqlFile := path.Join(schemaChangeDirectory, keyspaceName, "input/create_test_table_x.sql")
-	err := ioutil.WriteFile(sqlFile, []byte("create table test_table_x (id int)"), 0644)
+	err := os.WriteFile(sqlFile, []byte("create table test_table_x (id int)"), 0644)
 	require.Nil(t, err)
 	timeout := time.Now().Add(10 * time.Second)
 	matchFoundAfterAutoSchemaApply := false

--- a/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
+++ b/go/test/endtoend/vtgate/schematracker/loadkeyspace/schema_load_keyspace_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadkeyspace
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -82,7 +82,7 @@ func TestBlockedLoadKeyspace(t *testing.T) {
 
 	// check warning logs
 	logDir := clusterInstance.VtgateProcess.LogDir
-	all, err := ioutil.ReadFile(path.Join(logDir, "vtgate-stderr.txt"))
+	all, err := os.ReadFile(path.Join(logDir, "vtgate-stderr.txt"))
 	require.NoError(t, err)
 	require.Contains(t, string(all), "Unable to get initial schema reload")
 }
@@ -120,7 +120,7 @@ func TestLoadKeyspaceWithNoTablet(t *testing.T) {
 
 	// check warning logs
 	logDir := clusterInstance.VtgateProcess.LogDir
-	all, err := ioutil.ReadFile(path.Join(logDir, "vtgate-stderr.txt"))
+	all, err := os.ReadFile(path.Join(logDir, "vtgate-stderr.txt"))
 	require.NoError(t, err)
 	require.Contains(t, string(all), "Unable to get initial schema reload")
 }
@@ -148,7 +148,7 @@ func TestNoInitialKeyspace(t *testing.T) {
 	require.NoError(t, err)
 
 	// check info logs
-	all, err := ioutil.ReadFile(path.Join(logDir, "vtgate.INFO"))
+	all, err := os.ReadFile(path.Join(logDir, "vtgate.INFO"))
 	require.NoError(t, err)
 	require.Contains(t, string(all), "No keyspace to load")
 }

--- a/go/test/endtoend/worker/worker_test.go
+++ b/go/test/endtoend/worker/worker_test.go
@@ -20,7 +20,7 @@ package worker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -151,7 +151,7 @@ func TestWebInterface(t *testing.T) {
 		resp, err = http.Get(baseURL + "/status")
 		assert.Nil(t, err)
 		if resp.StatusCode == 200 {
-			respByte, _ := ioutil.ReadAll(resp.Body)
+			respByte, _ := io.ReadAll(resp.Body)
 			respStr := string(respByte)
 			assert.Contains(t, respStr, "Ping command was called with message: 'pong'", fmt.Sprintf("Command did not log output to /status: %s", respStr))
 		}
@@ -162,7 +162,7 @@ func TestWebInterface(t *testing.T) {
 		resp, err = http.Get(baseURL + "/status")
 		assert.Nil(t, err)
 		if resp.StatusCode == 200 {
-			respByte, _ := ioutil.ReadAll(resp.Body)
+			respByte, _ := io.ReadAll(resp.Body)
 			statusAfterReset := string(respByte)
 			assert.Contains(t, statusAfterReset, "This worker is idle.", "/status does not indicate that the reset was successful")
 		}

--- a/go/test/fuzzing/vtctl_fuzzer_test.go
+++ b/go/test/fuzzing/vtctl_fuzzer_test.go
@@ -20,7 +20,7 @@ limitations under the License.
 package fuzzing
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime/debug"
 	"testing"
@@ -30,7 +30,7 @@ import (
 
 func TestVtctlFuzzer(t *testing.T) {
 	directoryName := "fuzzdata"
-	files, err := ioutil.ReadDir(directoryName)
+	files, err := os.ReadDir(directoryName)
 	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file.Name(), func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestVtctlFuzzer(t *testing.T) {
 					t.Fatal(string(debug.Stack()))
 				}
 			}()
-			testcase, err := ioutil.ReadFile(path.Join(directoryName, file.Name()))
+			testcase, err := os.ReadFile(path.Join(directoryName, file.Name()))
 			require.NoError(t, err)
 			res := Fuzz(testcase)
 			require.Equal(t, 1, res)

--- a/go/tools/asthelpergen/asthelpergen.go
+++ b/go/tools/asthelpergen/asthelpergen.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"strings"
 
@@ -178,7 +178,7 @@ func (t *TypePaths) Set(path string) error {
 // currently exist on disk and returns any mismatches
 func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 	for fullPath, file := range result {
-		existing, err := ioutil.ReadFile(fullPath)
+		existing, err := os.ReadFile(fullPath)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("missing file on disk: %s (%w)", fullPath, err))
 			continue

--- a/go/tools/asthelpergen/main/main.go
+++ b/go/tools/asthelpergen/main/main.go
@@ -18,8 +18,8 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"vitess.io/vitess/go/tools/goimports"
 
@@ -53,7 +53,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("failed to apply goimport to '%s': %v", fullPath, err)
 			}
-			err = ioutil.WriteFile(fullPath, content, 0664)
+			err = os.WriteFile(fullPath, content, 0664)
 			if err != nil {
 				log.Fatalf("failed to save file to '%s': %v", fullPath, err)
 			}

--- a/go/tools/goimports/goimports.go
+++ b/go/tools/goimports/goimports.go
@@ -17,7 +17,6 @@ limitations under the License.
 package goimports
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -27,7 +26,7 @@ import (
 // FormatJenFile formats the given *jen.File with goimports and return a slice
 // of byte corresponding to the formatted file.
 func FormatJenFile(file *jen.File) ([]byte, error) {
-	tempFile, err := ioutil.TempFile("/tmp", "*.go")
+	tempFile, err := os.CreateTemp("/tmp", "*.go")
 	if err != nil {
 		return nil, err
 	}
@@ -43,5 +42,5 @@ func FormatJenFile(file *jen.File) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(tempFile.Name())
+	return os.ReadFile(tempFile.Name())
 }

--- a/go/tools/release-notes/release_notes.go
+++ b/go/tools/release-notes/release_notes.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -447,7 +446,7 @@ func createSortedPrTypeSlice(prPerType prsByType) []sortedPRType {
 }
 
 func releaseSummary(summaryFile string) (string, error) {
-	contentSummary, err := ioutil.ReadFile(summaryFile)
+	contentSummary, err := os.ReadFile(summaryFile)
 	if err != nil {
 		return "", err
 	}

--- a/go/tools/release-notes/release_notes_test.go
+++ b/go/tools/release-notes/release_notes_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -107,7 +107,7 @@ TEST@planetscale.com	docker/lite/install_dependencies.sh:  Upgrade MySQL 8 to 8.
 }
 
 func TestLoadSummaryReadme(t *testing.T) {
-	readmeFile, err := ioutil.TempFile("", "*.md")
+	readmeFile, err := os.CreateTemp("", "*.md")
 	require.NoError(t, err)
 
 	readmeContent := `- New Gen4 feature
@@ -115,7 +115,7 @@ func TestLoadSummaryReadme(t *testing.T) {
 - Bunch of features
 `
 
-	err = ioutil.WriteFile(readmeFile.Name(), []byte(readmeContent), 0644)
+	err = os.WriteFile(readmeFile.Name(), []byte(readmeContent), 0644)
 	require.NoError(t, err)
 
 	str, err := releaseSummary(readmeFile.Name())
@@ -191,11 +191,11 @@ func TestGenerateReleaseNotes(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			outFile, err := ioutil.TempFile("", "*.md")
+			outFile, err := os.CreateTemp("", "*.md")
 			require.NoError(t, err)
 			err = tc.releaseNote.generate(outFile)
 			require.NoError(t, err)
-			all, err := ioutil.ReadFile(outFile.Name())
+			all, err := os.ReadFile(outFile.Name())
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOut, string(all))
 		})

--- a/go/tools/sizegen/sizegen.go
+++ b/go/tools/sizegen/sizegen.go
@@ -21,8 +21,8 @@ import (
 	"flag"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -479,7 +479,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("failed to apply goimport to '%s': %v", fullPath, err)
 			}
-			err = ioutil.WriteFile(fullPath, content, 0664)
+			err = os.WriteFile(fullPath, content, 0664)
 			if err != nil {
 				log.Fatalf("failed to save file to '%s': %v", fullPath, err)
 			}
@@ -493,7 +493,7 @@ func main() {
 // this test fail.
 func VerifyFilesOnDisk(result map[string]*jen.File) (errors []error) {
 	for fullPath, file := range result {
-		existing, err := ioutil.ReadFile(fullPath)
+		existing, err := os.ReadFile(fullPath)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("missing file on disk: %s (%w)", fullPath, err))
 			continue

--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -119,7 +118,7 @@ func (fcs *FileCredentialsServer) GetUserAndPassword(user string) (string, strin
 	if fcs.dbCredentials == nil {
 		fcs.dbCredentials = make(map[string][]string)
 
-		data, err := ioutil.ReadFile(*dbCredentialsFile)
+		data, err := os.ReadFile(*dbCredentialsFile)
 		if err != nil {
 			log.Warningf("Failed to read dbCredentials file: %v", *dbCredentialsFile)
 			return "", "", err
@@ -249,7 +248,7 @@ func readFromFile(filePath string) (string, error) {
 	if filePath == "" {
 		return "", nil
 	}
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/dbconfigs/dbconfigs_test.go
+++ b/go/vt/dbconfigs/dbconfigs_test.go
@@ -18,7 +18,6 @@ package dbconfigs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -252,7 +251,7 @@ func TestAccessors(t *testing.T) {
 }
 
 func TestCredentialsFileHUP(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "credentials.json")
+	tmpFile, err := os.CreateTemp("", "credentials.json")
 	if err != nil {
 		t.Fatalf("couldn't create temp file: %v", err)
 	}
@@ -261,7 +260,7 @@ func TestCredentialsFileHUP(t *testing.T) {
 	*dbCredentialsServer = "file"
 	oldStr := "str1"
 	jsonConfig := fmt.Sprintf("{\"%s\": [\"%s\"]}", oldStr, oldStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 	cs := GetCredentialsServer()
@@ -276,7 +275,7 @@ func TestCredentialsFileHUP(t *testing.T) {
 func hupTest(t *testing.T, tmpFile *os.File, oldStr, newStr string) {
 	cs := GetCredentialsServer()
 	jsonConfig := fmt.Sprintf("{\"%s\": [\"%s\"]}", newStr, newStr)
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't overwrite temp file: %v", err)
 	}
 	_, pass, _ := cs.GetUserAndPassword(oldStr)

--- a/go/vt/grpcclient/client_auth_static.go
+++ b/go/vt/grpcclient/client_auth_static.go
@@ -19,7 +19,7 @@ package grpcclient
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"context"
 
@@ -59,7 +59,7 @@ func AppendStaticAuth(opts []grpc.DialOption) ([]grpc.DialOption, error) {
 	if *credsFile == "" {
 		return opts, nil
 	}
-	data, err := ioutil.ReadFile(*credsFile)
+	data, err := os.ReadFile(*credsFile)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/grpcoptionaltls/server_test.go
+++ b/go/vt/grpcoptionaltls/server_test.go
@@ -15,7 +15,6 @@ package grpcoptionaltls
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -51,7 +50,7 @@ type testCredentials struct {
 
 func createCredentials() (*testCredentials, error) {
 	// Create a temporary directory.
-	certDir, err := ioutil.TempDir("", "optionaltls_grpc_test")
+	certDir, err := os.MkdirTemp("", "optionaltls_grpc_test")
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/logutil/console_logger_test.go
+++ b/go/vt/logutil/console_logger_test.go
@@ -18,7 +18,7 @@ package logutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -61,9 +61,9 @@ func testConsoleLogger(t *testing.T, tee bool, entrypoint string) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("cmd.Start() error: %v", err)
 	}
-	out, err := ioutil.ReadAll(stderr)
+	out, err := io.ReadAll(stderr)
 	if err != nil {
-		t.Fatalf("ioutil.ReadAll(sterr) error: %v", err)
+		t.Fatalf("io.ReadAll(sterr) error: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("cmd.Wait() error: %v", err)

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -73,7 +72,7 @@ func azInternalCredentials() (string, string, error) {
 	var actKey string
 	if *accountKeyFile != "" {
 		log.Infof("Getting Azure Storage Account key from file: %s", *accountKeyFile)
-		dat, err := ioutil.ReadFile(*accountKeyFile)
+		dat, err := os.ReadFile(*accountKeyFile)
 		if err != nil {
 			return "", "", err
 		}

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysqlctl
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -26,7 +25,7 @@ import (
 )
 
 func TestFindFilesToBackup(t *testing.T) {
-	root, err := ioutil.TempDir("", "backuptest")
+	root, err := os.MkdirTemp("", "backuptest")
 	if err != nil {
 		t.Fatalf("os.TempDir failed: %v", err)
 	}
@@ -46,28 +45,28 @@ func TestFindFilesToBackup(t *testing.T) {
 			t.Fatalf("failed to create directory %v: %v", s, err)
 		}
 	}
-	if err := ioutil.WriteFile(path.Join(innodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(innodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file innodb_data_1: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(innodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(innodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file innodb_log_1: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(dataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(dataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file db.opt: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(extraDir, "extra.stuff"), []byte("extra file"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(extraDir, "extra.stuff"), []byte("extra file"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file extra.stuff: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(outsideDbDir, "table1.frm"), []byte("frm file"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(outsideDbDir, "table1.frm"), []byte("frm file"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file table1.opt: %v", err)
 	}
 	if err := os.Symlink(outsideDbDir, path.Join(dataDir, "vt_symlink")); err != nil {
 		t.Fatalf("failed to symlink vt_symlink: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(rocksdbDir, "000011.sst"), []byte("rocksdb file"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(rocksdbDir, "000011.sst"), []byte("rocksdb file"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file 000011.sst: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(sdiOnlyDir, "table1.sdi"), []byte("sdi file"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(sdiOnlyDir, "table1.sdi"), []byte("sdi file"), os.ModePerm); err != nil {
 		t.Fatalf("failed to write file table1.sdi: %v", err)
 	}
 

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -307,7 +306,7 @@ func isDbDir(p string) bool {
 	}
 
 	// Look for at least one database file
-	fis, err := ioutil.ReadDir(p)
+	fis, err := os.ReadDir(p)
 	if err != nil {
 		return false
 	}
@@ -340,11 +339,16 @@ func addDirectory(fes []FileEntry, base string, baseDir string, subDir string) (
 	p := path.Join(baseDir, subDir)
 	var size int64
 
-	fis, err := ioutil.ReadDir(p)
+	entries, err := os.ReadDir(p)
 	if err != nil {
 		return nil, 0, err
 	}
-	for _, fi := range fis {
+	for _, entry := range entries {
+		fi, err := entry.Info()
+		if err != nil {
+			return nil, 0, err
+		}
+
 		fes = append(fes, FileEntry{
 			Base: base,
 			Name: path.Join(subDir, fi.Name()),
@@ -397,7 +401,7 @@ func findFilesToBackup(cnf *Mycnf) ([]FileEntry, int64, error) {
 	totalSize = totalSize + size
 
 	// then add DB directories
-	fis, err := ioutil.ReadDir(cnf.DataDir)
+	fis, err := os.ReadDir(cnf.DataDir)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -113,7 +112,7 @@ type FileBackupStorage struct{}
 func (fbs *FileBackupStorage) ListBackups(ctx context.Context, dir string) ([]backupstorage.BackupHandle, error) {
 	// ReadDir already sorts the results
 	p := path.Join(*FileBackupStorageRoot, dir)
-	fi, err := ioutil.ReadDir(p)
+	fi, err := os.ReadDir(p)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/go/vt/mysqlctl/filebackupstorage/file_test.go
+++ b/go/vt/mysqlctl/filebackupstorage/file_test.go
@@ -18,7 +18,6 @@ package filebackupstorage
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -35,7 +34,7 @@ import (
 // setupFileBackupStorage creates a temporary directory, and
 // returns a FileBackupStorage based on it
 func setupFileBackupStorage(t *testing.T) *FileBackupStorage {
-	root, err := ioutil.TempDir("", "fbstest")
+	root, err := os.MkdirTemp("", "fbstest")
 	if err != nil {
 		t.Fatalf("os.TempDir failed: %v", err)
 	}

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -18,7 +18,6 @@ package mysqlctl
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -37,7 +36,7 @@ func TestMycnf(t *testing.T) {
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
-	f, _ := ioutil.ReadFile("../../../config/mycnf/default.cnf")
+	f, _ := os.ReadFile("../../../config/mycnf/default.cnf")
 	myTemplateSource.Write(f)
 	data, err := cnf.makeMycnf(myTemplateSource.String())
 	if err != nil {
@@ -45,11 +44,11 @@ func TestMycnf(t *testing.T) {
 	} else {
 		t.Logf("data: %v", data)
 	}
-	err = ioutil.WriteFile(MycnfPath, []byte(data), 0666)
+	err = os.WriteFile(MycnfPath, []byte(data), 0666)
 	if err != nil {
 		t.Errorf("failed creating my.cnf %v", err)
 	}
-	_, err = ioutil.ReadFile(MycnfPath)
+	_, err = os.ReadFile(MycnfPath)
 	if err != nil {
 		t.Errorf("failed reading, err %v", err)
 		return
@@ -106,7 +105,7 @@ func NoTestMycnfHook(t *testing.T) {
 	if err != nil {
 		t.Errorf("err: %v", err)
 	}
-	_, err = ioutil.ReadFile(cnf.path)
+	_, err = os.ReadFile(cnf.path)
 	if err != nil {
 		t.Errorf("failed reading, err %v", err)
 		return

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -30,9 +30,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -221,7 +221,7 @@ func (s3ServerSideEncryption *S3ServerSideEncryption) init() error {
 
 	if strings.HasPrefix(*sse, sseCustomerPrefix) {
 		sseCustomerKeyFile := strings.TrimPrefix(*sse, sseCustomerPrefix)
-		base64CodedKey, err := ioutil.ReadFile(sseCustomerKeyFile)
+		base64CodedKey, err := os.ReadFile(sseCustomerKeyFile)
 		if err != nil {
 			log.Errorf(err.Error())
 			return err

--- a/go/vt/mysqlctl/s3backupstorage/s3_test.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -82,7 +81,7 @@ func TestSSEAws(t *testing.T) {
 }
 
 func TestSSECustomerFileNotFound(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "filename")
+	tempFile, err := os.CreateTemp("", "filename")
 	require.NoErrorf(t, err, "TempFile() expected to succeed")
 	defer os.Remove(tempFile.Name())
 
@@ -99,7 +98,7 @@ func TestSSECustomerFileNotFound(t *testing.T) {
 }
 
 func TestSSECustomerFileBinaryKey(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "filename")
+	tempFile, err := os.CreateTemp("", "filename")
 	require.NoErrorf(t, err, "TempFile() expected to succeed")
 	defer os.Remove(tempFile.Name())
 
@@ -132,7 +131,7 @@ func TestSSECustomerFileBinaryKey(t *testing.T) {
 }
 
 func TestSSECustomerFileBase64Key(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "filename")
+	tempFile, err := os.CreateTemp("", "filename")
 	require.NoErrorf(t, err, "TempFile() expected to succeed")
 	defer os.Remove(tempFile.Name())
 

--- a/go/vt/orchestrator/os/process.go
+++ b/go/vt/orchestrator/os/process.go
@@ -18,7 +18,6 @@ package os
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -74,12 +73,12 @@ func generateShellScript(commandText string, env []string, arguments ...string) 
 	shell := config.Config.ProcessesShellCommand
 
 	commandBytes := []byte(commandText)
-	tmpFile, err := ioutil.TempFile("", "orchestrator-process-cmd-")
+	tmpFile, err := os.CreateTemp("", "orchestrator-process-cmd-")
 	if err != nil {
 		return nil, "", log.Errorf("generateShellScript() failed to create TempFile: %v", err.Error())
 	}
 	// write commandText to temporary file
-	ioutil.WriteFile(tmpFile.Name(), commandBytes, 0640)
+	os.WriteFile(tmpFile.Name(), commandBytes, 0640)
 	shellArguments := append([]string{}, tmpFile.Name())
 	shellArguments = append(shellArguments, arguments...)
 

--- a/go/vt/orchestrator/ssl/ssl.go
+++ b/go/vt/orchestrator/ssl/ssl.go
@@ -6,8 +6,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	nethttp "net/http"
+	"os"
 	"strings"
 
 	"github.com/go-martini/martini"
@@ -68,7 +68,7 @@ func NewTLSConfig(caFile string, verifyCert bool) (*tls.Config, error) {
 func ReadCAFile(caFile string) (*x509.CertPool, error) {
 	var caCertPool *x509.CertPool
 	if caFile != "" {
-		data, err := ioutil.ReadFile(caFile)
+		data, err := os.ReadFile(caFile)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func AppendKeyPairWithPassword(tlsConfig *tls.Config, certFile string, keyFile s
 
 // Read a PEM file and ask for a password to decrypt it if needed
 func ReadPEMData(pemFile string, pemPass []byte) ([]byte, error) {
-	pemData, err := ioutil.ReadFile(pemFile)
+	pemData, err := os.ReadFile(pemFile)
 	if err != nil {
 		return pemData, err
 	}
@@ -193,7 +193,7 @@ func GetPEMPassword(pemFile string) []byte {
 
 // Determine if PEM file is encrypted
 func IsEncryptedPEM(pemFile string) bool {
-	pemData, err := ioutil.ReadFile(pemFile)
+	pemData, err := os.ReadFile(pemFile)
 	if err != nil {
 		return false
 	}

--- a/go/vt/orchestrator/ssl/ssl_test.go
+++ b/go/vt/orchestrator/ssl/ssl_test.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	nethttp "net/http"
+	"os"
 	"reflect"
 	"strings"
 	"syscall"
@@ -184,11 +184,11 @@ func TestIsEncryptedPEM(t *testing.T) {
 }
 
 func writeFakeFile(content string) string {
-	f, err := ioutil.TempFile("", "ssl_test")
+	f, err := os.CreateTemp("", "ssl_test")
 	if err != nil {
 		return ""
 	}
-	ioutil.WriteFile(f.Name(), []byte(content), 0644)
+	os.WriteFile(f.Name(), []byte(content), 0644)
 	return f.Name()
 }
 

--- a/go/vt/schemamanager/local_controller.go
+++ b/go/vt/schemamanager/local_controller.go
@@ -18,7 +18,6 @@ package schemamanager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -77,7 +76,7 @@ func NewLocalController(schemaChangeDir string) *LocalController {
 // schema change.
 func (controller *LocalController) Open(ctx context.Context) error {
 	// find all keyspace directories.
-	fileInfos, err := ioutil.ReadDir(controller.schemaChangeDir)
+	fileInfos, err := os.ReadDir(controller.schemaChangeDir)
 	if err != nil {
 		return err
 	}
@@ -86,7 +85,7 @@ func (controller *LocalController) Open(ctx context.Context) error {
 			continue
 		}
 		dirpath := path.Join(controller.schemaChangeDir, fileinfo.Name())
-		schemaChanges, err := ioutil.ReadDir(path.Join(dirpath, "input"))
+		schemaChanges, err := os.ReadDir(path.Join(dirpath, "input"))
 		if err != nil {
 			log.Warningf("there is no input dir in %s", dirpath)
 			continue
@@ -119,7 +118,7 @@ func (controller *LocalController) Read(ctx context.Context) ([]string, error) {
 	if controller.keyspace == "" || controller.sqlPath == "" {
 		return []string{}, nil
 	}
-	data, err := ioutil.ReadFile(controller.sqlPath)
+	data, err := os.ReadFile(controller.sqlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -18,7 +18,6 @@ package schemamanager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestLocalControllerNoSchemaChanges(t *testing.T) {
-	schemaChangeDir, err := ioutil.TempDir("", "localcontroller-test")
+	schemaChangeDir, err := os.MkdirTemp("", "localcontroller-test")
 	defer os.RemoveAll(schemaChangeDir)
 	if err != nil {
 		t.Fatalf("failed to create temp schema change dir, error: %v", err)
@@ -59,7 +58,7 @@ func TestLocalControllerOpen(t *testing.T) {
 		t.Fatalf("Open should fail, no such dir, but got: %v", err)
 	}
 
-	schemaChangeDir, _ := ioutil.TempDir("", "localcontroller-test")
+	schemaChangeDir, _ := os.MkdirTemp("", "localcontroller-test")
 	defer os.RemoveAll(schemaChangeDir)
 
 	// create a file under schema change dir
@@ -101,7 +100,7 @@ func TestLocalControllerOpen(t *testing.T) {
 }
 
 func TestLocalControllerSchemaChange(t *testing.T) {
-	schemaChangeDir, err := ioutil.TempDir("", "localcontroller-test")
+	schemaChangeDir, err := os.MkdirTemp("", "localcontroller-test")
 	if err != nil {
 		t.Fatalf("failed to create temp schema change dir, error: %v", err)
 	}

--- a/go/vt/servenv/exporter_test.go
+++ b/go/vt/servenv/exporter_test.go
@@ -19,7 +19,7 @@ package servenv
 import (
 	"expvar"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -91,7 +91,7 @@ func httpGet(t *testing.T, url string) string {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"context"
 
@@ -78,7 +78,7 @@ func staticAuthPluginInitializer() (Authenticator, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(*credsFile)
+	data, err := os.ReadFile(*credsFile)
 	if err != nil {
 		err := fmt.Errorf("failed to load static auth plugin %v", err)
 		return nil, err

--- a/go/vt/servenv/liveness_test.go
+++ b/go/vt/servenv/liveness_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package servenv
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,9 +34,9 @@ func TestLivenessHandler(t *testing.T) {
 	defer resp.Body.Close()
 
 	// Make sure we can read the body, even though it's empty.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("ioutil.ReadAll: %v", err)
+		t.Fatalf("io.ReadAll: %v", err)
 	}
 	t.Logf("body: %q", body)
 }

--- a/go/vt/servenv/pprof.go
+++ b/go/vt/servenv/pprof.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -176,7 +175,7 @@ func (prof *profile) mkprofile() io.WriteCloser {
 		path = prof.path
 		err = os.MkdirAll(path, 0777)
 	} else {
-		path, err = ioutil.TempDir("", "profile")
+		path, err = os.MkdirTemp("", "profile")
 	}
 	if err != nil {
 		log.Fatalf("pprof: could not create initial output directory: %v", err)

--- a/go/vt/servenv/status_test.go
+++ b/go/vt/servenv/status_test.go
@@ -18,7 +18,7 @@ package servenv
 
 import (
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -51,7 +51,7 @@ func TestStatus(t *testing.T) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	cases := []string{
@@ -90,7 +90,7 @@ func TestNamedStatus(t *testing.T) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	cases := []string{

--- a/go/vt/sqlparser/goyacc/goyacc.go
+++ b/go/vt/sqlparser/goyacc/goyacc.go
@@ -51,7 +51,6 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -3411,7 +3410,7 @@ func exit(status int) {
 }
 
 func gofmt() {
-	src, err := ioutil.ReadFile(oflag)
+	src, err := os.ReadFile(oflag)
 	if err != nil {
 		return
 	}
@@ -3419,7 +3418,7 @@ func gofmt() {
 	if err != nil {
 		return
 	}
-	ioutil.WriteFile(oflag, src, 0666)
+	os.WriteFile(oflag, src, 0666)
 }
 
 var yaccpar string // will be processed version of yaccpartext: s/$$/prefix/g

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -3531,7 +3530,7 @@ func BenchmarkParse3(b *testing.B) {
 }
 
 func TestValidUnionCases(t *testing.T) {
-	testOutputTempDir, err := ioutil.TempDir("", "parse_test")
+	testOutputTempDir, err := os.MkdirTemp("", "parse_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -3543,7 +3542,7 @@ func TestValidUnionCases(t *testing.T) {
 }
 
 func TestValidSelectCases(t *testing.T) {
-	testOutputTempDir, err := ioutil.TempDir("", "parse_test")
+	testOutputTempDir, err := os.MkdirTemp("", "parse_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -3607,7 +3606,7 @@ func testFile(t *testing.T, filename, tempDir string) {
 
 		if fail && tempDir != "" {
 			gotFile := fmt.Sprintf("%s/%s", tempDir, filename)
-			_ = ioutil.WriteFile(gotFile, []byte(strings.TrimSpace(expected.String())+"\n"), 0644)
+			_ = os.WriteFile(gotFile, []byte(strings.TrimSpace(expected.String())+"\n"), 0644)
 			fmt.Println(fmt.Sprintf("Errors found in parse tests. If the output is correct, run `cp %s/* testdata/` to update test expectations", tempDir)) // nolint
 		}
 	})

--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -107,7 +107,7 @@ func (tacl *tableACL) init(configFile string, aclCB func()) error {
 	if configFile == "" {
 		return nil
 	}
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Infof("unable to read tableACL config file: %v  Error: %v", configFile, err)
 		return err

--- a/go/vt/tableacl/tableacl_test.go
+++ b/go/vt/tableacl/tableacl_test.go
@@ -19,7 +19,6 @@ package tableacl
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -59,7 +58,7 @@ var aclJSON = `{
 
 func TestInitWithValidConfig(t *testing.T) {
 	tacl := tableACL{factory: &simpleacl.Factory{}}
-	f, err := ioutil.TempFile("", "tableacl")
+	f, err := os.CreateTemp("", "tableacl")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -20,7 +20,6 @@ package tlstest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -108,7 +107,7 @@ func CreateCA(root string) {
 	openssl("genrsa", "-out", key)
 
 	config := path.Join(root, "ca.config")
-	if err := ioutil.WriteFile(config, []byte(caConfig), os.ModePerm); err != nil {
+	if err := os.WriteFile(config, []byte(caConfig), os.ModePerm); err != nil {
 		log.Fatalf("cannot write file %v: %v", config, err)
 	}
 	openssl("req", "-new", "-x509", "-nodes", "-days", "3600", "-batch",
@@ -129,7 +128,7 @@ func CreateSignedCert(root, parent, serial, name, commonName string) {
 	req := path.Join(root, name+"-req.pem")
 
 	config := path.Join(root, name+".config")
-	if err := ioutil.WriteFile(config, []byte(fmt.Sprintf(certConfig, commonName, commonName)), os.ModePerm); err != nil {
+	if err := os.WriteFile(config, []byte(fmt.Sprintf(certConfig, commonName, commonName)), os.ModePerm); err != nil {
 		log.Fatalf("cannot write file %v: %v", config, err)
 	}
 	openssl("req", "-newkey", "rsa:2048", "-days", "3600", "-nodes",

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ func TestClientServerWithCombineCerts(t *testing.T) {
 // And then performs a few tests on them.
 func testClientServer(t *testing.T, combineCerts bool) {
 	// Our test root.
-	root, err := ioutil.TempDir("", "tlstest")
+	root, err := os.MkdirTemp("", "tlstest")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -234,7 +233,7 @@ func TestClientTLSConfigCaching(t *testing.T) {
 
 func testConfigGeneration(t *testing.T, rootPrefix string, generateConfig func(ClientServerKeyPairs) (*tls.Config, error), getCertPool func(tlsConfig *tls.Config) *x509.CertPool) {
 	// Our test root.
-	root, err := ioutil.TempDir("", rootPrefix)
+	root, err := os.MkdirTemp("", rootPrefix)
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -281,7 +280,7 @@ func testConfigGeneration(t *testing.T, rootPrefix string, generateConfig func(C
 
 func testNumberOfCertsWithOrWithoutCombining(t *testing.T, numCertsExpected int, combine bool) {
 	// Our test root.
-	root, err := ioutil.TempDir("", "tlstest")
+	root, err := os.MkdirTemp("", "tlstest")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -72,7 +72,7 @@ func getClientCreds() (creds map[string]*ClientAuthCred, err error) {
 		return nil, nil
 	}
 
-	data, err := ioutil.ReadFile(*consulAuthClientStaticFile)
+	data, err := os.ReadFile(*consulAuthClientStaticFile)
 	if err != nil {
 		err = vterrors.Wrapf(err, "Failed to read consul_auth_static_file file")
 		return creds, err

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -19,7 +19,6 @@ package consultopo
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -46,7 +45,7 @@ func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
 	// Create a temporary config file, as ports cannot all be set
 	// via command line. The file name has to end with '.json' so
 	// we're not using TempFile.
-	configDir, err := ioutil.TempDir("", "consul")
+	configDir, err := os.MkdirTemp("", "consul")
 	if err != nil {
 		t.Fatalf("cannot create temp dir: %v", err)
 	}
@@ -236,7 +235,7 @@ func TestConsulTopoWithAuth(t *testing.T) {
 
 	// Run the TopoServerTestSuite tests.
 	testIndex := 0
-	tmpFile, err := ioutil.TempFile("", "consul_auth_client_static_file.json")
+	tmpFile, err := os.CreateTemp("", "consul_auth_client_static_file.json")
 
 	if err != nil {
 		t.Fatalf("couldn't create temp file: %v", err)
@@ -246,7 +245,7 @@ func TestConsulTopoWithAuth(t *testing.T) {
 	*consulAuthClientStaticFile = tmpFile.Name()
 
 	jsonConfig := "{\"global\":{\"acl_token\":\"123456\"}, \"test\":{\"acl_token\":\"123456\"}}"
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 
@@ -285,7 +284,7 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 		os.Remove(configFilename)
 	}()
 
-	tmpFile, err := ioutil.TempFile("", "consul_auth_client_static_file.json")
+	tmpFile, err := os.CreateTemp("", "consul_auth_client_static_file.json")
 
 	if err != nil {
 		t.Fatalf("couldn't create temp file: %v", err)
@@ -295,7 +294,7 @@ func TestConsulTopoWithAuthFailure(t *testing.T) {
 	*consulAuthClientStaticFile = tmpFile.Name()
 
 	jsonConfig := "{\"global\":{\"acl_token\":\"badtoken\"}}"
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(jsonConfig), 0600); err != nil {
 		t.Fatalf("couldn't write temp file: %v", err)
 	}
 

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -19,7 +19,6 @@ package etcd2topo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -39,7 +38,7 @@ import (
 // startEtcd starts an etcd subprocess, and waits for it to be ready.
 func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
 	// Create a temporary directory.
-	dataDir, err := ioutil.TempDir("", "etcd")
+	dataDir, err := os.MkdirTemp("", "etcd")
 	if err != nil {
 		t.Fatalf("cannot create tempdir: %v", err)
 	}
@@ -93,7 +92,7 @@ func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
 // startEtcdWithTLS starts an etcd subprocess with TLS setup, and waits for it to be ready.
 func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs, func()) {
 	// Create a temporary directory.
-	dataDir, err := ioutil.TempDir("", "etcd")
+	dataDir, err := os.MkdirTemp("", "etcd")
 	if err != nil {
 		t.Fatalf("cannot create tempdir: %v", err)
 	}

--- a/go/vt/topo/k8stopo/server.go
+++ b/go/vt/topo/k8stopo/server.go
@@ -30,7 +30,7 @@ package k8stopo
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -161,7 +161,7 @@ func NewServer(_, root string) (*Server, error) {
 		}
 
 		// When running in the cluster, use the namespace file to detect the current namespace
-		nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/topo/k8stopo/server_test.go
+++ b/go/vt/topo/k8stopo/server_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -46,14 +45,14 @@ func TestKubernetesTopo(t *testing.T) {
 	}
 
 	// Create a data dir for test data
-	testDataDir, err := ioutil.TempDir("", "vt-test-k3s")
+	testDataDir, err := os.MkdirTemp("", "vt-test-k3s")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(testDataDir) // clean up
 
 	// Gen a temp file name for the config
-	testConfig, err := ioutil.TempFile("", "vt-test-k3s-config")
+	testConfig, err := os.CreateTemp("", "vt-test-k3s-config")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -21,9 +21,9 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -291,7 +291,7 @@ func (c *ZkConn) maybeAddAuth(ctx context.Context) {
 	if *authFile == "" {
 		return
 	}
-	authInfoBytes, err := ioutil.ReadFile(*authFile)
+	authInfoBytes, err := os.ReadFile(*authFile)
 	if err != nil {
 		log.Errorf("failed to read topo_zk_auth_file: %v", err)
 		return
@@ -358,7 +358,7 @@ func dialZk(ctx context.Context, addr string) (*zk.Conn, <-chan zk.Event, error)
 			log.Fatalf("Unable to load cert %v and key %v, err %v", *certPath, *keyPath, err)
 		}
 
-		clientCACert, err := ioutil.ReadFile(*caPath)
+		clientCACert, err := os.ReadFile(*caPath)
 		if err != nil {
 			log.Fatalf("Unable to open ca cert %v, err %v", *caPath, err)
 		}

--- a/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_static_file.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 
 	"github.com/spf13/pflag"
 
@@ -94,7 +94,7 @@ func NewStaticFile(cluster *vtadminpb.Cluster, flags *pflag.FlagSet, args []stri
 		return nil, errors.New("must specify path to the service discovery JSON config file")
 	}
 
-	b, err := ioutil.ReadFile(*filePath)
+	b, err := os.ReadFile(*filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtadmin/cluster/file_config.go
+++ b/go/vt/vtadmin/cluster/file_config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cluster
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -90,7 +90,7 @@ func (fc *FileConfig) Type() string {
 // Set is part of the flag.Value interface. It loads the file configuration
 // found at the path passed to the flag.
 func (fc *FileConfig) Set(value string) error {
-	data, err := ioutil.ReadFile(value)
+	data, err := os.ReadFile(value)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtadmin/credentials/credentials.go
+++ b/go/vt/vtadmin/credentials/credentials.go
@@ -19,7 +19,7 @@ package credentials
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"text/template"
 
 	"vitess.io/vitess/go/vt/grpcclient"
@@ -58,7 +58,7 @@ func renderTemplate(tmplStr string, data interface{}) (string, error) {
 }
 
 func loadCredentials(path string) (*grpcclient.StaticAuthClientCreds, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtadmin/credentials/credentials_test.go
+++ b/go/vt/vtadmin/credentials/credentials_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package credentials
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -65,7 +64,7 @@ func Test_loadCredentials(t *testing.T) {
 			path := ""
 
 			if len(tt.contents) > 0 {
-				f, err := ioutil.TempFile("", "vtsql-credentials-test-*")
+				f, err := os.CreateTemp("", "vtsql-credentials-test-*")
 				require.NoError(t, err)
 				_, err = f.Write(tt.contents)
 				require.NoError(t, err)

--- a/go/vt/vtadmin/http/experimental/tablets.go
+++ b/go/vt/vtadmin/http/experimental/tablets.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"text/template"
 
@@ -73,7 +73,7 @@ func getDebugVars(ctx context.Context, api *vtadminhttp.API, tablet *vtadminpb.T
 
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtadmin/vtctldclient/config_test.go
+++ b/go/vt/vtadmin/vtctldclient/config_test.go
@@ -19,7 +19,6 @@ package vtctldclient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ import (
 )
 
 func withTempFile(t *testing.T, tmpdir string, name string, f func(*testing.T, *os.File)) {
-	tmpfile, err := ioutil.TempFile(tmpdir, name)
+	tmpfile, err := os.CreateTemp(tmpdir, name)
 	require.NoError(t, err, "TempFile(%s, %s)", tmpdir, name)
 	defer os.Remove(tmpfile.Name())
 

--- a/go/vt/vtadmin/vtsql/config_test.go
+++ b/go/vt/vtadmin/vtsql/config_test.go
@@ -18,7 +18,6 @@ package vtsql
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func TestConfigParse(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := ioutil.TempFile("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
+		f, err := os.CreateTemp("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
 		require.NoError(t, err)
 
 		_, err = f.Write([]byte(`{
@@ -100,7 +99,7 @@ func TestConfigParse(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := ioutil.TempFile("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
+		f, err := os.CreateTemp("", "vtsql-config-test-testcluster-*") // testcluster is going to appear in the template
 		require.NoError(t, err)
 
 		_, err = f.Write([]byte(`{

--- a/go/vt/vtctl/grpcvtctlclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctlclient/client_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -88,7 +87,7 @@ func TestVtctlAuthClient(t *testing.T) {
          "Password": "valid"
         }`
 
-	f, err := ioutil.TempFile("", "static_auth_creds.json")
+	f, err := os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtctl/topo.go
+++ b/go/vt/vtctl/topo.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -170,7 +170,7 @@ func copyFileFromTopo(ctx context.Context, ts *topo.Server, cell, from, to strin
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(to, data, 0644)
+	return os.WriteFile(to, data, 0644)
 }
 
 func copyFileToTopo(ctx context.Context, ts *topo.Server, cell, from, to string) error {
@@ -178,7 +178,7 @@ func copyFileToTopo(ctx context.Context, ts *topo.Server, cell, from, to string)
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadFile(from)
+	data, err := os.ReadFile(from)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -86,8 +86,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -570,7 +570,7 @@ func getFileParam(flag, flagFile, name string) (string, error) {
 	if flagFile == "" {
 		return "", fmt.Errorf("action requires one of %v or %v-file", name, name)
 	}
-	data, err := ioutil.ReadFile(flagFile)
+	data, err := os.ReadFile(flagFile)
 	if err != nil {
 		return "", fmt.Errorf("cannot read file %v: %v", flagFile, err)
 	}
@@ -3265,7 +3265,7 @@ func commandApplyVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 
 	if sqlMode {
 		if *sqlFile != "" {
-			sqlBytes, err := ioutil.ReadFile(*sqlFile)
+			sqlBytes, err := os.ReadFile(*sqlFile)
 			if err != nil {
 				return err
 			}
@@ -3300,7 +3300,7 @@ func commandApplyVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		var schema []byte
 		if *vschemaFile != "" {
 			var err error
-			schema, err = ioutil.ReadFile(*vschemaFile)
+			schema, err = os.ReadFile(*vschemaFile)
 			if err != nil {
 				return err
 			}
@@ -3363,7 +3363,7 @@ func commandApplyRoutingRules(ctx context.Context, wr *wrangler.Wrangler, subFla
 	var rulesBytes []byte
 	if *routingRulesFile != "" {
 		var err error
-		rulesBytes, err = ioutil.ReadFile(*routingRulesFile)
+		rulesBytes, err = os.ReadFile(*routingRulesFile)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -185,7 +185,7 @@ func getItemPath(url string) string {
 }
 
 func unmarshalRequest(r *http.Request, v interface{}) error {
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -431,11 +431,11 @@ func TestAPI(t *testing.T) {
 				return
 			}
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 
 			if err != nil {
-				t.Fatalf("[%v] ioutil.ReadAll(resp.Body) error: %v", in.path, err)
+				t.Fatalf("[%v] io.ReadAll(resp.Body) error: %v", in.path, err)
 				return
 			}
 

--- a/go/vt/vtctld/redirection.go
+++ b/go/vt/vtctld/redirection.go
@@ -19,7 +19,7 @@ package vtctld
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"strconv"
@@ -67,10 +67,10 @@ func initVTTabletRedirection(ts *topo.Server) {
 
 		prefixPath := fmt.Sprintf("/vttablet/%s/", tabletID)
 		rp.ModifyResponse = func(r *http.Response) error {
-			b, _ := ioutil.ReadAll(r.Body)
+			b, _ := io.ReadAll(r.Body)
 			b = bytes.ReplaceAll(b, []byte(`href="/`), []byte(fmt.Sprintf(`href="%s`, prefixPath)))
 			b = bytes.ReplaceAll(b, []byte(`href=/`), []byte(fmt.Sprintf(`href=%s`, prefixPath)))
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			r.Body = io.NopCloser(bytes.NewBuffer(b))
 			r.Header["Content-Length"] = []string{strconv.FormatInt(int64(len(b)), 10)}
 
 			// Don't forget redirects

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -19,7 +19,7 @@ package vtexplain
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -48,10 +48,10 @@ type testopts struct {
 }
 
 func initTest(mode string, opts *Options, topts *testopts, t *testing.T) {
-	schema, err := ioutil.ReadFile("testdata/test-schema.sql")
+	schema, err := os.ReadFile("testdata/test-schema.sql")
 	require.NoError(t, err)
 
-	vSchema, err := ioutil.ReadFile("testdata/test-vschema.json")
+	vSchema, err := os.ReadFile("testdata/test-vschema.json")
 	require.NoError(t, err)
 
 	shardmap := ""
@@ -86,11 +86,11 @@ func runTestCase(testcase, mode string, opts *Options, topts *testopts, t *testi
 		initTest(mode, opts, topts, t)
 
 		sqlFile := fmt.Sprintf("testdata/%s-queries.sql", testcase)
-		sql, err := ioutil.ReadFile(sqlFile)
+		sql, err := os.ReadFile(sqlFile)
 		require.NoError(t, err, "vtexplain error")
 
 		textOutFile := fmt.Sprintf("testdata/%s-output/%s-output.txt", mode, testcase)
-		expected, _ := ioutil.ReadFile(textOutFile)
+		expected, _ := os.ReadFile(textOutFile)
 
 		explains, err := Run(string(sql))
 		require.NoError(t, err, "vtexplain error")
@@ -103,11 +103,11 @@ func runTestCase(testcase, mode string, opts *Options, topts *testopts, t *testi
 			t.Errorf("Text output did not match (-want +got):\n%s", diff)
 
 			if testOutputTempDir == "" {
-				testOutputTempDir, err = ioutil.TempDir("", "vtexplain_output")
+				testOutputTempDir, err = os.MkdirTemp("", "vtexplain_output")
 				require.NoError(t, err, "error getting tempdir")
 			}
 			gotFile := fmt.Sprintf("%s/%s-output.txt", testOutputTempDir, testcase)
-			ioutil.WriteFile(gotFile, []byte(explainText), 0644)
+			os.WriteFile(gotFile, []byte(explainText), 0644)
 
 			t.Logf("run the following command to update the expected output:")
 			t.Logf("cp %s/* %s", testOutputTempDir, path.Dir(textOutFile))

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -1690,7 +1690,7 @@ func getTabletThrottlerStatus(tabletHostPort string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -19,7 +19,6 @@ package grpcvtgateconn
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -91,7 +90,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
          "Password": "valid"
         }`
 
-	f, err := ioutil.TempFile("", "static_auth_creds.json")
+	f, err := os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +123,7 @@ func TestGRPCVTGateConnAuth(t *testing.T) {
 	 "Password": "valid"
 	}`
 
-	f, err = ioutil.TempFile("", "static_auth_creds.json")
+	f, err = os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vtgate/grpcvtgateconn/fuzz_flaky_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/fuzz_flaky_test.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -77,7 +76,7 @@ func Fuzz(data []byte) int {
          "Password": "valid"
         }`
 
-	f, err := ioutil.TempFile("", "static_auth_creds.json")
+	f, err := os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		return -1
 	}

--- a/go/vt/vtgate/planbuilder/abstract/fuzz_test.go
+++ b/go/vt/vtgate/planbuilder/abstract/fuzz_test.go
@@ -20,7 +20,7 @@ limitations under the License.
 package abstract
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime/debug"
 	"testing"
@@ -30,7 +30,7 @@ import (
 
 func TestFuzzAnalyze(t *testing.T) {
 	directoryName := "fuzzdata"
-	files, err := ioutil.ReadDir(directoryName)
+	files, err := os.ReadDir(directoryName)
 	require.NoError(t, err)
 	for _, file := range files {
 		t.Run(file.Name(), func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestFuzzAnalyze(t *testing.T) {
 					t.Fatal(string(debug.Stack()))
 				}
 			}()
-			testcase, err := ioutil.ReadFile(path.Join(directoryName, file.Name()))
+			testcase, err := os.ReadFile(path.Join(directoryName, file.Name()))
 			require.NoError(t, err)
 			FuzzAnalyse(testcase)
 		})

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime/debug"
@@ -161,7 +160,7 @@ func TestPlan(t *testing.T) {
 		sysVarEnabled: true,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -204,7 +203,7 @@ func TestSysVarSetDisabled(t *testing.T) {
 		sysVarEnabled: false,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(testOutputTempDir)
 	testFile(t, "set_sysvar_disabled_cases.txt", testOutputTempDir, vschemaWrapper)
@@ -224,7 +223,7 @@ func TestRubyOnRailsQueries(t *testing.T) {
 		sysVarEnabled: true,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -241,7 +240,7 @@ func TestOLTP(t *testing.T) {
 		sysVarEnabled: true,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -258,7 +257,7 @@ func TestTPCC(t *testing.T) {
 		sysVarEnabled: true,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -275,7 +274,7 @@ func TestTPCH(t *testing.T) {
 		sysVarEnabled: true,
 	}
 
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -317,7 +316,7 @@ func benchmarkWorkload(b *testing.B, name string) {
 }
 
 func TestBypassPlanningShardTargetFromFile(t *testing.T) {
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(testOutputTempDir)
 
@@ -333,7 +332,7 @@ func TestBypassPlanningShardTargetFromFile(t *testing.T) {
 	testFile(t, "bypass_shard_cases.txt", testOutputTempDir, vschema)
 }
 func TestBypassPlanningKeyrangeTargetFromFile(t *testing.T) {
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(testOutputTempDir)
 
@@ -354,7 +353,7 @@ func TestBypassPlanningKeyrangeTargetFromFile(t *testing.T) {
 
 func TestWithDefaultKeyspaceFromFile(t *testing.T) {
 	// We are testing this separately so we can set a default keyspace
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer func() {
 		if !t.Failed() {
@@ -380,7 +379,7 @@ func TestWithDefaultKeyspaceFromFile(t *testing.T) {
 
 func TestWithSystemSchemaAsDefaultKeyspace(t *testing.T) {
 	// We are testing this separately so we can set a default keyspace
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(testOutputTempDir)
 	vschema := &vschemaWrapper{
@@ -394,7 +393,7 @@ func TestWithSystemSchemaAsDefaultKeyspace(t *testing.T) {
 
 func TestOtherPlanningFromFile(t *testing.T) {
 	// We are testing this separately so we can set a default keyspace
-	testOutputTempDir, err := ioutil.TempDir("", "plan_test")
+	testOutputTempDir, err := os.MkdirTemp("", "plan_test")
 	defer os.RemoveAll(testOutputTempDir)
 	require.NoError(t, err)
 	vschema := &vschemaWrapper{
@@ -640,7 +639,7 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vschemaWrapper) {
 
 		if tempDir != "" {
 			gotFile := fmt.Sprintf("%s/%s", tempDir, filename)
-			_ = ioutil.WriteFile(gotFile, []byte(strings.TrimSpace(expected.String())+"\n"), 0644)
+			_ = os.WriteFile(gotFile, []byte(strings.TrimSpace(expected.String())+"\n"), 0644)
 			fmt.Println(fmt.Sprintf("Errors found in plantests. If the output is correct, run `cp %s/* testdata/` to update test expectations", tempDir)) // nolint
 		}
 	})

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -19,7 +19,6 @@ package vtgate
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -76,7 +75,7 @@ func TestConnectionUnixSocket(t *testing.T) {
 
 	// Use tmp file to reserve a path, remove it immediately, we only care about
 	// name in this context
-	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	unixSocket, err := os.CreateTemp("", "mysql_vitess_test.sock")
 	if err != nil {
 		t.Fatalf("Failed to create temp file")
 	}
@@ -109,7 +108,7 @@ func TestConnectionStaleUnixSocket(t *testing.T) {
 
 	// First let's create a file. In this way, we simulate
 	// having a stale socket on disk that needs to be cleaned up.
-	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	unixSocket, err := os.CreateTemp("", "mysql_vitess_test.sock")
 	if err != nil {
 		t.Fatalf("Failed to create temp file")
 	}
@@ -139,7 +138,7 @@ func TestConnectionRespectsExistingUnixSocket(t *testing.T) {
 
 	authServer := newTestAuthServerStatic()
 
-	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	unixSocket, err := os.CreateTemp("", "mysql_vitess_test.sock")
 	if err != nil {
 		t.Fatalf("Failed to create temp file")
 	}
@@ -259,7 +258,7 @@ func TestInitTLSConfigWithServerCA(t *testing.T) {
 
 func testInitTLSConfig(t *testing.T, serverCA bool) {
 	// Create the certs.
-	root, err := ioutil.TempDir("", "TestInitTLSConfig")
+	root, err := os.MkdirTemp("", "TestInitTLSConfig")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -85,7 +85,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
 
 	// medium query
@@ -114,7 +114,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
 
 	// slow query
@@ -142,7 +142,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 
 	// ensure querylogz is not affected by the filter tag
@@ -152,7 +152,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 
 }

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -90,7 +90,7 @@ func TestQueryzHandler(t *testing.T) {
 	plan4.ExecTime = uint64(200 * time.Millisecond)
 
 	queryzHandler(executor, resp, req)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	planPattern1 := []string{
 		`<tr class="low">`,
 		`<td>select id from user where id = 1</td>`,

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -128,7 +128,7 @@ func (vind *NumericStaticMap) Map(cursor VCursor, ids []sqltypes.Value) ([]key.D
 func loadNumericLookupTable(path string) (NumericLookupTable, error) {
 	var m map[string]uint64
 	lt := make(map[uint64]uint64)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return lt, err
 	}

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -60,7 +60,7 @@ type RegionJSON struct {
 func NewRegionJSON(name string, m map[string]string) (Vindex, error) {
 	rmPath := m["region_map"]
 	rmap := make(map[string]uint64)
-	data, err := ioutil.ReadFile(rmPath)
+	data, err := os.ReadFile(rmPath)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -587,7 +587,7 @@ func LoadFormal(filename string) (*vschemapb.SrvVSchema, error) {
 	if filename == "" {
 		return formal, nil
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +605,7 @@ func LoadFormalKeyspace(filename string) (*vschemapb.Keyspace, error) {
 	if filename == "" {
 		return formal, nil
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
@@ -19,7 +19,7 @@ package filecustomrule
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"path"
 	"time"
 
@@ -63,7 +63,7 @@ func NewFileCustomRule() (fcr *FileCustomRule) {
 // of error it returns nil and that error. A log will be printed to capture the
 // stage at which parsing failed.
 func ParseRules(path string) (*rules.Rules, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Warningf("Error reading file %v: %v", path, err)
 		// Don't update any internal cache, just return error

--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule_test.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package filecustomrule
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -44,7 +43,7 @@ func TestFileCustomRule(t *testing.T) {
 	var qrs *rules.Rules
 	rulepath := path.Join(os.TempDir(), ".customrule.json")
 	// Set r1 and try to get it back
-	err := ioutil.WriteFile(rulepath, []byte(customRule1), os.FileMode(0644))
+	err := os.WriteFile(rulepath, []byte(customRule1), os.FileMode(0644))
 	if err != nil {
 		t.Fatalf("Cannot write r1 to rule file %s, err=%v", rulepath, err)
 	}

--- a/go/vt/vttablet/endtoend/connkilling/main_test.go
+++ b/go/vt/vttablet/endtoend/connkilling/main_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -100,7 +99,7 @@ func TestMain(m *testing.M) {
 }
 
 func initTableACL() error {
-	file, err := ioutil.TempFile("", "tableacl.json")
+	file, err := os.CreateTemp("", "tableacl.json")
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/endtoend/framework/debugvars.go
+++ b/go/vt/vttablet/endtoend/framework/debugvars.go
@@ -19,7 +19,7 @@ package framework
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -97,7 +97,7 @@ func FetchURL(urlPath string) string {
 		return ""
 	}
 	defer response.Body.Close()
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		return ""
 	}

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -102,7 +101,7 @@ func TestMain(m *testing.M) {
 }
 
 func initTableACL() error {
-	file, err := ioutil.TempFile("", "tableacl.json")
+	file, err := os.CreateTemp("", "tableacl.json")
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -19,7 +19,6 @@ package endtoend
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -398,7 +397,7 @@ func TestHealth(t *testing.T) {
 		return
 	}
 	defer response.Body.Close()
-	result, err := ioutil.ReadAll(response.Body)
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/vttablet/filelogger/filelogger_test.go
+++ b/go/vt/vttablet/filelogger/filelogger_test.go
@@ -18,7 +18,6 @@ package filelogger
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -30,7 +29,7 @@ import (
 
 // TestFileLog sends a stream of five query records to the plugin, and verifies that they are logged.
 func TestFileLog(t *testing.T) {
-	dir, err := ioutil.TempDir("", "filelogger_test")
+	dir, err := os.MkdirTemp("", "filelogger_test")
 	if err != nil {
 		t.Fatalf("error getting tempdir: %v", err)
 	}
@@ -66,7 +65,7 @@ func TestFileLog(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 
 		want := "\t\t\t''\t''\t0001-01-01 00:00:00.000000\t0001-01-01 00:00:00.000000\t0.000000\t\t\"test 1\"\tmap[]\t1\t\"test 1 PII\"\tmysql\t0.000000\t0.000000\t0\t0\t0\t\"\"\t\n\t\t\t''\t''\t0001-01-01 00:00:00.000000\t0001-01-01 00:00:00.000000\t0.000000\t\t\"test 2\"\tmap[]\t1\t\"test 2 PII\"\tmysql\t0.000000\t0.000000\t0\t0\t0\t\"\"\t\n"
-		contents, _ := ioutil.ReadFile(logPath)
+		contents, _ := os.ReadFile(logPath)
 		got := string(contents)
 		if want == got {
 			return
@@ -85,7 +84,7 @@ func TestFileLogRedacted(t *testing.T) {
 		*streamlog.RedactDebugUIQueries = false
 	}()
 
-	dir, err := ioutil.TempDir("", "filelogger_test")
+	dir, err := os.MkdirTemp("", "filelogger_test")
 	if err != nil {
 		t.Fatalf("error getting tempdir: %v", err)
 	}
@@ -120,7 +119,7 @@ func TestFileLogRedacted(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	want := "\t\t\t''\t''\t0001-01-01 00:00:00.000000\t0001-01-01 00:00:00.000000\t0.000000\t\t\"test 1\"\t\"[REDACTED]\"\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t0\t\"\"\t\n\t\t\t''\t''\t0001-01-01 00:00:00.000000\t0001-01-01 00:00:00.000000\t0.000000\t\t\"test 2\"\t\"[REDACTED]\"\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t0\t\"\"\t\n"
-	contents, _ := ioutil.ReadFile(logPath)
+	contents, _ := os.ReadFile(logPath)
 	got := string(contents)
 	if want != string(got) {
 		t.Errorf("streamlog file: want %q got %q", want, got)

--- a/go/vt/vttablet/grpctabletconn/conn_test.go
+++ b/go/vt/vttablet/grpctabletconn/conn_test.go
@@ -18,7 +18,6 @@ package grpctabletconn
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -90,7 +89,7 @@ func TestGRPCTabletAuthConn(t *testing.T) {
          "Password": "valid"
         }`
 
-	f, err := ioutil.TempFile("", "static_auth_creds.json")
+	f, err := os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -1023,7 +1022,7 @@ exit $exit_code
 		_ = e.updateMigrationMessage(ctx, onlineDDL.UUID, fmt.Sprintf("executed gh-ost --execute=%v, err=%v", execute, err))
 		if err != nil {
 			// See if we can get more info from the failure file
-			if content, ferr := ioutil.ReadFile(path.Join(tempDir, migrationFailureFileName)); ferr == nil {
+			if content, ferr := os.ReadFile(path.Join(tempDir, migrationFailureFileName)); ferr == nil {
 				failureMessage := strings.TrimSpace(string(content))
 				if failureMessage != "" {
 					// This message was produced by gh-ost itself. It is more informative than the default "migration failed..." message. Overwrite.
@@ -2055,7 +2054,7 @@ func (e *Executor) runNextMigration(ctx context.Context) error {
 // by examining its PID file
 func (e *Executor) isPTOSCMigrationRunning(ctx context.Context, uuid string) (isRunning bool, pid int, err error) {
 	// Try and read its PID file:
-	content, err := ioutil.ReadFile(e.ptPidFileName(uuid))
+	content, err := os.ReadFile(e.ptPidFileName(uuid))
 	if err != nil {
 		// file probably does not exist (migration not running)
 		// or any other issue --> we can't confirm that the migration is actually running
@@ -2899,7 +2898,7 @@ func (e *Executor) ShowMigrationLogs(ctx context.Context, stmt *sqlparser.ShowMi
 	if logFile == "" {
 		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "No log file for migration %v", stmt.UUID)
 	}
-	content, err := ioutil.ReadFile(logFile)
+	content, err := os.ReadFile(logFile)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/onlineddl/util.go
+++ b/go/vt/vttablet/onlineddl/util.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -66,16 +66,16 @@ func execCmd(name string, args, env []string, dir string, input io.Reader, outpu
 // createTempDir creates a temporary directory and returns its name
 func createTempDir(hint string) (dirName string, err error) {
 	if hint != "" {
-		return ioutil.TempDir("", fmt.Sprintf("online-ddl-%s-*", hint))
+		return os.MkdirTemp("", fmt.Sprintf("online-ddl-%s-*", hint))
 	}
-	return ioutil.TempDir("", "online-ddl-*")
+	return os.MkdirTemp("", "online-ddl-*")
 }
 
 // createTempScript creates an executable file in given directory and with given text as content.
 func createTempScript(dirName, fileName, text string) (fullName string, err error) {
 	fullName = filepath.Join(dirName, fileName)
 	bytes := []byte(text)
-	err = ioutil.WriteFile(fullName, bytes, 0755)
+	err = os.WriteFile(fullName, bytes, 0755)
 	return fullName, err
 }
 

--- a/go/vt/vttablet/tabletmanager/orchestrator.go
+++ b/go/vt/vttablet/tabletmanager/orchestrator.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -197,5 +197,5 @@ func (orc *orcClient) apiGet(pathParts ...string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -269,7 +268,7 @@ func TestMessageStreamingPlan(t *testing.T) {
 }
 
 func loadSchema(name string) map[string]*schema.Table {
-	b, err := ioutil.ReadFile(locateFile(name))
+	b, err := os.ReadFile(locateFile(name))
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vttablet/tabletserver/querylogz_test.go
+++ b/go/vt/vttablet/tabletserver/querylogz_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package tabletserver
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -91,7 +91,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
 
 	// medium query
@@ -122,7 +122,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
 
 	// slow query
@@ -152,7 +152,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 
 	// ensure querylogz is not affected by the filter tag
@@ -162,7 +162,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	ch <- logStats
 	querylogzHandler(ch, response, req)
 	close(ch)
-	body, _ = ioutil.ReadAll(response.Body)
+	body, _ = io.ReadAll(response.Body)
 	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
 }
 

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -18,7 +18,7 @@ package tabletserver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -90,7 +90,7 @@ func TestQueryzHandler(t *testing.T) {
 	qe.plans.Wait()
 
 	queryzHandler(qe, resp, req)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	planPattern1 := []string{
 		`<tr class="high">`,
 		`<td>select name from test_table</td>`,

--- a/go/vt/vttablet/tabletserver/schema/schemaz_test.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package schema
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -33,7 +33,7 @@ func TestSchamazHandler1(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/schemaz", nil)
 	tables := initialSchema()
 	schemazHandler(tables, resp, req)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	test01 := []string{
 		`<td>test_table_01</td>`,

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -1938,7 +1937,7 @@ func TestACLHUP(t *testing.T) {
 	config := tabletenv.NewDefaultConfig()
 	tsv := NewTabletServer("TabletServerTest", config, memorytopo.NewServer(""), &topodatapb.TabletAlias{})
 
-	f, err := ioutil.TempFile("", "tableacl")
+	f, err := os.CreateTemp("", "tableacl")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -18,7 +18,6 @@ package vttest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -206,7 +205,7 @@ func (env *LocalTestEnv) TearDown() error {
 }
 
 func tmpdir(dataroot string) (dir string, err error) {
-	dir, err = ioutil.TempDir(dataroot, "vttest")
+	dir, err = os.MkdirTemp(dataroot, "vttest")
 	return
 }
 

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -139,7 +138,7 @@ func (cfg *Config) InitSchemas(keyspace, schema string, vschema *vschemapb.Keysp
 	}
 
 	// Create a base temporary directory.
-	tempSchemaDir, err := ioutil.TempDir("", "vttest")
+	tempSchemaDir, err := os.MkdirTemp("", "vttest")
 	if err != nil {
 		return err
 	}
@@ -152,7 +151,7 @@ func (cfg *Config) InitSchemas(keyspace, schema string, vschema *vschemapb.Keysp
 			return err
 		}
 		fileName := path.Join(ksDir, "schema.sql")
-		err = ioutil.WriteFile(fileName, []byte(schema), 0666)
+		err = os.WriteFile(fileName, []byte(schema), 0666)
 		if err != nil {
 			return err
 		}
@@ -165,7 +164,7 @@ func (cfg *Config) InitSchemas(keyspace, schema string, vschema *vschemapb.Keysp
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(vschemaFilePath, vschemaJSON, 0644); err != nil {
+		if err := os.WriteFile(vschemaFilePath, vschemaJSON, 0644); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -19,7 +19,7 @@ package vttest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -68,7 +68,7 @@ func getVars(addr string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // defaultHealthCheck checks the health of the Vitess process using getVars.

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -19,7 +19,7 @@ package vttls
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 
@@ -251,7 +251,7 @@ func loadx509CertPool(ca string) (*x509.CertPool, error) {
 }
 
 func doLoadx509CertPool(ca string) error {
-	b, err := ioutil.ReadFile(ca)
+	b, err := os.ReadFile(ca)
 	if err != nil {
 		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to read ca file: %s", ca)
 	}
@@ -339,19 +339,19 @@ func doLoadAndCombineTLSCertificates(ca, cert, key string) error {
 	combinedTLSIdentifier := tlsCertificatesIdentifier(ca, cert, key)
 
 	// Read CA certificates chain
-	caB, err := ioutil.ReadFile(ca)
+	caB, err := os.ReadFile(ca)
 	if err != nil {
 		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to read ca file: %s", ca)
 	}
 
 	// Read server certificate
-	certB, err := ioutil.ReadFile(cert)
+	certB, err := os.ReadFile(cert)
 	if err != nil {
 		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to read server cert file: %s", cert)
 	}
 
 	// Read server key file
-	keyB, err := ioutil.ReadFile(key)
+	keyB, err := os.ReadFile(key)
 	if err != nil {
 		return vterrors.Errorf(vtrpc.Code_NOT_FOUND, "failed to read key file: %s", key)
 	}

--- a/go/vt/worker/grpcvtworkerclient/client_test.go
+++ b/go/vt/worker/grpcvtworkerclient/client_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -85,7 +84,7 @@ func TestVtworkerServerAuth(t *testing.T) {
          "Password": "valid"
         }`
 
-	f, err := ioutil.TempFile("", "static_auth_creds.json")
+	f, err := os.CreateTemp("", "static_auth_creds.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/workflow/long_polling.go
+++ b/go/vt/workflow/long_polling.go
@@ -19,7 +19,7 @@ package workflow
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -237,7 +237,7 @@ func (m *Manager) HandleHTTPLongPolling(pattern string) {
 			return err
 		}
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -18,7 +18,7 @@ package workflow
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -50,7 +50,7 @@ func TestLongPolling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("/create failed: %v", err)
 	}
-	tree, err := ioutil.ReadAll(resp.Body)
+	tree, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("/create reading failed: %v", err)
@@ -78,7 +78,7 @@ func TestLongPolling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("/poll/1 failed: %v", err)
 	}
-	tree, err = ioutil.ReadAll(resp.Body)
+	tree, err = io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("/poll/1 reading failed: %v", err)
@@ -119,7 +119,7 @@ func TestLongPolling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("/poll/1 failed: %v", err)
 	}
-	tree, err = ioutil.ReadAll(resp.Body)
+	tree, err = io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("/poll/1 reading failed: %v", err)

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testlib
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -77,7 +76,7 @@ func TestBackupRestore(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := ioutil.TempDir("", "backuptest")
+	root, err := os.MkdirTemp("", "backuptest")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 
@@ -94,9 +93,9 @@ func TestBackupRestore(t *testing.T) {
 	for _, s := range []string{sourceInnodbDataDir, sourceInnodbLogDir, sourceDataDbDir} {
 		require.NoError(t, os.MkdirAll(s, os.ModePerm))
 	}
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
 	// create a primary tablet, set its primary position
 	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, db)
@@ -282,7 +281,7 @@ func TestBackupRestoreLagged(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := ioutil.TempDir("", "backuptest")
+	root, err := os.MkdirTemp("", "backuptest")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 
@@ -299,9 +298,9 @@ func TestBackupRestoreLagged(t *testing.T) {
 	for _, s := range []string{sourceInnodbDataDir, sourceInnodbLogDir, sourceDataDbDir} {
 		require.NoError(t, os.MkdirAll(s, os.ModePerm))
 	}
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
 	// create a primary tablet, set its position
 	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, db)
@@ -479,7 +478,7 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := ioutil.TempDir("", "backuptest")
+	root, err := os.MkdirTemp("", "backuptest")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 
@@ -496,9 +495,9 @@ func TestRestoreUnreachablePrimary(t *testing.T) {
 	for _, s := range []string{sourceInnodbDataDir, sourceInnodbLogDir, sourceDataDbDir} {
 		require.NoError(t, os.MkdirAll(s, os.ModePerm))
 	}
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
 	// create a primary tablet, set its primary position
 	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, db)
@@ -632,7 +631,7 @@ func TestDisableActiveReparents(t *testing.T) {
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 
 	// Initialize our temp dirs
-	root, err := ioutil.TempDir("", "backuptest")
+	root, err := os.MkdirTemp("", "backuptest")
 	require.NoError(t, err)
 	defer os.RemoveAll(root)
 
@@ -649,9 +648,9 @@ func TestDisableActiveReparents(t *testing.T) {
 	for _, s := range []string{sourceInnodbDataDir, sourceInnodbLogDir, sourceDataDbDir} {
 		require.NoError(t, os.MkdirAll(s, os.ModePerm))
 	}
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
-	require.NoError(t, ioutil.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbDataDir, "innodb_data_1"), []byte("innodb data 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceInnodbLogDir, "innodb_log_1"), []byte("innodb log 1 contents"), os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(sourceDataDbDir, "db.opt"), []byte("db opt file"), os.ModePerm))
 
 	// create a primary tablet, set its primary position
 	primary := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_PRIMARY, db)

--- a/go/vt/wrangler/testlib/vtctl_topo_test.go
+++ b/go/vt/wrangler/testlib/vtctl_topo_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testlib
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -64,7 +63,7 @@ func TestVtctlTopoCommands(t *testing.T) {
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
 
-	tmp, err := ioutil.TempDir("", "vtctltopotest")
+	tmp, err := os.MkdirTemp("", "vtctltopotest")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -83,7 +82,7 @@ sharding_column_name:"col2"
 	if err != nil {
 		t.Fatalf("TopoCp(/keyspaces/ks1/Keyspace) failed: %v", err)
 	}
-	contents, err := ioutil.ReadFile(ksFile)
+	contents, err := os.ReadFile(ksFile)
 	if err != nil {
 		t.Fatalf("copy failed: %v", err)
 	}

--- a/go/vt/wrangler/version.go
+++ b/go/vt/wrangler/version.go
@@ -19,7 +19,7 @@ package wrangler
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"sync"
@@ -39,7 +39,7 @@ var getVersionFromTabletDebugVars = func(tabletAddr string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/go/vt/zkctl/zkconf.go
+++ b/go/vt/zkctl/zkconf.go
@@ -23,7 +23,7 @@ package zkctl
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -90,7 +90,7 @@ func (cnf *ZkConfig) MyidFile() string {
 }
 
 func (cnf *ZkConfig) WriteMyid() error {
-	return ioutil.WriteFile(cnf.MyidFile(), []byte(fmt.Sprintf("%v", cnf.ServerId)), 0664)
+	return os.WriteFile(cnf.MyidFile(), []byte(fmt.Sprintf("%v", cnf.ServerId)), 0664)
 }
 
 /*
@@ -103,7 +103,7 @@ func MakeZooCfg(cnfFiles []string, cnf *ZkConfig, header string) (string, error)
 	}
 	var dataErr error
 	for _, path := range cnfFiles {
-		data, dataErr := ioutil.ReadFile(path)
+		data, dataErr := os.ReadFile(path)
 		if dataErr != nil {
 			continue
 		}

--- a/go/vt/zkctl/zkctl.go
+++ b/go/vt/zkctl/zkctl.go
@@ -23,7 +23,6 @@ package zkctl
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -126,7 +125,7 @@ func (zkd *Zkd) Start() error {
 // Shutdown kills a ZooKeeper server, but keeps its data dir intact.
 func (zkd *Zkd) Shutdown() error {
 	log.Infof("zkctl.Shutdown")
-	pidData, err := ioutil.ReadFile(zkd.config.PidFile())
+	pidData, err := os.ReadFile(zkd.config.PidFile())
 	if err != nil {
 		return err
 	}
@@ -173,7 +172,7 @@ func (zkd *Zkd) Init() error {
 
 	configData, err := zkd.makeCfg()
 	if err == nil {
-		err = ioutil.WriteFile(zkd.config.ConfigFile(), []byte(configData), 0664)
+		err = os.WriteFile(zkd.config.ConfigFile(), []byte(configData), 0664)
 	}
 	if err != nil {
 		log.Errorf("failed creating %v: %v", zkd.config.ConfigFile(), err)

--- a/test.go
+++ b/test.go
@@ -42,7 +42,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -294,7 +293,7 @@ func main() {
 	log.Printf("Output directory: %v", outDir)
 
 	// Get test configs.
-	configData, err := ioutil.ReadFile(configFileName)
+	configData, err := os.ReadFile(configFileName)
 	if err != nil {
 		log.Fatalf("Can't read config file: %v", err)
 	}
@@ -371,7 +370,7 @@ func main() {
 	if *docker {
 		// Copy working repo to tmpDir.
 		// This doesn't work outside Docker since it messes up GOROOT.
-		tmpDir, err = ioutil.TempDir(os.TempDir(), "vt_")
+		tmpDir, err = os.MkdirTemp(os.TempDir(), "vt_")
 		if err != nil {
 			log.Fatalf("Can't create temp dir in %v", os.TempDir())
 		}
@@ -460,7 +459,7 @@ func main() {
 					test.logf("running (try %v/%v)...", try, tryMax)
 
 					// Make a unique VTDATAROOT.
-					dataDir, err := ioutil.TempDir(vtDataRoot, "vt_")
+					dataDir, err := os.MkdirTemp(vtDataRoot, "vt_")
 					if err != nil {
 						test.logf("Failed to create temporary subdir in VTDATAROOT: %v", vtDataRoot)
 						mu.Lock()
@@ -482,7 +481,7 @@ func main() {
 						outFile := fmt.Sprintf("%v.%v-%v.%v.log", test.flavor, test.name, test.runIndex+1, try)
 						outFilePath := path.Join(outDir, outFile)
 						test.logf("saving test output to %v", outFilePath)
-						if fileErr := ioutil.WriteFile(outFilePath, output, os.FileMode(0644)); fileErr != nil {
+						if fileErr := os.WriteFile(outFilePath, output, os.FileMode(0644)); fileErr != nil {
 							test.logf("WriteFile error: %v", fileErr)
 						}
 					}
@@ -661,7 +660,7 @@ func testFlaked(name string, try int) {
 func updateTestStats(name string, update func(*TestStats)) {
 	var stats Stats
 
-	data, err := ioutil.ReadFile(statsFileName)
+	data, err := os.ReadFile(statsFileName)
 	if err != nil {
 		log.Print("Can't read stats file, starting new one.")
 	} else {
@@ -683,7 +682,7 @@ func updateTestStats(name string, update func(*TestStats)) {
 		log.Printf("Can't encode stats file: %v", err)
 		return
 	}
-	if err := ioutil.WriteFile(statsFileName, data, 0644); err != nil {
+	if err := os.WriteFile(statsFileName, data, 0644); err != nil {
 		log.Printf("Can't write stats file: %v", err)
 	}
 }

--- a/tools/statsd.go
+++ b/tools/statsd.go
@@ -19,9 +19,9 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -110,7 +110,7 @@ func updateTestStats(name string, update func(*TestStats)) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	data, err := ioutil.ReadFile(statsFileName)
+	data, err := os.ReadFile(statsFileName)
 	if err != nil {
 		log.Print("Can't read stats file, starting new one.")
 	} else {
@@ -132,7 +132,7 @@ func updateTestStats(name string, update func(*TestStats)) {
 		log.Printf("Can't encode stats file: %v", err)
 		return
 	}
-	if err := ioutil.WriteFile(statsFileName, data, 0644); err != nil {
+	if err := os.WriteFile(statsFileName, data, 0644); err != nil {
 		log.Printf("Can't write stats file: %v", err)
 	}
 }

--- a/vitess-mixin/e2e/vtcompose/vtcompose.go
+++ b/vitess-mixin/e2e/vtcompose/vtcompose.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"regexp"
@@ -220,7 +219,7 @@ func main() {
 }
 
 func applyFilePatch(dockerYaml []byte, patchFile string) []byte {
-	yamlPatch, err := ioutil.ReadFile(patchFile)
+	yamlPatch, err := os.ReadFile(patchFile)
 	if err != nil {
 		log.Fatalf("reading yaml patch file %s: %s", patchFile, err)
 	}
@@ -272,7 +271,7 @@ func createFile(filePath string) *os.File {
 }
 
 func readFile(filePath string) []byte {
-	file, err := ioutil.ReadFile(filePath)
+	file, err := os.ReadFile(filePath)
 
 	if err != nil {
 		log.Fatalf("reading %s: %s", filePath, err)
@@ -296,7 +295,7 @@ func handleError(err error) {
 
 func appendToSqlFile(schemaFileNames []string, f *os.File) {
 	for _, file := range schemaFileNames {
-		data, err := ioutil.ReadFile(tablesPath + file)
+		data, err := os.ReadFile(tablesPath + file)
 		if err != nil {
 			log.Fatalf("reading %s: %s", tablesPath+file, err)
 		}
@@ -313,7 +312,7 @@ func appendToSqlFile(schemaFileNames []string, f *os.File) {
 }
 
 func getTableName(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -325,7 +324,7 @@ func getTableName(sqlFile string) string {
 }
 
 func getPrimaryKey(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -337,7 +336,7 @@ func getPrimaryKey(sqlFile string) string {
 }
 
 func getKeyColumns(sqlFile string) string {
-	sqlFileData, err := ioutil.ReadFile(sqlFile)
+	sqlFileData, err := os.ReadFile(sqlFile)
 	if err != nil {
 		log.Fatalf("reading sqlFile file %s: %s", sqlFile, err)
 	}
@@ -404,7 +403,7 @@ func writeVschemaFile(file []byte, fileName string) {
 }
 
 func writeFile(file []byte, fileName string) {
-	err := ioutil.WriteFile(fileName, file, 0644)
+	err := os.WriteFile(fileName, file, 0644)
 	if err != nil {
 		log.Fatalf("writing %s %s", fileName, err)
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since vitess has upgraded to Go 1.17 (d04e9bd6f80689f0dc6198a1ad3a1ae22658de13), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
