### PR TITLE
messager: do not lock when testing for openness

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
     # - revive
 
 issues:
-  new: true
   exclude-rules:
     - path: '^go/vt/proto/'
       linters:

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package messager
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"context"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/sqltypes"
@@ -146,26 +145,13 @@ func TestEngineGenerate(t *testing.T) {
 	engine.schemaChanged(map[string]*schema.Table{
 		"t1": meTable,
 	}, []string{"t1"}, nil, nil)
-	if _, _, err := engine.GenerateAckQuery("t1", []string{"1"}); err != nil {
+
+	if _, err := engine.GetGenerator("t1"); err != nil {
 		t.Error(err)
 	}
 	want := "message table t2 not found in schema"
-	if _, _, err := engine.GenerateAckQuery("t2", []string{"1"}); err == nil || err.Error() != want {
+	if _, err := engine.GetGenerator("t2"); err == nil || err.Error() != want {
 		t.Errorf("engine.GenerateAckQuery(invalid): %v, want %s", err, want)
-	}
-
-	if _, _, err := engine.GeneratePostponeQuery("t1", []string{"1"}); err != nil {
-		t.Error(err)
-	}
-	if _, _, err := engine.GeneratePostponeQuery("t2", []string{"1"}); err == nil || err.Error() != want {
-		t.Errorf("engine.GeneratePostponeQuery(invalid): %v, want %s", err, want)
-	}
-
-	if _, _, err := engine.GeneratePurgeQuery("t1", 0); err != nil {
-		t.Error(err)
-	}
-	if _, _, err := engine.GeneratePurgeQuery("t2", 0); err == nil || err.Error() != want {
-		t.Errorf("engine.GeneratePurgeQuery(invalid): %v, want %s", err, want)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package messager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,8 +30,6 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"vitess.io/vitess/go/test/utils"
-
-	"context"
 
 	"github.com/stretchr/testify/assert"
 
@@ -849,7 +848,7 @@ func (fts *fakeTabletServer) SetChannel(ch chan string) {
 	fts.mu.Unlock()
 }
 
-func (fts *fakeTabletServer) PostponeMessages(ctx context.Context, target *querypb.Target, name string, ids []string) (count int64, err error) {
+func (fts *fakeTabletServer) PostponeMessages(ctx context.Context, target *querypb.Target, gen QueryGenerator, ids []string) (count int64, err error) {
 	fts.postponeCount.Add(1)
 	fts.mu.Lock()
 	ch := fts.ch
@@ -860,7 +859,7 @@ func (fts *fakeTabletServer) PostponeMessages(ctx context.Context, target *query
 	return 0, nil
 }
 
-func (fts *fakeTabletServer) PurgeMessages(ctx context.Context, target *querypb.Target, name string, timeCutoff int64) (count int64, err error) {
+func (fts *fakeTabletServer) PurgeMessages(ctx context.Context, target *querypb.Target, gen QueryGenerator, timeCutoff int64) (count int64, err error) {
 	fts.purgeCount.Add(1)
 	fts.mu.Lock()
 	ch := fts.ch


### PR DESCRIPTION
## Description

When the Messager engine is shutting down and the Engine has been
closed, there may be other goroutines still attempting to access the
Engine to generate queries. Since the Engine takes its own internal
mutex while it's closing itself down, these other goroutines can
deadlock it by calling into any method in the Engine.

To prevent this deadlock, we're using an atomic test that will fail fast
any engine operations as soon as the engine has started shutting down.

Signed-off-by: Vicent Marti <vmg@strn.cat>

---

This is a potential fix for https://github.com/vitessio/vitess/issues/8909, which is proving itself really hard to reproduce.

cc @derekperkins -- could you please try this in your system and see if the deadlocking stops?
cc @aquarapid @deepthi 

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/8909

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->