### PR TITLE
Improve self hosted runner docs

### DIFF
--- a/GITHUB_SELF_HOSTED_RUNNERS.md
+++ b/GITHUB_SELF_HOSTED_RUNNERS.md
@@ -34,6 +34,7 @@ You will need access to the self-hosted runner machine to be able to connect to 
 4. From the output of the `Build Docker Image` step find the docker image built for this workflow
 5. On the machine run `docker run -d -v <volume-name>:/vt/vtdataroot <image-name> /bin/bash -c "sleep 600000000000"`
 6. On the terminal copy the docker id of the newly created container
-7. Now execute `docker exec -it <docker-id> /bin/bash`
-8. Use the `/vt/vtdataroot` directory to find the output of the run along with the debug files
-
+7. Now execute `docker exec -it <docker-id> /bin/bash` to go into the container and use the `/vt/vtdataroot` directory to find the output of the run along with the debug files
+8. Alternately, execute `docker cp <docker-id>:/vt/vtdataroot ./debugFiles/` to copy the files from the docker container to the servers local file system
+9. You can browse the files there or go a step further and download them locally via `scp`.
+10. Please remember to cleanup the folders created and remove the docker container via `docker stop <docker-id>`.

--- a/GITHUB_SELF_HOSTED_RUNNERS.md
+++ b/GITHUB_SELF_HOSTED_RUNNERS.md
@@ -28,7 +28,7 @@ access to Vitess.
 
 ### Using a self-hosted runner to debug a flaky test
 You will need access to the self-hosted runner machine to be able to connect to it via SSH.
-1. From the output of the run on GitHub Actions, find the `Machine name`
+1. From the output of the run on GitHub Actions, find the `Machine name` in the `Set up job` step 
 2. Find that machine on the Equinix dashboard and connect to it via ssh
 3. From the output of the `Print Volume Used` step find the volume used
 4. From the output of the `Build Docker Image` step find the docker image built for this workflow


### PR DESCRIPTION

## Description
While using the self hosted runners today to check some flaky tests, I realised that there are a few steps that I am using frequently like copying the files from the docker container to the server and then finally scp them to my local system for ease of use. These steps aren't documented and are really useful for anyone trying to use the self-hosted runners to fix flaky tests.

This PR adds those missing steps and improves the docs for using self-hosted runners.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->