### PR TITLE
Support MariaDB with SHOW vitess_replication_status

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1084,14 +1084,14 @@ func (e *Executor) showVitessReplicationStatus(ctx context.Context, show *sqlpar
 				replLag := int64(-1)
 				sql := "show slave status"
 				results, err := e.txConn.gateway.Execute(ctx, ts.Target, sql, nil, 0, 0, nil)
-				if err != nil {
+				if err != nil || results == nil {
 					log.Warningf("Could not get replication status from %s: %v", tabletHostPort, err)
-				} else if results != nil && len(results.Rows) == 1 {
-					replSourceHost = results.Rows[0][1].ToString()
-					replSourcePort, _ = results.Rows[0][3].ToInt64()
-					replIOThreadHealth = results.Rows[0][10].ToString()
-					replSQLThreadHealth = results.Rows[0][11].ToString()
-					replLastError = results.Rows[0][19].ToString()
+				} else if row := results.Named().Row(); row != nil {
+					replSourceHost = row["Master_Host"].ToString()
+					replSourcePort, _ = row["Master_Port"].ToInt64()
+					replIOThreadHealth = row["Slave_IO_Running"].ToString()
+					replSQLThreadHealth = row["Slave_SQL_Running"].ToString()
+					replLastError = row["Last_Error"].ToString()
 					if ts.Stats != nil {
 						replLag = int64(ts.Stats.ReplicationLagSeconds)
 					}


### PR DESCRIPTION
## Description
When adding this command (in https://github.com/vitessio/vitess/pull/8900) I leveraged the [`SHOW SLAVE STATUS`](https://dev.mysql.com/doc/refman/5.7/en/replication-administration-status.html) command against the database instances because that was the lowest common denominator across our [supported databases](https://vitess.io/docs/overview/supported-databases/) -- MariaDB did not have the  [replication status related](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-replication-tables.html) `performance_schema` tables.

**_But_**, what I didn't realize at the time was that MariaDB has added columns to the `SHOW SLAVE/REPLICA STATUS` output and some of these new columns were injected into the middle of the schema rather than appended. This means that in order to support MariaDB with this Vitess command we need to reference the column values by name rather than by index. See:
  - https://dev.mysql.com/doc/refman/5.7/en/replication-administration-status.html
  - https://mariadb.com/kb/en/show-replica-status/

> Note: once all supported databases support the `SHOW REPLICA STATUS` query then we can make the inclusive naming changes.

## Related Issue(s)
This is a forward port of https://github.com/vitessio/vitess/pull/8985

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required