### PR TITLE
12.0.0: add buffering and deprecations to release notes

### DIFF
--- a/doc/releasenotes/12_0_0_summary.md
+++ b/doc/releasenotes/12_0_0_summary.md
@@ -3,20 +3,27 @@
 This release includes the following major changes or new features.
 
 ### Inclusive Naming
-A number of commands and RPCs have been deprecated as we move from `master` to `primary`. 
+A number of CLI commands and vttablet RPCs have been deprecated as we move from `master` to `primary`. 
 All functionality is backwards compatible except as noted under Incompatible Changes.
+Deprecated commands and flags will be removed in the next release (13.0).
+Deprecated vttablet RPCs will be removed in the subsequent release (14.0).
 
 ### Gen4 Planner
-
 The newest version of the query planner, `Gen4`, becomes an experimental feature as part of this release.
 While `Gen4` has been under development for a few release cycles, we have now reached parity with its predecessor, `v3`.
 
 To use `Gen4`, VTGate's `-planner_version` flag needs to be set to `gen4`.
 
+### Query Buffering during failovers
+In order to support buffering during resharding cutovers in addition to primary failovers, a new implementation 
+of query buffering has been added. 
+This is considered experimental. To enable it the flag `buffer_implementation` should be set to `keyspace_events`.
+The existing implementation (flag value `healthcheck`) will be deprecated in a future release.
+
 ## Incompatible Changes
 
-### vtctl command output
-Wherever vtctl commands produced `master` or `MASTER` for tablet type, they now produce `primary` or `PRIMARY`.
+### CLI command output
+Wherever CLI commands produced `master` or `MASTER` for tablet type, they now produce `primary` or `PRIMARY`.
 Scripts and tools that depend on parsing command output will need to change.
 
 Example:
@@ -30,6 +37,23 @@ zone1-0000000103 sourcekeyspace 0 rdonly 192.168.0.134:15103 192.168.0.134:17103
 
 ## Deprecations
 
-The command `vtctl VExec` is deprecated and removed. All Online DDL commands should run through `vtctl OnlineDDL`.
+### CLI commands
+`VExec` is deprecated and removed. All Online DDL commands should be run through `OnlineDDL`.
 
-The command `vtctl OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `vtctl ApplySchema` or via `vtgate`.
+`OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `ApplySchema` or via `vtgate`.
+
+`InitShardMaster` is deprecated, use `InitShardPrimary` instead.
+
+`SetShardIsMasterServing` is deprecated, use `SetShardIsPrimaryServing` instead.
+
+Various command flags have been deprecated and new variants provided.
+* `DeleteTablet` flag `allow_master` replaced with `allow_primary`
+* `PlannedReparentShard` flag `avoid_master` replaced with `avoid_tablet`
+* `PlannedReparentShard` flag `new_master` replaced with `new_primary`
+* `BackupShard` flag `allow_master` replaced with `allow_primary`
+* `Backup` flag `allow_master` replaced with `allow_primary`
+* `EmergencyReparentShard` flag `new_master` replaced with `new_primary`
+* `ReloadSchemeShard` flag `include_master` replaced with `include_primary`
+* `ReloadSchemaKeyspace` flag `include_master` replaced with `include_primary`
+* `ValidateSchemaKeyspace` flag `skip-no-master` replaced with `skip-no-primary`
+


### PR DESCRIPTION
## Description
Expand release notes to list all deprecated vtctl commands and flags.
Add a section on vtgate query buffering

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->