### PR TITLE
vtctlclient Workflow command: handle empty workflow name in a keyspace.workflow spec 

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3847,6 +3847,9 @@ func commandWorkflow(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.
 		if err != nil {
 			return err
 		}
+		if workflow == "" {
+			return fmt.Errorf("workflow has to be defined for action %s", action)
+		}
 	}
 	_, err = wr.TopoServer().GetKeyspace(ctx, keyspace)
 	if err != nil {


### PR DESCRIPTION
## Description
The `Workflow` command takes a `keyspace.workflow`  spec to identify which workflow to operate on. All actions except `listall` require a workflow to be specified. The validation for this fails if the user specifies the trailing  `.`  but nothing after that. It then resolves to an empty workflow string and internally this results in the action to be operated on *all* workflows.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
#9137 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->