### PR TITLE
[vtadmin-web] Add useKeyspace hook

### DIFF
--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -149,6 +149,20 @@ export const fetchGates = async () =>
         },
     });
 
+export interface FetchKeyspaceParams {
+    clusterID: string;
+    name: string;
+}
+
+export const fetchKeyspace = async ({ clusterID, name }: FetchKeyspaceParams) => {
+    const { result } = await vtfetch(`/api/keyspace/${clusterID}/${name}`);
+
+    const err = pb.Keyspace.verify(result);
+    if (err) throw Error(err);
+
+    return pb.Keyspace.create(result);
+};
+
 export const fetchKeyspaces = async () =>
     vtfetchEntities({
         endpoint: '/api/keyspaces',

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
@@ -16,7 +16,7 @@
 import { Switch, useLocation, useParams, useRouteMatch } from 'react-router';
 import { Link, Redirect, Route } from 'react-router-dom';
 
-import { useKeyspaces } from '../../../hooks/api';
+import { useKeyspace } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
 import { NavCrumbs } from '../../layout/NavCrumbs';
 import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
@@ -36,10 +36,7 @@ export const Keyspace = () => {
 
     useDocumentTitle(`${name} (${clusterID})`);
 
-    // TODO(doeg): add a vtadmin-api endpoint to fetch a single keyspace
-    // See https://github.com/vitessio/vitess/projects/12#card-59980087
-    const { data: keyspaces = [], ...kq } = useKeyspaces();
-    const keyspace = keyspaces.find((k) => k.cluster?.id === clusterID && k.keyspace?.name === name);
+    const { data: keyspace, ...kq } = useKeyspace({ clusterID, name });
 
     if (kq.error) {
         return (

--- a/web/vtadmin/src/hooks/api.ts
+++ b/web/vtadmin/src/hooks/api.ts
@@ -19,6 +19,7 @@ import {
     fetchClusters,
     fetchExperimentalTabletDebugVars,
     fetchGates,
+    fetchKeyspace,
     fetchKeyspaces,
     fetchSchema,
     FetchSchemaParams,
@@ -53,6 +54,25 @@ export const useClusters = (options?: UseQueryOptions<pb.Cluster[], Error> | und
  */
 export const useGates = (options?: UseQueryOptions<pb.VTGate[], Error> | undefined) =>
     useQuery(['gates'], fetchGates, options);
+
+/**
+ * useKeyspace is a query hook that fetches a single keyspace by name.
+ */
+export const useKeyspace = (
+    params: Parameters<typeof fetchKeyspace>[0],
+    options?: UseQueryOptions<pb.Keyspace, Error>
+) => {
+    const queryClient = useQueryClient();
+    return useQuery(['keyspace', params], () => fetchKeyspace(params), {
+        initialData: () => {
+            const keyspaces = queryClient.getQueryData<pb.Keyspace[]>('keyspaces');
+            return (keyspaces || []).find(
+                (k) => k.cluster?.id === params.clusterID && k.keyspace?.name === params.name
+            );
+        },
+        ...options,
+    });
+};
 
 /**
  * useKeyspaces is a query hook that fetches all keyspaces across every cluster.


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>


## Description

This adds front-end bindings and a hook for the `/api/keyspace` endpoint added in https://github.com/vitessio/vitess/pull/8125, which tidies up a small todo and makes the keyspace page a little bit faster. This hook will also come in handy for the shard detail page. 

## Related Issue(s)

- API endpoint added in https://github.com/vitessio/vitess/pull/8125


## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A