### PR TITLE
Local example: fix local change that was committed erroneously

### DIFF
--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -49,7 +49,7 @@ sleep 3 # required for now
 ./203_switch_reads.sh
 
 ./204_switch_writes.sh
-exit
+
 mysql --table < ../common/select_customer0_data.sql
 # Expected to fail!
 mysql --table < ../common/select_commerce_data.sql || echo "DenyList working as expected"


### PR DESCRIPTION

## Description

A local change to local_example.sh used for local testing made it to a commit:
https://github.com/vitessio/vitess/commit/b7ced6123e3a7eace52c2def259c7900a7c8cafb

This PR reverts that.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
https://github.com/vitessio/vitess/pull/8630

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
