### PR TITLE
[vtadmin-web] Consolidate font sizing into tailwind.config.js

### DIFF
--- a/web/vtadmin/src/components/Button.module.scss
+++ b/web/vtadmin/src/components/Button.module.scss
@@ -69,14 +69,14 @@
 }
 
 .button.sizeLarge {
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     height: var(--inputHeightLarge);
     padding: 0 16px;
 }
 
 .button.sizeSmall {
     border-width: 1px;
-    font-size: var(--fontSizeSmall);
+    font-size: theme('fontSize.lg');
     height: var(--inputHeightSmall);
     padding: 0 6px;
 }

--- a/web/vtadmin/src/components/Button.module.scss
+++ b/web/vtadmin/src/components/Button.module.scss
@@ -6,7 +6,7 @@
     color: var(--textColorInverted);
     cursor: pointer;
     font-family: var(--fontFamilyPrimary);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     font-weight: 500;
     height: var(--inputHeightMedium);
     line-height: 1;

--- a/web/vtadmin/src/components/Code.module.scss
+++ b/web/vtadmin/src/components/Code.module.scss
@@ -31,7 +31,7 @@
     box-sizing: border-box;
     color: var(--textColorSecondary);
     font-family: var(--fontFamilyMonospace);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     line-height: 2.4rem;
     min-width: 5rem;
     padding: 0 1.2rem;
@@ -48,7 +48,7 @@
 
 .code {
     font-family: var(--fontFamilyMonospace);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     line-height: 2.4rem;
     padding: 0 1.2rem;
     tab-size: 8;

--- a/web/vtadmin/src/components/TextInput.module.scss
+++ b/web/vtadmin/src/components/TextInput.module.scss
@@ -34,7 +34,7 @@ $iconPositionHorizontalLarge: 1.6rem;
     }
 
     &.large {
-        font-size: var(--fontSizeLarge);
+        font-size: theme('fontSize.lg');
         height: var(--inputHeightLarge);
         line-height: var(--inputHeightLarge);
         padding: 0 16px;

--- a/web/vtadmin/src/components/charts/charts.scss
+++ b/web/vtadmin/src/components/charts/charts.scss
@@ -62,7 +62,7 @@ $colors: #8187ff #b17ff5 #d676e5 #f26fd1 #ff6bbb #ff6ca3 #ff738c #ff7e75 #ff8c60
 .highcharts-loading-inner {
     color: var(--textColorSecondary);
     font-family: var(--fontFamilyPrimary);
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     font-weight: 500;
 }
 

--- a/web/vtadmin/src/components/inputs/Select.module.scss
+++ b/web/vtadmin/src/components/inputs/Select.module.scss
@@ -56,7 +56,7 @@
 }
 
 .large .toggle {
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     height: var(--inputHeightLarge);
     min-width: 24rem;
     padding: 0 16px;
@@ -107,7 +107,7 @@
 }
 
 .large .menu li {
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     min-width: 24rem;
     padding: 8px 16px;
 }
@@ -137,7 +137,7 @@
 }
 
 .large .clear {
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     padding: 8px 16px;
 }
 

--- a/web/vtadmin/src/components/layout/WorkspaceTitle.module.scss
+++ b/web/vtadmin/src/components/layout/WorkspaceTitle.module.scss
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 h1.title {
-    font-size: var(--fontSizeHeading2);
+    font-size: theme('fontSize.2xl');
     margin: 0;
 }

--- a/web/vtadmin/src/components/routes/Backups.tsx
+++ b/web/vtadmin/src/components/routes/Backups.tsx
@@ -70,13 +70,13 @@ export const Backups = () => {
                 <tr key={`${row.clusterID}-${row.directory}-${row.name}`}>
                     <DataCell>
                         {formatDateTime(row.time)}
-                        <div className="font-size-small text-secondary">{formatRelativeTime(row.time)}</div>
+                        <div className="text-sm text-secondary">{formatRelativeTime(row.time)}</div>
                     </DataCell>
                     <DataCell>
                         <ShardLink clusterID={row.clusterID} keyspace={row.keyspace} shard={row.shard}>
                             {row.directory}
                         </ShardLink>
-                        <div className="font-size-small text-secondary">{row.clusterName}</div>
+                        <div className="text-sm text-secondary">{row.clusterName}</div>
                     </DataCell>
                     <DataCell>{row.name}</DataCell>
                     <DataCell>

--- a/web/vtadmin/src/components/routes/Debug.tsx
+++ b/web/vtadmin/src/components/routes/Debug.tsx
@@ -47,6 +47,62 @@ export const Debug = () => {
                 </section>
 
                 <section>
+                    <h3 className="mt-12 mb-8">Typography</h3>
+
+                    <div className="my-16">
+                        <p className="text-sm">The quick brown fox ...</p>
+                        <p className="text-base">The quick brown fox ...</p>
+                        <p className="text-lg">The quick brown fox ...</p>
+                        <p className="text-xl">The quick brown fox ...</p>
+                        <p className="text-2xl">The quick brown fox ...</p>
+                        <p className="text-3xl">The quick brown fox ...</p>
+                    </div>
+
+                    <div className="my-16">
+                        <p className="text-sm font-mono">The quick brown fox ...</p>
+                        <p className="text-base font-mono">The quick brown fox ...</p>
+                        <p className="text-lg font-mono">The quick brown fox ...</p>
+                        <p className="text-xl font-mono">The quick brown fox ...</p>
+                        <p className="text-2xl font-mono">The quick brown fox ...</p>
+                        <p className="text-3xl font-mono">The quick brown fox ...</p>
+                    </div>
+
+                    <div className="max-w-prose my-16">
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in facilisis libero, eget
+                            congue lorem. Nulla non ligula eget erat aliquam lacinia a eget felis. Nulla turpis sapien,
+                            ultricies sit amet suscipit quis, auctor id risus. Donec pellentesque tellus metus, in
+                            eleifend lacus euismod eget. Vestibulum vehicula ut metus id vestibulum. Nam vulputate
+                            sapien sit amet tempor efficitur. Donec dictum tellus nec leo fringilla, eu tempor neque
+                            posuere. Integer porta, velit quis interdum ultricies, quam enim suscipit eros, quis ornare
+                            metus ante vitae est. Sed quis dignissim justo, at ultrices urna. Suspendisse gravida,
+                            tortor sed semper tristique, erat metus vulputate augue, quis tempor mi nisi vitae magna.
+                            Donec auctor fermentum magna, ut feugiat odio tincidunt sit amet. Donec accumsan lorem mi,
+                            ut placerat ex lacinia vel. Nullam ut magna feugiat, ornare nibh vel, tincidunt nisi. Fusce
+                            tincidunt malesuada posuere.
+                        </p>
+
+                        <p>
+                            Cras elementum lacinia tristique. Vestibulum nec sem sit amet velit lobortis accumsan ut
+                            eget lacus. Nulla eros ipsum, pellentesque sed vehicula id, pulvinar ut dolor. Proin
+                            facilisis ligula vel faucibus iaculis. Donec venenatis massa lorem, sed tempus libero
+                            vulputate nec. Vestibulum semper nibh id tortor dapibus, a pellentesque libero porttitor.
+                            Pellentesque id elit nulla. Duis congue hendrerit rhoncus. Vivamus accumsan tincidunt augue
+                            in sollicitudin. Cras sed augue eget elit semper interdum tristique at ligula. Aliquam vel
+                            pretium sem. Donec egestas nisi blandit congue pretium.
+                        </p>
+
+                        <p>
+                            Duis vulputate blandit ante nec bibendum. Duis ipsum augue, tempus et viverra et, ultricies
+                            ac sapien. Nullam vel laoreet turpis, in convallis eros. Suspendisse sit amet magna turpis.
+                            Curabitur mi risus, facilisis vel fringilla ut, facilisis nec tortor. Mauris rutrum vehicula
+                            justo ac dapibus. Sed aliquam, eros non bibendum sodales, mauris est iaculis dui, ut
+                            tristique nibh sapien ac sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        </p>
+                    </div>
+                </section>
+
+                <section>
                     <h3 className="mt-12 mb-8">Tabs</h3>
 
                     <TabContainer className={style.tabContainer} size="small">

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -50,7 +50,7 @@ export const Gates = () => {
             <tr key={idx}>
                 <DataCell className="whitespace-nowrap">
                     <div>{gate.pool}</div>
-                    <div className="font-size-small text-secondary">{gate.cluster}</div>
+                    <div className="text-sm text-secondary">{gate.cluster}</div>
                 </DataCell>
                 <DataCell className="whitespace-nowrap">{gate.hostname}</DataCell>
                 <DataCell className="whitespace-nowrap">{gate.cell}</DataCell>

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -58,7 +58,7 @@ export const Keyspaces = () => {
                 <DataCell>
                     <KeyspaceLink clusterID={row.clusterID} name={row.name}>
                         <div className="font-bold">{row.name}</div>
-                        <div className="font-size-small text-secondary">{row.cluster}</div>
+                        <div className="text-sm text-secondary">{row.cluster}</div>
                     </KeyspaceLink>
                 </DataCell>
                 <DataCell>

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -91,13 +91,13 @@ export const Schemas = () => {
                     <DataCell>
                         <KeyspaceLink clusterID={row.clusterID} name={row.keyspace}>
                             <div>{row.keyspace}</div>
-                            <div className="font-size-small text-secondary">{row.cluster}</div>
+                            <div className="text-sm text-secondary">{row.cluster}</div>
                         </KeyspaceLink>
                     </DataCell>
                     <DataCell className="font-bold">{href ? <Link to={href}>{row.table}</Link> : row.table}</DataCell>
                     <DataCell className="text-right">
                         <div>{formatBytes(row._raw.tableSize?.data_length)}</div>
-                        <div className="font-size-small text-secondary">
+                        <div className="text-sm text-secondary">
                             {formatBytes(row._raw.tableSize?.data_length, 'B')}
                         </div>
                     </DataCell>

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -53,7 +53,7 @@ export const Tablets = () => {
                     <DataCell>
                         <KeyspaceLink clusterID={t._raw.cluster?.id} name={t.keyspace}>
                             <div>{t.keyspace}</div>
-                            <div className="font-size-small text-secondary">{t.cluster}</div>
+                            <div className="text-sm text-secondary">{t.cluster}</div>
                         </KeyspaceLink>
                     </DataCell>
                     <DataCell>
@@ -65,7 +65,7 @@ export const Tablets = () => {
                         >
                             <ShardServingPip isLoading={ksQuery.isLoading} isServing={t.isShardServing} /> {t.shard}
                             {ksQuery.isSuccess && (
-                                <div className="font-size-small text-secondary whitespace-nowrap">
+                                <div className="text-sm text-secondary whitespace-nowrap">
                                     {!t.isShardServing && 'NOT SERVING'}
                                 </div>
                             )}

--- a/web/vtadmin/src/components/routes/Vtctlds.tsx
+++ b/web/vtadmin/src/components/routes/Vtctlds.tsx
@@ -59,7 +59,7 @@ export const Vtctlds = () => {
                     </DataCell>
                     <DataCell>
                         {row.cluster}
-                        <div className="font-size-small text-secondary">{row.clusterID}</div>
+                        <div className="text-sm text-secondary">{row.clusterID}</div>
                     </DataCell>
                 </tr>
             );

--- a/web/vtadmin/src/components/routes/Workflows.module.scss
+++ b/web/vtadmin/src/components/routes/Workflows.module.scss
@@ -15,7 +15,7 @@
  */
 .shardList {
     color: var(--textColorSecondary);
-    font-size: var(--fontSizeSmall);
+    font-size: theme('fontSize.sm');
     max-width: 20rem;
     padding-right: 24px;
 }

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -67,7 +67,7 @@ export const Workflows = () => {
                 <tr key={idx}>
                     <DataCell>
                         <div className="font-bold">{href ? <Link to={href}>{row.name}</Link> : row.name}</div>
-                        <div className="font-size-small text-secondary">{row.clusterName}</div>
+                        <div className="text-sm text-secondary">{row.clusterName}</div>
                     </DataCell>
                     <DataCell>
                         {row.source ? (
@@ -125,9 +125,7 @@ export const Workflows = () => {
 
                     <DataCell>
                         <div className="font-sans whitespace-nowrap">{formatDateTime(row.timeUpdated)}</div>
-                        <div className="font-sans font-size-small text-secondary">
-                            {formatRelativeTime(row.timeUpdated)}
-                        </div>
+                        <div className="font-sans text-sm text-secondary">{formatRelativeTime(row.timeUpdated)}</div>
                     </DataCell>
                 </tr>
             );

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.module.scss
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.module.scss
@@ -37,7 +37,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     justify-content: center;
     margin: 25vh auto;
     max-width: 720px;

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -131,7 +131,7 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
                                     <TabletLink alias={row.primaryAlias} clusterID={keyspace?.cluster?.id}>
                                         <TabletServingPip state={row._primaryTablet.state} /> {row.primaryAlias}
                                     </TabletLink>
-                                    <div className="font-size-small text-secondary">{row.primaryHostname}</div>
+                                    <div className="text-sm text-secondary">{row.primaryHostname}</div>
                                 </div>
                             ) : (
                                 <span className="text-secondary">No primary tablet</span>

--- a/web/vtadmin/src/components/routes/schema/Schema.module.scss
+++ b/web/vtadmin/src/components/routes/schema/Schema.module.scss
@@ -72,7 +72,7 @@
     color: var(--colorPrimary);
     cursor: default;
     display: inline-block;
-    font-size: var(--fontSizeSmall);
+    font-size: theme('fontSize.sm');
     margin: 0 12px;
     padding: 4px 8px;
     text-transform: uppercase;

--- a/web/vtadmin/src/components/routes/schema/Schema.module.scss
+++ b/web/vtadmin/src/components/routes/schema/Schema.module.scss
@@ -50,7 +50,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     justify-content: center;
     margin: 25vh auto;
     max-width: 720px;

--- a/web/vtadmin/src/components/routes/schema/Schema.tsx
+++ b/web/vtadmin/src/components/routes/schema/Schema.tsx
@@ -165,7 +165,7 @@ export const Schema = () => {
                                                                 </div>
                                                             ))
                                                         ) : (
-                                                            <span className="font-size-small text-secondary">N/A</span>
+                                                            <span className="text-sm text-secondary">N/A</span>
                                                         )}
                                                     </td>
                                                 </tr>

--- a/web/vtadmin/src/components/routes/shard/Shard.module.scss
+++ b/web/vtadmin/src/components/routes/shard/Shard.module.scss
@@ -37,7 +37,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     justify-content: center;
     margin: 25vh auto;
     max-width: 720px;

--- a/web/vtadmin/src/components/routes/shard/ShardTablets.module.scss
+++ b/web/vtadmin/src/components/routes/shard/ShardTablets.module.scss
@@ -15,7 +15,7 @@
  */
 .placeholder {
     color: var(--textColorSecondary);
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     padding: 10vh 2.4rem;
     text-align: center;
 }

--- a/web/vtadmin/src/components/routes/tablet/Tablet.module.scss
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.module.scss
@@ -37,7 +37,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    font-size: var(--fontSizeLarge);
+    font-size: theme('fontSize.lg');
     justify-content: center;
     margin: 25vh auto;
     max-width: 720px;

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -68,7 +68,7 @@ export const WorkflowStreams = ({ clusterID, keyspace, name }: Props) => {
                         <Link className="font-bold" to={href}>
                             {row.key}
                         </Link>
-                        <div className="font-size-small text-secondary">
+                        <div className="text-sm text-secondary">
                             Updated {formatDateTime(row.time_updated?.seconds)}
                         </div>
                     </DataCell>

--- a/web/vtadmin/src/components/tabs/TabContainer.module.scss
+++ b/web/vtadmin/src/components/tabs/TabContainer.module.scss
@@ -23,7 +23,7 @@
     position: relative;
 
     &.small {
-        font-size: var(--fontSizeSmall);
+        font-size: theme('fontSize.sm');
     }
 
     &.large {

--- a/web/vtadmin/src/components/tabs/TabContainer.module.scss
+++ b/web/vtadmin/src/components/tabs/TabContainer.module.scss
@@ -27,7 +27,7 @@
     }
 
     &.large {
-        font-size: var(--fontSizeLarge);
+        font-size: theme('fontSize.lg');
     }
 
     &::after {

--- a/web/vtadmin/src/components/tooltip/Tooltip.module.scss
+++ b/web/vtadmin/src/components/tooltip/Tooltip.module.scss
@@ -18,7 +18,7 @@
     border-radius: 4px;
     color: var(--textColorInverted);
     font-family: var(--fontFamilyPrimary);
-    font-size: var(--fontSizeSmall);
+    font-size: theme('fontSize.sm');
     margin: 8px;
     max-width: 24rem;
     padding: 8px 12px;

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -44,7 +44,6 @@
     --fontFamilyMonospace: theme('fontFamily.mono');
 
     /* Body text */
-    --fontSizeLarge: 1.6rem;
     --fontSizeSmall: 1.2rem;
     --lineHeightBody: 1.36;
 

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -44,7 +44,6 @@
     --fontFamilyMonospace: theme('fontFamily.mono');
 
     /* Body text */
-    --fontSizeDefault: 1.4rem;
     --fontSizeLarge: 1.6rem;
     --fontSizeSmall: 1.2rem;
     --lineHeightBody: 1.36;
@@ -129,7 +128,7 @@ html {
 body {
     background: var(--backgroundPrimary);
     color: var(--textColorPrimary);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     line-height: var(--lineHeightBody);
     margin: 0;
     font-family: var(--fontFamilyPrimary);
@@ -189,7 +188,7 @@ table {
 table caption {
     background: var(--backgroundSecondary);
     color: var(--textColorPrimary);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     font-weight: 500;
     padding: 1.2rem var(--tableCellPadding) 0.8rem var(--tableCellPadding);
     text-align: left;
@@ -200,7 +199,7 @@ table th {
     border: solid 1px var(--backgroundSecondary);
     border-bottom-color: var(--tableBorderColor);
     color: var(--textColorSecondary);
-    font-size: var(--fontSizeDefault);
+    font-size: theme('fontSize.base');
     font-weight: 500;
     padding: 8px var(--tableCellPadding);
     text-align: left;

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -44,7 +44,6 @@
     --fontFamilyMonospace: theme('fontFamily.mono');
 
     /* Body text */
-    --fontSizeSmall: 1.2rem;
     --lineHeightBody: 1.36;
 
     /* Headings */

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -47,9 +47,6 @@
     --lineHeightBody: 1.36;
 
     /* Headings */
-    --fontSizeHeading1: 3.6rem;
-    --fontSizeHeading2: 2.8rem;
-    --fontSizeHeading3: 2rem;
     --lineHeightHeading: 1.36;
 
     /* Inputs + other form controls */
@@ -137,21 +134,21 @@ body {
 /* Typography */
 h1 {
     color: var(--textColorPrimary);
-    font-size: var(--fontSizeHeading1);
+    font-size: theme('fontSize.3xl');
     font-weight: 700;
     line-height: var(--lineHeightHeading);
 }
 
 h2 {
     color: var(--textColorPrimary);
-    font-size: var(--fontSizeHeading2);
+    font-size: theme('fontSize.2xl');
     font-weight: 700;
     line-height: var(--lineHeightHeading);
 }
 
 h3 {
     color: var(--textColorPrimary);
-    font-size: var(--fontSizeHeading3);
+    font-size: theme('fontSize.xl');
     font-weight: 700;
     line-height: var(--lineHeightHeading);
 }

--- a/web/vtadmin/src/index.css
+++ b/web/vtadmin/src/index.css
@@ -219,8 +219,3 @@ table tbody td {
 table tbody td[rowSpan] {
     border-right: solid 1px var(--tableBorderColor);
 }
-
-/* One-liner utilities */
-.font-size-small {
-    font-size: var(--fontSizeSmall);
-}

--- a/web/vtadmin/tailwind.config.js
+++ b/web/vtadmin/tailwind.config.js
@@ -25,6 +25,14 @@ module.exports = {
                 'sans-serif',
             ],
         },
+        fontSize: {
+            sm: '1.2rem',
+            base: '1.4rem',
+            lg: '1.6rem',
+            xl: '2rem',
+            '2xl': '2.8rem',
+            '3xl': '3.6rem',
+        },
     },
     variants: {
         extend: {},

--- a/web/vtadmin/tailwind.config.js
+++ b/web/vtadmin/tailwind.config.js
@@ -25,6 +25,8 @@ module.exports = {
                 'sans-serif',
             ],
         },
+        // Presently, we use a 1rem = 10px basis, which diverges from
+        // tailwind's (or, more specifically, most browsers') 16px default basis.
         fontSize: {
             sm: '1.2rem',
             base: '1.4rem',


### PR DESCRIPTION
## Description

This consolidates all of our font sizing variables into the tailwind.config.js file. Since we use a 10px basis, as opposed to the tailwind/browser default of 16px, our font scale differs from [the tailwind docs](https://tailwindcss.com/docs/font-size), hence the overrides. (This will also make it 1000x easier to adjust font sizes if we do ever decide to change the rem basis.) 

Also added some lorem ipsum to the /debug page until we get Storybook set up. 

## Related Issue(s)

- #9215 

## Checklist
- [ ] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A