### PR TITLE
Fix table/sizes query, to allow vttablet schema engine to see partitioned tables

### DIFF
--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -252,20 +252,25 @@ const TablesWithSize56 = `SELECT table_name, table_type, unix_timestamp(create_t
 // TablesWithSize57 is a query to select table along with size for mysql 5.7.
 // It's a little weird, because the JOIN predicate only works if the table and databases do not contain weird characters.
 // As a fallback, we use the mysql 5.6 query, which is not always up to date, but works for all table/db names.
-const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+const TablesWithSize57 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, sum(i.file_size), sum(i.allocated_size) 
 	FROM information_schema.tables t, information_schema.innodb_sys_tablespaces i 
-	WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)
+	WHERE t.table_schema = database() and 
+	(i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
+	group by t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size
 UNION ALL
 	SELECT table_name, table_type, unix_timestamp(create_time), table_comment, SUM( data_length + index_length), SUM( data_length + index_length)
 	FROM information_schema.tables t
-	WHERE table_schema = database() AND NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name)) 
+	WHERE table_schema = database() AND 
+	NOT EXISTS(SELECT * FROM information_schema.innodb_sys_tablespaces i WHERE i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
 	group by table_name, table_type, unix_timestamp(create_time), table_comment
 `
 
 // TablesWithSize80 is a query to select table along with size for mysql 8.0
-const TablesWithSize80 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, i.file_size, i.allocated_size 
+const TablesWithSize80 = `SELECT t.table_name, t.table_type, unix_timestamp(t.create_time), t.table_comment, sum(i.file_size), sum(i.allocated_size) 
 		FROM information_schema.tables t, information_schema.innodb_tablespaces i 
-		WHERE t.table_schema = database() and i.name = concat(t.table_schema,'/',t.table_name)`
+		WHERE t.table_schema = database() and 
+		(i.name = concat(t.table_schema,'/',t.table_name) or i.name like concat(t.table_schema,'/',t.table_name, '#p#%')) 
+		group by t.table_name, t.table_type, t.create_time, t.table_comment, i.file_size`
 
 // baseShowTablesWithSizes is part of the Flavor interface.
 func (mysqlFlavor56) baseShowTablesWithSizes() string {

--- a/go/test/endtoend/mysqlserver/main_test.go
+++ b/go/test/endtoend/mysqlserver/main_test.go
@@ -42,11 +42,20 @@ var (
 		data longblob,
 		primary key (id)
 		) Engine=InnoDB;
+	create table vt_partition_test (
+		c1 int NOT NULL,
+		logdata BLOB NOT NULL,
+		created DATETIME NOT NULL,
+		PRIMARY KEY(c1, created)
+		)
+		PARTITION BY HASH( TO_DAYS(created) )
+		PARTITIONS 10;
 `
 	createProcSQL = `use vt_test_keyspace;
 CREATE PROCEDURE testing()
 BEGIN
 	delete from vt_insert_test;
+	delete from vt_partition_test;
 END;
 `
 )
@@ -73,7 +82,7 @@ func TestMain(m *testing.M) {
 		ACLConfig := `{
 			"table_groups": [
 				{
-					"table_names_or_prefixes": ["vt_insert_test", "dual"],
+					"table_names_or_prefixes": ["vt_insert_test", "vt_partition_test", "dual"],
 					"readers": ["vtgate client 1"],
 					"writers": ["vtgate client 1"],
 					"admins": ["vtgate client 1"]

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -20,6 +20,8 @@ package mysqlserver
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -195,6 +197,24 @@ func TestSelectWithUnauthorizedUser(t *testing.T) {
 	require.NotNilf(t, err, "error expected, got nil")
 	assert.Contains(t, err.Error(), "Select command denied to user")
 	assert.Contains(t, err.Error(), "for table 'vt_insert_test' (ACL check error)")
+}
+
+// TestPartitionedTable validates that partitioned tables are recognized by schema engine
+func TestPartitionedTable(t *testing.T) {
+	defer cluster.PanicHandler(t)
+
+	tablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
+
+	// Partitioned table already created, check if vttablet knows about it
+	url := fmt.Sprintf("http://localhost:%d/schemaz", tablet.HTTPPort)
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Contains(t, string(body), "vt_partition_test")
 }
 
 func connectDB(t *testing.T, vtParams mysql.ConnParams, params ...string) *sql.DB {


### PR DESCRIPTION
Tested locally with both 5.7 and 8.0.

Will see if I can find somewhere in the e2e tests to add a partitioned table to exercise this.

Fixes #9180 