### PR TITLE
Explicit Collation Error

### DIFF
--- a/go/vt/vtgate/engine/comparer.go
+++ b/go/vt/vtgate/engine/comparer.go
@@ -44,10 +44,10 @@ func (c *comparer) compare(r1, r2 []sqltypes.Value) (int, error) {
 	if err != nil {
 		_, isComparisonErr := err.(evalengine.UnsupportedComparisonError)
 		_, isCollationErr := err.(evalengine.UnsupportedCollationError)
-		if !((isComparisonErr || isCollationErr) && c.weightString != -1) {
+		if !isComparisonErr && !isCollationErr || c.weightString == -1 {
 			return 0, err
 		}
-		// in case of a comparison error switch to using the weight string column for ordering
+		// in case of a comparison or collation error switch to using the weight string column for ordering
 		c.orderBy = c.weightString
 		c.weightString = -1
 		cmp, err = evalengine.NullsafeCompare(r1[c.orderBy], r2[c.orderBy], c.collationID)

--- a/go/vt/vtgate/engine/comparer.go
+++ b/go/vt/vtgate/engine/comparer.go
@@ -43,7 +43,8 @@ func (c *comparer) compare(r1, r2 []sqltypes.Value) (int, error) {
 	cmp, err := evalengine.NullsafeCompare(r1[colIndex], r2[colIndex], c.collationID)
 	if err != nil {
 		_, isComparisonErr := err.(evalengine.UnsupportedComparisonError)
-		if !(isComparisonErr && c.weightString != -1) {
+		_, isCollationErr := err.(evalengine.UnsupportedCollationError)
+		if !((isComparisonErr || isCollationErr) && c.weightString != -1) {
 			return 0, err
 		}
 		// in case of a comparison error switch to using the weight string column for ordering

--- a/go/vt/vtgate/engine/memory_sort_test.go
+++ b/go/vt/vtgate/engine/memory_sort_test.go
@@ -650,7 +650,7 @@ func TestMemorySortExecuteNoVarChar(t *testing.T) {
 	}
 
 	_, err := ms.TryExecute(&noopVCursor{}, nil, false)
-	want := "types are not comparable: VARCHAR vs VARCHAR"
+	want := "cannot compare strings, collation is unknown or unsupported (collation ID: 0)"
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute err: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -413,7 +413,7 @@ func (oa *OrderedAggregate) keysEqual(row1, row2 []sqltypes.Value, colls map[int
 		if err != nil {
 			_, isComparisonErr := err.(evalengine.UnsupportedComparisonError)
 			_, isCollationErr := err.(evalengine.UnsupportedCollationError)
-			if !((isComparisonErr || isCollationErr) && key.WeightStringCol != -1) {
+			if !isComparisonErr && !isCollationErr || key.WeightStringCol == -1 {
 				return false, err
 			}
 			key.KeyCol = key.WeightStringCol

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -412,7 +412,8 @@ func (oa *OrderedAggregate) keysEqual(row1, row2 []sqltypes.Value, colls map[int
 		cmp, err := evalengine.NullsafeCompare(row1[key.KeyCol], row2[key.KeyCol], colls[key.KeyCol])
 		if err != nil {
 			_, isComparisonErr := err.(evalengine.UnsupportedComparisonError)
-			if !(isComparisonErr && key.WeightStringCol != -1) {
+			_, isCollationErr := err.(evalengine.UnsupportedCollationError)
+			if !((isComparisonErr || isCollationErr) && key.WeightStringCol != -1) {
 				return false, err
 			}
 			key.KeyCol = key.WeightStringCol

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -568,7 +568,7 @@ func TestOrderedAggregateKeysFail(t *testing.T) {
 		Input:       fp,
 	}
 
-	want := "types are not comparable: VARCHAR vs VARCHAR"
+	want := "cannot compare strings, collation is unknown or unsupported (collation ID: 0)"
 	if _, err := oa.TryExecute(&noopVCursor{}, nil, false); err == nil || err.Error() != want {
 		t.Errorf("oa.Execute(): %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -877,7 +877,7 @@ func TestRouteSort(t *testing.T) {
 		},
 	}
 	_, err = sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
-	require.EqualError(t, err, `types are not comparable: VARCHAR vs VARCHAR`)
+	require.EqualError(t, err, `cannot compare strings, collation is unknown or unsupported (collation ID: 0)`)
 }
 
 func TestRouteSortWeightStrings(t *testing.T) {
@@ -978,7 +978,7 @@ func TestRouteSortWeightStrings(t *testing.T) {
 			},
 		}
 		_, err = sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
-		require.EqualError(t, err, `types are not comparable: VARCHAR vs VARCHAR`)
+		require.EqualError(t, err, `cannot compare strings, collation is unknown or unsupported (collation ID: 0)`)
 	})
 }
 
@@ -1083,7 +1083,7 @@ func TestRouteSortCollation(t *testing.T) {
 			},
 		}
 		_, err = sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
-		require.EqualError(t, err, "types are not comparable: VARCHAR vs VARCHAR")
+		require.EqualError(t, err, "cannot compare strings, collation is unknown or unsupported (collation ID: 0)")
 	})
 
 	t.Run("Error when Unsupported Collation", func(t *testing.T) {
@@ -1109,7 +1109,7 @@ func TestRouteSortCollation(t *testing.T) {
 			},
 		}
 		_, err = sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
-		require.EqualError(t, err, "comparison using collation 1111 isn't possible")
+		require.EqualError(t, err, "cannot compare strings, collation is unknown or unsupported (collation ID: 1111)")
 	})
 }
 

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -670,20 +670,20 @@ func TestNullsafeCompareCollate(t *testing.T) {
 			v1:        "abcd",
 			v2:        "abcd",
 			collation: 0,
-			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "cannot compare strings, collation is unknown or unsupported (collation ID: 0)"),
 		},
 		{
 			v1:        "abcd",
 			v2:        "abcd",
 			collation: 1111,
-			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 1111 isn't possible"),
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "cannot compare strings, collation is unknown or unsupported (collation ID: 1111)"),
 		},
 		{
 			v1: "abcd",
 			v2: "abcd",
 			// unsupported collation gb18030_bin
 			collation: 249,
-			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "comparison using collation 249 isn't possible"),
+			err:       vterrors.New(vtrpcpb.Code_UNKNOWN, "cannot compare strings, collation is unknown or unsupported (collation ID: 249)"),
 		},
 	}
 	for _, tcase := range tcases {
@@ -1371,7 +1371,7 @@ func TestMin(t *testing.T) {
 	}, {
 		v1:  TestValue(querypb.Type_VARCHAR, "aa"),
 		v2:  TestValue(querypb.Type_VARCHAR, "aa"),
-		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
+		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "cannot compare strings, collation is unknown or unsupported (collation ID: 0)"),
 	}}
 	for _, tcase := range tcases {
 		v, err := Min(tcase.v1, tcase.v2, collations.Unknown)
@@ -1478,7 +1478,7 @@ func TestMax(t *testing.T) {
 	}, {
 		v1:  TestValue(querypb.Type_VARCHAR, "aa"),
 		v2:  TestValue(querypb.Type_VARCHAR, "aa"),
-		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "types are not comparable: VARCHAR vs VARCHAR"),
+		err: vterrors.New(vtrpcpb.Code_UNKNOWN, "cannot compare strings, collation is unknown or unsupported (collation ID: 0)"),
 	}}
 	for _, tcase := range tcases {
 		v, err := Max(tcase.v1, tcase.v2, collations.Unknown)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
While working on #9155 it was suggested by @frouioui that we can use better error formatting to explicitly let the user know about the error being caused due to missing collation information or it is an unsupported collation.

Earlier the case for missing collation information was being suggested as a `UnsupportedComparisonError` error but given collation support is inbound we should update the error message to explicitly tell in case of `text` values that collation information is missing using `UnsupportedCollationError`

To support this the following was done:
- Error message was updated in `UnsupportedCollationError`
- `if` check with `text` types now also handles the case for `collation.Unknown`
- Accommodate the return of `UnsupportedCollationError` in `ordered_aggregate.go` and `comparer.go` so that they can use weight string in case `UnsupportedCollationError` or `UnsupportedComparisonError` is being returned
- Update the tests to compare with newly formated string

Commits Made:
- feat: explicit error for collation with text
- fix: accommodate both support and collation error
- fix: update tests to compare with new error str

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- #8606 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->