### PR TITLE
only grab gh-ost exec if not overridden

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -169,12 +169,12 @@ func initConfig(tabletAlias *topodatapb.TabletAlias) (*tabletenv.TabletConfig, *
 // extractOnlineDDL extracts the gh-ost binary from this executable. gh-ost is appended
 // to vttablet executable by `make build` and via ricebox
 func extractOnlineDDL() error {
-	riceBox, err := rice.FindBox("../../../resources/bin")
-	if err != nil {
-		return err
-	}
-
 	if binaryFileName, isOverride := onlineddl.GhostBinaryFileName(); !isOverride {
+		riceBox, err := rice.FindBox("../../../resources/bin")
+		if err != nil {
+			return err
+		}
+
 		// there is no path override for gh-ost. We're expected to auto-extract gh-ost.
 		ghostBinary, err := riceBox.Bytes("gh-ost")
 		if err != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
[`ricebox`](https://github.com/GeertJohan/go.rice) is an interesting tool to embed assets in binaries. As best I can tell, it does some hackery with symbol tables and embedding extraneous zips in binaries to make assets available at runtime.

This is not really compatible with golang's standard tooling (or bazel), it's manipulation that must be done after-build (at least for `append`).

Notably, the ricebox embedded assets don't actually seem to be critical to run-time. At least, with `gh-ost`, there's a flag to override the bin.

Can we eliminate the dependence on this `ricebox` if the `gh-ost` bin is overridden?

## Related Issue(s)
- None

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
None