### PR TITLE
Checking if pull requests have a release notes label

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,4 +43,8 @@ jobs:
           echo "Expecting PR to have label 'Type: ...'"
           exit 1
         fi
+        if ! cat ${LABELS_JSON} | jq -r '.[].name ' | grep 'release notes' | wc -l | grep -q 1 ; then
+          echo "Expecting PR to have only one of the following labels: 'release notes', 'release notes none', 'release notes (needs details)'."
+          exit 1
+        fi
         exit 0


### PR DESCRIPTION
## Description

Since #8877, we only list pull requests with either the `release notes` or `release notes (needs details)` label in our release notes. To make sure all pull requests are labeled correctly from now on,  the `pr_label` workflow has been changed to also check that a pull request is labeled with one of the following: `release notes`, `release notes none`, `release notes (needs details)`.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
