### PR TITLE
Fix sqlparser.Walk compilation error when passing Select's From field

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -207,7 +207,7 @@ type (
 		StraightJoinHint bool
 		SQLCalcFoundRows bool
 		// The From field must be the first AST element of this struct so the rewriter sees it first
-		From        []TableExpr
+		From        TableExprs
 		Comments    Comments
 		SelectExprs SelectExprs
 		Where       *Where


### PR DESCRIPTION
## Description
Fixes the following compilation error:
```
river/config.go:863:39: cannot use e.From (type []sqlparser.TableExpr) as type sqlparser.SQLNode in argument to sqlparser.Walk:
        []sqlparser.TableExpr does not implement sqlparser.SQLNode (missing Format method)
```

## Related Issue(s)
None


## Checklist
- [x] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
None
