### PR TITLE
Ensure that vtgate's two tablet caches are in sync

### DIFF
--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -204,7 +204,7 @@ func TestReplicaTransactions(t *testing.T) {
 	require.Nil(t, err)
 	serving := replicaTablet.VttabletProcess.WaitForStatus("SERVING", time.Duration(60*time.Second))
 	assert.Equal(t, serving, true, "Tablet did not become ready within a reasonable time")
-	exec(t, readConn, fetchAllCustomers, "is either down or nonexistent")
+	exec(t, readConn, fetchAllCustomers, "not found")
 
 	// create a new connection, should be able to query again
 	readConn, err = mysql.Connect(ctx, &vtParams)

--- a/go/vt/discovery/fake_healthcheck.go
+++ b/go/vt/discovery/fake_healthcheck.go
@@ -181,6 +181,17 @@ func (fhc *FakeHealthCheck) AddTablet(tablet *topodatapb.Tablet) {
 	fhc.items[key] = item
 }
 
+// AddTabletIfNotPresent adds the tablet, if not present.
+// This adds idempotency to AddTablet
+func (fhc *FakeHealthCheck) AddTabletIfNotPresent(tablet *topodatapb.Tablet) {
+	fhc.mu.Lock()
+	_, exists := fhc.items[TabletToMapKey(tablet)]
+	fhc.mu.Unlock()
+	if !exists {
+		fhc.AddTablet(tablet)
+	}
+}
+
 // RemoveTablet removes the tablet.
 func (fhc *FakeHealthCheck) RemoveTablet(tablet *topodatapb.Tablet) {
 	fhc.mu.Lock()

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -228,6 +228,10 @@ func (tw *TopologyWatcher) loadTablets() {
 				// a different address key.
 				tw.tabletRecorder.ReplaceTablet(val.tablet, newVal.tablet)
 				topologyWatcherOperations.Add(topologyWatcherOpReplaceTablet, 1)
+			} else {
+				// The tablet is in our cache so let's ensure that the healthcheck record exists
+				// as it is critical for query serving
+				tw.tabletRecorder.AddTabletIfNotPresent(newVal.tablet)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Matt Lord <mattalord@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->