### PR TITLE
Backport12.0: Use decoded hex string when calculating the keyspace ID

### DIFF
--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
 	"context"
@@ -1025,7 +1027,12 @@ func TestRowReplicationTypes(t *testing.T) {
 		sql.WriteString(", ")
 		sql.WriteString(tcase.name)
 		sql.WriteString(" = ")
-		if values[i+1].Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(values[i+1].ToBytes(), mysql.ZeroTimestamp) {
+		valueBytes, err := values[i+1].ToBytes()
+		// Expression values are not supported with ToBytes
+		if values[i+1].Type() != querypb.Type_EXPRESSION {
+			require.NoError(t, err)
+		}
+		if values[i+1].Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(valueBytes, mysql.ZeroTimestamp) {
 			// Values in the binary log are UTC. Let's convert them
 			// to whatever timezone the connection is using,
 			// so MySQL properly converts them back to UTC.

--- a/go/sqltypes/plan_value.go
+++ b/go/sqltypes/plan_value.go
@@ -150,7 +150,7 @@ func (pv PlanValue) MarshalJSON() ([]byte, error) {
 		return json.Marshal(":" + pv.Key)
 	case !pv.Value.IsNull():
 		if pv.Value.IsIntegral() {
-			return pv.Value.ToBytes(), nil
+			return pv.Value.ToBytes()
 		}
 		return json.Marshal(pv.Value.ToString())
 	case pv.ListKey != "":

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -221,9 +221,9 @@ func saveRowsAnalysis(r Result, allRows map[string]int, totalRows *int, incremen
 	for _, row := range r.Rows {
 		newHash := hashCodeForRow(row)
 		if increment {
-			allRows[newHash] += 1
+			allRows[newHash]++
 		} else {
-			allRows[newHash] -= 1
+			allRows[newHash]--
 		}
 	}
 	if increment {

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -19,9 +19,11 @@ package sqltypes
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -29,6 +31,9 @@ import (
 	"vitess.io/vitess/go/hack"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 var (
@@ -204,13 +209,21 @@ func (v Value) Raw() []byte {
 
 // ToBytes returns the value as MySQL would return it as []byte.
 // In contrast, Raw returns the internal representation of the Value, which may not
-// match MySQL's representation for newer types.
-// If the value is not convertible like in the case of Expression, it returns nil.
-func (v Value) ToBytes() []byte {
+// match MySQL's representation for hex encoded binary data or newer types.
+// If the value is not convertible like in the case of Expression, it returns an error.
+func (v Value) ToBytes() ([]byte, error) {
 	if v.typ == Expression {
-		return nil
+		return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "expression cannot be converted to bytes")
 	}
-	return v.val
+	if v.typ == HexVal {
+		dv, err := v.decodeHexVal()
+		return dv, err
+	}
+	if v.typ == HexNum {
+		dv, err := v.decodeHexNum()
+		return dv, err
+	}
+	return v.val, nil
 }
 
 // Len returns the length.
@@ -435,6 +448,38 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 	}
 	*v, err = InterfaceToValue(val)
 	return err
+}
+
+// decodeHexVal decodes the SQL hex value of the form x'A1' into a byte
+// array matching what MySQL would return when querying the column where
+// an INSERT was performed with x'A1' having been specified as a value
+func (v *Value) decodeHexVal() ([]byte, error) {
+	match, err := regexp.Match("^x'.*'$", v.val)
+	if !match || err != nil {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid hex value: %v", v.val)
+	}
+	hexBytes := v.val[2 : len(v.val)-1]
+	decodedHexBytes, err := hex.DecodeString(string(hexBytes))
+	if err != nil {
+		return nil, err
+	}
+	return decodedHexBytes, nil
+}
+
+// decodeHexNum decodes the SQL hex value of the form 0xA1 into a byte
+// array matching what MySQL would return when querying the column where
+// an INSERT was performed with 0xA1 having been specified as a value
+func (v *Value) decodeHexNum() ([]byte, error) {
+	match, err := regexp.Match("^0x.*$", v.val)
+	if !match || err != nil {
+		return nil, vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "invalid hex number: %v", v.val)
+	}
+	hexBytes := v.val[2:]
+	decodedHexBytes, err := hex.DecodeString(string(hexBytes))
+	if err != nil {
+		return nil, err
+	}
+	return decodedHexBytes, nil
 }
 
 func encodeBytesSQL(val []byte, b BinWriter) {

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
@@ -403,7 +405,9 @@ func TestToBytesAndString(t *testing.T) {
 		TestValue(Int64, "1"),
 		TestValue(Int64, "12"),
 	} {
-		if b := v.ToBytes(); !bytes.Equal(b, v.Raw()) {
+		vBytes, err := v.ToBytes()
+		require.NoError(t, err)
+		if b := vBytes; !bytes.Equal(b, v.Raw()) {
 			t.Errorf("%v.ToBytes: %s, want %s", v, b, v.Raw())
 		}
 		if s := v.ToString(); s != string(v.Raw()) {
@@ -412,7 +416,9 @@ func TestToBytesAndString(t *testing.T) {
 	}
 
 	tv := TestValue(Expression, "aa")
-	if b := tv.ToBytes(); b != nil {
+	tvBytes, err := tv.ToBytes()
+	require.EqualError(t, err, "expression cannot be converted to bytes")
+	if b := tvBytes; b != nil {
 		t.Errorf("%v.ToBytes: %s, want nil", tv, b)
 	}
 	if s := tv.ToString(); s != "" {

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -425,7 +425,11 @@ func (vttablet *VttabletProcess) getDBSystemValues(placeholder string, value str
 		return "", err
 	}
 	if len(output.Rows) > 0 {
-		return fmt.Sprintf("%s", output.Rows[0][1].ToBytes()), nil
+		rowBytes, err := output.Rows[0][1].ToBytes()
+		if err != nil {
+			return "", err
+		}
+		return string(rowBytes), nil
 	}
 	return "", nil
 }

--- a/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
+++ b/go/test/endtoend/recovery/shardedrecovery/sharded_recovery_test.go
@@ -331,27 +331,35 @@ func TestShardedRecovery(t *testing.T) {
 
 	qr, err := shard0Primary.VttabletProcess.QueryTablet("select count(*) from vt_insert_test", keyspaceName, true)
 	require.NoError(t, err)
-	shard0CountStr := fmt.Sprintf("%s", qr.Rows[0][0].ToBytes())
+	rowBytes, err := qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	shard0CountStr := string(rowBytes)
 	shard0Count, err := strconv.Atoi(shard0CountStr)
 	require.NoError(t, err)
 	var shard0TestID string
 	if shard0Count > 0 {
 		qr, err := shard0Primary.VttabletProcess.QueryTablet("select id from vt_insert_test", keyspaceName, true)
 		require.NoError(t, err)
-		shard0TestID = fmt.Sprintf("%s", qr.Rows[0][0].ToBytes())
+		rowBytes, err = qr.Rows[0][0].ToBytes()
+		assert.NoError(t, err)
+		shard0TestID = string(rowBytes)
 		require.NoError(t, err)
 	}
 
 	qr, err = shard1Primary.VttabletProcess.QueryTablet("select count(*) from vt_insert_test", keyspaceName, true)
 	require.NoError(t, err)
-	shard1CountStr := fmt.Sprintf("%s", qr.Rows[0][0].ToBytes())
+	rowBytes, err = qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	shard1CountStr := string(rowBytes)
 	shard1Count, err := strconv.Atoi(shard1CountStr)
 	require.NoError(t, err)
 	var shard1TestID string
 	if shard1Count > 0 {
 		qr, err := shard1Primary.VttabletProcess.QueryTablet("select id from vt_insert_test", keyspaceName, true)
 		require.NoError(t, err)
-		shard1TestID = fmt.Sprintf("%s", qr.Rows[0][0].ToBytes())
+		rowBytes, err := qr.Rows[0][0].ToBytes()
+		assert.NoError(t, err)
+		shard1TestID = string(rowBytes)
 		require.NoError(t, err)
 	}
 

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -233,12 +233,16 @@ func TestRecoveryImpl(t *testing.T) {
 	//verify that primary has new value
 	qr, err := primary.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "msgx1", fmt.Sprintf("%s", qr.Rows[0][0].ToBytes()))
+	rowBytes, err := qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t, "msgx1", string(rowBytes))
 
 	//verify that restored replica has old value
 	qr, err = replica2.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "test1", fmt.Sprintf("%s", qr.Rows[0][0].ToBytes()))
+	rowBytes, err = qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t, "test1", string(rowBytes))
 
 	err = localCluster.VtctlclientProcess.ExecuteCommand("Backup", replica1.Alias)
 	assert.NoError(t, err)
@@ -262,12 +266,16 @@ func TestRecoveryImpl(t *testing.T) {
 	//verify that primary has new value
 	qr, err = primary.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "msgx2", fmt.Sprintf("%s", qr.Rows[0][0].ToBytes()))
+	rowBytes, err = qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t, "msgx2", string(rowBytes))
 
 	//verify that restored replica has old value
 	qr, err = replica3.VttabletProcess.QueryTablet("select msg from vt_insert_test where id = 1", keyspaceName, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "msgx1", fmt.Sprintf("%s", qr.Rows[0][0].ToBytes()))
+	rowBytes, err = qr.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t, "msgx1", string(rowBytes))
 
 	vtgateInstance := localCluster.NewVtgateInstance()
 	vtgateInstance.TabletTypesToWait = "REPLICA"

--- a/go/test/endtoend/worker/worker_test.go
+++ b/go/test/endtoend/worker/worker_test.go
@@ -353,7 +353,9 @@ func assertShardDataEqual(t *testing.T, shardNum string, sourceTablet *cluster.V
 	countQuery := "select count(*) from worker_test"
 	qrDestinationCount, err := destinationTablet.VttabletProcess.QueryTablet(countQuery, keyspaceName, true)
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", len(qrDestination.Rows)), fmt.Sprintf("%s", qrDestinationCount.Rows[0][0].ToBytes()))
+	rowBytes, err := qrDestinationCount.Rows[0][0].ToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%d", len(qrDestination.Rows)), string(rowBytes))
 
 }
 

--- a/go/vt/binlog/binlog_connection.go
+++ b/go/vt/binlog/binlog_connection.go
@@ -41,6 +41,7 @@ var (
 // connecting for replication. Each such connection must identify itself to
 // mysqld with a server ID that is unique both among other BinlogConnections and
 // among actual replicas in the topology.
+//revive:disable because I'm not trying to refactor the entire code base right now
 type BinlogConnection struct {
 	*mysql.Conn
 	cp       dbconfigs.Connector

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -758,7 +758,11 @@ func writeValuesAsSQL(sql *sqlparser.TrackedBuffer, tce *tableCacheEntry, rs *my
 		if err != nil {
 			return keyspaceIDCell, nil, err
 		}
-		if value.Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(value.ToBytes(), mysql.ZeroTimestamp) {
+		vBytes, err := value.ToBytes()
+		if err != nil {
+			return sqltypes.Value{}, nil, err
+		}
+		if value.Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(vBytes, mysql.ZeroTimestamp) {
 			// Values in the binary log are UTC. Let's convert them
 			// to whatever timezone the connection is using,
 			// so MySQL properly converts them back to UTC.
@@ -819,7 +823,11 @@ func writeIdentifiersAsSQL(sql *sqlparser.TrackedBuffer, tce *tableCacheEntry, r
 		if err != nil {
 			return keyspaceIDCell, nil, err
 		}
-		if value.Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(value.ToBytes(), mysql.ZeroTimestamp) {
+		vBytes, err := value.ToBytes()
+		if err != nil {
+			return keyspaceIDCell, nil, err
+		}
+		if value.Type() == querypb.Type_TIMESTAMP && !bytes.HasPrefix(vBytes, mysql.ZeroTimestamp) {
 			// Values in the binary log are UTC. Let's convert them
 			// to whatever timezone the connection is using,
 			// so MySQL properly converts them back to UTC.

--- a/go/vt/binlog/keyspace_id_resolver.go
+++ b/go/vt/binlog/keyspace_id_resolver.go
@@ -103,7 +103,11 @@ type keyspaceIDResolverFactoryV2 struct {
 func (r *keyspaceIDResolverFactoryV2) keyspaceID(v sqltypes.Value) ([]byte, error) {
 	switch r.shardingColumnType {
 	case topodatapb.KeyspaceIdType_BYTES:
-		return v.ToBytes(), nil
+		vBytes, err := v.ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		return vBytes, nil
 	case topodatapb.KeyspaceIdType_UINT64:
 		i, err := evalengine.ToUint64(v)
 		if err != nil {

--- a/go/vt/mysqlctl/tmutils/permissions.go
+++ b/go/vt/mysqlctl/tmutils/permissions.go
@@ -68,7 +68,8 @@ func NewUserPermission(fields []*querypb.Field, values []sqltypes.Value) *tablet
 		case "user":
 			up.User = values[i].ToString()
 		case "password":
-			up.PasswordChecksum = crc64.Checksum(values[i].ToBytes(), hashTable)
+			vBytes, _ := values[i].ToBytes()
+			up.PasswordChecksum = crc64.Checksum(vBytes, hashTable)
 		case "password_last_changed":
 			// we skip this one, as the value may be
 			// different on primary and replicas.

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	"vitess.io/vitess/go/hack"
@@ -481,7 +482,7 @@ func (node *Literal) HexDecode() ([]byte, error) {
 	return hex.DecodeString(node.Val)
 }
 
-// EncodeHexValToMySQLQueryFormat encodes the hexval back into the query format
+// encodeHexValToMySQLQueryFormat encodes the hexval back into the query format
 // for passing on to MySQL as a bind var
 func (node *Literal) encodeHexValToMySQLQueryFormat() ([]byte, error) {
 	nb := node.Bytes()
@@ -490,7 +491,11 @@ func (node *Literal) encodeHexValToMySQLQueryFormat() ([]byte, error) {
 	}
 
 	// Let's make this idempotent in case it's called more than once
-	if nb[0] == 'x' && nb[1] == '0' && nb[len(nb)-1] == '\'' {
+	match, err := regexp.Match("^x'.*'$", nb)
+	if err != nil {
+		return nb, err
+	}
+	if match {
 		return nb, nil
 	}
 

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -100,7 +100,11 @@ func (s *Server) CheckReshardingJournalExistsOnTablet(ctx context.Context, table
 
 	if len(p3qr.Rows) != 0 {
 		qr := sqltypes.Proto3ToResult(p3qr)
-		if err := prototext.Unmarshal(qr.Rows[0][0].ToBytes(), &journal); err != nil {
+		qrBytes, err := qr.Rows[0][0].ToBytes()
+		if err != nil {
+			return nil, false, err
+		}
+		if err := prototext.Unmarshal(qrBytes, &journal); err != nil {
 			return nil, false, err
 		}
 
@@ -334,7 +338,11 @@ func (s *Server) GetWorkflows(ctx context.Context, req *vtctldatapb.GetWorkflows
 		}
 
 		var bls binlogdatapb.BinlogSource
-		if err := prototext.Unmarshal(row[2].ToBytes(), &bls); err != nil {
+		rowBytes, err := row[2].ToBytes()
+		if err != nil {
+			return err
+		}
+		if err := prototext.Unmarshal(rowBytes, &bls); err != nil {
 			return err
 		}
 

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -227,7 +227,11 @@ func (sm *StreamMigrator) readTabletStreams(ctx context.Context, ti *topo.Tablet
 		}
 
 		var bls binlogdatapb.BinlogSource
-		if err := prototext.Unmarshal(row[2].ToBytes(), &bls); err != nil {
+		rowBytes, err := row[2].ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		if err := prototext.Unmarshal(rowBytes, &bls); err != nil {
 			return nil, err
 		}
 

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -236,7 +236,11 @@ func BuildTargets(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManag
 			}
 
 			var bls binlogdatapb.BinlogSource
-			if err := prototext.Unmarshal(row[1].ToBytes(), &bls); err != nil {
+			rowBytes, err := row[1].ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			if err := prototext.Unmarshal(rowBytes, &bls); err != nil {
 				return nil, err
 			}
 

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -445,7 +445,11 @@ func (oa *OrderedAggregate) merge(fields []*querypb.Field, row1, row2 []sqltypes
 			result[aggr.Col] = evalengine.NullsafeAdd(row1[aggr.Col], row2[aggr.Col], OpcodeType[aggr.Opcode])
 		case AggregateGtid:
 			vgtid := &binlogdatapb.VGtid{}
-			err = proto.Unmarshal(row1[aggr.Col].ToBytes(), vgtid)
+			rowBytes, err := row1[aggr.Col].ToBytes()
+			if err != nil {
+				return nil, nil, err
+			}
+			err = proto.Unmarshal(rowBytes, vgtid)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -528,7 +532,11 @@ func (oa *OrderedAggregate) convertFinal(current []sqltypes.Value) ([]sqltypes.V
 		switch aggr.Opcode {
 		case AggregateGtid:
 			vgtid := &binlogdatapb.VGtid{}
-			err := proto.Unmarshal(current[aggr.Col].ToBytes(), vgtid)
+			currentBytes, err := current[aggr.Col].ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			err = proto.Unmarshal(currentBytes, vgtid)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vtgate/evalengine/arithmetic.go
+++ b/go/vt/vtgate/evalengine/arithmetic.go
@@ -210,7 +210,15 @@ func NullsafeCompare(v1, v2 sqltypes.Value) (int, error) {
 		return compareNumeric(lv1, lv2)
 	}
 	if isByteComparable(v1) && isByteComparable(v2) {
-		return bytes.Compare(v1.ToBytes(), v2.ToBytes()), nil
+		v1Bytes, err1 := v1.ToBytes()
+		if err1 != nil {
+			return 0, err1
+		}
+		v2Bytes, err2 := v2.ToBytes()
+		if err2 != nil {
+			return 0, err2
+		}
+		return bytes.Compare(v1Bytes, v2Bytes), nil
 	}
 	return 0, UnsupportedComparisonError{
 		Type1: v1.Type(),

--- a/go/vt/vtgate/evalengine/arithmetic_test.go
+++ b/go/vt/vtgate/evalengine/arithmetic_test.go
@@ -679,7 +679,7 @@ func TestCast(t *testing.T) {
 	}, {
 		typ: querypb.Type_VARCHAR,
 		v:   TestValue(sqltypes.Expression, "bad string"),
-		err: vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "EXPRESSION(bad string) cannot be cast to VARCHAR"),
+		err: vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "expression cannot be converted to bytes"),
 	}}
 	for _, tcase := range tcases {
 		got, err := Cast(tcase.v, tcase.typ)
@@ -1351,7 +1351,8 @@ func TestHashCodes(t *testing.T) {
 }
 
 func printValue(v sqltypes.Value) string {
-	return fmt.Sprintf("%v:%q", v.Type(), v.ToBytes())
+	vBytes, _ := v.ToBytes()
+	return fmt.Sprintf("%v:%q", v.Type(), vBytes)
 }
 
 // These benchmarks show that using existing ASCII representations

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -63,7 +63,11 @@ func (vind *Binary) NeedsVCursor() bool {
 func (vind *Binary) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	out := make([]bool, len(ids))
 	for i := range ids {
-		out[i] = bytes.Equal(ids[i].ToBytes(), ksids[i])
+		idBytes, err := ids[i].ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = bytes.Equal(idBytes, ksids[i])
 	}
 	return out, nil
 }
@@ -72,7 +76,11 @@ func (vind *Binary) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]b
 func (vind *Binary) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
-		out[i] = key.DestinationKeyspaceID(id.ToBytes())
+		idBytes, err := id.ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = key.DestinationKeyspaceID(idBytes)
 	}
 	return out, nil
 }

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -18,6 +18,8 @@ package vindexes
 
 import (
 	"bytes"
+	"encoding/hex"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -69,13 +71,17 @@ func TestBinaryMap(t *testing.T) {
 }
 
 func TestBinaryVerify(t *testing.T) {
-	ids := []sqltypes.Value{sqltypes.NewVarBinary("1"), sqltypes.NewVarBinary("2")}
-	ksids := [][]byte{[]byte("1"), []byte("1")}
+	hexValStr := "8a1e"
+	hexValStrSQL := fmt.Sprintf("x'%s'", hexValStr)
+	hexNumStrSQL := fmt.Sprintf("0x%s", hexValStr)
+	hexBytes, _ := hex.DecodeString(hexValStr)
+	ids := []sqltypes.Value{sqltypes.NewVarBinary("1"), sqltypes.NewVarBinary("2"), sqltypes.NewHexVal([]byte(hexValStrSQL)), sqltypes.NewHexNum([]byte(hexNumStrSQL))}
+	ksids := [][]byte{[]byte("1"), []byte("1"), hexBytes, hexBytes}
 	got, err := binOnlyVindex.Verify(nil, ids, ksids)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []bool{true, false}
+	want := []bool{true, false, true, true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("binary.Verify: %v, want %v", got, want)
 	}

--- a/go/vt/vtgate/vindexes/binarymd5.go
+++ b/go/vt/vtgate/vindexes/binarymd5.go
@@ -62,7 +62,11 @@ func (vind *BinaryMD5) NeedsVCursor() bool {
 func (vind *BinaryMD5) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	out := make([]bool, len(ids))
 	for i := range ids {
-		out[i] = bytes.Equal(vMD5Hash(ids[i].ToBytes()), ksids[i])
+		idBytes, err := ids[i].ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = bytes.Equal(vMD5Hash(idBytes), ksids[i])
 	}
 	return out, nil
 }
@@ -71,7 +75,11 @@ func (vind *BinaryMD5) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) (
 func (vind *BinaryMD5) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
-		out[i] = key.DestinationKeyspaceID(vMD5Hash(id.ToBytes()))
+		idBytes, err := id.ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = key.DestinationKeyspaceID(vMD5Hash(idBytes))
 	}
 	return out, nil
 }

--- a/go/vt/vtgate/vindexes/binarymd5_test.go
+++ b/go/vt/vtgate/vindexes/binarymd5_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vindexes
 
 import (
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
@@ -72,13 +73,17 @@ func TestBinaryMD5Map(t *testing.T) {
 }
 
 func TestBinaryMD5Verify(t *testing.T) {
-	ids := []sqltypes.Value{sqltypes.NewVarBinary("Test"), sqltypes.NewVarBinary("TEst")}
-	ksids := [][]byte{[]byte("\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za["), []byte("\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za[")}
+	hexValStr := "21cf"
+	hexValStrSQL := fmt.Sprintf("x'%s'", hexValStr)
+	hexNumStrSQL := fmt.Sprintf("0x%s", hexValStr)
+	hexBytes, _ := hex.DecodeString(hexValStr)
+	ids := []sqltypes.Value{sqltypes.NewVarBinary("Test"), sqltypes.NewVarBinary("TEst"), sqltypes.NewHexVal([]byte(hexValStrSQL)), sqltypes.NewHexNum([]byte(hexNumStrSQL))}
+	ksids := [][]byte{[]byte("\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za["), []byte("\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za["), vMD5Hash(hexBytes), vMD5Hash(hexBytes)}
 	got, err := binVindex.Verify(nil, ids, ksids)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []bool{true, false}
+	want := []bool{true, false, true, true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("binaryMD5.Verify: %v, want %v", got, want)
 	}

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -207,7 +207,11 @@ func (vind *CFC) computeKsid(v []byte, prefix bool) ([]byte, error) {
 func (vind *CFC) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	out := make([]bool, len(ids))
 	for i := range ids {
-		v, err := vind.computeKsid(ids[i].ToBytes(), false)
+		idBytes, err := ids[i].ToBytes()
+		if err != nil {
+			return out, err
+		}
+		v, err := vind.computeKsid(idBytes, false)
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +224,11 @@ func (vind *CFC) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool
 func (vind *CFC) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
-		v, err := vind.computeKsid(id.ToBytes(), false)
+		idBytes, err := id.ToBytes()
+		if err != nil {
+			return out, err
+		}
+		v, err := vind.computeKsid(idBytes, false)
 		if err != nil {
 			return nil, err
 		}
@@ -292,7 +300,10 @@ func (vind *prefixCFC) IsUnique() bool {
 func (vind *prefixCFC) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
-		value := id.ToBytes()
+		value, err := id.ToBytes()
+		if err != nil {
+			return out, err
+		}
 		prefix := findPrefix(value)
 		begin, err := vind.computeKsid(prefix, true)
 		if err != nil {

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -95,7 +95,11 @@ func (ln *LookupNonUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([]key.Des
 		}
 		ksids := make([][]byte, 0, len(result.Rows))
 		for _, row := range result.Rows {
-			ksids = append(ksids, row[0].ToBytes())
+			rowBytes, err := row[0].ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			ksids = append(ksids, rowBytes)
 		}
 		out = append(out, key.DestinationKeyspaceIDs(ksids))
 	}
@@ -247,7 +251,11 @@ func (lu *LookupUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([]key.Destin
 		case 0:
 			out = append(out, key.DestinationNone{})
 		case 1:
-			out = append(out, key.DestinationKeyspaceID(result.Rows[0][0].ToBytes()))
+			rowBytes, err := result.Rows[0][0].ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, key.DestinationKeyspaceID(rowBytes))
 		default:
 			return nil, fmt.Errorf("Lookup.Map: unexpected multiple results from vindex %s: %v", lu.lkp.Table, ids[i])
 		}

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -174,7 +174,9 @@ func (v *sorter) Less(i, j int) bool {
 	rightRow := v.rowsColValues[j]
 	for cell, left := range leftRow {
 		right := rightRow[cell]
-		compare := bytes.Compare(left.ToBytes(), right.ToBytes())
+		lBytes, _ := left.ToBytes()
+		rBytes, _ := right.ToBytes()
+		compare := bytes.Compare(lBytes, rBytes)
 		if compare < 0 {
 			return true
 		}
@@ -182,7 +184,9 @@ func (v *sorter) Less(i, j int) bool {
 			return false
 		}
 	}
-	return bytes.Compare(v.toValues[i].ToBytes(), v.toValues[j].ToBytes()) < 0
+	iBytes, _ := v.toValues[i].ToBytes()
+	jBytes, _ := v.toValues[j].ToBytes()
+	return bytes.Compare(iBytes, jBytes) < 0
 }
 
 func (v *sorter) Swap(i, j int) {

--- a/go/vt/vtgate/vindexes/unicode.go
+++ b/go/vt/vtgate/vindexes/unicode.go
@@ -35,7 +35,11 @@ func unicodeHash(hashFunc func([]byte) []byte, key sqltypes.Value) ([]byte, erro
 	collator := collatorPool.Get().(*pooledCollator)
 	defer collatorPool.Put(collator)
 
-	norm, err := normalize(collator.col, collator.buf, key.ToBytes())
+	keyBytes, err := key.ToBytes()
+	if err != nil {
+		return nil, err
+	}
+	norm, err := normalize(collator.col, collator.buf, keyBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/xxhash.go
+++ b/go/vt/vtgate/vindexes/xxhash.go
@@ -65,8 +65,11 @@ func (vind *XXHash) NeedsVCursor() bool {
 func (vind *XXHash) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i := range ids {
-		id := ids[i].ToBytes()
-		out[i] = key.DestinationKeyspaceID(vXXHash(id))
+		idBytes, err := ids[i].ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = key.DestinationKeyspaceID(vXXHash(idBytes))
 	}
 	return out, nil
 }
@@ -75,8 +78,11 @@ func (vind *XXHash) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination
 func (vind *XXHash) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
 	out := make([]bool, len(ids))
 	for i := range ids {
-		id := ids[i].ToBytes()
-		out[i] = bytes.Equal(vXXHash(id), ksids[i])
+		idBytes, err := ids[i].ToBytes()
+		if err != nil {
+			return out, err
+		}
+		out[i] = bytes.Equal(vXXHash(idBytes), ksids[i])
 	}
 	return out, nil
 }

--- a/go/vt/vtgate/vindexes/xxhash_test.go
+++ b/go/vt/vtgate/vindexes/xxhash_test.go
@@ -18,6 +18,7 @@ package vindexes
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
@@ -94,13 +95,17 @@ func TestXXHashMap(t *testing.T) {
 }
 
 func TestXXHashVerify(t *testing.T) {
-	ids := []sqltypes.Value{sqltypes.NewUint64(1), sqltypes.NewUint64(2)}
-	ksids := [][]byte{{0xd4, 0x64, 0x5, 0x36, 0x76, 0x12, 0xb4, 0xb7}, {0xd4, 0x64, 0x5, 0x36, 0x76, 0x12, 0xb4, 0xb7}}
+	hexValStr := "9efa"
+	hexValStrSQL := fmt.Sprintf("x'%s'", hexValStr)
+	hexNumStrSQL := fmt.Sprintf("0x%s", hexValStr)
+	hexBytes, _ := hex.DecodeString(hexValStr)
+	ids := []sqltypes.Value{sqltypes.NewUint64(1), sqltypes.NewUint64(2), sqltypes.NewHexVal([]byte(hexValStrSQL)), sqltypes.NewHexNum([]byte(hexNumStrSQL))}
+	ksids := [][]byte{{0xd4, 0x64, 0x5, 0x36, 0x76, 0x12, 0xb4, 0xb7}, {0xd4, 0x64, 0x5, 0x36, 0x76, 0x12, 0xb4, 0xb7}, vXXHash(hexBytes), vXXHash(hexBytes)}
 	got, err := xxHash.Verify(nil, ids, ksids)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []bool{true, false}
+	want := []bool{true, false, true, true}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("xxHash.Verify: %v, want %v", got, want)
 	}

--- a/go/vt/vttablet/tabletserver/schema/historian.go
+++ b/go/vt/vttablet/tabletserver/schema/historian.go
@@ -184,17 +184,29 @@ func (h *historian) loadFromDB(ctx context.Context) error {
 // readRow converts a row from the schema_version table to a trackedSchema
 func (h *historian) readRow(row []sqltypes.Value) (*trackedSchema, int64, error) {
 	id, _ := evalengine.ToInt64(row[0])
-	pos, err := mysql.DecodePosition(string(row[1].ToBytes()))
+	rowBytes, err := row[1].ToBytes()
 	if err != nil {
 		return nil, 0, err
 	}
-	ddl := string(row[2].ToBytes())
+	pos, err := mysql.DecodePosition(string(rowBytes))
+	if err != nil {
+		return nil, 0, err
+	}
+	rowBytes, err = row[2].ToBytes()
+	if err != nil {
+		return nil, 0, err
+	}
+	ddl := string(rowBytes)
 	timeUpdated, err := evalengine.ToInt64(row[3])
 	if err != nil {
 		return nil, 0, err
 	}
 	sch := &binlogdatapb.MinimalSchema{}
-	if err := proto.Unmarshal(row[4].ToBytes(), sch); err != nil {
+	rowBytes, err = row[4].ToBytes()
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := proto.Unmarshal(rowBytes, sch); err != nil {
 		return nil, 0, err
 	}
 	log.V(vl).Infof("Read tracked schema from db: id %d, pos %v, ddl %s, schema len %d, time_updated %d \n",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -801,7 +801,11 @@ nextrow:
 				continue
 			}
 			journal := &binlogdatapb.Journal{}
-			if err := prototext.Unmarshal(afterValues[i].ToBytes(), journal); err != nil {
+			avBytes, err := afterValues[i].ToBytes()
+			if err != nil {
+				return nil, err
+			}
+			if err := prototext.Unmarshal(avBytes, journal); err != nil {
 				return nil, err
 			}
 			vevents = append(vevents, &binlogdatapb.VEvent{
@@ -910,7 +914,11 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 			if maxBytesPerChar > 1 {
 				maxCharLen := plan.Table.Fields[colNum].ColumnLength / maxBytesPerChar
 				if uint32(value.Len()) > maxCharLen {
-					originalVal := value.ToBytes()
+					ovBytes, err := value.ToBytes()
+					if err != nil {
+						return false, nil, err
+					}
+					originalVal := ovBytes
 
 					// Let's be sure that we're not going to be trimming non-null bytes
 					firstNullBytePos := bytes.IndexByte(originalVal, byte(0))

--- a/go/vt/worker/key_resolver.go
+++ b/go/vt/worker/key_resolver.go
@@ -77,7 +77,11 @@ func (r *v2Resolver) keyspaceID(row []sqltypes.Value) ([]byte, error) {
 	v := row[r.shardingColumnIndex]
 	switch r.keyspaceInfo.ShardingColumnType {
 	case topodatapb.KeyspaceIdType_BYTES:
-		return v.ToBytes(), nil
+		vBytes, err := v.ToBytes()
+		if err != nil {
+			return nil, err
+		}
+		return vBytes, nil
 	case topodatapb.KeyspaceIdType_UINT64:
 		i, err := evalengine.ToUint64(v)
 		if err != nil {

--- a/go/vt/wrangler/resharder.go
+++ b/go/vt/wrangler/resharder.go
@@ -210,7 +210,11 @@ func (rs *resharder) readRefStreams(ctx context.Context) error {
 				return fmt.Errorf("VReplication streams must have named workflows for migration: shard: %s:%s", source.Keyspace(), source.ShardName())
 			}
 			var bls binlogdatapb.BinlogSource
-			if err := prototext.Unmarshal(row[1].ToBytes(), &bls); err != nil {
+			rowBytes, err := row[1].ToBytes()
+			if err != nil {
+				return err
+			}
+			if err := prototext.Unmarshal(rowBytes, &bls); err != nil {
 				return vterrors.Wrapf(err, "prototext.Unmarshal: %v", row)
 			}
 			isReference, err := rs.blsIsReference(&bls)

--- a/go/vt/wrangler/vexec.go
+++ b/go/vt/wrangler/vexec.go
@@ -414,7 +414,11 @@ func (wr *Wrangler) getReplicationStatusFromRow(ctx context.Context, row []sqlty
 	if err != nil {
 		return nil, "", err
 	}
-	if err := prototext.Unmarshal(row[1].ToBytes(), &bls); err != nil {
+	rowBytes, err := row[1].ToBytes()
+	if err != nil {
+		return nil, "", err
+	}
+	if err := prototext.Unmarshal(rowBytes, &bls); err != nil {
 		return nil, "", err
 	}
 

--- a/misc/git/hooks/golangci-lint
+++ b/misc/git/hooks/golangci-lint
@@ -20,7 +20,7 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 
 # xargs -n1 because dirname on MacOS does not support multiple arguments.
-gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u)
+gopackages=$(echo $gofiles | xargs -n1 dirname | sort -u -)
 
 GOLANGCI_LINT=$(command -v golangci-lint >/dev/null 2>&1)
 if [ $? -eq 1 ]; then


### PR DESCRIPTION
## Description
This is a backport of https://github.com/vitessio/vitess/pull/9277, please see there for details.

The combination of https://github.com/vitessio/vitess/pull/9118 and https://github.com/vitessio/vitess/pull/9277 add more complete support for hex values of the form `x'e19a'` and `0xe19a` in queries within vitess, specifically:
1. The hex predicates/input values are normalized in the query -- without this the query planner cache is unused and each query is seen as unique, which has a very large impact on performance when some of your primary queries use hex values
2. The columns where you insert these hex values can (still) be used in primary vindexes as the keyspace ID is calculated using the bytes stored for the column in MySQL rather than the "raw" BindVar value which is the string literal representation used in the query

## Related Issue(s)
Backports: https://github.com/vitessio/vitess/pull/9277

## Checklist
- [x] Should this PR be backported? No, not beyond 12.0
- [x] Tests were added
- [x] Documentation is not required