### PR TITLE
Better handling of partial dml query exec in transaction

### DIFF
--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2020 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedconn
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	keyspaceName    = "ks"
+	cell            = "zone1"
+	hostname        = "localhost"
+	sqlSchema       = `
+	create table test(
+		id bigint,
+		val1 varchar(16),
+		val2 int,
+		val3 float,
+		primary key(id)
+	)Engine=InnoDB;
+
+CREATE TABLE test_vdx (
+    val1 varchar(16) NOT NULL,
+    keyspace_id binary(8),
+    UNIQUE KEY (val1)
+) ENGINE=Innodb;
+`
+
+	vSchema = `
+		{	
+			"sharded":true,
+			"vindexes": {
+				"hash_index": {
+					"type": "hash"
+				},
+				"lookup1": {
+					"type": "consistent_lookup",
+					"params": {
+						"table": "test_vdx",
+						"from": "val1",
+						"to": "keyspace_id",
+						"ignore_nulls": "true"
+					},
+					"owner": "test"
+				},
+				"unicode_vdx":{
+					"type": "unicode_loose_md5"
+                }
+			},	
+			"tables": {
+				"test":{
+					"column_vindexes": [
+						{
+							"column": "id",
+							"name": "hash_index"
+						},
+						{
+							"column": "val1",
+							"name": "lookup1"
+						}
+					]
+				},
+				"test_vdx":{
+					"column_vindexes": [
+						{
+							"column": "val1",
+							"name": "unicode_vdx"
+						}
+					]
+				}
+			}
+		}
+	`
+)
+
+func TestMain(m *testing.M) {
+	defer cluster.PanicHandler(nil)
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1
+		}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+		if err := clusterInstance.StartKeyspace(*keyspace, []string{"-40", "40-80", "80-c0", "c0-"}, 0, false); err != nil {
+
+			return 1
+		}
+
+		// Start vtgate
+		if err := clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func TestPartialQueryFailure(t *testing.T) {
+	tcases := []struct {
+		mode string
+	}{
+		{"set workload = oltp"},
+		{"set workload = oltp; set sql_mode = ''"},
+		{"set workload = olap"},
+		{"set workload = olap; set sql_mode = ''"},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.mode, func(t *testing.T) {
+			conn, err := mysql.Connect(context.Background(), &vtParams)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			// setup the mode
+			utils.Exec(t, conn, tc.mode)
+
+			// cleanup previous run data from table.
+			utils.Exec(t, conn, `delete from test`)
+
+			utils.Exec(t, conn, `begin`)
+			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `AlreadyExists`)
+			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+			utils.Exec(t, conn, `commit`)
+			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		})
+	}
+}

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -164,7 +164,7 @@ func TestPartialQueryFailure(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `failed to execute due to partial DML execution`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `revered partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `commit`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -200,7 +200,7 @@ func TestPartialVindexQueryFailure(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -271,7 +271,7 @@ func TestPartialVindexQueryFailureNoAutoCommit(t *testing.T) {
 
 			utils.Exec(t, conn, `set autocommit = off`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -340,7 +340,7 @@ func TestPartialVindexQueryFailureAutoCommit(t *testing.T) {
 			utils.Exec(t, conn, `delete from test`)
 
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -411,7 +411,7 @@ func TestPartialVindexQueryFailureRollback(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)
@@ -482,7 +482,7 @@ func TestPartialVindexQueryFailureNoAutoCommitRollback(t *testing.T) {
 
 			utils.Exec(t, conn, `set autocommit = off`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)
@@ -551,7 +551,7 @@ func TestPartialVindexQueryFailureAutoCommitRollback(t *testing.T) {
 			utils.Exec(t, conn, `delete from test`)
 
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -164,7 +164,7 @@ func TestPartialQueryFailure(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `revered partial DML execution failure`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `commit`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Vitess Authors.
+Copyright 2021 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ func TestPartialVindexQueryFailure(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -271,7 +271,7 @@ func TestPartialVindexQueryFailureNoAutoCommit(t *testing.T) {
 
 			utils.Exec(t, conn, `set autocommit = off`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -340,7 +340,7 @@ func TestPartialVindexQueryFailureAutoCommit(t *testing.T) {
 			utils.Exec(t, conn, `delete from test`)
 
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `commit`)
@@ -411,7 +411,7 @@ func TestPartialVindexQueryFailureRollback(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)
@@ -482,7 +482,7 @@ func TestPartialVindexQueryFailureNoAutoCommitRollback(t *testing.T) {
 
 			utils.Exec(t, conn, `set autocommit = off`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)
@@ -551,7 +551,7 @@ func TestPartialVindexQueryFailureAutoCommitRollback(t *testing.T) {
 			utils.Exec(t, conn, `delete from test`)
 
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `lookup.Create`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
 			utils.Exec(t, conn, `rollback`)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -140,11 +140,12 @@ func TestMain(m *testing.M) {
 func TestPartialQueryFailure(t *testing.T) {
 	tcases := []struct {
 		mode string
+		qs   []string
 	}{
-		{"set workload = oltp"},
-		{"set workload = oltp; set sql_mode = ''"},
-		{"set workload = olap"},
-		{"set workload = olap; set sql_mode = ''"},
+		{"oltp", []string{"set workload = oltp"}},
+		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
+		{"olap", []string{"set workload = olap"}},
+		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
 	}
 
 	for _, tc := range tcases {
@@ -154,7 +155,9 @@ func TestPartialQueryFailure(t *testing.T) {
 			defer conn.Close()
 
 			// setup the mode
-			utils.Exec(t, conn, tc.mode)
+			for _, q := range tc.qs {
+				utils.Exec(t, conn, q)
+			}
 
 			// cleanup previous run data from table.
 			utils.Exec(t, conn, `delete from test`)

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -138,7 +138,9 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func TestPartialQueryFailure(t *testing.T) {
+func testAllModes(t *testing.T, stmts func(conn *mysql.Conn)) {
+	t.Helper()
+
 	tcases := []struct {
 		mode string
 		qs   []string
@@ -163,399 +165,161 @@ func TestPartialQueryFailure(t *testing.T) {
 			// cleanup previous run data from table.
 			utils.Exec(t, conn, `delete from test`)
 
-			utils.Exec(t, conn, `begin`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+			// execute all the test stmts.
+			stmts(conn)
 		})
 	}
 }
+func TestPartialQueryFailureExplicitTx(t *testing.T) {
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `begin`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+	})
+}
 
-func TestPartialVindexQueryFailure(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `begin`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
-		})
-	}
+func TestPartialVindexQueryFailureExplicitTx(t *testing.T) {
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `begin`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
+	})
 }
 
 func TestPartialQueryFailureNoAutoCommit(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `set autocommit = off`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		// autocommit is false.
+		utils.Exec(t, conn, `set autocommit = off`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+	})
 }
 
 func TestPartialVindexQueryFailureNoAutoCommit(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `set autocommit = off`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		// autocommit is false.
+		utils.Exec(t, conn, `set autocommit = off`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
+	})
 }
 
 func TestPartialQueryFailureAutoCommit(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `transaction rolled back to reverse changes of partial DML execution`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate, transaction is rolled back as it was an implicit transaction started by vtgate.
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `transaction rolled back to reverse changes of partial DML execution`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		// commit will not have any effect on the state in autocommit mode.
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+	})
 }
 
 func TestPartialVindexQueryFailureAutoCommit(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `commit`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate, transaction is rolled back as it was an implicit transaction started by vtgate.
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		// commit will not have any effect on the state in autocommit mode.
+		utils.Exec(t, conn, `commit`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
+	})
 }
 
 func TestPartialQueryFailureRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `begin`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `begin`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
+	})
 }
 
 func TestPartialVindexQueryFailureRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `begin`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `begin`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
+	})
 }
 
 func TestPartialQueryFailureNoAutoCommitRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `set autocommit = off`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		// autocommit is false.
+		utils.Exec(t, conn, `set autocommit = off`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
+	})
 }
 
 func TestPartialVindexQueryFailureNoAutoCommitRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `set autocommit = off`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		// autocommit is false.  y 6
+		utils.Exec(t, conn, `set autocommit = off`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `reverted partial DML execution failure`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[]`)
+	})
 }
 
 func TestPartialQueryFailureAutoCommitRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `transaction rolled back to reverse changes of partial DML execution`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// primary vindex is duplicate, transaction is rolled back as it was an implicit transaction started by vtgate.
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `transaction rolled back to reverse changes of partial DML execution`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		// rollback will not have any effect on the state in autocommit mode.
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+	})
 }
 
 func TestPartialVindexQueryFailureAutoCommitRollback(t *testing.T) {
-	tcases := []struct {
-		mode string
-		qs   []string
-	}{
-		{"oltp", []string{"set workload = oltp"}},
-		{"oltp-reserved", []string{"set workload = oltp", "set sql_mode = ''"}},
-		{"olap", []string{"set workload = olap"}},
-		{"olap-reserved", []string{"set workload = olap", "set sql_mode = ''"}},
-	}
-
-	for _, tc := range tcases {
-		t.Run(tc.mode, func(t *testing.T) {
-			conn, err := mysql.Connect(context.Background(), &vtParams)
-			require.NoError(t, err)
-			defer conn.Close()
-
-			// setup the mode
-			for _, q := range tc.qs {
-				utils.Exec(t, conn, q)
-			}
-
-			// cleanup previous run data from table.
-			utils.Exec(t, conn, `delete from test`)
-
-			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
-			utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
-			utils.Exec(t, conn, `rollback`)
-			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
-		})
-	}
+	testAllModes(t, func(conn *mysql.Conn) {
+		utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
+		// lookup vindex is duplicate, transaction is rolled back as it was an implicit transaction started by vtgate.
+		utils.AssertContainsError(t, conn, `insert into test(id, val1) values (4,'D'),(5,'C')`, `transaction rolled back to reverse changes of partial DML execution`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
+		utils.Exec(t, conn, `insert into test(id, val1) values (4,'D'),(5,'E')`)
+		// rollback will not have any effect on the state in autocommit mode.
+		utils.Exec(t, conn, `rollback`)
+		utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")] [INT64(4) VARCHAR("D")] [INT64(5) VARCHAR("E")]]`)
+	})
 }

--- a/go/test/endtoend/vtgate/partialfailure/main_test.go
+++ b/go/test/endtoend/vtgate/partialfailure/main_test.go
@@ -161,7 +161,7 @@ func TestPartialQueryFailure(t *testing.T) {
 
 			utils.Exec(t, conn, `begin`)
 			utils.Exec(t, conn, `insert into test(id, val1) values (1,'A'),(2,'B'),(3,'C')`)
-			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `AlreadyExists`)
+			utils.AssertContainsError(t, conn, `insert into test(id, val1) values (1,'D'),(4,'E')`, `failed to execute due to partial DML execution`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)
 			utils.Exec(t, conn, `commit`)
 			utils.AssertMatches(t, conn, `select id, val1 from test order by id`, `[[INT64(1) VARCHAR("A")] [INT64(2) VARCHAR("B")] [INT64(3) VARCHAR("C")]]`)

--- a/go/test/endtoend/vtgate/utils/utils.go
+++ b/go/test/endtoend/vtgate/utils/utils.go
@@ -43,6 +43,7 @@ func AssertContainsError(t *testing.T, conn *mysql.Conn, query, expected string)
 	t.Helper()
 	_, err := ExecAllowError(t, conn, query)
 	require.Error(t, err)
+	fmt.Println(err.Error())
 	require.Contains(t, err.Error(), expected)
 }
 

--- a/go/test/endtoend/vtgate/utils/utils.go
+++ b/go/test/endtoend/vtgate/utils/utils.go
@@ -43,8 +43,7 @@ func AssertContainsError(t *testing.T, conn *mysql.Conn, query, expected string)
 	t.Helper()
 	_, err := ExecAllowError(t, conn, query)
 	require.Error(t, err)
-	fmt.Println(err.Error())
-	require.Contains(t, err.Error(), expected)
+	require.Contains(t, err.Error(), expected, "actual error: %s", err.Error())
 }
 
 func AssertMatchesNoOrder(t *testing.T, conn *mysql.Conn, query, expected string) {

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -351,6 +351,10 @@ func SkipQueryPlanCacheDirective(stmt Statement) bool {
 // directive is set to true.
 func IgnoreMaxPayloadSizeDirective(stmt Statement) bool {
 	switch stmt := stmt.(type) {
+	// For transactional statements, they should always be passed down and
+	// should not come into max payload size requirement.
+	case *Begin, *Commit, *Rollback, *Savepoint, *SRollback, *Release:
+		return true
 	case *Select:
 		directives := ExtractCommentDirectives(stmt.Comments)
 		return directives.IsSet(DirectiveIgnoreMaxPayloadSize)

--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -1416,7 +1416,10 @@ func (api *API) VTExplain(ctx context.Context, req *vtadminpb.VTExplainRequest) 
 		return nil, fmt.Errorf("error running vtexplain: %w", err)
 	}
 
-	response := vtexplain.ExplainsAsText(plans)
+	response, err := vtexplain.ExplainsAsText(plans)
+	if err != nil {
+		return nil, fmt.Errorf("error converting vtexplain to text output: %w", err)
+	}
 	return &vtadminpb.VTExplainResponse{
 		Response: response,
 	}, nil

--- a/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/updatesharded-output.txt
@@ -85,17 +85,19 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
+1 ks_sharded/-40: savepoint x1
 1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=1
 
-2 ks_sharded/-40: update `user` set nickname = 'bob' where id = 1 limit 10001
+2 ks_sharded/-40: savepoint x2
+3 ks_sharded/-40: update `user` set nickname = 'bob' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 commit
 
-3 ks_sharded/-40: commit
+4 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 begin
@@ -105,18 +107,22 @@ begin
 update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
+1 ks_sharded/-40: savepoint x3
 1 ks_sharded/-40: update `user` set nickname = 'alice' where id = 1 limit 10001
 
 ----------------------------------------------------------------------
 update user set nickname='bob' where id=3
 
-2 ks_sharded/40-80: begin
-2 ks_sharded/40-80: update `user` set nickname = 'bob' where id = 3 limit 10001
+2 ks_sharded/-40: savepoint x4
+3 ks_sharded/40-80: begin
+3 ks_sharded/40-80: savepoint x3
+3 ks_sharded/40-80: savepoint x4
+3 ks_sharded/40-80: update `user` set nickname = 'bob' where id = 3 limit 10001
 
 ----------------------------------------------------------------------
 commit
 
-3 ks_sharded/-40: commit
-4 ks_sharded/40-80: commit
+4 ks_sharded/-40: commit
+5 ks_sharded/40-80: commit
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -111,7 +111,9 @@ func runTestCase(testcase, mode string, opts *Options, topts *testopts, t *testi
 			}
 		}
 
-		explainText := ExplainsAsText(explains)
+		explainText, err := ExplainsAsText(explains)
+		require.NoError(t, err, "vtexplain error")
+
 		if diff := cmp.Diff(strings.TrimSpace(string(expected)), strings.TrimSpace(explainText)); diff != "" {
 			// Print the Text that was actually returned and also dump to a
 			// temp file to be able to diff the results.

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -637,7 +637,8 @@ func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*
 		resultJSON, _ := json.MarshalIndent(result, "", "    ")
 		log.V(100).Infof("query %s result %s\n", query, string(resultJSON))
 
-	case sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtSet:
+	case sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtSet,
+		sqlparser.StmtSavepoint, sqlparser.StmtSRollback, sqlparser.StmtRelease:
 		result = &sqltypes.Result{}
 	case sqlparser.StmtShow:
 		result = &sqltypes.Result{Fields: sqltypes.MakeTestFields("", "")}

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -385,10 +385,10 @@ func TestAutocommitTransactionStarted(t *testing.T) {
 	_, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
-		Sql:           "update `user` set a = 2 where id = 1",
-		BindVariables: map[string]*querypb.BindVariable{},
-	}})
+	require.Equal(t, 2, len(sbc1.Queries))
+	require.Contains(t, sbc1.Queries[0].Sql, "savepoint")
+	require.Equal(t, sbc1.Queries[1].Sql, "update `user` set a = 2 where id = 1")
+
 	testCommitCount(t, "sbc1", sbc1, 0)
 }
 

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -41,13 +41,13 @@ func TestAutocommitUpdateSharded(t *testing.T) {
 	_, err := autocommitExec(executor, "update user set a=2 where id = 1")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "update `user` set a = 2 where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, nil)
+	testQueries(t, sbc2, nil)
 	testCommitCount(t, "sbc1", sbc1, 0)
 }
 
@@ -65,7 +65,7 @@ func TestAutocommitUpdateLookup(t *testing.T) {
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(2)})
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql: "select music_id, user_id from music_user_map where music_id in ::music_id for update",
 		BindVariables: map[string]*querypb.BindVariable{
 			"music_id": vars,
@@ -73,7 +73,7 @@ func TestAutocommitUpdateLookup(t *testing.T) {
 	}})
 	testCommitCount(t, "sbclookup", sbclookup, 1)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "update music set a = 2 where id = 2",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
@@ -92,7 +92,7 @@ func TestAutocommitUpdateVindexChange(t *testing.T) {
 	_, err := autocommitExec(executor, "update user2 set name='myname', lastname='mylastname' where id = 1")
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql: "delete from name_lastname_keyspace_id_map where `name` = :name and lastname = :lastname and keyspace_id = :keyspace_id",
 		BindVariables: map[string]*querypb.BindVariable{
 			"lastname":    sqltypes.ValueBindVariable(sqltypes.NewVarChar("foo")),
@@ -109,7 +109,7 @@ func TestAutocommitUpdateVindexChange(t *testing.T) {
 	}})
 	testCommitCount(t, "sbclookup", sbclookup, 1)
 
-	testQueries(t, "sbc", sbc, []*querypb.BoundQuery{{
+	testQueries(t, sbc, []*querypb.BoundQuery{{
 		Sql:           "select id, `name`, lastname, `name` = 'myname' and lastname = 'mylastname' from user2 where id = 1 for update",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}, {
@@ -126,13 +126,13 @@ func TestAutocommitDeleteSharded(t *testing.T) {
 	_, err := autocommitExec(executor, "delete from user_extra where user_id = 1")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra where user_id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, nil)
+	testQueries(t, sbc2, nil)
 	testCommitCount(t, "sbc1", sbc1, 0)
 }
 
@@ -154,7 +154,7 @@ func TestAutocommitDeleteLookup(t *testing.T) {
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql: "select music_id, user_id from music_user_map where music_id in ::music_id for update",
 		BindVariables: map[string]*querypb.BindVariable{
 			"music_id": vars,
@@ -168,7 +168,7 @@ func TestAutocommitDeleteLookup(t *testing.T) {
 	}})
 	testCommitCount(t, "sbclookup", sbclookup, 1)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "select user_id, id from music where id = 1 for update",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}, {
@@ -185,13 +185,13 @@ func TestAutocommitDeleteIn(t *testing.T) {
 	_, err := autocommitExec(executor, "delete from user_extra where user_id in (1, 2)")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra where user_id in (1, 2)",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, nil)
+	testQueries(t, sbc2, nil)
 	testCommitCount(t, "sbc2", sbc2, 0)
 }
 
@@ -202,13 +202,13 @@ func TestAutocommitDeleteMultiShard(t *testing.T) {
 	_, err := autocommitExec(executor, "delete from user_extra where user_id = user_id + 1")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra where user_id = user_id + 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testCommitCount(t, "sbc1", sbc1, 1)
 
-	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+	testQueries(t, sbc2, []*querypb.BoundQuery{{
 		Sql:           "delete from user_extra where user_id = user_id + 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
@@ -222,13 +222,13 @@ func TestAutocommitDeleteMultiShardAutoCommit(t *testing.T) {
 	_, err := autocommitExec(executor, "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id = user_id + 1")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id = user_id + 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+	testQueries(t, sbc2, []*querypb.BoundQuery{{
 		Sql:           "delete /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ from user_extra where user_id = user_id + 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
@@ -242,7 +242,7 @@ func TestAutocommitInsertSharded(t *testing.T) {
 	_, err := autocommitExec(executor, "insert into user_extra(user_id, v) values (1, 2)")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql: "insert into user_extra(user_id, v) values (:_user_id_0, 2)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -250,7 +250,7 @@ func TestAutocommitInsertSharded(t *testing.T) {
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, nil)
+	testQueries(t, sbc2, nil)
 	testCommitCount(t, "sbc1", sbc1, 0)
 }
 
@@ -261,7 +261,7 @@ func TestAutocommitInsertLookup(t *testing.T) {
 	_, err := autocommitExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')")
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"name_0":    sqltypes.BytesBindVariable([]byte("myname")),
@@ -270,7 +270,7 @@ func TestAutocommitInsertLookup(t *testing.T) {
 	}})
 	testCommitCount(t, "sbclookup", sbclookup, 1)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql: "insert into `user`(id, v, `name`) values (:_Id_0, 2, :_name_0)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_Id_0":   sqltypes.Int64BindVariable(1),
@@ -288,7 +288,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	_, err := autocommitExec(executor, "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (1, 2), (3, 4)")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id_0, 2)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -297,7 +297,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 	}})
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+	testQueries(t, sbc2, []*querypb.BoundQuery{{
 		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id_1, 4)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -315,7 +315,7 @@ func TestAutocommitInsertMultishardAutoCommit(t *testing.T) {
 
 	testCommitCount(t, "sbc1", sbc1, 0)
 
-	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+	testQueries(t, sbc2, []*querypb.BoundQuery{{
 		Sql: "insert /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ into user_extra(user_id, v) values (:_user_id_1, 4)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -332,7 +332,7 @@ func TestAutocommitInsertMultishard(t *testing.T) {
 	_, err := autocommitExec(executor, "insert into user_extra(user_id, v) values (1, 2), (3, 4)")
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql: "insert into user_extra(user_id, v) values (:_user_id_0, 2)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -341,7 +341,7 @@ func TestAutocommitInsertMultishard(t *testing.T) {
 	}})
 	testCommitCount(t, "sbc1", sbc1, 1)
 
-	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+	testQueries(t, sbc2, []*querypb.BoundQuery{{
 		Sql: "insert into user_extra(user_id, v) values (:_user_id_1, 4)",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_user_id_0": sqltypes.Int64BindVariable(1),
@@ -358,7 +358,7 @@ func TestAutocommitInsertAutoinc(t *testing.T) {
 	_, err := autocommitExec(executor, "insert into main1(id, name) values (null, 'myname')")
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
 	}, {
@@ -406,7 +406,7 @@ func TestAutocommitDirectTarget(t *testing.T) {
 	_, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql:           sql,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})
@@ -427,7 +427,7 @@ func TestAutocommitDirectRangeTarget(t *testing.T) {
 	_, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 
-	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+	testQueries(t, sbc1, []*querypb.BoundQuery{{
 		Sql:           sql,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}})

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -385,9 +385,9 @@ func TestAutocommitTransactionStarted(t *testing.T) {
 	_, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(sbc1.Queries))
+	require.Len(t, sbc1.Queries, 2)
 	require.Contains(t, sbc1.Queries[0].Sql, "savepoint")
-	require.Equal(t, sbc1.Queries[1].Sql, "update `user` set a = 2 where id = 1")
+	require.Equal(t, "update `user` set a = 2 where id = 1", sbc1.Queries[1].Sql)
 
 	testCommitCount(t, "sbc1", sbc1, 0)
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -273,8 +273,8 @@ func (e *Executor) StreamExecute(
 
 		// Check if there was partial DML execution. If so, rollback the transaction.
 		if err != nil {
-			if !canReturnRows(plan.Type) && safeSession.InTransaction() && vc.rollbackOnPartialExec != "" {
-				_, _, sErr := e.execute(ctx, safeSession, vc.rollbackOnPartialExec, bindVars, logStats)
+			if !canReturnRows(plan.Type) && safeSession.InTransaction() && safeSession.rollbackOnPartialExec != "" {
+				_, _, sErr := e.execute(ctx, safeSession, safeSession.rollbackOnPartialExec, bindVars, logStats)
 				if sErr == nil {
 					err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "failed to execute due to partial DML execution: %v", err)
 				} else {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -609,6 +609,9 @@ func (e *Executor) executeSPInAllSessions(ctx context.Context, safeSession *Safe
 		var rss []*srvtopo.ResolvedShard
 		var queries []*querypb.BoundQuery
 		for _, shardSession := range safeSession.GetSessions() {
+			if shardSession.TransactionId == 0 {
+				continue
+			}
 			rss = append(rss, &srvtopo.ResolvedShard{
 				Target:  shardSession.Target,
 				Gateway: e.resolver.resolver.GetGateway(),

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -271,7 +271,18 @@ func (e *Executor) StreamExecute(
 			return srr.storeResultStats(plan.Type, qr)
 		})
 
+		// Check if there was partial DML execution. If so, rollback the transaction.
 		if err != nil {
+			if !canReturnRows(plan.Type) && safeSession.InTransaction() && vc.rollbackOnPartialExec != "" {
+				_, _, sErr := e.execute(ctx, safeSession, vc.rollbackOnPartialExec, bindVars, logStats)
+				if sErr == nil {
+					err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "failed to execute due to partial DML execution: %v", err)
+				} else {
+					// not able to rollback changes of the failed query, so have to abort the complete transaction.
+					_ = e.txConn.Rollback(ctx, safeSession)
+					err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "transaction rolled back due to not able to reverse changes of partial DML execution: %v:%v", sErr, err)
+				}
+			}
 			return err
 		}
 
@@ -294,17 +305,6 @@ func (e *Executor) StreamExecute(
 
 		e.updateQueryCounts(plan.Instructions.RouteType(), plan.Instructions.GetKeyspaceName(), plan.Instructions.GetTableName(), int64(logStats.ShardQueries))
 
-		// Check if there was partial DML execution. If so, rollback the transaction.
-		if err != nil && safeSession.InTransaction() && vc.rollbackOnPartialExec != "" {
-			_, _, sErr := e.execute(ctx, safeSession, vc.rollbackOnPartialExec, bindVars, logStats)
-			if sErr == nil {
-				err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "failed to execute due to partial DML execution: %v", err)
-			} else {
-				// not able to rollback changes of the failed query, so have to abort the complete transaction.
-				_ = e.txConn.Rollback(ctx, safeSession)
-				err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "transaction rolled back due to not able to reverse changes of partial DML execution: %v:%v", sErr, err)
-			}
-		}
 		return err
 	}
 
@@ -1683,7 +1683,7 @@ func (e *Executor) ExecuteMultiShard(ctx context.Context, rss []*srvtopo.Resolve
 }
 
 // StreamExecuteMulti implements the IExecutor interface
-func (e *Executor) StreamExecuteMulti(ctx context.Context, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, rollbackOnError string, autocommit bool, callback func(reply *sqltypes.Result) error) []error {
+func (e *Executor) StreamExecuteMulti(ctx context.Context, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error) []error {
 	return e.scatterConn.StreamExecuteMulti(ctx, query, rss, vars, session, autocommit, callback)
 }
 

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -21,11 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/test/utils"
+
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql"
-
-	"vitess.io/vitess/go/test/utils"
 
 	"github.com/stretchr/testify/require"
 
@@ -53,12 +53,8 @@ func TestUpdateEqual(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	testQueryLog(t, logChan, "TestExecute", "UPDATE", "update user set a=2 where id = 1", 1)
 
 	sbc1.Queries = nil
@@ -68,12 +64,8 @@ func TestUpdateEqual(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 3",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
-	}
-	if sbc1.Queries != nil {
-		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
-	}
+	testQueries(t, sbc2, wantQueries)
+	testQueries(t, sbc1, nil)
 
 	// Update by secondary vindex.
 	sbc1.Queries = nil
@@ -89,15 +81,9 @@ func TestUpdateEqual(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
-	if sbc1.Queries != nil {
-		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
-	}
+	testQueries(t, sbclookup, wantQueries)
+	testQueries(t, sbc2, nil)
+	testQueries(t, sbc1, nil)
 
 	// Update changes lookup vindex values.
 	sbc1.Queries = nil
@@ -121,12 +107,8 @@ func TestUpdateEqual(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 
 	wantQueries = []*querypb.BoundQuery{
 		{
@@ -147,9 +129,7 @@ func TestUpdateEqual(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateMultiOwned(t *testing.T) {
@@ -231,12 +211,8 @@ func TestUpdateMultiOwned(t *testing.T) {
 		Sql:           "update `user` set a = 1, b = 2, f = 4, e = 3 where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
@@ -268,7 +244,7 @@ func TestUpdateMultiOwned(t *testing.T) {
 		},
 	}}
 
-	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateComments(t *testing.T) {
@@ -280,12 +256,8 @@ func TestUpdateComments(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 }
 
 func TestUpdateNormalize(t *testing.T) {
@@ -301,12 +273,8 @@ func TestUpdateNormalize(t *testing.T) {
 			"vtg2": sqltypes.TestBindVariable(int64(1)),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	sbc1.Queries = nil
 
 	// Force the query to go to the "wrong" shard and ensure that normalization still happens
@@ -320,8 +288,8 @@ func TestUpdateNormalize(t *testing.T) {
 			"vtg2": sqltypes.TestBindVariable(int64(1)),
 		},
 	}}
-	assert.Empty(t, sbc1.Queries)
-	utils.MustMatch(t, sbc2.Queries, wantQueries, "didn't get expected queries")
+	testQueries(t, sbc1, nil)
+	testQueries(t, sbc2, wantQueries)
 	sbc2.Queries = nil
 	primarySession.TargetString = ""
 }
@@ -350,9 +318,7 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from `user` where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from name_user_map where `name` = :name and user_id = :user_id",
@@ -361,9 +327,7 @@ func TestDeleteEqual(t *testing.T) {
 			"name":    sqltypes.ValueBindVariable(sqltypes.NewVarChar("myname")),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -377,12 +341,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from `user` where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
-	if sbclookup.Queries != nil {
-		t.Errorf("sbclookup.Queries: %+v, want nil\n", sbclookup.Queries)
-	}
+	testQueries(t, sbc, wantQueries)
+	testQueries(t, sbclookup, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -397,12 +357,8 @@ func TestDeleteEqual(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
-	if sbc.Queries != nil {
-		t.Errorf("sbc.Queries: %+v, want nil\n", sbc.Queries)
-	}
+	testQueries(t, sbclookup, wantQueries)
+	testQueries(t, sbc, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -413,12 +369,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from user_extra where user_id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
-	if sbclookup.Queries != nil {
-		t.Errorf("sbc.Queries: %+v, want nil\n", sbc.Queries)
-	}
+	testQueries(t, sbc, wantQueries)
+	testQueries(t, sbclookup, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -439,9 +391,7 @@ func TestDeleteEqual(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries: %+v, want %+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{
 		{
@@ -454,9 +404,7 @@ func TestDeleteEqual(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateScatter(t *testing.T) {
@@ -468,12 +416,8 @@ func TestUpdateScatter(t *testing.T) {
 		Sql:           "update user_extra set col = 2",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteScatter(t *testing.T) {
@@ -485,12 +429,8 @@ func TestDeleteScatter(t *testing.T) {
 		Sql:           "delete from user_extra",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, wantQueries)
 }
 
 func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
@@ -511,8 +451,8 @@ func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		}}
 
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	utils.MustMatch(t, wantQueries, sbc2.Queries)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, wantQueries)
 
 	bq1 := &querypb.BoundQuery{
 		Sql: "delete from lu_idx where lu_col = :lu_col and keyspace_id = :keyspace_id",
@@ -529,7 +469,7 @@ func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 		},
 	}
 	lookWant := []*querypb.BoundQuery{bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
+	testQueries(t, sbcLookup, lookWant)
 }
 
 func TestUpdateEqualWithMultipleLookupVindex(t *testing.T) {
@@ -577,9 +517,9 @@ func TestUpdateEqualWithMultipleLookupVindex(t *testing.T) {
 			"lu_col_0":      sqltypes.Int64BindVariable(5),
 		},
 	}}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	assert.Nil(t, sbc2.Queries)
+	testQueries(t, sbcLookup, lookWant)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 }
 
 func TestUpdateUseHigherCostVindexIfBackfilling(t *testing.T) {
@@ -642,9 +582,9 @@ func TestUpdateUseHigherCostVindexIfBackfilling(t *testing.T) {
 			"lu_col_0":      sqltypes.Int64BindVariable(5),
 		},
 	}}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	assert.Nil(t, sbc2.Queries)
+	testQueries(t, sbcLookup, lookWant)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 }
 
 func TestDeleteEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
@@ -680,9 +620,9 @@ func TestDeleteEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 		},
 	}
 	lookWant := []*querypb.BoundQuery{bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	utils.MustMatch(t, wantQueries, sbc2.Queries)
+	testQueries(t, sbcLookup, lookWant)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteEqualWithMultipleLookupVindex(t *testing.T) {
@@ -730,10 +670,10 @@ func TestDeleteEqualWithMultipleLookupVindex(t *testing.T) {
 			"lu_col":      {Type: querypb.Type_INT64, Value: []byte("1")},
 		},
 	}}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
+	testQueries(t, sbcLookup, lookWant)
 
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	assert.Nil(t, sbc2.Queries)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 }
 
 func TestDeleteUseHigherCostVindexIfBackfilling(t *testing.T) {
@@ -796,10 +736,10 @@ func TestDeleteUseHigherCostVindexIfBackfilling(t *testing.T) {
 			"lu_col":      sqltypes.Int64BindVariable(2),
 		},
 	}}
-	utils.MustMatch(t, lookWant, sbcLookup.Queries)
+	testQueries(t, sbcLookup, lookWant)
 
-	utils.MustMatch(t, wantQueries, sbc1.Queries)
-	assert.Nil(t, sbc2.Queries)
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 }
 
 func TestDeleteByDestination(t *testing.T) {
@@ -812,12 +752,8 @@ func TestDeleteByDestination(t *testing.T) {
 		Sql:           "delete from user_extra limit 10",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteComments(t *testing.T) {
@@ -844,9 +780,7 @@ func TestDeleteComments(t *testing.T) {
 		Sql:           "delete from `user` where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from name_user_map where `name` = :name and user_id = :user_id /* trailing */",
@@ -855,9 +789,7 @@ func TestDeleteComments(t *testing.T) {
 			"name":    sqltypes.ValueBindVariable(sqltypes.NewVarChar("myname")),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertSharded(t *testing.T) {
@@ -876,12 +808,8 @@ func TestInsertSharded(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -889,9 +817,7 @@ func TestInsertSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 
 	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)", 1)
 	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (1, 2, 'myname')", 1)
@@ -908,12 +834,8 @@ func TestInsertSharded(t *testing.T) {
 			"_name_0": sqltypes.BytesBindVariable([]byte("myname2")),
 		},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
-	}
-	if sbc1.Queries != nil {
-		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
-	}
+	testQueries(t, sbc2, wantQueries)
+	testQueries(t, sbc1, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -921,9 +843,7 @@ func TestInsertSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 
 	sbc1.Queries = nil
 	_, err = executorExec(executor, "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname')", nil)
@@ -936,9 +856,7 @@ func TestInsertSharded(t *testing.T) {
 			"_lastname_0": sqltypes.BytesBindVariable([]byte("mylastname")),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
 }
 
 func TestInsertShardedKeyrange(t *testing.T) {
@@ -997,7 +915,7 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 `
 	executor, sbc1, sbc2, sbclookup := createCustomExecutor(vschema)
 
-	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
+	_, err := executorExecSession(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil, &vtgatepb.Session{})
 	require.NoError(t, err)
 	wantQueries := []*querypb.BoundQuery{{
 		Sql: "insert into `user`(id, v, `name`) values (:_Id_0, 2, :_name_0)",
@@ -1007,12 +925,8 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0) on duplicate key update `name` = values(`name`), user_id = values(user_id)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1021,9 +935,7 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 		},
 	}}
 	// autocommit should go as ExecuteBatch
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.BatchQueries[0]: \n%+v, want \n%+v", sbclookup.BatchQueries[0], wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertShardedIgnore(t *testing.T) {
@@ -1072,9 +984,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"_verify_5": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_5, :_owned_5, :_verify_5)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1089,9 +999,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"_verify_5": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
-		t.Errorf("sbc2.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
-	}
+	testQueries(t, sbc2, wantQueries)
 
 	vars, err := sqltypes.BuildBindVariable([]interface{}{
 		sqltypes.NewInt64(1),
@@ -1152,9 +1060,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"tocol":   sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 
 	// Test the 0 rows case,
 	sbc1.Queries = nil
@@ -1169,12 +1075,8 @@ func TestInsertShardedIgnore(t *testing.T) {
 	if !reflect.DeepEqual(qr, &sqltypes.Result{}) {
 		t.Errorf("qr: %v, want empty result", qr)
 	}
-	if sbc1.Queries != nil {
-		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, nil)
+	testQueries(t, sbc2, nil)
 	vars, err = sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1183,9 +1085,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertOnDupKey(t *testing.T) {
@@ -1207,12 +1107,8 @@ func TestInsertOnDupKey(t *testing.T) {
 			"_verify_0": sqltypes.Int64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1233,9 +1129,7 @@ func TestInsertOnDupKey(t *testing.T) {
 			"tocol":   sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestAutocommitFail(t *testing.T) {
@@ -1268,12 +1162,8 @@ func TestInsertComments(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1281,9 +1171,7 @@ func TestInsertComments(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertGeneratorSharded(t *testing.T) {
@@ -1306,9 +1194,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 			"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries: %+v, want %+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
@@ -1319,7 +1205,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
+	testQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1347,13 +1233,11 @@ func TestInsertAutoincSharded(t *testing.T) {
 			"_user_id_0": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
-	assert.Equal(t, primarySession.LastInsertId, uint64(2))
+	assert.EqualValues(t, 2, primarySession.LastInsertId)
 }
 
 func TestInsertGeneratorUnsharded(t *testing.T) {
@@ -1369,9 +1253,7 @@ func TestInsertGeneratorUnsharded(t *testing.T) {
 			"__seq0": sqltypes.Int64BindVariable(1),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1399,9 +1281,7 @@ func TestInsertAutoincUnsharded(t *testing.T) {
 		Sql:           query,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%#v, want \n%#v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
@@ -1420,9 +1300,7 @@ func TestInsertLookupOwned(t *testing.T) {
 			"__seq0":     sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1430,7 +1308,7 @@ func TestInsertLookupOwned(t *testing.T) {
 			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertLookupOwnedGenerator(t *testing.T) {
@@ -1453,9 +1331,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 			"__seq0":     sqltypes.Int64BindVariable(4),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
@@ -1466,9 +1342,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     4,
 		RowsAffected: 1,
@@ -1488,9 +1362,7 @@ func TestInsertLookupUnowned(t *testing.T) {
 			"_music_id_0": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries: %+v, want %+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select music_id from music_user_map where music_id = :music_id and user_id = :user_id",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1498,9 +1370,7 @@ func TestInsertLookupUnowned(t *testing.T) {
 			"user_id":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%v, want\n%v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertLookupUnownedUnsupplied(t *testing.T) {
@@ -1518,9 +1388,7 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 			"_music_id_0": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(3)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1529,9 +1397,7 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 // If a statement gets broken up into two, and the first one fails,
@@ -1568,7 +1434,8 @@ func TestInsertPartialFail2(t *testing.T) {
 		"insert into user(id, v, name) values (1, 2, 'myname')",
 		nil,
 	)
-	want := "transaction rolled back"
+	//todo: add savepoint
+	want := "revered partial DML execution failure"
 	if err == nil || !strings.HasPrefix(err.Error(), want) {
 		t.Errorf("insert first DML fail: %v, must start with %s", err, want)
 	}
@@ -1602,13 +1469,8 @@ func TestMultiInsertSharded(t *testing.T) {
 			"__seq1":  sqltypes.Int64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries1) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries1)
-	}
-
-	if !reflect.DeepEqual(sbc2.Queries, wantQueries2) {
-		t.Errorf("sbc2.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries2)
-	}
+	testQueries(t, sbc1, wantQueries1)
+	testQueries(t, sbc2, wantQueries2)
 
 	wantQueries1 = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
@@ -1619,9 +1481,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"user_id_1": sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries1) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries1)
-	}
+	testQueries(t, sbclookup, wantQueries1)
 
 	sbc1.Queries = nil
 	sbclookup.Queries = nil
@@ -1640,12 +1500,8 @@ func TestMultiInsertSharded(t *testing.T) {
 		},
 	}}
 
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1655,9 +1511,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"user_id_1": sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 
 	// Insert multiple rows in a multi column vindex
 	sbc1.Queries = nil
@@ -1676,9 +1530,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"_lastname_1": sqltypes.BytesBindVariable([]byte("mylastname2")),
 		},
 	}}
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
+	testQueries(t, sbc1, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_lastname_keyspace_id_map(`name`, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0), (:name_1, :lastname_1, :keyspace_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1690,9 +1542,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"keyspace_id_1": sqltypes.BytesBindVariable([]byte("N\xb1\x90ɢ\xfa\x16\x9c")),
 		},
 	}}
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestMultiInsertGenerator(t *testing.T) {
@@ -1719,9 +1569,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 			"_user_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
@@ -1734,7 +1582,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 			"music_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
+	testQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1769,9 +1617,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 			"_user_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
@@ -1786,7 +1632,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 			"music_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries, "sbclookup.Queries")
+	testQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1925,7 +1771,7 @@ func assertQueriesContain(t *testing.T, sql, sbcName string, sbc *sandboxconn.Sa
 		Sql:           sql,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbcName, sbc, expectedQuery)
+	testQueries(t, sbc, expectedQuery)
 }
 
 // Prepared statement tests
@@ -1943,15 +1789,9 @@ func TestUpdateEqualWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
-	if sbc1.Queries != nil {
-		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
-	}
+	testQueries(t, sbclookup, wantQueries)
+	testQueries(t, sbc2, nil)
+	testQueries(t, sbc1, nil)
 }
 func TestInsertShardedWithPrepare(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createLegacyExecutorEnv()
@@ -1968,16 +1808,10 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
-	}
-	if sbc2.Queries != nil {
-		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
-	}
+	testQueries(t, sbc1, wantQueries)
+	testQueries(t, sbc2, nil)
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestDeleteEqualWithPrepare(t *testing.T) {
@@ -1989,13 +1823,9 @@ func TestDeleteEqualWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
-	}
+	testQueries(t, sbc, wantQueries)
 
-	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
-		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
-	}
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateLastInsertID(t *testing.T) {
@@ -2013,7 +1843,7 @@ func TestUpdateLastInsertID(t *testing.T) {
 			"vtg1":           sqltypes.Int64BindVariable(1)},
 	}}
 
-	require.Equal(t, wantQueries, sbc1.Queries)
+	testQueries(t, sbc1, wantQueries)
 }
 
 func TestDeleteLookupOwnedEqual(t *testing.T) {
@@ -2039,8 +1869,8 @@ func TestDeleteLookupOwnedEqual(t *testing.T) {
 		Sql:           "delete from t1 where unq_col = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	utils.MustMatch(t, sbc1.Queries, sbc1wantQueries, "")
-	utils.MustMatch(t, sbc2.Queries, sbc2wantQueries, "")
+	testQueries(t, sbc1, sbc1wantQueries)
+	testQueries(t, sbc2, sbc2wantQueries)
 }
 
 func TestReservedConnDML(t *testing.T) {
@@ -2063,7 +1893,7 @@ func TestReservedConnDML(t *testing.T) {
 	})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "set default_week_format = 1", nil)
 	require.NoError(t, err)
-	utils.MustMatch(t, wantQueries, sbc.Queries)
+	testQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "begin", nil)
 	require.NoError(t, err)
@@ -2073,7 +1903,7 @@ func TestReservedConnDML(t *testing.T) {
 		&querypb.BoundQuery{Sql: "insert into simple values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into simple() values ()", nil)
 	require.NoError(t, err)
-	utils.MustMatch(t, wantQueries, sbc.Queries)
+	testQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "commit", nil)
 	require.NoError(t, err)
@@ -2088,7 +1918,7 @@ func TestReservedConnDML(t *testing.T) {
 		&querypb.BoundQuery{Sql: "insert into simple values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into simple() values ()", nil)
 	require.NoError(t, err)
-	utils.MustMatch(t, wantQueries, sbc.Queries)
+	testQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "commit", nil)
 	require.NoError(t, err)
@@ -2113,12 +1943,12 @@ func TestStreamingDML(t *testing.T) {
 		openTx      bool
 		changedRows int
 		commitCount int
-		expQuery    []string
+		expQuery    []*querypb.BoundQuery
 	}{{
 		query: "begin",
 
 		inTx:     true,
-		expQuery: []string{},
+		expQuery: []*querypb.BoundQuery{},
 	}, {
 		query:  "insert into simple() values ()",
 		result: &sqltypes.Result{RowsAffected: 1},
@@ -2126,7 +1956,10 @@ func TestStreamingDML(t *testing.T) {
 		inTx:        true,
 		openTx:      true,
 		changedRows: 1,
-		expQuery:    []string{"insert into simple values ()"},
+		expQuery: []*querypb.BoundQuery{{
+			Sql:           "insert into simple values ()",
+			BindVariables: map[string]*querypb.BindVariable{},
+		}},
 	}, {
 		query:  "update simple set name = 'V' where col = 2",
 		result: &sqltypes.Result{RowsAffected: 3},
@@ -2134,7 +1967,10 @@ func TestStreamingDML(t *testing.T) {
 		inTx:        true,
 		openTx:      true,
 		changedRows: 3,
-		expQuery:    []string{"update simple set `name` = 'V' where col = 2"},
+		expQuery: []*querypb.BoundQuery{{
+			Sql:           "update simple set `name` = 'V' where col = 2",
+			BindVariables: map[string]*querypb.BindVariable{},
+		}},
 	}, {
 		query:  "delete from simple",
 		result: &sqltypes.Result{RowsAffected: 12},
@@ -2142,12 +1978,15 @@ func TestStreamingDML(t *testing.T) {
 		inTx:        true,
 		openTx:      true,
 		changedRows: 12,
-		expQuery:    []string{"delete from simple"},
+		expQuery: []*querypb.BoundQuery{{
+			Sql:           "delete from simple",
+			BindVariables: map[string]*querypb.BindVariable{},
+		}},
 	}, {
 		query: "commit",
 
 		commitCount: 1,
-		expQuery:    []string{},
+		expQuery:    []*querypb.BoundQuery{},
 	}}
 
 	var qr *sqltypes.Result
@@ -2166,7 +2005,7 @@ func TestStreamingDML(t *testing.T) {
 		// row affected as returned by result
 		assert.EqualValues(t, tcase.changedRows, qr.RowsAffected)
 		// match the query received on tablet
-		utils.MustMatch(t, tcase.expQuery, sbc.StringQueries())
+		testQueries(t, sbc, tcase.expQuery)
 
 		assert.EqualValues(t, tcase.commitCount, sbc.CommitCount.Get())
 	}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -54,8 +54,8 @@ func TestUpdateEqual(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	testQueryLog(t, logChan, "TestExecute", "UPDATE", "update user set a=2 where id = 1", 1)
 
 	sbc1.Queries = nil
@@ -65,8 +65,8 @@ func TestUpdateEqual(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 3",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc2, wantQueries)
-	testQueries(t, sbc1, nil)
+	assertQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, nil)
 
 	// Update by secondary vindex.
 	sbc1.Queries = nil
@@ -82,9 +82,9 @@ func TestUpdateEqual(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
-	testQueries(t, sbc2, nil)
-	testQueries(t, sbc1, nil)
+	assertQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, nil)
 
 	// Update changes lookup vindex values.
 	sbc1.Queries = nil
@@ -108,8 +108,8 @@ func TestUpdateEqual(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 
 	wantQueries = []*querypb.BoundQuery{
 		{
@@ -130,7 +130,7 @@ func TestUpdateEqual(t *testing.T) {
 		},
 	}
 
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateMultiOwned(t *testing.T) {
@@ -212,8 +212,8 @@ func TestUpdateMultiOwned(t *testing.T) {
 		Sql:           "update `user` set a = 1, b = 2, f = 4, e = 3 where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
@@ -245,7 +245,7 @@ func TestUpdateMultiOwned(t *testing.T) {
 		},
 	}}
 
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateComments(t *testing.T) {
@@ -257,8 +257,8 @@ func TestUpdateComments(t *testing.T) {
 		Sql:           "update `user` set a = 2 where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 }
 
 func TestUpdateNormalize(t *testing.T) {
@@ -274,8 +274,8 @@ func TestUpdateNormalize(t *testing.T) {
 			"vtg2": sqltypes.TestBindVariable(int64(1)),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	sbc1.Queries = nil
 
 	// Force the query to go to the "wrong" shard and ensure that normalization still happens
@@ -289,8 +289,8 @@ func TestUpdateNormalize(t *testing.T) {
 			"vtg2": sqltypes.TestBindVariable(int64(1)),
 		},
 	}}
-	testQueries(t, sbc1, nil)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, nil)
+	assertQueries(t, sbc2, wantQueries)
 	sbc2.Queries = nil
 	primarySession.TargetString = ""
 }
@@ -319,7 +319,7 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from `user` where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from name_user_map where `name` = :name and user_id = :user_id",
@@ -328,7 +328,7 @@ func TestDeleteEqual(t *testing.T) {
 			"name":    sqltypes.ValueBindVariable(sqltypes.NewVarChar("myname")),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -342,8 +342,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from `user` where id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc, wantQueries)
-	testQueries(t, sbclookup, nil)
+	assertQueries(t, sbc, wantQueries)
+	assertQueries(t, sbclookup, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -358,8 +358,8 @@ func TestDeleteEqual(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
-	testQueries(t, sbc, nil)
+	assertQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbc, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -370,8 +370,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "delete from user_extra where user_id = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc, wantQueries)
-	testQueries(t, sbclookup, nil)
+	assertQueries(t, sbc, wantQueries)
+	assertQueries(t, sbclookup, nil)
 
 	sbc.Queries = nil
 	sbclookup.Queries = nil
@@ -392,7 +392,7 @@ func TestDeleteEqual(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{
 		{
@@ -405,7 +405,7 @@ func TestDeleteEqual(t *testing.T) {
 		},
 	}
 
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateScatter(t *testing.T) {
@@ -417,8 +417,8 @@ func TestUpdateScatter(t *testing.T) {
 		Sql:           "update user_extra set col = 2",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteScatter(t *testing.T) {
@@ -430,8 +430,8 @@ func TestDeleteScatter(t *testing.T) {
 		Sql:           "delete from user_extra",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 }
 
 func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
@@ -452,8 +452,8 @@ func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		}}
 
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 
 	bq1 := &querypb.BoundQuery{
 		Sql: "delete from lu_idx where lu_col = :lu_col and keyspace_id = :keyspace_id",
@@ -470,7 +470,7 @@ func TestUpdateEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 		},
 	}
 	lookWant := []*querypb.BoundQuery{bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2}
-	testQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbcLookup, lookWant)
 }
 
 func TestUpdateEqualWithMultipleLookupVindex(t *testing.T) {
@@ -518,9 +518,9 @@ func TestUpdateEqualWithMultipleLookupVindex(t *testing.T) {
 			"lu_col_0":      sqltypes.Int64BindVariable(5),
 		},
 	}}
-	testQueries(t, sbcLookup, lookWant)
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 }
 
 func TestUpdateUseHigherCostVindexIfBackfilling(t *testing.T) {
@@ -583,9 +583,9 @@ func TestUpdateUseHigherCostVindexIfBackfilling(t *testing.T) {
 			"lu_col_0":      sqltypes.Int64BindVariable(5),
 		},
 	}}
-	testQueries(t, sbcLookup, lookWant)
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 }
 
 func TestDeleteEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
@@ -621,9 +621,9 @@ func TestDeleteEqualWithWriteOnlyLookupUniqueVindex(t *testing.T) {
 		},
 	}
 	lookWant := []*querypb.BoundQuery{bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2, bq1, bq2}
-	testQueries(t, sbcLookup, lookWant)
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteEqualWithMultipleLookupVindex(t *testing.T) {
@@ -671,10 +671,10 @@ func TestDeleteEqualWithMultipleLookupVindex(t *testing.T) {
 			"lu_col":      {Type: querypb.Type_INT64, Value: []byte("1")},
 		},
 	}}
-	testQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbcLookup, lookWant)
 
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 }
 
 func TestDeleteUseHigherCostVindexIfBackfilling(t *testing.T) {
@@ -737,10 +737,10 @@ func TestDeleteUseHigherCostVindexIfBackfilling(t *testing.T) {
 			"lu_col":      sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbcLookup, lookWant)
+	assertQueries(t, sbcLookup, lookWant)
 
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 }
 
 func TestDeleteByDestination(t *testing.T) {
@@ -753,8 +753,8 @@ func TestDeleteByDestination(t *testing.T) {
 		Sql:           "delete from user_extra limit 10",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 }
 
 func TestDeleteComments(t *testing.T) {
@@ -781,7 +781,7 @@ func TestDeleteComments(t *testing.T) {
 		Sql:           "delete from `user` where id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "delete from name_user_map where `name` = :name and user_id = :user_id /* trailing */",
@@ -790,7 +790,7 @@ func TestDeleteComments(t *testing.T) {
 			"name":    sqltypes.ValueBindVariable(sqltypes.NewVarChar("myname")),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertSharded(t *testing.T) {
@@ -809,8 +809,8 @@ func TestInsertSharded(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -818,7 +818,7 @@ func TestInsertSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name_0, :user_id_0)", 1)
 	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (1, 2, 'myname')", 1)
@@ -835,8 +835,8 @@ func TestInsertSharded(t *testing.T) {
 			"_name_0": sqltypes.BytesBindVariable([]byte("myname2")),
 		},
 	}}
-	testQueries(t, sbc2, wantQueries)
-	testQueries(t, sbc1, nil)
+	assertQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc1, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -844,7 +844,7 @@ func TestInsertSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	sbc1.Queries = nil
 	_, err = executorExec(executor, "insert into user2(id, name, lastname) values (2, 'myname', 'mylastname')", nil)
@@ -857,7 +857,7 @@ func TestInsertSharded(t *testing.T) {
 			"_lastname_0": sqltypes.BytesBindVariable([]byte("mylastname")),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
 }
 
 func TestInsertShardedKeyrange(t *testing.T) {
@@ -926,8 +926,8 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0) on duplicate key update `name` = values(`name`), user_id = values(user_id)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -936,7 +936,7 @@ func TestInsertShardedAutocommitLookup(t *testing.T) {
 		},
 	}}
 	// autocommit should go as ExecuteBatch
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertShardedIgnore(t *testing.T) {
@@ -985,7 +985,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"_verify_5": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert ignore into insert_ignore_test(pv, owned, verify) values (:_pv_5, :_owned_5, :_verify_5)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1000,7 +1000,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"_verify_5": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc2, wantQueries)
+	assertQueries(t, sbc2, wantQueries)
 
 	vars, err := sqltypes.BuildBindVariable([]interface{}{
 		sqltypes.NewInt64(1),
@@ -1061,7 +1061,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"tocol":   sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	// Test the 0 rows case,
 	sbc1.Queries = nil
@@ -1076,8 +1076,8 @@ func TestInsertShardedIgnore(t *testing.T) {
 	if !reflect.DeepEqual(qr, &sqltypes.Result{}) {
 		t.Errorf("qr: %v, want empty result", qr)
 	}
-	testQueries(t, sbc1, nil)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, nil)
+	assertQueries(t, sbc2, nil)
 	vars, err = sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1086,7 +1086,7 @@ func TestInsertShardedIgnore(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertOnDupKey(t *testing.T) {
@@ -1108,8 +1108,8 @@ func TestInsertOnDupKey(t *testing.T) {
 			"_verify_0": sqltypes.Int64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(1)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1130,7 +1130,7 @@ func TestInsertOnDupKey(t *testing.T) {
 			"tocol":   sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestAutocommitFail(t *testing.T) {
@@ -1163,8 +1163,8 @@ func TestInsertComments(t *testing.T) {
 			"__seq0":  sqltypes.Int64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1172,7 +1172,7 @@ func TestInsertComments(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertGeneratorSharded(t *testing.T) {
@@ -1195,7 +1195,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 			"_name_0": sqltypes.BytesBindVariable([]byte("myname")),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
@@ -1206,7 +1206,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 			"user_id_0": sqltypes.Uint64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1234,7 +1234,7 @@ func TestInsertAutoincSharded(t *testing.T) {
 			"_user_id_0": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
@@ -1254,7 +1254,7 @@ func TestInsertGeneratorUnsharded(t *testing.T) {
 			"__seq0": sqltypes.Int64BindVariable(1),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1282,7 +1282,7 @@ func TestInsertAutoincUnsharded(t *testing.T) {
 		Sql:           query,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
@@ -1301,7 +1301,7 @@ func TestInsertLookupOwned(t *testing.T) {
 			"__seq0":     sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into music_user_map(music_id, user_id) values (:music_id_0, :user_id_0)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1309,7 +1309,7 @@ func TestInsertLookupOwned(t *testing.T) {
 			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertLookupOwnedGenerator(t *testing.T) {
@@ -1332,7 +1332,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 			"__seq0":     sqltypes.Int64BindVariable(4),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
@@ -1343,7 +1343,7 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 			"user_id_0":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     4,
 		RowsAffected: 1,
@@ -1363,7 +1363,7 @@ func TestInsertLookupUnowned(t *testing.T) {
 			"_music_id_0": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "select music_id from music_user_map where music_id = :music_id and user_id = :user_id",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1371,7 +1371,7 @@ func TestInsertLookupUnowned(t *testing.T) {
 			"user_id":  sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestInsertLookupUnownedUnsupplied(t *testing.T) {
@@ -1389,7 +1389,7 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 			"_music_id_0": sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	vars, err := sqltypes.BuildBindVariable([]interface{}{sqltypes.NewInt64(3)})
 	require.NoError(t, err)
 	wantQueries = []*querypb.BoundQuery{{
@@ -1398,7 +1398,7 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 			"music_id": vars,
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 // If a statement gets broken up into two, and the first one fails,
@@ -1458,7 +1458,7 @@ func TestInsertPartialFail2(t *testing.T) {
 			Sql:           "rollback to x",
 			BindVariables: map[string]*querypb.BindVariable{},
 		}}
-	testQueriesWithSavepoint(t, sbc1, wantQueries)
+	assertQueriesWithSavepoint(t, sbc1, wantQueries)
 }
 
 func TestMultiInsertSharded(t *testing.T) {
@@ -1489,8 +1489,8 @@ func TestMultiInsertSharded(t *testing.T) {
 			"__seq1":  sqltypes.Int64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries1)
-	testQueries(t, sbc2, wantQueries2)
+	assertQueries(t, sbc1, wantQueries1)
+	assertQueries(t, sbc2, wantQueries2)
 
 	wantQueries1 = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
@@ -1501,7 +1501,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"user_id_1": sqltypes.Uint64BindVariable(3),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries1)
+	assertQueries(t, sbclookup, wantQueries1)
 
 	sbc1.Queries = nil
 	sbclookup.Queries = nil
@@ -1520,8 +1520,8 @@ func TestMultiInsertSharded(t *testing.T) {
 		},
 	}}
 
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_user_map(`name`, user_id) values (:name_0, :user_id_0), (:name_1, :user_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1531,7 +1531,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"user_id_1": sqltypes.Uint64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	// Insert multiple rows in a multi column vindex
 	sbc1.Queries = nil
@@ -1550,7 +1550,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"_lastname_1": sqltypes.BytesBindVariable([]byte("mylastname2")),
 		},
 	}}
-	testQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql: "insert into name_lastname_keyspace_id_map(`name`, lastname, keyspace_id) values (:name_0, :lastname_0, :keyspace_id_0), (:name_1, :lastname_1, :keyspace_id_1)",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -1562,7 +1562,7 @@ func TestMultiInsertSharded(t *testing.T) {
 			"keyspace_id_1": sqltypes.BytesBindVariable([]byte("N\xb1\x90ɢ\xfa\x16\x9c")),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestMultiInsertGenerator(t *testing.T) {
@@ -1589,7 +1589,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 			"_user_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
@@ -1602,7 +1602,7 @@ func TestMultiInsertGenerator(t *testing.T) {
 			"music_id_1": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1637,7 +1637,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 			"_user_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 	wantQueries = []*querypb.BoundQuery{{
 		Sql:           "select next :n values from user_seq",
 		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(2)},
@@ -1652,7 +1652,7 @@ func TestMultiInsertGeneratorSparse(t *testing.T) {
 			"music_id_2": sqltypes.Int64BindVariable(2),
 		},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 	wantResult := &sqltypes.Result{
 		InsertID:     1,
 		RowsAffected: 1,
@@ -1791,7 +1791,7 @@ func assertQueriesContain(t *testing.T, sql, sbcName string, sbc *sandboxconn.Sa
 		Sql:           sql,
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc, expectedQuery)
+	assertQueries(t, sbc, expectedQuery)
 }
 
 // Prepared statement tests
@@ -1809,9 +1809,9 @@ func TestUpdateEqualWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	testQueries(t, sbclookup, wantQueries)
-	testQueries(t, sbc2, nil)
-	testQueries(t, sbc1, nil)
+	assertQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, nil)
 }
 func TestInsertShardedWithPrepare(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createLegacyExecutorEnv()
@@ -1828,10 +1828,10 @@ func TestInsertShardedWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	testQueries(t, sbc1, wantQueries)
-	testQueries(t, sbc2, nil)
+	assertQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc2, nil)
 
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestDeleteEqualWithPrepare(t *testing.T) {
@@ -1843,9 +1843,9 @@ func TestDeleteEqualWithPrepare(t *testing.T) {
 
 	var wantQueries []*querypb.BoundQuery
 
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestUpdateLastInsertID(t *testing.T) {
@@ -1863,7 +1863,7 @@ func TestUpdateLastInsertID(t *testing.T) {
 			"vtg1":           sqltypes.Int64BindVariable(1)},
 	}}
 
-	testQueries(t, sbc1, wantQueries)
+	assertQueries(t, sbc1, wantQueries)
 }
 
 func TestDeleteLookupOwnedEqual(t *testing.T) {
@@ -1889,8 +1889,8 @@ func TestDeleteLookupOwnedEqual(t *testing.T) {
 		Sql:           "delete from t1 where unq_col = 1",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbc1, sbc1wantQueries)
-	testQueries(t, sbc2, sbc2wantQueries)
+	assertQueries(t, sbc1, sbc1wantQueries)
+	assertQueries(t, sbc2, sbc2wantQueries)
 }
 
 func TestReservedConnDML(t *testing.T) {
@@ -1913,7 +1913,7 @@ func TestReservedConnDML(t *testing.T) {
 	})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "set default_week_format = 1", nil)
 	require.NoError(t, err)
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "begin", nil)
 	require.NoError(t, err)
@@ -1923,7 +1923,7 @@ func TestReservedConnDML(t *testing.T) {
 		&querypb.BoundQuery{Sql: "insert into simple values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into simple() values ()", nil)
 	require.NoError(t, err)
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "commit", nil)
 	require.NoError(t, err)
@@ -1938,7 +1938,7 @@ func TestReservedConnDML(t *testing.T) {
 		&querypb.BoundQuery{Sql: "insert into simple values ()", BindVariables: map[string]*querypb.BindVariable{}})
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "insert into simple() values ()", nil)
 	require.NoError(t, err)
-	testQueries(t, sbc, wantQueries)
+	assertQueries(t, sbc, wantQueries)
 
 	_, err = executor.Execute(ctx, "TestReservedConnDML", session, "commit", nil)
 	require.NoError(t, err)
@@ -2025,7 +2025,7 @@ func TestStreamingDML(t *testing.T) {
 		// row affected as returned by result
 		assert.EqualValues(t, tcase.changedRows, qr.RowsAffected)
 		// match the query received on tablet
-		testQueries(t, sbc, tcase.expQuery)
+		assertQueries(t, sbc, tcase.expQuery)
 
 		assert.EqualValues(t, tcase.commitCount, sbc.CommitCount.Get())
 	}
@@ -2072,11 +2072,11 @@ func TestTestPartialVindexInsertQueryFailure(t *testing.T) {
 	require.True(t, session.GetAutocommit())
 	require.True(t, session.InTransaction())
 
-	testQueriesWithSavepoint(t, sbc1, wantQ)
+	assertQueriesWithSavepoint(t, sbc1, wantQ)
 
 	// only parameter in expected query changes
 	wantQ[1].Sql = "insert into t1_lkp_idx(unq_col, keyspace_id) values (:_unq_col_1, :keyspace_id_1)"
-	testQueriesWithSavepoint(t, sbc2, wantQ)
+	assertQueriesWithSavepoint(t, sbc2, wantQ)
 
 	testQueryLogWithSavepoint(t, logChan, "TestExecute", "BEGIN", "begin", 0, true)
 	testQueryLogWithSavepoint(t, logChan, "MarkSavepoint", "SAVEPOINT", "savepoint x", 0, true)

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -2078,7 +2078,8 @@ func TestTestPartialVindexInsertQueryFailure(t *testing.T) {
 	wantQ[1].Sql = "insert into t1_lkp_idx(unq_col, keyspace_id) values (:_unq_col_1, :keyspace_id_1)"
 	testQueriesWithSavepoint(t, sbc2, wantQ)
 
-	testQueryLog(t, logChan, "TestExecute", "BEGIN", "begin", 0)
-	testQueryLog(t, logChan, "VindexCreate", "SAVEPOINT_ROLLBACK", "rollback to x", 0)
-	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into t1(id, unq_col) values (1, 1), (2, 3)", 0)
+	testQueryLogWithSavepoint(t, logChan, "TestExecute", "BEGIN", "begin", 0, true)
+	testQueryLogWithSavepoint(t, logChan, "MarkSavepoint", "SAVEPOINT", "savepoint x", 0, true)
+	testQueryLogWithSavepoint(t, logChan, "VindexCreate", "SAVEPOINT_ROLLBACK", "rollback to x", 0, true)
+	testQueryLogWithSavepoint(t, logChan, "TestExecute", "INSERT", "insert into t1(id, unq_col) values (1, 1), (2, 3)", 0, true)
 }

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -19,7 +19,6 @@ package vtgate
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -572,10 +571,47 @@ func executorStream(executor *Executor, sql string) (qr *sqltypes.Result, err er
 	return qr, nil
 }
 
-func testQueries(t *testing.T, sbcName string, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
+func testQueries(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
 	t.Helper()
-	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
-		t.Errorf("%s.Queries:\n%+v, want\n%+v\n", sbcName, sbc.Queries, wantQueries)
+	idx := 0
+	for _, query := range sbc.Queries {
+		if strings.HasPrefix(query.Sql, "savepoint") || strings.HasPrefix(query.Sql, "rollback to") {
+			continue
+		}
+		if len(wantQueries) < idx {
+			t.Errorf("got more queries than expected")
+		}
+		require.Equal(t, query.BindVariables, wantQueries[idx].BindVariables)
+		got := query.Sql
+		expected := wantQueries[idx].Sql
+		idx++
+		assert.Equal(t, expected, got)
+	}
+}
+
+func testQueriesWithSavepoint(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
+	t.Helper()
+	require.Equal(t, len(wantQueries), len(sbc.Queries), sbc.Queries)
+	savepointStore := make(map[string]string)
+	for idx, query := range sbc.Queries {
+		require.Equal(t, query.BindVariables, wantQueries[idx].BindVariables)
+		got := query.Sql
+		expected := wantQueries[idx].Sql
+		if strings.HasPrefix(got, "savepoint") {
+			if !strings.HasPrefix(expected, "savepoint") {
+				t.Fatal("savepoint expected")
+			}
+			savepointStore[expected[10:]] = got[10:]
+			continue
+		}
+		if strings.HasPrefix(got, "rollback to") {
+			if !strings.HasPrefix(expected, "rollback to") {
+				t.Fatal("rollback to expected")
+			}
+			assert.Equal(t, savepointStore[expected[12:]], got[12:])
+			continue
+		}
+		assert.Equal(t, expected, got)
 	}
 }
 
@@ -615,8 +651,14 @@ var testPlannedQueries = map[string]bool{}
 func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql string, shardQueries int) *LogStats {
 	t.Helper()
 
-	logStats := getQueryLog(logChan)
-	require.NotNil(t, logStats)
+	var logStats *LogStats
+	for {
+		logStats = getQueryLog(logChan)
+		require.NotNil(t, logStats)
+		if logStats.Method != "MarkSavepoint" {
+			break
+		}
+	}
 
 	var log bytes.Buffer
 	streamlog.GetFormatter(QueryLogger)(&log, nil, logStats)
@@ -627,6 +669,7 @@ func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql 
 
 	// fields[1] - fields[6] are the caller id, start/end times, etc
 
+	checkEqualQuery := true
 	// only test the durations if there is no error (fields[16])
 	if fields[16] == "\"\"" {
 		// fields[7] is the total execution time
@@ -643,7 +686,9 @@ func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql 
 		// fields[9] is ExecuteTime which is not set for certain statements SET,
 		// BEGIN, COMMIT, ROLLBACK, etc
 		switch stmtType {
-		case "BEGIN", "COMMIT", "ROLLBACK", "SET", "SAVEPOINT", "SAVEPOINT_ROLLBACK", "RELEASE":
+		case "BEGIN", "COMMIT", "SET", "ROLLBACK":
+		case "SAVEPOINT", "SAVEPOINT_ROLLBACK", "RELEASE":
+			checkEqualQuery = false
 		default:
 			testNonZeroDuration(t, "ExecuteTime", fields[9])
 		}
@@ -655,10 +700,11 @@ func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql 
 	// fields[11] is the statement type
 	assert.Equal(t, stmtType, fields[11], "logstats: stmtType")
 
-	// fields[12] is the original sql
-	wantSQL := fmt.Sprintf("%q", sql)
-	assert.Equal(t, wantSQL, fields[12], "logstats: SQL")
-
+	if checkEqualQuery {
+		// fields[12] is the original sql
+		wantSQL := fmt.Sprintf("%q", sql)
+		assert.Equal(t, wantSQL, fields[12], "logstats: SQL")
+	}
 	// fields[13] contains the formatted bind vars
 
 	// fields[14] is the count of shard queries

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -571,7 +571,7 @@ func executorStream(executor *Executor, sql string) (qr *sqltypes.Result, err er
 	return qr, nil
 }
 
-func testQueries(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
+func assertQueries(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
 	t.Helper()
 	idx := 0
 	for _, query := range sbc.Queries {
@@ -589,7 +589,7 @@ func testQueries(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*quer
 	}
 }
 
-func testQueriesWithSavepoint(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
+func assertQueriesWithSavepoint(t *testing.T, sbc *sandboxconn.SandboxConn, wantQueries []*querypb.BoundQuery) {
 	t.Helper()
 	require.Equal(t, len(wantQueries), len(sbc.Queries), sbc.Queries)
 	savepointStore := make(map[string]string)

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -230,7 +230,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "update music_user_map set id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "delete from music_user_map /* trailing */", nil)
@@ -239,7 +239,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "delete from music_user_map /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "insert into music_user_map values (1) /* trailing */", nil)
@@ -248,7 +248,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "insert into music_user_map values (1) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	testQueries(t, sbclookup, wantQueries)
+	assertQueries(t, sbclookup, wantQueries)
 }
 
 func TestStreamUnsharded(t *testing.T) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -230,7 +230,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "update music_user_map set id = 1 /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	testQueries(t, sbclookup, wantQueries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "delete from music_user_map /* trailing */", nil)
@@ -239,7 +239,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "delete from music_user_map /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	testQueries(t, sbclookup, wantQueries)
 
 	sbclookup.Queries = nil
 	_, err = executorExec(executor, "insert into music_user_map values (1) /* trailing */", nil)
@@ -248,7 +248,7 @@ func TestUnshardedComments(t *testing.T) {
 		Sql:           "insert into music_user_map values (1) /* trailing */",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}}
-	utils.MustMatch(t, wantQueries, sbclookup.Queries)
+	testQueries(t, sbclookup, wantQueries)
 }
 
 func TestStreamUnsharded(t *testing.T) {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -210,7 +210,7 @@ func TestDirectTargetRewrites(t *testing.T) {
 
 	_, err := executor.Execute(ctx, "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
-	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+	testQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql:           "select :__vtdbname as `database()` from dual",
 		BindVariables: map[string]*querypb.BindVariable{"__vtdbname": sqltypes.StringBindVariable("TestUnsharded/0@primary")},
 	}})

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -210,7 +210,7 @@ func TestDirectTargetRewrites(t *testing.T) {
 
 	_, err := executor.Execute(ctx, "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
 	require.NoError(t, err)
-	testQueries(t, sbclookup, []*querypb.BoundQuery{{
+	assertQueries(t, sbclookup, []*querypb.BoundQuery{{
 		Sql:           "select :__vtdbname as `database()` from dual",
 		BindVariables: map[string]*querypb.BindVariable{"__vtdbname": sqltypes.StringBindVariable("TestUnsharded/0@primary")},
 	}})

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -179,7 +179,7 @@ func (e *Executor) insideTransaction(ctx context.Context, safeSession *SafeSessi
 	// at the beginning, but never after.
 	safeSession.SetAutocommittable(mustCommit)
 
-	// If we to instantly commit the query, then there is no need to add savepoints.
+	// If we want to instantly commit the query, then there is no need to add savepoints.
 	// Any partial failure of the query will be taken care by rollback.
 	safeSession.SetSavepointState(!mustCommit)
 

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -179,6 +179,10 @@ func (e *Executor) insideTransaction(ctx context.Context, safeSession *SafeSessi
 	// at the beginning, but never after.
 	safeSession.SetAutocommittable(mustCommit)
 
+	// If we to instantly commit the query, then there is no need to add savepoints.
+	// Any partial failure of the query will be taken care by rollback.
+	safeSession.SetSavepointState(!mustCommit)
+
 	// Execute!
 	err := execPlan()
 	if err != nil {

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -216,11 +216,11 @@ func (e *Executor) executePlan(
 	e.setLogStats(logStats, plan, vcursor, execStart, err, qr)
 
 	// Check if there was partial DML execution. If so, rollback the transaction.
-	if err != nil && safeSession.InTransaction() && vcursor.rollbackOnPartialExec != "" {
-		if vcursor.rollbackOnPartialExec != txRollback {
-			_, _, sErr := e.execute(ctx, safeSession, vcursor.rollbackOnPartialExec, bindVars, logStats)
+	if err != nil && safeSession.InTransaction() && safeSession.rollbackOnPartialExec != "" {
+		if safeSession.rollbackOnPartialExec != txRollback {
+			_, _, sErr := e.execute(ctx, safeSession, safeSession.rollbackOnPartialExec, bindVars, logStats)
 			if sErr == nil {
-				return nil, vterrors.Errorf(vtrpcpb.Code_ABORTED, "revered partial DML execution failure: %v", err)
+				return nil, vterrors.Errorf(vtrpcpb.Code_ABORTED, "reverted partial DML execution failure: %v", err)
 			}
 			// not able to rollback changes of the failed query, so have to abort the complete transaction.
 			err = vterrors.Aggregate([]error{sErr, err})

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -38,9 +38,13 @@ import (
 type SafeSession struct {
 	mu              sync.Mutex
 	mustRollback    bool
-	savepointState  savepointState
 	autocommitState autocommitState
 	commitOrder     vtgatepb.CommitOrder
+	savepointState  savepointState
+	// rollbackOnPartialExec is set if any DML was successfully
+	// executed. If there was a subsequent failure, if we have a savepoint we rollback to that.
+	// Otherwise, the transaction is rolled back.
+	rollbackOnPartialExec string
 
 	// this is a signal that found_rows has already been handles by the primitives,
 	// and doesn't have to be updated by the executor

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -187,11 +187,12 @@ func (session *SafeSession) AutocommitApproval() bool {
 	return false
 }
 
-// SetSavepointState sets the state to insertSavepoints if true and noInsertSavepoints if false
-// only when the savepointState is not already set.
-// Calling the function multiple times will have no effect, only
-// the first call would be used.
-func (session *SafeSession) SetSavepointState(flag bool) {
+// SetSavepointState sets the state only once for the complete query execution life.
+// Calling the function multiple times will have no effect, only the first call would be used.
+// Default state is savepointStateNotSet,
+// if savepoint needed (spNeed true) then it will be set to savepointNeeded otherwise savepointNotNeeded.
+
+func (session *SafeSession) SetSavepointState(spNeed bool) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
 
@@ -199,7 +200,7 @@ func (session *SafeSession) SetSavepointState(flag bool) {
 		return
 	}
 
-	if flag {
+	if spNeed {
 		session.savepointState = savepointNeeded
 	} else {
 		session.savepointState = savepointNotNeeded

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -576,3 +576,24 @@ func (session *SafeSession) getSelectLimit() int {
 
 	return int(session.Options.SqlSelectLimit)
 }
+
+func (session *SafeSession) isTxOpen() bool {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	return len(session.ShardSessions) > 0 || len(session.PreSessions) > 0 || len(session.PostSessions) > 0
+}
+
+func (session *SafeSession) GetSessions() []*vtgatepb.Session_ShardSession {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	switch session.commitOrder {
+	case vtgatepb.CommitOrder_PRE:
+		return session.PreSessions
+	case vtgatepb.CommitOrder_POST:
+		return session.PostSessions
+	default:
+		return session.ShardSessions
+	}
+}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -421,8 +421,6 @@ func (vc *vcursorImpl) StreamExecutePrimitive(primitive engine.Primitive, bindVa
 	return vterrors.New(vtrpcpb.Code_UNAVAILABLE, "upstream shards are not available")
 }
 
-const txRollback = "Rollback Transaction"
-
 // Execute is part of the engine.VCursor interface.
 func (vc *vcursorImpl) Execute(method string, query string, bindVars map[string]*querypb.BindVariable, rollbackOnError bool, co vtgatepb.CommitOrder) (*sqltypes.Result, error) {
 	session := vc.safeSession
@@ -450,6 +448,8 @@ func (vc *vcursorImpl) markSavepoint(rollbackOnError bool, bindVars map[string]*
 	}
 	return uID, nil
 }
+
+const txRollback = "Rollback Transaction"
 
 // ExecuteMultiShard is part of the engine.VCursor interface.
 func (vc *vcursorImpl) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, autocommit bool) (*sqltypes.Result, []error) {

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -461,7 +461,7 @@ func (vc *vcursorImpl) ExecuteMultiShard(rss []*srvtopo.ResolvedShard, queries [
 
 	qr, errs := vc.executor.ExecuteMultiShard(vc.ctx, rss, commentedShardQueries(queries, vc.marginComments), vc.safeSession, autocommit, vc.ignoreMaxMemoryRows)
 
-	if len(errs) == 0 && rollbackOnError && vc.safeSession.rollbackOnPartialExec == "" {
+	if len(errs) != len(rss) && rollbackOnError && vc.safeSession.rollbackOnPartialExec == "" {
 		if uID == "" {
 			vc.safeSession.rollbackOnPartialExec = txRollback
 		} else {
@@ -525,7 +525,7 @@ func (vc *vcursorImpl) StreamExecuteMulti(query string, rss []*srvtopo.ResolvedS
 
 	errs := vc.executor.StreamExecuteMulti(vc.ctx, vc.marginComments.Leading+query+vc.marginComments.Trailing, rss, bindVars, vc.safeSession, autocommit, callback)
 
-	if len(errs) == 0 && rollbackOnError && vc.safeSession.rollbackOnPartialExec == "" {
+	if len(errs) != len(rss) && rollbackOnError && vc.safeSession.rollbackOnPartialExec == "" {
 		if uID == "" {
 			vc.safeSession.rollbackOnPartialExec = txRollback
 		} else {

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -56,7 +56,8 @@ type SandboxConn struct {
 	MustFailSetRollback         int
 	MustFailConcludeTransaction int
 	// MustFailExecute is keyed by the statement type and stores the number
-	// of errors to return for that statement type.
+	// of times to fail when it sees that statement type.
+	// Once, exhausted it will start returning non-error response.
 	MustFailExecute map[sqlparser.StatementType]int
 
 	// These Count vars report how often the corresponding

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -604,6 +604,12 @@ func (sbc *SandboxConn) ChangeTabletType(typ topodatapb.TabletType) {
 }
 
 func (sbc *SandboxConn) getNextResult(stmt sqlparser.Statement) *sqltypes.Result {
+	switch stmt.(type) {
+	case *sqlparser.Savepoint,
+		*sqlparser.SRollback,
+		*sqlparser.Release:
+		return &sqltypes.Result{}
+	}
 	if len(sbc.results) != 0 {
 		r := sbc.results[0]
 		sbc.results = sbc.results[1:]
@@ -625,10 +631,7 @@ func (sbc *SandboxConn) getNextResult(stmt sqlparser.Statement) *sqltypes.Result
 		*sqlparser.AlterVschema,
 		*sqlparser.Use,
 		*sqlparser.OtherAdmin,
-		*sqlparser.SetTransaction,
-		*sqlparser.Savepoint,
-		*sqlparser.SRollback,
-		*sqlparser.Release:
+		*sqlparser.SetTransaction:
 		return &sqltypes.Result{}
 	}
 

--- a/test/config.json
+++ b/test/config.json
@@ -822,6 +822,15 @@
 			"RetryMax": 1,
 			"Tags": []
 		},
+		"vtgate_transaction_partial_exec": {
+			"File": "unused.go",
+			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/partialfailure"],
+			"Command": [],
+			"Manual": false,
+			"Shard": "vtgate_transaction",
+			"RetryMax": 1,
+			"Tags": []
+		},
 		"vtgate_unsharded": {
 			"File": "unused.go",
 			"Args": ["vitess.io/vitess/go/test/endtoend/vtgate/unsharded"],


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR reverses the effect of partial dml query execution instead of rolling back the complete transaction when the transaction is explicitly created by the user.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Closes #9266 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->