### PR TITLE
Prevent Race Conditions Between Tablet Deletes and Updates

### DIFF
--- a/go/test/endtoend/tabletgateway/vtgate_test.go
+++ b/go/test/endtoend/tabletgateway/vtgate_test.go
@@ -204,7 +204,7 @@ func TestReplicaTransactions(t *testing.T) {
 	require.Nil(t, err)
 	serving := replicaTablet.VttabletProcess.WaitForStatus("SERVING", time.Duration(60*time.Second))
 	assert.Equal(t, serving, true, "Tablet did not become ready within a reasonable time")
-	exec(t, readConn, fetchAllCustomers, "is either down or nonexistent")
+	exec(t, readConn, fetchAllCustomers, "not found")
 
 	// create a new connection, should be able to query again
 	readConn, err = mysql.Connect(ctx, &vtParams)

--- a/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
+++ b/go/test/endtoend/vtgate/tablet_healthcheck_cache/correctness_test.go
@@ -130,7 +130,7 @@ func TestMain(m *testing.M) {
 // conditions with these operations and their interactions with the cache.
 func TestHealthCheckCacheWithTabletChurn(t *testing.T) {
 	ctx := context.Background()
-	tries := 10
+	tries := 5
 	numShards := len(shards)
 	// 1 for primary,replica
 	expectedTabletHCcacheEntries := numShards * 2
@@ -155,8 +155,13 @@ func TestHealthCheckCacheWithTabletChurn(t *testing.T) {
 		qr, _ := vtgateConn.ExecuteFetch(query, 100, true)
 		assert.Equal(t, expectedTabletHCcacheEntries, len(qr.Rows), "wrong number of tablet records in healthcheck cache, expected %d but had %d. Results: %v", expectedTabletHCcacheEntries, len(qr.Rows), qr.Rows)
 
-		killTablet(t, tablet)
+		deleteTablet(t, tablet)
 		expectedTabletHCcacheEntries--
+
+		// We need to sleep for at least vtgate's -tablet_refresh_interval to be sure we
+		// have resynchronized the healthcheck cache with the topo server via the topology
+		// watcher and pruned the deleted tablet from the healthcheck cache.
+		time.Sleep(1 * time.Minute)
 
 		qr, _ = vtgateConn.ExecuteFetch(query, 100, true)
 		assert.Equal(t, expectedTabletHCcacheEntries, len(qr.Rows), "wrong number of tablet records in healthcheck cache, expected %d but had %d. Results: %v", expectedTabletHCcacheEntries, len(qr.Rows), qr.Rows)
@@ -213,8 +218,7 @@ func addTablet(t *testing.T, tabletUID int, tabletType string) *cluster.Vttablet
 	return tablet
 }
 
-func killTablet(t *testing.T, tablet *cluster.Vttablet) {
-	t.Logf("Killing tablet: %s", tablet.Alias)
+func deleteTablet(t *testing.T, tablet *cluster.Vttablet) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func(tablet *cluster.Vttablet) {
@@ -225,6 +229,8 @@ func killTablet(t *testing.T, tablet *cluster.Vttablet) {
 	}(tablet)
 	wg.Wait()
 
-	err := clusterInstance.VtctlclientProcess.ExecuteCommand("RebuildKeyspaceGraph", keyspaceName)
+	err := clusterInstance.VtctlclientProcess.ExecuteCommand("DeleteTablet", tablet.Alias)
 	require.Nil(t, err)
+
+	t.Logf("Deleted tablet: %s", tablet.Alias)
 }

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -410,7 +410,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 	defer hc.mu.Unlock()
 
 	tabletAlias := tabletAliasString(topoproto.TabletAliasString(th.Tablet.Alias))
-	// let's be sure that this tablet hasn't been deleted from the authortative map
+	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
 	// tablet record that was deleted
 	if _, ok := hc.healthByAlias[tabletAlias]; !ok {

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -385,7 +385,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	// delete from authoritative map
 	th, ok := hc.healthByAlias[tabletAlias]
 	if !ok {
-		log.Infof("We have no health data for tablet: %v, it might have been deleted already", tabletAlias)
+		log.Infof("We have no health data for tablet: %v, it might have been deleted already", tablet)
 		return
 	}
 	// Calling this will end the context associated with th.checkConn,
@@ -421,7 +421,7 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 	// tablet record that was deleted
 	_, ok := hc.healthByAlias[tabletAlias]
 	if !ok {
-		log.Infof("Tablet %s has been deleted, skipping health update", tabletAlias)
+		log.Infof("Tablet %v has been deleted, skipping health update", th.Tablet)
 		return
 	}
 

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -289,10 +289,13 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 
 		if err != nil {
 			hcErrorCounters.Add([]string{thc.Target.Keyspace, thc.Target.Shard, topoproto.TabletTypeLString(thc.Target.TabletType)}, 1)
-			// We have reason to suspect the tablet healthcheck record is corrupted or invalid so let's remove the tablet's record
-			// from the healthcheck cache and the corrected tablet record will be fetched from the topology and added to the
-			// healthcheck cache again via the topology watcher.
+			// This means that another tablet has taken over the host:port that we were connected to.
+			// So let's remove the tablet's data from the healthcheck, and if it is still a part of the
+			// cluster, the new tablet record will be fetched from the topology server and re-added to
+			// the healthcheck cache again via the topology watcher.
+			// WARNING: Under no other circumstances should we be deleting the tablet here.
 			if strings.Contains(err.Error(), "health stats mismatch") {
+				log.Warningf("deleting tablet %v from healthcheck due to health stats mismatch", thc.Tablet)
 				hc.deleteTablet(thc.Tablet)
 				return
 			}
@@ -329,7 +332,7 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 }
 
 func (thc *tabletHealthCheck) closeConnection(ctx context.Context, err error) {
-	log.Warningf("tablet %v healthcheck stream error: %v", thc.Tablet.Alias, err)
+	log.Warningf("tablet %v healthcheck stream error: %v", thc.Tablet, err)
 	thc.setServingState(false, err.Error())
 	thc.LastError = err
 	_ = thc.Conn.Close(ctx)

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -290,11 +290,9 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 		if err != nil {
 			hcErrorCounters.Add([]string{thc.Target.Keyspace, thc.Target.Shard, topoproto.TabletTypeLString(thc.Target.TabletType)}, 1)
 			// We have reason to suspect the tablet healthcheck record is corrupted or invalid so let's remove the tablet's record
-			// from the healthcheck cache and it will get re-added again if the tablet is reachable
-			if strings.Contains(err.Error(), "health stats mismatch") ||
-				strings.HasSuffix(err.Error(), context.Canceled.Error()) ||
-				strings.Contains(err.Error(), `"error reading from server: EOF", received prior goaway`) {
-				log.Warningf("tablet %s had a suspect healthcheck error: %s -- clearing cache record", thc.Tablet.Alias, err.Error())
+			// from the healthcheck cache and the corrected tablet record will be fetched from the topology and added to the
+			// healthcheck cache again via the topology watcher.
+			if strings.Contains(err.Error(), "health stats mismatch") {
 				hc.deleteTablet(thc.Tablet)
 				return
 			}

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -216,19 +216,20 @@ func (tw *TopologyWatcher) loadTablets() {
 
 	for alias, newVal := range newTablets {
 		// trust the alias from topo and add it if it doesn't exist
-		if val, ok := tw.tablets[alias]; !ok {
-			tw.tabletRecorder.AddTablet(newVal.tablet)
-			topologyWatcherOperations.Add(topologyWatcherOpAddTablet, 1)
-		} else {
-			// check if the host and port have changed. If yes, replace tablet
+		if val, ok := tw.tablets[alias]; ok {
+			// check if the host and port have changed. If yes, replace tablet.
 			oldKey := TabletToMapKey(val.tablet)
 			newKey := TabletToMapKey(newVal.tablet)
 			if oldKey != newKey {
 				// This is the case where the same tablet alias is now reporting
-				// a different address key.
+				// a different address (host:port) key.
 				tw.tabletRecorder.ReplaceTablet(val.tablet, newVal.tablet)
 				topologyWatcherOperations.Add(topologyWatcherOpReplaceTablet, 1)
 			}
+		} else {
+			// This is a new tablet record, let's add it to the healthcheck
+			tw.tabletRecorder.AddTablet(newVal.tablet)
+			topologyWatcherOperations.Add(topologyWatcherOpAddTablet, 1)
 		}
 	}
 

--- a/test/config.json
+++ b/test/config.json
@@ -801,7 +801,7 @@
 			"Command": [],
 			"Manual": false,
 			"Shard": "vtgate_tablet_healthcheck_cache",
-			"RetryMax": 2,
+			"RetryMax": 1,
 			"Tags": []
 		},
 		"vtgate_transaction": {


### PR DESCRIPTION
## Description
There was a race condition between [deleting a tablet's healthcheck record](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/healthcheck.go#L379-L408) from the authoritative map ([`hc.healthByAlias`](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/healthcheck.go#L227)) and [updating the same tablet's health data record](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/healthcheck.go#L410-L485) ([`hc.healthData`](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/healthcheck.go#L227)).

This could cause us to effectively re-add an updated copy of the tablet healthcheck record after it's been deleted [due to the open stream with the tablet encounting an error](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/tablet_health_check.go#L275-L304) -- often a context being cancelled or a gRPC goaway error seen due to the tablet shutting down. This then leads to "zombie" tablet records in the `SHOW VITESS_TABLETS` output as it is based on what is in the `hc.healthData` map and it had records for tablets that were no longer in `hc.healthByAlias` (so the authoritative map was no longer authoritative):
https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/vtgate/executor.go#L1108
...
https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/healthcheck.go#L537-L557

## Changes
 - **_KEY:_** The healthcheck will **_ONLY_** delete from its own lower level cache directly -- via `hc.deleteTablet()` -- if there's mismatching endpoints for the tablet indicating that the healthcheck record is no longer valid (this was the case before https://github.com/vitessio/vitess/pull/9106) 
   - This is the **_only_** safe exception to the rule that the healthcheck cache be updated (add,replace,delete) via topo server -> topology watcher -> healthcheck [here](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/topology_watcher.go#L217-L240), as in this case the record is simply not valid and will get corrected in the noted path via the topo server tablet records in the next refresh
 - **_KEY:_** We avoid the race condition between`hc.deleteTablet()` and `hc.updateHealth()` by confirming that the tablet record still exists in the authoritative `hc.healthByAlias` map before updating the health of the tablet in the sibling `hc.healthData` map because the mutex does not enforce order of operations. If it does NOT exist there then the update is a no-op (the old tablet health data record copy made [here](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/tablet_health_check.go#L303) or [here](https://github.com/vitessio/vitess/blob/693c5dbdeacdd7a705b46ebce6776a5256c8cfef/go/vt/discovery/tablet_health_check.go#L314) will go out of scope and be GC'd).
 - The `vtgate/tablet_healthcheck_cache/correctness` end2end test was updated to verify the correct behavior (unfortunately the test originally added in https://github.com/vitessio/vitess/pull/9106 was simply verifying bad behavior)
 - We create the record in the sibling `hc.healthData` map -- if it doesn't exist -- when updating the health record for a tablet that we have confirmed exists in the authoritative `hc.healthByAlias` map 

With these changes, I could no longer repeat the zombie tablet record using [the steps shown here](https://github.com/vitessio/vitess/issues/8465#issuecomment-951433088), and we see the expected log messages indicating that we've avoided the race condition:
```
/vt/vtdataroot/tmp/vtgate.INFO:I1115 23:31:18.311915    2021 healthcheck.go:424] Tablet zone1-0000000201 has been deleted, skipping health update
/vt/vtdataroot/tmp/vtgate.INFO:I1115 23:31:18.311976    2021 healthcheck.go:424] Tablet zone1-0000000200 has been deleted, skipping health update
/vt/vtdataroot/tmp/vtgate.INFO:I1115 23:31:18.311994    2021 healthcheck.go:424] Tablet zone1-0000000202 has been deleted, skipping health update
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes: https://github.com/vitessio/vitess/issues/9238
**_Properly_** Fixes: https://github.com/vitessio/vitess/issues/8465


## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were added/updated
- [x] Documentation is not required