### PR TITLE
Fix sqlparser.Walk compilation error when passing Select's From field

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -207,7 +207,7 @@ type (
 		StraightJoinHint bool
 		SQLCalcFoundRows bool
 		// The From field must be the first AST element of this struct so the rewriter sees it first
-		From        []TableExpr
+		From        TableExprs
 		Comments    Comments
 		SelectExprs SelectExprs
 		Where       *Where

--- a/go/vt/sqlparser/ast_clone.go
+++ b/go/vt/sqlparser/ast_clone.go
@@ -1364,7 +1364,7 @@ func CloneRefOfSelect(n *Select) *Select {
 	}
 	out := *n
 	out.Cache = CloneRefOfBool(n.Cache)
-	out.From = CloneSliceOfTableExpr(n.From)
+	out.From = CloneTableExprs(n.From)
 	out.Comments = CloneComments(n.Comments)
 	out.SelectExprs = CloneSelectExprs(n.SelectExprs)
 	out.Where = CloneRefOfWhere(n.Where)
@@ -2439,18 +2439,6 @@ func CloneRefOfBool(n *bool) *bool {
 	}
 	out := *n
 	return &out
-}
-
-// CloneSliceOfTableExpr creates a deep clone of the input.
-func CloneSliceOfTableExpr(n []TableExpr) []TableExpr {
-	if n == nil {
-		return nil
-	}
-	res := make([]TableExpr, 0, len(n))
-	for _, x := range n {
-		res = append(res, CloneTableExpr(x))
-	}
-	return res
 }
 
 // CloneSliceOfCharacteristic creates a deep clone of the input.

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -2150,7 +2150,7 @@ func EqualsRefOfSelect(a, b *Select) bool {
 		a.StraightJoinHint == b.StraightJoinHint &&
 		a.SQLCalcFoundRows == b.SQLCalcFoundRows &&
 		EqualsRefOfBool(a.Cache, b.Cache) &&
-		EqualsSliceOfTableExpr(a.From, b.From) &&
+		EqualsTableExprs(a.From, b.From) &&
 		EqualsComments(a.Comments, b.Comments) &&
 		EqualsSelectExprs(a.SelectExprs, b.SelectExprs) &&
 		EqualsRefOfWhere(a.Where, b.Where) &&
@@ -3878,19 +3878,6 @@ func EqualsRefOfBool(a, b *bool) bool {
 		return false
 	}
 	return *a == *b
-}
-
-// EqualsSliceOfTableExpr does deep equals between the two objects.
-func EqualsSliceOfTableExpr(a, b []TableExpr) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if !EqualsTableExpr(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
 }
 
 // EqualsSliceOfCharacteristic does deep equals between the two objects.

--- a/go/vt/sqlparser/ast_rewrite.go
+++ b/go/vt/sqlparser/ast_rewrite.go
@@ -3310,14 +3310,10 @@ func (a *application) rewriteRefOfSelect(parent SQLNode, node *Select, replacer 
 			return true
 		}
 	}
-	for x, el := range node.From {
-		if !a.rewriteTableExpr(node, el, func(idx int) replacerFunc {
-			return func(newNode, parent SQLNode) {
-				parent.(*Select).From[idx] = newNode.(TableExpr)
-			}
-		}(x)) {
-			return false
-		}
+	if !a.rewriteTableExprs(node, node.From, func(newNode, parent SQLNode) {
+		parent.(*Select).From = newNode.(TableExprs)
+	}) {
+		return false
 	}
 	if !a.rewriteComments(node, node.Comments, func(newNode, parent SQLNode) {
 		parent.(*Select).Comments = newNode.(Comments)

--- a/go/vt/sqlparser/ast_visit.go
+++ b/go/vt/sqlparser/ast_visit.go
@@ -1673,10 +1673,8 @@ func VisitRefOfSelect(in *Select, f Visit) error {
 	if cont, err := f(in); err != nil || !cont {
 		return err
 	}
-	for _, el := range in.From {
-		if err := VisitTableExpr(el, f); err != nil {
-			return err
-		}
+	if err := VisitTableExprs(in.From, f); err != nil {
+		return err
 	}
 	if err := VisitComments(in.Comments, f); err != nil {
 		return err

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -1679,7 +1679,7 @@ func (cached *Select) CachedSize(alloc bool) int64 {
 	}
 	// field Cache *bool
 	size += hack.RuntimeAllocSize(int64(1))
-	// field From []vitess.io/vitess/go/vt/sqlparser.TableExpr
+	// field From vitess.io/vitess/go/vt/sqlparser.TableExprs
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.From)) * int64(16))
 		for _, elem := range cached.From {


### PR DESCRIPTION
## Description
Fixes the following compilation error:
```
river/config.go:863:39: cannot use e.From (type []sqlparser.TableExpr) as type sqlparser.SQLNode in argument to sqlparser.Walk:
        []sqlparser.TableExpr does not implement sqlparser.SQLNode (missing Format method)
```

## Related Issue(s)
None


## Checklist
- [x] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
None
