### PR TITLE
Migrate k8s topo CRD to v1 api

### DIFF
--- a/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
+++ b/go/vt/topo/k8stopo/VitessTopoNodes-crd.yaml
@@ -1,38 +1,41 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vitesstoponodes.topo.vitess.io
 spec:
   group: topo.vitess.io
-  additionalPrinterColumns:
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    additionalPrinterColumns:
     - name: Key
       type: string
       description: The full key path
-      JSONPath: .data.key
-  validation:
-    openAPIV3Schema:
-      type: object
-      required:
-        - data
-      properties:
-        data:
-          type: object
-          required:
-            - key
-            - value
-          properties:
-            key:
-              description: A file-path like key. Must be an absolute path. Must not end with a /.
-              type: string
-              pattern: '^\/.+[^\/]$'
-            value:
-              description: A base64 encoded value. Must be a base64 encoded string or empty string.
-              type: string
-              pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
-            ephemeral:
-              description: Whether or not the node is considered ephemeral. True for lock and election nodes.
-              type: boolean
-  version: v1beta1
+      jsonPath: .data.key
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+          - data
+        properties:
+          data:
+            type: object
+            required:
+              - key
+              - value
+            properties:
+              key:
+                description: A file-path like key. Must be an absolute path. Must not end with a /.
+                type: string
+                pattern: '^\/.+[^\/]$'
+              value:
+                description: A base64 encoded value. Must be a base64 encoded string or empty string.
+                type: string
+                pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+              ephemeral:
+                description: Whether or not the node is considered ephemeral. True for lock and election nodes.
+                type: boolean
   scope: Namespaced
   names:
     plural: vitesstoponodes

--- a/go/vt/topo/k8stopo/server_test.go
+++ b/go/vt/topo/k8stopo/server_test.go
@@ -28,7 +28,7 @@ import (
 
 	"testing"
 
-	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -107,11 +107,11 @@ func TestKubernetesTopo(t *testing.T) {
 			defer crdFile.Close()
 		}
 
-		crd := &extensionsv1beta1.CustomResourceDefinition{}
+		crd := &extensionsv1.CustomResourceDefinition{}
 
 		kubeyaml.NewYAMLOrJSONDecoder(crdFile, 2048).Decode(crd)
 
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+		_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This change only applies to the tests and new clusters. The CRD does not need
to be re-applied on old clusters. There is no functional change to the topo