### PR TITLE
[12.0] Fix for show commands in prepare statement

### DIFF
--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -379,3 +379,24 @@ func TestSelectDBA(t *testing.T) {
 	}
 	require.Equal(t, 2, rowCount)
 }
+
+func TestShowColumns(t *testing.T) {
+	defer cluster.PanicHandler(t)
+	dbo := Connect(t)
+	defer dbo.Close()
+
+	prepare, err := dbo.Prepare("show columns from vt_prepare_stmt_test where Field = 'id'")
+	require.NoError(t, err)
+
+	rows, err := prepare.Query()
+	require.NoError(t, err)
+	defer rows.Close()
+
+	require.True(t, rows.Next(), "no rows found")
+	cols, err := rows.Columns()
+	if err != nil {
+		return
+	}
+	require.Len(t, cols, 6)
+	require.False(t, rows.Next())
+}

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -70,6 +70,7 @@ func TestShowColumns(t *testing.T) {
 	utils.AssertMatches(t, conn, "show columns from `t5_null_vindex` in `ks`", expected)
 	utils.AssertMatches(t, conn, "SHOW COLUMNS from `t5_null_vindex` in `ks`", expected)
 	utils.AssertMatches(t, conn, "SHOW columns FROM `t5_null_vindex` in `ks`", expected)
+	utils.AssertMatches(t, conn, "SHOW columns FROM `t5_null_vindex` where Field = 'id'", `[[VARCHAR("id") TEXT("bigint(20)") VARCHAR("NO") VARCHAR("PRI") NULL VARCHAR("")]]`)
 }
 
 func TestShowTables(t *testing.T) {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1564,17 +1564,19 @@ func (e *Executor) prepare(ctx context.Context, safeSession *SafeSession, sql st
 	}
 
 	switch stmtType {
-	case sqlparser.StmtSelect:
-		return e.handlePrepare(ctx, safeSession, sql, bindVars, logStats)
+	case sqlparser.StmtShow, sqlparser.StmtSelect:
+		qr, err := e.handlePrepare(ctx, safeSession, sql, bindVars, logStats)
+		if err == planbuilder.ErrPlanNotSupported {
+			res, err := e.handleShow(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
+			if err != nil {
+				return nil, err
+			}
+			return res.Fields, nil
+		}
+		return qr, err
 	case sqlparser.StmtDDL, sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtRollback, sqlparser.StmtSet, sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete,
 		sqlparser.StmtUse, sqlparser.StmtOther, sqlparser.StmtComment, sqlparser.StmtExplain, sqlparser.StmtFlush:
 		return nil, nil
-	case sqlparser.StmtShow:
-		res, err := e.handleShow(ctx, safeSession, sql, bindVars, dest, destKeyspace, destTabletType, logStats)
-		if err != nil {
-			return nil, err
-		}
-		return res.Fields, nil
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unrecognized prepare statement: %s", sql)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the bug of handling show statements via plan or legacy way.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- fixes #9268
- backport of #9280 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->