### PR TITLE
git: optimize golangci-lint post-commit hook

### DIFF
--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -19,4 +19,12 @@ if [ $? -eq 1 ]; then
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
 fi
 
-golangci-lint run --new -E revive ./go/...
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+if [ -z "$gofiles" ]; then
+  exit 0
+fi
+
+gopackages=$(echo "$gofiles" | xargs -n1 dirname | sort -u | paste -sd ' ')
+
+echo "Linting $gopackages"
+golangci-lint run -E revive $gopackages


### PR DESCRIPTION
## Description

As suggested by @ajm188 in https://github.com/vitessio/vitess/pull/9049, the `--new` flag to `golangci-lint` that we're running in our post-commit hook doesn't work great if you have untracked files, if you're doing a partial commit, etc.

I'm switching the post-commit hook to work only on the packages that have actually been touched by the last commit. This code looks a lot like the one we had before except:

- We're running `revive` to check our style
- We're not running `golangci-lint` once for each package. We can just pass all the packages to a single invocation to significantly speed up processing time.

## Related Issue(s)
- https://github.com/vitessio/vitess/pull/9049


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->