### PR TITLE
[vtadmin-web] Bugfix to stop overwriting default tailwindcss text color rules

### DIFF
--- a/web/vtadmin/tailwind.config.js
+++ b/web/vtadmin/tailwind.config.js
@@ -2,7 +2,12 @@ module.exports = {
     purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
     darkMode: false,
     theme: {
-        extend: {},
+        extend: {
+            textColor: {
+                primary: '#17171b',
+                secondary: '#718096',
+            },
+        },
         fontFamily: {
             mono: ['NotoMono', 'source-code-pro', 'menlo', 'monaco', 'consolas', 'Courier New', 'monospace'],
             sans: [
@@ -19,10 +24,6 @@ module.exports = {
                 'Helvetica Neue',
                 'sans-serif',
             ],
-        },
-        textColor: {
-            primary: '#17171b',
-            secondary: '#718096',
         },
     },
     variants: {


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

... so _that's_ what `extend` is for. 🤡  I noticed classes like `text-red-500` weren't working and it's because I put the `textColors` config in the [wrong place](https://tailwindcss.com/docs/theme#extending-the-default-theme).

## Related Issue(s)

A fix for https://github.com/vitessio/vitess/pull/9215


## Checklist
- [ ] Should this PR be backported? No
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A