### PR TITLE
collations: implement TestSupportTables

### DIFF
--- a/go/mysql/collations/mysqlversion.go
+++ b/go/mysql/collations/mysqlversion.go
@@ -20,19 +20,19 @@ func (v collver) String() string {
 	case collverInvalid:
 		return "Invalid"
 	case collverMariaDB100:
-		return "MariaDB100"
+		return "MariaDB 10.0"
 	case collverMariaDB101:
-		return "MariaDB101"
+		return "MariaDB 10.1"
 	case collverMariaDB102:
-		return "MariaDB102"
+		return "MariaDB 10.2"
 	case collverMariaDB103:
-		return "MariaDB103"
+		return "MariaDB 10.3"
 	case collverMySQL56:
-		return "MySQL56"
+		return "MySQL 5.6"
 	case collverMySQL57:
-		return "MySQL57"
+		return "MySQL 5.7"
 	case collverMySQL80:
-		return "MySQL80"
+		return "MySQL 8.0"
 	default:
 		panic("invalid version identifier")
 	}

--- a/go/mysql/collations/tools/makecolldata/mysqlversions.go
+++ b/go/mysql/collations/tools/makecolldata/mysqlversions.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"vitess.io/vitess/go/mysql/collations/tools/makecolldata/codegen"
 )
@@ -111,8 +112,13 @@ func makeversions(output string) {
 	g.P("func (v collver) String() string {")
 	g.P("switch v {")
 	g.P("case collverInvalid: return \"Invalid\"")
-	for _, version := range versions {
-		g.P("case collver", version, ": return ", codegen.Quote(version))
+	for _, cv := range versions {
+		vi := strings.IndexFunc(cv, unicode.IsNumber)
+		database := cv[:vi]
+		version, _ := strconv.Atoi(cv[vi:])
+		toString := fmt.Sprintf("%s %.1f", database, float64(version)/10.0)
+
+		g.P("case collver", cv, ": return ", codegen.Quote(toString))
 	}
 	g.P("default: panic(\"invalid version identifier\")")
 	g.P("}")


### PR DESCRIPTION
## Description

Small change to the Collations package: a test (turned off by default) that prints an up-to-date table with all the collations that we support for each MySQL version. The table can be added to our docs and it looks very neat: https://github.com/vitessio/website/pull/883

## Related Issue(s)
- https://github.com/vitessio/website/pull/883

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->