### PR TITLE
Updated make do_release command example in the release instructions

### DIFF
--- a/doc/internal/ReleaseInstructions.md
+++ b/doc/internal/ReleaseInstructions.md
@@ -117,7 +117,7 @@ The release cutover section is divided in 4 steps:
 
 * Build a Release Notes document using the Makefile: 
     ```shell
-    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
+    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" SUMMARY="./doc/releasenotes/12_0_0_summary.md" release-notes
     ```
 
 * Check to make sure all labels and categories set for each PR.
@@ -165,7 +165,7 @@ The release cutover section is divided in 4 steps:
 
 * Build a Release Notes document using the Makefile:
     ```shell
-    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" release-notes
+    make VERSION="v12.0.0" FROM="<ref/SHA of the latest tag for v11>" TO="<ref/SHA of main>" SUMMARY="./doc/releasenotes/12_0_0_summary.md" release-notes
     ```
 
 * Check to make sure all labels and categories set for each PR.


### PR DESCRIPTION
## Description

This pull request adds the `SUMMARY` variable to the `make do_release` examples in the release instructions.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
