### PR TITLE
Backoff on inconsistent member state

### DIFF
--- a/go/vt/vtgr/controller/diagnose.go
+++ b/go/vt/vtgr/controller/diagnose.go
@@ -121,7 +121,7 @@ func (shard *GRShard) Diagnose(ctx context.Context) (DiagnoseType, error) {
 	shard.shardStatusCollector.recordDiagnoseResult(diagnoseResult)
 	shard.populateVTGRStatusLocked()
 	if diagnoseResult != DiagnoseTypeHealthy {
-		shard.logger.Warningf(`VTGR diagnose shard as unhealthy for %s/%s: result=%v | last_result=%v | instances=%v | primary=%v | primary_tablet=%v | problematics=%v | unreachables=%v | SQL group=%v`,
+		shard.logger.Warningf(`VTGR diagnose shard as unhealthy for %s/%s: result=%v, last_result=%v, instances=%v, primary=%v, primary_tablet=%v, problematics=%v, unreachables=%v,\n%v`,
 			shard.KeyspaceShard.Keyspace, shard.KeyspaceShard.Shard,
 			shard.shardStatusCollector.status.DiagnoseResult,
 			shard.lastDiagnoseResult,

--- a/go/vt/vtgr/controller/diagnose_test.go
+++ b/go/vt/vtgr/controller/diagnose_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -51,10 +52,11 @@ var (
 )
 
 type testGroupInput struct {
-	groupName  string
-	readOnly   bool
-	groupState []db.TestGroupState
-	gtid       mysql.GTIDSet
+	groupName   string
+	readOnly    bool
+	checkResult int
+	groupState  []db.TestGroupState
+	gtid        mysql.GTIDSet
 }
 
 func TestShardIsHealthy(t *testing.T) {
@@ -81,7 +83,7 @@ func TestShardIsHealthy(t *testing.T) {
 		EXPECT().
 		FetchGroupView(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(alias string, target *inst.InstanceKey) (*db.GroupView, error) {
-			return db.BuildGroupView(alias, "group", testHost, testPort0, false, []db.TestGroupState{
+			return db.BuildGroupView(alias, "group", testHost, testPort0, false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -189,7 +191,7 @@ func TestTabletIssueDiagnoses(t *testing.T) {
 						if target.Hostname == "" || target.Port == 0 {
 							return nil, errors.New("invalid mysql instance key")
 						}
-						return db.BuildGroupView(alias, "group", testHost, testPort0, false, []db.TestGroupState{
+						return db.BuildGroupView(alias, "group", testHost, testPort0, false, 0, []db.TestGroupState{
 							{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 							{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 							{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -241,12 +243,17 @@ func TestTabletIssueDiagnoses(t *testing.T) {
 func TestMysqlIssueDiagnoses(t *testing.T) {
 	cfg := &config.VTGRConfig{GroupSize: diagnoseGroupSize, MinNumReplica: 2, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
 	disableProtectionCfg := &config.VTGRConfig{GroupSize: diagnoseGroupSize, MinNumReplica: 2, DisableReadOnlyProtection: true, BackoffErrorWaitTimeSeconds: 1, BootstrapWaitTimeSeconds: 1}
+	*heartbeatThreshold = 10
+	defer func() {
+		*heartbeatThreshold = math.MaxInt64
+	}()
 	type data struct {
-		alias      string
-		groupName  string
-		readOnly   bool
-		groupInput []db.TestGroupState
-		ttype      topodatapb.TabletType
+		alias       string
+		groupName   string
+		readOnly    bool
+		checkResult int
+		groupInput  []db.TestGroupState
+		ttype       topodatapb.TabletType
 	}
 	var sqltests = []struct {
 		name          string
@@ -257,287 +264,312 @@ func TestMysqlIssueDiagnoses(t *testing.T) {
 		removeTablets []string // to simulate missing tablet in topology
 	}{
 		{name: "healthy shard", expected: DiagnoseTypeHealthy, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "recovering primary shard", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "RECOVERING", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "RECOVERING", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "RECOVERING", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "no group in shard", expected: DiagnoseTypeShardHasNoGroup, errMessage: "", inputs: []data{
-			{alias0, "", true, []db.TestGroupState{
+			{alias0, "", true, 0, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
-			{alias1, "", true, []db.TestGroupState{
+			{alias1, "", true, 0, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "", true, []db.TestGroupState{
+			{alias2, "", true, 0, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "unreachable node", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "mysql and tablet has different primary", expected: DiagnoseTypeWrongPrimaryTablet, errMessage: "", inputs: []data{ // vtgr should failover vttablet
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "mysql primary out of topology", expected: DiagnoseTypeUnreachablePrimary, errMessage: "", inputs: []data{ // vtgr should failover mysql
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}, removeTablets: []string{alias0}},
 		{name: "one error node", expected: DiagnoseTypeUnconnectedReplica, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
+		{name: "inactive group with divergent state", expected: DiagnoseTypeShardHasInactiveGroup, errMessage: "", inputs: []data{
+			{alias0, "group", true, 11, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "OFFLINE", MemberRole: "SECONDARY"},
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
+			}, topodatapb.TabletType_PRIMARY},
+			{alias1, "group", true, 11, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias2, "group", true, 11, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+		}},
 		{name: "two error node", expected: DiagnoseTypeInsufficientGroupSize, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "insufficient group member", expected: DiagnoseTypeInsufficientGroupSize, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "unconnected node", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "unreachable primary", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "UNREACHABLE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "UNREACHABLE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "UNREACHABLE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "more than one group name", expected: DiagnoseTypeError, errMessage: "fail to refreshSQLGroup: group has split brain", inputs: []data{ // vtgr should raise error
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group_xxx", false, []db.TestGroupState{
+			{alias1, "group_xxx", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "different primary", expected: DiagnoseTypeError, errMessage: "fail to refreshSQLGroup: group has split brain", inputs: []data{ // vtgr should raise error
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", false, []db.TestGroupState{
+			{alias1, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "insufficient members in group", expected: DiagnoseTypeInsufficientGroupSize, errMessage: "", inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		// the shard has insufficient member, but the primary is already read_only
 		// we should try to connect the replica node
 		{name: "insufficient members in read only shard", expected: DiagnoseTypeUnconnectedReplica, errMessage: "", inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "insufficient members in group with disable read only protection", expected: DiagnoseTypeUnconnectedReplica, errMessage: "", config: disableProtectionCfg, inputs: []data{
-			{alias0, "group", false, []db.TestGroupState{
+			{alias0, "group", false, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "read only with disable read only protection", expected: DiagnoseTypeReadOnlyShard, errMessage: "", config: disableProtectionCfg, inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ERROR", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "read only healthy shard", expected: DiagnoseTypeReadOnlyShard, errMessage: "", inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
+		{name: "inconsistent member state", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
+			{alias0, "group", true, 11, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+			{alias1, "group", true, 12, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "SECONDARY"},
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "PRIMARY"},
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
+			}, topodatapb.TabletType_PRIMARY},
+			{alias2, "group", true, math.MaxInt64, []db.TestGroupState{
+				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "OFFLINE", MemberRole: ""},
+			}, topodatapb.TabletType_REPLICA},
+		}},
 		{name: "network partition", expected: DiagnoseTypeBackoffError, errMessage: "", inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "UNREACHABLE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_PRIMARY},
-			{alias1, "group", true, []db.TestGroupState{
+			{alias1, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "OFFLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias2, "group", true, []db.TestGroupState{
+			{alias2, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "OFFLINE", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
 		}},
 		{name: "start bootstrap in progress", expected: DiagnoseTypeBootstrapBackoff, errMessage: "", inputs: []data{
-			{alias0, "group", true, []db.TestGroupState{
+			{alias0, "group", true, 0, []db.TestGroupState{
 				{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "RECOVERING", MemberRole: "SECONDARY"},
 			}, topodatapb.TabletType_REPLICA},
-			{alias1, "", true, []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
-			{alias2, "", true, []db.TestGroupState{
+			{alias1, "", true, 0, []db.TestGroupState{}, topodatapb.TabletType_REPLICA},
+			{alias2, "", true, 0, []db.TestGroupState{
 				{MemberHost: "", MemberPort: "", MemberState: "OFFLINE", MemberRole: ""},
 			}, topodatapb.TabletType_REPLICA},
 		}},
@@ -565,6 +597,7 @@ func TestMysqlIssueDiagnoses(t *testing.T) {
 				inputMap[input.alias] = testGroupInput{
 					input.groupName,
 					input.readOnly,
+					input.checkResult,
 					input.groupInput,
 					nil,
 				}
@@ -588,7 +621,7 @@ func TestMysqlIssueDiagnoses(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -749,6 +782,7 @@ func TestDiagnoseWithInactive(t *testing.T) {
 				inputMap[input.alias] = testGroupInput{
 					input.groupName,
 					input.readOnly,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -767,7 +801,7 @@ func TestDiagnoseWithInactive(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()

--- a/go/vt/vtgr/controller/group.go
+++ b/go/vt/vtgr/controller/group.go
@@ -17,7 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"flag"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -31,22 +33,31 @@ import (
 var (
 	groupOnlineSize = stats.NewGaugesWithMultiLabels("MysqlGroupOnlineSize", "Online MySQL server in the group", []string{"Keyspace", "Shard"})
 	isLostQuorum    = stats.NewGaugesWithMultiLabels("MysqlGroupLostQuorum", "If MySQL group lost quorum", []string{"Keyspace", "Shard"})
+
+	heartbeatThreshold = flag.Int("group_heartbeat_threshold", 0, "Group heartbeat staleness threshold. Need to set together with -enable_heartbeat_check")
 )
 
 // SQLGroup contains views from all the nodes within the shard
 type SQLGroup struct {
-	views         []*db.GroupView
-	resolvedView  *ResolvedView
-	logger        *log.Logger
-	size          int
-	singlePrimary bool
-	statsTags     []string
+	views                       []*db.GroupView
+	resolvedView                *ResolvedView
+	logger                      *log.Logger
+	size                        int
+	singlePrimary               bool
+	heartbeatStalenessThreshold int
+	statsTags                   []string
 	sync.Mutex
 }
 
 // NewSQLGroup creates a new SQLGroup
 func NewSQLGroup(size int, singlePrimary bool, keyspace, shard string) *SQLGroup {
-	return &SQLGroup{size: size, singlePrimary: singlePrimary, statsTags: []string{keyspace, shard}, logger: log.NewVTGRLogger(keyspace, shard)}
+	return &SQLGroup{
+		size:                        size,
+		singlePrimary:               singlePrimary,
+		statsTags:                   []string{keyspace, shard},
+		logger:                      log.NewVTGRLogger(keyspace, shard),
+		heartbeatStalenessThreshold: *heartbeatThreshold,
+	}
 }
 
 // ResolvedView is the resolved view
@@ -205,6 +216,14 @@ func (group *SQLGroup) Resolve() error {
 func (group *SQLGroup) resolveLocked() error {
 	rv := &ResolvedView{logger: group.logger}
 	group.resolvedView = rv
+	// a node that is not in the group might be outlier with big lag
+	// iterate over all views to get global minStalenessResult first
+	minStalenessResult := math.MaxInt32
+	for _, view := range group.views {
+		if view.HeartbeatStaleness < minStalenessResult {
+			minStalenessResult = view.HeartbeatStaleness
+		}
+	}
 	m := make(map[inst.InstanceKey]db.GroupMember)
 	for _, view := range group.views {
 		if rv.groupName == "" && view.GroupName != "" {
@@ -232,6 +251,25 @@ func (group *SQLGroup) resolveLocked() error {
 			}
 			if st.State == memberState && st.Role == memberRole && st.ReadOnly == isReadOnly {
 				continue
+			}
+			// Members in a group should eventually converge on a state
+			// if there is a partition, then a node should be removed from
+			// a group and we will only see state from this node only
+			// therefore we back off if we see a node with diverged state
+			if memberState != db.UNKNOWNSTATE &&
+				st.State != db.UNKNOWNSTATE &&
+				st.State != memberState &&
+				(st.State == db.ONLINE || memberState == db.ONLINE) {
+				group.logger.Warningf("found inconsistent member state for %v: %v vs %v", instance.Hostname, st.State, memberState)
+				if group.heartbeatStalenessThreshold != 0 && minStalenessResult >= group.heartbeatStalenessThreshold {
+					group.logger.Warningf("ErrGroupBackoffError by staled heartbeat check %v", minStalenessResult)
+					var sb strings.Builder
+					for _, view := range group.views {
+						sb.WriteString(fmt.Sprintf("%v staleness=%v\n", view.MySQLHost, view.HeartbeatStaleness))
+					}
+					group.logger.Warningf("%v", sb.String())
+					return db.ErrGroupBackoffError
+				}
 			}
 			m[instance] = db.GroupMember{
 				HostName: instance.Hostname,

--- a/go/vt/vtgr/controller/group_test.go
+++ b/go/vt/vtgr/controller/group_test.go
@@ -199,13 +199,81 @@ func TestNetworkPartition(t *testing.T) {
 	group.recordView(v2)
 	group.recordView(v3)
 	err := group.Resolve()
-	assert.Errorf(t, err, "group backoff error")
+	assert.EqualErrorf(t, err, "group backoff error", err.Error())
 	rv := group.resolvedView
 	assert.Equal(t, "group", rv.groupName)
 	assert.Equal(t, map[inst.InstanceKey]db.GroupMember{
 		{Hostname: "host1", Port: 10}: {HostName: "host1", Port: 10, Role: db.PRIMARY, State: db.ONLINE, ReadOnly: false},
 		{Hostname: "host2", Port: 10}: {HostName: "host2", Port: 10, Role: db.SECONDARY, State: db.UNREACHABLE, ReadOnly: true},
 		{Hostname: "host3", Port: 10}: {HostName: "host3", Port: 10, Role: db.SECONDARY, State: db.UNREACHABLE, ReadOnly: true},
+	}, rv.view)
+}
+
+func TestInconsistentState(t *testing.T) {
+	group := NewSQLGroup(3, true, "ks", "0")
+	v1 := db.NewGroupView("v1", "host1", 10)
+	v1.GroupName = "group"
+	v1.HeartbeatStaleness = 11
+	v1.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("ONLINE", "PRIMARY", "host1", 10, false),
+		db.NewGroupMember("ONLINE", "SECONDARY", "host2", 10, true),
+		db.NewGroupMember("UNREACHABLE", "SECONDARY", "host3", 10, true),
+	}
+	v2 := db.NewGroupView("v2", "host2", 10)
+	v2.GroupName = "group"
+	v2.HeartbeatStaleness = 11
+	v2.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("OFFLINE", "", "host2", 10, true),
+	}
+	v3 := db.NewGroupView("v3", "host3", 10)
+	v3.GroupName = "group"
+	v3.HeartbeatStaleness = 13
+	v3.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("OFFLINE", "", "host3", 10, true),
+	}
+	group.recordView(v1)
+	group.recordView(v2)
+	group.recordView(v3)
+	group.heartbeatStalenessThreshold = 10
+	err := group.Resolve()
+	assert.EqualErrorf(t, err, "group backoff error", err.Error())
+	rv := group.resolvedView
+	assert.Equal(t, "group", rv.groupName)
+	assert.Nil(t, rv.view)
+}
+
+func TestInconsistentUnknownState(t *testing.T) {
+	group := NewSQLGroup(3, true, "ks", "0")
+	v1 := db.NewGroupView("v1", "host1", 10)
+	v1.GroupName = "group"
+	v1.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("ONLINE", "PRIMARY", "host1", 10, false),
+		db.NewGroupMember("RECOVERING", "SECONDARY", "host2", 10, true),
+		db.NewGroupMember("ONLINE", "SECONDARY", "host3", 10, true),
+	}
+	v2 := db.NewGroupView("v2", "host2", 10)
+	v2.GroupName = "group"
+	v2.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("", "", "host2", 10, true),
+	}
+	v3 := db.NewGroupView("v3", "host3", 10)
+	v3.GroupName = "group"
+	v3.UnresolvedMembers = []*db.GroupMember{
+		db.NewGroupMember("ONLINE", "SECONDARY", "host3", 10, true),
+	}
+	group.recordView(v1)
+	group.recordView(v2)
+	group.recordView(v3)
+	err := group.Resolve()
+	// host 2 reports itself with empty state
+	// therefore we shouldn't raise error even with inconsistent state
+	assert.NoError(t, err)
+	rv := group.resolvedView
+	assert.Equal(t, "group", rv.groupName)
+	assert.Equal(t, map[inst.InstanceKey]db.GroupMember{
+		{Hostname: "host1", Port: 10}: {HostName: "host1", Port: 10, Role: db.PRIMARY, State: db.ONLINE, ReadOnly: false},
+		{Hostname: "host2", Port: 10}: {HostName: "host2", Port: 10, Role: db.SECONDARY, State: db.RECOVERING, ReadOnly: true},
+		{Hostname: "host3", Port: 10}: {HostName: "host3", Port: 10, Role: db.SECONDARY, State: db.ONLINE, ReadOnly: true},
 	}, rv.view)
 }
 

--- a/go/vt/vtgr/controller/repair_test.go
+++ b/go/vt/vtgr/controller/repair_test.go
@@ -176,6 +176,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 				inputMap[input.mysqlport] = testGroupInput{
 					input.groupName,
 					input.readOnly,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -187,7 +188,7 @@ func TestRepairShardHasNoGroup(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[target.Port]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -403,6 +404,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 				inputMap[input.mysqlport] = testGroupInput{
 					input.groupName,
 					false,
+					0,
 					input.groupInput,
 					input.gtid,
 				}
@@ -415,7 +417,7 @@ func TestRepairShardHasInactiveGroup(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[target.Port]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -617,6 +619,7 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 				inputMap[tablet.AliasString()] = testGroupInput{
 					input.groupName,
 					false,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -631,7 +634,7 @@ func TestRepairWrongPrimaryTablet(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -767,6 +770,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 				inputMap[input.alias] = testGroupInput{
 					input.groupName,
 					input.readOnly,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -778,7 +782,7 @@ func TestRepairUnconnectedReplica(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -846,7 +850,7 @@ func TestRepairUnreachablePrimary(t *testing.T) {
 				EXPECT().
 				FetchGroupView(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(alias string, target *inst.InstanceKey) (*db.GroupView, error) {
-					return db.BuildGroupView(alias, "group", target.Hostname, target.Port, false, []db.TestGroupState{
+					return db.BuildGroupView(alias, "group", target.Hostname, target.Port, false, 0, []db.TestGroupState{
 						{MemberHost: testHost, MemberPort: strconv.Itoa(testPort0), MemberState: "ONLINE", MemberRole: "PRIMARY"},
 						{MemberHost: testHost, MemberPort: strconv.Itoa(testPort1), MemberState: "ONLINE", MemberRole: "SECONDARY"},
 						{MemberHost: testHost, MemberPort: strconv.Itoa(testPort2), MemberState: "ONLINE", MemberRole: "SECONDARY"},
@@ -990,6 +994,7 @@ func TestRepairInsufficientGroupSize(t *testing.T) {
 				inputMap[input.alias] = testGroupInput{
 					"group",
 					input.readOnly,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -1001,7 +1006,7 @@ func TestRepairInsufficientGroupSize(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -1106,6 +1111,7 @@ func TestRepairReadOnlyShard(t *testing.T) {
 				inputMap[input.alias] = testGroupInput{
 					"group",
 					input.readOnly,
+					0,
 					input.groupInput,
 					nil,
 				}
@@ -1117,7 +1123,7 @@ func TestRepairReadOnlyShard(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[alias]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()
@@ -1240,6 +1246,7 @@ func TestRepairBackoffError(t *testing.T) {
 				inputMap[input.mysqlport] = testGroupInput{
 					input.groupName,
 					false,
+					0,
 					input.groupInput,
 					input.gtid,
 				}
@@ -1252,7 +1259,7 @@ func TestRepairBackoffError(t *testing.T) {
 							return nil, errors.New("invalid mysql instance key")
 						}
 						s := inputMap[target.Port]
-						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.groupState)
+						view := db.BuildGroupView(alias, s.groupName, target.Hostname, target.Port, s.readOnly, s.checkResult, s.groupState)
 						return view, nil
 					}).
 					AnyTimes()

--- a/go/vt/vtgr/db/mock_mysql.go
+++ b/go/vt/vtgr/db/mock_mysql.go
@@ -169,7 +169,7 @@ type TestGroupState struct {
 }
 
 // BuildGroupView builds gruop view from input
-func BuildGroupView(alias, groupName, host string, port int, readOnly bool, inputs []TestGroupState) *GroupView {
+func BuildGroupView(alias, groupName, host string, port int, readOnly bool, stalenessResult int, inputs []TestGroupState) *GroupView {
 	view := NewGroupView(alias, host, port)
 	view.GroupName = groupName
 	// group_name, member_host, member_port, member_state, member_role, is_local
@@ -185,6 +185,7 @@ func BuildGroupView(alias, groupName, host string, port int, readOnly bool, inpu
 			member.ReadOnly = readOnly
 		}
 		view.UnresolvedMembers = append(view.UnresolvedMembers, member)
+		view.HeartbeatStaleness = stalenessResult
 	}
 	return view
 }


### PR DESCRIPTION
Signed-off-by: Yang Wu <y.wu4515@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
We had an AZ gameday between 19:11 to 19:21 UTC, around the same time there seems to be a network blip that leads to a lost of quorum in the group:

2021-10-14T19:12:19.552500Z 0 [ERROR] [MY-011496] [Repl] Plugin group_replication reported: 'This server is not able to reach a majority of members in the group. This server will now block all updates. The server will remain blocked for the next 5 seconds. Unless contact with the majority is restored, after this time the member will error out and leave the group. It is possible to use group_replication_force_members to force a new group membership.'
There is something fishy happened inside mysql that makes different node reported different group view:

on primary:
```
mysql> select * from performance_schema.replication_group_members;
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
| CHANNEL_NAME              | MEMBER_ID                             | MEMBER_ROLE | MEMBER_VERSION |
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
| group_replication_applier | 0d2f5008-2c71-11ec-9588-0208f3fcc021  | ONLINE       | PRIMARY     | 8.0.22         |
| group_replication_applier | 4c13646c-2c70-11ec-991a-06731dd33837  | ONLINE       | SECONDARY   | 8.0.22         |
| group_replication_applier | dcee6acb-2c70-11ec-ae59-0a8fcea3b2db  | ONLINE       | SECONDARY   | 8.0.22         |
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
```
on secondary that appears to be online from above:
```
mysql> select * from performance_schema.replication_group_members;
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
| CHANNEL_NAME              | MEMBER_ID                             | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION |
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
| group_replication_applier | dcee6acb-2c70-11ec-ae59-0a8fcea3b2db | OFFLINE      |             |                |
+---------------------------+--------------------------------------+---------------------------------------------------------+-------------+--------------+-------------+----------------+
1 row in set (0.00 sec)
```
As a result, the group is stuck. The only way to get away this situation is to stop the group and rebootstrap.

This PR handles this situation by transit into back off mode when there is a discrepancy in member_state reported by different nodes, if it happens for longer than a threshold VTGR will reboot the group.

And to make it more conservative, it also adds an option to integrate with Vitess's heartbeat table: only execute backoff if there is no heartbeat for a certain period of time.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
^

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->