### PR TITLE
add more retries to cluster end to end tests

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -171,7 +171,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "12",
-			"RetryMax": 1,
+			"RetryMax": 3,
 			"Tags": []
 		},
 		"prepare_statement": {
@@ -198,7 +198,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "12",
-			"RetryMax": 1,
+			"RetryMax": 3,
 			"Tags": []
 		},
 		"clustertest": {

--- a/test/config.json
+++ b/test/config.json
@@ -153,7 +153,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "20",
-			"RetryMax": 1,
+			"RetryMax": 2,
 			"Tags": []
 		},
 		"backup_xtrabackup_xbstream": {
@@ -252,7 +252,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "",
-			"RetryMax": 1,
+			"RetryMax": 3,
 			"Tags": []
 		},
 		"keyspace": {
@@ -864,7 +864,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "vtgate_gen4",
-			"RetryMax": 1,
+			"RetryMax": 2,
 			"Tags": []
 		},
 		"vtgate_godriver": {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR increases the retry count on some flaky end-to-end tests. This does not reduce any flakyness of the tests, but the contributor will see less unrelated test failure.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->