### PR TITLE
mysql: Pass mysql.Conn through {Hash,PlainText,Caching}Storage interfaces

### DIFF
--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"crypto/x509"
 	"flag"
 	"fmt"
 	"net"
@@ -85,7 +84,8 @@ func (asl *AuthServerClientCert) HandleUser(user string) bool {
 }
 
 // UserEntryWithPassword is part of the PlaintextStorage interface
-func (asl *AuthServerClientCert) UserEntryWithPassword(userCerts []*x509.Certificate, user string, password string, remoteAddr net.Addr) (Getter, error) {
+func (asl *AuthServerClientCert) UserEntryWithPassword(conn *Conn, user string, password string, remoteAddr net.Addr) (Getter, error) {
+	userCerts := conn.GetTLSClientCerts()
 	if len(userCerts) == 0 {
 		return nil, fmt.Errorf("no client certs for connection")
 	}

--- a/go/mysql/auth_server_none.go
+++ b/go/mysql/auth_server_none.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mysql
 
 import (
-	"crypto/x509"
 	"net"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -51,7 +50,7 @@ func (a *AuthServerNone) HandleUser(user string) bool {
 
 // UserEntryWithHash validates the user if it exists and returns the information.
 // Always accepts any user.
-func (a *AuthServerNone) UserEntryWithHash(userCerts []*x509.Certificate, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
+func (a *AuthServerNone) UserEntryWithHash(conn *Conn, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
 	return &NoneGetter{}, nil
 }
 

--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"bytes"
 	"crypto/subtle"
-	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"net"
@@ -161,7 +160,7 @@ func (a *AuthServerStatic) HandleUser(user string) bool {
 
 // UserEntryWithPassword implements password lookup based on a plain
 // text password that is negotiated with the client.
-func (a *AuthServerStatic) UserEntryWithPassword(userCerts []*x509.Certificate, user string, password string, remoteAddr net.Addr) (Getter, error) {
+func (a *AuthServerStatic) UserEntryWithPassword(conn *Conn, user string, password string, remoteAddr net.Addr) (Getter, error) {
 	a.mu.Lock()
 	entries, ok := a.entries[user]
 	a.mu.Unlock()
@@ -181,7 +180,7 @@ func (a *AuthServerStatic) UserEntryWithPassword(userCerts []*x509.Certificate, 
 
 // UserEntryWithHash implements password lookup based on a
 // mysql_native_password hash that is negotiated with the client.
-func (a *AuthServerStatic) UserEntryWithHash(userCerts []*x509.Certificate, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
+func (a *AuthServerStatic) UserEntryWithHash(conn *Conn, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
 	a.mu.Lock()
 	entries, ok := a.entries[user]
 	a.mu.Unlock()
@@ -214,7 +213,7 @@ func (a *AuthServerStatic) UserEntryWithHash(userCerts []*x509.Certificate, salt
 
 // UserEntryWithCacheHash implements password lookup based on a
 // caching_sha2_password hash that is negotiated with the client.
-func (a *AuthServerStatic) UserEntryWithCacheHash(userCerts []*x509.Certificate, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, CacheState, error) {
+func (a *AuthServerStatic) UserEntryWithCacheHash(conn *Conn, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, CacheState, error) {
 	a.mu.Lock()
 	entries, ok := a.entries[user]
 	a.mu.Unlock()

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ldapauthserver
 
 import (
-	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -118,7 +117,7 @@ func (asl *AuthServerLdap) HandleUser(user string) bool {
 
 // UserEntryWithPassword is part of the PlaintextStorage interface
 // and called after the password is sent by the client.
-func (asl *AuthServerLdap) UserEntryWithPassword(userCerts []*x509.Certificate, user string, password string, remoteAddr net.Addr) (mysql.Getter, error) {
+func (asl *AuthServerLdap) UserEntryWithPassword(conn *mysql.Conn, user string, password string, remoteAddr net.Addr) (mysql.Getter, error) {
 	return asl.validate(user, password)
 }
 

--- a/go/mysql/vault/auth_server_vault.go
+++ b/go/mysql/vault/auth_server_vault.go
@@ -18,7 +18,6 @@ package vault
 
 import (
 	"crypto/subtle"
-	"crypto/x509"
 	"flag"
 	"fmt"
 	"net"
@@ -166,7 +165,7 @@ func (a *AuthServerVault) HandleUser(user string) bool {
 }
 
 // UserEntryWithHash is called when mysql_native_password is used.
-func (a *AuthServerVault) UserEntryWithHash(userCerts []*x509.Certificate, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (mysql.Getter, error) {
+func (a *AuthServerVault) UserEntryWithHash(conn *mysql.Conn, salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (mysql.Getter, error) {
 	a.mu.Lock()
 	userEntries, ok := a.entries[user]
 	a.mu.Unlock()


### PR DESCRIPTION
The TLS client certificates can simply be derived based on the
mysql.Conn passed through, but passing through the actual Conn, gives us
access to Conn.ClientData or anything else an Auth{Method,Server} might need to
implement.

It's arguable that if we need access to the lower level Conn, we could
simply implement the actual HandleAuthPluginData instead of these
*Storage interfaces, and that's true. But not all AuthMethods can get
away with this because they need to write to the Conn's connection using
private functions.

For example, the `mysqlCachingSha2AuthMethod` needs to write more data
on the socket after calling `UserEntryWithCacheHash`, so to write a new
`UserEntryWithCacheHash` that needs data from `mysql.Conn`, I'm left
wtih no other options since I can't vendor or reimplement the rest of
the logic without having access to the private functions/methods within
the `mysql` package.


## Checklist
- [ ] Should this PR be backported? (no)
- [x] Tests were added or are not required (no, existing tests were modified)
- [ ] Documentation was added or is not required (In changelog probably?)