### PR TITLE
Online DDL: vtctl OnlineDDL supports 'complete' command

### DIFF
--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -1,12 +1,12 @@
 ## Enhancements
 
-- `vtctl ApplySchema` now respects `-allow-zero-in-date` for `direct` strategy. For example, the following statement is now accepted: `vtctlclient ApplySchema -skip_preflight -ddl_strategy='direct -allow-zero-in-date' -sql "create table if not exists t2(id int primary key, dt datetime default '0000-00-00 00:00:00')" commerce`
+- `vtctl/vtctlclient ApplySchema` now respects `-allow-zero-in-date` for `direct` strategy. For example, the following statement is now accepted: `vtctlclient ApplySchema -skip_preflight -ddl_strategy='direct -allow-zero-in-date' -sql "create table if not exists t2(id int primary key, dt datetime default '0000-00-00 00:00:00')" commerce`
 
 ## Major Changes
 
 ### ddl_strategy: -postpone-completion flag
 
-`ddl_strategy` (either `@@ddl_strategy` in VtGate or `-ddl_strategy` in `vtctl ApplySchema`) supports the flag `-postpone-completion`
+`ddl_strategy` (either `@@ddl_strategy` in VtGate or `-ddl_strategy` in `vtctlclient ApplySchema`) supports the flag `-postpone-completion`
 
 This flag indicates that the migration should not auto-complete. This applies for:
 
@@ -49,10 +49,10 @@ This command indicates that a migration executed with `-postpone-completion` is 
 
 ### vtctl OnlineDDL ... complete
 
-Complementing the `alter vitess_migration ... complete` query, a migration can also be completed via `vtctl`:
+Complementing the `alter vitess_migration ... complete` query, a migration can also be completed via `vtctl` or `vtctlclient`:
 
 ```shell
-vtctl OnlineDDL <keyspace> complete <uuid>
+vtctlclient OnlineDDL <keyspace> complete <uuid>
 ```
 For example:
 

--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -47,6 +47,19 @@ This command indicates that a migration executed with `-postpone-completion` is 
 - For running `ALTER`s (`online` and `gh-ost`) which are only partly through the migration: they will cut-over automatically when they complete their work, as if `-postpone-completion` wasn't indicated
 - For queued `CREATE` and `DROP` migrations: "unblock" them from being scheduled. They'll be scheduled at the scheduler's discretion. there is no guarantee that they will be scheduled to run immediately.
 
+### vtctl OnlineDDL ... complete
+
+Complementing the `alter vitess_migration ... complete` query, a migration can also be completed via `vtctl`:
+
+```shell
+vtctl OnlineDDL <keyspace> complete <uuid>
+```
+For example:
+
+```shell
+vtctlclient OnlineDDL commerce complete d08ffe6b_51c9_11ec_9cf2_0a43f95f28a3
+```
+
 ## Incompatible Changes
 
 ## Deprecations

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -249,13 +249,9 @@ func (exec *TabletExecutor) executeSQL(ctx context.Context, sql string, execResu
 				return err
 			}
 			for _, onlineDDL := range onlineDDLs {
-				if exec.ddlStrategySetting.IsSkipTopo() {
-					exec.executeOnAllTablets(ctx, execResult, onlineDDL.SQL, true)
-					if len(execResult.SuccessShards) > 0 {
-						exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
-					}
-				} else {
-					exec.executeOnlineDDL(ctx, execResult, onlineDDL)
+				exec.executeOnAllTablets(ctx, execResult, onlineDDL.SQL, true)
+				if len(execResult.SuccessShards) > 0 {
+					exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
 				}
 			}
 			return nil
@@ -267,15 +263,13 @@ func (exec *TabletExecutor) executeSQL(ctx context.Context, sql string, execResu
 			execResult.ExecutorErr = err.Error()
 			return err
 		}
-		if exec.ddlStrategySetting.IsSkipTopo() {
-			exec.executeOnAllTablets(ctx, execResult, onlineDDL.SQL, true)
-			exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
-		} else {
-			exec.executeOnlineDDL(ctx, execResult, onlineDDL)
-		}
+		exec.executeOnAllTablets(ctx, execResult, onlineDDL.SQL, true)
+		exec.wr.Logger().Printf("%s\n", onlineDDL.UUID)
+		return nil
+	case *sqlparser.AlterMigration:
+		exec.executeOnAllTablets(ctx, execResult, sql, true)
 		return nil
 	}
-	exec.wr.Logger().Infof("Received DDL request. strategy=%+v", schema.DDLStrategyDirect)
 	exec.executeOnAllTablets(ctx, execResult, sql, false)
 	return nil
 }

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3328,6 +3328,14 @@ func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag
 			uuid = arg
 			query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='retry' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
 		}
+	case "complete":
+		{
+			if arg == "" {
+				return fmt.Errorf("UUID required")
+			}
+			uuid = arg
+			query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='complete' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
+		}
 	case "cancel":
 		{
 			if arg == "" {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -3293,64 +3293,54 @@ func commandOnlineDDL(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag
 	var bindErr error
 	switch command {
 	case "show":
-		{
-			condition := ""
-			switch arg {
-			case "", "all":
-				condition = "migration_uuid like '%'"
-			case "recent":
-				condition = "requested_timestamp > now() - interval 1 week"
-			case
-				string(schema.OnlineDDLStatusCancelled),
-				string(schema.OnlineDDLStatusQueued),
-				string(schema.OnlineDDLStatusReady),
-				string(schema.OnlineDDLStatusRunning),
-				string(schema.OnlineDDLStatusComplete),
-				string(schema.OnlineDDLStatusFailed):
-				condition, bindErr = sqlparser.ParseAndBind("migration_status=%a", sqltypes.StringBindVariable(arg))
-			default:
-				if schema.IsOnlineDDLUUID(arg) {
-					uuid = arg
-					condition, bindErr = sqlparser.ParseAndBind("migration_uuid=%a", sqltypes.StringBindVariable(arg))
-				} else {
-					condition, bindErr = sqlparser.ParseAndBind("migration_context=%a", sqltypes.StringBindVariable(arg))
-				}
+		condition := ""
+		switch arg {
+		case "", "all":
+			condition = "migration_uuid like '%'"
+		case "recent":
+			condition = "requested_timestamp > now() - interval 1 week"
+		case
+			string(schema.OnlineDDLStatusCancelled),
+			string(schema.OnlineDDLStatusQueued),
+			string(schema.OnlineDDLStatusReady),
+			string(schema.OnlineDDLStatusRunning),
+			string(schema.OnlineDDLStatusComplete),
+			string(schema.OnlineDDLStatusFailed):
+			condition, bindErr = sqlparser.ParseAndBind("migration_status=%a", sqltypes.StringBindVariable(arg))
+		default:
+			if schema.IsOnlineDDLUUID(arg) {
+				uuid = arg
+				condition, bindErr = sqlparser.ParseAndBind("migration_uuid=%a", sqltypes.StringBindVariable(arg))
+			} else {
+				condition, bindErr = sqlparser.ParseAndBind("migration_context=%a", sqltypes.StringBindVariable(arg))
 			}
-			query = fmt.Sprintf(`select
+		}
+		query = fmt.Sprintf(`select
 				shard, mysql_schema, mysql_table, ddl_action, migration_uuid, strategy, started_timestamp, completed_timestamp, migration_status
 				from _vt.schema_migrations where %s`, condition)
-		}
 	case "retry":
-		{
-			if arg == "" {
-				return fmt.Errorf("UUID required")
-			}
-			uuid = arg
-			query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='retry' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
+		if arg == "" {
+			return fmt.Errorf("UUID required")
 		}
+		uuid = arg
+		query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='retry' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
 	case "complete":
-		{
-			if arg == "" {
-				return fmt.Errorf("UUID required")
-			}
-			uuid = arg
-			query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='complete' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
+		if arg == "" {
+			return fmt.Errorf("UUID required")
 		}
+		uuid = arg
+		query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='complete' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
 	case "cancel":
-		{
-			if arg == "" {
-				return fmt.Errorf("UUID required")
-			}
-			uuid = arg
-			query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='cancel' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
+		if arg == "" {
+			return fmt.Errorf("UUID required")
 		}
+		uuid = arg
+		query, bindErr = sqlparser.ParseAndBind(`update _vt.schema_migrations set migration_status='cancel' where migration_uuid=%a`, sqltypes.StringBindVariable(arg))
 	case "cancel-all":
-		{
-			if arg != "" {
-				return fmt.Errorf("UUID not allowed in %s", command)
-			}
-			query = `update _vt.schema_migrations set migration_status='cancel-all'`
+		if arg != "" {
+			return fmt.Errorf("UUID not allowed in %s", command)
 		}
+		query = `update _vt.schema_migrations set migration_status='cancel-all'`
 	default:
 		return fmt.Errorf("Unknown OnlineDDL command: %s", command)
 	}

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3280,6 +3280,15 @@ func (e *Executor) VExec(ctx context.Context, vx *vexec.TabletVExec) (qr *queryp
 		switch statusVal {
 		case retryMigrationHint:
 			return response(e.retryMigrationWhere(ctx, sqlparser.String(stmt.Where.Expr)))
+		case completeMigrationHint:
+			uuid, err := vx.ColumnStringVal(vx.WhereCols, "migration_uuid")
+			if err != nil {
+				return nil, err
+			}
+			if !schema.IsOnlineDDLUUID(uuid) {
+				return nil, fmt.Errorf("Not an Online DDL UUID: %s", uuid)
+			}
+			return response(e.CompleteMigration(ctx, uuid))
 		case cancelMigrationHint:
 			uuid, err := vx.ColumnStringVal(vx.WhereCols, "migration_uuid")
 			if err != nil {

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -519,6 +519,7 @@ const (
 	retryMigrationHint     = "retry"
 	cancelMigrationHint    = "cancel"
 	cancelAllMigrationHint = "cancel-all"
+	completeMigrationHint  = "complete"
 )
 
 var (


### PR DESCRIPTION

## Description

Followup to https://github.com/vitessio/vitess/pull/9171
In https://github.com/vitessio/vitess/pull/9171 we introduced `ALTER VITESS_MIGRATION '...' COMPLETE` command. This PR complements the SQL interface by adding a `vtctl OnlineDDL <keyspace> complete <uuid>` command.

To be documented.

## Related Issue(s)

Tracking: #6926

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

