### PR TITLE
Fix race condition when rapidly starting/stopping health check

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -279,7 +279,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 	var topoWatchers []*TopologyWatcher
 	var filter TabletFilter
 	cells := strings.Split(cellsToWatch, ",")
-	if len(cells) == 0 {
+	if cellsToWatch == "" {
 		cells = append(cells, localCell)
 	}
 	for _, c := range cells {
@@ -310,7 +310,7 @@ func NewHealthCheck(ctx context.Context, retryDelay, healthCheckTimeout time.Dur
 
 	// start the topo watches here
 	for _, tw := range hc.topoWatchers {
-		go tw.Start()
+		tw.Start()
 	}
 
 	return hc

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -125,17 +125,19 @@ func NewCellTabletsWatcher(ctx context.Context, topoServer *topo.Server, tr Tabl
 // Start starts the topology watcher
 func (tw *TopologyWatcher) Start() {
 	tw.wg.Add(1)
-	defer tw.wg.Done()
-	ticker := time.NewTicker(tw.refreshInterval)
-	defer ticker.Stop()
-	for {
-		tw.loadTablets()
-		select {
-		case <-tw.ctx.Done():
-			return
-		case <-ticker.C:
+	go func() {
+		defer tw.wg.Done()
+		ticker := time.NewTicker(tw.refreshInterval)
+		defer ticker.Stop()
+		for {
+			tw.loadTablets()
+			select {
+			case <-tw.ctx.Done():
+				return
+			case <-ticker.C:
+			}
 		}
-	}
+	}()
 }
 
 // Stop stops the watcher. It does not clean up the tablets added to LegacyTabletRecorder.

--- a/go/vt/vtgate/tabletgateway_test.go
+++ b/go/vt/vtgate/tabletgateway_test.go
@@ -104,7 +104,8 @@ func TestTabletGatewayBeginExecuteBatch(t *testing.T) {
 }
 
 func TestTabletGatewayShuffleTablets(t *testing.T) {
-	tg := NewTabletGateway(context.Background(), nil, nil, "local")
+	hc := discovery.NewFakeHealthCheck(nil)
+	tg := NewTabletGateway(context.Background(), hc, nil, "local")
 
 	ts1 := &discovery.TabletHealth{
 		Tablet:  topo.NewTablet(1, "cell1", "host1"),


### PR DESCRIPTION
## Description
There's an interesting race condition when starting/stopping a healthcheck.
1. Create `NewHealthCheck`
2. `NewHealthCheck` spawns topo-watchers in goroutines
3. `hc.Close()` is called
4. `Stop()` is called on the topo-watchers
5. The topo-watcher cancels the ctx and calls `Wait()` on the wait-group. The `Wait()` returns immediately, because the `Start()` goroutine hasn't even started yet. So nothing was ever added to the wait-group.
6. You close the topo-srv, which should be safe, because the health-check has already been closed
7. The `Start()` goroutine now fires, which calls `tw.loadTablets()` (before even checking ctx!). This will NPE because the topo-srv has already been closed.

I actually managed to reproduce this with a test.

There's another potential fix here:
- Move `loadTablets` under `case <-ticker.C`. Note that [`cancelFunc` is called before `Wait()`](https://github.com/vitessio/vitess/blob/f085f12b1cd38a9bcf907604a747af308e93c4fd/go/vt/discovery/topology_watcher.go#L142-L146). When `Stop()` is called, if we've already added to the wait-group, than `wg.Wait()` will make sure the goroutine actually exits. If we _haven't_ yet added to the wait-group, `tw.ctx.Done()` will fire before `ticker.C`, and again, we won't load tablets.


The last, unrelated fix I made is to check if the cell to watch is `""`. Splitting empty string cannot yield length 0: https://play.golang.org/p/5mKKN9TkMh5, so that check was not doing anything.

Lastly, I validated there were no other call-sites of `Start()` that we'd have to get rid of `go` in front:
```
rg 'go .*\.Start()'
```

## Related Issue(s)
- N/A

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
N/A