### PR TITLE
VReplication Workflow Create: Check for Copying state while waiting for streams to start

### DIFF
--- a/go/test/endtoend/vreplication/migrate_test.go
+++ b/go/test/endtoend/vreplication/migrate_test.go
@@ -108,6 +108,7 @@ func TestMigrate(t *testing.T) {
 			"-source=ext1.rating", "create", ksWorkflow); err != nil {
 			t.Fatalf("Migrate command failed with %+v : %s\n", err, output)
 		}
+		time.Sleep(1 * time.Second) // wait for migrate to run
 		expectNumberOfStreams(t, vtgateConn, "migrate", "e1", "product:0", 1)
 		validateCount(t, vtgateConn, "product:0", "rating", 2)
 		validateCount(t, vtgateConn, "product:0", "review", 3)


### PR DESCRIPTION

## Description
Workflow Create polls the status of all vreplication streams for _timeout_ seconds (default:30) and reports an error if all streams are deemed not to have started. 

Currently we poll for each stream to reach the Running state. This is incorrect we start with the copy phase which can take a significant amount of time for large data. This PR also checks for the Copying state.

It is expected that, if the workflow is configured correctly, the default 30 seconds will be enough for all streams to find source tablets to start the copy phase.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
#9000 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
