### PR TITLE
Fixes TypeError for vtorc cluster UI

### DIFF
--- a/web/orchestrator/public/js/cluster.js
+++ b/web/orchestrator/public/js/cluster.js
@@ -1632,12 +1632,10 @@ function Cluster() {
     instances.forEach(function(instance) {
       if (instance.isMaster) {
         getData("/api/recently-active-instance-recovery/" + instance.Key.Hostname + "/" + instance.Key.Port, function(recoveries) {
-          if (!recoveries) {
-            return
-          }
-          // Result is an array: either empty (no active recovery) or with multiple entries
-          var recoveryEntry = recoveries[0];
-          addInfo('<strong>' + instance.title + '</strong> has just recently (' + recoveryEntry.RecoveryEndTimestamp + ') been promoted as result of <strong>' + recoveryEntry.AnalysisEntry.Analysis + '</strong>. It may still take some time to rebuild topology graph.');
+          // Result is undefined or an array: either empty (no active recovery) or with multiple entries
+          (recoveries || []).slice(0,1).forEach(function(recoveryEntry) {
+            addInfo('<strong>' + instance.title + '</strong> has just recently (' + recoveryEntry.RecoveryEndTimestamp + ') been promoted as result of <strong>' + recoveryEntry.AnalysisEntry.Analysis + '</strong>. It may still take some time to rebuild topology graph.');
+          });
         });
       }
     });
@@ -1723,12 +1721,10 @@ function Cluster() {
       });
     });
     getData("/api/recently-active-cluster-recovery/" + currentClusterName(), function(recoveries) {
-      if (!recoveries) {
-        return
-      }
-      // Result is an array: either empty (no active recovery) or with multiple entries
-      var recoveryEntry = recoveries[0]
-      addInfo('This cluster just recently (' + recoveryEntry.RecoveryEndTimestamp + ') recovered from <strong><a href="' + appUrl('/web/audit-recovery/cluster/' + currentClusterName()) + '">' + recoveryEntry.AnalysisEntry.Analysis + '</strong></a>. It may still take some time to rebuild topology graph.');
+      // Result is undefined or an array: either empty (no active recovery) or with multiple entries
+      (recoveries || []).slice(0,1).forEach(function(recoveryEntry) {
+        addInfo('This cluster just recently (' + recoveryEntry.RecoveryEndTimestamp + ') recovered from <strong><a href="' + appUrl('/web/audit-recovery/cluster/' + currentClusterName()) + '">' + recoveryEntry.AnalysisEntry.Analysis + '</strong></a>. It may still take some time to rebuild topology graph.');
+      });
     });
     getData("/api/blocked-recoveries/cluster/" + currentClusterName(), function(blockedRecoveries) {
       // Result is an array: either empty (no active recovery) or with multiple entries


### PR DESCRIPTION
## Description

Loading a cluster UI without previous recoveries, or from a recently
restarted vtorc process using a memory database, the topology appeared
incomplete due to missing instances.

When the /api/recently-active-instance-recovery returns `[]`, the first
value is undefined.

Fixes:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'RecoveryEndTimestamp')
```

## Design decisions

 * `(recoveries || [])` was chosen to communicate the expected types, matching the existing comment.
 * `forEach()` was chosen to match the surrounding `addInfo()` calls from other recovery displays
 * `slice(0,1)` was chosen to take one of the available recent recoveries.

An alternative would be to change the guard:

```js
if (!recoveries || recoveries.length == 0) {
  return
}
```

I'm happy to contribute either approach.

## Related Issue(s)

This also appears in the upstream: https://github.com/openark/orchestrator/blob/master/resources/public/js/cluster.js#L1770-L1775