### PR TITLE
[vtctldclient] fix newlines in codegen template

### DIFF
--- a/go/vt/vtctl/vtctldclient/codegen/template.go
+++ b/go/vt/vtctl/vtctldclient/codegen/template.go
@@ -49,7 +49,7 @@ import (
 
 	{{ range .Imports -}}
 	{{ if ne .Alias "" }}{{ .Alias }} {{ end }}"{{ .Path }}"
-	{{- end }}
+	{{ end -}}
 )
 {{ range .Methods }}
 // {{ .Name }} is part of the vtctlservicepb.VtctldClient interface.


### PR DESCRIPTION
## Description 

This PR adds a fix for newlines in the vtctldclient codegen template.

Before, this would put all imports on the same line, which of course
breaks the Go parser.

Signed-off-by: Andrew Mason <amason@slack-corp.com>

I have another PR in-progress that surfaced this issue, but I wanted to separate out this change.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->