### PR TITLE
Fuzzing: Add more fuzzers

### DIFF
--- a/go/test/fuzzing/oss_fuzz_build.sh
+++ b/go/test/fuzzing/oss_fuzz_build.sh
@@ -22,20 +22,25 @@ set -x
 go get github.com/AdaLogics/go-fuzz-headers
 go mod vendor
 
+mv ./go/vt/vttablet/tabletmanager/vreplication/framework_test.go \
+   ./go/vt/vttablet/tabletmanager/vreplication/framework_fuzz.go
+
 #consistent_lookup_test.go is needed for loggingVCursor
 mv ./go/vt/vtgate/vindexes/consistent_lookup_test.go \
    ./go/vt/vtgate/vindexes/consistent_lookup_test_fuzz.go
-compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/vindexes FuzzVindex fuzz_vindex
 
 # fake_vcursor_test.go is needed for loggingVCursor
 mv ./go/vt/vtgate/engine/fake_vcursor_test.go \
     ./go/vt/vtgate/engine/fake_vcursor.go
-compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/engine FuzzEngine engine_fuzzer
 
 # plan_test.go is needed for vschemaWrapper
 mv ./go/vt/vtgate/planbuilder/plan_test.go \
     ./go/vt/vtgate/planbuilder/plan_test_fuzz.go
+
 compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/planbuilder FuzzTestBuilder fuzz_test_builder gofuzz
+compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/vindexes FuzzVindex fuzz_vindex
+compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication FuzzEngine fuzz_replication_engine
+compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/engine FuzzEngine engine_fuzzer
 
 
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing Fuzz vtctl_fuzzer
@@ -46,11 +51,15 @@ compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzGRPCTMServer fuzz_grpc_tm
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzOnlineDDLFromCommentedStatement fuzz_online_ddl_from_commented_statement
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzNewOnlineDDLs fuzz_new_online_ddls
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzEqualsSQLNode fuzz_equals_sql_node
+compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzSplitStatementToPieces fuzz_split_statement_to_pieces
+compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzTabletManager_ExecuteFetchAsDba fuzz_tablet_manager_execute_fetch_as_dba
 
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzWritePacket write_packet_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzHandleNextCommand handle_next_command_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzReadQueryResults read_query_results_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzTLSServer fuzz_tls
+
+compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer Fuzz vstreamer_planbuilder_fuzzer
 
 # Several test utils are needed from suite_test.go:
 mv ./go/vt/vtgate/grpcvtgateconn/suite_test.go \

--- a/go/test/fuzzing/oss_fuzz_build.sh
+++ b/go/test/fuzzing/oss_fuzz_build.sh
@@ -37,6 +37,10 @@ mv ./go/vt/vtgate/engine/fake_vcursor_test.go \
 mv ./go/vt/vtgate/planbuilder/plan_test.go \
     ./go/vt/vtgate/planbuilder/plan_test_fuzz.go
 
+# tabletserver fuzzer
+mv ./go/vt/vttablet/tabletserver/testutils_test.go \
+   ./go/vt/vttablet/tabletserver/testutils_fuzz.go
+
 compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/planbuilder FuzzTestBuilder fuzz_test_builder gofuzz
 compile_go_fuzzer vitess.io/vitess/go/vt/vtgate/vindexes FuzzVindex fuzz_vindex
 compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication FuzzEngine fuzz_replication_engine
@@ -47,12 +51,15 @@ compile_go_fuzzer vitess.io/vitess/go/test/fuzzing Fuzz vtctl_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzIsDML is_dml_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzNormalizer normalizer_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzParser parser_fuzzer
+compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzNodeFormat fuzz_node_format
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzGRPCTMServer fuzz_grpc_tm_server
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzOnlineDDLFromCommentedStatement fuzz_online_ddl_from_commented_statement
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzNewOnlineDDLs fuzz_new_online_ddls
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzEqualsSQLNode fuzz_equals_sql_node
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzSplitStatementToPieces fuzz_split_statement_to_pieces
 compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzTabletManager_ExecuteFetchAsDba fuzz_tablet_manager_execute_fetch_as_dba
+compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzUnmarshalJSON fuzz_tabletserver_rules_unmarshal_json
+compile_go_fuzzer vitess.io/vitess/go/test/fuzzing FuzzLoadTable fuzz_load_table
 
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzWritePacket write_packet_fuzzer
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzHandleNextCommand handle_next_command_fuzzer
@@ -60,6 +67,7 @@ compile_go_fuzzer vitess.io/vitess/go/mysql FuzzReadQueryResults read_query_resu
 compile_go_fuzzer vitess.io/vitess/go/mysql FuzzTLSServer fuzz_tls
 
 compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer Fuzz vstreamer_planbuilder_fuzzer
+compile_go_fuzzer vitess.io/vitess/go/vt/vttablet/tabletserver FuzzGetPlan fuzz_get_plan
 
 # Several test utils are needed from suite_test.go:
 mv ./go/vt/vtgate/grpcvtgateconn/suite_test.go \

--- a/go/test/fuzzing/parser_fuzzer.go
+++ b/go/test/fuzzing/parser_fuzzer.go
@@ -46,3 +46,8 @@ func FuzzParser(data []byte) int {
 	}
 	return 1
 }
+
+func FuzzSplitStatementToPieces(data []byte) int {
+	_, _ = sqlparser.SplitStatementToPieces(string(data))
+	return 1
+}

--- a/go/test/fuzzing/parser_fuzzer.go
+++ b/go/test/fuzzing/parser_fuzzer.go
@@ -22,6 +22,8 @@ package fuzzing
 import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
 func FuzzIsDML(data []byte) int {
@@ -44,6 +46,25 @@ func FuzzParser(data []byte) int {
 	if err != nil {
 		return 0
 	}
+	return 1
+}
+
+func FuzzNodeFormat(data []byte) int {
+	f := fuzz.NewConsumer(data)
+	query, err := f.GetSQLString()
+	if err != nil {
+		return 0
+	}
+	node, err := sqlparser.Parse(query)
+	if err != nil {
+		return 0
+	}
+	buf := &sqlparser.TrackedBuffer{}
+	err = f.GenerateStruct(buf)
+	if err != nil {
+		return 0
+	}
+	node.Format(buf)
 	return 1
 }
 

--- a/go/test/fuzzing/tablet_manager_fuzzer.go
+++ b/go/test/fuzzing/tablet_manager_fuzzer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzing
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager"
+	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
+)
+
+var fuzzInitter sync.Once
+
+func initTesting() {
+	testing.Init()
+}
+
+func FuzzTabletManager_ExecuteFetchAsDba(data []byte) int {
+	fuzzInitter.Do(initTesting)
+	t := &testing.T{}
+	ctx := context.Background()
+	cp := mysql.ConnParams{}
+	db := fakesqldb.New(t)
+	db.AddQueryPattern(".*", &sqltypes.Result{})
+	daemon := fakemysqldaemon.NewFakeMysqlDaemon(db)
+
+	dbName := "dbname"
+	tm := &tabletmanager.TabletManager{
+		MysqlDaemon:         daemon,
+		DBConfigs:           dbconfigs.NewTestDBConfigs(cp, cp, dbName),
+		QueryServiceControl: tabletservermock.NewController(),
+	}
+	_, _ = tm.ExecuteFetchAsDba(ctx, data, dbName, 10, false, false)
+	return 1
+}

--- a/go/test/fuzzing/tabletserver_rules_fuzzer.go
+++ b/go/test/fuzzing/tabletserver_rules_fuzzer.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzing
+
+import (
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
+)
+
+func FuzzUnmarshalJSON(data []byte) int {
+	qrs := rules.New()
+	_ = qrs.UnmarshalJSON(data)
+	return 1
+}

--- a/go/test/fuzzing/tabletserver_schema_fuzzer.go
+++ b/go/test/fuzzing/tabletserver_schema_fuzzer.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuzzing
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+var initter sync.Once
+
+func FuzzLoadTable(data []byte) int {
+	initter.Do(initTesting)
+	f := fuzz.NewConsumer(data)
+	tableName, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	comment, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	query, err := f.GetSQLString()
+	if err != nil {
+		return 0
+	}
+
+	t := &testing.T{}
+
+	db := fakesqldb.New(t)
+	defer db.Close()
+	db.AddQuery(query, &sqltypes.Result{})
+
+	_, _ = newTestLoadTable(tableName, comment, db)
+	return 1
+}
+
+func newTestLoadTable(tableName, comment string, db *fakesqldb.DB) (*schema.Table, error) {
+	ctx := context.Background()
+	appParams := db.ConnParams()
+	dbaParams := db.ConnParams()
+	connPool := connpool.NewPool(tabletenv.NewEnv(nil, "SchemaTest"), "", tabletenv.ConnPoolConfig{
+		Size:               2,
+		IdleTimeoutSeconds: 10,
+	})
+	connPool.Open(appParams, dbaParams, appParams)
+	conn, err := connPool.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+
+	return schema.LoadTable(conn, tableName, comment)
+}

--- a/go/test/fuzzing/vttablet_fuzzer.go
+++ b/go/test/fuzzing/vttablet_fuzzer.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -33,8 +32,6 @@ import (
 
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
-
-var initter sync.Once
 
 func onceInit() {
 	testing.Init()

--- a/go/vt/vtgate/planbuilder/abstract/fuzz.go
+++ b/go/vt/vtgate/planbuilder/abstract/fuzz.go
@@ -24,6 +24,8 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
 var _ semantics.SchemaInformation = (*fakeFuzzSI)(nil)
@@ -43,7 +45,12 @@ func (s *fakeFuzzSI) FindTableOrVindex(tablename sqlparser.TableName) (*vindexes
 
 // FuzzAnalyse implements the fuzzer
 func FuzzAnalyse(data []byte) int {
-	tree, err := sqlparser.Parse(string(data))
+	f := fuzz.NewConsumer(data)
+	query, err := f.GetSQLString()
+	if err != nil {
+		return 0
+	}
+	tree, err := sqlparser.Parse(query)
 	if err != nil {
 		return -1
 	}

--- a/go/vt/vtgate/planbuilder/fuzz.go
+++ b/go/vt/vtgate/planbuilder/fuzz.go
@@ -80,7 +80,7 @@ func loadFormalForFuzzing(f *fuzz.ConsumeFuzzer) (*vschemapb.SrvVSchema, error) 
 func FuzzTestBuilder(data []byte) int {
 	initter.Do(onceInit)
 	f := fuzz.NewConsumer(data)
-	query, err := f.GetString()
+	query, err := f.GetSQLString()
 	if err != nil {
 		return 0
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/fuzz.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/fuzz.go
@@ -96,7 +96,6 @@ func FuzzEngine(data []byte) int {
 	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
 	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
 
-	// Test Insert
 	vre := NewTestEngine(topoServer, "cell1", mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
 
 	// Fuzzer fails if this expectation is not made first:

--- a/go/vt/vttablet/tabletmanager/vreplication/fuzz.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/fuzz.go
@@ -1,0 +1,120 @@
+//go:build gofuzz
+// +build gofuzz
+
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/sync2"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+var initter sync.Once
+
+func initTesting() {
+	testing.Init()
+}
+
+func createQueries(f *fuzz.ConsumeFuzzer) ([]string, error) {
+	query1, err := f.GetSQLString()
+	if err != nil {
+		return []string{}, err
+	}
+	query2, err := f.GetSQLString()
+	if err != nil {
+		return []string{}, err
+	}
+	query3, err := f.GetSQLString()
+	if err != nil {
+		return []string{}, err
+	}
+	query4, err := f.GetSQLString()
+	if err != nil {
+		return []string{}, err
+	}
+	query5, err := f.GetSQLString()
+	if err != nil {
+		return []string{}, err
+	}
+	return []string{query1, query2, query3, query4, query5}, nil
+}
+
+func makeExpectations(dbClient *binlogplayer.MockDBClient, f *fuzz.ConsumeFuzzer) error {
+	noOfExpects, err := f.GetInt()
+	if err != nil {
+		return err
+	}
+	if noOfExpects%15 == 0 {
+		return fmt.Errorf("len is 0")
+	}
+	for i := 0; i < noOfExpects%15; i++ {
+		query, err := f.GetString()
+		if err != nil {
+			return err
+		}
+		dbClient.ExpectRequest(query, &sqltypes.Result{}, nil)
+	}
+	return nil
+}
+
+func FuzzEngine(data []byte) int {
+	initter.Do(initTesting)
+	t := &testing.T{}
+	f := fuzz.NewConsumer(data)
+	queries, err := createQueries(f)
+	if err != nil {
+		return 0
+	}
+	topoServer := memorytopo.NewServer("cell1")
+	_ = topoServer
+	defer func() { globalStats = &vrStats{} }()
+
+	resetBinlogClient()
+	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClientFactory := func() binlogplayer.DBClient { return dbClient }
+	mysqld := &fakemysqldaemon.FakeMysqlDaemon{MysqlPort: sync2.NewAtomicInt32(3306)}
+
+	// Test Insert
+	vre := NewTestEngine(topoServer, "cell1", mysqld, dbClientFactory, dbClientFactory, dbClient.DBName(), nil)
+
+	// Fuzzer fails if this expectation is not made first:
+	dbClient.ExpectRequest("select * from _vt.vreplication where db_name='db'", &sqltypes.Result{}, nil)
+	err = makeExpectations(dbClient, f)
+	if err != nil {
+		return 0
+	}
+	vre.Open(context.Background())
+	defer vre.Close()
+	if !vre.IsOpen() {
+		return 0
+	}
+	_, _ = vre.Exec(queries[0])
+	_, _ = vre.Exec(queries[1])
+	_, _ = vre.Exec(queries[2])
+	_, _ = vre.Exec(queries[3])
+	_, _ = vre.Exec(queries[4])
+
+	return 1
+}

--- a/go/vt/vttablet/tabletserver/fuzz.go
+++ b/go/vt/vttablet/tabletserver/fuzz.go
@@ -1,0 +1,72 @@
+//go:build gofuzz
+// +build gofuzz
+
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+var initter sync.Once
+
+func initForFuzzing() {
+	testing.Init()
+}
+
+// FuzzGetPlan implements a fuzzer that tests GetPlan.
+func FuzzGetPlan(data []byte) int {
+	initter.Do(initForFuzzing)
+	t := &testing.T{}
+	f := fuzz.NewConsumer(data)
+	query1, err := f.GetSQLString()
+	if err != nil {
+		return 0
+	}
+	query2, err := f.GetString()
+	if err != nil {
+		return 0
+	}
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	// Add a query
+	db.AddQuery(query1, &sqltypes.Result{})
+
+	// Set up the environment
+	config := tabletenv.NewDefaultConfig()
+	config.DB = newDBConfigs(db)
+	env := tabletenv.NewEnv(config, "TabletServerTest")
+	se := schema.NewEngine(env)
+	qe := NewQueryEngine(env, se)
+	defer qe.Close()
+	qe.Open()
+
+	logStats := tabletenv.NewLogStats(context.Background(), "GetPlanStats")
+	qe.SetQueryPlanCacheCap(1024)
+
+	// Call target
+	_, _ = qe.GetPlan(context.Background(), logStats, query2, true, false)
+	return 1
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Adds 9 fuzzers and build instructions so that OSS-fuzz can run them.
Modifies 3 fuzzers.

The fuzzers are:

1. `FuzzTabletManager_ExecuteFetchAsDba`
2. `FuzzEngine`
3. `FuzzSplitStatementToPieces`
4. `FuzzTabletManager_ExecuteFetchAsDba`
5. `FuzzParserStructured`
6. `FuzzUnmarshalJSON`
7. `FuzzLoadTable`
8. `FuzzGetPlan`
9. `FuzzNodeFormat`

It furthermore modifies the string-getter helper in:

1. `FuzzAnalyse`
2. `FuzzTestBuilder`
3. `FuzzEqualsSQLNode`

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->