### PR TITLE
[vtadmin-web] Add Shard detail route + ShardLink component

### DIFF
--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -33,6 +33,7 @@ import { VTExplain } from './routes/VTExplain';
 import { Keyspace } from './routes/keyspace/Keyspace';
 import { Tablet } from './routes/tablet/Tablet';
 import { Backups } from './routes/Backups';
+import { Shard } from './routes/shard/Shard';
 
 export const App = () => {
     return (
@@ -58,6 +59,10 @@ export const App = () => {
 
                         <Route path="/keyspaces">
                             <Keyspaces />
+                        </Route>
+
+                        <Route path="/keyspace/:clusterID/:keyspace/shard/:shard">
+                            <Shard />
                         </Route>
 
                         <Route path="/keyspace/:clusterID/:name">

--- a/web/vtadmin/src/components/links/ShardLink.tsx
+++ b/web/vtadmin/src/components/links/ShardLink.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+    className?: string;
+    clusterID: string | null | undefined;
+    keyspace: string | null | undefined;
+    shard: string | null | undefined;
+}
+
+export const ShardLink: React.FunctionComponent<Props> = ({ children, className, clusterID, keyspace, shard }) => {
+    if (!clusterID || !keyspace || !shard) {
+        return <span className={className}>{children}</span>;
+    }
+
+    const to = { pathname: `/keyspace/${clusterID}/${keyspace}/shard/${shard}` };
+
+    return (
+        <Link className={className} to={to}>
+            {children}
+        </Link>
+    );
+};

--- a/web/vtadmin/src/components/routes/Backups.tsx
+++ b/web/vtadmin/src/components/routes/Backups.tsx
@@ -29,10 +29,10 @@ import { DataTable } from '../dataTable/DataTable';
 import { ContentContainer } from '../layout/ContentContainer';
 import { WorkspaceHeader } from '../layout/WorkspaceHeader';
 import { WorkspaceTitle } from '../layout/WorkspaceTitle';
-import { KeyspaceLink } from '../links/KeyspaceLink';
 import { TabletLink } from '../links/TabletLink';
 import { BackupStatusPip } from '../pips/BackupStatusPip';
 import { filterNouns } from '../../util/filterNouns';
+import { ShardLink } from '../links/ShardLink';
 
 const COLUMNS = ['Started at', 'Directory', 'Backup', 'Tablet', 'Status'];
 
@@ -73,9 +73,9 @@ export const Backups = () => {
                         <div className="font-size-small text-color-secondary">{formatRelativeTime(row.time)}</div>
                     </DataCell>
                     <DataCell>
-                        <KeyspaceLink clusterID={row.clusterID} name={row.keyspace} shard={row.shard}>
+                        <ShardLink clusterID={row.clusterID} keyspace={row.keyspace} shard={row.shard}>
                             {row.directory}
-                        </KeyspaceLink>
+                        </ShardLink>
                         <div className="font-size-small text-color-secondary">{row.clusterName}</div>
                     </DataCell>
                     <DataCell>{row.name}</DataCell>

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -33,6 +33,7 @@ import { DataFilter } from '../dataTable/DataFilter';
 import { KeyspaceLink } from '../links/KeyspaceLink';
 import { TabletLink } from '../links/TabletLink';
 import { ExternalTabletLink } from '../links/ExternalTabletLink';
+import { ShardLink } from '../links/ShardLink';
 
 export const Tablets = () => {
     useDocumentTitle('Tablets');
@@ -56,10 +57,10 @@ export const Tablets = () => {
                         </KeyspaceLink>
                     </DataCell>
                     <DataCell>
-                        <KeyspaceLink
+                        <ShardLink
                             className="white-space-nowrap"
                             clusterID={t._raw.cluster?.id}
-                            name={t.keyspace}
+                            keyspace={t.keyspace}
                             shard={t.shard}
                         >
                             <ShardServingPip isLoading={ksQuery.isLoading} isServing={t.isShardServing} /> {t.shard}
@@ -68,7 +69,7 @@ export const Tablets = () => {
                                     {!t.isShardServing && 'NOT SERVING'}
                                 </div>
                             )}
-                        </KeyspaceLink>
+                        </ShardLink>
                     </DataCell>
                     <DataCell>
                         <TabletLink alias={t.alias} className="font-weight-bold" clusterID={t._raw.cluster?.id}>

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -28,6 +28,7 @@ import { useSyncedURLParam } from '../../../hooks/useSyncedURLParam';
 import { filterNouns } from '../../../util/filterNouns';
 import { ContentContainer } from '../../layout/ContentContainer';
 import { TabletLink } from '../../links/TabletLink';
+import { ShardLink } from '../../links/ShardLink';
 interface Props {
     keyspace: pb.Keyspace | null | undefined;
 }
@@ -56,7 +57,13 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
                     acc.push(
                         <tr key={row.shard}>
                             <DataCell rowSpan={1}>
-                                <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                <ShardLink
+                                    clusterID={keyspace?.cluster?.id}
+                                    keyspace={keyspace?.keyspace?.name}
+                                    shard={row.shard}
+                                >
+                                    <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                </ShardLink>
                                 {row.shardState === 'NOT_SERVING' && (
                                     <div className="font-size-small text-color-secondary white-space-nowrap">
                                         {row.shardState}
@@ -79,7 +86,13 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
                         <tr key={rowKey}>
                             {tdx === 0 && (
                                 <DataCell rowSpan={row.tablets.length}>
-                                    <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                    <ShardLink
+                                        clusterID={keyspace?.cluster?.id}
+                                        keyspace={keyspace?.keyspace?.name}
+                                        shard={row.shard}
+                                    >
+                                        <ShardServingPip isServing={row.isShardServing} /> {row.shard}
+                                    </ShardLink>
                                     {row.shardState === 'NOT_SERVING' && (
                                         <div className="font-size-small text-color-secondary white-space-nowrap">
                                             {row.shardState}

--- a/web/vtadmin/src/components/routes/shard/Shard.module.scss
+++ b/web/vtadmin/src/components/routes/shard/Shard.module.scss
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.headingMeta {
+    display: flex;
+}
+
+.headingMeta span {
+    display: inline-block;
+    line-height: 2;
+
+    &::after {
+        color: var(--colorScaffoldingHighlight);
+        content: '/';
+        display: inline-block;
+        margin: 0 1.2rem;
+    }
+
+    &:last-child::after {
+        content: none;
+    }
+}
+
+.placeholder {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    font-size: var(--fontSizeLarge);
+    justify-content: center;
+    margin: 25vh auto;
+    max-width: 720px;
+    text-align: center;
+
+    h1 {
+        margin: 1.6rem 0;
+    }
+}
+
+.errorEmoji {
+    display: block;
+    font-size: 5.6rem;
+}

--- a/web/vtadmin/src/components/routes/shard/Shard.tsx
+++ b/web/vtadmin/src/components/routes/shard/Shard.tsx
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Redirect, Route, Switch, useParams } from 'react-router';
+import { Link, useRouteMatch } from 'react-router-dom';
+
+import style from './Shard.module.scss';
+import { NavCrumbs } from '../../layout/NavCrumbs';
+import { WorkspaceHeader } from '../../layout/WorkspaceHeader';
+import { WorkspaceTitle } from '../../layout/WorkspaceTitle';
+import { ContentContainer } from '../../layout/ContentContainer';
+import { Tab } from '../../tabs/Tab';
+import { TabContainer } from '../../tabs/TabContainer';
+import { Code } from '../../Code';
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+import { KeyspaceLink } from '../../links/KeyspaceLink';
+import { useKeyspace } from '../../../hooks/api';
+
+interface RouteParams {
+    clusterID: string;
+    keyspace: string;
+    shard: string;
+}
+
+export const Shard = () => {
+    const params = useParams<RouteParams>();
+    const { path, url } = useRouteMatch();
+
+    const shardName = `${params.keyspace}/${params.shard}`;
+
+    useDocumentTitle(`${shardName} (${params.clusterID})`);
+
+    const { data: keyspace, ...kq } = useKeyspace({ clusterID: params.clusterID, name: params.keyspace });
+
+    if (kq.error) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😰</span>
+                <h1>An error occurred</h1>
+                <code>{(kq.error as any).response?.error?.message || kq.error?.message}</code>
+                <p>
+                    <Link to="/keyspaces">← All keyspaces</Link>
+                </p>
+            </div>
+        );
+    }
+
+    if (!kq.isLoading && !keyspace) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😖</span>
+                <h1>Keyspace not found</h1>
+                <p>
+                    <Link to="/keyspaces">← All keyspaces</Link>
+                </p>
+            </div>
+        );
+    }
+
+    let shard = null;
+    if (keyspace?.shards && params.shard in keyspace.shards) {
+        shard = keyspace.shards[params.shard];
+    }
+
+    if (!kq.isLoading && !shard) {
+        return (
+            <div className={style.placeholder}>
+                <span className={style.errorEmoji}>😖</span>
+                <h1>Shard not found</h1>
+                <p>
+                    <KeyspaceLink clusterID={params.clusterID} name={params.keyspace}>
+                        ← All shards in {params.keyspace}
+                    </KeyspaceLink>
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <WorkspaceHeader>
+                <NavCrumbs>
+                    <Link to="/keyspaces">Keyspaces</Link>
+                    <KeyspaceLink clusterID={params.clusterID} name={params.keyspace}>
+                        {params.keyspace}
+                    </KeyspaceLink>
+                </NavCrumbs>
+
+                <WorkspaceTitle className="font-family-monospace">{shardName}</WorkspaceTitle>
+
+                <div className={style.headingMeta}>
+                    <span>
+                        Cluster: <code>{params.clusterID}</code>
+                    </span>
+                </div>
+            </WorkspaceHeader>
+
+            <ContentContainer>
+                <TabContainer>
+                    <Tab text="JSON" to={`${url}/json`} />
+                </TabContainer>
+
+                <Switch>
+                    <Route path={`${path}/json`}>{shard && <Code code={JSON.stringify(shard, null, 2)} />}</Route>
+
+                    <Redirect from={path} to={`${path}/json`} />
+                </Switch>
+            </ContentContainer>
+
+            {/* TODO skeleton placeholder */}
+            {!!kq.isLoading && <div className={style.placeholder}>Loading</div>}
+        </div>
+    );
+};

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -26,10 +26,10 @@ import { formatDateTime } from '../../../util/time';
 import { getStreams, formatStreamKey, getStreamSource, getStreamTarget } from '../../../util/workflows';
 import { DataCell } from '../../dataTable/DataCell';
 import { DataTable } from '../../dataTable/DataTable';
-import { KeyspaceLink } from '../../links/KeyspaceLink';
 import { TabletLink } from '../../links/TabletLink';
 import { StreamStatePip } from '../../pips/StreamStatePip';
 import { WorkflowStreamsLagChart } from '../../charts/WorkflowStreamsLagChart';
+import { ShardLink } from '../../links/ShardLink';
 
 interface Props {
     clusterID: string;
@@ -76,22 +76,22 @@ export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
                     </DataCell>
                     <DataCell>
                         {source ? (
-                            <KeyspaceLink
+                            <ShardLink
                                 clusterID={clusterID}
-                                name={row.binlog_source?.keyspace}
+                                keyspace={row.binlog_source?.keyspace}
                                 shard={row.binlog_source?.shard}
                             >
                                 {source}
-                            </KeyspaceLink>
+                            </ShardLink>
                         ) : (
                             <span className="text-color-secondary">N/A</span>
                         )}
                     </DataCell>
                     <DataCell>
                         {target ? (
-                            <KeyspaceLink clusterID={clusterID} name={keyspace} shard={row.shard}>
+                            <ShardLink clusterID={clusterID} keyspace={keyspace} shard={row.shard}>
                                 {target}
-                            </KeyspaceLink>
+                            </ShardLink>
                         ) : (
                             <span className="text-color-secondary">N/A</span>
                         )}


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds a skeleton page for viewing the details of a shard, soon to be used for all kinds of things: shard tablets, shard replication positions (to complement #8775), streams running on the shard, schema sizes, etc. For now it's just JSON, to keep the PR small. 

<img width="1792" alt="Screen Shot 2021-10-26 at 3 48 47 PM" src="https://user-images.githubusercontent.com/855595/138950979-a1e77c68-2e3b-4ae9-b83a-11a7cfba39a1.png">

## Related Issue(s)

N/A


## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A