### PR TITLE
Add support for changing Planner Version in vttestserver docker image

### DIFF
--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -40,6 +40,7 @@ rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
 	-foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
 	-enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
 	-enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
+	-planner_version="${PLANNER_VERSION:-v3}" \
 	-vschema_ddl_authorized_users=% \
 	-schema_dir="/vt/schema/"
 

--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -137,6 +137,9 @@ func init() {
 
 	flag.StringVar(&config.Charset, "charset", "utf8mb4", "MySQL charset")
 	flag.StringVar(&config.Collation, "collation", "", "MySQL collation")
+
+	flag.StringVar(&config.PlannerVersion, "planner_version", "v3", "Sets the default planner to use when the session has not changed it. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the new gen4 planner and falls back to the V3 planner if the gen4 fails. All Gen4 versions should be considered experimental!")
+
 	flag.StringVar(&config.SnapshotFile, "snapshot_file", "",
 		"A MySQL DB snapshot file")
 

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -84,6 +84,10 @@ type Config struct {
 	// to define the value of Charset
 	Collation string
 
+	// PlannerVersion is the planner version to use for the vtgate.
+	// Choose between V3, Gen4, Gen4Greedy and Gen4Fallback
+	PlannerVersion string
+
 	// ExtraMyCnf are the extra .CNF files to be added to the MySQL config
 	ExtraMyCnf []string
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -231,6 +231,7 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 		"-enable_query_plan_field_caching=false",
 		"-dbddl_plugin", "vttest",
 		"-foreign_key_mode", args.ForeignKeyMode,
+		"-planner_version", args.PlannerVersion,
 		fmt.Sprintf("-enable_online_ddl=%t", args.EnableOnlineDDL),
 		fmt.Sprintf("-enable_direct_ddl=%t", args.EnableDirectDDL),
 	}...)


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for changing Planner Version in vttestserver docker image by providing the environment variable. This is needed for the rails sharded blog, so that the readers can follow along with the code examples if they want to without bringing up the entire Vitess cluster, but just using the docker image for vttestserver. However, rails only works with Gen4, so we need the functionality for changing the planner version.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required - Tested manually
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->