### PR TITLE
[Backport 12.0]: Add planner-version flag to vtexplain

### DIFF
--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -58,6 +58,9 @@ type Options struct {
 	// NumShards indicates the number of shards in the topology
 	NumShards int
 
+	// PlannerVersion indicates whether or not we should use the Gen4 planner
+	PlannerVersion querypb.ExecuteOptions_PlannerVersion
+
 	// ReplicationMode must be set to either "ROW" or "STATEMENT" before
 	// initialization
 	ReplicationMode string

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -38,6 +38,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
@@ -67,6 +68,13 @@ func initVtgateExecutor(vSchemaStr, ksShardMapStr string, opts *Options) error {
 	}
 
 	vtgateSession.TargetString = opts.Target
+
+	if opts.PlannerVersion != querypb.ExecuteOptions_DEFAULT_PLANNER {
+		if vtgateSession.Options == nil {
+			vtgateSession.Options = &querypb.ExecuteOptions{}
+		}
+		vtgateSession.Options.PlannerVersion = opts.PlannerVersion
+	}
 
 	streamSize := 10
 	var schemaTracker vtgate.SchemaInfo // no schema tracker for these tests

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -506,11 +506,12 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 			return fmt.Errorf("vtexplain: unsupported statement type +%v", reflect.TypeOf(stmt))
 		}
 
-		if len(selStmt.From) != 1 {
-			return fmt.Errorf("unsupported select with multiple from clauses")
+		// Gen4 supports more complex queries so we now need to
+		// handle multiple FROM clauses
+		tables := make([]sqlparser.TableIdent, len(selStmt.From))
+		for _, from := range selStmt.From {
+			tables = append(tables, getTables(from)...)
 		}
-
-		tables := getTables(selStmt.From[0])
 		colTypeMap := map[string]querypb.Type{}
 		for _, table := range tables {
 			tableName := sqlparser.String(table)


### PR DESCRIPTION
## Description
With Vitess 12.0 we hope to begin migrating more users and workloads from the `V3` planner to the new `Gen4` planner as it should offer better performance, improved correctness, and additional query language support.

But in order to aid in that effort, users will need a way to try and compare the planner results between the two for their common queries in order to gauge the impact of this migration.

Toward that end, this adds a new `-planner-version` flag to `vtexplain` that allows you to get the explain output using the `Gen4` planner instead of using the default of `V3`.

## Related Issue(s)
Backport of: https://github.com/vitessio/vitess/pull/8979
Docs: https://github.com/vitessio/website/pull/843


## Checklist
- [x] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required