### PR TITLE
Add experimental `whoami` api endpoint

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -178,6 +178,7 @@ func NewAPI(clusters []*cluster.Cluster, opts Options) *API {
 
 	experimentalRouter := router.PathPrefix("/experimental").Subrouter()
 	experimentalRouter.HandleFunc("/tablet/{tablet}/debug/vars", httpAPI.Adapt(experimental.TabletDebugVarsPassthrough)).Name("API.TabletDebugVarsPassthrough")
+	experimentalRouter.HandleFunc("/whoami", httpAPI.Adapt(experimental.WhoAmI))
 
 	if !opts.HTTPOpts.DisableDebug {
 		// Due to the way net/http/pprof insists on registering its handlers, we

--- a/go/vt/vtadmin/http/experimental/whoami.go
+++ b/go/vt/vtadmin/http/experimental/whoami.go
@@ -1,0 +1,21 @@
+package experimental
+
+import (
+	"context"
+
+	vtadminhttp "vitess.io/vitess/go/vt/vtadmin/http"
+	"vitess.io/vitess/go/vt/vtadmin/rbac"
+)
+
+// WhoAmI is an experimental route for extracting authenticated Actors from
+// the request, to see who is authenticated on the frontend.
+func WhoAmI(ctx context.Context, r vtadminhttp.Request, api *vtadminhttp.API) *vtadminhttp.JSONResponse {
+	data := map[string]interface{}{}
+	actor, ok := rbac.FromContext(ctx)
+	data["authenticated"] = ok
+	if ok {
+		data["actor"] = actor
+	}
+
+	return vtadminhttp.NewJSONResponse(data, nil)
+}

--- a/go/vt/vtadmin/rbac/authentication.go
+++ b/go/vt/vtadmin/rbac/authentication.go
@@ -90,8 +90,8 @@ func AuthenticationUnaryInterceptor(authn Authenticator) grpc.UnaryServerInterce
 // Actor represents the subject in the "subject action resource" of an
 // authorization check. It has a name and many roles.
 type Actor struct {
-	Name  string
-	Roles []string
+	Name  string   `json:"name"`
+	Roles []string `json:"roles"`
 }
 
 type actorkey struct{}


### PR DESCRIPTION
Signed-off-by: Andrew Mason <amason@slack-corp.com>


## Description

We're just pulling the actor out of the current request, assuming that the actor making this request is also the actor making other requests, for the purposes of the frontend.

I added a "dumb" authenticator to test both versions, which looks like:

```diff
diff --git a/go/vt/vtadmin/rbac/authentication.go b/go/vt/vtadmin/rbac/authentication.go
index a43dcbb2e1..f5cb42f86c 100644
--- a/go/vt/vtadmin/rbac/authentication.go
+++ b/go/vt/vtadmin/rbac/authentication.go
@@ -134,6 +134,19 @@ func RegisterAuthenticator(name string, f func() Authenticator) {
        authenticators[name] = f
 }
 
+type dumbAuthn struct{}
+
+func (authn *dumbAuthn) Authenticate(ctx context.Context) (*Actor, error) { return nil, nil }
+func (authn *dumbAuthn) AuthenticateHTTP(r *http.Request) (*Actor, error) {
+       return &Actor{"andrew", []string{"role1", "role2"}}, nil
+}
+
+func init() {
+       RegisterAuthenticator("dumb", func() Authenticator {
+               return &dumbAuthn{}
+       })
+}
+
```

<img width="724" alt="Screen Shot 2021-11-15 at 9 37 23 AM" src="https://user-images.githubusercontent.com/4276638/141800814-3d174464-2242-4f19-b6ad-058ef5c4f5d2.png">
<img width="580" alt="Screen Shot 2021-11-15 at 9 38 23 AM" src="https://user-images.githubusercontent.com/4276638/141800815-0415d011-803d-466b-bc7b-cf9f4543f2e8.png">


## Related Issue(s)


## Checklist
- [x] Should this PR be backported? **no**
- [x] Tests were added or are not required **no**
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->