### PR TITLE
[vtadmin-web] Add tablets to Shard view

### DIFF
--- a/web/vtadmin/src/components/routes/shard/Shard.tsx
+++ b/web/vtadmin/src/components/routes/shard/Shard.tsx
@@ -28,6 +28,7 @@ import { Code } from '../../Code';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
 import { KeyspaceLink } from '../../links/KeyspaceLink';
 import { useKeyspace } from '../../../hooks/api';
+import { ShardTablets } from './ShardTablets';
 
 interface RouteParams {
     clusterID: string;
@@ -110,13 +111,18 @@ export const Shard = () => {
 
             <ContentContainer>
                 <TabContainer>
+                    <Tab text="Tablets" to={`${url}/tablets`} />
                     <Tab text="JSON" to={`${url}/json`} />
                 </TabContainer>
 
                 <Switch>
+                    <Route path={`${path}/tablets`}>
+                        <ShardTablets {...params} />
+                    </Route>
+
                     <Route path={`${path}/json`}>{shard && <Code code={JSON.stringify(shard, null, 2)} />}</Route>
 
-                    <Redirect from={path} to={`${path}/json`} />
+                    <Redirect from={path} to={`${path}/tablets`} />
                 </Switch>
             </ContentContainer>
 

--- a/web/vtadmin/src/components/routes/shard/ShardTablets.module.scss
+++ b/web/vtadmin/src/components/routes/shard/ShardTablets.module.scss
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.placeholder {
+    color: var(--textColorSecondary);
+    font-size: var(--fontSizeLarge);
+    padding: 10vh 2.4rem;
+    text-align: center;
+}
+
+.emoji {
+    display: block;
+    font-size: 100px;
+}

--- a/web/vtadmin/src/components/routes/shard/ShardTablets.tsx
+++ b/web/vtadmin/src/components/routes/shard/ShardTablets.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { orderBy } from 'lodash';
+import { useMemo } from 'react';
+
+import style from './ShardTablets.module.scss';
+import { useTablets } from '../../../hooks/api';
+import { formatAlias, formatDisplayType, formatState } from '../../../util/tablets';
+import { DataCell } from '../../dataTable/DataCell';
+import { DataTable } from '../../dataTable/DataTable';
+import { ExternalTabletLink } from '../../links/ExternalTabletLink';
+import { TabletLink } from '../../links/TabletLink';
+import { TabletServingPip } from '../../pips/TabletServingPip';
+
+interface Props {
+    clusterID: string;
+    keyspace: string;
+    shard: string;
+}
+
+const COLUMNS = ['Alias', 'Type', 'Tablet State', 'Hostname'];
+
+export const ShardTablets: React.FunctionComponent<Props> = (props) => {
+    // TODO(doeg): add more vtadmin-api params to query tablets for only this shard.
+    // In practice, this isn't _too_ bad since this query will almost always be cached
+    // from the /api/tablets sidebar query.
+    const { data: allTablets = [], ...tq } = useTablets();
+
+    const tablets = useMemo(() => {
+        const rows = allTablets
+            .filter(
+                (t) =>
+                    t.cluster?.id === props.clusterID &&
+                    t.tablet?.keyspace === props.keyspace &&
+                    t.tablet?.shard === props.shard
+            )
+            .map((t) => ({
+                alias: formatAlias(t.tablet?.alias),
+                clusterID: t.cluster?.id,
+                fqdn: t.FQDN,
+                hostname: t.tablet?.hostname,
+                keyspace: t.tablet?.keyspace,
+                state: formatState(t),
+                tabletType: formatDisplayType(t),
+                // underscore prefix excludes the following properties from filtering
+                _state: t.state,
+                _typeSortOrder: formatDisplayType(t) === 'PRIMARY' ? 1 : 2,
+            }));
+        return orderBy(rows, ['_typeSortOrder', 'tabletType', 'state', 'alias']);
+    }, [allTablets, props.clusterID, props.keyspace, props.shard]);
+
+    if (!tq.isLoading && !tablets.length) {
+        return (
+            <div className={style.placeholder}>
+                <div className={style.emoji}>🏜</div>
+                <div>
+                    No tablets in{' '}
+                    <span className="font-family-monospace">
+                        {props.keyspace}/{props.shard}
+                    </span>
+                    .
+                </div>
+            </div>
+        );
+    }
+
+    const renderRows = (rows: typeof tablets) => {
+        return rows.map((t) => {
+            return (
+                <tr key={t.alias}>
+                    <DataCell>
+                        <TabletLink alias={t.alias} clusterID={t.clusterID}>
+                            {t.alias}
+                        </TabletLink>
+                    </DataCell>
+
+                    <DataCell>{t.tabletType}</DataCell>
+
+                    <DataCell>
+                        <TabletServingPip state={t._state} /> {t.state}
+                    </DataCell>
+
+                    <DataCell>
+                        <ExternalTabletLink fqdn={`//${t.fqdn}`}>{t.hostname}</ExternalTabletLink>
+                    </DataCell>
+                </tr>
+            );
+        });
+    };
+
+    return <DataTable columns={COLUMNS} data={tablets} renderRows={renderRows} />;
+};


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds tablets to the shard view:

<img width="2672" alt="Screen Shot 2021-10-29 at 2 52 43 PM" src="https://user-images.githubusercontent.com/855595/139487700-7b8205d6-1ed3-4334-8d4f-4759ee31f32c.png">

(Quick note on ordering! This implementation uses VTAdmin's default tablet ordering, which lists primaries first, then alphabetically by tablet type. In this case `PRIMARY`, `RDONLY`, `REPLICA`. It does _not_ sort alphabetically by alias by default. Adding react-table (noted below) will let us add table sorting, which should make this less (in my opinion) weird.) 

... and a placeholder: 

<img width="2672" alt="Screen Shot 2021-10-29 at 2 51 39 PM" src="https://user-images.githubusercontent.com/855595/139487726-a88be89a-83a5-4331-a90c-b4f055ace9ce.png">

Very straightforward. I admit I kept things pretty simple to get this out the door, as this unblocks me from (a) simplifying the keyspace shard table, and then (the piece of been wanting to do forever) (b) rewrite the DataTable component to use react-table 🎉 

## Related Issue(s)

N/A

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A