### PR TITLE
OnlineDDL: formalize artifact cleanup time via retain_artifacts_seconds column

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -259,6 +259,13 @@ func TestSchemaChange(t *testing.T) {
 		testMigrationRowCount(t, uuid)
 		onlineddl.CheckCancelMigration(t, &vtParams, shards, uuid, false)
 		onlineddl.CheckRetryMigration(t, &vtParams, shards, uuid, false)
+
+		rs := onlineddl.ReadMigrations(t, &vtParams, uuid)
+		require.NotNil(t, rs)
+		for _, row := range rs.Named().Rows {
+			retainArtifactSeconds := row.AsInt64("retain_artifacts_seconds", 0)
+			assert.Equal(t, 86400, retainArtifactSeconds)
+		}
 	})
 	t.Run("successful online alter, vtctl", func(t *testing.T) {
 		insertRows(t, 2)

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -2894,6 +2894,8 @@ func (e *Executor) SubmitMigration(
 		return nil, err
 	}
 
+	retainArtifactsSeconds := int64((*retainOnlineDDLTables).Seconds())
+
 	query, err := sqlparser.ParseAndBind(sqlInsertMigration,
 		sqltypes.StringBindVariable(onlineDDL.UUID),
 		sqltypes.StringBindVariable(e.keyspace),
@@ -2907,6 +2909,7 @@ func (e *Executor) SubmitMigration(
 		sqltypes.StringBindVariable(onlineDDL.RequestContext),
 		sqltypes.StringBindVariable(string(schema.OnlineDDLStatusQueued)),
 		sqltypes.StringBindVariable(e.TabletAliasString()),
+		sqltypes.Int64BindVariable(retainArtifactsSeconds),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We add the column `retain_artifacts_seconds` to `schema_migrations` table. This will allow us to control, per migration, how long we must retain the artifacts after migration is complete.
In turn, this implies: how long after migration completion are we still able to [revert](https://vitess.io/docs/user-guides/schema-changes/revertible-migrations/) it?

Cleanup now checks the value of `retain_artifacts_seconds`. For backwards compatibility (in-place upgrades of vttablets) the value `0` implies "use the flag `-retainOnlineDDLTables`". Any non-zero value overrides that (e.g. a negative `-1` really means "yes this migration can be cleaned up right now").

In later steps (separate PRs) we can:

- Support a `ALTER VITESS_MIGRATION '<uuid>' CLEANUP` to suggest/request an earlier cleanup than desired
- Allow custom retain time, e.g. as a new flag in `ddl_strategy`

In both cases the effect will be achieved by updating the value of `retain_artifacts_seconds` in the table.


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

