### PR TITLE
Change default for super_read_only to true

### DIFF
--- a/config/mycnf/mysql57.cnf
+++ b/config/mycnf/mysql57.cnf
@@ -12,6 +12,9 @@ relay_log_info_repository = TABLE
 relay_log_purge = 1
 relay_log_recovery = 1
 
+# we should never need super privileges
+super-read-only
+
 # In MySQL 5.7 the default charset is latin1
 
 character_set_server = utf8

--- a/config/mycnf/mysql80.cnf
+++ b/config/mycnf/mysql80.cnf
@@ -11,6 +11,9 @@ binlog_expire_logs_seconds = 259200
 # disable mysqlx
 mysqlx = 0
 
+# we should never need super privileges
+super-read-only
+
 # 8.0 changes the default auth-plugin to caching_sha2_password
 default_authentication_plugin = mysql_native_password
 

--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -4,6 +4,11 @@
 
 ## Major Changes
 
+### vttablet -use_super_read_only flag now defaults to true
+The default value used to be false. What this means is that during a failover, we will set `super_read_only` on database flavors that support them (MySQL 5.7+ and Percona 5.7+).
+In addition, all Vitess-managed databases will be started with `super-read-only` in the cnf file.
+It is expected that this change is safe and backwards-compatible. Anyone who is relying on the current behavior should pass -use_super_read_only=false on the vttablet command line, and make sure they are using a custom my.cnf instead of the one provided as the default by Vitess.
+
 ### ddl_strategy: -postpone-completion flag
 
 `ddl_strategy` (either `@@ddl_strategy` in VtGate or `-ddl_strategy` in `vtctl ApplySchema`) supports the flag `-postpone-completion`

--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -7,7 +7,7 @@
 ### vttablet -use_super_read_only flag now defaults to true
 The default value used to be false. What this means is that during a failover, we will set `super_read_only` on database flavors that support them (MySQL 5.7+ and Percona 5.7+).
 In addition, all Vitess-managed databases will be started with `super-read-only` in the cnf file.
-It is expected that this change is safe and backwards-compatible. Anyone who is relying on the current behavior should pass -use_super_read_only=false on the vttablet command line, and make sure they are using a custom my.cnf instead of the one provided as the default by Vitess.
+It is expected that this change is safe and backwards-compatible. Anyone who is relying on the current behavior should pass `-use_super_read_only=false` on the vttablet command line, and make sure they are using a custom my.cnf instead of the one provided as the default by Vitess.
 
 ### ddl_strategy: -postpone-completion flag
 

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,8 +59,6 @@ const (
 const (
 	// replicationStartDeadline is the deadline for starting replication
 	replicationStartDeadline = 30
-
-	Error1193 = "Unknown system variable"
 )
 
 var (
@@ -343,8 +342,8 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 	// This is safe, since we're restarting MySQL after the restore anyway
 	params.Logger.Infof("Restore: disabling super_read_only")
 	if err := params.Mysqld.SetSuperReadOnly(false); err != nil {
-		if strings.Contains(err.Error(), Error1193) {
-			params.Logger.Warningf("Restore: server does not know about super_read_only; maybe MariaDB? Continuing anyway.")
+		if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
+			params.Logger.Warningf("Restore: server does not know about super_read_only, continuing anyway...")
 		} else {
 			params.Logger.Errorf("Restore: unexpected error while trying to set super_read_only: %v", err)
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -433,7 +433,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		// Setting super_read_only also sets read_only
 		if err := tm.MysqlDaemon.SetSuperReadOnly(true); err != nil {
 			if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
-				log.Warningf("server does not know about super_read_only; maybe MariaDB? Continuing anyway.")
+				log.Warningf("server does not know about super_read_only, continuing anyway...")
 			} else {
 				return nil, err
 			}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -19,6 +19,7 @@ package tabletmanager
 import (
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,7 +40,7 @@ import (
 
 var (
 	enableSemiSync   = flag.Bool("enable_semi_sync", false, "Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack).")
-	setSuperReadOnly = flag.Bool("use_super_read_only", false, "Set super_read_only flag when performing planned failover.")
+	setSuperReadOnly = flag.Bool("use_super_read_only", true, "Set super_read_only flag when performing planned failover.")
 )
 
 // ReplicationStatus returns the replication status
@@ -431,7 +432,11 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	if *setSuperReadOnly {
 		// Setting super_read_only also sets read_only
 		if err := tm.MysqlDaemon.SetSuperReadOnly(true); err != nil {
-			return nil, err
+			if strings.Contains(err.Error(), strconv.Itoa(mysql.ERUnknownSystemVariable)) {
+				log.Warningf("server does not know about super_read_only; maybe MariaDB? Continuing anyway.")
+			} else {
+				return nil, err
+			}
 		}
 	} else {
 		if err := tm.MysqlDaemon.SetReadOnly(true); err != nil {

--- a/go/vt/vttablet/tabletmanager/shard_sync.go
+++ b/go/vt/vttablet/tabletmanager/shard_sync.go
@@ -114,10 +114,10 @@ func (tm *TabletManager) shardSyncLoop(ctx context.Context, notifyChan <-chan st
 			}
 			if shouldDemote {
 				// Someone updated the PrimaryTermStartTime while we still think we're primary.
-				// This means that we should abort our term, since someone else must have claimed primaryship
+				// This means that we should end our term, since someone else must have claimed primaryship
 				// and wrote to the shard record
 				if err := tm.endPrimaryTerm(ctx, primaryAlias); err != nil {
-					log.Errorf("Failed to abort primary term: %v", err)
+					log.Errorf("Failed to end primary term: %v", err)
 					// Start retry timer and go back to sleep.
 					retryChan = time.After(*shardSyncRetryDelay)
 					continue


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
While looking into #9290 we discovered that the heartbeat writer was creating errant transactions during a failover (PlannedReparent). While we need to fix that properly, it has been suggested that we should run with `super_read_only` on MySQL versions that support it.
This PR does two things.
- change default for use_super_read_only to true
- set super-read-only in cnf files

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#9290 

## Checklist
- [ ] Should this PR be backported? NO
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required - needs to be added in website docs

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
It is expected that this change is safe and backwards-compatible. Anyone who is relying on the current behavior should pass `-use_super_read_only=false` on the vttablet command line, and make sure they are using a custom my.cnf instead of the one provided as the default by Vitess.