### PR TITLE
Gen4: Removing table name qualifiers to derived tables' column name expressions

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
@@ -655,8 +655,7 @@ Gen4 plan same as above
       "Sharded": false
     },
     "FieldQuery": "select table_name from (select * from information_schema.`tables` where 1 != 1) as _subquery where 1 != 1",
-    "Query": "select table_name from (select * from information_schema.`tables` where table_schema = :__vtschemaname and _subquery.table_type = 'table_type' and _subquery.table_name = :_subquery_table_name) as _subquery",
-    "SysTableTableName": "[_subquery_table_name:VARBINARY(\"table_name\")]",
+    "Query": "select table_name from (select * from information_schema.`tables` where table_schema = :__vtschemaname and table_type = 'table_type' and table_name = 'table_name') as _subquery",
     "SysTableTableSchema": "[VARBINARY(\"table_schema\")]",
     "Table": "information_schema.`tables`"
   }

--- a/go/vt/vtgate/semantics/semantic_state.go
+++ b/go/vt/vtgate/semantics/semantic_state.go
@@ -259,10 +259,14 @@ func RewriteDerivedExpression(expr sqlparser.Expr, vt TableInfo) (sqlparser.Expr
 		switch node := cursor.Node().(type) {
 		case *sqlparser.ColName:
 			exp, err := vt.getExprFor(node.Name.String())
-			if err != nil {
-				return false
+			if err == nil {
+				cursor.Replace(exp)
+			} else {
+				// cloning the expression and removing the qualifier
+				col := *node
+				col.Qualifier = sqlparser.TableName{}
+				cursor.Replace(&col)
 			}
-			cursor.Replace(exp)
 			return false
 		}
 		return true


### PR DESCRIPTION
## Description

This pull request fixes #8976 by removing column name's qualifier when pushing them to a derived table.

## Related Issue(s)

- #7280 
- #8976 

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
