### PR TITLE
Add a failing test case showing that a unique key error can cause Vitess to lose transaction state.

### DIFF
--- a/go/test/endtoend/vtgate/unique_key_indexes/main_test.go
+++ b/go/test/endtoend/vtgate/unique_key_indexes/main_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	_ "embed"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
+)
+
+var (
+	clusterInstance       *cluster.LocalProcessCluster
+	vtParams              mysql.ConnParams
+	keyspaceShardedName   = "sharded"
+	keyspaceUnshardedName = "unsharded"
+	Cell                  = "test"
+
+	//go:embed unsharded/schema.sql
+	unshardedSchemaSQL string
+
+	//go:embed unsharded/vschema.json
+	unshardedVSchema string
+
+	//go:embed sharded/schema.sql
+	shardedSchemaSQL string
+
+	//go:embed sharded/vschema.json
+	shardedVSchema string
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(Cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// Start unsharded keyspace
+		keyspaceUnsharded := &cluster.Keyspace{
+			Name:      keyspaceUnshardedName,
+			SchemaSQL: unshardedSchemaSQL,
+			VSchema:   unshardedVSchema,
+		}
+
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspaceUnsharded, 0, false); err != nil {
+			return 1
+		}
+
+		// Start sharded keyspace
+		keyspaceSharded := &cluster.Keyspace{
+			Name:      keyspaceShardedName,
+			SchemaSQL: shardedSchemaSQL,
+			VSchema:   shardedVSchema,
+		}
+		err = clusterInstance.StartKeyspace(*keyspaceSharded, []string{"-80", "80-"}, 0, false)
+		if err != nil {
+			return 1
+		}
+
+		clusterInstance.VtGateExtraArgs = []string{"-enable_system_settings=true"}
+
+		// Start vtgate
+		err = clusterInstance.StartVtgate()
+		if err != nil {
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestDuplicateKeyOnUnshardedKeyspaceKeepsTransaction(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "USE unsharded")
+
+	utils.Exec(t, conn, "BEGIN")
+	utils.Exec(t, conn, "SAVEPOINT sp_1")
+	utils.Exec(t, conn, "insert into t1 (`id`, `unique_num`) values (1, 1)")
+
+	_, err = conn.ExecuteFetch("insert into t1 (`id`, `unique_num`) values (2, 1)", 1, false)
+	require.Error(t, err)
+
+	utils.Exec(t, conn, "RELEASE SAVEPOINT sp_1")
+	utils.Exec(t, conn, "COMMIT")
+}
+
+func TestDuplicateKeyOnShardedKeyspaceKeepsTransaction(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.Nil(t, err)
+	defer conn.Close()
+
+	utils.Exec(t, conn, "USE sharded")
+
+	utils.Exec(t, conn, "BEGIN")
+	utils.Exec(t, conn, "SAVEPOINT sp_1")
+	utils.Exec(t, conn, "insert into t2 (`sharding_id`, `unique_num`, `lookup_id`) values (1, 1, 100)")
+
+	_, err = conn.ExecuteFetch("insert into t2 (`sharding_id`, `unique_num`, `lookup_id`) values (1, 1, 101)", 1, false)
+	require.Error(t, err)
+
+	utils.Exec(t, conn, "RELEASE SAVEPOINT sp_1")
+	utils.Exec(t, conn, "COMMIT")
+}

--- a/go/test/endtoend/vtgate/unique_key_indexes/sharded/schema.sql
+++ b/go/test/endtoend/vtgate/unique_key_indexes/sharded/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `t2` (
+  `sharding_id` bigint unsigned NOT NULL,
+  `lookup_id` bigint unsigned NOT NULL,
+  `unique_num` int NOT NULL,
+  UNIQUE KEY `index_t2_on_unique_num` (`sharding_id`, `unique_num`)
+) ENGINE=InnoDB;

--- a/go/test/endtoend/vtgate/unique_key_indexes/sharded/vschema.json
+++ b/go/test/endtoend/vtgate/unique_key_indexes/sharded/vschema.json
@@ -1,0 +1,37 @@
+{
+  "sharded": true,
+  "vindexes": {
+    "hash": {
+      "type": "hash"
+    },
+
+    "t2_lookup_id_keyspace_idx": {
+      "type": "lookup_unique",
+      "params": {
+        "from": "lookup_id",
+        "table": "unsharded.t2_lookup_id_keyspace_idx",
+        "to": "keyspace_id"
+      },
+      "owner": "t2"
+    }
+  },
+  "tables": {
+    "t2": {
+      "column_vindexes": [
+        {
+          "name": "hash",
+          "columns": [
+            "sharding_id"
+          ]
+        },
+
+        {
+          "name": "t2_lookup_id_keyspace_idx",
+          "columns": [
+            "lookup_id"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/go/test/endtoend/vtgate/unique_key_indexes/unsharded/schema.sql
+++ b/go/test/endtoend/vtgate/unique_key_indexes/unsharded/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `t1` (
+  `id` bigint unsigned NOT NULL,
+  `unique_num` int NOT NULL,
+  PRIMARY KEY(`id`),
+  UNIQUE KEY `index_t1_on_unique_num` (`unique_num`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `t2_lookup_id_keyspace_idx` (
+  `lookup_id` VARBINARY(128) NOT NULL,
+  `keyspace_id` VARBINARY(128) NOT NULL,
+  PRIMARY KEY(`lookup_id`)
+) ENGINE=InnoDB;

--- a/go/test/endtoend/vtgate/unique_key_indexes/unsharded/vschema.json
+++ b/go/test/endtoend/vtgate/unique_key_indexes/unsharded/vschema.json
@@ -1,0 +1,3 @@
+{
+  "sharded": false
+}


### PR DESCRIPTION
## Description

We've encountered an issue where writing to a sharded table with a lookup VIndex can fail and cause the surrounding transaction state to be lost.

In our case, writing to the original table failed due to a `unique key` constraint not being met. Because this failure happens after Vitess has written information to the Lookup Vindex's table, Vitess performs a rollback of the transaction.

When outside of a user-initiated transaction, this is the correct behaviour to revert all changes that were performed. But when inside of a user-initiated transaction, this will actually abort the user's transaction, and can leave the application that is performing the operation in an undefined state.

I think the correct behaviour here would be to check whether a transaction was already started. If no transaction was started yet, the current behaviour is correct and should be used. If a transaction was already started, Vitess should create a new savepoint that it can roll back to in case of a later failure, or release the savepoint if the insert operation on the table succeeds.

Is https://github.com/arthurschreiber/vitess/blob/f10fa1eb0060f58e1088726a7330a61340dfabe9/go/vt/vtgate/plan_execute.go#L118-L123 the location in the code where that logic would have to be implemented / modified?