### PR TITLE
Re-enable default Make behavior of failing target if any command fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ e2e_test_cluster: build
 
 .ONESHELL:
 SHELL = /bin/bash
+.SHELLFLAGS = -ec
 
 # Run the following tests after making worker changes.
 worker_test:


### PR DESCRIPTION
Signed-off-by: John Watson <johnw@planetscale.com>

## Description
With `.ONESHELL` enabled in the Makefile, it disables the default behavior of failing targets if any command fails. As the default is only `.SHELLFLAGS = -c`.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->