### PR TITLE
InitShardPrimary: don't use new InitPrimary RPC yet

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1428,7 +1428,7 @@ func (s *VtctldServer) InitShardPrimaryLocked(
 	// position
 	logger.Infof("initializing primary on %v", topoproto.TabletAliasString(req.PrimaryElectTabletAlias))
 	event.DispatchUpdate(ev, "initializing primary")
-	rp, err := tmc.InitPrimary(ctx, primaryElectTabletInfo.Tablet)
+	rp, err := tmc.InitMaster(ctx, primaryElectTabletInfo.Tablet)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
We have introduced new TabletManager RPCs that change master -> primary. However, we cannot use them yet because of cross-version compatibility requirements.
There was one instance where we are using a new RPC, this PR reverts to use the old one.
Technically, no one should be using InitShardPrimary with a v12 vtctld and v11 vttablets, so this bug isn't likely to manifest in a real deployment.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->