### PR TITLE
Estimate replica lag when seconds behind from mysqld is unknown

### DIFF
--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -19,12 +19,14 @@ package mysql
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
 	"context"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
 )
@@ -315,7 +317,11 @@ func parseReplicationStatus(fields map[string]string) ReplicationStatus {
 	status.SourcePort = int(parseInt)
 	parseInt, _ = strconv.ParseInt(fields["Connect_Retry"], 10, 0)
 	status.ConnectRetry = int(parseInt)
-	parseUint, _ := strconv.ParseUint(fields["Seconds_Behind_Master"], 10, 0)
+	parseUint, err := strconv.ParseUint(fields["Seconds_Behind_Master"], 10, 0)
+	if err != nil {
+		log.Errorf("Could not compute replica lag from seconds_behind_master value of '%s', this means that replication is unhealthy; setting replica lag to max value to prevent the serving of queries", fields["Seconds_Behind_Master"])
+		parseUint = math.MaxUint32
+	}
 	status.ReplicationLagSeconds = uint(parseUint)
 	parseUint, _ = strconv.ParseUint(fields["Master_Server_Id"], 10, 0)
 	status.SourceServerID = uint(parseUint)

--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -31,7 +31,7 @@ type ReplicationStatus struct {
 	// However, some MySQL flavors don't expose this information,
 	// in which case RelayLogPosition.IsZero() will be true.
 	// If ReplicationLagUnknown is true then we should not rely on the seconds
-	// behind value and we can instead try to calcuate the lag ourselves when
+	// behind value and we can instead try to calculate the lag ourselves when
 	// appropriate.
 	RelayLogPosition      Position
 	FilePosition          Position

--- a/go/mysql/replication_status.go
+++ b/go/mysql/replication_status.go
@@ -30,6 +30,9 @@ type ReplicationStatus struct {
 	// were to finish executing everything that's currently in its relay log.
 	// However, some MySQL flavors don't expose this information,
 	// in which case RelayLogPosition.IsZero() will be true.
+	// If ReplicationLagUnknown is true then we should not rely on the seconds
+	// behind value and we can instead try to calcuate the lag ourselves when
+	// appropriate.
 	RelayLogPosition      Position
 	FilePosition          Position
 	FileRelayLogPosition  Position
@@ -37,6 +40,7 @@ type ReplicationStatus struct {
 	IOThreadRunning       bool
 	SQLThreadRunning      bool
 	ReplicationLagSeconds uint
+	ReplicationLagUnknown bool
 	SourceHost            string
 	SourcePort            int
 	ConnectRetry          int

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -50,6 +50,7 @@ var (
 	username                         = "vt_dba"
 	cell                             = "zone1"
 	tabletHealthcheckRefreshInterval = 5 * time.Second
+	tabletUnhealthyThreshold         = tabletHealthcheckRefreshInterval * 2
 	sqlSchema                        = `
 	create table t1(
 		id bigint,
@@ -94,13 +95,17 @@ func TestMain(m *testing.M) {
 		}
 
 		// List of users authorized to execute vschema ddl operations
-		clusterInstance.VtGateExtraArgs = []string{"-vschema_ddl_authorized_users=%"}
+		clusterInstance.VtGateExtraArgs = []string{
+			"-vschema_ddl_authorized_users=%",
+			"-discovery_low_replication_lag", tabletUnhealthyThreshold.String(),
+		}
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"-lock_tables_timeout", "5s",
 			"-watch_replication_stream",
 			"-enable_replication_reporter",
 			"-health_check_interval", tabletHealthcheckRefreshInterval.String(),
+			"-unhealthy_threshold", tabletUnhealthyThreshold.String(),
 		}
 		// We do not need semiSync for this test case.
 		clusterInstance.EnableSemiSync = false

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -35,21 +35,22 @@ import (
 )
 
 var (
-	clusterInstance     *cluster.LocalProcessCluster
-	tmClient            *tmc.Client
-	primaryTabletParams mysql.ConnParams
-	replicaTabletParams mysql.ConnParams
-	primaryTablet       cluster.Vttablet
-	replicaTablet       cluster.Vttablet
-	rdonlyTablet        cluster.Vttablet
-	hostname            = "localhost"
-	keyspaceName        = "ks"
-	shardName           = "0"
-	keyspaceShard       = "ks/" + shardName
-	dbName              = "vt_" + keyspaceName
-	username            = "vt_dba"
-	cell                = "zone1"
-	sqlSchema           = `
+	clusterInstance                  *cluster.LocalProcessCluster
+	tmClient                         *tmc.Client
+	primaryTabletParams              mysql.ConnParams
+	replicaTabletParams              mysql.ConnParams
+	primaryTablet                    cluster.Vttablet
+	replicaTablet                    cluster.Vttablet
+	rdonlyTablet                     cluster.Vttablet
+	hostname                         = "localhost"
+	keyspaceName                     = "ks"
+	shardName                        = "0"
+	keyspaceShard                    = "ks/" + shardName
+	dbName                           = "vt_" + keyspaceName
+	username                         = "vt_dba"
+	cell                             = "zone1"
+	tabletHealthcheckRefreshInterval = 5 * time.Second
+	sqlSchema                        = `
 	create table t1(
 		id bigint,
 		value varchar(16),
@@ -99,6 +100,7 @@ func TestMain(m *testing.M) {
 			"-lock_tables_timeout", "5s",
 			"-watch_replication_stream",
 			"-enable_replication_reporter",
+			"-health_check_interval", tabletHealthcheckRefreshInterval.String(),
 		}
 		// We do not need semiSync for this test case.
 		clusterInstance.EnableSemiSync = false

--- a/go/test/endtoend/tabletmanager/tablet_health_test.go
+++ b/go/test/endtoend/tabletmanager/tablet_health_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -134,7 +135,7 @@ func TestHealthCheck(t *testing.T) {
 	// make sure the health stream is updated
 	result, err := clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "-count", "1", rTablet.Alias)
 	require.NoError(t, err)
-	verifyStreamHealth(t, result)
+	verifyStreamHealth(t, result, true)
 
 	// then restart replication, make sure we stay healthy
 	err = clusterInstance.VtctlclientProcess.ExecuteCommand("StartReplication", rTablet.Alias)
@@ -148,7 +149,47 @@ func TestHealthCheck(t *testing.T) {
 	require.NoError(t, err)
 	scanner := bufio.NewScanner(strings.NewReader(result))
 	for scanner.Scan() {
-		verifyStreamHealth(t, scanner.Text())
+		verifyStreamHealth(t, scanner.Text(), true)
+	}
+
+	// stop the replica's source mysqld instance to break replication
+	// and test that the tablet becomes unhealthy and non-serving
+	err = primaryTablet.MysqlctlProcess.Stop()
+	require.NoError(t, err)
+
+	time.Sleep(tabletHealthcheckRefreshInterval)
+
+	// now the replica's VtTabletStreamHealth should show it as unhealthy
+	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "-count", "1", rTablet.Alias)
+	require.NoError(t, err)
+	scanner = bufio.NewScanner(strings.NewReader(result))
+	for scanner.Scan() {
+		verifyStreamHealth(t, scanner.Text(), false)
+	}
+
+	// start the primary tablet's mysqld back up
+	primaryTablet.MysqlctlProcess.InitMysql = false
+	err = primaryTablet.MysqlctlProcess.Start()
+	primaryTablet.MysqlctlProcess.InitMysql = true
+	require.NoError(t, err)
+
+	// explicitly start replication on all of the replicas to avoid any test flakiness as they were all
+	// replicating from the primary instance
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("StartReplication", rTablet.Alias)
+	require.NoError(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("StartReplication", replicaTablet.Alias)
+	require.NoError(t, err)
+	err = clusterInstance.VtctlclientProcess.ExecuteCommand("StartReplication", rdonlyTablet.Alias)
+	require.NoError(t, err)
+
+	time.Sleep(tabletHealthcheckRefreshInterval)
+
+	// now the replica's VtTabletStreamHealth should show it as healthy again
+	result, err = clusterInstance.VtctlclientProcess.ExecuteCommandWithOutput("VtTabletStreamHealth", "-count", "1", rTablet.Alias)
+	require.NoError(t, err)
+	scanner = bufio.NewScanner(strings.NewReader(result))
+	for scanner.Scan() {
+		verifyStreamHealth(t, scanner.Text(), true)
 	}
 
 	// Manual cleanup of processes
@@ -183,7 +224,7 @@ func checkTabletType(t *testing.T, tabletAlias string, typeWant string) {
 	assert.Equal(t, want, got)
 }
 
-func verifyStreamHealth(t *testing.T, result string) {
+func verifyStreamHealth(t *testing.T, result string, expectHealthy bool) {
 	var streamHealthResponse querypb.StreamHealthResponse
 	err := json2.Unmarshal([]byte(result), &streamHealthResponse)
 	require.NoError(t, err)
@@ -191,10 +232,15 @@ func verifyStreamHealth(t *testing.T, result string) {
 	UID := streamHealthResponse.GetTabletAlias().GetUid()
 	realTimeStats := streamHealthResponse.GetRealtimeStats()
 	replicationLagSeconds := realTimeStats.GetReplicationLagSeconds()
-	assert.True(t, serving, "Tablet should be in serving state")
 	assert.True(t, UID > 0, "Tablet should contain uid")
-	// replicationLagSeconds varies till 7200 so setting safe limit
-	assert.True(t, replicationLagSeconds < 10000, "replica should not be behind primary")
+	if expectHealthy {
+		assert.True(t, serving, "Tablet should be in serving state")
+		// replicationLagSeconds varies till 7200 so setting safe limit
+		assert.True(t, replicationLagSeconds < 10000, "replica should not be behind primary")
+	} else {
+		assert.False(t, serving, "Tablet should not be in serving state")
+		assert.False(t, replicationLagSeconds < 10000, "replica should be behind primary")
+	}
 }
 
 func TestHealthCheckDrainedStateDoesNotShutdownQueryService(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -50,7 +50,12 @@ func (p *poller) Status() (time.Duration, error) {
 		return 0, err
 	}
 
-	if !status.ReplicationRunning() {
+	// If replication is not currently running or we don't know what the lag is -- most commonly
+	// because the replica mysqld is in the process of trying to start replicating from its source
+	// but it hasn't yet reached the point where it can calculate the seconds_behind_master
+	// value and it's thus NULL -- then we will estimate the lag ourselves using the last seen
+	// value + the time elapsed since.
+	if !status.ReplicationRunning() || status.ReplicationLagUnknown {
 		if p.timeRecorded.IsZero() {
 			return 0, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "replication is not running")
 		}


### PR DESCRIPTION
## Description
When mysqld tells us that [`seconds_behind_master`](https://dev.mysql.com/doc/refman/5.7/en/show-slave-status.html) is unknown (`NULL`) — or we get back any other value that cannot be converted to a uint — let's estimate the replication lag seconds value ([`seconds_behind_master` itself is fuzzy](https://dev.mysql.com/doc/refman/5.7/en/replication-administration-status.html)) in vttablet's healthcheck stats using the last seen value and the time elapsed since. This gives us the most accurate estimate possible of the replica lag when the replica cannot talk to its source and is constantly retrying and in a state where `Slave_IO_Running` == `Connecting`, [which we consider to be equivalent to running](https://github.com/vitessio/vitess/blob/5c7ee04b64ecf2cbe7b7430091f7e14d16f39723/go/mysql/flavor.go#L308-L313) as reconnects happen regularly anyway e.g. due to [`slave_net_timeout`](https://dev.mysql.com/doc/refman/5.7/en/replication-options-replica.html#sysvar_slave_net_timeout), and allows us to correctly support the defined [`-unhealthy_threshold`](https://vitess.io/docs/reference/programs/vttablet/) behavior for the replica tablet — preventing us from serving queries from a replica that may have very stale data.

With these changes, the results of [the test here](https://github.com/vitessio/vitess/issues/9307#issue-1067845996) seem to be expected and correct:
```
vitess@fb5036c15bc9:/vt/local$ for i in {1..5}; do
>   echo -n "mysqld says:"
>   command mysql -u root --socket=/vt/vtdataroot/vt_0000000101/mysql.sock -e "show slave status\G" | grep Seconds | cut -d: -f2
>   echo -n "vttablet says: "
>   curl -s localhost:15101/debug/status_details | jq -r '.[1].Value'
>   echo
>   sleep 5
> done
mysqld says: 0
vttablet says: 0s

mysqld says: NULL
vttablet says: 5s

mysqld says: NULL
vttablet says: 10s

mysqld says: NULL
vttablet says: 15s

mysqld says: NULL
vttablet says: 20s


vitess@fb5036c15bc9:/vt/local$ mysql commerce/0@replica -e "select * from customer"
ERROR 1105 (HY000) at line 1: target: commerce.0.replica: no healthy tablet available for 'keyspace:"commerce" shard:"0" tablet_type:REPLICA'

vitess@fb5036c15bc9:/vt/local$ curl -s localhost:15101/debug/status_details
[
 {
  "Key": "Current State",
  "Class": "healthy",
  "Value": "REPLICA: Serving"
 },
 {
  "Key": "Replication Lag",
  "Class": "unhealthy",
  "Value": "25s"
 }
]

vitess@fb5036c15bc9:/vt/local$ mysql -e "show vitess_tablets"
+-------+----------+-------+------------+-------------+------------------+--------------+----------------------+
| Cell  | Keyspace | Shard | TabletType | State       | Alias            | Hostname     | PrimaryTermStartTime |
+-------+----------+-------+------------+-------------+------------------+--------------+----------------------+
| zone1 | commerce | 0     | PRIMARY    | NOT_SERVING | zone1-0000000100 | fb5036c15bc9 | 2021-12-03T01:10:04Z |
| zone1 | commerce | 0     | REPLICA    | NOT_SERVING | zone1-0000000101 | fb5036c15bc9 |                      |
| zone1 | commerce | 0     | RDONLY     | SERVING     | zone1-0000000102 | fb5036c15bc9 |                      |
+-------+----------+-------+------------+-------------+------------------+--------------+----------------------+
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 - Fixes: https://github.com/vitessio/vitess/issues/9307

## Checklist
- [x] Should this PR be backported? NO
- [x] Tests were added
- [x] Documentation is not required (**_[I don't think?](https://github.com/vitessio/vitess/pull/9308#issuecomment-985178985)_**)
