### PR TITLE
restore 'vtctl VExec' command (backport v12)

### DIFF
--- a/doc/releasenotes/12_0_0_release_notes.md
+++ b/doc/releasenotes/12_0_0_release_notes.md
@@ -31,8 +31,6 @@ zone1-0000000103 sourcekeyspace 0 rdonly 192.168.0.134:15103 192.168.0.134:17103
 
 ## Deprecations
 
-The command `vtctl VExec` is deprecated and removed. All Online DDL commands should run through `vtctl OnlineDDL`.
-
 The command `vtctl OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `vtctl ApplySchema` or via `vtgate`.
 
 

--- a/doc/releasenotes/12_0_0_release_notes.md
+++ b/doc/releasenotes/12_0_0_release_notes.md
@@ -31,6 +31,8 @@ zone1-0000000103 sourcekeyspace 0 rdonly 192.168.0.134:15103 192.168.0.134:17103
 
 ## Deprecations
 
+The command `vtctl VExec` is deprecated and removed. All Online DDL commands should run through `vtctl OnlineDDL`.
+
 The command `vtctl OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `vtctl ApplySchema` or via `vtgate`.
 
 

--- a/doc/releasenotes/12_0_1_release_notes.md
+++ b/doc/releasenotes/12_0_1_release_notes.md
@@ -1,0 +1,17 @@
+# Release of Vitess v12.0.1
+
+## Major Changes
+
+
+## Deprecations
+
+## Minor Changes
+
+### vtctl VExec
+
+The command `vtctl VExec` is restored after being deprecated in `v12.0.0`.
+
+
+------------
+## Changelog
+

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -769,6 +769,16 @@ var commands = []commandGroup{
 	{
 		"Workflow", []command{
 			{
+				name:   "VExec",
+				method: commandVExec,
+				params: "<ks.workflow> <query> --dry-run",
+				help:   "Runs query on all tablets in workflow. Example: VExec merchant.morders \"update _vt.vreplication set Status='Running'\"",
+			},
+		},
+	},
+	{
+		"Workflow", []command{
+			{
 				name:   "Workflow",
 				method: commandWorkflow,
 				params: "<ks.workflow> <action> --dry-run",
@@ -3788,6 +3798,45 @@ func commandHelp(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Flag
 		return fmt.Errorf("when calling the Help command, either specify a single argument that identifies the name of the command to get help with or do not specify any additional arguments")
 	}
 
+	return nil
+}
+
+func commandVExec(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	deprecationMessage := `VExec command will be deprecated in version v12. For Online DDL control, use "vtctl OnlineDDL" commands or SQL syntax`
+	log.Warningf(deprecationMessage)
+
+	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
+	dryRun := subFlags.Bool("dry_run", false, "Does a dry run of VExec and only reports the final query and list of tablets on which it will be applied")
+	if err := subFlags.Parse(args); err != nil {
+		return err
+	}
+	if subFlags.NArg() != 2 {
+		return fmt.Errorf("usage: VExec --dry-run keyspace.workflow \"<query>\"")
+	}
+	keyspace, workflow, err := splitKeyspaceWorkflow(subFlags.Arg(0))
+	if err != nil {
+		return err
+	}
+	_, err = wr.TopoServer().GetKeyspace(ctx, keyspace)
+	if err != nil {
+		wr.Logger().Errorf("keyspace %s not found", keyspace)
+	}
+	query := subFlags.Arg(1)
+
+	qr, err := wr.VExecResult(ctx, workflow, keyspace, query, *dryRun)
+	if err != nil {
+		return err
+	}
+	if *dryRun {
+		return nil
+	}
+	if qr == nil {
+		wr.Logger().Printf("no result returned\n")
+	}
+	if *json {
+		return printJSON(wr.Logger(), qr)
+	}
+	printQueryResult(loggerWriter{wr.Logger()}, qr)
 	return nil
 }
 


### PR DESCRIPTION
## Description

Fixes #9193 
Followup to https://github.com/vitessio/vitess/pull/8972

This PR restores `vtctl VExec` functionality. It was removed based on the assumption the only uses for this command were for Online DDL command. This was wrong, and VExec is also used as a wrapper around VReplication.

For now, we restore the full functionality, although we intend to deprecate use of VExec for Online DDL. See some discussion in https://github.com/vitessio/vitess/pull/8972

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

cc @deepthi @hallaroo @mattlord 