### PR TITLE
[12.0] make sure to copy bindvars when using them concurrently

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -579,150 +579,103 @@ func TestUnionWithManyInfSchemaQueries(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	utils.Exec(t, conn, `SELECT
-	kcu.TABLE_SCHEMA,
-	kcu.TABLE_NAME,
-	kcu.CONSTRAINT_NAME,
-	kcu.COLUMN_NAME,
-	kcu.REFERENCED_TABLE_SCHEMA,
-	kcu.REFERENCED_TABLE_NAME,
-	kcu.REFERENCED_COLUMN_NAME,
-	rc.DELETE_RULE ON_DELETE,
-	rc.UPDATE_RULE ON_UPDATE
-FROM (
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't1'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't1_id2_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 'vstream_test'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't2'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't2_id4_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't3'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't3_id7_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-	WHERE
-		kcu.TABLE_SCHEMA = 'ks'
-		AND
-		kcu.TABLE_NAME = 't4'
-) kcu
-INNER JOIN (
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't1'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't1_id2_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 'vstream_test'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't2'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't2_id4_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't3'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't3_id7_idx'
- UNION 
-	SELECT
-		*
-	FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-	WHERE
-		CONSTRAINT_SCHEMA = 'ks'
-		AND
-		TABLE_NAME = 't4'
-) rc
-	ON
-		rc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
-		AND
-		rc.TABLE_NAME = kcu.TABLE_NAME
-		AND
-		rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME`)
+	utils.Exec(t, conn, `SELECT /* GEN4_COMPARE_ONLY_GEN4 */ 
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'company_invite_code'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'site_role'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'item'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'site_item_urgent'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'site_item_event'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'site_item'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'site'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'company'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'user_company'
+                 UNION 
+                SELECT
+                    TABLE_SCHEMA,
+                    TABLE_NAME
+                FROM
+                    INFORMATION_SCHEMA.TABLES
+                WHERE
+                    TABLE_SCHEMA = 'ionescu'
+                    AND
+                    TABLE_NAME = 'user'`)
 }

--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -124,8 +124,9 @@ func (c *Concatenate) execSources(vcursor VCursor, bindVars map[string]*querypb.
 	defer restoreCtx()
 	for i, source := range c.Sources {
 		currIndex, currSource := i, source
+		vars := copyBindVars(bindVars)
 		g.Go(func() error {
-			result, err := vcursor.ExecutePrimitive(currSource, bindVars, wantfields)
+			result, err := vcursor.ExecutePrimitive(currSource, vars, wantfields)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
When executing `UNION` queries, the individual queries are sent concurrently to the tablets. For `information_schema`  queries, the bind variables are changed before sending them down to the tablet. These two features together lead to one map being iterated over while being updated, which is a no-no that will panic.

The solution is to make a copy of the bindvars before executing the individual queries of the `UNION`.

## Related Issue(s)
Fixes #9139
Backport of #9191 