### PR TITLE
Ignore Vitess internal tables in VReplication

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -70,7 +72,11 @@ func (lvs *localVSchema) findTable(tablename string) (*vindexes.Table, error) {
 	}
 	table := ks.Tables[tablename]
 	if table == nil {
-		return nil, fmt.Errorf("table %s not found", tablename)
+		if schema.IsInternalOperationTableName(tablename) {
+			log.Infof("found internal table %s, ignoring in local vschema search", tablename)
+		} else {
+			return nil, fmt.Errorf("table %s not found", tablename)
+		}
 	}
 	return table, nil
 }

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -31,6 +31,7 @@ import (
 	"vitess.io/vitess/go/vt/concurrency"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
+	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
 
@@ -300,7 +301,11 @@ func (wr *Wrangler) ValidateVSchema(ctx context.Context, keyspace string, shards
 			}
 			for _, tableDef := range primarySchema.TableDefinitions {
 				if _, ok := vschm.Tables[tableDef.Name]; !ok {
-					notFoundTables = append(notFoundTables, tableDef.Name)
+					if schema.IsInternalOperationTableName(tableDef.Name) {
+						log.Infof("found internal table %s, ignoring in vschema validation", tableDef.Name)
+					} else {
+						notFoundTables = append(notFoundTables, tableDef.Name)
+					}
 				}
 			}
 			if len(notFoundTables) > 0 {


### PR DESCRIPTION
## Description
This will e.g. allow `Reshard`/`MoveTables` workflows when there are online schema change lifecycle tables in the database schema.

## Related Issue(s)
 - https://github.com/vitessio/vitess/issues/8880

## Checklist
- [x] Should this PR be backported? I think not -- rather let it bake in 13.0-SNAPSHOT
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->