### PR TITLE
[mockgen] update generator directives and regenerate

### DIFF
--- a/go/vt/vttablet/tabletserver/txthrottler/mock_healthcheck_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_healthcheck_test.go
@@ -14,121 +14,139 @@ import (
 	queryservice "vitess.io/vitess/go/vt/vttablet/queryservice"
 )
 
-// MockHealthCheck is a mock of LegacyHealthCheck interface
+// MockHealthCheck is a mock of LegacyHealthCheck interface.
 type MockHealthCheck struct {
 	ctrl     *gomock.Controller
 	recorder *MockHealthCheckMockRecorder
 }
 
-// MockHealthCheckMockRecorder is the mock recorder for MockHealthCheck
+// MockHealthCheckMockRecorder is the mock recorder for MockHealthCheck.
 type MockHealthCheckMockRecorder struct {
 	mock *MockHealthCheck
 }
 
-// NewMockHealthCheck creates a new mock instance
+// NewMockHealthCheck creates a new mock instance.
 func NewMockHealthCheck(ctrl *gomock.Controller) *MockHealthCheck {
 	mock := &MockHealthCheck{ctrl: ctrl}
 	mock.recorder = &MockHealthCheckMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHealthCheck) EXPECT() *MockHealthCheckMockRecorder {
 	return m.recorder
 }
 
-// AddTablet mocks base method
+// AddTablet mocks base method.
 func (m *MockHealthCheck) AddTablet(arg0 *topodata.Tablet, arg1 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddTablet", arg0, arg1)
 }
 
-// AddTablet indicates an expected call of AddTablet
+// AddTablet indicates an expected call of AddTablet.
 func (mr *MockHealthCheckMockRecorder) AddTablet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTablet", reflect.TypeOf((*MockHealthCheck)(nil).AddTablet), arg0, arg1)
 }
 
-// CacheStatus mocks base method
+// CacheStatus mocks base method.
 func (m *MockHealthCheck) CacheStatus() discovery.LegacyTabletsCacheStatusList {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CacheStatus")
 	ret0, _ := ret[0].(discovery.LegacyTabletsCacheStatusList)
 	return ret0
 }
 
-// CacheStatus indicates an expected call of CacheStatus
+// CacheStatus indicates an expected call of CacheStatus.
 func (mr *MockHealthCheckMockRecorder) CacheStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheStatus", reflect.TypeOf((*MockHealthCheck)(nil).CacheStatus))
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockHealthCheck) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockHealthCheckMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHealthCheck)(nil).Close))
 }
 
-// GetConnection mocks base method
+// GetConnection mocks base method.
 func (m *MockHealthCheck) GetConnection(arg0 string) queryservice.QueryService {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnection", arg0)
 	ret0, _ := ret[0].(queryservice.QueryService)
 	return ret0
 }
 
-// GetConnection indicates an expected call of GetConnection
+// GetConnection indicates an expected call of GetConnection.
 func (mr *MockHealthCheckMockRecorder) GetConnection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnection", reflect.TypeOf((*MockHealthCheck)(nil).GetConnection), arg0)
 }
 
-// RegisterStats mocks base method
+// RegisterStats mocks base method.
 func (m *MockHealthCheck) RegisterStats() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RegisterStats")
 }
 
-// RegisterStats indicates an expected call of RegisterStats
+// RegisterStats indicates an expected call of RegisterStats.
 func (mr *MockHealthCheckMockRecorder) RegisterStats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterStats", reflect.TypeOf((*MockHealthCheck)(nil).RegisterStats))
 }
 
-// RemoveTablet mocks base method
+// RemoveTablet mocks base method.
 func (m *MockHealthCheck) RemoveTablet(arg0 *topodata.Tablet) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RemoveTablet", arg0)
 }
 
-// RemoveTablet indicates an expected call of RemoveTablet
+// RemoveTablet indicates an expected call of RemoveTablet.
 func (mr *MockHealthCheckMockRecorder) RemoveTablet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTablet", reflect.TypeOf((*MockHealthCheck)(nil).RemoveTablet), arg0)
 }
 
-// ReplaceTablet mocks base method
+// ReplaceTablet mocks base method.
 func (m *MockHealthCheck) ReplaceTablet(arg0, arg1 *topodata.Tablet, arg2 string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReplaceTablet", arg0, arg1, arg2)
 }
 
-// ReplaceTablet indicates an expected call of ReplaceTablet
+// ReplaceTablet indicates an expected call of ReplaceTablet.
 func (mr *MockHealthCheckMockRecorder) ReplaceTablet(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTablet", reflect.TypeOf((*MockHealthCheck)(nil).ReplaceTablet), arg0, arg1, arg2)
 }
 
-// SetListener mocks base method
+// SetListener mocks base method.
 func (m *MockHealthCheck) SetListener(arg0 discovery.LegacyHealthCheckStatsListener, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetListener", arg0, arg1)
 }
 
-// SetListener indicates an expected call of SetListener
+// SetListener indicates an expected call of SetListener.
 func (mr *MockHealthCheckMockRecorder) SetListener(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetListener", reflect.TypeOf((*MockHealthCheck)(nil).SetListener), arg0, arg1)
 }
 
-// WaitForInitialStatsUpdates mocks base method
+// WaitForInitialStatsUpdates mocks base method.
 func (m *MockHealthCheck) WaitForInitialStatsUpdates() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WaitForInitialStatsUpdates")
 }
 
-// WaitForInitialStatsUpdates indicates an expected call of WaitForInitialStatsUpdates
+// WaitForInitialStatsUpdates indicates an expected call of WaitForInitialStatsUpdates.
 func (mr *MockHealthCheckMockRecorder) WaitForInitialStatsUpdates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInitialStatsUpdates", reflect.TypeOf((*MockHealthCheck)(nil).WaitForInitialStatsUpdates))
 }

--- a/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_throttler_test.go
@@ -14,123 +14,141 @@ import (
 	throttlerdata "vitess.io/vitess/go/vt/proto/throttlerdata"
 )
 
-// MockThrottlerInterface is a mock of ThrottlerInterface interface
+// MockThrottlerInterface is a mock of ThrottlerInterface interface.
 type MockThrottlerInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockThrottlerInterfaceMockRecorder
 }
 
-// MockThrottlerInterfaceMockRecorder is the mock recorder for MockThrottlerInterface
+// MockThrottlerInterfaceMockRecorder is the mock recorder for MockThrottlerInterface.
 type MockThrottlerInterfaceMockRecorder struct {
 	mock *MockThrottlerInterface
 }
 
-// NewMockThrottlerInterface creates a new mock instance
+// NewMockThrottlerInterface creates a new mock instance.
 func NewMockThrottlerInterface(ctrl *gomock.Controller) *MockThrottlerInterface {
 	mock := &MockThrottlerInterface{ctrl: ctrl}
 	mock.recorder = &MockThrottlerInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockThrottlerInterface) EXPECT() *MockThrottlerInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockThrottlerInterface) Close() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockThrottlerInterfaceMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockThrottlerInterface)(nil).Close))
 }
 
-// GetConfiguration mocks base method
+// GetConfiguration mocks base method.
 func (m *MockThrottlerInterface) GetConfiguration() *throttlerdata.Configuration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfiguration")
 	ret0, _ := ret[0].(*throttlerdata.Configuration)
 	return ret0
 }
 
-// GetConfiguration indicates an expected call of GetConfiguration
+// GetConfiguration indicates an expected call of GetConfiguration.
 func (mr *MockThrottlerInterfaceMockRecorder) GetConfiguration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockThrottlerInterface)(nil).GetConfiguration))
 }
 
-// MaxRate mocks base method
+// MaxRate mocks base method.
 func (m *MockThrottlerInterface) MaxRate() int64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaxRate")
 	ret0, _ := ret[0].(int64)
 	return ret0
 }
 
-// MaxRate indicates an expected call of MaxRate
+// MaxRate indicates an expected call of MaxRate.
 func (mr *MockThrottlerInterfaceMockRecorder) MaxRate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxRate", reflect.TypeOf((*MockThrottlerInterface)(nil).MaxRate))
 }
 
-// RecordReplicationLag mocks base method
+// RecordReplicationLag mocks base method.
 func (m *MockThrottlerInterface) RecordReplicationLag(arg0 time.Time, arg1 *discovery.LegacyTabletStats) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RecordReplicationLag", arg0, arg1)
 }
 
-// RecordReplicationLag indicates an expected call of RecordReplicationLag
+// RecordReplicationLag indicates an expected call of RecordReplicationLag.
 func (mr *MockThrottlerInterfaceMockRecorder) RecordReplicationLag(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordReplicationLag", reflect.TypeOf((*MockThrottlerInterface)(nil).RecordReplicationLag), arg0, arg1)
 }
 
-// ResetConfiguration mocks base method
+// ResetConfiguration mocks base method.
 func (m *MockThrottlerInterface) ResetConfiguration() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetConfiguration")
 }
 
-// ResetConfiguration indicates an expected call of ResetConfiguration
+// ResetConfiguration indicates an expected call of ResetConfiguration.
 func (mr *MockThrottlerInterfaceMockRecorder) ResetConfiguration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetConfiguration", reflect.TypeOf((*MockThrottlerInterface)(nil).ResetConfiguration))
 }
 
-// SetMaxRate mocks base method
+// SetMaxRate mocks base method.
 func (m *MockThrottlerInterface) SetMaxRate(arg0 int64) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMaxRate", arg0)
 }
 
-// SetMaxRate indicates an expected call of SetMaxRate
+// SetMaxRate indicates an expected call of SetMaxRate.
 func (mr *MockThrottlerInterfaceMockRecorder) SetMaxRate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxRate", reflect.TypeOf((*MockThrottlerInterface)(nil).SetMaxRate), arg0)
 }
 
-// ThreadFinished mocks base method
+// ThreadFinished mocks base method.
 func (m *MockThrottlerInterface) ThreadFinished(arg0 int) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ThreadFinished", arg0)
 }
 
-// ThreadFinished indicates an expected call of ThreadFinished
+// ThreadFinished indicates an expected call of ThreadFinished.
 func (mr *MockThrottlerInterfaceMockRecorder) ThreadFinished(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThreadFinished", reflect.TypeOf((*MockThrottlerInterface)(nil).ThreadFinished), arg0)
 }
 
-// Throttle mocks base method
+// Throttle mocks base method.
 func (m *MockThrottlerInterface) Throttle(arg0 int) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Throttle", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
-// Throttle indicates an expected call of Throttle
+// Throttle indicates an expected call of Throttle.
 func (mr *MockThrottlerInterfaceMockRecorder) Throttle(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Throttle", reflect.TypeOf((*MockThrottlerInterface)(nil).Throttle), arg0)
 }
 
-// UpdateConfiguration mocks base method
+// UpdateConfiguration mocks base method.
 func (m *MockThrottlerInterface) UpdateConfiguration(arg0 *throttlerdata.Configuration, arg1 bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateConfiguration", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateConfiguration indicates an expected call of UpdateConfiguration
+// UpdateConfiguration indicates an expected call of UpdateConfiguration.
 func (mr *MockThrottlerInterfaceMockRecorder) UpdateConfiguration(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfiguration", reflect.TypeOf((*MockThrottlerInterface)(nil).UpdateConfiguration), arg0, arg1)
 }

--- a/go/vt/vttablet/tabletserver/txthrottler/mock_topology_watcher_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_topology_watcher_test.go
@@ -10,47 +10,51 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockTopologyWatcherInterface is a mock of TopologyWatcherInterface interface
+// MockTopologyWatcherInterface is a mock of TopologyWatcherInterface interface.
 type MockTopologyWatcherInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockTopologyWatcherInterfaceMockRecorder
 }
 
-// MockTopologyWatcherInterfaceMockRecorder is the mock recorder for MockTopologyWatcherInterface
+// MockTopologyWatcherInterfaceMockRecorder is the mock recorder for MockTopologyWatcherInterface.
 type MockTopologyWatcherInterfaceMockRecorder struct {
 	mock *MockTopologyWatcherInterface
 }
 
-// NewMockTopologyWatcherInterface creates a new mock instance
+// NewMockTopologyWatcherInterface creates a new mock instance.
 func NewMockTopologyWatcherInterface(ctrl *gomock.Controller) *MockTopologyWatcherInterface {
 	mock := &MockTopologyWatcherInterface{ctrl: ctrl}
 	mock.recorder = &MockTopologyWatcherInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTopologyWatcherInterface) EXPECT() *MockTopologyWatcherInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockTopologyWatcherInterface) Stop() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Stop")
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockTopologyWatcherInterfaceMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockTopologyWatcherInterface)(nil).Stop))
 }
 
-// WaitForInitialTopology mocks base method
+// WaitForInitialTopology mocks base method.
 func (m *MockTopologyWatcherInterface) WaitForInitialTopology() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForInitialTopology")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WaitForInitialTopology indicates an expected call of WaitForInitialTopology
+// WaitForInitialTopology indicates an expected call of WaitForInitialTopology.
 func (mr *MockTopologyWatcherInterfaceMockRecorder) WaitForInitialTopology() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInitialTopology", reflect.TypeOf((*MockTopologyWatcherInterface)(nil).WaitForInitialTopology))
 }

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package txthrottler
 
 // Commands to generate the mocks for this test.
-//go:generate mockgen -destination mock_healthcheck_test.go -package txthrottler vitess.io/vitess/go/vt/discovery LegacyHealthCheck
+//go:generate mockgen -destination mock_healthcheck_test.go -package txthrottler -mock_names "LegacyHealthCheck=MockHealthCheck" vitess.io/vitess/go/vt/discovery LegacyHealthCheck
 //go:generate mockgen -destination mock_throttler_test.go -package txthrottler vitess.io/vitess/go/vt/vttablet/tabletserver/txthrottler ThrottlerInterface
 //go:generate mockgen -destination mock_topology_watcher_test.go -package txthrottler vitess.io/vitess/go/vt/vttablet/tabletserver/txthrottler TopologyWatcherInterface
 

--- a/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
+++ b/go/vt/workflow/resharding/mock_resharding_wrangler_test.go
@@ -5,71 +5,76 @@
 package resharding
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
-
-	context "context"
 
 	gomock "github.com/golang/mock/gomock"
 
 	topodata "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-// MockReshardingWrangler is a mock of Wrangler interface from resharding_wrangler.go
+// MockReshardingWrangler is a mock of Wrangler interface.
 type MockReshardingWrangler struct {
 	ctrl     *gomock.Controller
 	recorder *MockReshardingWranglerMockRecorder
 }
 
-// MockReshardingWranglerMockRecorder is the mock recorder for MockReshardingWrangler
+// MockReshardingWranglerMockRecorder is the mock recorder for MockReshardingWrangler.
 type MockReshardingWranglerMockRecorder struct {
 	mock *MockReshardingWrangler
 }
 
-// NewMockReshardingWrangler creates a new mock instance
+// NewMockReshardingWrangler creates a new mock instance.
 func NewMockReshardingWrangler(ctrl *gomock.Controller) *MockReshardingWrangler {
 	mock := &MockReshardingWrangler{ctrl: ctrl}
 	mock.recorder = &MockReshardingWranglerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReshardingWrangler) EXPECT() *MockReshardingWranglerMockRecorder {
 	return m.recorder
 }
 
-// CopySchemaShardFromShard mocks base method
+// CopySchemaShardFromShard mocks base method.
 func (m *MockReshardingWrangler) CopySchemaShardFromShard(ctx context.Context, tables, excludeTables []string, includeViews bool, sourceKeyspace, sourceShard, destKeyspace, destShard string, waitReplicasTimeout time.Duration, skipVerify bool) error {
-	ret := m.ctrl.Call(m, "CopySchemaShardFromShard", ctx, tables, excludeTables, includeViews, sourceKeyspace, sourceShard, destKeyspace, destShard, waitReplicasTimeout, false)
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopySchemaShardFromShard", ctx, tables, excludeTables, includeViews, sourceKeyspace, sourceShard, destKeyspace, destShard, waitReplicasTimeout, skipVerify)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CopySchemaShardFromShard indicates an expected call of CopySchemaShardFromShard
-func (mr *MockReshardingWranglerMockRecorder) CopySchemaShardFromShard(ctx, tables, excludeTables, includeViews, sourceKeyspace, sourceShard, destKeyspace, destShard, waitReplicasTimeout interface{}, skipVerify bool) *gomock.Call {
+// CopySchemaShardFromShard indicates an expected call of CopySchemaShardFromShard.
+func (mr *MockReshardingWranglerMockRecorder) CopySchemaShardFromShard(ctx, tables, excludeTables, includeViews, sourceKeyspace, sourceShard, destKeyspace, destShard, waitReplicasTimeout, skipVerify interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySchemaShardFromShard", reflect.TypeOf((*MockReshardingWrangler)(nil).CopySchemaShardFromShard), ctx, tables, excludeTables, includeViews, sourceKeyspace, sourceShard, destKeyspace, destShard, waitReplicasTimeout, skipVerify)
 }
 
-// WaitForFilteredReplication mocks base method
-func (m *MockReshardingWrangler) WaitForFilteredReplication(ctx context.Context, keyspace, shard string, maxDelay time.Duration) error {
-	ret := m.ctrl.Call(m, "WaitForFilteredReplication", ctx, keyspace, shard, maxDelay)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WaitForFilteredReplication indicates an expected call of WaitForFilteredReplication
-func (mr *MockReshardingWranglerMockRecorder) WaitForFilteredReplication(ctx, keyspace, shard, maxDelay interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFilteredReplication", reflect.TypeOf((*MockReshardingWrangler)(nil).WaitForFilteredReplication), ctx, keyspace, shard, maxDelay)
-}
-
-// MigrateServedTypes mocks base method
+// MigrateServedTypes mocks base method.
 func (m *MockReshardingWrangler) MigrateServedTypes(ctx context.Context, keyspace, shard string, cells []string, servedType topodata.TabletType, reverse, skipReFreshState bool, filteredReplicationWaitTime time.Duration, reverseReplication bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateServedTypes", ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// MigrateServedTypes indicates an expected call of MigrateServedTypes
+// MigrateServedTypes indicates an expected call of MigrateServedTypes.
 func (mr *MockReshardingWranglerMockRecorder) MigrateServedTypes(ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateServedTypes", reflect.TypeOf((*MockReshardingWrangler)(nil).MigrateServedTypes), ctx, keyspace, shard, cells, servedType, reverse, skipReFreshState, filteredReplicationWaitTime, reverseReplication)
+}
+
+// WaitForFilteredReplication mocks base method.
+func (m *MockReshardingWrangler) WaitForFilteredReplication(ctx context.Context, keyspace, shard string, maxDelay time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForFilteredReplication", ctx, keyspace, shard, maxDelay)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForFilteredReplication indicates an expected call of WaitForFilteredReplication.
+func (mr *MockReshardingWranglerMockRecorder) WaitForFilteredReplication(ctx, keyspace, shard, maxDelay interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForFilteredReplication", reflect.TypeOf((*MockReshardingWrangler)(nil).WaitForFilteredReplication), ctx, keyspace, shard, maxDelay)
 }

--- a/go/vt/workflow/resharding/resharding_wrangler.go
+++ b/go/vt/workflow/resharding/resharding_wrangler.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Command to generate a mock for this interface with mockgen.
-//go:generate mockgen -source resharding_wrangler.go -destination mock_resharding_wrangler_test.go -package resharding
+//go:generate mockgen -source resharding_wrangler.go -destination mock_resharding_wrangler_test.go -package resharding -mock_names "Wrangler=MockReshardingWrangler"
 
 package resharding
 


### PR DESCRIPTION
## Description

This updates our `go:generate` directives to work with the version of mockgen we upgraded to in May, and then runs the generators, which produced some mostly comment-only diffs.

## Related Issue(s)

Follow-up tasks: https://github.com/vitessio/vitess/issues/9148


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **no**
- [x] Documentation was added or is not required **no**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->