### PR TITLE
Lock primitive GetFields implementation

### DIFF
--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -343,10 +343,12 @@ func buildLockingPrimitive(sel *sqlparser.Select, vschema ContextVSchema) (engin
 	if err != nil {
 		return nil, err
 	}
+	buf := sqlparser.NewTrackedBuffer(sqlparser.FormatImpossibleQuery).WriteNode(sel)
 	return &engine.Lock{
 		Keyspace:          ks,
 		TargetDestination: key.DestinationKeyspaceID{0},
 		Query:             sqlparser.String(sel),
+		FieldQuery:        buf.String(),
 	}, nil
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/lock_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/lock_cases.txt
@@ -10,6 +10,7 @@
       "Sharded": false
     },
     "TargetDestination": "KeyspaceID(00)",
+    "FieldQuery": "select get_lock('xyz', 10) from dual where 1 != 1",
     "Query": "select get_lock('xyz', 10) from dual"
   }
 }
@@ -27,7 +28,26 @@ Gen4 plan same as above
       "Sharded": false
     },
     "TargetDestination": "KeyspaceID(00)",
+    "FieldQuery": "select is_free_lock('xyz') from dual where 1 != 1",
     "Query": "select is_free_lock('xyz') from dual"
+  }
+}
+Gen4 plan same as above
+
+# get_lock from dual prepare query
+"select get_lock(?, ?)"
+{
+  "QueryType": "SELECT",
+  "Original": "select get_lock(?, ?)",
+  "Instructions": {
+    "OperatorType": "Lock",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "TargetDestination": "KeyspaceID(00)",
+    "FieldQuery": "select get_lock(:v1, :v2) from dual where 1 != 1",
+    "Query": "select get_lock(:v1, :v2) from dual"
   }
 }
 Gen4 plan same as above


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for using advisory lock in prepare query by implementing GetFields method in lock primitive.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->