### PR TITLE
[vtadmin-web] Add 'npm run local' command

### DIFF
--- a/web/vtadmin/README.md
+++ b/web/vtadmin/README.md
@@ -11,7 +11,8 @@ Scripts for common and not-so-common tasks. These are always run from the `vites
 
 | Command | Description |
 |---|---|
-| `npm start` | Start vtadmin-web on [http://localhost:3000](http://localhost:3000) with the development server. Changes you make will be automatically picked up in the browser, no need to refresh. |
+| `npm local` | Start vtadmin-web in development mode on [http://localhost:3000](http://localhost:3000), pointed at a vtadmin-api server running on [http://localhost:14200](http://localhost:14200). This is most useful when running against a [local Vitess cluster](https://vitess.io/docs/get-started/local/). |
+| `npm start` | Start vtadmin-web in development mode on [http://localhost:3000](http://localhost:3000). Additional environment variables can be specified on the command line or in a .env file; see [Environment Variables](#environment-variables). |
 | `npm run test` | Launches the test runner in the interactive watch mode. See the create-react-app documentation about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information. |
 | `npm run lint` | Run all of the linters and formatters. The `package.json` file defines a bunch more scripts to run individual linters, if you prefer, like `npm run lint:eslint`. |
 | `npm run lint:fix` | Run all of the linters and fix errors (where possible) in place. Note that this will overwrite your files so you may want to consider committing your work beforehand! |

--- a/web/vtadmin/package.json
+++ b/web/vtadmin/package.json
@@ -39,6 +39,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
+    "local": "REACT_APP_VTADMIN_API_ADDRESS=\"http://localhost:14200\" REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS=\"true\" craco start",
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This adds a lil helper command for running vtadmin-web against the local example in dev mode, to complement some docs I'm writing. (It effectively matches what's in the [vtadmin-up.sh script](https://github.com/vitessio/vitess/blob/main/examples/local/scripts/vtadmin-up.sh), but I didn't want to conflate the two since I think of vtadmin-up.sh as for running VTAdmin, not developing it.) 

## Related Issue(s)

N/A


## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A