### PR TITLE
Topo write error in change tablet type

### DIFF
--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package faketopo
+
+import (
+	"context"
+
+	"vitess.io/vitess/go/vt/topo"
+)
+
+// FakeFactory implements the Factory interface. This is supposed to be used only for testing
+type FakeFactory struct {
+}
+
+var _ topo.Factory = (*FakeFactory)(nil)
+
+// HasGlobalReadOnlyCell implements the Factory interface
+func (f FakeFactory) HasGlobalReadOnlyCell(serverAddr, root string) bool {
+	return false
+}
+
+// Create implements the Factory interface
+// It creates a fake connection which is supposed to be used only for testing
+func (f FakeFactory) Create(cell, serverAddr, root string) (topo.Conn, error) {
+	panic("implement me")
+}
+
+// FakeConn implements the Conn interface. It is used only for testing
+type FakeConn struct {
+}
+
+var _ topo.Conn = (*FakeConn)(nil)
+
+// ListDir implements the Conn interface
+func (f *FakeConn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
+	panic("implement me")
+}
+
+// Create implements the Conn interface
+func (f *FakeConn) Create(ctx context.Context, filePath string, contents []byte) (topo.Version, error) {
+	panic("implement me")
+}
+
+// Update implements the Conn interface
+func (f *FakeConn) Update(ctx context.Context, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
+	panic("implement me")
+}
+
+// Get implements the Conn interface
+func (f *FakeConn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
+	panic("implement me")
+}
+
+// Delete implements the Conn interface
+func (f *FakeConn) Delete(ctx context.Context, filePath string, version topo.Version) error {
+	panic("implement me")
+}
+
+// Lock implements the Conn interface
+func (f *FakeConn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
+	panic("implement me")
+}
+
+// Watch implements the Conn interface
+func (f *FakeConn) Watch(ctx context.Context, filePath string) (current *topo.WatchData, changes <-chan *topo.WatchData, cancel topo.CancelFunc) {
+	panic("implement me")
+}
+
+// NewMasterParticipation implements the Conn interface
+func (f *FakeConn) NewMasterParticipation(name, id string) (topo.MasterParticipation, error) {
+	panic("implement me")
+}
+
+// Close implements the Conn interface
+func (f *FakeConn) Close() {
+	panic("implement me")
+}
+
+func NewFakeTopoServer() *topo.Server {
+	factory := &FakeFactory{}
+	server, _ := topo.NewWithFactory(factory, "" /*serverAddress*/, "" /*root*/)
+	return server
+}

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -282,7 +282,7 @@ func (f *FakeConn) Watch(ctx context.Context, filePath string) (*topo.WatchData,
 		for i, watch := range watches {
 			if notifications == watch {
 				close(notifications)
-				watches = append(watches[0:i], watches[i+1:]...)
+				f.watches[filePath] = append(watches[0:i], watches[i+1:]...)
 				break
 			}
 		}

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -144,9 +144,25 @@ func (f *FakeConn) Delete(ctx context.Context, filePath string, version topo.Ver
 	panic("implement me")
 }
 
+// fakeLockDescriptor implements the topo.LockDescriptor interface
+type fakeLockDescriptor struct {
+}
+
+// Check implements the topo.LockDescriptor interface
+func (f fakeLockDescriptor) Check(ctx context.Context) error {
+	return nil
+}
+
+// Unlock implements the topo.LockDescriptor interface
+func (f fakeLockDescriptor) Unlock(ctx context.Context) error {
+	return nil
+}
+
+var _ topo.LockDescriptor = (*fakeLockDescriptor)(nil)
+
 // Lock implements the Conn interface
 func (f *FakeConn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
-	panic("implement me")
+	return &fakeLockDescriptor{}, nil
 }
 
 // Watch implements the Conn interface

--- a/go/vt/topo/faketopo/faketopo.go
+++ b/go/vt/topo/faketopo/faketopo.go
@@ -18,29 +18,83 @@ package faketopo
 
 import (
 	"context"
+	"sync"
+
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+
+	"vitess.io/vitess/go/vt/log"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 
 	"vitess.io/vitess/go/vt/topo"
 )
 
 // FakeFactory implements the Factory interface. This is supposed to be used only for testing
 type FakeFactory struct {
+	// mu protects the following field.
+	mu sync.Mutex
+	// cells is the toplevel map that has one entry per cell. It has a list of connections that this fake server will return
+	cells map[string][]*FakeConn
 }
 
 var _ topo.Factory = (*FakeFactory)(nil)
 
+// NewFakeTopoFactory creates a new fake topo factory
+func NewFakeTopoFactory(cells ...string) *FakeFactory {
+	factory := &FakeFactory{
+		mu:    sync.Mutex{},
+		cells: map[string][]*FakeConn{},
+	}
+	for _, cell := range cells {
+		factory.cells[cell] = []*FakeConn{}
+	}
+	factory.cells[topo.GlobalCell] = []*FakeConn{newFakeConnection()}
+	return factory
+}
+
 // HasGlobalReadOnlyCell implements the Factory interface
-func (f FakeFactory) HasGlobalReadOnlyCell(serverAddr, root string) bool {
+func (f *FakeFactory) HasGlobalReadOnlyCell(serverAddr, root string) bool {
 	return false
 }
 
 // Create implements the Factory interface
 // It creates a fake connection which is supposed to be used only for testing
-func (f FakeFactory) Create(cell, serverAddr, root string) (topo.Conn, error) {
-	panic("implement me")
+func (f *FakeFactory) Create(cell, serverAddr, root string) (topo.Conn, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	connections, ok := f.cells[cell]
+	if !ok || len(connections) == 0 {
+		return nil, topo.NewError(topo.NoNode, cell)
+	}
+	// pick the first connection and remove it from the list
+	conn := connections[0]
+	f.cells[cell] = connections[1:]
+
+	conn.serverAddr = serverAddr
+	conn.cell = cell
+	return conn, nil
 }
 
 // FakeConn implements the Conn interface. It is used only for testing
 type FakeConn struct {
+	cell       string
+	serverAddr string
+
+	// getResultMap is a map storing the results for each filepath
+	getResultMap map[string]result
+}
+
+// newFakeConnection creates a new fake connection
+func newFakeConnection() *FakeConn {
+	return &FakeConn{
+		getResultMap: map[string]result{},
+	}
+}
+
+// result keeps track of the fields needed to respond to a Get function call
+type result struct {
+	contents []byte
+	version  uint64
+	err      error
 }
 
 var _ topo.Conn = (*FakeConn)(nil)
@@ -52,17 +106,37 @@ func (f *FakeConn) ListDir(ctx context.Context, dirPath string, full bool) ([]to
 
 // Create implements the Conn interface
 func (f *FakeConn) Create(ctx context.Context, filePath string, contents []byte) (topo.Version, error) {
-	panic("implement me")
+	f.getResultMap[filePath] = result{
+		contents: contents,
+		version:  1,
+		err:      nil,
+	}
+	return memorytopo.NodeVersion(1), nil
 }
 
 // Update implements the Conn interface
 func (f *FakeConn) Update(ctx context.Context, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
-	panic("implement me")
+	if version == nil {
+		_, err := f.Create(ctx, filePath, contents)
+		if err != nil {
+			return nil, err
+		}
+	}
+	res, isPresent := f.getResultMap[filePath]
+	if !isPresent {
+		return nil, topo.NewError(topo.NoNode, filePath)
+	}
+	res.contents = contents
+	return memorytopo.NodeVersion(res.version), res.err
 }
 
 // Get implements the Conn interface
 func (f *FakeConn) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
-	panic("implement me")
+	res, isPresent := f.getResultMap[filePath]
+	if !isPresent {
+		return nil, nil, topo.NewError(topo.NoNode, filePath)
+	}
+	return res.contents, memorytopo.NodeVersion(res.version), res.err
 }
 
 // Delete implements the Conn interface
@@ -90,8 +164,16 @@ func (f *FakeConn) Close() {
 	panic("implement me")
 }
 
-func NewFakeTopoServer() *topo.Server {
-	factory := &FakeFactory{}
-	server, _ := topo.NewWithFactory(factory, "" /*serverAddress*/, "" /*root*/)
-	return server
+// NewFakeTopoServer creates a new fake topo server
+func NewFakeTopoServer(factory *FakeFactory) *topo.Server {
+	ts, err := topo.NewWithFactory(factory, "" /*serverAddress*/, "" /*root*/)
+	if err != nil {
+		log.Exitf("topo.NewWithFactory() failed: %v", err)
+	}
+	for cell := range factory.cells {
+		if err := ts.CreateCellInfo(context.Background(), cell, &topodatapb.CellInfo{}); err != nil {
+			log.Exitf("ts.CreateCellInfo(%v) failed: %v", cell, err)
+		}
+	}
+	return ts
 }

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -181,22 +181,21 @@ func (ts *tmState) ChangeTabletType(ctx context.Context, tabletType topodatapb.T
 		// Update the tablet record first.
 		_, err := topotools.ChangeType(ctx, ts.tm.TopoServer, ts.tm.tabletAlias, tabletType, PrimaryTermStartTime)
 		if err != nil {
-			log.Errorf("error in changing type in tablet record in topo for tablet %s :- %v", topoproto.TabletAliasString(ts.tm.tabletAlias), err)
-			log.Errorf("will keep trying to read from the topo server")
+			log.Errorf("Error changing type in topo record for tablet %s :- %v\nWill keep trying to read from the toposerver", topoproto.TabletAliasString(ts.tm.tabletAlias), err)
 			// In case of a topo error, we aren't sure if the data has been written or not.
 			// We must read the data again and verify whether the previous write succeeded or not.
 			// The only way to guarantee safety is to keep retrying read until we succeed
 			for {
 				ti, errInReading := ts.tm.TopoServer.GetTablet(ctx, ts.tm.tabletAlias)
 				if errInReading != nil {
-					time.Sleep(100 * time.Millisecond)
+					<-time.After(100 * time.Millisecond)
 					continue
 				}
 				if ti.Type == tabletType && proto.Equal(ti.PrimaryTermStartTime, PrimaryTermStartTime) {
-					log.Errorf("read successful. data written to topo-server, continuing operation")
+					log.Infof("Tablet record in toposerver matches, continuing operation")
 					break
 				}
-				log.Errorf("read successful. data not written to topo-server, canceling operation")
+				log.Errorf("Tablet record read from toposerver does not match what we attempted to write, canceling operation")
 				return err
 			}
 		}

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"vitess.io/vitess/go/vt/topo/faketopo"
+
 	"vitess.io/vitess/go/test/utils"
 
 	"vitess.io/vitess/go/vt/key"
@@ -378,6 +380,76 @@ func TestStateChangeTabletType(t *testing.T) {
 	assert.Equal(t, "replica", statsTabletType.Get())
 	assert.Equal(t, 2, len(statsTabletTypeCount.Counts()))
 	assert.Equal(t, int64(2), statsTabletTypeCount.Counts()["replica"])
+}
+
+// TestChangeTypeErrorWhileWritingToTopo tests the case where we fail while writing to the topo-server
+func TestChangeTypeErrorWhileWritingToTopo(t *testing.T) {
+	testcases := []struct {
+		name               string
+		writePersists      bool
+		numberOfReadErrors int
+		expectedTabletType topodatapb.TabletType
+		expectedError      string
+	}{
+		{
+			name:               "Write persists even when error thrown from topo server",
+			writePersists:      true,
+			numberOfReadErrors: 5,
+			expectedTabletType: topodatapb.TabletType_PRIMARY,
+		}, {
+			name:               "Topo server throws error and the write also fails",
+			writePersists:      false,
+			numberOfReadErrors: 17,
+			expectedTabletType: topodatapb.TabletType_REPLICA,
+			expectedError:      "deadline exceeded: tablets/cell1-0000000002/Tablet",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			factory := faketopo.NewFakeTopoFactory()
+			// add cell1 to the factory. Make it so that the fourth call to update fails with an error. This will be the call from ChangeTabletType.
+			factory.AddCell("cell1", getErrorsList(testcase.numberOfReadErrors) /* update errors */, []bool{false, false, false, true} /* write Persists */, []bool{true, true, true, testcase.writePersists})
+			ts := faketopo.NewFakeTopoServer(factory)
+			statsTabletTypeCount.ResetAll()
+			tm := newTestTM(t, ts, 2, "ks", "0")
+			defer tm.Stop()
+
+			ctx := context.Background()
+			err := tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_PRIMARY, DBActionSetReadWrite)
+			if testcase.expectedError != "" {
+				require.EqualError(t, err, testcase.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			alias := &topodatapb.TabletAlias{
+				Cell: "cell1",
+				Uid:  2,
+			}
+			ti, err := ts.GetTablet(ctx, alias)
+			require.NoError(t, err)
+			require.Equal(t, testcase.expectedTabletType, ti.Type)
+
+			// assert that next change type succeeds irrespective of previous failures
+			err = tm.tmState.ChangeTabletType(context.Background(), topodatapb.TabletType_REPLICA, DBActionNone)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// getErrorsList creates an array of getErrors that is passed to the fake topo server.
+// There are initially some number of get requests to pass so that the tablet comes up properly
+// After that we start fail the number of specified requests
+func getErrorsList(readErrors int) []bool {
+	var res []bool
+	for i := 0; i < 9; i++ {
+		res = append(res, false)
+	}
+	for i := 0; i < readErrors; i++ {
+		res = append(res, true)
+	}
+	return res
 }
 
 func TestPublishStateNew(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -409,7 +409,7 @@ func TestChangeTypeErrorWhileWritingToTopo(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			factory := faketopo.NewFakeTopoFactory()
 			// add cell1 to the factory. Make it so that the fourth call to update fails with an error. This will be the call from ChangeTabletType.
-			factory.AddCell("cell1", getErrorsList(testcase.numberOfReadErrors) /* update errors */, []bool{false, false, false, true} /* write Persists */, []bool{true, true, true, testcase.writePersists})
+			factory.AddCell("cell1", getErrorsList(testcase.numberOfReadErrors), []bool{false, false, false, true} /* update errors */, []bool{true, true, true, testcase.writePersists} /* write Persists */)
 			ts := faketopo.NewFakeTopoServer(factory)
 			statsTabletTypeCount.ResetAll()
 			tm := newTestTM(t, ts, 2, "ks", "0")


### PR DESCRIPTION

## Description
Topo write error during TabletManager.ChangeType resulting in actual successful topo write led to a bug where the vttablet did not update its state to reflect the change and did not converge with shard sync.

Consider the case where we try to upgrade a replica to a primary tablet. Before we change the internal state of the tablet, we try to write to the topo server.
Assume that the write succeeds but an error is returned from the topo server. In this case, the tablet does not update its local information and continues to believe it is a replica. All the other tablets and vtgate register this change because of shard-sync and make changes accordingly. 
Since we do not start shard-sync for replica tablets, the tablet does not converge to the correct state. 
We are left in a state where the tablet thinks that it is a replica, but everyone else including the topo think that it is a primary.

This issue is addressed in this PR. After a discussion with @sougou, we converged on the solution to wait indefinitely in case of an error while writing to a topo server, until we are able to read the data from it successfully. If the write was successful, we continue with the operations, if the write wasn't successful, we fail the operation like before.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->