### PR TITLE
Do keyspace filtering when possible with `show vitess_shards`

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -686,10 +686,16 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 			filter := show.ShowTablesOpt.Filter
 
 			if filter.Like != "" {
-				likeRexep := sqlparser.LikeToRegexp(filter.Like)
+				shardLikeRexep := sqlparser.LikeToRegexp(filter.Like)
 
+				if strings.Contains(filter.Like, "/") {
+					keyspaceLikeRexep := sqlparser.LikeToRegexp(strings.Split(filter.Like, "/")[0])
+					keyspaceFilters = append(keyspaceFilters, func(ks string) bool {
+						return keyspaceLikeRexep.MatchString(ks)
+					})
+				}
 				shardFilters = append(shardFilters, func(ks string, shard *topodatapb.ShardReference) bool {
-					return likeRexep.MatchString(topoproto.KeyspaceShardString(ks, shard.Name))
+					return shardLikeRexep.MatchString(topoproto.KeyspaceShardString(ks, shard.Name))
 				})
 
 				return keyspaceFilters, shardFilters

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -716,7 +716,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
-	query = "show vitess_shards like 'TestSharded%/%'"
+	query = "show vitess_shards like 'TestShard%/%'"
 	qr, err = executor.Execute(ctx, "TestExecute", session, query, nil)
 	require.NoError(t, err)
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -701,6 +701,36 @@ func TestExecutorShow(t *testing.T) {
 	}
 	utils.MustMatch(t, wantqr, qr, query)
 
+	query = "show vitess_shards like 'TestSharded/%'"
+	qr, err = executor.Execute(ctx, "TestExecute", session, query, nil)
+	require.NoError(t, err)
+
+	// Just test for first & last.
+	qr.Rows = [][]sqltypes.Value{qr.Rows[0], qr.Rows[len(qr.Rows)-1]}
+	wantqr = &sqltypes.Result{
+		Fields: buildVarCharFields("Shards"),
+		Rows: [][]sqltypes.Value{
+			buildVarCharRow("TestSharded/-20"),
+			buildVarCharRow("TestSharded/e0-"),
+		},
+	}
+	utils.MustMatch(t, wantqr, qr, query)
+
+	query = "show vitess_shards like 'TestSharded%/%'"
+	qr, err = executor.Execute(ctx, "TestExecute", session, query, nil)
+	require.NoError(t, err)
+
+	// Just test for first & last.
+	qr.Rows = [][]sqltypes.Value{qr.Rows[0], qr.Rows[len(qr.Rows)-1]}
+	wantqr = &sqltypes.Result{
+		Fields: buildVarCharFields("Shards"),
+		Rows: [][]sqltypes.Value{
+			buildVarCharRow("TestSharded/-20"),
+			buildVarCharRow("TestSharded/e0-"),
+		},
+	}
+	utils.MustMatch(t, wantqr, qr, query)
+
 	// The FakeLegacyTablets in FakeLegacyHealthCheck don't have support for these columns/values
 	// So let's just be sure the statement works and we get the expected results (none)
 	query = "show vitess_replication_status"


### PR DESCRIPTION
When using a `show vitess_shards like 'keyspace1/%'`
filter, actually use the keyspace part of the query to limit the
keyspaces for which we fetch all shards, instead of getting all
shards from all keyspaces the vtgate knows about and then
filtering them out. This probably does not matter unless you
have a lot of shards and/or are running `show vitess_shards`
like this frequently.