### PR TITLE
Properly handle case-sensitivity and reserved words in routing rules

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -208,6 +208,7 @@ func TestAddCellsAlias(t *testing.T) {
 	}
 }
 
+// This also verifies proper case sensitivity and reserved word handling
 func TestApplyRoutingRules(t *testing.T) {
 	t.Parallel()
 
@@ -227,8 +228,8 @@ func TestApplyRoutingRules(t *testing.T) {
 				RoutingRules: &vschemapb.RoutingRules{
 					Rules: []*vschemapb.RoutingRule{
 						{
-							FromTable: "t1",
-							ToTables:  []string{"t1", "t2"},
+							FromTable: "Table1",
+							ToTables:  []string{"Table1", "select"},
 						},
 					},
 				},
@@ -236,8 +237,8 @@ func TestApplyRoutingRules(t *testing.T) {
 			expectedRules: &vschemapb.RoutingRules{
 				Rules: []*vschemapb.RoutingRule{
 					{
-						FromTable: "t1",
-						ToTables:  []string{"t1", "t2"},
+						FromTable: "Table1",
+						ToTables:  []string{"Table1", "select"},
 					},
 				},
 			},
@@ -249,8 +250,8 @@ func TestApplyRoutingRules(t *testing.T) {
 				RoutingRules: &vschemapb.RoutingRules{
 					Rules: []*vschemapb.RoutingRule{
 						{
-							FromTable: "t1",
-							ToTables:  []string{"t1", "t2"},
+							FromTable: "Table1",
+							ToTables:  []string{"Table1", "select"},
 						},
 					},
 				},
@@ -268,8 +269,8 @@ func TestApplyRoutingRules(t *testing.T) {
 				RoutingRules: &vschemapb.RoutingRules{
 					Rules: []*vschemapb.RoutingRule{
 						{
-							FromTable: "t1",
-							ToTables:  []string{"t1", "t2"},
+							FromTable: "Table1",
+							ToTables:  []string{"Table1", "select"},
 						},
 					},
 				},
@@ -279,8 +280,8 @@ func TestApplyRoutingRules(t *testing.T) {
 			expectedRules: &vschemapb.RoutingRules{
 				Rules: []*vschemapb.RoutingRule{
 					{
-						FromTable: "t1",
-						ToTables:  []string{"t1", "t2"},
+						FromTable: "Table1",
+						ToTables:  []string{"Table1", "select"},
 					},
 				},
 			},
@@ -3120,16 +3121,16 @@ func TestGetRoutingRules(t *testing.T) {
 			rrIn: &vschemapb.RoutingRules{
 				Rules: []*vschemapb.RoutingRule{
 					{
-						FromTable: "t1",
-						ToTables:  []string{"t2", "t3"},
+						FromTable: "Table1",
+						ToTables:  []string{"select", "t3"},
 					},
 				},
 			},
 			expected: &vschemapb.RoutingRules{
 				Rules: []*vschemapb.RoutingRule{
 					{
-						FromTable: "t1",
-						ToTables:  []string{"t2", "t3"},
+						FromTable: "Table1",
+						ToTables:  []string{"select", "t3"},
 					},
 				},
 			},
@@ -3214,8 +3215,8 @@ func TestGetSchema(t *testing.T) {
 				DatabaseSchema: "CREATE DATABASE vt_testkeyspace",
 				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 					{
-						Name: "t1",
-						Schema: `CREATE TABLE t1 (
+						Name: "Table1",
+						Schema: `CREATE TABLE Table1 (
 	id int(11) not null,
 	PRIMARY KEY (id)
 );`,
@@ -3252,8 +3253,8 @@ func TestGetSchema(t *testing.T) {
 					DatabaseSchema: "CREATE DATABASE vt_testkeyspace",
 					TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 						{
-							Name: "t1",
-							Schema: `CREATE TABLE t1 (
+							Name: "Table1",
+							Schema: `CREATE TABLE Table1 (
 	id int(11) not null,
 	PRIMARY KEY (id)
 );`,
@@ -3284,7 +3285,7 @@ func TestGetSchema(t *testing.T) {
 					DatabaseSchema: "CREATE DATABASE vt_testkeyspace",
 					TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 						{
-							Name: "t1",
+							Name: "Table1",
 						},
 					},
 				},
@@ -3302,7 +3303,7 @@ func TestGetSchema(t *testing.T) {
 					DatabaseSchema: "CREATE DATABASE vt_testkeyspace",
 					TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 						{
-							Name:       "t1",
+							Name:       "Table1",
 							Type:       "BASE",
 							DataLength: 100,
 							RowCount:   50,
@@ -3324,7 +3325,7 @@ func TestGetSchema(t *testing.T) {
 					DatabaseSchema: "CREATE DATABASE vt_testkeyspace",
 					TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 						{
-							Name: "t1",
+							Name: "Table1",
 						},
 					},
 				},
@@ -6570,12 +6571,12 @@ func TestSetShardTabletControl(t *testing.T) {
 							{
 								TabletType:   topodatapb.TabletType_REPLICA,
 								Cells:        []string{"zone1"},
-								DeniedTables: []string{"t1"},
+								DeniedTables: []string{"Table1"},
 							},
 							{
 								TabletType:   topodatapb.TabletType_REPLICA,
 								Cells:        []string{"zone2", "zone3"},
-								DeniedTables: []string{"t2"},
+								DeniedTables: []string{"select"},
 							},
 						},
 					},
@@ -6584,7 +6585,7 @@ func TestSetShardTabletControl(t *testing.T) {
 			req: &vtctldatapb.SetShardTabletControlRequest{
 				Keyspace:     "testkeyspace",
 				Shard:        "-",
-				DeniedTables: []string{"t1"},
+				DeniedTables: []string{"Table1"},
 				Cells:        []string{"zone2", "zone3"},
 				TabletType:   topodatapb.TabletType_REPLICA,
 			},
@@ -6594,12 +6595,12 @@ func TestSetShardTabletControl(t *testing.T) {
 						{
 							TabletType:   topodatapb.TabletType_REPLICA,
 							Cells:        []string{"zone1", "zone2", "zone3"},
-							DeniedTables: []string{"t1"},
+							DeniedTables: []string{"Table1"},
 						},
 						{
 							TabletType:   topodatapb.TabletType_REPLICA,
 							Cells:        []string{"zone2", "zone3"},
-							DeniedTables: []string{"t2"},
+							DeniedTables: []string{"select"},
 						},
 					},
 				},
@@ -6619,12 +6620,12 @@ func TestSetShardTabletControl(t *testing.T) {
 							{
 								TabletType:   topodatapb.TabletType_REPLICA,
 								Cells:        []string{"zone1"},
-								DeniedTables: []string{"t1"},
+								DeniedTables: []string{"Table1"},
 							},
 							{
 								TabletType:   topodatapb.TabletType_REPLICA,
 								Cells:        []string{"zone2", "zone3"},
-								DeniedTables: []string{"t2"},
+								DeniedTables: []string{"select"},
 							},
 						},
 					},
@@ -6758,7 +6759,7 @@ func TestSetShardTabletControl(t *testing.T) {
 			req: &vtctldatapb.SetShardTabletControlRequest{
 				Keyspace:     "testkeyspace",
 				Shard:        "-",
-				DeniedTables: []string{"t1"},
+				DeniedTables: []string{"Table1"},
 				TabletType:   topodatapb.TabletType_REPLICA,
 			},
 			shouldErr: true,

--- a/go/vt/wrangler/traffic_switcher.go
+++ b/go/vt/wrangler/traffic_switcher.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/vt/discovery"
 
 	"vitess.io/vitess/go/json2"
@@ -203,7 +204,7 @@ func (wr *Wrangler) getWorkflowState(ctx context.Context, targetKeyspace, workfl
 		for _, table := range ts.tables {
 			rr := rules[table]
 			// if a rule exists for the table and points to the target keyspace, writes have been switched
-			if len(rr) > 0 && rr[0] == fmt.Sprintf("%s.%s", keyspace, table) {
+			if len(rr) > 0 && rr[0] == fmt.Sprintf("%s.%s", sqlescape.EscapeID(keyspace), sqlescape.EscapeID(table)) {
 				ws.WritesSwitched = true
 			}
 		}
@@ -1446,7 +1447,7 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 		for fromTable, toTables := range rules {
 			for _, toTable := range toTables {
 				for _, table := range ts.tables {
-					if toTable == fmt.Sprintf("%s.%s", ts.sourceKeyspace, table) {
+					if toTable == fmt.Sprintf("%s.%s", sqlescape.EscapeID(ts.sourceKeyspace), sqlescape.EscapeID(table)) {
 						rec.RecordError(fmt.Errorf("routing still exists from keyspace %s table %s to %s", ts.sourceKeyspace, table, fromTable))
 					}
 				}


### PR DESCRIPTION
## Description
We need to ensure proper escaping of identifiers (keyspace/database/schema and table names) in VReplication. This should support use of reserved words (e.g. `SELECT`) and special characters (e.g. `-`) and ensure that case-sensitivity is correctly respected as the object identifiers are then treated as literals.

h/t to @msolters for reporting the identifier escaping issue in his related PR

## Related Issue(s)
 - https://github.com/vitessio/vitess/issues/8994
 - https://github.com/vitessio/vitess/pull/8872


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->