### PR TITLE
Fix `DeleteCellInfo(force=true)` with downed local topo

### DIFF
--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -27,6 +27,10 @@ import (
 
 // ListDir is part of the topo.Conn interface.
 func (c *Conn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
+	if err := c.dial(ctx); err != nil {
+		return nil, err
+	}
+
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 

--- a/go/vt/topo/memorytopo/file.go
+++ b/go/vt/topo/memorytopo/file.go
@@ -30,6 +30,10 @@ import (
 
 // Create is part of topo.Conn interface.
 func (c *Conn) Create(ctx context.Context, filePath string, contents []byte) (topo.Version, error) {
+	if err := c.dial(ctx); err != nil {
+		return nil, err
+	}
+
 	if contents == nil {
 		contents = []byte{}
 	}
@@ -61,6 +65,10 @@ func (c *Conn) Create(ctx context.Context, filePath string, contents []byte) (to
 
 // Update is part of topo.Conn interface.
 func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
+	if err := c.dial(ctx); err != nil {
+		return nil, err
+	}
+
 	if contents == nil {
 		contents = []byte{}
 	}
@@ -125,6 +133,10 @@ func (c *Conn) Update(ctx context.Context, filePath string, contents []byte, ver
 
 // Get is part of topo.Conn interface.
 func (c *Conn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
+	if err := c.dial(ctx); err != nil {
+		return nil, nil, err
+	}
+
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 
@@ -146,6 +158,10 @@ func (c *Conn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, 
 
 // Delete is part of topo.Conn interface.
 func (c *Conn) Delete(ctx context.Context, filePath string, version topo.Version) error {
+	if err := c.dial(ctx); err != nil {
+		return err
+	}
+
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -44,6 +44,10 @@ type memoryTopoLockDescriptor struct {
 // Lock is part of the topo.Conn interface.
 func (c *Conn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
 	for {
+		if err := c.dial(ctx); err != nil {
+			return nil, err
+		}
+
 		c.factory.mu.Lock()
 
 		if c.factory.err != nil {

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -38,6 +38,15 @@ const (
 	electionsPath = "elections"
 )
 
+const (
+	// UnreachableServerAddr is a sentinel value for CellInfo.ServerAddr.
+	// If a memorytopo topo.Conn is created with this serverAddr then every
+	// method on that Conn which takes a context will simply block until the
+	// context finishes, and return ctx.Err(), in order to simulate an
+	// unreachable local cell for testing.
+	UnreachableServerAddr = "unreachable"
+)
+
 var (
 	nextWatchIndex = 0
 )
@@ -79,8 +88,9 @@ func (f *Factory) Create(cell, serverAddr, root string) (topo.Conn, error) {
 		return nil, topo.NewError(topo.NoNode, cell)
 	}
 	return &Conn{
-		factory: f,
-		cell:    cell,
+		factory:    f,
+		cell:       cell,
+		serverAddr: serverAddr,
 	}, nil
 }
 
@@ -110,11 +120,24 @@ func (f *Factory) Unlock() {
 	f.mu.Unlock()
 }
 
-// Conn implements the topo.Conn interface. It remembers the cell, and
-// points at the Factory that has all the data.
+// Conn implements the topo.Conn interface. It remembers the cell and serverAddr,
+// and points at the Factory that has all the data.
 type Conn struct {
-	factory *Factory
-	cell    string
+	factory    *Factory
+	cell       string
+	serverAddr string
+}
+
+// dial returns immediately, unless the Conn points to the sentinel
+// UnreachableServerAddr, in which case it will block until the context expires
+// and return the context's error.
+func (c *Conn) dial(ctx context.Context) error {
+	if c.serverAddr == UnreachableServerAddr {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	return nil
 }
 
 // Close is part of the topo.Conn interface.


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Implements the fix proposed in #8220. When `GetSrvKeyspaceNames` fails (for reasons _other_ than NoNode) _and_ the context expired, we assume it's because the local cell is shutdown, spin up a background context, and delete it anyway.

### Manual testing

```
❯ vtctlclient -server "localhost:15999" AddCellInfo -server_address "localhost:99999" -root "/vitess/zone2" zone2
❯ vtctlclient -server ":15999" GetCellInfoNames
zone1
zone2
❯ vtctlclient -server "localhost:15999" DeleteCellInfo zone2
DeleteCellInfo Error: rpc error: code = Unknown desc = can't list SrvKeyspace entries in the cell; use -force flag to continue anyway (e.g. if cell-local topo was already permanently shut down): failed to create topo connection to localhost:99999, /vitess/zone2: context deadline exceeded
E1025 11:20:39.650251   35350 main.go:76] remote error: rpc error: code = Unknown desc = can't list SrvKeyspace entries in the cell; use -force flag to continue anyway (e.g. if cell-local topo was already permanently shut down): failed to create topo connection to localhost:99999, /vitess/zone2: context deadline exceeded
❯ vtctlclient -server "localhost:15999" DeleteCellInfo -force zone2
❯ vtctlclient -server ":15999" GetCellInfoNames
zone1
```

## Related Issue(s)

Fixes #8220 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **not possible with memorytopo**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->