### PR TITLE
Inclusive naming: removing vtctl flags and commands that were deprecated in 12.0

### DIFF
--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get latest Vitess tag
         run: |
-          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n3)
+          last_major_releases=$(git show-ref --tags | grep -E 'refs/tags/v[0-9]*.[0-9]*.0$' | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
           last_major_release_nb=$(echo "$last_major_releases" | head -n1 | sed 's/.[0-9]*.[0-9]*$//')
           last_minor_release=$(git show-ref --tags | grep -E "refs/tags/v$last_major_release_nb.[0-9]*.[1-9]*$" | sed 's/[a-z0-9]* refs\/tags\/v//' | sort -nr | head -n1)
           major_and_minor_releases=$last_major_releases

--- a/examples/legacy_local/101_initial_cluster.sh
+++ b/examples/legacy_local/101_initial_cluster.sh
@@ -38,7 +38,7 @@ for i in 100 101 102; do
 done
 
 # set one of the replicas to primary
-vtctlclient -server localhost:15999 InitShardMaster -force commerce/0 zone1-100
+vtctlclient -server localhost:15999 InitShardPrimary -force commerce/0 zone1-100
 
 # create the schema
 vtctlclient -server localhost:15999 ApplySchema -sql-file create_commerce_schema.sql commerce

--- a/examples/legacy_local/202_customer_tablets.sh
+++ b/examples/legacy_local/202_customer_tablets.sh
@@ -25,7 +25,7 @@ for i in 200 201 202; do
  CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctlclient -server localhost:15999 InitShardMaster -force customer/0 zone1-200
+vtctlclient -server localhost:15999 InitShardPrimary -force customer/0 zone1-200
 vtctlclient -server localhost:15999 CopySchemaShard -tables customer,corder commerce/0 customer/0
 vtctlclient -server localhost:15999 ApplyVSchema -vschema_file vschema_commerce_vsplit.json commerce
 vtctlclient -server localhost:15999 ApplyVSchema -vschema_file vschema_customer_vsplit.json customer

--- a/examples/legacy_local/302_new_shards.sh
+++ b/examples/legacy_local/302_new_shards.sh
@@ -29,7 +29,7 @@ for i in 400 401 402; do
  SHARD=80- CELL=zone1 KEYSPACE=customer TABLET_UID=$i ./scripts/vttablet-up.sh
 done
 
-vtctlclient -server localhost:15999 InitShardMaster -force customer/-80 zone1-300
-vtctlclient -server localhost:15999 InitShardMaster -force customer/80- zone1-400
+vtctlclient -server localhost:15999 InitShardPrimary -force customer/-80 zone1-300
+vtctlclient -server localhost:15999 InitShardPrimary -force customer/80- zone1-400
 vtctlclient -server localhost:15999 CopySchemaShard customer/0 customer/-80
 vtctlclient -server localhost:15999 CopySchemaShard customer/0 customer/80-

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -267,10 +267,7 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 				Alias:     fmt.Sprintf("%s-%010d", cluster.Cell, tabletUID),
 			}
 			if i == 0 { // Make the first one as primary
-				// version_upgrade test depends on using older binaries
-				// which means we cannot use the new PRIMARY tabletType here
-				// TODO(deepthi): fix after v12.0
-				tablet.Type = "master"
+				tablet.Type = "primary"
 			} else if i == totalTabletsRequired-1 && rdonly { // Make the last one as rdonly if rdonly flag is passed
 				tablet.Type = "rdonly"
 			}

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -44,16 +44,13 @@ type VtctlClientParams struct {
 
 // InitShardPrimary executes vtctlclient command to make specified tablet the primary for the shard.
 func (vtctlclient *VtctlClientProcess) InitShardPrimary(Keyspace string, Shard string, Cell string, TabletUID int) (err error) {
-	// version_upgrade test depends on using older binaries
-	// which means we cannot use the new InitShardPrimary command here
-	// TODO(deepthi): fix after v12.0
 	output, err := vtctlclient.ExecuteCommandWithOutput(
-		"InitShardMaster",
+		"InitShardPrimary",
 		"-force", "-wait_replicas_timeout", "31s",
 		fmt.Sprintf("%s/%s", Keyspace, Shard),
 		fmt.Sprintf("%s-%d", Cell, TabletUID))
 	if err != nil {
-		log.Errorf("error in InitShardMaster output %s, err %s", output, err.Error())
+		log.Errorf("error in InitShardPrimary output %s, err %s", output, err.Error())
 	}
 	return err
 }

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -62,9 +62,8 @@ func TestMain(m *testing.M) {
 
 		// Collect tablet paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
-		// TODO(deepthi): can remove master after 12.0
 		for _, tablet := range tablets {
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = *tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = *tablet

--- a/go/test/endtoend/mysqlctld/mysqlctld_test.go
+++ b/go/test/endtoend/mysqlctld/mysqlctld_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 		// Collect tablet paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = tablet

--- a/go/test/endtoend/sharding/base_sharding.go
+++ b/go/test/endtoend/sharding/base_sharding.go
@@ -139,10 +139,6 @@ func CheckBinlogPlayerVars(t *testing.T, vttablet cluster.Vttablet, sourceShards
 	tabletVars := vttablet.VttabletProcess.GetVars()
 
 	assert.Contains(t, tabletVars, "VReplicationStreamCount")
-	// DEPRECATED, can be deleted after v12.0
-	assert.Contains(t, tabletVars, "VReplicationSecondsBehindMasterMax")
-	assert.Contains(t, tabletVars, "VReplicationSecondsBehindMaster")
-
 	assert.Contains(t, tabletVars, "VReplicationLagSecondsMax")
 	assert.Contains(t, tabletVars, "VReplicationLagSeconds")
 	assert.Contains(t, tabletVars, "VReplicationSource")

--- a/go/test/endtoend/sharding/resharding/resharding_base.go
+++ b/go/test/endtoend/sharding/resharding/resharding_base.go
@@ -812,10 +812,9 @@ func TestResharding(t *testing.T, useVarbinaryShardingKeyType bool) {
 	// do a Migrate that will fail waiting for replication
 	// which should cause the Migrate to be canceled and the source
 	// primary to be serving again.
-	// This is the legacy resharding migration command which should work with either primary or master
-	// We will leave this one to test that, all other usages have been replaced with "primary"
+	// This is the legacy resharding migration command
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("MigrateServedTypes",
-		"-filtered_replication_wait_time", "0s", shard1Ks, "master")
+		"-filtered_replication_wait_time", "0s", shard1Ks, "primary")
 	require.Error(t, err)
 
 	expectedPartitions = map[topodata.TabletType][]string{}

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -122,8 +122,7 @@ func TestMain(m *testing.M) {
 		// Collect table paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			// TODO(deepthi): fix after v12.0
-			if tablet.Type == "primary" || tablet.Type == "master" {
+			if tablet.Type == "primary" {
 				primaryTablet = *tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = *tablet

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -108,8 +108,7 @@ func TestMain(m *testing.M) {
 		// Collect table paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			// TODO(deepthi): fix after v12.0
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = *tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = *tablet

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -107,8 +107,7 @@ func TestMain(m *testing.M) {
 		// Collect table paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			// TODO(deepthi): fix after v12.0
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = *tablet
 			}
 		}

--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -118,7 +118,7 @@ func TestMain(m *testing.M) {
 		// Collect table paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = tablet

--- a/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_custom_config/throttler_test.go
@@ -123,7 +123,7 @@ func TestMain(m *testing.M) {
 		// Collect table paths and ports
 		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 		for _, tablet := range tablets {
-			if tablet.Type == "master" || tablet.Type == "primary" {
+			if tablet.Type == "primary" {
 				primaryTablet = tablet
 			} else if tablet.Type != "rdonly" {
 				replicaTablet = tablet

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -60,10 +60,6 @@ import (
 var (
 	hcErrorCounters = stats.NewCountersWithMultiLabels("HealthcheckErrors", "Healthcheck Errors", []string{"Keyspace", "ShardName", "TabletType"})
 
-	// DEPRECATED HealthcheckMasterPromoted in favor of HealthcheckPrimaryPromoted
-	//TODO(rohit) : remove this metric and related parameter in V13
-	hcMasterPromotedCounters = stats.NewCountersWithMultiLabels("HealthcheckMasterPromoted", "Primary promoted in keyspace/shard name because of health check errors", []string{"Keyspace", "ShardName"})
-
 	hcPrimaryPromotedCounters = stats.NewCountersWithMultiLabels("HealthcheckPrimaryPromoted", "Primary promoted in keyspace/shard name because of health check errors", []string{"Keyspace", "ShardName"})
 	healthcheckOnce           sync.Once
 
@@ -481,7 +477,6 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 	isNewPrimary := isPrimary && prevTarget.TabletType != topodata.TabletType_PRIMARY
 	if isNewPrimary {
 		log.Errorf("Adding 1 to PrimaryPromoted counter for target: %v, tablet: %v, tabletType: %v", prevTarget, topoproto.TabletAliasString(th.Tablet.Alias), th.Target.TabletType)
-		hcMasterPromotedCounters.Add([]string{th.Target.Keyspace, th.Target.Shard}, 1)
 		hcPrimaryPromotedCounters.Add([]string{th.Target.Keyspace, th.Target.Shard}, 1)
 	}
 

--- a/go/vt/discovery/legacy_healthcheck.go
+++ b/go/vt/discovery/legacy_healthcheck.go
@@ -501,7 +501,6 @@ func (hc *LegacyHealthCheckImpl) updateHealth(ts *LegacyTabletStats, conn querys
 		// Track how often a tablet gets promoted to primary. It is used for
 		// comparing against the variables in go/vtgate/buffer/variables.go.
 		if oldts.Target.TabletType != topodatapb.TabletType_PRIMARY && ts.Target.TabletType == topodatapb.TabletType_PRIMARY {
-			hcMasterPromotedCounters.Add([]string{ts.Target.Keyspace, ts.Target.Shard}, 1)
 			hcPrimaryPromotedCounters.Add([]string{ts.Target.Keyspace, ts.Target.Shard}, 1)
 		}
 	}

--- a/go/vt/vtctl/backup.go
+++ b/go/vt/vtctl/backup.go
@@ -73,10 +73,6 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	concurrency := subFlags.Int("concurrency", 4, "Specifies the number of compression/checksum jobs to run simultaneously")
 	allowPrimary := subFlags.Bool("allow_primary", false, "Allows backups to be taken on primary. Warning!! If you are using the builtin backup engine, this will shutdown your primary mysql for as long as it takes to create a backup.")
 
-	// handle deprecated flags
-	// should be deleted in a future release
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use -allow_primary instead")
-
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -92,9 +88,6 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	if err != nil {
 		return err
 	}
-	if *deprecatedAllowMaster {
-		*allowPrimary = *deprecatedAllowMaster
-	}
 
 	return execBackup(ctx, wr, tabletInfo.Tablet, *concurrency, *allowPrimary)
 }
@@ -102,10 +95,6 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 4, "Specifies the number of compression/checksum jobs to run simultaneously")
 	allowPrimary := subFlags.Bool("allow_primary", false, "Whether to use primary tablet for backup. Warning!! If you are using the builtin backup engine, this will shutdown your primary mysql for as long as it takes to create a backup.")
-
-	// handle deprecated flags
-	// should be deleted in a future release
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use -allow_primary instead")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -165,10 +154,6 @@ func commandBackupShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 
 	if tabletForBackup == nil {
 		return errors.New("no tablet available for backup")
-	}
-
-	if *deprecatedAllowMaster {
-		*allowPrimary = *deprecatedAllowMaster
 	}
 
 	return execBackup(ctx, wr, tabletForBackup, *concurrency, *allowPrimary)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -323,14 +323,6 @@ var commands = []commandGroup{
 				help:   "Add or remove a shard from serving. This is meant as an emergency function. It does not rebuild any serving graph i.e. does not run 'RebuildKeyspaceGraph'.",
 			},
 			{
-				name:         "SetShardIsMasterServing",
-				method:       commandSetShardIsPrimaryServing,
-				params:       "<keyspace/shard> <is_master_serving>",
-				help:         "DEPRECATED. Use SetShardIsPrimaryServing instead.",
-				deprecated:   true,
-				deprecatedBy: "SetShardIsPrimaryServing",
-			},
-			{
 				name:   "SetShardTabletControl",
 				method: commandSetShardTabletControl,
 				params: "[--cells=c1,c2,...] [--denied_tables=t1,t2,...] [--remove] [--disable_query_service] <keyspace/shard> <tablet type>",
@@ -1069,7 +1061,6 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 }
 
 func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	deprecatedAllowMaster := subFlags.Bool("allow_master", false, "DEPRECATED. Use allow_primary instead.")
 	allowPrimary := subFlags.Bool("allow_primary", false, "Allows for the primary tablet of a shard to be deleted. Use with caution.")
 
 	if err := subFlags.Parse(args); err != nil {
@@ -1082,11 +1073,6 @@ func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 	tabletAliases, err := tabletParamsToTabletAliases(subFlags.Args())
 	if err != nil {
 		return err
-	}
-	// deprecated flags
-	// delete in a future release
-	if *deprecatedAllowMaster {
-		allowPrimary = deprecatedAllowMaster
 	}
 	for _, tabletAlias := range tabletAliases {
 		if err := wr.DeleteTablet(ctx, tabletAlias, *allowPrimary); err != nil {
@@ -3139,10 +3125,6 @@ func commandReloadSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFla
 	concurrency := subFlags.Int("concurrency", 10, "How many tablets to reload in parallel")
 	includePrimary := subFlags.Bool("include_primary", true, "Include the primary tablet")
 
-	// handle deprecated flags
-	// should be deleted in a future release
-	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "DEPRECATED. Use -include_primary instead")
-
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -3152,9 +3134,6 @@ func commandReloadSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFla
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
 		return err
-	}
-	if *deprecatedIncludeMaster {
-		includePrimary = deprecatedIncludeMaster
 	}
 	resp, err := wr.VtctldServer().ReloadSchemaShard(ctx, &vtctldatapb.ReloadSchemaShardRequest{
 		Keyspace:       keyspace,
@@ -3175,18 +3154,11 @@ func commandReloadSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, sub
 	concurrency := subFlags.Int("concurrency", 10, "How many tablets to reload in parallel")
 	includePrimary := subFlags.Bool("include_primary", true, "Include the primary tablet(s)")
 
-	// handle deprecated flags
-	// should be deleted in a future release
-	deprecatedIncludeMaster := subFlags.Bool("include_master", true, "DEPRECATED. Use -include_primary instead")
-
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 1 {
 		return fmt.Errorf("the <keyspace> argument is required for the ReloadSchemaKeyspace command")
-	}
-	if *deprecatedIncludeMaster {
-		includePrimary = deprecatedIncludeMaster
 	}
 	resp, err := wr.VtctldServer().ReloadSchemaKeyspace(ctx, &vtctldatapb.ReloadSchemaKeyspaceRequest{
 		Keyspace:       subFlags.Arg(0),
@@ -3230,10 +3202,6 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 	skipNoPrimary := subFlags.Bool("skip-no-primary", true, "Skip shards that don't have primary when performing validation")
 	includeVSchema := subFlags.Bool("include-vschema", false, "Validate schemas against the vschema")
 
-	// handle deprecated flags
-	// should be deleted in a future release
-	deprecatedSkipNoMaster := subFlags.Bool("skip-no-master", false, "DEPRECATED. Use -skip-no-primary instead")
-
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -3241,9 +3209,6 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 		return fmt.Errorf("the <keyspace name> argument is required for the ValidateSchemaKeyspace command")
 	}
 
-	if *deprecatedSkipNoMaster {
-		skipNoPrimary = deprecatedSkipNoMaster
-	}
 	keyspace := subFlags.Arg(0)
 	var excludeTableArray []string
 	if *excludeTables != "" {

--- a/go/vt/vttablet/tabletmanager/vreplication/stats.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/stats.go
@@ -60,37 +60,6 @@ type vrStats struct {
 }
 
 func (st *vrStats) register() {
-	// DEPRECATED
-	//TODO(rohit) : remove this metric and related parameter in V13
-
-	stats.NewGaugeFunc("VReplicationSecondsBehindMasterMax", "Max vreplication seconds behind primary", st.maxReplicationLagSeconds)
-	stats.NewGaugesFuncWithMultiLabels(
-		"VReplicationSecondsBehindMaster",
-		"vreplication seconds behind primary per stream",
-		[]string{"source_keyspace", "source_shard", "workflow", "counts"},
-		func() map[string]int64 {
-			st.mu.Lock()
-			defer st.mu.Unlock()
-			result := make(map[string]int64, len(st.controllers))
-			for _, ct := range st.controllers {
-				result[ct.source.Keyspace+"."+ct.source.Shard+"."+ct.workflow+"."+fmt.Sprintf("%v", ct.id)] = ct.blpStats.ReplicationLagSeconds.Get()
-			}
-			return result
-		})
-
-	stats.NewCounterFunc(
-		"VReplicationSecondsBehindMasterTotal",
-		"vreplication seconds behind primary aggregated across all streams",
-		func() int64 {
-			st.mu.Lock()
-			defer st.mu.Unlock()
-			result := int64(0)
-			for _, ct := range st.controllers {
-				result += ct.blpStats.ReplicationLagSeconds.Get()
-			}
-			return result
-		})
-
 	stats.NewGaugeFunc("VReplicationStreamCount", "Number of vreplication streams", st.numControllers)
 	stats.NewGaugeFunc("VReplicationLagSecondsMax", "Max vreplication seconds behind primary", st.maxReplicationLagSeconds)
 	stats.Publish("VReplicationStreamState", stats.StringMapFunc(func() map[string]string {

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -288,8 +288,7 @@ func TestPlannedReparentNoPrimary(t *testing.T) {
 	NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, nil)
 	NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, nil)
 
-	// use deprecated flag new_master to ensure coverage
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", replica1.Tablet.Keyspace + "/" + replica1.Tablet.Shard, "-new_master", topoproto.TabletAliasString(replica1.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", replica1.Tablet.Keyspace + "/" + replica1.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(replica1.Tablet.Alias)})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "the shard has no current primary")
 }
@@ -485,8 +484,7 @@ func TestPlannedReparentShardWaitForPositionTimeout(t *testing.T) {
 	defer goodReplica2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	// use deprecated flag new_master to ensure coverage
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "replication on primary-elect cell1-0000000001 did not catch up in time")
 
@@ -626,8 +624,7 @@ func TestPlannedReparentShardRelayLogErrorStartReplication(t *testing.T) {
 	defer goodReplica1.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	// use deprecated flag new_master to ensure coverage
-	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", primary.Tablet.Keyspace + "/" + primary.Tablet.Shard, "-new_master",
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", primary.Tablet.Keyspace + "/" + primary.Tablet.Shard, "-new_primary",
 		topoproto.TabletAliasString(primary.Tablet.Alias)})
 	require.NoError(t, err)
 	// check what was run
@@ -770,8 +767,7 @@ func TestPlannedReparentShardPromoteReplicaFail(t *testing.T) {
 	}
 
 	// run PlannedReparentShard
-	// use deprecated flag new_master to ensure coverage
-	err = vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
+	err = vp.Run([]string{"PlannedReparentShard", "-wait_replicas_timeout", "10s", "-keyspace_shard", newPrimary.Tablet.Keyspace + "/" + newPrimary.Tablet.Shard, "-new_primary", topoproto.TabletAliasString(newPrimary.Tablet.Alias)})
 	require.NoError(t, err)
 
 	// check that primary changed correctly


### PR DESCRIPTION
## Description
This is a BREAKING CHANGE!!!
- Delete deprecated flags, commands and metrics.
- Remove checks for "master" tablet_type in tests, they should all now be "primary"
- Change upgrade tests to only run against most recent version (12.0), they will no longer work against older versions.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #8838 

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required (website PR https://github.com/vitessio/website/pull/868)

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
Any deployment code/scripts that use the old flags or commands will need to change. Full list is in #8838 