### PR TITLE
Default buildinfo tablet tags to off

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -79,7 +79,7 @@ var (
 	initShard          = flag.String("init_shard", "", "(init parameter) shard to use for this tablet")
 	initTabletType     = flag.String("init_tablet_type", "", "(init parameter) the tablet type to use for this tablet.")
 	initDbNameOverride = flag.String("init_db_name_override", "", "(init parameter) override the name of the db used by vttablet. Without this flag, the db name defaults to vt_<keyspacename>")
-	skipBuildInfoTags  = flag.String("vttablet_skip_buildinfo_tags", "", "comma-separated list of buildinfo tags to skip from merging with -init_tags. each tag is either an exact match or a regular expression of the form '/regexp/'.")
+	skipBuildInfoTags  = flag.String("vttablet_skip_buildinfo_tags", "/.*/", "comma-separated list of buildinfo tags to skip from merging with -init_tags. each tag is either an exact match or a regular expression of the form '/regexp/'.")
 	initTags           flagutil.StringMapValue
 
 	initPopulateMetadata = flag.Bool("init_populate_metadata", false, "(init parameter) populate metadata tables even if restore_from_backup is disabled. If restore_from_backup is enabled, metadata tables are always populated regardless of this flag.")

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -32,7 +32,6 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
-	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/topotools"
@@ -67,7 +66,7 @@ func TestStartBuildTabletFromInput(t *testing.T) {
 		Shard:          "0",
 		KeyRange:       nil,
 		Type:           topodatapb.TabletType_REPLICA,
-		Tags:           servenv.AppVersion.ToStringMap(),
+		Tags:           map[string]string{},
 		DbNameOverride: "aa",
 	}
 


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This is follow-up to #8973 and fixes #9186.

Without changing any of the flags in the local example:

```
❯ vtctlclient -server ":15999" ListAllTablets
zone1-0000000100 commerce 0 primary localhost:15100 localhost:17100 [] 2021-11-10T20:29:30Z
zone1-0000000101 commerce 0 replica localhost:15101 localhost:17101 [] <null>
zone1-0000000102 commerce 0 rdonly localhost:15102 localhost:17102 [] <null>
```

## Related Issue(s)


Fixes #9186 

## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **n/a**
- [x] Documentation was added or is not required **n/a**

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->