### PR TITLE
tabletmanager: correct implementations of deprecated RPCs for backwards compatibility

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1383,7 +1383,7 @@ func TestServerFlush(t *testing.T) {
 	flds, err := c.Fields()
 	require.NoError(t, err)
 	if duration, want := time.Since(start), 20*time.Millisecond; duration < *mysqlServerFlushDelay || duration > want {
-		assert.Fail(t, "duration: %v, want between %v and %v", duration.String(), (*mysqlServerFlushDelay).String(), want.String())
+		assert.Fail(t, "duration out of expected range", "duration: %v, want between %v and %v", duration.String(), (*mysqlServerFlushDelay).String(), want.String())
 	}
 	want1 := []*querypb.Field{{
 		Name: "result",
@@ -1394,7 +1394,7 @@ func TestServerFlush(t *testing.T) {
 	row, err := c.FetchNext(nil)
 	require.NoError(t, err)
 	if duration, want := time.Since(start), 50*time.Millisecond; duration < want {
-		assert.Fail(t, "duration: %v, want > %v", duration, want)
+		assert.Fail(t, "duration is too low", "duration: %v, want > %v", duration, want)
 	}
 	want2 := []sqltypes.Value{sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("delayed"))}
 	assert.Equal(t, want2, row)

--- a/go/vt/proto/tabletmanagerservice/tabletmanagerservice_grpc.pb.go
+++ b/go/vt/proto/tabletmanagerservice/tabletmanagerservice_grpc.pb.go
@@ -47,11 +47,11 @@ type TabletManagerClient interface {
 	ExecuteFetchAsApp(ctx context.Context, in *tabletmanagerdata.ExecuteFetchAsAppRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ExecuteFetchAsAppResponse, error)
 	// ReplicationStatus returns the current replication status.
 	ReplicationStatus(ctx context.Context, in *tabletmanagerdata.ReplicationStatusRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ReplicationStatusResponse, error)
-	// MasterStatus returns the current primary status.
+	// Deprecated, use PrimaryStatus instead
 	MasterStatus(ctx context.Context, in *tabletmanagerdata.PrimaryStatusRequest, opts ...grpc.CallOption) (*tabletmanagerdata.PrimaryStatusResponse, error)
 	// PrimaryStatus returns the current primary status.
 	PrimaryStatus(ctx context.Context, in *tabletmanagerdata.PrimaryStatusRequest, opts ...grpc.CallOption) (*tabletmanagerdata.PrimaryStatusResponse, error)
-	// MasterPosition returns the current primary position
+	// Deprecated, use PrimaryPosition instead
 	MasterPosition(ctx context.Context, in *tabletmanagerdata.PrimaryPositionRequest, opts ...grpc.CallOption) (*tabletmanagerdata.PrimaryPositionResponse, error)
 	// PrimaryPosition returns the current primary position
 	PrimaryPosition(ctx context.Context, in *tabletmanagerdata.PrimaryPositionRequest, opts ...grpc.CallOption) (*tabletmanagerdata.PrimaryPositionResponse, error)
@@ -93,7 +93,7 @@ type TabletManagerClient interface {
 	UndoDemotePrimary(ctx context.Context, in *tabletmanagerdata.UndoDemotePrimaryRequest, opts ...grpc.CallOption) (*tabletmanagerdata.UndoDemotePrimaryResponse, error)
 	// ReplicaWasPromoted tells the remote tablet it is now the primary
 	ReplicaWasPromoted(ctx context.Context, in *tabletmanagerdata.ReplicaWasPromotedRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ReplicaWasPromotedResponse, error)
-	// SetMaster tells the replica to reparent
+	// Deprecated, use SetReplicationSource instead
 	SetMaster(ctx context.Context, in *tabletmanagerdata.SetReplicationSourceRequest, opts ...grpc.CallOption) (*tabletmanagerdata.SetReplicationSourceResponse, error)
 	// SetReplicationSource tells the replica to reparent
 	SetReplicationSource(ctx context.Context, in *tabletmanagerdata.SetReplicationSourceRequest, opts ...grpc.CallOption) (*tabletmanagerdata.SetReplicationSourceResponse, error)
@@ -656,11 +656,11 @@ type TabletManagerServer interface {
 	ExecuteFetchAsApp(context.Context, *tabletmanagerdata.ExecuteFetchAsAppRequest) (*tabletmanagerdata.ExecuteFetchAsAppResponse, error)
 	// ReplicationStatus returns the current replication status.
 	ReplicationStatus(context.Context, *tabletmanagerdata.ReplicationStatusRequest) (*tabletmanagerdata.ReplicationStatusResponse, error)
-	// MasterStatus returns the current primary status.
+	// Deprecated, use PrimaryStatus instead
 	MasterStatus(context.Context, *tabletmanagerdata.PrimaryStatusRequest) (*tabletmanagerdata.PrimaryStatusResponse, error)
 	// PrimaryStatus returns the current primary status.
 	PrimaryStatus(context.Context, *tabletmanagerdata.PrimaryStatusRequest) (*tabletmanagerdata.PrimaryStatusResponse, error)
-	// MasterPosition returns the current primary position
+	// Deprecated, use PrimaryPosition instead
 	MasterPosition(context.Context, *tabletmanagerdata.PrimaryPositionRequest) (*tabletmanagerdata.PrimaryPositionResponse, error)
 	// PrimaryPosition returns the current primary position
 	PrimaryPosition(context.Context, *tabletmanagerdata.PrimaryPositionRequest) (*tabletmanagerdata.PrimaryPositionResponse, error)
@@ -702,7 +702,7 @@ type TabletManagerServer interface {
 	UndoDemotePrimary(context.Context, *tabletmanagerdata.UndoDemotePrimaryRequest) (*tabletmanagerdata.UndoDemotePrimaryResponse, error)
 	// ReplicaWasPromoted tells the remote tablet it is now the primary
 	ReplicaWasPromoted(context.Context, *tabletmanagerdata.ReplicaWasPromotedRequest) (*tabletmanagerdata.ReplicaWasPromotedResponse, error)
-	// SetMaster tells the replica to reparent
+	// Deprecated, use SetReplicationSource instead
 	SetMaster(context.Context, *tabletmanagerdata.SetReplicationSourceRequest) (*tabletmanagerdata.SetReplicationSourceResponse, error)
 	// SetReplicationSource tells the replica to reparent
 	SetReplicationSource(context.Context, *tabletmanagerdata.SetReplicationSourceRequest) (*tabletmanagerdata.SetReplicationSourceResponse, error)

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -540,7 +540,16 @@ func (client *Client) ReplicationStatus(ctx context.Context, tablet *topodatapb.
 
 // MasterStatus is part of the tmclient.TabletManagerClient interface.
 func (client *Client) MasterStatus(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
-	return client.PrimaryStatus(ctx, tablet)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	response, err := c.MasterStatus(ctx, &tabletmanagerdatapb.PrimaryStatusRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return response.Status, nil
 }
 
 // PrimaryStatus is part of the tmclient.TabletManagerClient interface.
@@ -559,7 +568,16 @@ func (client *Client) PrimaryStatus(ctx context.Context, tablet *topodatapb.Tabl
 
 // MasterPosition is part of the tmclient.TabletManagerClient interface.
 func (client *Client) MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
-	return client.PrimaryPosition(ctx, tablet)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return "", err
+	}
+	defer closer.Close()
+	response, err := c.MasterPosition(ctx, &tabletmanagerdatapb.PrimaryPositionRequest{})
+	if err != nil {
+		return "", err
+	}
+	return response.Position, nil
 }
 
 // PrimaryPosition is part of the tmclient.TabletManagerClient interface.
@@ -569,7 +587,7 @@ func (client *Client) PrimaryPosition(ctx context.Context, tablet *topodatapb.Ta
 		return "", err
 	}
 	defer closer.Close()
-	response, err := c.MasterPosition(ctx, &tabletmanagerdatapb.PrimaryPositionRequest{})
+	response, err := c.PrimaryPosition(ctx, &tabletmanagerdatapb.PrimaryPositionRequest{})
 	if err != nil {
 		return "", err
 	}
@@ -713,7 +731,17 @@ func (client *Client) ResetReplication(ctx context.Context, tablet *topodatapb.T
 
 // InitMaster is part of the tmclient.TabletManagerClient interface.
 func (client *Client) InitMaster(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
-	return client.InitPrimary(ctx, tablet)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return "", err
+	}
+	defer closer.Close()
+
+	response, err := c.InitMaster(ctx, &tabletmanagerdatapb.InitPrimaryRequest{})
+	if err != nil {
+		return "", err
+	}
+	return response.Position, nil
 }
 
 // InitPrimary is part of the tmclient.TabletManagerClient interface.
@@ -764,7 +792,25 @@ func (client *Client) InitReplica(ctx context.Context, tablet *topodatapb.Tablet
 
 // DemoteMaster is part of the tmclient.TabletManagerClient interface.
 func (client *Client) DemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
-	return client.DemotePrimary(ctx, tablet)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	response, err := c.DemoteMaster(ctx, &tabletmanagerdatapb.DemotePrimaryRequest{})
+	if err != nil {
+		return nil, err
+	}
+	status := response.PrimaryStatus
+	if status == nil {
+		// We are assuming this means a response came from an older server.
+		status = &replicationdatapb.PrimaryStatus{
+			Position:     response.DeprecatedPosition, //nolint
+			FilePosition: "",
+		}
+	}
+	return status, nil
+
 }
 
 // DemotePrimary is part of the tmclient.TabletManagerClient interface.
@@ -791,7 +837,13 @@ func (client *Client) DemotePrimary(ctx context.Context, tablet *topodatapb.Tabl
 
 // UndoDemoteMaster is part of the tmclient.TabletManagerClient interface.
 func (client *Client) UndoDemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) error {
-	return client.UndoDemotePrimary(ctx, tablet)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return err
+	}
+	defer closer.Close()
+	_, err = c.UndoDemoteMaster(ctx, &tabletmanagerdatapb.UndoDemotePrimaryRequest{})
+	return err
 }
 
 // UndoDemotePrimary is part of the tmclient.TabletManagerClient interface.
@@ -801,7 +853,7 @@ func (client *Client) UndoDemotePrimary(ctx context.Context, tablet *topodatapb.
 		return err
 	}
 	defer closer.Close()
-	_, err = c.UndoDemoteMaster(ctx, &tabletmanagerdatapb.UndoDemotePrimaryRequest{})
+	_, err = c.UndoDemotePrimary(ctx, &tabletmanagerdatapb.UndoDemotePrimaryRequest{})
 	return err
 }
 
@@ -818,7 +870,18 @@ func (client *Client) ReplicaWasPromoted(ctx context.Context, tablet *topodatapb
 
 // SetMaster is part of the tmclient.TabletManagerClient interface.
 func (client *Client) SetMaster(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
-	return client.SetReplicationSource(ctx, tablet, parent, timeCreatedNS, waitPosition, forceStartReplication)
+	c, closer, err := client.dialer.dial(ctx, tablet)
+	if err != nil {
+		return err
+	}
+	defer closer.Close()
+	_, err = c.SetMaster(ctx, &tabletmanagerdatapb.SetReplicationSourceRequest{
+		Parent:                parent,
+		TimeCreatedNs:         timeCreatedNS,
+		WaitPosition:          waitPosition,
+		ForceStartReplication: forceStartReplication,
+	})
+	return err
 }
 
 // SetReplicationSource is part of the tmclient.TabletManagerClient interface.

--- a/go/vt/vttablet/grpctmserver/server.go
+++ b/go/vt/vttablet/grpctmserver/server.go
@@ -285,7 +285,7 @@ func (s *server) MasterPosition(ctx context.Context, request *tabletmanagerdatap
 	defer s.tm.HandleRPCPanic(ctx, "PrimaryPosition", request, response, false /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response = &tabletmanagerdatapb.PrimaryPositionResponse{}
-	position, err := s.tm.MasterPosition(ctx)
+	position, err := s.tm.PrimaryPosition(ctx)
 	if err == nil {
 		response.Position = position
 	}
@@ -296,7 +296,7 @@ func (s *server) PrimaryPosition(ctx context.Context, request *tabletmanagerdata
 	defer s.tm.HandleRPCPanic(ctx, "PrimaryPosition", request, response, false /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response = &tabletmanagerdatapb.PrimaryPositionResponse{}
-	position, err := s.tm.MasterPosition(ctx)
+	position, err := s.tm.PrimaryPosition(ctx)
 	if err == nil {
 		response.Position = position
 	}
@@ -391,7 +391,7 @@ func (s *server) InitMaster(ctx context.Context, request *tabletmanagerdatapb.In
 	defer s.tm.HandleRPCPanic(ctx, "InitMaster", request, response, true /*verbose*/, &err)
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response = &tabletmanagerdatapb.InitPrimaryResponse{}
-	position, err := s.tm.InitMaster(ctx)
+	position, err := s.tm.InitPrimary(ctx)
 	if err == nil {
 		response.Position = position
 	}

--- a/proto/tabletmanagerservice.proto
+++ b/proto/tabletmanagerservice.proto
@@ -87,13 +87,13 @@ service TabletManager {
   // ReplicationStatus returns the current replication status.
   rpc ReplicationStatus(tabletmanagerdata.ReplicationStatusRequest) returns (tabletmanagerdata.ReplicationStatusResponse) {};
 
-  // MasterStatus returns the current primary status.
+  // Deprecated, use PrimaryStatus instead
   rpc MasterStatus(tabletmanagerdata.PrimaryStatusRequest) returns (tabletmanagerdata.PrimaryStatusResponse) {};
 
   // PrimaryStatus returns the current primary status.
   rpc PrimaryStatus(tabletmanagerdata.PrimaryStatusRequest) returns (tabletmanagerdata.PrimaryStatusResponse) {};
 
-  // MasterPosition returns the current primary position
+  // Deprecated, use PrimaryPosition instead
   rpc MasterPosition(tabletmanagerdata.PrimaryPositionRequest) returns (tabletmanagerdata.PrimaryPositionResponse) {};
 
   // PrimaryPosition returns the current primary position
@@ -158,7 +158,7 @@ service TabletManager {
   // ReplicaWasPromoted tells the remote tablet it is now the primary
   rpc ReplicaWasPromoted(tabletmanagerdata.ReplicaWasPromotedRequest) returns (tabletmanagerdata.ReplicaWasPromotedResponse) {};
 
-  // SetMaster tells the replica to reparent
+  // Deprecated, use SetReplicationSource instead
   rpc SetMaster(tabletmanagerdata.SetReplicationSourceRequest) returns (tabletmanagerdata.SetReplicationSourceResponse) {};
 
   // SetReplicationSource tells the replica to reparent


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
In various PRs for inclusive naming, we introduced new RPCs and deprecated existing RPCs.
In that process, we did not implement the grpc client correctly.

Here's how it needs to work for backwards compatibility. Let us assume that we have upgraded vtctld (new version aka v12) but not vttablets (old version aka v11).
When a vtctl command is executed that calls an RPC on a vttablet, it goes through TabletManagerClient (`wr.tmc`) like here:
https://github.com/vitessio/vitess/blob/32b74e6d2cfcfe1439b6faf690f8cbfa971382df/go/vt/vtctl/reparentutil/planned_reparenter.go#L228
`wr.tmc` is initialized via a call to `NewTabletManagerClient`
https://github.com/vitessio/vitess/blob/32b74e6d2cfcfe1439b6faf690f8cbfa971382df/go/vt/vtctld/action_repository.go#L117
which ultimately calls
https://github.com/vitessio/vitess/blob/32b74e6d2cfcfe1439b6faf690f8cbfa971382df/go/vt/vttablet/grpctmclient/client.go#L106-L110

IOW, the vtctld binary includes the client code provided by vttablet.

When an RPC is invoked by vtctld/wrangler, it ends up in the code in this client.go, but the version of code is v12. So for instance, when we call `tmc.SetMaster` as above, it is invoking this func
https://github.com/vitessio/vitess/blob/32b74e6d2cfcfe1439b6faf690f8cbfa971382df/go/vt/vttablet/grpctmclient/client.go#L821-L835

You can see the problem right away. `SetMaster` -> `SetReplicationSource` -> `c.SetReplicationSource`
`c` is a connection to a tablet that is running v11 of the code. So when we try to invoke `SetReplicationSource` on that connection, it fails because that RPC is unknown to the tablet.
In the client code, we need to continue to call the old RPCs, so that we have `SetMaster` -> `c.SetMaster`

I have made similar changes to all the affected RPCs (6 of them).
InitMaster
SetMaster
MasterStatus
MasterPosition
DemoteMaster
UndoDemoteMaster

Another way of doing this would have been to do `SetMaster` -> `SetReplicationSource` -> `c.SetMaster`.
I chose to do it this way so that when we go to delete the old RPCs before the next release, no changes will be needed to the new ones.

I have tested this by running a cluster with v12 vtctld and vtgate, and v11 vttablets. PlannedReparentShard failed initially, but passes with this fix.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#7114 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required (eventually we will automate version-compatibility testing)
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->