### PR TITLE
[RFC] Add version-info to tablet tags in the topo

### DIFF
--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -56,6 +56,24 @@ type versionInfo struct {
 	version            string
 }
 
+// ToStringMap returns the version info as a map[string]string, allowing version
+// info to be used in things like arbitrary string-tag maps (e.g. tablet tags
+// in the topo).
+func (v *versionInfo) ToStringMap() map[string]string {
+	return map[string]string{
+		"build_host":           v.buildHost,
+		"build_user":           v.buildUser,
+		"build_time":           v.buildTimePretty,
+		"build_git_rev":        v.buildGitRev,
+		"build_git_branch":     v.buildGitBranch,
+		"jenkins_build_number": fmt.Sprintf("%d", v.jenkinsBuildNumber),
+		"go_version":           v.goVersion,
+		"goos":                 v.goOS,
+		"goarch":               v.goArch,
+		"version":              v.version,
+	}
+}
+
 func (v *versionInfo) Print() {
 	fmt.Println(v)
 }

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -61,16 +61,15 @@ type versionInfo struct {
 // in the topo).
 func (v *versionInfo) ToStringMap() map[string]string {
 	return map[string]string{
-		"build_host":           v.buildHost,
-		"build_user":           v.buildUser,
-		"build_time":           v.buildTimePretty,
-		"build_git_rev":        v.buildGitRev,
-		"build_git_branch":     v.buildGitBranch,
-		"jenkins_build_number": fmt.Sprintf("%d", v.jenkinsBuildNumber),
-		"go_version":           v.goVersion,
-		"goos":                 v.goOS,
-		"goarch":               v.goArch,
-		"version":              v.version,
+		"build_host":       v.buildHost,
+		"build_user":       v.buildUser,
+		"build_time":       v.buildTimePretty,
+		"build_git_rev":    v.buildGitRev,
+		"build_git_branch": v.buildGitBranch,
+		"go_version":       v.goVersion,
+		"goos":             v.goOS,
+		"goarch":           v.goArch,
+		"version":          v.version,
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -237,8 +237,26 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32) (
 		KeyRange:       keyRange,
 		Type:           tabletType,
 		DbNameOverride: *initDbNameOverride,
-		Tags:           initTags,
+		Tags:           mergeTags(servenv.AppVersion.ToStringMap(), initTags),
 	}, nil
+}
+
+func mergeTags(a, b map[string]string) map[string]string {
+	maxCap := len(a)
+	if x := len(b); x > maxCap {
+		maxCap = x
+	}
+
+	result := make(map[string]string, maxCap)
+	for k, v := range a {
+		result[k] = v
+	}
+
+	for k, v := range b {
+		result[k] = v
+	}
+
+	return result
 }
 
 // Start starts the TabletManager.

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -34,25 +34,25 @@ and which run changeCallback.
 package tabletmanager
 
 import (
+	"context"
 	"encoding/hex"
 	"flag"
 	"fmt"
 	"math/rand"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"vitess.io/vitess/go/flagutil"
-	"vitess.io/vitess/go/sync2"
-	"vitess.io/vitess/go/vt/vterrors"
-
-	"context"
-
-	"vitess.io/vitess/go/vt/dbconnpool"
-
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/sync2"
 	"vitess.io/vitess/go/vt/binlog"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
@@ -61,6 +61,7 @@ import (
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/topotools"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver"
 
@@ -78,6 +79,7 @@ var (
 	initShard          = flag.String("init_shard", "", "(init parameter) shard to use for this tablet")
 	initTabletType     = flag.String("init_tablet_type", "", "(init parameter) the tablet type to use for this tablet.")
 	initDbNameOverride = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet. Without this flag, the db name defaults to vt_<keyspacename>")
+	skipBuildInfoTags  = flag.String("vttablet_skip_buildinfo_tags", "", "comma-separated list of buildinfo tags to skip from merging with -init_tags. each tag is either an exact match or a regular expression of the form '/regexp/'.")
 	initTags           flagutil.StringMapValue
 
 	initPopulateMetadata = flag.Bool("init_populate_metadata", false, "(init parameter) populate metadata tables even if restore_from_backup is disabled. If restore_from_backup is enabled, metadata tables are always populated regardless of this flag.")
@@ -225,6 +227,11 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32) (
 		return nil, fmt.Errorf("invalid init_tablet_type %v; can only be REPLICA, RDONLY or SPARE", tabletType)
 	}
 
+	buildTags, err := getBuildTags(servenv.AppVersion.ToStringMap(), *skipBuildInfoTags)
+	if err != nil {
+		return nil, err
+	}
+
 	return &topodatapb.Tablet{
 		Alias:    alias,
 		Hostname: hostname,
@@ -237,8 +244,57 @@ func BuildTabletFromInput(alias *topodatapb.TabletAlias, port, grpcPort int32) (
 		KeyRange:       keyRange,
 		Type:           tabletType,
 		DbNameOverride: *initDbNameOverride,
-		Tags:           mergeTags(servenv.AppVersion.ToStringMap(), initTags),
+		Tags:           mergeTags(buildTags, initTags),
 	}, nil
+}
+
+func getBuildTags(buildTags map[string]string, skipTagsCSV string) (map[string]string, error) {
+	if skipTagsCSV == "" {
+		return buildTags, nil
+	}
+
+	skipTags := strings.Split(skipTagsCSV, ",")
+	skippers := make([]func(string) bool, len(skipTags))
+	for i, skipTag := range skipTags {
+		skipTag := skipTag // copy to preserve iteration scope in the closures below
+		if strings.HasPrefix(skipTag, "/") && strings.HasSuffix(skipTag, "/") && len(skipTag) > 1 {
+			// regexp mode
+			tagRegexp, err := regexp.Compile(skipTag[1 : len(skipTag)-1])
+			if err != nil {
+				return nil, err
+			}
+
+			skippers[i] = func(s string) bool {
+				return tagRegexp.MatchString(s)
+			}
+		} else {
+			skippers[i] = func(s string) bool {
+				log.Warningf(skipTag)
+				return s == skipTag
+			}
+		}
+	}
+
+	skippedTags := sets.NewString()
+	for tag := range buildTags {
+		for _, skipFn := range skippers {
+			if skipFn(tag) {
+				skippedTags.Insert(tag)
+				break
+			}
+		}
+	}
+
+	result := make(map[string]string, len(buildTags)-skippedTags.Len())
+	for tag, val := range buildTags {
+		if skippedTags.Has(tag) {
+			continue
+		}
+
+		result[tag] = val
+	}
+
+	return result, nil
 }
 
 func mergeTags(a, b map[string]string) map[string]string {

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -17,12 +17,9 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"vitess.io/vitess/go/test/utils"
-
-	"context"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,16 +28,18 @@ import (
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/sync2"
+	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
-	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topotools"
 	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 )
 
 func TestStartBuildTabletFromInput(t *testing.T) {
@@ -509,6 +508,67 @@ func TestCheckTabletTypeResets(t *testing.T) {
 	ter0 := ti.GetPrimaryTermStartTime()
 	assert.Equal(t, now, ter0)
 	tm.Stop()
+}
+
+func TestGetBuildTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in      map[string]string
+		skipCSV string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			in: map[string]string{
+				"a": "a",
+				"b": "b",
+				"c": "c",
+			},
+			skipCSV: "a,c",
+			want: map[string]string{
+				"b": "b",
+			},
+		},
+		{
+			in: map[string]string{
+				"hello": "world",
+				"help":  "me",
+				"good":  "bye",
+				"a":     "b",
+			},
+			skipCSV: "a,/hel.*/",
+			want: map[string]string{
+				"good": "bye",
+			},
+		},
+		{
+			in: map[string]string{
+				"a":      "a",
+				"/hello": "/hello",
+			},
+			skipCSV: "/,a", // len(skipTag) <= 1, so not a regexp
+			want: map[string]string{
+				"/hello": "/hello",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.skipCSV, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := getBuildTags(tt.in, tt.skipCSV)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
 }
 
 func newTestMysqlDaemon(t *testing.T, port int32) *fakemysqldaemon.FakeMysqlDaemon {

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -36,6 +36,7 @@ import (
 	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topotools"
@@ -67,6 +68,7 @@ func TestStartBuildTabletFromInput(t *testing.T) {
 		Shard:          "0",
 		KeyRange:       nil,
 		Type:           topodatapb.TabletType_REPLICA,
+		Tags:           servenv.AppVersion.ToStringMap(),
 		DbNameOverride: "aa",
 	}
 


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>


## Description

This PR is both a feature request and the implementation (I will retcon an issue, but in this case the code was so small I found it was easier to discuss the concrete implementation than the abstract description).

This modifies both `servenv.versionInfo` and `tabletmanager.BuildTabletFromInput` to the aim of getting the metadata in the tablet process's `servenv.AppVersion` into the topo, so that others can access it (without needing to `curl $tablet/debug/vars | jq '.BuildHost'`, for e.g.)

<details>
<summary>Demo</summary>

```
I1009 18:24:22.974719   75906 main.go:67] I1009 22:24:22.974216 tablet_executor.go:277] Received DDL request. strategy=direct
I1009 18:24:23.374617   75906 main.go:67] I1009 22:24:23.374484 tablet_executor.go:277] Received DDL request. strategy=direct
I1009 18:24:23.913219   75906 main.go:67] I1009 22:24:23.912934 tablet_executor.go:277] Received DDL request. strategy=direct
New VSchema object:
{
  "tables": {
    "corder": {},
    "customer": {},
    "product": {}
  }
}
If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
Waiting for vtgate to be up...
vtgate is up!
Access vtgate at http://SFO-M-AMASON02:15001/debug/status
❯ vtctldclient --server ":15999" GetTablet zone1-100
{
  "alias": {
    "cell": "zone1",
    "uid": 100
  },
  "hostname": "localhost",
  "port_map": {
    "grpc": 16100,
    "vt": 15100
  },
  "keyspace": "commerce",
  "shard": "0",
  "key_range": null,
  "type": 1,
  "db_name_override": "",
  "tags": {
    "build_git_branch": "vttablet-buildinfo-tags",
    "build_git_rev": "e524e61559",
    "build_host": "SFO-M-AMASON02",
    "build_time": "Sat Oct  9 18:22:37 EDT 2021",
    "build_user": "amason",
    "go_version": "go1.17",
    "goarch": "amd64",
    "goos": "darwin",
    "jenkins_build_number": "0",
    "version": "12.0.0-SNAPSHOT"
  },
  "mysql_hostname": "localhost",
  "mysql_port": 17100,
  "primary_term_start_time": {
    "seconds": "1633818258",
    "nanoseconds": 985660000
  }
}
```

</details>

### Use case(s)

* I want to build some automation/monitoring/alerting off some of this information without having to curl every tablet in the fleet.
* There are probably other use cases as well that I havent' thought of.

### Open Questions From Me:

1. First and foremost: **is this a good idea? Should we pursue/refine this, or abandon it?**
1. **Should `servenv.versionInfo` have its fields made public?** I can't see a reason other than "we're worried someone will write code to modify this at runtime" but I feel like we can catch that in code review.
1. **Should we make this opt-outable?**
1. In my implementation, user-specified `init_tags` takes precedence over the tags from `servenv.AppVersion.ToStringMap()`. So, for example, if a user specifies a tag called `version`, then the vitess build version will not be present in the topo. **Should we make the buildinfo tags take precedence instead?**
1. **How do we feel about the tag names?** I didn't give these a ton of thought, but we should be deliberate about how we name these tags now, because changing them later will be harder due to deprecation cycles.

## Related Issue(s)

Issue TBD


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [ ] Documentation was added or is not required - TODO

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->