### PR TITLE
Replication manager should not start health ticks after calling Promote Replica

### DIFF
--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -133,6 +133,10 @@ func (rm *replManager) checkActionLocked() {
 // reset the replication manager state and deleting the marker-file.
 // it does not start or stop the ticks. Use setReplicationStopped instead to change that.
 func (rm *replManager) reset() {
+	if *mysqlctl.DisableActiveReparents {
+		return
+	}
+
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 

--- a/go/vt/vttablet/tabletmanager/replmanager.go
+++ b/go/vt/vttablet/tabletmanager/replmanager.go
@@ -130,6 +130,19 @@ func (rm *replManager) checkActionLocked() {
 	rm.failed = false
 }
 
+// reset the replication manager state and deleting the marker-file.
+// it does not start or stop the ticks. Use setReplicationStopped instead to change that.
+func (rm *replManager) reset() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	rm.replStopped = nil
+	if rm.markerFile == "" {
+		return
+	}
+	os.Remove(rm.markerFile)
+}
+
 // setReplicationStopped performs a best effort attempt of
 // remembering a decision to stop replication.
 func (rm *replManager) setReplicationStopped(stopped bool) {

--- a/go/vt/vttablet/tabletmanager/replmanager_test.go
+++ b/go/vt/vttablet/tabletmanager/replmanager_test.go
@@ -80,3 +80,25 @@ func TestReplManagerSetReplicationStopped(t *testing.T) {
 	tm.replManager.setReplicationStopped(true)
 	assert.False(t, tm.replManager.ticks.Running())
 }
+
+func TestReplManagerReset(t *testing.T) {
+	defer func(saved bool) { *mysqlctl.DisableActiveReparents = saved }(*mysqlctl.DisableActiveReparents)
+
+	tm := &TabletManager{}
+	tm.replManager = newReplManager(context.Background(), tm, 100*time.Millisecond)
+
+	*mysqlctl.DisableActiveReparents = false
+	tm.replManager.setReplicationStopped(false)
+	assert.True(t, tm.replManager.ticks.Running())
+	// reset should not affect the ticks, but the replication stopped should be false
+	tm.replManager.reset()
+	assert.True(t, tm.replManager.ticks.Running())
+	assert.False(t, tm.replManager.replicationStopped())
+
+	tm.replManager.setReplicationStopped(true)
+	assert.False(t, tm.replManager.ticks.Running())
+	tm.replManager.reset()
+	// reset should not affect the ticks, but the replication stopped should be false
+	assert.False(t, tm.replManager.ticks.Running())
+	assert.False(t, tm.replManager.replicationStopped())
+}

--- a/go/vt/vttablet/tabletmanager/replmanager_test.go
+++ b/go/vt/vttablet/tabletmanager/replmanager_test.go
@@ -101,4 +101,11 @@ func TestReplManagerReset(t *testing.T) {
 	// reset should not affect the ticks, but the replication stopped should be false
 	assert.False(t, tm.replManager.ticks.Running())
 	assert.False(t, tm.replManager.replicationStopped())
+
+	tm.replManager.setReplicationStopped(true)
+	assert.True(t, tm.replManager.replicationStopped())
+	// DisableActiveReparents == true should result in no-op
+	*mysqlctl.DisableActiveReparents = true
+	tm.replManager.reset()
+	assert.True(t, tm.replManager.replicationStopped())
 }

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -814,7 +814,8 @@ func (tm *TabletManager) PromoteReplica(ctx context.Context) (string, error) {
 
 	// Clear replication sentinel flag for this primary,
 	// or we might block replication the next time we demote it
-	tm.replManager.setReplicationStopped(false)
+	// here, we do not want to start the health ticks, so we should use reset.
+	tm.replManager.reset()
 
 	// Tell Orchestrator we're no longer in maintenance mode.
 	// Do this in the background, as it's best-effort.

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+// TestPromoteReplicaHealthTicksStopped checks that the health ticks are not running on the
+// replication manager after running PromoteReplica
+func TestPromoteReplicaHealthTicksStopped(t *testing.T) {
+	ctx := context.Background()
+	ts := memorytopo.NewServer("cell1")
+	statsTabletTypeCount.ResetAll()
+	tm := newTestTM(t, ts, 100, keyspace, shard)
+	defer tm.Stop()
+
+	_, err := tm.PromoteReplica(ctx)
+	require.NoError(t, err)
+	require.False(t, tm.replManager.ticks.Running())
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
During the call to `PromoteReplica`, we initially stop the replication manager health ticks.
The steps for that we follow are `PromoteReplica` -> `tm.changeTypeLocked` -> `tm.tmState.ChangeTabletType` -> `ts.updateLocked(ctx)` -> `ts.tm.replManager.SetTabletType(ts.tablet.Type)` .
This is called with PRIMARY as the tablet type which stops the ticks.

But in the PRs, #8422 and #8745, we started calling `tm.replManager.setReplicationStopped(false)` to reset the replication manager's state to not indicate that replication had been stopped. As a side-effect, we also enabled the replication manager ticks in this call. This should not be done on a PRIMARY tablet since it does not replicate from any other tablet.
This led to logs being seen on the primary tablet similar to `Failed to reconnect to primary: shard ks/0 record claims tablet zone2-0000000201 is primary, but its type is PRIMARY, will keep retrying`

This PR fixes this issue by creating a new function in the replication manager to reset it's state without starting or stopping the ticks.

<details>
  <summary><code>Old Logs (Before the changes)</code></summary>

```
I1120 18:49:26.046105   65783 rpc_replication.go:524] SetReplicationSource: parent: cell:"zone1" uid:101  position: MySQL56/770214f4-4a04-11ec-8c6a-f3447a988df7:1-13 force: true
I1120 18:49:26.051857   65783 replication.go:466] Setting semi-sync mode: primary=false, replica=true
I1120 18:49:26.052385   65783 query.go:81] exec SET GLOBAL rpl_semi_sync_master_enabled = 0, GLOBAL rpl_semi_sync_slave_enabled = 1
I1120 18:49:26.053513   65783 rpc_server.go:84] TabletManager.SetReplicationSource(parent:{cell:"zone1" uid:101} force_start_replication:true wait_position:"MySQL56/770214f4-4a04-11ec-8c6a-f3447a988df7:1-13")(on zone2-0000000201 from ): (*tabletmanagerdata.SetReplicationSourceResponse)(nil)
I1120 18:49:26.770509   65783 rpc_replication.go:84] WaitForPosition: MySQL56/770214f4-4a04-11ec-8c6a-f3447a988df7:1-13
I1120 18:49:26.772236   65783 rpc_replication.go:784] PromoteReplica
I1120 18:49:26.772872   65783 query.go:81] exec STOP SLAVE
I1120 18:49:26.774462   65783 query.go:81] exec RESET SLAVE ALL
I1120 18:49:26.779617   65783 query.go:81] exec FLUSH BINARY LOGS
I1120 18:49:26.783695   65783 replication.go:466] Setting semi-sync mode: primary=true, replica=true
I1120 18:49:26.784097   65783 query.go:81] exec SET GLOBAL rpl_semi_sync_master_enabled = 1, GLOBAL rpl_semi_sync_slave_enabled = 1
I1120 18:49:26.784215   65783 tm_state.go:176] Changing Tablet Type: PRIMARY
I1120 18:49:26.785103   65783 query.go:81] exec SET GLOBAL read_only = OFF
I1120 18:49:26.785352   65783 engine.go:194] VReplication Engine: opening
I1120 18:49:26.786587   65783 state_manager.go:214] Starting transition to PRIMARY Serving, timestamp: 2021-11-20 13:19:26.78422 +0000 UTC
I1120 18:49:26.786607   65783 binlog_watcher.go:79] Binlog Watcher: closed
I1120 18:49:26.786883   65783 repltracker.go:86] Replication Tracker: going into primary mode
I1120 18:49:26.786888   65783 tracker.go:95] Schema Tracker: opening
I1120 18:49:26.786896   65783 tx_engine.go:158] TxEngine transition: AcceptReadWrite
I1120 18:49:26.786913   65783 tx_engine.go:317] Immediate shutdown: rolling back now.
I1120 18:49:26.786948   65783 stateful_connection_pool.go:79] Starting transaction id: {1637414364469913000}
I1120 18:49:26.786980   65783 engine.go:82] Messager: opening
I1120 18:49:26.787005   65783 tablegc.go:173] TableGC: opening
I1120 18:49:26.787347   65783 uvstreamer.go:363] Stream() called
I1120 18:49:26.787417   65783 state_manager.go:563] TabletServer transition: REPLICA: Serving -> PRIMARY: Serving, Nov 20, 2021 at 18:49:26 (IST) for tablet :ks/0
I1120 18:49:26.787429   65783 state_manager.go:663] State: exiting lameduck
I1120 18:49:26.787432   65783 tm_state.go:371] Publishing state: alias:{cell:"zone2" uid:201} hostname:"localhost" port_map:{key:"grpc" value:7117} port_map:{key:"vt" value:7116} keyspace:"ks" shard:"0" type:PRIMARY mysql_hostname:"localhost" mysql_port:7118 primary_term_start_time:{seconds:1637414366 nanoseconds:784220000} db_server_version:"8.0.27" default_conn_collation:255
I1120 18:49:26.787742   65783 uvstreamer.go:298] sendEventsForCurrentPos
I1120 18:49:26.787756   65783 vstreamer.go:149] Starting Stream() with startPos MySQL56/770214f4-4a04-11ec-8c6a-f3447a988df7:1-13
I1120 18:49:26.788044   65783 binlog_connection.go:78] new binlog connection: serverID=1996649568
I1120 18:49:26.788050   65783 binlog_connection.go:124] sending binlog dump command: startPos=770214f4-4a04-11ec-8c6a-f3447a988df7:1-13, serverID=1996649568
I1120 18:49:26.842313   65783 shard_sync.go:70] Change to tablet state
I1120 18:49:26.842421   65783 rpc_server.go:84] TabletManager.PromoteReplica()(on zone2-0000000201 from ): (*tabletmanagerdata.PromoteReplicaResponse)(nil)
I1120 18:49:26.844458   65783 rpc_replication.go:286] PopulateReparentJournal: action: PlannedReparentShard parent: cell:"zone2" uid:201  position: MySQL56/770214f4-4a04-11ec-8c6a-f3447a988df7:1-13
I1120 18:49:26.844888   65783 query.go:81] exec CREATE DATABASE IF NOT EXISTS _vt
I1120 18:49:26.861640   65783 shard_sync.go:183] Updating shard record: primary_alias=zone2-0000000201, primary_term_start_time=2021-11-20 13:19:26.78422 +0000 UTC
I1120 18:49:26.862297   65783 shard_watcher.go:39] Starting shard watch of ks/0
I1120 18:49:26.904500   65783 shard_sync.go:78] Change in shard record
I1120 18:49:27.005336   65783 query.go:81] exec CREATE TABLE IF NOT EXISTS _vt.reparent_journal (
  time_created_ns BIGINT UNSIGNED NOT NULL,
  action_name VARBINARY(250) NOT NULL,
  master_alias VARBINARY(32) NOT NULL,
  replication_position VARBI
I1120 18:49:27.005970   65783 query.go:81] exec INSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES (1637414366843049000, 'PlannedReparentShard', 'zone2-0000000201', 'MySQL56/770214f4-4a04-11ec
I1120 18:49:29.685496   65783 tablegc.go:233] TableGC: transition into primary
I1120 18:49:31.850579   65783 replmanager.go:129] Failed to reconnect to primary: shard ks/0 record claims tablet zone2-0000000201 is primary, but its type is PRIMARY, will keep retrying.

```
</details>

<details>
  <summary><code>New Logs (After the changes)</code></summary>

```
I1122 09:20:47.758676   26106 rpc_replication.go:524] SetReplicationSource: parent: cell:"zone1" uid:101  position: MySQL56/5bc9704e-4b47-11ec-9a37-04859041952a:1-13 force: true
I1122 09:20:47.764936   26106 replication.go:466] Setting semi-sync mode: primary=false, replica=true
I1122 09:20:47.765339   26106 query.go:81] exec SET GLOBAL rpl_semi_sync_master_enabled = 0, GLOBAL rpl_semi_sync_slave_enabled = 1
I1122 09:20:47.766214   26106 rpc_server.go:84] TabletManager.SetReplicationSource(parent:{cell:"zone1" uid:101} force_start_replication:true wait_position:"MySQL56/5bc9704e-4b47-11ec-9a37-04859041952a:1-13")(on zone2-0000000201 from ): (*tabletmanagerdata.SetReplicationSourceResponse)(nil)
I1122 09:20:48.487286   26106 rpc_replication.go:84] WaitForPosition: MySQL56/5bc9704e-4b47-11ec-9a37-04859041952a:1-13
I1122 09:20:48.490185   26106 rpc_replication.go:784] PromoteReplica
I1122 09:20:48.491236   26106 query.go:81] exec STOP SLAVE
I1122 09:20:48.493407   26106 query.go:81] exec RESET SLAVE ALL
I1122 09:20:48.499374   26106 query.go:81] exec FLUSH BINARY LOGS
I1122 09:20:48.504710   26106 replication.go:466] Setting semi-sync mode: primary=true, replica=true
I1122 09:20:48.505511   26106 query.go:81] exec SET GLOBAL rpl_semi_sync_master_enabled = 1, GLOBAL rpl_semi_sync_slave_enabled = 1
I1122 09:20:48.505723   26106 tm_state.go:176] Changing Tablet Type: PRIMARY
I1122 09:20:48.507170   26106 query.go:81] exec SET GLOBAL read_only = OFF
I1122 09:20:48.507409   26106 engine.go:194] VReplication Engine: opening
I1122 09:20:48.508478   26106 state_manager.go:214] Starting transition to PRIMARY Serving, timestamp: 2021-11-22 03:50:48.505731 +0000 UTC
I1122 09:20:48.508498   26106 binlog_watcher.go:79] Binlog Watcher: closed
I1122 09:20:48.508822   26106 repltracker.go:86] Replication Tracker: going into primary mode
I1122 09:20:48.508828   26106 tracker.go:95] Schema Tracker: opening
I1122 09:20:48.508836   26106 tx_engine.go:158] TxEngine transition: AcceptReadWrite
I1122 09:20:48.508853   26106 tx_engine.go:317] Immediate shutdown: rolling back now.
I1122 09:20:48.508873   26106 stateful_connection_pool.go:79] Starting transaction id: {1637553046282058000}
I1122 09:20:48.508941   26106 engine.go:82] Messager: opening
I1122 09:20:48.508967   26106 tablegc.go:173] TableGC: opening
I1122 09:20:48.509390   26106 state_manager.go:563] TabletServer transition: REPLICA: Serving -> PRIMARY: Serving, Nov 22, 2021 at 09:20:48 (IST) for tablet :ks/0
I1122 09:20:48.509400   26106 state_manager.go:663] State: exiting lameduck
I1122 09:20:48.509402   26106 tm_state.go:371] Publishing state: alias:{cell:"zone2" uid:201} hostname:"localhost" port_map:{key:"grpc" value:6917} port_map:{key:"vt" value:6916} keyspace:"ks" shard:"0" type:PRIMARY mysql_hostname:"localhost" mysql_port:6918 primary_term_start_time:{seconds:1637553048 nanoseconds:505731000} db_server_version:"8.0.27" default_conn_collation:255
I1122 09:20:48.509467   26106 uvstreamer.go:363] Stream() called
I1122 09:20:48.509891   26106 uvstreamer.go:298] sendEventsForCurrentPos
I1122 09:20:48.509906   26106 vstreamer.go:149] Starting Stream() with startPos MySQL56/5bc9704e-4b47-11ec-9a37-04859041952a:1-13
I1122 09:20:48.510311   26106 binlog_connection.go:78] new binlog connection: serverID=977215955
I1122 09:20:48.510318   26106 binlog_connection.go:124] sending binlog dump command: startPos=5bc9704e-4b47-11ec-9a37-04859041952a:1-13, serverID=977215955
I1122 09:20:48.527455   26106 shard_sync.go:70] Change to tablet state
I1122 09:20:48.527473   26106 rpc_server.go:84] TabletManager.PromoteReplica()(on zone2-0000000201 from ): (*tabletmanagerdata.PromoteReplicaResponse)(nil)
I1122 09:20:48.529416   26106 rpc_replication.go:286] PopulateReparentJournal: action: PlannedReparentShard parent: cell:"zone2" uid:201  position: MySQL56/5bc9704e-4b47-11ec-9a37-04859041952a:1-13
I1122 09:20:48.529652   26106 query.go:81] exec CREATE DATABASE IF NOT EXISTS _vt
I1122 09:20:48.602928   26106 shard_sync.go:183] Updating shard record: primary_alias=zone2-0000000201, primary_term_start_time=2021-11-22 03:50:48.505731 +0000 UTC
I1122 09:20:48.603914   26106 shard_watcher.go:39] Starting shard watch of ks/0
I1122 09:20:48.677802   26106 query.go:81] exec CREATE TABLE IF NOT EXISTS _vt.reparent_journal (
  time_created_ns BIGINT UNSIGNED NOT NULL,
  action_name VARBINARY(250) NOT NULL,
  master_alias VARBINARY(32) NOT NULL,
  replication_position VARBI
I1122 09:20:48.678447   26106 query.go:81] exec INSERT INTO _vt.reparent_journal (time_created_ns, action_name, master_alias, replication_position) VALUES (1637553048528292000, 'PlannedReparentShard', 'zone2-0000000201', 'MySQL56/5bc9704e-4b47-11ec
I1122 09:20:48.774387   26106 shard_sync.go:78] Change in shard record
I1122 09:20:51.497032   26106 tablegc.go:233] TableGC: transition into primary

```
</details>

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #9272 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->