### PR TITLE
Migrate jQuery (pt. 2/3) 

### DIFF
--- a/go/vt/logz/logz_utils.go
+++ b/go/vt/logz/logz_utils.go
@@ -79,14 +79,33 @@ func StartHTMLTable(w http.ResponseWriter) {
                 }
 </style>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+<table class="gridtable">
+`))
+}
 
+// EndHTMLTable writes the end of a logz-style table to an HTTP response.
+func EndHTMLTable(w http.ResponseWriter) {
+	w.Write([]byte(`
+</table>
 <script type="text/javascript">
-$.fn.sortableByColumn = function() {
-  var body = this.find('tbody');
-  var header = this.find('thead');
-  var contents = function(el, i) {
-    var data = $(el).children('td').eq(i).text().toLowerCase();
+function wrapInner(parent, element, style) {
+
+  const wrapper = document.createElement(element);
+  wrapper.style = style
+
+  const div = parent.appendChild(wrapper);
+
+  while(parent.firstChild !== wrapper) {
+      wrapper.appendChild(parent.firstChild);
+  }
+}
+
+function sortableByColumn(element) {
+  const body = element.querySelector('tbody')
+  const header = element.querySelector('thead')
+
+  const contents = (element, i) => {
+    const data = element.querySelectorAll("td")[i].innerText.toLowerCase();
     if (data == "n/a") {
       return -1;
     }
@@ -97,19 +116,22 @@ $.fn.sortableByColumn = function() {
       return asNumber;
     }
     return data == asNumber ? asNumber : data;
-  };
+  }
 
-  this.find('thead tr th').each(function(index, th) {
-    $(th).wrapInner('<div width="5em;"></div>');
+  element.querySelectorAll('thead tr th').forEach((th, index) => {
+    wrapInner(th, "div", "overflow: auto; display: inline-block;");
+    let direction = -1;
 
-    var direction = -1;
-    $(th).click(function() {
+    th.onclick=() => {
       direction *= -1;
+      const headerCells = header.querySelectorAll('th');
+      headerCells.forEach((hc) => {
+        hc.classList.remove('ascending', 'descending');
+      })
+      th.classList.add(direction > 0? 'ascending' : 'descending');
+      const rows = body.querySelectorAll('tr');
 
-      header.find('th').removeClass('ascending descending');
-      $(th).addClass(direction > 0? 'ascending' : 'descending');
-      var rows = body.find('tr').detach();
-      rows.sort(function(left, right) {
+      const sortedRows = Array.from(rows).sort(function(left, right) {
         var cl = contents(left, index);
         var cr = contents(right, index);
         if (cl === cr) {
@@ -119,24 +141,23 @@ $.fn.sortableByColumn = function() {
         }
       });
 
-      body.append(rows);
-    });
-  });
+      // Remove original rows
+      rows.forEach(row => row.remove());
+
+      // Add new sorted rows
+      sortedRows.forEach(row => {
+        body.appendChild(row);
+      });
+    }
+  })
 }
 
-$(function() {
-  $('table').sortableByColumn();
-});
+// Execute the function when the DOM loads
+(function() {
+  const table = document.querySelector('table');
+  sortableByColumn(table)
+})();
 </script>
-
-<table class="gridtable">
-`))
-}
-
-// EndHTMLTable writes the end of a logz-style table to an HTTP response.
-func EndHTMLTable(w http.ResponseWriter) {
-	w.Write([]byte(`
-</table>
 `))
 }
 

--- a/go/vt/logz/logz_utils.go
+++ b/go/vt/logz/logz_utils.go
@@ -64,19 +64,22 @@ func StartHTMLTable(w http.ResponseWriter) {
 			padding: 4px;
 			border-style: solid;
 		}
-                table.gridtable th {
-                  padding-left: 2em;
-                  padding-right: 2em;
-                }
+    table.gridtable th {
+      padding-left: 2em;
+      padding-right: 2em;
+    }
+    table.gridtable thead th {
+      cursor: pointer;
+    }
 
-                table.gridtable th.descending:before {
-                  content: "▲";
-                  float: left;
-                }
-                table.gridtable th.ascending:before {
-                  content: "▼";
-                  float: left;
-                }
+    table.gridtable th.descending:before {
+      content: "▲";
+      float: left;
+    }
+    table.gridtable th.ascending:before {
+      content: "▼";
+      float: left;
+    }
 </style>
 
 <table class="gridtable">


### PR DESCRIPTION
Signed-off-by: notfelineit <notfelineit@gmail.com>

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR is part of a continuing effort to remove or update jQuery across the vitess repo. In particular, it removes jQuery from the `logz` package used to render sortable tables in the vtgate UI, by rewriting the logic in pure javascript.

Functionality has been tested manually, and currently works:
![ezgif com-gif-maker (20)](https://user-images.githubusercontent.com/31225471/142271870-0d469b36-164b-4741-9658-b61546ce2308.gif)

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
pt. 1 of jquery removal/migration was merged: https://github.com/vitessio/vitess/pull/9239

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
No further deployment steps are needed.