### PR TITLE
Change heartbeat writer to use vt_app user

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -114,6 +114,12 @@ func (w *heartbeatWriter) Open() {
 	}
 	log.Info("Hearbeat Writer: opening")
 
+	// We cannot create the database and tables in this Open function
+	// since, this is run when a tablet changes to Primary type. The other replicas
+	// might not have started replication. So if we run the create commands, it will
+	// block this thread, and we could end up in a deadlock.
+	// Instead, we try creating the database and table in each tick which runs in a go routine
+	// keeping us safe from hanging the main thread.
 	w.pool.Open(w.env.Config().DB.AppWithDB())
 	w.enableWrites(true)
 	w.isOpen = true

--- a/go/vt/vttablet/tabletserver/repltracker/writer.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer.go
@@ -114,7 +114,7 @@ func (w *heartbeatWriter) Open() {
 	}
 	log.Info("Hearbeat Writer: opening")
 
-	w.pool.Open(w.env.Config().DB.DbaWithDB())
+	w.pool.Open(w.env.Config().DB.AppWithDB())
 	w.enableWrites(true)
 	w.isOpen = true
 }

--- a/go/vt/vttablet/tabletserver/repltracker/writer_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/writer_test.go
@@ -105,7 +105,7 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *heartbeatWriter 
 	tw := newHeartbeatWriter(tabletenv.NewEnv(config, "WriterTest"), &topodatapb.TabletAlias{Cell: "test", Uid: 1111})
 	tw.keyspaceShard = "test:0"
 	tw.now = nowFunc
-	tw.pool.Open(dbc.DbaWithDB())
+	tw.pool.Open(dbc.AppWithDB())
 
 	return tw
 }


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

As described in the issue, we do not want the heartbeat writer to be using the `vt_dba` user which has super privileges. This creates issues with PRS wherein, the insert commands succeed even after the mysql instance has been set to read only causing the old primary to diverge from the new primary.

This PR changes the user back to `vt_app`. 

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #9290 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->