### PR TITLE
ci: do not run golangci-lint with `new` in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters:
     # - revive
 
 issues:
-  new: true
   exclude-rules:
     - path: '^go/vt/proto/'
       linters:


### PR DESCRIPTION
## Description

Small bug in the previous PR:

The `new` flag will only check the _LAST_ commit in a PR, not all of
them. We only want to use `--new` when running in a git post-commit
hook.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->