### PR TITLE
Use relay log position in PRS while choosing the new primary

### DIFF
--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -125,7 +125,7 @@ func findPositionForTablet(ctx context.Context, tablet *topodatapb.Tablet, logge
 		return mysql.Position{}, err
 	}
 
-	// Use the relay log position if available, otherwise use the executed GTID set executed.
+	// Use the relay log position if available, otherwise use the executed GTID set (binary log position).
 	positionString := status.Position
 	if status.RelayLogPosition != "" {
 		positionString = status.RelayLogPosition

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -125,9 +125,14 @@ func findPositionForTablet(ctx context.Context, tablet *topodatapb.Tablet, logge
 		return mysql.Position{}, err
 	}
 
-	pos, err := mysql.DecodePosition(status.Position)
+	// Use the relay log position if available, otherwise use the executed GTID set executed.
+	positionString := status.Position
+	if status.RelayLogPosition != "" {
+		positionString = status.RelayLogPosition
+	}
+	pos, err := mysql.DecodePosition(positionString)
 	if err != nil {
-		logger.Warningf("cannot decode replica position %v for tablet %v, ignoring tablet: %v", status.Position, topoproto.TabletAliasString(tablet.Alias), err)
+		logger.Warningf("cannot decode replica position %v for tablet %v, ignoring tablet: %v", positionString, topoproto.TabletAliasString(tablet.Alias), err)
 		return mysql.Position{}, err
 	}
 

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql"
@@ -402,6 +404,99 @@ func TestChooseNewPrimary(t *testing.T) {
 
 			assert.NoError(t, err)
 			utils.MustMatch(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestFindPositionForTablet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := logutil.NewMemoryLogger()
+	tests := []struct {
+		name             string
+		tmc              *testutil.TabletManagerClient
+		tablet           *topodatapb.Tablet
+		expectedPosition string
+		expectedErr      string
+	}{
+		{
+			name: "executed gtid set",
+			tmc: &testutil.TabletManagerClient{
+				ReplicationStatusResults: map[string]struct {
+					Position *replicationdatapb.Status
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Position: &replicationdatapb.Status{
+							Position: "MySQL56/3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+						},
+					},
+				},
+			},
+			tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			},
+			expectedPosition: "MySQL56/3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+		}, {
+			name: "relay log",
+			tmc: &testutil.TabletManagerClient{
+				ReplicationStatusResults: map[string]struct {
+					Position *replicationdatapb.Status
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Position: &replicationdatapb.Status{
+							Position:         "unused",
+							RelayLogPosition: "MySQL56/3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+						},
+					},
+				},
+			},
+			tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			},
+			expectedPosition: "MySQL56/3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+		}, {
+			name: "error in parsing position",
+			tmc: &testutil.TabletManagerClient{
+				ReplicationStatusResults: map[string]struct {
+					Position *replicationdatapb.Status
+					Error    error
+				}{
+					"zone1-0000000100": {
+						Position: &replicationdatapb.Status{
+							Position: "unused",
+						},
+					},
+				},
+			},
+			tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			},
+			expectedErr: `parse error: unknown GTIDSet flavor ""`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pos, err := findPositionForTablet(ctx, test.tablet, logger, test.tmc, 10*time.Second)
+			if test.expectedErr != "" {
+				require.EqualError(t, err, test.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			posString := mysql.EncodePosition(pos)
+			require.Equal(t, test.expectedPosition, posString)
 		})
 	}
 }

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -129,7 +129,7 @@ func TestChooseNewPrimary(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name: "found a replica",
+			name: "found a replica - more advanced relay log position",
 			tmc: &chooseNewPrimaryTestTMClient{
 				// zone1-101 is behind zone1-102
 				// since the relay log position for zone1-102 is more advanced


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

While choosing the new primary in PRS, we should be using the relay log position, if it is available. This PR makes that change and adds tests for it.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Closes #5991

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
This PR has been created on top of #9259, and it should be merged after it.