### PR TITLE
Fuzzing: Disable logging for mysql fuzzers

### DIFF
--- a/go/test/fuzzing/oss_fuzz_build.sh
+++ b/go/test/fuzzing/oss_fuzz_build.sh
@@ -22,6 +22,10 @@ set -x
 go get github.com/AdaLogics/go-fuzz-headers
 go mod vendor
 
+# Disable logging for mysql conn
+# This affects the mysql fuzzers
+sed -i '/log.Errorf/c\\/\/log.Errorf' $SRC/vitess/go/mysql/conn.go
+
 mv ./go/vt/vttablet/tabletmanager/vreplication/framework_test.go \
    ./go/vt/vttablet/tabletmanager/vreplication/framework_fuzz.go
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The mysql fuzzers print out lots of error messages. This disables the `Errorf` logging.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->