### PR TITLE
Use `fmt.Fprintf` instead of `fmt.Sprintf`

### DIFF
--- a/go/vt/vtadmin/http/debug/cluster.go
+++ b/go/vt/vtadmin/http/debug/cluster.go
@@ -43,7 +43,7 @@ func Cluster(api API) http.HandlerFunc {
 		data, err := json.Marshal(c.Debug())
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(fmt.Sprintf("could not marshal cluster debug map: %s\n", err)))
+			fmt.Fprintf(w, "could not marshal cluster debug map: %s\n", err)
 			return
 		}
 
@@ -64,7 +64,7 @@ func Clusters(api API) http.HandlerFunc {
 		data, err := json.Marshal(m)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(fmt.Sprintf("could not marshal cluster debug map: %s\n", err)))
+			fmt.Fprintf(w, "could not marshal cluster debug map: %s\n", err)
 			return
 		}
 

--- a/go/vt/vtgate/debugenv.go
+++ b/go/vt/vtgate/debugenv.go
@@ -156,7 +156,7 @@ func debugEnvHandler(vtg *VTGate, w http.ResponseWriter, r *http.Request) {
 	w.Write(gridTable)
 	w.Write([]byte("<h3>Internal Variables</h3>\n"))
 	if msg != "" {
-		w.Write([]byte(fmt.Sprintf("<b>%s</b><br /><br />\n", html.EscapeString(msg))))
+		fmt.Fprintf(w, "<b>%s</b><br /><br />\n", html.EscapeString(msg))
 	}
 	w.Write(startTable)
 	w.Write(debugEnvHeader)

--- a/go/vt/vtgate/executor_scatter_stats.go
+++ b/go/vt/vtgate/executor_scatter_stats.go
@@ -145,7 +145,7 @@ func (e *Executor) WriteScatterStats(w http.ResponseWriter) {
 		http.Error(w, err.Error(), 500)
 	}
 
-	_, err = w.Write([]byte(fmt.Sprintf("Percentage of time spent on scatter queries: %2.2f%%", results.PercentTimeScatter)))
+	_, err = fmt.Fprintf(w, "Percentage of time spent on scatter queries: %2.2f%%", results.PercentTimeScatter)
 
 	if err != nil {
 		http.Error(w, err.Error(), 500)

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -163,7 +163,7 @@ func debugEnvHandler(tsv *TabletServer, w http.ResponseWriter, r *http.Request) 
 	w.Write(gridTable)
 	w.Write([]byte("<h3>Internal Variables</h3>\n"))
 	if msg != "" {
-		w.Write([]byte(fmt.Sprintf("<b>%s</b><br /><br />\n", html.EscapeString(msg))))
+		fmt.Fprintf(w, "<b>%s</b><br /><br />\n", html.EscapeString(msg))
 	}
 	w.Write(startTable)
 	w.Write(debugEnvHeader)

--- a/go/vt/vttablet/tabletserver/twopcz.go
+++ b/go/vt/vttablet/tabletserver/twopcz.go
@@ -181,7 +181,7 @@ func twopczHandler(txe *TxExecutor, w http.ResponseWriter, r *http.Request) {
 	w.Write(gridTable)
 	w.Write([]byte("<h2>WARNING: Actions on this page can jeopardize data integrity.</h2>\n"))
 	if msg != "" {
-		w.Write([]byte(fmt.Sprintf("%s\n", msg)))
+		fmt.Fprintln(w, msg)
 	}
 
 	w.Write(startTable)


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR replaces `fmt.Sprintf` calls with `fmt.Fprintf` and friends
where it is possible.

The `w.Write([]byte(fmt.Sprintf(...)))` pattern is quite inefficient, it allocates
3x more than `fmt.Fprintf`.

I see that this PR changes only some debug and observability-related code. Anyway, I hope it will be helpful.
