### PR TITLE
Remove primary check when VTGR add unconnected node to group

### DIFF
--- a/go/vt/vtgr/controller/diagnose.go
+++ b/go/vt/vtgr/controller/diagnose.go
@@ -420,11 +420,6 @@ func (shard *GRShard) disconnectedInstance() (*grInstance, error) {
 		shard.instances[i], shard.instances[j] = shard.instances[j], shard.instances[i]
 	})
 	for _, instance := range shard.instances {
-		// Skip primary because VTGR always join group and then update tablet type
-		// which means if a tablet has type primary then it should have a group already
-		if instance.tablet.Type == topodatapb.TabletType_PRIMARY {
-			continue
-		}
 		// Skip instance without hostname because they are not up and running
 		// also skip instances that raised unrecoverable errors
 		if shard.shardStatusCollector.isUnreachable(instance) {


### PR DESCRIPTION
Signed-off-by: Yang Wu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
VTGR used to skip primary tablet when it checks all the nodes that are not in a group. This was based on the assumption that the primary tablet should already in the group when we bootstrap one. 

However, it is possible there are two tablets both marked as primary in topo, and skipping one of them is incorrect.

Also, add a node to group is orthogonal to if it is primary or not, based on the logic in VTGR, we will only try to repair unconnected node after bootstrap, which means we will skip real primary node automatically (which is used  to bootstrap the group and returns false on L434)

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->