### PR TITLE
[vtadmin] Add GitHub Actions for vtadmin-web CI 

### DIFF
--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -1,15 +1,15 @@
-name: vtadmin_web_ci
+name: Build vtadmin-web
 
 # In specifying the 'paths' property, we need to include the path to this workflow .yml file. 
 # See https://github.community/t/trigger-a-workflow-on-change-to-the-yml-file-itself/17792/4)
 on:
   push:
     paths:
-      - '.github/workflows/vtadmin_web_ci.yml'
+      - '.github/workflows/vtadmin_web_build.yml'
       - 'web/vtadmin/**'
   pull_request:
     paths:
-      - '.github/workflows/vtadmin_web_ci.yml'
+      - '.github/workflows/vtadmin_web_build.yml'
       - 'web/vtadmin/**'
 
 defaults:


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds a new CI check that checks that vtadmin-web builds. If the build fails, then the CI check fails.

This check only runs when there are changes to `web/vtadmin/`. (This the files output by `make vtadmin_web_proto_types` when protos are updated; see also https://github.com/vitessio/vitess/issues/9001 for the other half of this.) 

Here's what it looks like when passing:

<img width="2672" alt="Screen Shot 2021-10-13 at 4 37 31 PM" src="https://user-images.githubusercontent.com/855595/137209121-2ec93a15-13f3-45af-bafd-f5b02bbaa85c.png">

... and when failing:

<img width="2672" alt="Screen Shot 2021-10-13 at 4 38 15 PM" src="https://user-images.githubusercontent.com/855595/137209206-36e1593a-cea9-453b-a228-30a5b03d83b9.png">

I do think it'd be nice for the check to add [annotations](https://github.community/t/what-are-annotations/16173), but I'm going to leave that as a future enhancement. 🤔 

## Related Issue(s)

This complements the CI check proposed in https://github.com/vitessio/vitess/issues/9001. Together, they will prevent situations like the one described in that issue: a change to a .proto file is made, one which VTAdmin depends on, and then the vtadmin-web build breaks. 

This PR is based off of https://github.com/vitessio/vitess/pull/7643. We decided that using generator scripts would be overkill for CI checks, like this one, that don't run against a MySQL version matrix. 

## Checklist
- [ ] Should this PR be backported? (No)
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A. This is a CI change only. 