### PR TITLE
Collations Module Integration

### DIFF
--- a/go/vt/vtgate/engine/comparer.go
+++ b/go/vt/vtgate/engine/comparer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
@@ -38,7 +39,8 @@ func (c *comparer) compare(r1, r2 []sqltypes.Value) (int, error) {
 	} else {
 		colIndex = c.orderBy
 	}
-	cmp, err := evalengine.NullsafeCompare(r1[colIndex], r2[colIndex])
+	// TODO(king-11) make collation aware
+	cmp, err := evalengine.NullsafeCompare(r1[colIndex], r2[colIndex], collations.Unknown)
 	if err != nil {
 		_, isComparisonErr := err.(evalengine.UnsupportedComparisonError)
 		if !(isComparisonErr && c.weightString != -1) {
@@ -47,7 +49,8 @@ func (c *comparer) compare(r1, r2 []sqltypes.Value) (int, error) {
 		// in case of a comparison error switch to using the weight string column for ordering
 		c.orderBy = c.weightString
 		c.weightString = -1
-		cmp, err = evalengine.NullsafeCompare(r1[c.orderBy], r2[c.orderBy])
+		// TODO(king-11) make collation aware
+		cmp, err = evalengine.NullsafeCompare(r1[c.orderBy], r2[c.orderBy], collations.Unknown)
 		if err != nil {
 			return 0, err
 		}

--- a/go/vt/vtgate/engine/distinct.go
+++ b/go/vt/vtgate/engine/distinct.go
@@ -17,6 +17,7 @@ limitations under the License.
 package engine
 
 import (
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -73,7 +74,8 @@ func (pt *probeTable) exists(inputRow row) (bool, error) {
 
 func equal(a, b []sqltypes.Value) (bool, error) {
 	for i, aVal := range a {
-		cmp, err := evalengine.NullsafeCompare(aVal, b[i])
+		// TODO(king-11) make collation aware
+		cmp, err := evalengine.NullsafeCompare(aVal, b[i], collations.Unknown)
 		if err != nil {
 			return false, err
 		}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -190,7 +190,9 @@ func (oa *OrderedAggregate) GetTableName() string {
 func (oa *OrderedAggregate) getCollations() map[int]collations.ID {
 	colls := make(map[int]collations.ID)
 	for _, key := range oa.GroupByKeys {
-		colls[key.KeyCol] = key.CollationID
+		if key.CollationID != collations.Unknown {
+			colls[key.KeyCol] = key.CollationID
+		}
 	}
 	return colls
 }

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -451,9 +451,9 @@ func (oa *OrderedAggregate) merge(fields []*querypb.Field, row1, row2 []sqltypes
 			v2 := row2[aggr.Col]
 			result[aggr.Col] = evalengine.NullsafeAdd(value, v2, fields[aggr.Col].Type)
 		case AggregateMin:
-			result[aggr.Col], err = evalengine.Min(row1[aggr.Col], row2[aggr.Col])
+			result[aggr.Col], err = evalengine.Min(row1[aggr.Col], row2[aggr.Col], colls[aggr.Col])
 		case AggregateMax:
-			result[aggr.Col], err = evalengine.Max(row1[aggr.Col], row2[aggr.Col])
+			result[aggr.Col], err = evalengine.Max(row1[aggr.Col], row2[aggr.Col], colls[aggr.Col])
 		case AggregateCountDistinct:
 			result[aggr.Col] = evalengine.NullsafeAdd(row1[aggr.Col], countOne, OpcodeType[aggr.Opcode])
 		case AggregateSumDistinct:

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -652,13 +652,13 @@ func TestMerge(t *testing.T) {
 		"1|3|2.8|2|bc",
 	)
 
-	merged, _, err := oa.merge(fields, r.Rows[0], r.Rows[1], nil)
+	merged, _, err := oa.merge(fields, r.Rows[0], r.Rows[1], nil, nil)
 	assert.NoError(err)
 	want := sqltypes.MakeTestResult(fields, "1|5|6|2|bc").Rows[0]
 	assert.Equal(want, merged)
 
 	// swap and retry
-	merged, _, err = oa.merge(fields, r.Rows[1], r.Rows[0], nil)
+	merged, _, err = oa.merge(fields, r.Rows[1], r.Rows[0], nil, nil)
 	assert.NoError(err)
 	assert.Equal(want, merged)
 }

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -1073,12 +1073,13 @@ func TestOrderedAggregateCollate(t *testing.T) {
 		)},
 	}
 
+	collationID, _ := collations.IDFromName("utf8mb4_0900_ai_ci")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
 			Opcode: AggregateCount,
 			Col:    1,
 		}},
-		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collations.LookupIDByName("utf8mb4_0900_ai_ci")}},
+		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
 		Input:       fp,
 	}
 
@@ -1114,12 +1115,13 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 		)},
 	}
 
+	collationID, _ := collations.IDFromName("utf8mb4_0900_as_ci")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
 			Opcode: AggregateCount,
 			Col:    1,
 		}},
-		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collations.LookupIDByName("utf8mb4_0900_as_ci")}},
+		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
 		Input:       fp,
 	}
 
@@ -1157,12 +1159,13 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 		)},
 	}
 
+	collationID, _ := collations.IDFromName("utf8mb4_ja_0900_as_cs_ks")
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{{
 			Opcode: AggregateCount,
 			Col:    1,
 		}},
-		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks")}},
+		GroupByKeys: []*GroupByParams{{KeyCol: 0, CollationID: collationID}},
 		Input:       fp,
 	}
 

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -257,18 +257,18 @@ func isByteComparable(v sqltypes.Value) bool {
 // Min returns the minimum of v1 and v2. If one of the
 // values is NULL, it returns the other value. If both
 // are NULL, it returns NULL.
-func Min(v1, v2 sqltypes.Value) (sqltypes.Value, error) {
-	return minmax(v1, v2, true)
+func Min(v1, v2 sqltypes.Value, collation collations.ID) (sqltypes.Value, error) {
+	return minmax(v1, v2, true, collation)
 }
 
 // Max returns the maximum of v1 and v2. If one of the
 // values is NULL, it returns the other value. If both
 // are NULL, it returns NULL.
-func Max(v1, v2 sqltypes.Value) (sqltypes.Value, error) {
-	return minmax(v1, v2, false)
+func Max(v1, v2 sqltypes.Value, collation collations.ID) (sqltypes.Value, error) {
+	return minmax(v1, v2, false, collation)
 }
 
-func minmax(v1, v2 sqltypes.Value, min bool) (sqltypes.Value, error) {
+func minmax(v1, v2 sqltypes.Value, min bool, collation collations.ID) (sqltypes.Value, error) {
 	if v1.IsNull() {
 		return v2, nil
 	}

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -224,7 +224,7 @@ func NullsafeCompare(v1, v2 sqltypes.Value, collationID collations.ID) (int, err
 		return bytes.Compare(v1.ToBytes(), v2.ToBytes()), nil
 	}
 	if v1.IsText() && v2.IsText() && collationID != collations.Unknown {
-		collation := collations.LookupById(collationID)
+		collation := collations.FromID(collationID)
 		if collation == nil {
 			return 0, UnsupportedCollationError{
 				ID: collationID,

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -215,7 +215,14 @@ func NullsafeCompare(v1, v2 sqltypes.Value, collation collations.ID) (int, error
 	}
 	if v1.IsText() && v2.IsText() && collation != collations.Unknown {
 		collation := collations.LookupById(collation)
-		return collation.Collate(v1.ToBytes(), v2.ToBytes(), false), nil
+		switch result := collation.Collate(v1.ToBytes(), v2.ToBytes(), false); {
+		case result < 0:
+			return -1, nil
+		case result > 0:
+			return 1, nil
+		default:
+			return 0, nil
+		}
 	}
 	return 0, UnsupportedComparisonError{
 		Type1: v1.Type(),

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -599,6 +599,11 @@ func TestNullsafeCompare(t *testing.T) {
 	}
 }
 
+func getCollationID(collation string) collations.ID {
+	id, _ := collations.IDFromName(collation)
+	return id
+}
+
 func TestNullsafeCompareCollate(t *testing.T) {
 	tcases := []struct {
 		v1, v2    string
@@ -611,42 +616,42 @@ func TestNullsafeCompareCollate(t *testing.T) {
 			v1:        "abCd",
 			v2:        "aBcd",
 			out:       0,
-			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+			collation: getCollationID("utf8mb4_0900_as_ci"),
 		},
 		{
 			// accent sensitive
 			v1:        "ǍḄÇ",
 			v2:        "ÁḆĈ",
 			out:       1,
-			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+			collation: getCollationID("utf8mb4_0900_as_ci"),
 		},
 		{
 			// hangul decomposition
 			v1:        "\uAC00",
 			v2:        "\u326E",
 			out:       0,
-			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+			collation: getCollationID("utf8mb4_0900_as_ci"),
 		},
 		{
 			// kana sensitive
 			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
 			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
 			out:       -1,
-			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+			collation: getCollationID("utf8mb4_ja_0900_as_cs_ks"),
 		},
 		{
 			// non breaking space
 			v1:        "abc ",
 			v2:        "abc\u00a0",
 			out:       -1,
-			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+			collation: getCollationID("utf8mb4_0900_as_cs"),
 		},
 		{
 			// "cs" counts as a separate letter, where c < cs < d
 			v1:        "c",
 			v2:        "cs",
 			out:       -1,
-			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+			collation: getCollationID("utf8mb4_hu_0900_ai_ci"),
 		},
 		{
 			v1:        "abcd",
@@ -661,8 +666,8 @@ func TestNullsafeCompareCollate(t *testing.T) {
 			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 1111 isn't possible"),
 		},
 		{
-			v1:        "abcd",
-			v2:        "abcd",
+			v1: "abcd",
+			v2: "abcd",
 			// unsupported collation gb18030_bin
 			collation: 249,
 			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 249 isn't possible"),
@@ -1379,35 +1384,35 @@ func TestMinCollate(t *testing.T) {
 			v1:        "ǍḄÇ",
 			v2:        "ÁḆĈ",
 			out:       "ǍḄÇ",
-			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+			collation: getCollationID("utf8mb4_0900_as_ci"),
 		},
 		{
 			// kana sensitive
 			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
 			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
 			out:       "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
-			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+			collation: getCollationID("utf8mb4_ja_0900_as_cs_ks"),
 		},
 		{
 			// non breaking space
 			v1:        "abc ",
 			v2:        "abc\u00a0",
 			out:       "abc\u00a0",
-			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+			collation: getCollationID("utf8mb4_0900_as_cs"),
 		},
 		{
 			// "cs" counts as a separate letter, where c < cs < d
 			v1:        "c",
 			v2:        "cs",
 			out:       "cs",
-			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+			collation: getCollationID("utf8mb4_hu_0900_ai_ci"),
 		},
 		{
 			// "cs" counts as a separate letter, where c < cs < d
 			v1:        "cukor",
 			v2:        "csak",
 			out:       "csak",
-			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+			collation: getCollationID("utf8mb4_hu_0900_ai_ci"),
 		},
 	}
 	for _, tcase := range tcases {
@@ -1486,35 +1491,35 @@ func TestMaxCollate(t *testing.T) {
 			v1:        "ǍḄÇ",
 			v2:        "ÁḆĈ",
 			out:       "ǍḄÇ",
-			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+			collation: getCollationID("utf8mb4_0900_as_ci"),
 		},
 		{
 			// kana sensitive
 			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
 			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
 			out:       "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
-			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+			collation: getCollationID("utf8mb4_ja_0900_as_cs_ks"),
 		},
 		{
 			// non breaking space
 			v1:        "abc ",
 			v2:        "abc\u00a0",
 			out:       "abc\u00a0",
-			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+			collation: getCollationID("utf8mb4_0900_as_cs"),
 		},
 		{
 			// "cs" counts as a separate letter, where c < cs < d
 			v1:        "c",
 			v2:        "cs",
 			out:       "cs",
-			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+			collation: getCollationID("utf8mb4_hu_0900_ai_ci"),
 		},
 		{
 			// "cs" counts as a separate letter, where c < cs < d
 			v1:        "cukor",
 			v2:        "csak",
 			out:       "csak",
-			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+			collation: getCollationID("utf8mb4_hu_0900_ai_ci"),
 		},
 	}
 	for _, tcase := range tcases {

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -654,6 +654,19 @@ func TestNullsafeCompareCollate(t *testing.T) {
 			collation: 0,
 			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
 		},
+		{
+			v1:        "abcd",
+			v2:        "abcd",
+			collation: 1111,
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 1111 isn't possible"),
+		},
+		{
+			v1:        "abcd",
+			v2:        "abcd",
+			// unsupported collation gb18030_bin
+			collation: 249,
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 249 isn't possible"),
+		},
 	}
 	for _, tcase := range tcases {
 		got, err := NullsafeCompare(TestValue(querypb.Type_VARCHAR, tcase.v1), TestValue(querypb.Type_VARCHAR, tcase.v2), tcase.collation)

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -585,7 +585,6 @@ func TestNullsafeCompare(t *testing.T) {
 		out: -1,
 	}}
 	for _, tcase := range tcases {
-		// TODO(king-11) separate test for collation awareness
 		got, err := NullsafeCompare(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), vterrors.Print(err), vterrors.Print(tcase.err))
@@ -596,6 +595,77 @@ func TestNullsafeCompare(t *testing.T) {
 
 		if got != tcase.out {
 			t.Errorf("NullsafeCompare(%v, %v): %v, want %v", printValue(tcase.v1), printValue(tcase.v2), got, tcase.out)
+		}
+	}
+}
+
+func TestNullsafeCompareCollate(t *testing.T) {
+	tcases := []struct {
+		v1, v2    string
+		collation collations.ID
+		out       int
+		err       error
+	}{
+		{
+			// case insensitive
+			v1:        "abCd",
+			v2:        "aBcd",
+			out:       0,
+			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+		},
+		{
+			// accent sensitive
+			v1:        "ǍḄÇ",
+			v2:        "ÁḆĈ",
+			out:       1,
+			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+		},
+		{
+			// hangul decomposition
+			v1:        "\uAC00",
+			v2:        "\u326E",
+			out:       0,
+			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+		},
+		{
+			// kana sensitive
+			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
+			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
+			out:       -1,
+			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+		},
+		{
+			// non breaking space
+			v1:        "abc ",
+			v2:        "abc\u00a0",
+			out:       -1,
+			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+		},
+		{
+			// "cs" counts as a separate letter, where c < cs < d
+			v1:        "c",
+			v2:        "cs",
+			out:       -1,
+			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+		},
+		{
+			v1:        "abcd",
+			v2:        "abcd",
+			collation: 0,
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
+		},
+	}
+	for _, tcase := range tcases {
+		got, err := NullsafeCompare(TestValue(querypb.Type_VARCHAR, tcase.v1), TestValue(querypb.Type_VARCHAR, tcase.v2), tcase.collation)
+		if !vterrors.Equals(err, tcase.err) {
+			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", tcase.v1, tcase.v2, vterrors.Print(err), vterrors.Print(tcase.err))
+		}
+		if tcase.err != nil {
+			continue
+		}
+
+		if got != tcase.out {
+			t.Errorf("NullsafeCompare(%v, %v): %v, want %v", tcase.v1, tcase.v2, got, tcase.out)
 		}
 	}
 }
@@ -1270,7 +1340,6 @@ func TestMin(t *testing.T) {
 		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
 	}}
 	for _, tcase := range tcases {
-		// TODO(king-11) separate test for collation awareness
 		v, err := Min(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("Min error: %v, want %v", vterrors.Print(err), vterrors.Print(tcase.err))
@@ -1281,6 +1350,64 @@ func TestMin(t *testing.T) {
 
 		if !reflect.DeepEqual(v, tcase.min) {
 			t.Errorf("Min(%v, %v): %v, want %v", tcase.v1, tcase.v2, v, tcase.min)
+		}
+	}
+}
+
+func TestMinCollate(t *testing.T) {
+	tcases := []struct {
+		v1, v2    string
+		collation collations.ID
+		out       string
+		err       error
+	}{
+		{
+			// accent insensitive
+			v1:        "ǍḄÇ",
+			v2:        "ÁḆĈ",
+			out:       "ǍḄÇ",
+			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+		},
+		{
+			// kana sensitive
+			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
+			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
+			out:       "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
+			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+		},
+		{
+			// non breaking space
+			v1:        "abc ",
+			v2:        "abc\u00a0",
+			out:       "abc\u00a0",
+			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+		},
+		{
+			// "cs" counts as a separate letter, where c < cs < d
+			v1:        "c",
+			v2:        "cs",
+			out:       "cs",
+			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+		},
+		{
+			// "cs" counts as a separate letter, where c < cs < d
+			v1:        "cukor",
+			v2:        "csak",
+			out:       "csak",
+			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+		},
+	}
+	for _, tcase := range tcases {
+		got, err := Min(TestValue(querypb.Type_VARCHAR, tcase.v1), TestValue(querypb.Type_VARCHAR, tcase.v2), tcase.collation)
+		if !vterrors.Equals(err, tcase.err) {
+			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", tcase.v1, tcase.v2, vterrors.Print(err), vterrors.Print(tcase.err))
+		}
+		if tcase.err != nil {
+			continue
+		}
+
+		if got.ToString() == tcase.out {
+			t.Errorf("NullsafeCompare(%v, %v): %v, want %v", tcase.v1, tcase.v2, got, tcase.out)
 		}
 	}
 }
@@ -1320,7 +1447,6 @@ func TestMax(t *testing.T) {
 		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
 	}}
 	for _, tcase := range tcases {
-		// TODO(king-11) separate test for collation awareness
 		v, err := Max(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("Max error: %v, want %v", vterrors.Print(err), vterrors.Print(tcase.err))
@@ -1331,6 +1457,64 @@ func TestMax(t *testing.T) {
 
 		if !reflect.DeepEqual(v, tcase.max) {
 			t.Errorf("Max(%v, %v): %v, want %v", tcase.v1, tcase.v2, v, tcase.max)
+		}
+	}
+}
+
+func TestMaxCollate(t *testing.T) {
+	tcases := []struct {
+		v1, v2    string
+		collation collations.ID
+		out       string
+		err       error
+	}{
+		{
+			// accent insensitive
+			v1:        "ǍḄÇ",
+			v2:        "ÁḆĈ",
+			out:       "ǍḄÇ",
+			collation: collations.LookupIDByName("utf8mb4_0900_as_ci"),
+		},
+		{
+			// kana sensitive
+			v1:        "\xE3\x81\xAB\xE3\x81\xBB\xE3\x82\x93\xE3\x81\x94",
+			v2:        "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
+			out:       "\xE3\x83\x8B\xE3\x83\x9B\xE3\x83\xB3\xE3\x82\xB4",
+			collation: collations.LookupIDByName("utf8mb4_ja_0900_as_cs_ks"),
+		},
+		{
+			// non breaking space
+			v1:        "abc ",
+			v2:        "abc\u00a0",
+			out:       "abc\u00a0",
+			collation: collations.LookupIDByName("utf8mb4_0900_as_cs"),
+		},
+		{
+			// "cs" counts as a separate letter, where c < cs < d
+			v1:        "c",
+			v2:        "cs",
+			out:       "cs",
+			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+		},
+		{
+			// "cs" counts as a separate letter, where c < cs < d
+			v1:        "cukor",
+			v2:        "csak",
+			out:       "csak",
+			collation: collations.LookupIDByName("utf8mb4_hu_0900_ai_ci"),
+		},
+	}
+	for _, tcase := range tcases {
+		got, err := Max(TestValue(querypb.Type_VARCHAR, tcase.v1), TestValue(querypb.Type_VARCHAR, tcase.v2), tcase.collation)
+		if !vterrors.Equals(err, tcase.err) {
+			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", tcase.v1, tcase.v2, vterrors.Print(err), vterrors.Print(tcase.err))
+		}
+		if tcase.err != nil {
+			continue
+		}
+
+		if got.ToString() != tcase.out {
+			t.Errorf("NullsafeCompare(%v, %v): %v, want %v", tcase.v1, tcase.v2, got, tcase.out)
 		}
 	}
 }

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"testing"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/test/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -584,7 +585,8 @@ func TestNullsafeCompare(t *testing.T) {
 		out: -1,
 	}}
 	for _, tcase := range tcases {
-		got, err := NullsafeCompare(tcase.v1, tcase.v2)
+		// TODO(king-11) separate test for collation awareness
+		got, err := NullsafeCompare(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), vterrors.Print(err), vterrors.Print(tcase.err))
 		}
@@ -1268,7 +1270,8 @@ func TestMin(t *testing.T) {
 		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
 	}}
 	for _, tcase := range tcases {
-		v, err := Min(tcase.v1, tcase.v2)
+		// TODO(king-11) separate test for collation awareness
+		v, err := Min(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("Min error: %v, want %v", vterrors.Print(err), vterrors.Print(tcase.err))
 		}
@@ -1317,7 +1320,8 @@ func TestMax(t *testing.T) {
 		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
 	}}
 	for _, tcase := range tcases {
-		v, err := Max(tcase.v1, tcase.v2)
+		// TODO(king-11) separate test for collation awareness
+		v, err := Max(tcase.v1, tcase.v2, collations.Unknown)
 		if !vterrors.Equals(err, tcase.err) {
 			t.Errorf("Max error: %v, want %v", vterrors.Print(err), vterrors.Print(tcase.err))
 		}

--- a/go/vt/vtgate/vindexes/consistent_lookup.go
+++ b/go/vt/vtgate/vindexes/consistent_lookup.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -314,7 +315,8 @@ func (lu *clCommon) Delete(vcursor VCursor, rowsColValues [][]sqltypes.Value, ks
 func (lu *clCommon) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error {
 	equal := true
 	for i := range oldValues {
-		result, err := evalengine.NullsafeCompare(oldValues[i], newValues[i])
+		// TODO(king-11) make collation aware
+		result, err := evalengine.NullsafeCompare(oldValues[i], newValues[i], collations.Unknown)
 		// errors from NullsafeCompare can be ignored. if they are real problems, we'll see them in the Create/Update
 		if err != nil || result != 0 {
 			equal = false

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -26,6 +26,7 @@ import (
 
 	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -281,7 +282,8 @@ func (tp *TablePlan) isOutsidePKRange(bindvars map[string]*querypb.BindVariable,
 		}
 
 		rowVal, _ := sqltypes.BindVariableToValue(bindvar)
-		result, err := evalengine.NullsafeCompare(rowVal, tp.Lastpk.Rows[0][0])
+		// TODO(king-11) make collation aware
+		result, err := evalengine.NullsafeCompare(rowVal, tp.Lastpk.Rows[0][0], collations.Unknown)
 		// If rowVal is > last pk, transaction will be a noop, so don't apply this statement
 		if err == nil && result > 0 {
 			tp.Stats.NoopQueryCount.Add(stmtType, 1)

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -164,7 +165,8 @@ func compare(comparison Opcode, columnValue, filterValue sqltypes.Value) (bool, 
 	}
 	// at this point neither values can be null
 	// NullsafeCompare returns 0 if values match, -1 if columnValue < filterValue, 1 if columnValue > filterValue
-	result, err := evalengine.NullsafeCompare(columnValue, filterValue)
+	// TODO(king-11) make collation aware
+	result, err := evalengine.NullsafeCompare(columnValue, filterValue, collations.Unknown)
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/concurrency"
@@ -1057,7 +1058,8 @@ func (td *tableDiffer) compare(sourceRow, targetRow []sqltypes.Value, cols []com
 		if sourceRow[compareIndex].IsText() && targetRow[compareIndex].IsText() {
 			c = bytes.Compare(sourceRow[compareIndex].ToBytes(), targetRow[compareIndex].ToBytes())
 		} else {
-			c, err = evalengine.NullsafeCompare(sourceRow[compareIndex], targetRow[compareIndex])
+			// TODO(king-11) make collation aware
+			c, err = evalengine.NullsafeCompare(sourceRow[compareIndex], targetRow[compareIndex], collations.Unknown)
 		}
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
### Integration of Collation Module into Vitess Engine

- #8991

Adds in the collation module into the Vitess Code which can then be used to replace instances of the `weight_string` function used in the vitess codebase. The major change that this PR makes is with the `NullSafeComparator`

https://github.com/vitessio/vitess/blob/315d90751886b5901672a7278623de7d48aa4ec2/go/vt/vtgate/evalengine/arithmetic.go#L187

which now takes in additional collation info parameter which is used by the `collations.LookupByID` to find out the collation and then use it to collate the `varchar` strings based on their collation set.

### Update Function Calls

So given the `NullSafeComparator` needs access to collation info we intend to provide the information available to it by updating the function calls and trying to fetch charset info from the `result` or `Fields` available at the least distant parent function calls and trickle it down the succeeding calls.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8606 


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->