### PR TITLE
collations: Wildcard matching for the 'LIKE' operator

### DIFF
--- a/go/mysql/collations/collation.go
+++ b/go/mysql/collations/collation.go
@@ -121,6 +121,25 @@ type Collation interface {
 	// For collations with NO PAD, the numCodepoint argument is ignored.
 	Hash(src []byte, numCodepoints int) HashCode
 
+	// Wildcard returns a matcher for the given wildcard pattern. The matcher can be used to repeatedly
+	// test different strings to check if they match the pattern. The pattern must be a traditional wildcard
+	// pattern, which may contain the provided special characters for matching one character or several characters.
+	// The provided `escape` character will be used as an escape sequence in front of the other special characters.
+	//
+	// This method is fully collation aware; the matching will be performed according to the underlying collation.
+	// I.e. if this is a case-insensitive collation, matching will be case-insensitive.
+	//
+	// The returned WildcardPattern is always valid, but if the provided special characters do not exist in this
+	// collation's repertoire, the returned pattern will not match any strings. Likewise, if the provided pattern
+	// has invalid syntax, the returned pattern will not match any strings.
+	//
+	// If the provided special characters are 0, the defaults to parse an SQL 'LIKE' statement will be used.
+	// This is, '_' for matching one character, '%' for matching many and '\\' for escape.
+	//
+	// This method can also be used for Shell-like matching with '?', '*' and '\\' as their respective special
+	// characters.
+	Wildcard(pat []byte, matchOne, matchMany, escape rune) WildcardPattern
+
 	// Charset returns the Charset with which this collation is encoded
 	Charset() charset.Charset
 
@@ -129,6 +148,12 @@ type Collation interface {
 }
 
 type HashCode = uintptr
+
+// WildcardPattern is a matcher for a wildcard pattern, constructed from a given collation
+type WildcardPattern interface {
+	// Match returns whether the given string matches this pattern
+	Match(in []byte) bool
+}
 
 const PadToMax = math.MaxInt32
 

--- a/go/mysql/collations/integration/wildcard_test.go
+++ b/go/mysql/collations/integration/wildcard_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"vitess.io/vitess/go/mysql/collations/internal/charset"
+	"vitess.io/vitess/go/mysql/collations/remote"
+)
+
+func TestRemoteWildcardMatches(t *testing.T) {
+	conn := mysqlconn(t)
+	defer conn.Close()
+
+	var cases = []struct {
+		in, pat string
+	}{
+		{"abc", "abc"},
+		{"Abc", "aBc"},
+		{"abc", "_bc"},
+		{"abc", "a_c"},
+		{"abc", "ab_"},
+		{"abc", "%c"},
+		{"abc", "a%c"},
+		{"abc", "a%"},
+		{"abcdef", "a%d_f"},
+		{"abcdefg", "a%d%g"},
+		{"a\\", "a\\"},
+		{"aa\\", "a%\\"},
+		{"Y", "\u00dd"},
+		{"abcd", "abcde"},
+		{"abcde", "abcd"},
+		{"abcde", "a%f"},
+		{"abcdef", "a%%f"},
+		{"abcd", "a__d"},
+		{"abcd", "a\\bcd"},
+		{"a\\bcd", "abcd"},
+		{"abdbcd", "a%cd"},
+		{"abecd", "a%bd"},
+		{"ǎḄÇ", "Ǎḅç"},
+		{"ÁḆĈ", "Ǎḅç"},
+		{"ǍBc", "_bc"},
+		{"Aḅc", "a_c"},
+		{"Abç", "ab_"},
+		{"Ǎḅç", "%ç"},
+		{"Ǎḅç", "ǎ%Ç"},
+		{"aḅç", "a%"},
+		{"Ǎḅçdef", "ǎ%d_f"},
+		{"Ǎḅçdefg", "ǎ%d%g"},
+		{"ǎ\\", "Ǎ\\"},
+		{"ǎa\\", "Ǎ%\\"},
+		{"Y", "\u00dd"},
+		{"abcd", "Ǎḅçde"},
+		{"abcde", "Ǎḅçd"},
+		{"Ǎḅçde", "a%f"},
+		{"Ǎḅçdef", "ǎ%%f"},
+		{"Ǎḅçd", "ǎ__d"},
+		{"Ǎḅçd", "ǎ\\ḄÇd"},
+		{"a\\bcd", "Ǎḅçd"},
+		{"Ǎḅdbçd", "ǎ%Çd"},
+		{"Ǎḅeçd", "a%bd"},
+	}
+
+	for _, local := range defaultenv.AllCollations() {
+		t.Run(local.Name(), func(t *testing.T) {
+			var remote = remote.NewCollation(conn, local.Name())
+			var err error
+			var chEscape = '\\'
+
+			if !charset.IsBackslashSafe(local.Charset()) {
+				chEscape = '/'
+			}
+
+			for _, tc := range cases {
+				input, pat := []byte(tc.in), []byte(tc.pat)
+
+				if chEscape != '\\' {
+					for i := range pat {
+						if pat[i] == '\\' {
+							pat[i] = byte(chEscape)
+						}
+					}
+				}
+
+				input, err = charset.ConvertFromUTF8(nil, local.Charset(), input)
+				if err != nil {
+					continue
+				}
+				pat, err = charset.ConvertFromUTF8(nil, local.Charset(), pat)
+				if err != nil {
+					continue
+				}
+
+				localResult := local.Wildcard(pat, 0, 0, chEscape).Match(input)
+				remoteResult := remote.Wildcard(pat, 0, 0, chEscape).Match(input)
+				if err := remote.LastError(); err != nil {
+					t.Fatalf("remote collation failed: %v", err)
+				}
+				if localResult != remoteResult {
+					t.Errorf("expected %q LIKE %q = %v (got %v)", tc.in, tc.pat, remoteResult, localResult)
+
+					printDebugData(t, []string{
+						"wildcmp",
+						"--collation", local.Name(),
+						"--input", hex.EncodeToString(input),
+						"--pattern", hex.EncodeToString(pat),
+					})
+				}
+			}
+		})
+	}
+}

--- a/go/mysql/collations/internal/charset/charset.go
+++ b/go/mysql/collations/internal/charset/charset.go
@@ -94,3 +94,12 @@ func IsUnicodeByName(csname string) bool {
 		return false
 	}
 }
+
+func IsBackslashSafe(charset Charset) bool {
+	switch charset.(type) {
+	case Charset_sjis, Charset_cp932, Charset_gb18030 /*, Charset_gbk, Charset_big5 */ :
+		return false
+	default:
+		return true
+	}
+}

--- a/go/mysql/collations/multibyte.go
+++ b/go/mysql/collations/multibyte.go
@@ -183,3 +183,23 @@ func (c *Collation_multibyte) Hash(src []byte, numCodepoints int) HashCode {
 func (c *Collation_multibyte) WeightStringLen(numCodepoints int) int {
 	return numCodepoints
 }
+
+func (c *Collation_multibyte) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	var equals func(rune, rune) bool
+	var sortOrder = c.sort
+
+	if sortOrder != nil {
+		equals = func(a, b rune) bool {
+			if a < 128 && b < 128 {
+				return sortOrder[a] == sortOrder[b]
+			}
+			return a == b
+		}
+	} else {
+		equals = func(a, b rune) bool {
+			return a == b
+		}
+	}
+
+	return newUnicodeWildcardMatcher(c.charset, equals, c.Collate, pat, matchOne, matchMany, escape)
+}

--- a/go/mysql/collations/uca.go
+++ b/go/mysql/collations/uca.go
@@ -200,6 +200,10 @@ func (c *Collation_utf8mb4_uca_0900) WeightStringLen(numBytes int) int {
 	return weights * 2    // two bytes per weight
 }
 
+func (c *Collation_utf8mb4_uca_0900) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	return newUnicodeWildcardMatcher(charset.Charset_utf8mb4{}, c.uca.WeightsEqual, c.Collate, pat, matchOne, matchMany, escape)
+}
+
 type Collation_utf8mb4_0900_bin struct{}
 
 func (c *Collation_utf8mb4_0900_bin) Init() {}
@@ -240,6 +244,13 @@ func (c *Collation_utf8mb4_0900_bin) Hash(src []byte, _ int) HashCode {
 
 func (c *Collation_utf8mb4_0900_bin) WeightStringLen(numBytes int) int {
 	return numBytes
+}
+
+func (c *Collation_utf8mb4_0900_bin) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	equals := func(a, b rune) bool {
+		return a == b
+	}
+	return newUnicodeWildcardMatcher(charset.Charset_utf8mb4{}, equals, c.Collate, pat, matchOne, matchMany, escape)
 }
 
 type Collation_uca_legacy struct {
@@ -368,4 +379,8 @@ func (c *Collation_uca_legacy) Hash(src []byte, numCodepoints int) HashCode {
 func (c *Collation_uca_legacy) WeightStringLen(numBytes int) int {
 	// TODO: This is literally the worst case scenario. Improve on this.
 	return numBytes * 8
+}
+
+func (c *Collation_uca_legacy) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	return newUnicodeWildcardMatcher(c.charset, c.uca.WeightsEqual, c.Collate, pat, matchOne, matchMany, escape)
 }

--- a/go/mysql/collations/unicode.go
+++ b/go/mysql/collations/unicode.go
@@ -157,6 +157,14 @@ func (c *Collation_unicode_general_ci) WeightStringLen(numBytes int) int {
 	return ((numBytes + 3) / 4) * 2
 }
 
+func (c *Collation_unicode_general_ci) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	var sort = c.unicase.unicodeSort
+	var equals = func(a, b rune) bool {
+		return sort(a) == sort(b)
+	}
+	return newUnicodeWildcardMatcher(c.charset, equals, c.Collate, pat, matchOne, matchMany, escape)
+}
+
 type Collation_unicode_bin struct {
 	id      ID
 	name    string
@@ -339,6 +347,13 @@ func (c *Collation_unicode_bin) hashBMP(src []byte, numCodepoints int) uintptr {
 
 func (c *Collation_unicode_bin) WeightStringLen(numBytes int) int {
 	return ((numBytes + 3) / 4) * 3
+}
+
+func (c *Collation_unicode_bin) Wildcard(pat []byte, matchOne rune, matchMany rune, escape rune) WildcardPattern {
+	equals := func(a, b rune) bool {
+		return a == b
+	}
+	return newUnicodeWildcardMatcher(c.charset, equals, c.Collate, pat, matchOne, matchMany, escape)
 }
 
 func collationBinary(left, right []byte, rightPrefix bool) int {

--- a/go/mysql/collations/wildcard.go
+++ b/go/mysql/collations/wildcard.go
@@ -212,7 +212,6 @@ retry:
 				return false
 			}
 			s = s[width:]
-			break
 		case patternMatchMany:
 			star = true
 			str = s

--- a/go/mysql/collations/wildcard.go
+++ b/go/mysql/collations/wildcard.go
@@ -1,0 +1,532 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collations
+
+import (
+	"unicode/utf8"
+
+	"vitess.io/vitess/go/mysql/collations/internal/charset"
+)
+
+type match byte
+
+const (
+	matchOK match = iota
+	matchFail
+	matchOver
+)
+
+// wildcardRecursionDepth is the maximum amount of recursive calls that can be performed when
+// matching a wildcard. If set to 0, the default wildcard matcher will use an alternative algorithm
+// that does not use recursion.
+const wildcardRecursionDepth = 32
+
+// patternMatchOne is a special value for compiled patterns which matches a single char (it usually replaces '_' or '?')
+const patternMatchOne = -128
+
+// patternMatchMany is a special value for compiled pattern that matches any amount of chars (it usually replaces '%' or '*')
+const patternMatchMany = -256
+
+// nopMatcher is an implementation of WildcardPattern that never matches anything.
+// It is returned when we detect that a provided wildcard pattern cannot match anything
+type nopMatcher struct{}
+
+func (nopMatcher) Match(_ []byte) bool {
+	return false
+}
+
+// emptyMatcher is an implementation of WildcardPattern that only matches the empty string
+type emptyMatcher struct{}
+
+func (emptyMatcher) Match(in []byte) bool {
+	return len(in) == 0
+}
+
+// fastMatcher is an implementation of WildcardPattern that uses a collation's Collate method
+// to perform wildcard matching.
+// It is returned:
+// 	- when the wildcard pattern has no wildcard characters at all
+// 	- when the wildcard pattern has a single '%' (patternMatchMany) and it is the very last
+//		character of the pattern (in this case, we set isPrefix to true to use prefix-match collation)
+type fastMatcher struct {
+	collate  func(left, right []byte, isPrefix bool) int
+	pattern  []byte
+	isPrefix bool
+}
+
+func (cm *fastMatcher) Match(in []byte) bool {
+	return cm.collate(in, cm.pattern, cm.isPrefix) == 0
+}
+
+// unicodeWildcard is an implementation of WildcardPattern for multibyte charsets;
+// it is used for all UCA collations, multibyte collations and all Unicode-based collations
+type unicodeWildcard struct {
+	equals  func(a, b rune) bool
+	charset charset.Charset
+	pattern []rune
+}
+
+func newUnicodeWildcardMatcher(
+	cs charset.Charset,
+	equals func(a rune, b rune) bool,
+	collate func(left []byte, right []byte, isPrefix bool) int,
+	pat []byte, chOne, chMany, chEsc rune,
+) WildcardPattern {
+	var escape bool
+	var chOneCount, chManyCount, chEscCount int
+	var parsedPattern = make([]rune, 0, len(pat))
+	var patOriginal = pat
+
+	if chOne == 0 {
+		chOne = '_'
+	}
+	if chMany == 0 {
+		chMany = '%'
+	}
+	if chEsc == 0 {
+		chEsc = '\\'
+	}
+
+	for len(pat) > 0 {
+		cp, width := cs.DecodeRune(pat)
+		if cp == charset.RuneError && width < 3 {
+			return nopMatcher{}
+		}
+		pat = pat[width:]
+
+		if escape {
+			parsedPattern = append(parsedPattern, cp)
+			escape = false
+			continue
+		}
+
+		switch cp {
+		case chOne:
+			chOneCount++
+			parsedPattern = append(parsedPattern, patternMatchOne)
+		case chMany:
+			if len(parsedPattern) > 0 && parsedPattern[len(parsedPattern)-1] == patternMatchMany {
+				continue
+			}
+			chManyCount++
+			parsedPattern = append(parsedPattern, patternMatchMany)
+		case chEsc:
+			chEscCount++
+			escape = true
+		default:
+			parsedPattern = append(parsedPattern, cp)
+		}
+	}
+	if escape {
+		parsedPattern = append(parsedPattern, chEsc)
+	}
+
+	// if we have a collation callback, we can detect some common cases for patterns
+	// here and optimize them away without having to return a full WildcardPattern
+	if collate != nil {
+		if len(parsedPattern) == 0 {
+			return emptyMatcher{}
+		}
+		if chOneCount == 0 && chEscCount == 0 {
+			if chManyCount == 0 {
+				return &fastMatcher{
+					collate:  collate,
+					pattern:  patOriginal,
+					isPrefix: false,
+				}
+			}
+			if chManyCount == 1 && chMany < utf8.RuneSelf && parsedPattern[len(parsedPattern)-1] == chMany {
+				return &fastMatcher{
+					collate:  collate,
+					pattern:  patOriginal[:len(patOriginal)-1],
+					isPrefix: true,
+				}
+			}
+		}
+	}
+
+	return &unicodeWildcard{
+		equals:  equals,
+		charset: cs,
+		pattern: parsedPattern,
+	}
+}
+
+func (wc *unicodeWildcard) matchFast(str []byte, pat []rune) bool {
+	var s []byte
+	var p []rune
+	var star = false
+	var cs = wc.charset
+
+retry:
+	s = str
+	p = pat
+	for len(s) > 0 {
+		var p0 rune
+		if len(p) > 0 {
+			p0 = p[0]
+		}
+
+		switch p0 {
+		case patternMatchOne:
+			c0, width := cs.DecodeRune(s)
+			if c0 == charset.RuneError && width < 3 {
+				return false
+			}
+			s = s[width:]
+			break
+		case patternMatchMany:
+			star = true
+			str = s
+			pat = p[1:]
+			if len(pat) == 0 {
+				return true
+			}
+			goto retry
+		default:
+			c0, width := cs.DecodeRune(s)
+			if c0 == charset.RuneError && width < 3 {
+				return false
+			}
+			if !wc.equals(c0, p0) {
+				goto starCheck
+			}
+			s = s[width:]
+		}
+		p = p[1:]
+	}
+	return len(p) == 0 || (len(p) == 1 && p[0] == patternMatchMany)
+
+starCheck:
+	if !star {
+		return false
+	}
+	if len(str) > 0 {
+		c0, width := cs.DecodeRune(str)
+		if c0 == charset.RuneError && width < 3 {
+			return false
+		}
+		str = str[width:]
+	}
+	goto retry
+}
+
+func (wc *unicodeWildcard) Match(in []byte) bool {
+	if wildcardRecursionDepth == 0 {
+		return wc.matchFast(in, wc.pattern)
+	}
+	return wc.matchInner(in, wc.pattern, 0) == matchOK
+}
+
+func (wc *unicodeWildcard) matchMany(in []byte, pat []rune, depth int) match {
+	var cs = wc.charset
+	var p0 rune
+
+many:
+	if len(pat) == 0 {
+		return matchOK
+	}
+	p0 = pat[0]
+	pat = pat[1:]
+
+	switch p0 {
+	case patternMatchMany:
+		goto many
+	case patternMatchOne:
+		cpIn, width := cs.DecodeRune(in)
+		if cpIn == charset.RuneError && width < 3 {
+			return matchFail
+		}
+		in = in[width:]
+		goto many
+	}
+
+	if len(in) == 0 {
+		return matchOver
+	}
+
+retry:
+	var width int
+	for len(in) > 0 {
+		var cpIn rune
+		cpIn, width = cs.DecodeRune(in)
+		if cpIn == charset.RuneError && width < 3 {
+			return matchFail
+		}
+		if wc.equals(cpIn, p0) {
+			break
+		}
+		in = in[width:]
+	}
+
+	if len(in) == 0 {
+		return matchOver
+	}
+	in = in[width:]
+
+	m := wc.matchInner(in, pat, depth+1)
+	if m == matchFail {
+		goto retry
+	}
+	return m
+}
+
+func (wc *unicodeWildcard) matchInner(in []byte, pat []rune, depth int) match {
+	if depth >= wildcardRecursionDepth {
+		return matchFail
+	}
+
+	var cs = wc.charset
+	for len(pat) > 0 {
+		if pat[0] == patternMatchMany {
+			return wc.matchMany(in, pat[1:], depth)
+		}
+
+		cpIn, width := cs.DecodeRune(in)
+		if cpIn == charset.RuneError && width < 3 {
+			return matchFail
+		}
+
+		switch {
+		case pat[0] == patternMatchOne:
+		case wc.equals(pat[0], cpIn):
+		default:
+			return matchFail
+		}
+
+		in = in[width:]
+		pat = pat[1:]
+	}
+
+	if len(in) == 0 {
+		return matchOK
+	}
+	return matchFail
+}
+
+// eightbitWildcard is an implementation of WildcardPattern used for 8-bit charsets.
+// It is used for all 8-bit encodings.
+type eightbitWildcard struct {
+	sort    *[256]byte
+	pattern []int16
+}
+
+func newEightbitWildcardMatcher(
+	sort *[256]byte,
+	collate func(left []byte, right []byte, isPrefix bool) int,
+	pat []byte, chOneRune, chManyRune, chEscRune rune,
+) WildcardPattern {
+	var escape bool
+	var parsedPattern = make([]int16, 0, len(pat))
+	var chOne, chMany, chEsc byte = '_', '%', '\\'
+	var chOneCount, chManyCount, chEscCount int
+
+	if chOneRune > 255 || chManyRune > 255 || chEscRune > 255 {
+		return nopMatcher{}
+	}
+	if chOneRune != 0 {
+		chOne = byte(chOneRune)
+	}
+	if chManyRune != 0 {
+		chMany = byte(chManyRune)
+	}
+	if chEscRune != 0 {
+		chEsc = byte(chEscRune)
+	}
+
+	for _, ch := range pat {
+		if escape {
+			parsedPattern = append(parsedPattern, int16(ch))
+			escape = false
+			continue
+		}
+
+		switch ch {
+		case chOne:
+			chOneCount++
+			parsedPattern = append(parsedPattern, patternMatchOne)
+		case chMany:
+			if len(parsedPattern) > 0 && parsedPattern[len(parsedPattern)-1] == patternMatchMany {
+				continue
+			}
+			chManyCount++
+			parsedPattern = append(parsedPattern, patternMatchMany)
+		case chEsc:
+			chEscCount++
+			escape = true
+		default:
+			parsedPattern = append(parsedPattern, int16(ch))
+		}
+	}
+	if escape {
+		parsedPattern = append(parsedPattern, int16(chEsc))
+	}
+
+	// if we have a collation callback, we can detect some common cases for patterns
+	// here and optimize them away without having to return a full WildcardPattern
+	if collate != nil {
+		if len(parsedPattern) == 0 {
+			return emptyMatcher{}
+		}
+		if chOneCount == 0 && chEscCount == 0 {
+			if chManyCount == 0 {
+				return &fastMatcher{
+					collate:  collate,
+					pattern:  pat,
+					isPrefix: false,
+				}
+			}
+			if chManyCount == 1 && pat[len(pat)-1] == chMany {
+				return &fastMatcher{
+					collate:  collate,
+					pattern:  pat[:len(pat)-1],
+					isPrefix: true,
+				}
+			}
+		}
+	}
+
+	return &eightbitWildcard{
+		sort:    sort,
+		pattern: parsedPattern,
+	}
+}
+
+func (wc *eightbitWildcard) Match(in []byte) bool {
+	if wildcardRecursionDepth == 0 {
+		return wc.matchFast(in, wc.pattern)
+	}
+	return wc.matchInner(in, wc.pattern, 0) == matchOK
+}
+
+func (wc *eightbitWildcard) matchMany(in []byte, pat []int16, depth int) match {
+	var p0 int16
+
+many:
+	if len(pat) == 0 {
+		return matchOK
+	}
+
+	p0 = pat[0]
+	pat = pat[1:]
+
+	switch p0 {
+	case patternMatchMany:
+		goto many
+	case patternMatchOne:
+		if len(in) == 0 {
+			return matchFail
+		}
+		in = in[1:]
+		goto many
+	}
+
+	if len(in) == 0 {
+		return matchOver
+	}
+
+retry:
+	for len(in) > 0 {
+		if wc.sort[in[0]] == wc.sort[byte(p0)] {
+			break
+		}
+		in = in[1:]
+	}
+	if len(in) == 0 {
+		return matchOver
+	}
+	in = in[1:]
+
+	m := wc.matchInner(in, pat, depth+1)
+	if m == matchFail {
+		goto retry
+	}
+	return m
+}
+
+func (wc *eightbitWildcard) matchInner(in []byte, pat []int16, depth int) match {
+	if depth >= wildcardRecursionDepth {
+		return matchFail
+	}
+	for len(pat) > 0 {
+		if pat[0] == patternMatchMany {
+			return wc.matchMany(in, pat[1:], depth)
+		}
+
+		if len(in) == 0 {
+			return matchFail
+		}
+
+		switch {
+		case pat[0] == patternMatchOne:
+		case wc.sort[byte(pat[0])] == wc.sort[in[0]]:
+		default:
+			return matchFail
+		}
+
+		in = in[1:]
+		pat = pat[1:]
+	}
+
+	if len(in) == 0 {
+		return matchOK
+	}
+	return matchFail
+}
+
+func (wc *eightbitWildcard) matchFast(str []byte, pat []int16) bool {
+	var s []byte
+	var p []int16
+	var star = false
+
+retry:
+	s = str
+	p = pat
+	for len(s) > 0 {
+		var p0 int16
+		if len(p) > 0 {
+			p0 = p[0]
+		}
+
+		switch p0 {
+		case patternMatchOne:
+			break
+		case patternMatchMany:
+			star = true
+			str = s
+			pat = p[1:]
+			if len(pat) == 0 {
+				return true
+			}
+			goto retry
+		default:
+			if wc.sort[byte(p0)] != wc.sort[s[0]] {
+				goto starCheck
+			}
+		}
+		s = s[1:]
+		p = p[1:]
+	}
+	return len(p) == 0 || (len(p) == 1 && p[0] == patternMatchMany)
+
+starCheck:
+	if !star {
+		return false
+	}
+	str = str[1:]
+	goto retry
+}

--- a/go/mysql/collations/wildcard_test.go
+++ b/go/mysql/collations/wildcard_test.go
@@ -1,0 +1,403 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"},
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collations
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/mysql/collations/internal/charset"
+)
+
+type wildcardtest struct {
+	in, pat string
+	match   bool
+}
+
+func testWildcardMatches(t *testing.T, collName string, chOne, chMany, chEsc rune, cases []wildcardtest) {
+	t.Run(collName, func(t *testing.T) {
+		coll := testcollation(t, collName)
+		for _, tc := range cases {
+			pat := coll.Wildcard([]byte(tc.pat), chOne, chMany, chEsc)
+			match := pat.Match([]byte(tc.in))
+			if match != tc.match {
+				t.Errorf("%q LIKE %q = %v (expected %v)", tc.in, tc.pat, match, tc.match)
+			}
+		}
+	})
+}
+
+func TestLikeMatches(t *testing.T) {
+	testWildcardMatches(t, "utf8mb4_0900_ai_ci", 0, 0, 0, []wildcardtest{
+		{"abc", "abc", true},
+		{"Abc", "aBc", true},
+		{"abc", "_bc", true},
+		{"abc", "a_c", true},
+		{"abc", "ab_", true},
+		{"abc", "%c", true},
+		{"abc", "a%c", true},
+		{"abc", "a%", true},
+		{"abcdef", "a%d_f", true},
+		{"abcdefg", "a%d%g", true},
+		{"a\\", "a\\", true},
+		{"aa\\", "a%\\", true},
+		{"Y", "\u00dd", true},
+		{"abcd", "abcde", false},
+		{"abcde", "abcd", false},
+		{"abcde", "a%f", false},
+		{"abcdef", "a%%f", true},
+		{"abcd", "a__d", true},
+		{"abcd", "a\\bcd", true},
+		{"a\\bcd", "abcd", false},
+		{"abdbcd", "a%cd", true},
+		{"abecd", "a%bd", false},
+	})
+
+	testWildcardMatches(t, "utf8mb4_0900_as_cs", 0, 0, 0, []wildcardtest{
+		{"abc", "abc", true},
+		{"Abc", "aBc", false},
+		{"abc", "_bc", true},
+		{"abc", "a_c", true},
+		{"abc", "ab_", true},
+		{"abc", "%c", true},
+		{"abc", "a%c", true},
+		{"abc", "a%", true},
+		{"abcdef", "a%d_f", true},
+		{"abcdefg", "a%d%g", true},
+		{"a\\", "a\\", true},
+		{"aa\\", "a%\\", true},
+		{"Y", "\u00dd", false},
+		{"abcd", "abcde", false},
+		{"abcde", "abcd", false},
+		{"abcde", "a%f", false},
+		{"abcdef", "a%%f", true},
+		{"abcd", "a__d", true},
+		{"abcd", "a\\bcd", true},
+		{"a\\bcd", "abcd", false},
+		{"abdbcd", "a%cd", true},
+		{"abecd", "a%bd", false},
+	})
+
+	testWildcardMatches(t, "utf8mb4_0900_as_ci", 0, 0, 0, []wildcardtest{
+		{"ǎḄÇ", "Ǎḅç", true},
+		{"ÁḆĈ", "Ǎḅç", false},
+		{"ǍBc", "_bc", true},
+		{"Aḅc", "a_c", true},
+		{"Abç", "ab_", true},
+		{"Ǎḅç", "%ç", true},
+		{"Ǎḅç", "ǎ%Ç", true},
+		{"aḅç", "a%", true},
+		{"Ǎḅçdef", "ǎ%d_f", true},
+		{"Ǎḅçdefg", "ǎ%d%g", true},
+		{"ǎ\\", "Ǎ\\", true},
+		{"ǎa\\", "Ǎ%\\", true},
+		{"Y", "\u00dd", false},
+		{"abcd", "Ǎḅçde", false},
+		{"abcde", "Ǎḅçd", false},
+		{"Ǎḅçde", "a%f", false},
+		{"Ǎḅçdef", "ǎ%%f", true},
+		{"Ǎḅçd", "ǎ__d", true},
+		{"Ǎḅçd", "ǎ\\ḄÇd", true},
+		{"a\\bcd", "Ǎḅçd", false},
+		{"Ǎḅdbçd", "ǎ%Çd", true},
+		{"Ǎḅeçd", "a%bd", false},
+	})
+}
+
+// from http://developforperformance.com/MatchingWildcards_AnImprovedAlgorithmForBigData.html
+// Copyright 2018 IBM Corporation
+// Licensed under the Apache License, Version 2.0
+var wildcardTestCases = []wildcardtest{
+	{"Hi", "Hi*", true},
+	{"abc", "ab*d", false},
+	{"abcccd", "*ccd", true},
+	{"mississipissippi", "*issip*ss*", true},
+	{"xxxx*zzzzzzzzy*f", "xxxx*zzy*fffff", false},
+	{"xxxx*zzzzzzzzy*f", "xxx*zzy*f", true},
+	{"xxxxzzzzzzzzyf", "xxxx*zzy*fffff", false},
+	{"xxxxzzzzzzzzyf", "xxxx*zzy*f", true},
+	{"xyxyxyzyxyz", "xy*z*xyz", true},
+	{"mississippi", "*sip*", true},
+	{"xyxyxyxyz", "xy*xyz", true},
+	{"mississippi", "mi*sip*", true},
+	{"ababac", "*abac*", true},
+	{"ababac", "*abac*", true},
+	{"aaazz", "a*zz*", true},
+	{"a12b12", "*12*23", false},
+	{"a12b12", "a12b", false},
+	{"a12b12", "*12*12*", true},
+	{"caaab", "*a?b", true},
+	{"*", "*", true},
+	{"a*abab", "a*b", true},
+	{"a*r", "a*", true},
+	{"a*ar", "a*aar", false},
+	{"XYXYXYZYXYz", "XY*Z*XYz", true},
+	{"missisSIPpi", "*SIP*", true},
+	{"mississipPI", "*issip*PI", true},
+	{"xyxyxyxyz", "xy*xyz", true},
+	{"miSsissippi", "mi*sip*", true},
+	{"miSsissippi", "mi*Sip*", false},
+	{"abAbac", "*Abac*", true},
+	{"abAbac", "*Abac*", true},
+	{"aAazz", "a*zz*", true},
+	{"A12b12", "*12*23", false},
+	{"a12B12", "*12*12*", true},
+	{"oWn", "*oWn*", true},
+	{"bLah", "bLah", true},
+	{"bLah", "bLaH", false},
+	{"a", "*?", true},
+	{"ab", "*?", true},
+	{"abc", "*?", true},
+	{"a", "??", false},
+	{"ab", "?*?", true},
+	{"ab", "*?*?*", true},
+	{"abc", "?**?*?", true},
+	{"abc", "?**?*&?", false},
+	{"abcd", "?b*??", true},
+	{"abcd", "?a*??", false},
+	{"abcd", "?**?c?", true},
+	{"abcd", "?**?d?", false},
+	{"abcde", "?*b*?*d*?", true},
+	{"bLah", "bL?h", true},
+	{"bLaaa", "bLa?", false},
+	{"bLah", "bLa?", true},
+	{"bLaH", "?Lah", false},
+	{"bLaH", "?LaH", true},
+	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "a*a*a*a*a*a*aa*aaa*a*a*b", true},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "*a*b*ba*ca*a*aa*aaa*fa*ga*b*", true},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "*a*b*ba*ca*a*x*aaa*fa*ga*b*", false},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "*a*b*ba*ca*aaaa*fa*ga*gggg*b*", false},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "*a*b*ba*ca*aaaa*fa*ga*ggg*b*", true},
+	{"aaabbaabbaab", "*aabbaa*a*", true},
+	{"a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*", "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*", true},
+	{"aaaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*", true},
+	{"aaaaaaaaaaaaaaaa", "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*", false},
+	{"abc*abcd*abcde*abcdef*abcdefg*abcdefgh*abcdefghi*abcdefghij*abcdefghijk*abcdefghijkl*abcdefghijklm*abcdefghijklmn", "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*", false},
+	{"abc*abcd*abcde*abcdef*abcdefg*abcdefgh*abcdefghi*abcdefghij*abcdefghijk*abcdefghijkl*abcdefghijklm*abcdefghijklmn", "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*", true},
+	{"abc*abcd*abcd*abc*abcd", "abc*abc*abc*abc*abc", false},
+	{"abc*abcd*abcd*abc*abcd*abcd*abc*abcd*abc*abc*abcd", "abc*abc*abc*abc*abc*abc*abc*abc*abc*abc*abcd", true},
+	{"abc", "********a********b********c********", true},
+	{"********a********b********c********", "abc", false},
+	{"abc", "********a********b********b********", false},
+	{"*abc*", "***a*b*c***", true},
+	{"", "?", false},
+	{"", "*?", false},
+	{"", "", true},
+	{"a", "", false},
+
+	{"abc", "abd", false},
+	{"abcccd", "abcccd", true},
+	{"mississipissippi", "mississipissippi", true},
+	{"xxxxzzzzzzzzyf", "xxxxzzzzzzzzyfffff", false},
+	{"xxxxzzzzzzzzyf", "xxxxzzzzzzzzyf", true},
+	{"xxxxzzzzzzzzyf", "xxxxzzy.fffff", false},
+	{"xxxxzzzzzzzzyf", "xxxxzzzzzzzzyf", true},
+	{"xyxyxyzyxyz", "xyxyxyzyxyz", true},
+	{"mississippi", "mississippi", true},
+	{"xyxyxyxyz", "xyxyxyxyz", true},
+	{"m ississippi", "m ississippi", true},
+	{"ababac", "ababac?", false},
+	{"dababac", "ababac", false},
+	{"aaazz", "aaazz", true},
+	{"a12b12", "1212", false},
+	{"a12b12", "a12b", false},
+	{"a12b12", "a12b12", true},
+	{"n", "n", true},
+	{"aabab", "aabab", true},
+	{"ar", "ar", true},
+	{"aar", "aaar", false},
+	{"XYXYXYZYXYz", "XYXYXYZYXYz", true},
+	{"missisSIPpi", "missisSIPpi", true},
+	{"mississipPI", "mississipPI", true},
+	{"xyxyxyxyz", "xyxyxyxyz", true},
+	{"miSsissippi", "miSsissippi", true},
+	{"miSsissippi", "miSsisSippi", false},
+	{"abAbac", "abAbac", true},
+	{"abAbac", "abAbac", true},
+	{"aAazz", "aAazz", true},
+	{"A12b12", "A12b123", false},
+	{"a12B12", "a12B12", true},
+	{"oWn", "oWn", true},
+	{"bLah", "bLah", true},
+	{"bLah", "bLaH", false},
+	{"a", "a", true},
+	{"ab", "a?", true},
+	{"abc", "ab?", true},
+	{"a", "??", false},
+	{"ab", "??", true},
+	{"abc", "???", true},
+	{"abcd", "????", true},
+	{"abc", "????", false},
+	{"abcd", "?b??", true},
+	{"abcd", "?a??", false},
+	{"abcd", "??c?", true},
+	{"abcd", "??d?", false},
+	{"abcde", "?b?d*?", true},
+	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", true},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", true},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "abababababababababababababababababababaacacacacacacacadaeafagahaiajaxalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", false},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaggggagaaaaaaaab", false},
+	{"abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", "abababababababababababababababababababaacacacacacacacadaeafagahaiajakalaaaaaaaaaaaaaaaaaffafagaagggagaaaaaaaab", true},
+	{"aaabbaabbaab", "aaabbaabbaab", true},
+	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+	{"aaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", true},
+	{"aaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaa", false},
+	{"abcabcdabcdeabcdefabcdefgabcdefghabcdefghiabcdefghijabcdefghijkabcdefghijklabcdefghijklmabcdefghijklmn", "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc", false},
+	{"abcabcdabcdeabcdefabcdefgabcdefghabcdefghiabcdefghijabcdefghijkabcdefghijklabcdefghijklmabcdefghijklmn", "abcabcdabcdeabcdefabcdefgabcdefghabcdefghiabcdefghijabcdefghijkabcdefghijklabcdefghijklmabcdefghijklmn", true},
+	{"abcabcdabcdabcabcd", "abcabc?abcabcabc", false},
+	{"abcabcdabcdabcabcdabcdabcabcdabcabcabcd", "abcabc?abc?abcabc?abc?abc?bc?abc?bc?bcd", true},
+	{"?abc?", "?abc?", true},
+
+	{"", "abd", false},
+	{"", "abcccd", false},
+	{"", "mississipissippi", false},
+	{"", "xxxxzzzzzzzzyfffff", false},
+	{"", "xxxxzzzzzzzzyf", false},
+	{"", "xxxxzzy.fffff", false},
+	{"", "xxxxzzzzzzzzyf", false},
+	{"", "xyxyxyzyxyz", false},
+	{"", "mississippi", false},
+	{"", "xyxyxyxyz", false},
+	{"", "m ississippi", false},
+	{"", "ababac*", false},
+	{"", "ababac", false},
+	{"", "aaazz", false},
+	{"", "1212", false},
+	{"", "a12b", false},
+	{"", "a12b12", false},
+	{"", "n", false},
+	{"", "aabab", false},
+	{"", "ar", false},
+	{"", "aaar", false},
+	{"", "XYXYXYZYXYz", false},
+	{"", "missisSIPpi", false},
+	{"", "mississipPI", false},
+	{"", "xyxyxyxyz", false},
+	{"", "miSsissippi", false},
+	{"", "miSsisSippi", false},
+	{"", "abAbac", false},
+	{"", "abAbac", false},
+	{"", "aAazz", false},
+	{"", "A12b123", false},
+	{"", "a12B12", false},
+	{"", "oWn", false},
+	{"", "bLah", false},
+	{"", "bLaH", false},
+	{"", "", true},
+	{"abc", "", false},
+	{"abcccd", "", false},
+	{"mississipissippi", "", false},
+	{"xxxxzzzzzzzzyf", "", false},
+	{"xxxxzzzzzzzzyf", "", false},
+	{"xxxxzzzzzzzzyf", "", false},
+	{"xxxxzzzzzzzzyf", "", false},
+	{"xyxyxyzyxyz", "", false},
+	{"mississippi", "", false},
+	{"xyxyxyxyz", "", false},
+	{"m ississippi", "", false},
+	{"ababac", "", false},
+	{"dababac", "", false},
+	{"aaazz", "", false},
+	{"a12b12", "", false},
+	{"a12b12", "", false},
+	{"a12b12", "", false},
+	{"n", "", false},
+	{"aabab", "", false},
+	{"ar", "", false},
+	{"aar", "", false},
+	{"XYXYXYZYXYz", "", false},
+	{"missisSIPpi", "", false},
+	{"mississipPI", "", false},
+	{"xyxyxyxyz", "", false},
+	{"miSsissippi", "", false},
+	{"miSsissippi", "", false},
+	{"abAbac", "", false},
+	{"abAbac", "", false},
+	{"aAazz", "", false},
+	{"A12b12", "", false},
+	{"a12B12", "", false},
+	{"oWn", "", false},
+	{"bLah", "", false},
+	{"bLah", "", false},
+}
+
+func identity(a, b rune) bool {
+	return a == b
+}
+
+func TestWildcardMatches(t *testing.T) {
+	t.Run("UnicodeWildcardMatcher (no optimization)", func(t *testing.T) {
+		for _, tc := range wildcardTestCases {
+			wildcard := newUnicodeWildcardMatcher(charset.Charset_utf8mb4{}, identity, nil, []byte(tc.pat), '?', '*', '\\')
+			match := wildcard.Match([]byte(tc.in))
+			if match != tc.match {
+				t.Errorf("wildcard(%q, %q) = %v (expected %v)", tc.in, tc.pat, match, tc.match)
+			}
+		}
+	})
+
+	t.Run("EightbitWildcardMatcher (no optimization)", func(t *testing.T) {
+		for _, tc := range wildcardTestCases {
+			wildcard := newEightbitWildcardMatcher(&sortOrderIdentity, nil, []byte(tc.pat), '?', '*', '\\')
+			match := wildcard.Match([]byte(tc.in))
+			if match != tc.match {
+				t.Errorf("wildcard(%q, %q) = %v (expected %v)", tc.in, tc.pat, match, tc.match)
+			}
+		}
+	})
+
+	testWildcardMatches(t, "utf8mb4_0900_bin", '?', '*', '\\', wildcardTestCases)
+	testWildcardMatches(t, "utf8mb4_0900_as_cs", '?', '*', '\\', wildcardTestCases)
+}
+
+func BenchmarkWildcardMatching(b *testing.B) {
+	type bench struct {
+		input []byte
+		m1    WildcardPattern
+		m2    WildcardPattern
+	}
+
+	var patterns []bench
+	for _, tc := range wildcardTestCases {
+		patterns = append(patterns, bench{
+			input: []byte(tc.in),
+			m1:    newUnicodeWildcardMatcher(charset.Charset_utf8mb4{}, identity, nil, []byte(tc.pat), '?', '*', '\\'),
+			m2:    newEightbitWildcardMatcher(&sortOrderIdentity, nil, []byte(tc.pat), '?', '*', '\\'),
+		})
+	}
+
+	b.Run("unicode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			for _, bb := range patterns {
+				_ = bb.m1.Match(bb.input)
+			}
+		}
+	})
+
+	b.Run("8bit", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			for _, bb := range patterns {
+				_ = bb.m2.Match(bb.input)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Description

I've added support to the `collations` package to perform collation-aware wildcard matching. I've written an API optimized for our evaluation engine, where you pass in a pattern (i.e. the right side of the `LIKE` operator) and it compiles it to a `WildcardPattern` matcher that can be repeatedly be called on different values for the left side to see if they match.

The wildcard patterns are pre-processed and optimized: any wildcards that can be matched using `Collate` directly (i.e. wildcards without any special matching characters, or wildcards where the only special character is at the end, `"foobar%"`) will not use the wildcard matcher.

I've added comprehensive tests for all collations and many different patterns against a live MySQL instance.

cc @systay @frouioui 

## Related Issue(s)
- https://github.com/vitessio/vitess/issues/8606


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->