### PR TITLE
Respect --allow-zero-in-date in CREATE and in -declarative migrations

### DIFF
--- a/go/test/endtoend/onlineddl/declarative/onlineddl_declarative_test.go
+++ b/go/test/endtoend/onlineddl/declarative/onlineddl_declarative_test.go
@@ -422,10 +422,9 @@ func TestSchemaChange(t *testing.T) {
 		// IF NOT EXISTS is supported in non-declarative mode. Just verifying that the statement itself is good,
 		// so that the failure we tested for, above, actually tests the "declarative" logic, rather than some
 		// unrelated error.
-		uuid := testOnlineDDLStatement(t, createStatementZeroDate, "online --allow-zero-in-date", "vtgate", "")
+		uuid := testOnlineDDLStatement(t, createStatementZeroDate, "online -declarative --allow-zero-in-date", "vtgate", "")
 		uuids = append(uuids, uuid)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
-		// the table existed, so we expect no changes in this non-declarative DDL
 		checkMigratedTable(t, tableName, "create_with_zero")
 		checkTable(t, tableName, true)
 		testSelectTableMetrics(t)

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1748,6 +1748,12 @@ func (e *Executor) evaluateDeclarativeDiff(ctx context.Context, onlineDDL *schem
 		ddlStmt.SetTable("", comparisonTableName)
 		modifiedCreateSQL := sqlparser.String(ddlStmt)
 
+		restoreSQLModeFunc, err := e.initMigrationSQLMode(ctx, onlineDDL, conn)
+		defer restoreSQLModeFunc()
+		if err != nil {
+			return "", err
+		}
+
 		if _, err := conn.ExecuteFetch(modifiedCreateSQL, 0, false); err != nil {
 			return "", err
 		}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -456,6 +456,12 @@ func (e *Executor) executeDirectly(ctx context.Context, onlineDDL *schema.Online
 	}
 	defer conn.Close()
 
+	restoreSQLModeFunc, err := e.initMigrationSQLMode(ctx, onlineDDL, conn)
+	defer restoreSQLModeFunc()
+	if err != nil {
+		return false, err
+	}
+
 	_ = e.onSchemaMigrationStatus(ctx, onlineDDL.UUID, schema.OnlineDDLStatusRunning, false, progressPctStarted, etaSecondsUnknown, rowsCopiedUnknown)
 	_, err = conn.ExecuteFetch(onlineDDL.SQL, 0, false)
 
@@ -716,9 +722,9 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream) er
 	// deferred function will unlock keyspace
 }
 
-// initVreplicationMigrationSQLMode sets sql_mode according to DDL strategy, and returns a function that
+// initMigrationSQLMode sets sql_mode according to DDL strategy, and returns a function that
 // restores sql_mode to original state
-func (e *Executor) initVreplicationMigrationSQLMode(ctx context.Context, onlineDDL *schema.OnlineDDL, conn *dbconnpool.DBConnection) (deferFunc func(), err error) {
+func (e *Executor) initMigrationSQLMode(ctx context.Context, onlineDDL *schema.OnlineDDL, conn *dbconnpool.DBConnection) (deferFunc func(), err error) {
 	deferFunc = func() {}
 	if !onlineDDL.StrategySetting().IsAllowZeroInDateFlag() {
 		// No need to change sql_mode.
@@ -748,7 +754,7 @@ func (e *Executor) initVreplicationMigrationSQLMode(ctx context.Context, onlineD
 }
 
 func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, onlineDDL *schema.OnlineDDL, conn *dbconnpool.DBConnection) (v *VRepl, err error) {
-	restoreSQLModeFunc, err := e.initVreplicationMigrationSQLMode(ctx, onlineDDL, conn)
+	restoreSQLModeFunc, err := e.initMigrationSQLMode(ctx, onlineDDL, conn)
 	defer restoreSQLModeFunc()
 	if err != nil {
 		return v, err
@@ -779,7 +785,7 @@ func (e *Executor) initVreplicationOriginalMigration(ctx context.Context, online
 // about the two, and about the transition between the two.
 func (e *Executor) postInitVreplicationOriginalMigration(ctx context.Context, onlineDDL *schema.OnlineDDL, v *VRepl, conn *dbconnpool.DBConnection) (err error) {
 	if v.sourceAutoIncrement > 0 && !v.parser.IsAutoIncrementDefined() {
-		restoreSQLModeFunc, err := e.initVreplicationMigrationSQLMode(ctx, onlineDDL, conn)
+		restoreSQLModeFunc, err := e.initMigrationSQLMode(ctx, onlineDDL, conn)
 		defer restoreSQLModeFunc()
 		if err != nil {
 			return err


### PR DESCRIPTION
Followup to #9089 

This PR respects `--allow-zero-in-date` for `ddl_strategy` in the following:

- Any `CREATE TABLE` statement, whether online or not
- Any `-declarative` migration, whether it turns out to be an actual `CREATE TABLE` or an `ALTER TABLE`.

I believe this completes and covers all cases for `--allow-zero-in-date`.

`endtoend` tests added for validation.

Documentation PR to follow.

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->