### PR TITLE
Inclusive naming: use new RPCs in vtctl/vtctld/wrangler etc.

### DIFF
--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -487,8 +487,6 @@ func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, t
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary tablet record %v: %v", topoproto.TabletAliasString(si.PrimaryAlias), err)
 	}
-	// Use old RPC for backwards-compatibility
-	// TODO(deepthi): change to PrimaryPosition after v12.0
 	posStr, err := tmc.PrimaryPosition(ctx, ti.Tablet)
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary replication position: %v", err)

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -489,7 +489,7 @@ func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, t
 	}
 	// Use old RPC for backwards-compatibility
 	// TODO(deepthi): change to PrimaryPosition after v12.0
-	posStr, err := tmc.MasterPosition(ctx, ti.Tablet)
+	posStr, err := tmc.PrimaryPosition(ctx, ti.Tablet)
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary replication position: %v", err)
 	}

--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -165,7 +165,7 @@ func TestReparentReplicaOffline(t *testing.T) {
 	// Perform a graceful reparent operation.
 	out, err := prsWithTimeout(t, tab2, false, "", "31s")
 	require.Error(t, err)
-	assert.Contains(t, out, fmt.Sprintf("tablet %s failed to SetMaster", tab4.Alias))
+	assert.Contains(t, out, fmt.Sprintf("tablet %s failed to SetReplicationSource", tab4.Alias))
 
 	checkPrimaryTablet(t, tab2)
 }
@@ -313,7 +313,7 @@ func TestReparentWithDownReplica(t *testing.T) {
 	// Perform a graceful reparent operation. It will fail as one tablet is down.
 	out, err := prs(t, tab2)
 	require.Error(t, err)
-	assert.Contains(t, out, fmt.Sprintf("tablet %s failed to SetMaster", tab3.Alias))
+	assert.Contains(t, out, fmt.Sprintf("tablet %s failed to SetReplicationSource", tab3.Alias))
 
 	// insert data into the new primary, check the connected replica work
 	confirmReplication(t, tab2, []*cluster.Vttablet{tab1, tab4})

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -633,7 +633,6 @@ func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, t
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary tablet record %v: %v", topoproto.TabletAliasString(si.PrimaryAlias), err)
 	}
-	// TODO(deepthi): fix after v12.0
 	posStr, err := tmc.PrimaryPosition(ctx, ti.Tablet)
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary replication position: %v", err)

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -634,7 +634,7 @@ func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, t
 		return mysql.Position{}, fmt.Errorf("can't get primary tablet record %v: %v", topoproto.TabletAliasString(si.PrimaryAlias), err)
 	}
 	// TODO(deepthi): fix after v12.0
-	posStr, err := tmc.MasterPosition(ctx, ti.Tablet)
+	posStr, err := tmc.PrimaryPosition(ctx, ti.Tablet)
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("can't get primary replication position: %v", err)
 	}

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -424,7 +424,7 @@ func (exec *TabletExecutor) executeOneTablet(
 	}
 	// Get a replication position that's guaranteed to be after the schema change
 	// was applied on the primary.
-	pos, err := exec.wr.TabletManagerClient().MasterPosition(ctx, tablet)
+	pos, err := exec.wr.TabletManagerClient().PrimaryPosition(ctx, tablet)
 	if err != nil {
 		errChan <- ShardWithError{
 			Shard: tablet.Shard,

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1923,7 +1923,7 @@ func (s *VtctldServer) ReparentTablet(ctx context.Context, req *vtctldatapb.Repa
 		return nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "cannot ReparentTablet current shard primary (%v) onto itself", topoproto.TabletAliasString(req.Tablet))
 	}
 
-	if err := s.tmc.SetMaster(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false); err != nil {
+	if err := s.tmc.SetReplicationSource(ctx, tablet.Tablet, shard.PrimaryAlias, 0, "", false); err != nil {
 		return nil, err
 	}
 
@@ -2215,7 +2215,7 @@ func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctl
 
 				var status *replicationdatapb.Status
 
-				pos, err := s.tmc.MasterPosition(ctx, tablet)
+				pos, err := s.tmc.PrimaryPosition(ctx, tablet)
 				if err != nil {
 					switch ctx.Err() {
 					case context.Canceled:
@@ -2225,7 +2225,7 @@ func (s *VtctldServer) ShardReplicationPositions(ctx context.Context, req *vtctl
 					default:
 						// The RPC was not timed out or canceled. We treat this
 						// as a fatal error for the overall request.
-						rec.RecordError(fmt.Errorf("MasterPosition(%s) failed: %w", alias, err))
+						rec.RecordError(fmt.Errorf("PrimaryPosition(%s) failed: %w", alias, err))
 						return
 					}
 				} else {

--- a/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_slow_test.go
@@ -96,7 +96,7 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -118,13 +118,13 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 				}{
 					"zone1-0000000200": {},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
 					"zone1-0000000200": {},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -215,7 +215,7 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -237,13 +237,13 @@ func TestEmergencyReparentShardSlow(t *testing.T) {
 				}{
 					"zone1-0000000200": {},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
 					"zone1-0000000200": {},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -393,7 +393,7 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -404,7 +404,7 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -428,9 +428,9 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
-					"zone1-0000000200": nil, // waiting for master-position during promotion
-					// reparent SetMaster calls
+				SetReplicationSourceResults: map[string]error{
+					"zone1-0000000200": nil, // waiting for primary-position during promotion
+					// reparent SetReplicationSource calls
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -496,7 +496,7 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -507,7 +507,7 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -531,9 +531,9 @@ func TestPlannedReparentShardSlow(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
-					"zone1-0000000200": nil, // waiting for master-position during promotion
-					// reparent SetMaster calls
+				SetReplicationSourceResults: map[string]error{
+					"zone1-0000000200": nil, // waiting for primary-position during promotion
+					// reparent SetReplicationSource calls
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},

--- a/go/vt/vtctl/grpcvtctldserver/server_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/server_test.go
@@ -2637,7 +2637,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -2656,13 +2656,13 @@ func TestEmergencyReparentShard(t *testing.T) {
 				}{
 					"zone1-0000000200": {},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
 					"zone1-0000000200": {},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -4931,7 +4931,7 @@ func TestPlannedReparentShard(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -4942,7 +4942,7 @@ func TestPlannedReparentShard(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -4963,9 +4963,9 @@ func TestPlannedReparentShard(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
-					"zone1-0000000200": nil, // waiting for master-position during promotion
-					// reparent SetMaster calls
+				SetReplicationSourceResults: map[string]error{
+					"zone1-0000000200": nil, // waiting for primary-position during promotion
+					// reparent SetReplicationSource calls
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -6341,7 +6341,7 @@ func TestReparentTablet(t *testing.T) {
 		{
 			name: "success",
 			tmc: &testutil.TabletManagerClient{
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
 			},
@@ -6740,9 +6740,9 @@ func TestReparentTablet(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "tmc.SetMaster failure",
+			name: "tmc.SetReplicationSource failure",
 			tmc: &testutil.TabletManagerClient{
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
 				},
 			},
@@ -6797,7 +6797,7 @@ func TestReparentTablet(t *testing.T) {
 		{
 			name: "topo is down",
 			tmc: &testutil.TabletManagerClient{
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
 			},
@@ -7814,7 +7814,7 @@ func TestShardReplicationPositions(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -7893,10 +7893,10 @@ func TestShardReplicationPositions(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionDelays: map[string]time.Duration{
+				PrimaryPositionDelays: map[string]time.Duration{
 					"zone1-0000000100": time.Millisecond * 100,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -7975,7 +7975,7 @@ func TestShardReplicationPositions(t *testing.T) {
 				},
 			},
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{

--- a/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
+++ b/go/vt/vtctl/grpcvtctldserver/testutil/test_tmclient.go
@@ -132,9 +132,9 @@ type TabletManagerClient struct {
 	// keyed by tablet alias.
 	ChangeTabletTypeResult map[string]error
 	// keyed by tablet alias.
-	DemoteMasterDelays map[string]time.Duration
+	DemotePrimaryDelays map[string]time.Duration
 	// keyed by tablet alias.
-	DemoteMasterResults map[string]struct {
+	DemotePrimaryResults map[string]struct {
 		Status *replicationdatapb.PrimaryStatus
 		Error  error
 	}
@@ -158,9 +158,9 @@ type TabletManagerClient struct {
 		Error  error
 	}
 	// keyed by tablet alias.
-	MasterPositionDelays map[string]time.Duration
+	PrimaryPositionDelays map[string]time.Duration
 	// keyed by tablet alias.
-	MasterPositionResults map[string]struct {
+	PrimaryPositionResults map[string]struct {
 		Position string
 		Error    error
 	}
@@ -198,10 +198,9 @@ type TabletManagerClient struct {
 	// keyed by tablet alias
 	RunHealthCheckResults map[string]error
 	// keyed by tablet alias.
-	SetMasterDelays map[string]time.Duration
+	SetReplicationSourceDelays map[string]time.Duration
 	// keyed by tablet alias.
-	// TODO(deepthi): fix after v12.0
-	SetMasterResults map[string]error
+	SetReplicationSourceResults map[string]error
 	// keyed by tablet alias
 	SetReadOnlyDelays map[string]time.Duration
 	// keyed by tablet alias
@@ -231,9 +230,9 @@ type TabletManagerClient struct {
 		Error      error
 	}
 	// keyed by tablet alias.
-	UndoDemoteMasterDelays map[string]time.Duration
+	UndoDemotePrimaryDelays map[string]time.Duration
 	// keyed by tablet alias
-	UndoDemoteMasterResults map[string]error
+	UndoDemotePrimaryResults map[string]error
 	// tablet alias => duration
 	VReplicationExecDelays map[string]time.Duration
 	// tablet alias => query string => result
@@ -265,9 +264,9 @@ func (fake *TabletManagerClient) ChangeType(ctx context.Context, tablet *topodat
 	return err
 }
 
-// DemoteMaster is part of the tmclient.TabletManagerClient interface.
-func (fake *TabletManagerClient) DemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
-	if fake.DemoteMasterResults == nil {
+// DemotePrimary is part of the tmclient.TabletManagerClient interface.
+func (fake *TabletManagerClient) DemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) (*replicationdatapb.PrimaryStatus, error) {
+	if fake.DemotePrimaryResults == nil {
 		return nil, assert.AnError
 	}
 
@@ -277,8 +276,8 @@ func (fake *TabletManagerClient) DemoteMaster(ctx context.Context, tablet *topod
 
 	key := topoproto.TabletAliasString(tablet.Alias)
 
-	if fake.DemoteMasterDelays != nil {
-		if delay, ok := fake.DemoteMasterDelays[key]; ok {
+	if fake.DemotePrimaryDelays != nil {
+		if delay, ok := fake.DemotePrimaryDelays[key]; ok {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -288,7 +287,7 @@ func (fake *TabletManagerClient) DemoteMaster(ctx context.Context, tablet *topod
 		}
 	}
 
-	if result, ok := fake.DemoteMasterResults[key]; ok {
+	if result, ok := fake.DemotePrimaryResults[key]; ok {
 		return result.Status, result.Error
 	}
 
@@ -363,9 +362,9 @@ func (fake *TabletManagerClient) GetSchema(ctx context.Context, tablet *topodata
 	return nil, fmt.Errorf("%w: no schemas for %s", assert.AnError, key)
 }
 
-// MasterPosition is part of the tmclient.TabletManagerClient interface.
-func (fake *TabletManagerClient) MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
-	if fake.MasterPositionResults == nil {
+// PrimaryPosition is part of the tmclient.TabletManagerClient interface.
+func (fake *TabletManagerClient) PrimaryPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
+	if fake.PrimaryPositionResults == nil {
 		return "", assert.AnError
 	}
 
@@ -375,8 +374,8 @@ func (fake *TabletManagerClient) MasterPosition(ctx context.Context, tablet *top
 
 	key := topoproto.TabletAliasString(tablet.Alias)
 
-	if fake.MasterPositionDelays != nil {
-		if delay, ok := fake.MasterPositionDelays[key]; ok {
+	if fake.PrimaryPositionDelays != nil {
+		if delay, ok := fake.PrimaryPositionDelays[key]; ok {
 			select {
 			case <-ctx.Done():
 				return "", ctx.Err()
@@ -386,7 +385,7 @@ func (fake *TabletManagerClient) MasterPosition(ctx context.Context, tablet *top
 		}
 	}
 
-	if result, ok := fake.MasterPositionResults[key]; ok {
+	if result, ok := fake.PrimaryPositionResults[key]; ok {
 		return result.Position, result.Error
 	}
 
@@ -581,16 +580,16 @@ func (fake *TabletManagerClient) RunHealthCheck(ctx context.Context, tablet *top
 	return fmt.Errorf("%w: no result for key %s", assert.AnError, key)
 }
 
-// SetMaster is part of the tmclient.TabletManagerClient interface.
-func (fake *TabletManagerClient) SetMaster(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
-	if fake.SetMasterResults == nil {
+// SetReplicationSource is part of the tmclient.TabletManagerClient interface.
+func (fake *TabletManagerClient) SetReplicationSource(ctx context.Context, tablet *topodatapb.Tablet, parent *topodatapb.TabletAlias, timeCreatedNS int64, waitPosition string, forceStartReplication bool) error {
+	if fake.SetReplicationSourceResults == nil {
 		return assert.AnError
 	}
 
 	key := topoproto.TabletAliasString(tablet.Alias)
 
-	if fake.SetMasterDelays != nil {
-		if delay, ok := fake.SetMasterDelays[key]; ok {
+	if fake.SetReplicationSourceDelays != nil {
+		if delay, ok := fake.SetReplicationSourceDelays[key]; ok {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -600,7 +599,7 @@ func (fake *TabletManagerClient) SetMaster(ctx context.Context, tablet *topodata
 		}
 	}
 
-	if result, ok := fake.SetMasterResults[key]; ok {
+	if result, ok := fake.SetReplicationSourceResults[key]; ok {
 		return result
 	}
 
@@ -831,9 +830,9 @@ func (fake *TabletManagerClient) WaitForPosition(ctx context.Context, tablet *to
 	return result
 }
 
-// UndoDemoteMaster is part of the tmclient.TabletManagerClient interface.
-func (fake *TabletManagerClient) UndoDemoteMaster(ctx context.Context, tablet *topodatapb.Tablet) error {
-	if fake.UndoDemoteMasterResults == nil {
+// UndoDemotePrimary is part of the tmclient.TabletManagerClient interface.
+func (fake *TabletManagerClient) UndoDemotePrimary(ctx context.Context, tablet *topodatapb.Tablet) error {
+	if fake.UndoDemotePrimaryResults == nil {
 		return assert.AnError
 	}
 
@@ -843,8 +842,8 @@ func (fake *TabletManagerClient) UndoDemoteMaster(ctx context.Context, tablet *t
 
 	key := topoproto.TabletAliasString(tablet.Alias)
 
-	if fake.UndoDemoteMasterDelays != nil {
-		if delay, ok := fake.UndoDemoteMasterDelays[key]; ok {
+	if fake.UndoDemotePrimaryDelays != nil {
+		if delay, ok := fake.UndoDemotePrimaryDelays[key]; ok {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -854,7 +853,7 @@ func (fake *TabletManagerClient) UndoDemoteMaster(ctx context.Context, tablet *t
 		}
 	}
 
-	if result, ok := fake.UndoDemoteMasterResults[key]; ok {
+	if result, ok := fake.UndoDemotePrimaryResults[key]; ok {
 		return result
 	}
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -143,7 +143,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -151,7 +151,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -250,7 +250,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000101": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -267,7 +267,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000102": nil,
 				},
@@ -357,7 +357,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 			name:                 "success with existing primary",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -367,7 +367,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						},
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -387,7 +387,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -890,12 +890,12 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1003,7 +1003,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error: assert.AnError,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1058,7 +1058,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						"MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-21": nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
@@ -1119,7 +1119,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1127,7 +1127,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -1234,7 +1234,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1242,7 +1242,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil,
 					"zone1-0000000101": nil,
 				},
@@ -1419,7 +1419,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1435,7 +1435,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 					"zone1-0000000404": assert.AnError, // okay, because we're ignoring it.
@@ -1499,10 +1499,10 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:                 "MasterPosition error",
+			name:                 "PrimaryPosition error",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1552,7 +1552,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1596,13 +1596,13 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			errShouldContain: "failed to PopulateReparentJournal on primary",
 		},
 		{
-			name:                 "all replicas failing to SetMaster does fail the promotion",
+			name:                 "all replicas failing to SetReplicationSource does fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1619,7 +1619,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 					},
 				},
 
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					// everyone fails, we all fail
 					"zone1-0000000101": assert.AnError,
 					"zone1-0000000102": assert.AnError,
@@ -1660,13 +1660,13 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			errShouldContain: " replica(s) failed",
 		},
 		{
-			name:                 "all replicas slow to SetMaster does fail the promotion",
+			name:                 "all replicas slow to SetReplicationSource does fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{WaitReplicasTimeout: time.Millisecond * 10},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1683,12 +1683,12 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 					},
 				},
 
-				SetMasterDelays: map[string]time.Duration{
+				SetReplicationSourceDelays: map[string]time.Duration{
 					// nothing is failing, we're just slow
 					"zone1-0000000101": time.Millisecond * 100,
 					"zone1-0000000102": time.Millisecond * 75,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 				},
@@ -1728,13 +1728,13 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 			errShouldContain: "context deadline exceeded",
 		},
 		{
-			name:                 "one replica failing to SetMaster does not fail the promotion",
+			name:                 "one replica failing to SetReplicationSource does not fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1751,7 +1751,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 					},
 				},
 
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil, // this one succeeds, so we're good
 					"zone1-0000000102": assert.AnError,
 				},
@@ -2101,7 +2101,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 				Error:  nil,
 			},
 		},
-		MasterPositionResults: map[string]struct {
+		PrimaryPositionResults: map[string]struct {
 			Position string
 			Error    error
 		}{
@@ -2109,7 +2109,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 				Error: nil,
 			},
 		},
-		SetMasterResults: map[string]error{
+		SetReplicationSourceResults: map[string]error{
 			"zone1-0000000100": nil,
 			"zone1-0000000101": nil,
 		},
@@ -2608,7 +2608,7 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2616,7 +2616,7 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 					"zone1-0000000404": assert.AnError, // okay, because we're ignoring it.
@@ -2680,10 +2680,10 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:                 "MasterPosition error",
+			name:                 "PrimaryPosition error",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2725,7 +2725,7 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2761,13 +2761,13 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			errShouldContain: "failed to PopulateReparentJournal on primary",
 		},
 		{
-			name:                 "all replicas failing to SetMaster does fail the promotion",
+			name:                 "all replicas failing to SetReplicationSource does fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2776,7 +2776,7 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 					},
 				},
 
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					// everyone fails, we all fail
 					"zone1-0000000101": assert.AnError,
 					"zone1-0000000102": assert.AnError,
@@ -2817,13 +2817,13 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			errShouldContain: " replica(s) failed",
 		},
 		{
-			name:                 "all replicas slow to SetMaster does fail the promotion",
+			name:                 "all replicas slow to SetReplicationSource does fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{WaitReplicasTimeout: time.Millisecond * 10},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2831,12 +2831,12 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterDelays: map[string]time.Duration{
+				SetReplicationSourceDelays: map[string]time.Duration{
 					// nothing is failing, we're just slow
 					"zone1-0000000101": time.Millisecond * 100,
 					"zone1-0000000102": time.Millisecond * 75,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 				},
@@ -2876,13 +2876,13 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 			errShouldContain: "context deadline exceeded",
 		},
 		{
-			name:                 "one replica failing to SetMaster does not fail the promotion",
+			name:                 "one replica failing to SetReplicationSource does not fail the promotion",
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2890,7 +2890,7 @@ func TestEmergencyReparenter_reparentReplicas(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil, // this one succeeds, so we're good
 					"zone1-0000000102": assert.AnError,
 				},
@@ -3000,7 +3000,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -3008,7 +3008,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil,
 					"zone1-0000000102": nil,
 					"zone1-0000000404": assert.AnError, // okay, because we're ignoring it.
@@ -3099,7 +3099,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -3108,7 +3108,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 					},
 				},
 
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					// everyone fails, we all fail
 					"zone1-0000000101": assert.AnError,
 					"zone1-0000000102": assert.AnError,
@@ -3155,7 +3155,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -3163,7 +3163,7 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000101": nil, // this one succeeds, so we're good
 					"zone1-0000000102": assert.AnError,
 				},

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -90,7 +90,7 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			name: "success",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -102,7 +102,7 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				SetReadWriteResults: map[string]error{
@@ -681,7 +681,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "successful promotion",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -696,7 +696,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -713,7 +713,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -748,7 +748,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "cannot get snapshot of current primary",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -782,7 +782,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "primary-elect fails to catch up to current primary snapshot position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -790,7 +790,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": assert.AnError,
 				},
 			},
@@ -819,7 +819,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "primary-elect times out catching up to current primary snapshot position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -827,10 +827,10 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterDelays: map[string]time.Duration{
+				SetReplicationSourceDelays: map[string]time.Duration{
 					"zone1-0000000200": time.Millisecond * 100,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 			},
@@ -861,7 +861,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "lost topology lock",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -869,7 +869,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 			},
@@ -899,7 +899,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "failed to demote current primary",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -907,7 +907,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: assert.AnError,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -915,7 +915,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 			},
@@ -944,7 +944,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "primary-elect fails to catch up to current primary demotion position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -959,7 +959,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -967,7 +967,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -1001,7 +1001,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "primary-elect times out catching up to current primary demotion position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1016,7 +1016,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1024,7 +1024,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionDelays: map[string]time.Duration{
@@ -1063,7 +1063,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "demotion succeeds but parent context times out",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1074,7 +1074,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1096,7 +1096,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionPostDelays: map[string]time.Duration{
@@ -1134,7 +1134,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "rollback fails",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1149,7 +1149,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1157,7 +1157,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -1165,7 +1165,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						"position1": assert.AnError,
 					},
 				},
-				UndoDemoteMasterResults: map[string]error{
+				UndoDemotePrimaryResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
 				},
 			},
@@ -1190,14 +1190,14 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 			extraAssertions: func(t *testing.T, pos string, err error) {
-				assert.Contains(t, err.Error(), "UndoDemoteMaster", "expected error to include information about failed demotion rollback")
+				assert.Contains(t, err.Error(), "UndoDemotePrimary", "expected error to include information about failed demotion rollback")
 			},
 		},
 		{
 			name: "rollback succeeds",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1212,7 +1212,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1220,7 +1220,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -1228,7 +1228,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						"position1": assert.AnError,
 					},
 				},
-				UndoDemoteMasterResults: map[string]error{
+				UndoDemotePrimaryResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
 			},
@@ -1253,14 +1253,14 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			opts:      PlannedReparentOptions{},
 			shouldErr: true,
 			extraAssertions: func(t *testing.T, pos string, err error) {
-				assert.NotContains(t, err.Error(), "UndoDemoteMaster", "expected error to not include information about failed demotion rollback")
+				assert.NotContains(t, err.Error(), "UndoDemotePrimary", "expected error to not include information about failed demotion rollback")
 			},
 		},
 		{
 			name: "primary-elect fails to promote",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1275,7 +1275,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1291,7 +1291,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: assert.AnError,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -1325,7 +1325,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 			name: "promotion succeeds but parent context times out",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1340,7 +1340,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1359,7 +1359,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 						Error: nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				WaitForPositionResults: map[string]map[string]error{
@@ -1470,7 +1470,7 @@ func TestPlannedReparenter_performPartialPromotionRecovery(t *testing.T) {
 		{
 			name: "successful recovery",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1527,9 +1527,9 @@ func TestPlannedReparenter_performPartialPromotionRecovery(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "failed to get MasterPosition from refreshed primary",
+			name: "failed to get PrimaryPosition from refreshed primary",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1551,12 +1551,12 @@ func TestPlannedReparenter_performPartialPromotionRecovery(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "MasterPosition timed out",
+			name: "PrimaryPosition timed out",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionDelays: map[string]time.Duration{
+				PrimaryPositionDelays: map[string]time.Duration{
 					"zone1-0000000100": time.Millisecond * 50,
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -1634,7 +1634,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "success",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1706,10 +1706,10 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			shouldErr:   false,
 		},
 		{
-			name: "failed to DemoteMaster on a tablet",
+			name: "failed to DemotePrimary on a tablet",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1741,13 +1741,13 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "timed out during DemoteMaster on a tablet",
+			name: "timed out during DemotePrimary on a tablet",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterDelays: map[string]time.Duration{
+				DemotePrimaryDelays: map[string]time.Duration{
 					"zone1-0000000100": time.Millisecond * 50,
 				},
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1785,7 +1785,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "failed to DecodePosition on a tablet's demote position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1838,7 +1838,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "primary-elect not most at most advanced position",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1903,7 +1903,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "lost topology lock",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -1968,7 +1968,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "failed to promote primary-elect",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -2042,7 +2042,7 @@ func TestPlannedReparenter_performPotentialPromotion(t *testing.T) {
 			name: "timed out while promoting primary-elect",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -2189,7 +2189,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			name: "success: current primary cannot be determined", // "Case (1)"
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -2218,7 +2218,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // zone1-100 gets reparented under zone1-200
 				},
 			},
@@ -2269,7 +2269,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			name: "success: current primary is desired primary", // "Case (2)"
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2281,7 +2281,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 				},
 				SetReadWriteResults: map[string]error{
@@ -2344,7 +2344,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			name: "success: graceful promotion", // "Case (3)"
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				DemoteMasterResults: map[string]struct {
+				DemotePrimaryResults: map[string]struct {
 					Status *replicationdatapb.PrimaryStatus
 					Error  error
 				}{
@@ -2356,7 +2356,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error: nil,
 					},
 				},
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2377,7 +2377,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 						Error:  nil,
 					},
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000100": nil, // called during reparentTablets to make oldPrimary a replica of newPrimary
 					"zone1-0000000200": nil, // called during performGracefulPromotion to ensure newPrimary is caught up
 				},
@@ -2595,7 +2595,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			name: "lost topology lock",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2666,7 +2666,7 @@ func TestPlannedReparenter_reparentShardLocked(t *testing.T) {
 			name: "failed to reparent tablets",
 			ts:   memorytopo.NewServer("zone1"),
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -2805,7 +2805,7 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 					"zone1-0000000201": nil,
 					"zone1-0000000202": nil,
@@ -2861,12 +2861,12 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name: "SetMaster failed on replica",
+			name: "SetReplicationSource failed on replica",
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 					"zone1-0000000201": assert.AnError,
 					"zone1-0000000202": nil,
@@ -2922,15 +2922,15 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "SetMaster timed out on replica",
+			name: "SetReplicationSource timed out on replica",
 			tmc: &testutil.TabletManagerClient{
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterDelays: map[string]time.Duration{
+				SetReplicationSourceDelays: map[string]time.Duration{
 					"zone1-0000000201": time.Millisecond * 50,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 					"zone1-0000000201": nil,
 					"zone1-0000000202": nil,
@@ -2994,7 +2994,7 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": assert.AnError,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 					"zone1-0000000201": nil,
 					"zone1-0000000202": nil,
@@ -3058,7 +3058,7 @@ func TestPlannedReparenter_reparentTablets(t *testing.T) {
 				PopulateReparentJournalResults: map[string]error{
 					"zone1-0000000100": nil,
 				},
-				SetMasterResults: map[string]error{
+				SetReplicationSourceResults: map[string]error{
 					"zone1-0000000200": nil,
 					"zone1-0000000201": nil,
 					"zone1-0000000202": nil,

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -185,7 +185,7 @@ func StopReplicationAndBuildStatusMaps(
 		case mysql.ErrNotReplica:
 			var primaryStatus *replicationdatapb.PrimaryStatus
 
-			primaryStatus, err = tmc.DemoteMaster(groupCtx, tabletInfo.Tablet)
+			primaryStatus, err = tmc.DemotePrimary(groupCtx, tabletInfo.Tablet)
 			if err != nil {
 				msg := "replica %v thinks it's primary but we failed to demote it"
 				err = vterrors.Wrapf(err, msg+": %v", alias, err)

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -232,7 +232,7 @@ func waitForCatchUp(
 ) error {
 	logger.Infof("waiting for %v to catch up to %v", newPrimary.Alias, source.Alias)
 	// Find the primary position of the previous primary
-	pos, err := tmc.MasterPosition(ctx, source)
+	pos, err := tmc.PrimaryPosition(ctx, source)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -640,7 +640,7 @@ func TestWaitForCatchUp(t *testing.T) {
 		{
 			name: "success",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -670,7 +670,7 @@ func TestWaitForCatchUp(t *testing.T) {
 		}, {
 			name: "error in primary position",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{
@@ -701,7 +701,7 @@ func TestWaitForCatchUp(t *testing.T) {
 		}, {
 			name: "error in waiting for position",
 			tmc: &testutil.TabletManagerClient{
-				MasterPositionResults: map[string]struct {
+				PrimaryPositionResults: map[string]struct {
 					Position string
 					Error    error
 				}{

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -417,17 +417,17 @@ func (tm *TabletManager) catchupToGTID(ctx context.Context, afterGTIDPos string,
 
 	if *binlogSslCa != "" || *binlogSslCert != "" {
 		// We need to use TLS
-		changeMasterCmd := fmt.Sprintf("CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d, MASTER_USER='%s', MASTER_PASSWORD='%s', MASTER_AUTO_POSITION=1, MASTER_SSL=1", *binlogHost, *binlogPort, *binlogUser, *binlogPwd)
+		cmd := fmt.Sprintf("CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d, MASTER_USER='%s', MASTER_PASSWORD='%s', MASTER_AUTO_POSITION=1, MASTER_SSL=1", *binlogHost, *binlogPort, *binlogUser, *binlogPwd)
 		if *binlogSslCa != "" {
-			changeMasterCmd += fmt.Sprintf(", MASTER_SSL_CA='%s'", *binlogSslCa)
+			cmd += fmt.Sprintf(", MASTER_SSL_CA='%s'", *binlogSslCa)
 		}
 		if *binlogSslCert != "" {
-			changeMasterCmd += fmt.Sprintf(", MASTER_SSL_CERT='%s'", *binlogSslCert)
+			cmd += fmt.Sprintf(", MASTER_SSL_CERT='%s'", *binlogSslCert)
 		}
 		if *binlogSslKey != "" {
-			changeMasterCmd += fmt.Sprintf(", MASTER_SSL_KEY='%s'", *binlogSslKey)
+			cmd += fmt.Sprintf(", MASTER_SSL_KEY='%s'", *binlogSslKey)
 		}
-		cmds = append(cmds, changeMasterCmd+";")
+		cmds = append(cmds, cmd+";")
 	} else {
 		// No TLS
 		cmds = append(cmds, fmt.Sprintf("CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d, MASTER_USER='%s', MASTER_PASSWORD='%s', MASTER_AUTO_POSITION=1;", *binlogHost, *binlogPort, *binlogUser, *binlogPwd))
@@ -551,7 +551,7 @@ func (tm *TabletManager) startReplication(ctx context.Context, pos mysql.Positio
 	defer tmc.Close()
 	remoteCtx, remoteCancel := context.WithTimeout(ctx, *topo.RemoteOperationTimeout)
 	defer remoteCancel()
-	posStr, err := tmc.MasterPosition(remoteCtx, ti.Tablet)
+	posStr, err := tmc.PrimaryPosition(remoteCtx, ti.Tablet)
 	if err != nil {
 		// It is possible that though PrimaryAlias is set, the primary tablet is unreachable
 		// Log a warning and let tablet restore in that case

--- a/go/vt/vttablet/tmrpctest/test_tm_rpc.go
+++ b/go/vt/vttablet/tmrpctest/test_tm_rpc.go
@@ -1111,10 +1111,10 @@ func (fra *fakeRPCTM) SetReplicationSource(ctx context.Context, parent *topodata
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	compare(fra.t, "SetMaster parent", parent, testPrimaryAlias)
-	compare(fra.t, "SetMaster timeCreatedNS", timeCreatedNS, testTimeCreatedNS)
-	compare(fra.t, "SetMaster waitPosition", waitPosition, testWaitPosition)
-	compare(fra.t, "SetMaster forceStartReplica", forceStartReplica, testForceStartReplica)
+	compare(fra.t, "SetReplicationSource parent", parent, testPrimaryAlias)
+	compare(fra.t, "SetReplicationSource timeCreatedNS", timeCreatedNS, testTimeCreatedNS)
+	compare(fra.t, "SetReplicationSource waitPosition", waitPosition, testWaitPosition)
+	compare(fra.t, "SetReplicationSource forceStartReplica", forceStartReplica, testForceStartReplica)
 	testSetMasterCalled = true
 	return nil
 }

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -756,7 +756,7 @@ func CreateConsistentTransactions(ctx context.Context, tablet *topo.TabletInfo, 
 		return nil, "", vterrors.Wrapf(err, "failed to create transactions on %v", topoproto.TabletAliasString(tablet.Tablet.Alias))
 	}
 	wr.Logger().Infof("transactions created on %v", topoproto.TabletAliasString(tablet.Tablet.Alias))
-	executedGtid, err := tm.MasterPosition(ctx, tablet.Tablet)
+	executedGtid, err := tm.PrimaryPosition(ctx, tablet.Tablet)
 	if err != nil {
 		return nil, "", vterrors.Wrapf(err, "could not read executed GTID set on %v", topoproto.TabletAliasString(tablet.Tablet.Alias))
 	}

--- a/go/vt/worker/multi_split_diff.go
+++ b/go/vt/worker/multi_split_diff.go
@@ -446,10 +446,10 @@ func (msdw *MultiSplitDiffWorker) stopVreplicationAt(ctx context.Context, shardI
 	}
 
 	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
-	primaryPos, err := msdw.wr.TabletManagerClient().MasterPosition(shortCtx, primaryInfo.Tablet)
+	primaryPos, err := msdw.wr.TabletManagerClient().PrimaryPosition(shortCtx, primaryInfo.Tablet)
 	cancel()
 	if err != nil {
-		return "", vterrors.Wrapf(err, "MasterPosition for %v failed", msdw.shardInfo.PrimaryAlias)
+		return "", vterrors.Wrapf(err, "PrimaryPosition for %v failed", msdw.shardInfo.PrimaryAlias)
 	}
 	return primaryPos, nil
 }
@@ -654,10 +654,10 @@ func (msdw *MultiSplitDiffWorker) synchronizeSrcAndDestTxState(ctx context.Conte
 func (msdw *MultiSplitDiffWorker) waitForDestinationTabletToReach(ctx context.Context, tablet *topodatapb.Tablet, mysqlPos string) error {
 	for i := 0; i < 20; i++ {
 		shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
-		pos, err := msdw.wr.TabletManagerClient().MasterPosition(shortCtx, tablet)
+		pos, err := msdw.wr.TabletManagerClient().PrimaryPosition(shortCtx, tablet)
 		cancel()
 		if err != nil {
-			return vterrors.Wrapf(err, "get MasterPosition for %v failed", tablet)
+			return vterrors.Wrapf(err, "get PrimaryPosition for %v failed", tablet)
 		}
 
 		if pos == mysqlPos {

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -356,9 +356,9 @@ func (sdw *SplitDiffWorker) synchronizeReplication(ctx context.Context) error {
 	if err := sdw.wr.TabletManagerClient().VReplicationWaitForPos(shortCtx, primaryInfo.Tablet, int(sdw.sourceShard.Uid), mysqlPos); err != nil {
 		return vterrors.Wrapf(err, "VReplicationWaitForPos for %v until %v failed", sdw.shardInfo.PrimaryAlias, mysqlPos)
 	}
-	primaryPos, err := sdw.wr.TabletManagerClient().MasterPosition(shortCtx, primaryInfo.Tablet)
+	primaryPos, err := sdw.wr.TabletManagerClient().PrimaryPosition(shortCtx, primaryInfo.Tablet)
 	if err != nil {
-		return vterrors.Wrapf(err, "MasterPosition for %v failed", sdw.shardInfo.PrimaryAlias)
+		return vterrors.Wrapf(err, "PrimaryPosition for %v failed", sdw.shardInfo.PrimaryAlias)
 	}
 
 	// 4 - wait until the destination tablet is equal or passed

--- a/go/vt/worker/vertical_split_diff.go
+++ b/go/vt/worker/vertical_split_diff.go
@@ -317,9 +317,9 @@ func (vsdw *VerticalSplitDiffWorker) synchronizeReplication(ctx context.Context)
 	if err := vsdw.wr.TabletManagerClient().VReplicationWaitForPos(shortCtx, masterInfo.Tablet, int(ss.Uid), mysqlPos); err != nil {
 		return vterrors.Wrapf(err, "VReplicationWaitForPos for %v until %v failed", vsdw.shardInfo.PrimaryAlias, mysqlPos)
 	}
-	masterPos, err := vsdw.wr.TabletManagerClient().MasterPosition(shortCtx, masterInfo.Tablet)
+	masterPos, err := vsdw.wr.TabletManagerClient().PrimaryPosition(shortCtx, masterInfo.Tablet)
 	if err != nil {
-		return vterrors.Wrapf(err, "MasterPosition for %v failed", vsdw.shardInfo.PrimaryAlias)
+		return vterrors.Wrapf(err, "PrimaryPosition for %v failed", vsdw.shardInfo.PrimaryAlias)
 	}
 
 	// 4 - wait until the destination tablet is equal or passed

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -502,7 +502,7 @@ func (wr *Wrangler) getPrimaryPositions(ctx context.Context, shards []*topo.Shar
 				return
 			}
 
-			pos, err := wr.tmc.MasterPosition(ctx, ti.Tablet)
+			pos, err := wr.tmc.PrimaryPosition(ctx, ti.Tablet)
 			if err != nil {
 				rec.RecordError(err)
 				return
@@ -822,7 +822,7 @@ func (wr *Wrangler) setupReverseReplication(ctx context.Context, sourceShards, d
 		}
 
 		wr.Logger().Infof("Gathering primary position for %v", topoproto.TabletAliasString(dest.PrimaryAlias))
-		primaryPositions[i], err = wr.tmc.MasterPosition(ctx, ti.Tablet)
+		primaryPositions[i], err = wr.tmc.PrimaryPosition(ctx, ti.Tablet)
 		if err != nil {
 			return err
 		}
@@ -1269,7 +1269,7 @@ func (wr *Wrangler) masterMigrateServedFrom(ctx context.Context, ki *topo.Keyspa
 
 	// get the position
 	event.DispatchUpdate(ev, "getting primary position")
-	primaryPosition, err := wr.tmc.MasterPosition(ctx, sourcePrimaryTabletInfo.Tablet)
+	primaryPosition, err := wr.tmc.PrimaryPosition(ctx, sourcePrimaryTabletInfo.Tablet)
 	if err != nil {
 		return err
 	}

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -63,9 +63,9 @@ func (wr *Wrangler) ShardReplicationStatuses(ctx context.Context, keyspace, shar
 			wg.Add(1)
 			go func(i int, ti *topo.TabletInfo) {
 				defer wg.Done()
-				pos, err := wr.tmc.MasterPosition(ctx, ti.Tablet)
+				pos, err := wr.tmc.PrimaryPosition(ctx, ti.Tablet)
 				if err != nil {
-					rec.RecordError(fmt.Errorf("MasterPosition(%v) failed: %v", ti.AliasString(), err))
+					rec.RecordError(fmt.Errorf("PrimaryPosition(%v) failed: %v", ti.AliasString(), err))
 					return
 				}
 				result[i] = &replicationdatapb.Status{

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -307,7 +307,7 @@ func (wr *Wrangler) CopySchemaShard(ctx context.Context, sourceTabletAlias *topo
 	}
 
 	// Remember the replication position after all the above were applied.
-	destPrimaryPos, err := wr.tmc.MasterPosition(ctx, destTabletInfo.Tablet)
+	destPrimaryPos, err := wr.tmc.PrimaryPosition(ctx, destTabletInfo.Tablet)
 	if err != nil {
 		return fmt.Errorf("CopySchemaShard: can't get replication position after schema applied: %v", err)
 	}

--- a/go/vt/wrangler/vdiff_env_test.go
+++ b/go/vt/wrangler/vdiff_env_test.go
@@ -335,7 +335,7 @@ func (tmc *testVDiffTMClient) VReplicationWaitForPos(ctx context.Context, tablet
 	return nil
 }
 
-// TODO(deepthi): remove this after v12.0
+// TODO(deepthi): remove this after v13.0
 func (tmc *testVDiffTMClient) MasterPosition(ctx context.Context, tablet *topodatapb.Tablet) (string, error) {
 	return tmc.PrimaryPosition(ctx, tablet)
 }


### PR DESCRIPTION
## Description
Replace calls to deprecated RPCs with new ones.

## Related Issue(s)
Fixes #8837 

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
This is not a breaking change per se. However, it does mean that a new vtctld will not work against a vttablet that is pre-12.0.