### PR TITLE
fix: avoid parenthesis around default null in BLOB, TEXT, GEOMETRY and JSON column

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1586,6 +1586,12 @@ func (es *ExtractedSubquery) updateAlternative() {
 }
 
 func defaultRequiresParens(ct *ColumnType) bool {
+	// in 5.7 null value should be without parenthesis, in 8.0 it is allowed either way.
+	// so it is safe to not keep parenthesis around null.
+	if _, isNullVal := ct.Options.Default.(*NullVal); isNullVal {
+		return false
+	}
+
 	switch strings.ToUpper(ct.Type) {
 	case "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT", "TINYBLOB", "BLOB", "MEDIUMBLOB",
 		"LONGBLOB", "JSON", "GEOMETRY", "POINT",
@@ -1596,9 +1602,8 @@ func defaultRequiresParens(ct *ColumnType) bool {
 
 	_, isLiteral := ct.Options.Default.(*Literal)
 	_, isBool := ct.Options.Default.(BoolVal)
-	_, isNullVal := ct.Options.Default.(*NullVal)
 
-	if isLiteral || isNullVal || isBool || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
+	if isLiteral || isBool || isExprAliasForCurrentTimeStamp(ct.Options.Default) {
 		return false
 	}
 

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -129,6 +129,12 @@ var (
 		input:  "CREATE TABLE t2 (b LONGTEXT DEFAULT ('abc'))",
 		output: "create table t2 (\n\tb LONGTEXT default ('abc')\n)",
 	}, {
+		input:  "CREATE TABLE t2 (b JSON DEFAULT null)",
+		output: "create table t2 (\n\tb JSON default null\n)",
+	}, {
+		input:  "CREATE TABLE t2 (b JSON DEFAULT (null))",
+		output: "create table t2 (\n\tb JSON default null\n)",
+	}, {
 		input:  "CREATE TABLE t2 (b JSON DEFAULT '{name:abc}')",
 		output: "create table t2 (\n\tb JSON default ('{name:abc}')\n)",
 	}, {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR avoids adding parenthesis around null value in default for BLOB, TEXT, GEOMETRY and JSON column.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Fixes #9297 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->