### PR TITLE
Add a testcase that shows savepoints not working correctly after a change to `sql_mode`.

### DIFF
--- a/go/test/endtoend/vtgate/system_settings_and_savepoints/main_test.go
+++ b/go/test/endtoend/vtgate/system_settings_and_savepoints/main_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	_ "embed"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
+)
+
+var (
+	clusterInstance       *cluster.LocalProcessCluster
+	vtParams              mysql.ConnParams
+	keyspaceShardedName   = "sharded"
+	keyspaceUnshardedName = "unsharded"
+	Cell                  = "test"
+
+	//go:embed unsharded/schema.sql
+	unshardedSchemaSQL string
+
+	//go:embed unsharded/vschema.json
+	unshardedVSchema string
+
+	//go:embed sharded/schema.sql
+	shardedSchemaSQL string
+
+	//go:embed sharded/vschema.json
+	shardedVSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(Cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Start unsharded keyspace
+		keyspaceUnsharded := &cluster.Keyspace{
+			Name:      keyspaceUnshardedName,
+			SchemaSQL: unshardedSchemaSQL,
+			VSchema:   unshardedVSchema,
+		}
+
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspaceUnsharded, 0, false); err != nil {
+			return 1
+		}
+
+		// Start sharded keyspace
+		keyspaceSharded := &cluster.Keyspace{
+			Name:      keyspaceShardedName,
+			SchemaSQL: shardedSchemaSQL,
+			VSchema:   shardedVSchema,
+		}
+		err = clusterInstance.StartKeyspace(*keyspaceSharded, []string{"-80", "80-"}, 0, false)
+		if err != nil {
+			return 1
+		}
+
+		clusterInstance.VtGateExtraArgs = []string{"-enable_system_settings=true"}
+
+		// Start vtgate
+		err = clusterInstance.StartVtgate()
+		if err != nil {
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host:   clusterInstance.Hostname,
+			Port:   clusterInstance.VtgateMySQLPort,
+			DbName: keyspaceShardedName,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestInsertingWithLookupIndexInsideTransaction(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	// Change the sql mode without _actually_ changing it
+	utils.Exec(t, conn, "set session sql_mode = CONCAT(@@sql_mode, ',', @@sql_mode)")
+
+	utils.Exec(t, conn, "BEGIN")
+	utils.Exec(t, conn, "SAVEPOINT sp_1")
+	utils.Exec(t, conn, "insert into t1 (lookup_id) values (2921)")
+	utils.Exec(t, conn, "RELEASE SAVEPOINT sp_1")
+	utils.Exec(t, conn, "COMMIT")
+}

--- a/go/test/endtoend/vtgate/system_settings_and_savepoints/sharded/schema.sql
+++ b/go/test/endtoend/vtgate/system_settings_and_savepoints/sharded/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `t1` (
+  `id` bigint(11) unsigned NOT NULL,
+  `lookup_id` int(11) NOT NULL,
+  PRIMARY KEY(id)
+) ENGINE=InnoDB;

--- a/go/test/endtoend/vtgate/system_settings_and_savepoints/sharded/vschema.json
+++ b/go/test/endtoend/vtgate/system_settings_and_savepoints/sharded/vschema.json
@@ -1,0 +1,39 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    },
+    "t1_id_keyspace_idx": {
+      "type": "lookup_unique",
+      "params": {
+        "from": "id",
+        "table": "unsharded.t1_id_keyspace_idx",
+        "to": "keyspace_id"
+      },
+      "owner": "t1"
+    }
+  },
+  "tables": {
+    "t1": {
+      "column_vindexes": [
+        {
+          "name": "hash",
+          "columns": [
+            "lookup_id"
+          ]
+        },
+        {
+          "name": "t1_id_keyspace_idx",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "auto_increment": {
+        "column": "id",
+        "sequence": "unsharded.t1_id_seq"
+      }
+    }
+  }
+}

--- a/go/test/endtoend/vtgate/system_settings_and_savepoints/unsharded/schema.sql
+++ b/go/test/endtoend/vtgate/system_settings_and_savepoints/unsharded/schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `t1_id_seq` (
+  `id` bigint,
+  `next_id` bigint,
+  `cache` bigint,
+  PRIMARY KEY(`id`)
+) COMMENT 'vitess_sequence';
+
+INSERT INTO `t1_id_seq` (id, next_id, cache) VALUES (0, 1, 1);
+
+CREATE TABLE `t1_id_keyspace_idx` (
+  `id` VARBINARY(128) NOT NULL,
+  `keyspace_id` VARBINARY(128) NOT NULL,
+  PRIMARY KEY(`id`)
+);

--- a/go/test/endtoend/vtgate/system_settings_and_savepoints/unsharded/vschema.json
+++ b/go/test/endtoend/vtgate/system_settings_and_savepoints/unsharded/vschema.json
@@ -1,0 +1,8 @@
+{
+  "sharded": false,
+  "tables": {
+    "t1_id_seq": {
+      "type": "sequence"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This adds a failing end2end test case that shows that save point support breaks when `-enable_system_settings` is enabled (which it is by default) and a change to `sql_mode` is detected (even if there is no "real" change to the mode).

This also causes the connection to be stuck and stick around until it gets killed by the transaction killer, causing MySQL to hit the connection limit if many of these savepoint errors are encountered in a short timeframe.

This is especially problematic e.g. in Rails application test suites, where transactions and savepoints are used to manage database state during test execution.

## Related Issue(s)

This might be the same issue as described in https://github.com/vitessio/vitess/issues/6754.