### PR TITLE
Renamed docker_test workflows

### DIFF
--- a/.github/workflows/docker_test_cluster_10.yml
+++ b/.github/workflows/docker_test_cluster_10.yml
@@ -1,9 +1,9 @@
-name: docker_test_3
+name: docker_test_cluster_10
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Docker Test 3
+    name: Docker Test Cluster 10
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Run tests which require docker - 3
+    - name: Run tests which require docker - 1
       run: |
-        go run test.go -docker=true --follow -shard 26
+        go run test.go -docker=true --follow -shard 10

--- a/.github/workflows/docker_test_cluster_25.yml
+++ b/.github/workflows/docker_test_cluster_25.yml
@@ -1,9 +1,9 @@
-name: docker_test_1
+name: docker_test_cluster_25
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Docker Test 1
+    name: Docker Test Cluster 25
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Run tests which require docker - 1
+    - name: Run tests which require docker - 2
       run: |
-        go run test.go -docker=true --follow -shard 10
+        go run test.go -docker=true --follow -shard 25

--- a/.github/workflows/docker_test_cluster_26.yml
+++ b/.github/workflows/docker_test_cluster_26.yml
@@ -1,9 +1,9 @@
-name: docker_test_2
+name: docker_test_cluster_26
 on: [push, pull_request]
 jobs:
 
   build:
-    name: Docker Test 2
+    name: Docker Test Cluster 26
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Run tests which require docker - 2
+    - name: Run tests which require docker - 3
       run: |
-        go run test.go -docker=true --follow -shard 25
+        go run test.go -docker=true --follow -shard 26

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -41,6 +41,7 @@ const (
 )
 
 var (
+	// Clusters 10, 25 and 26 are executed by the docker_test_cluster 10, 25, 26 workflows.
 	clusterList = []string{
 		"11",
 		"12",


### PR DESCRIPTION
## Description

This pull request renames the `docker_test_1|2|3` GHA workflows to `docker_test_cluster_10|25|26` to improve clarity. Additionally a note regarding the GHA clusters numeration has been added in the CI Workflows generation file.


## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
