### PR TITLE
Schema Engine: fix to account for  Online DDL swapped tables 

### DIFF
--- a/go/vt/topo/vschema.go
+++ b/go/vt/topo/vschema.go
@@ -48,7 +48,7 @@ func (ts *Server) SaveVSchema(ctx context.Context, keyspace string, vschema *vsc
 	if err != nil {
 		log.Errorf("failed to update vschema for keyspace %s: %v", keyspace, err)
 	} else {
-		log.Infof("successfully updated vschema for keyspace %s: %v", keyspace, data)
+		log.Infof("successfully updated vschema for keyspace %s: %+v", keyspace, vschema)
 	}
 	return err
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -188,6 +188,7 @@ func addTablet(id int) *topodatapb.Tablet {
 	if err := env.TopoServ.CreateTablet(context.Background(), tablet); err != nil {
 		panic(err)
 	}
+	env.SchemaEngine.Reload(context.Background())
 	return tablet
 }
 
@@ -208,6 +209,7 @@ func addOtherTablet(id int, keyspace, shard string) *topodatapb.Tablet {
 	if err := env.TopoServ.CreateTablet(context.Background(), tablet); err != nil {
 		panic(err)
 	}
+	env.SchemaEngine.Reload(context.Background())
 	return tablet
 }
 
@@ -215,6 +217,7 @@ func deleteTablet(tablet *topodatapb.Tablet) {
 	env.TopoServ.DeleteTablet(context.Background(), tablet.Alias)
 	// This is not automatically removed from shard replication, which results in log spam.
 	topo.DeleteTabletReplicationData(context.Background(), env.TopoServ, tablet)
+	env.SchemaEngine.Reload(context.Background())
 }
 
 // fakeTabletConn implement TabletConn interface. We only care about the

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -61,6 +61,7 @@ type Engine struct {
 	mu         sync.Mutex
 	isOpen     bool
 	tables     map[string]*Table
+	lastChange int64
 	reloadTime time.Duration
 	//the position at which the schema was last loaded. it is only used in conjunction with ReloadAt
 	reloadAtPos mysql.Position
@@ -234,6 +235,7 @@ func (se *Engine) Close() {
 	se.conns.Close()
 
 	se.tables = make(map[string]*Table)
+	se.lastChange = 0
 	se.notifiers = make(map[string]notifier)
 	se.isOpen = false
 	log.Info("Schema Engine: closed")
@@ -301,6 +303,11 @@ func (se *Engine) reload(ctx context.Context) error {
 	}
 	defer conn.Recycle()
 
+	// curTime will be saved into lastChange after schema is loaded.
+	curTime, err := se.mysqlTime(ctx, conn)
+	if err != nil {
+		return err
+	}
 	// if this flag is set, then we don't need table meta information
 	if se.SkipMetaCheck {
 		return nil
@@ -336,7 +343,7 @@ func (se *Engine) reload(ctx context.Context) error {
 		// TODO(sougou); find a better way detect changed tables. This method
 		// seems unreliable. The endtoend test flags all tables as changed.
 		tbl, isInTablesMap := se.tables[tableName]
-		if isInTablesMap && createTime == tbl.CreateTime {
+		if isInTablesMap && createTime == tbl.CreateTime && !(createTime >= se.lastChange) {
 			tbl.FileSize = fileSize
 			tbl.AllocatedSize = allocatedSize
 			continue
@@ -384,6 +391,7 @@ func (se *Engine) reload(ctx context.Context) error {
 	for k, t := range changedTables {
 		se.tables[k] = t
 	}
+	se.lastChange = curTime
 	if len(created) > 0 || len(altered) > 0 || len(dropped) > 0 {
 		log.Infof("schema engine created %v, altered %v, dropped %v", created, altered, dropped)
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -61,7 +61,6 @@ type Engine struct {
 	mu         sync.Mutex
 	isOpen     bool
 	tables     map[string]*Table
-	lastChange int64
 	reloadTime time.Duration
 	//the position at which the schema was last loaded. it is only used in conjunction with ReloadAt
 	reloadAtPos mysql.Position
@@ -235,7 +234,6 @@ func (se *Engine) Close() {
 	se.conns.Close()
 
 	se.tables = make(map[string]*Table)
-	se.lastChange = 0
 	se.notifiers = make(map[string]notifier)
 	se.isOpen = false
 	log.Info("Schema Engine: closed")
@@ -303,11 +301,6 @@ func (se *Engine) reload(ctx context.Context) error {
 	}
 	defer conn.Recycle()
 
-	// curTime will be saved into lastChange after schema is loaded.
-	curTime, err := se.mysqlTime(ctx, conn)
-	if err != nil {
-		return err
-	}
 	// if this flag is set, then we don't need table meta information
 	if se.SkipMetaCheck {
 		return nil
@@ -343,7 +336,7 @@ func (se *Engine) reload(ctx context.Context) error {
 		// TODO(sougou); find a better way detect changed tables. This method
 		// seems unreliable. The endtoend test flags all tables as changed.
 		tbl, isInTablesMap := se.tables[tableName]
-		if isInTablesMap && createTime < se.lastChange {
+		if isInTablesMap && createTime == tbl.CreateTime {
 			tbl.FileSize = fileSize
 			tbl.AllocatedSize = allocatedSize
 			continue
@@ -357,6 +350,7 @@ func (se *Engine) reload(ctx context.Context) error {
 		}
 		table.FileSize = fileSize
 		table.AllocatedSize = allocatedSize
+		table.CreateTime = createTime
 		changedTables[tableName] = table
 		if isInTablesMap {
 			altered = append(altered, tableName)
@@ -386,11 +380,10 @@ func (se *Engine) reload(ctx context.Context) error {
 		return err
 	}
 
-	// Update se.tables and se.lastChange
+	// Update se.tables
 	for k, t := range changedTables {
 		se.tables[k] = t
 	}
-	se.lastChange = curTime
 	if len(created) > 0 || len(altered) > 0 || len(dropped) > 0 {
 		log.Infof("schema engine created %v, altered %v, dropped %v", created, altered, dropped)
 	}

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -340,10 +340,18 @@ func (se *Engine) reload(ctx context.Context) error {
 		se.tableFileSizeGauge.Set(tableName, int64(fileSize))
 		se.tableAllocatedSizeGauge.Set(tableName, int64(allocatedSize))
 
-		// TODO(sougou); find a better way detect changed tables. This method
-		// seems unreliable. The endtoend test flags all tables as changed.
+		// Table schemas are cached by tabletserver. For each table we cache `information_schema.tables.create_time` (`tbl.CreateTime`).
+		// We also record the last time the schema was loaded (`se.lastChange`). Both are in seconds. We reload a table only when:
+		//   1. A table's underlying mysql metadata has changed: `se.lastChange >= createTime`. This can happen if a table was directly altered.
+		//      Note that we also reload if `se.lastChange == createTime` since it is possible, especially in unit tests,
+		//      that a table might be changed multiple times within the same second.
+		//
+		//   2. A table was swapped in by Online DDL: `createTime != tbl.CreateTime`. When an Online DDL migration is completed the temporary table is
+		//      renamed to the table being altered. `se.lastChange` is updated every time the schema is reloaded (default: 30m).
+		//      Online DDL can take hours. So it is possible that the `create_time` of the temporary table is before se.lastChange. Hence,
+		//      #1 will not identify the renamed table as a changed one.
 		tbl, isInTablesMap := se.tables[tableName]
-		if isInTablesMap && createTime == tbl.CreateTime && !(createTime >= se.lastChange) {
+		if isInTablesMap && createTime == tbl.CreateTime && createTime < se.lastChange {
 			tbl.FileSize = fileSize
 			tbl.AllocatedSize = allocatedSize
 			continue

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schema
 
 import (
+	"context"
 	"expvar"
 	"fmt"
 	"net/http"
@@ -27,8 +28,6 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/test/utils"
-
-	"context"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +69,12 @@ func TestOpenAndReload(t *testing.T) {
 			StatusFlags:         0,
 		})
 
+	// advance to one second after the default 1427325875.
+	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"t",
+		"int64"),
+		"1427325876",
+	))
 	firstReadRowsValue := 12
 	AddFakeInnoDBReadRowsResult(db, firstReadRowsValue)
 	se := newEngine(10, 10*time.Second, 10*time.Second, db)
@@ -80,6 +85,13 @@ func TestOpenAndReload(t *testing.T) {
 	mustMatch(t, want, se.GetSchema())
 	assert.Equal(t, int64(100), se.tableFileSizeGauge.Counts()["msg"])
 	assert.Equal(t, int64(150), se.tableAllocatedSizeGauge.Counts()["msg"])
+
+	// Advance time some more.
+	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"t",
+		"int64"),
+		"1427325877",
+	))
 	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Get())
 
 	// Modify test_table_03
@@ -265,6 +277,12 @@ func TestReloadWithSwappedTables(t *testing.T) {
 	mustMatch(t, want, se.GetSchema())
 
 	// Add test_table_04 with a newer timestamp
+	// Advance time some more.
+	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"t",
+		"int64"),
+		"1427325876",
+	))
 	db.ClearQueryPattern()
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
@@ -314,9 +332,16 @@ func TestReloadWithSwappedTables(t *testing.T) {
 		FileSize:      128,
 		AllocatedSize: 256,
 	}
-	assert.Equal(t, want, se.GetSchema())
+
+	mustMatch(t, want, se.GetSchema())
 
 	// swap test_table_03 and test_table_04
+	// Advance time some more.
+	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
+		"t",
+		"int64"),
+		"1427325877",
+	))
 	db.ClearQueryPattern()
 	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
 		Fields: mysql.BaseShowTablesFields,
@@ -386,7 +411,7 @@ func TestReloadWithSwappedTables(t *testing.T) {
 		FileSize:      100,
 		AllocatedSize: 150,
 	}
-	assert.Equal(t, want, se.GetSchema())
+	mustMatch(t, want, se.GetSchema())
 }
 
 func TestOpenFailedDueToExecErr(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -70,12 +70,6 @@ func TestOpenAndReload(t *testing.T) {
 			StatusFlags:         0,
 		})
 
-	// pre-advance to above the default 1427325875.
-	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-		"t",
-		"int64"),
-		"1427325876",
-	))
 	firstReadRowsValue := 12
 	AddFakeInnoDBReadRowsResult(db, firstReadRowsValue)
 	se := newEngine(10, 10*time.Second, 10*time.Second, db)
@@ -86,14 +80,8 @@ func TestOpenAndReload(t *testing.T) {
 	mustMatch(t, want, se.GetSchema())
 	assert.Equal(t, int64(100), se.tableFileSizeGauge.Counts()["msg"])
 	assert.Equal(t, int64(150), se.tableAllocatedSizeGauge.Counts()["msg"])
-
-	// Advance time some more.
-	db.AddQuery("select unix_timestamp()", sqltypes.MakeTestResult(sqltypes.MakeTestFields(
-		"t",
-		"int64"),
-		"1427325877",
-	))
 	assert.EqualValues(t, firstReadRowsValue, se.innoDbReadRowsGauge.Get())
+
 	// Modify test_table_03
 	// Add test_table_04
 	// Drop msg
@@ -106,7 +94,7 @@ func TestOpenAndReload(t *testing.T) {
 			{
 				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("test_table_03")), // table_name
 				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("BASE TABLE")),    // table_type
-				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1427325877")),      // unix_timestamp(t.create_time) // Match the timestamp.
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1427325877")),      // unix_timestamp(t.create_time)
 				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("")),              // table_comment
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("128")),             // file_size
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("256")),             // allocated_size
@@ -182,6 +170,7 @@ func TestOpenAndReload(t *testing.T) {
 			Type: sqltypes.Int32,
 		}},
 		PKColumns:     []int{0, 1},
+		CreateTime:    1427325877,
 		FileSize:      128,
 		AllocatedSize: 256,
 	}
@@ -192,6 +181,7 @@ func TestOpenAndReload(t *testing.T) {
 			Type: sqltypes.Int32,
 		}},
 		PKColumns:     []int{0},
+		CreateTime:    1427325875,
 		FileSize:      100,
 		AllocatedSize: 150,
 	}
@@ -221,7 +211,6 @@ func TestOpenAndReload(t *testing.T) {
 		Rows: [][]sqltypes.Value{
 			mysql.BaseShowTablesRow("test_table_01", false, ""),
 			mysql.BaseShowTablesRow("test_table_02", false, ""),
-			// test_table_04 will in spite of older timestamp because it doesn't exist yet.
 			mysql.BaseShowTablesRow("test_table_04", false, ""),
 			mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
 		},
@@ -245,65 +234,159 @@ func TestOpenAndReload(t *testing.T) {
 	assert.Equal(t, want, se.GetSchema())
 }
 
-func TestOpenFailedDueToMissMySQLTime(t *testing.T) {
+func TestReloadWithSwappedTables(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	db.AddQuery("select unix_timestamp()", &sqltypes.Result{
-		// Make this query fail by returning 2 values.
-		Fields: []*querypb.Field{
-			{Type: sqltypes.Uint64},
-		},
-		Rows: [][]sqltypes.Value{
-			{sqltypes.NewVarBinary("1427325875")},
-			{sqltypes.NewVarBinary("1427325875")},
-		},
-	})
-	se := newEngine(10, 1*time.Second, 1*time.Second, db)
-	err := se.Open()
-	want := "could not get MySQL time"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("se.Open: %v, want %s", err, want)
+	for query, result := range schematest.Queries() {
+		db.AddQuery(query, result)
 	}
-}
+	db.AddQueryPattern(baseShowTablesPattern,
+		&sqltypes.Result{
+			Fields:       mysql.BaseShowTablesFields,
+			RowsAffected: 0,
+			InsertID:     0,
+			Rows: [][]sqltypes.Value{
+				mysql.BaseShowTablesRow("test_table_01", false, ""),
+				mysql.BaseShowTablesRow("test_table_02", false, ""),
+				mysql.BaseShowTablesRow("test_table_03", false, ""),
+				mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
+				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
+			},
+			SessionStateChanges: "",
+			StatusFlags:         0,
+		})
+	firstReadRowsValue := 12
+	AddFakeInnoDBReadRowsResult(db, firstReadRowsValue)
 
-func TestOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
-	db := fakesqldb.New(t)
-	defer db.Close()
-	db.AddQuery("select unix_timestamp()", &sqltypes.Result{
-		Fields: []*querypb.Field{{
-			Type: sqltypes.Uint64,
-		}},
-		Rows: [][]sqltypes.Value{
-			// make this query fail by returning NULL
-			{sqltypes.NULL},
-		},
-	})
-	se := newEngine(10, 1*time.Second, 1*time.Second, db)
-	err := se.Open()
-	want := "unexpected result for MySQL time"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("se.Open: %v, want %s", err, want)
-	}
-}
+	se := newEngine(10, 10*time.Second, 10*time.Second, db)
+	se.Open()
+	defer se.Close()
+	want := initialSchema()
+	mustMatch(t, want, se.GetSchema())
 
-func TestOpenFailedDueToInvalidTimeFormat(t *testing.T) {
-	db := fakesqldb.New(t)
-	defer db.Close()
-	db.AddQuery("select unix_timestamp()", &sqltypes.Result{
-		Fields: []*querypb.Field{{
-			Type: sqltypes.VarChar,
-		}},
+	// Add test_table_04 with a newer timestamp
+	db.ClearQueryPattern()
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
 		Rows: [][]sqltypes.Value{
-			// make safety check fail, invalid time format
-			{sqltypes.NewVarBinary("invalid_time")},
+			mysql.BaseShowTablesRow("test_table_01", false, ""),
+			mysql.BaseShowTablesRow("test_table_02", false, ""),
+			mysql.BaseShowTablesRow("test_table_03", false, ""),
+			{
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("test_table_04")),
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("BASE TABLE")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1427325877")), // unix_timestamp(create_time)
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("128")), // file_size
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("256")), // allocated_size
+			},
+			mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
+			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 		},
 	})
-	se := newEngine(10, 1*time.Second, 1*time.Second, db)
-	err := se.Open()
-	want := "could not parse time"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("se.Open: %v, want %s", err, want)
+	db.AddQuery("select * from test_table_04 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "mypk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
+		Fields: mysql.ShowPrimaryFields,
+		Rows: [][]sqltypes.Value{
+			mysql.ShowPrimaryRow("test_table_01", "pk"),
+			mysql.ShowPrimaryRow("test_table_02", "pk"),
+			mysql.ShowPrimaryRow("test_table_03", "pk"),
+			mysql.ShowPrimaryRow("test_table_04", "mypk"),
+			mysql.ShowPrimaryRow("seq", "id"),
+			mysql.ShowPrimaryRow("msg", "id"),
+		},
+	})
+	err := se.Reload(context.Background())
+	require.NoError(t, err)
+	want["test_table_04"] = &Table{
+		Name: sqlparser.NewTableIdent("test_table_04"),
+		Fields: []*querypb.Field{{
+			Name: "mypk",
+			Type: sqltypes.Int32,
+		}},
+		PKColumns:     []int{0},
+		CreateTime:    1427325877,
+		FileSize:      128,
+		AllocatedSize: 256,
 	}
+	assert.Equal(t, want, se.GetSchema())
+
+	// swap test_table_03 and test_table_04
+	db.ClearQueryPattern()
+	db.AddQueryPattern(baseShowTablesPattern, &sqltypes.Result{
+		Fields: mysql.BaseShowTablesFields,
+		Rows: [][]sqltypes.Value{
+			mysql.BaseShowTablesRow("test_table_01", false, ""),
+			mysql.BaseShowTablesRow("test_table_02", false, ""),
+			{
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("test_table_03")),
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("BASE TABLE")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1427325877")), // unix_timestamp(create_time)
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("128")), // file_size
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("256")), // allocated_size
+			},
+			mysql.BaseShowTablesRow("test_table_04", false, ""),
+			mysql.BaseShowTablesRow("seq", false, "vitess_sequence"),
+			mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
+		},
+	})
+	db.AddQuery("select * from test_table_03 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "mypk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQuery("select * from test_table_04 where 1 != 1", &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}},
+	})
+	db.AddQuery(mysql.BaseShowPrimary, &sqltypes.Result{
+		Fields: mysql.ShowPrimaryFields,
+		Rows: [][]sqltypes.Value{
+			mysql.ShowPrimaryRow("test_table_01", "pk"),
+			mysql.ShowPrimaryRow("test_table_02", "pk"),
+			mysql.ShowPrimaryRow("test_table_03", "mypk"),
+			mysql.ShowPrimaryRow("test_table_04", "pk"),
+			mysql.ShowPrimaryRow("seq", "id"),
+			mysql.ShowPrimaryRow("msg", "id"),
+		},
+	})
+	err = se.Reload(context.Background())
+	require.NoError(t, err)
+
+	delete(want, "test_table_03")
+	delete(want, "test_table_04")
+	want["test_table_03"] = &Table{
+		Name: sqlparser.NewTableIdent("test_table_03"),
+		Fields: []*querypb.Field{{
+			Name: "mypk",
+			Type: sqltypes.Int32,
+		}},
+		PKColumns:     []int{0},
+		CreateTime:    1427325877,
+		FileSize:      128,
+		AllocatedSize: 256,
+	}
+	want["test_table_04"] = &Table{
+		Name: sqlparser.NewTableIdent("test_table_04"),
+		Fields: []*querypb.Field{{
+			Name: "pk",
+			Type: sqltypes.Int32,
+		}},
+		PKColumns:     []int{0},
+		CreateTime:    1427325875,
+		FileSize:      100,
+		AllocatedSize: 150,
+	}
+	assert.Equal(t, want, se.GetSchema())
 }
 
 func TestOpenFailedDueToExecErr(t *testing.T) {
@@ -413,6 +496,7 @@ func initialSchema() map[string]*Table {
 				Type: sqltypes.Int32,
 			}},
 			PKColumns:     []int{0},
+			CreateTime:    1427325875,
 			FileSize:      0x64,
 			AllocatedSize: 0x96,
 		},
@@ -423,6 +507,7 @@ func initialSchema() map[string]*Table {
 				Type: sqltypes.Int32,
 			}},
 			PKColumns:     []int{0},
+			CreateTime:    1427325875,
 			FileSize:      0x64,
 			AllocatedSize: 0x96,
 		},
@@ -433,6 +518,7 @@ func initialSchema() map[string]*Table {
 				Type: sqltypes.Int32,
 			}},
 			PKColumns:     []int{0},
+			CreateTime:    1427325875,
 			FileSize:      0x64,
 			AllocatedSize: 0x96,
 		},
@@ -453,6 +539,7 @@ func initialSchema() map[string]*Table {
 				Type: sqltypes.Int64,
 			}},
 			PKColumns:     []int{0},
+			CreateTime:    1427325875,
 			FileSize:      0x64,
 			AllocatedSize: 0x96,
 			SequenceInfo:  &SequenceInfo{},
@@ -480,6 +567,7 @@ func initialSchema() map[string]*Table {
 				Type: sqltypes.Int64,
 			}},
 			PKColumns:     []int{0},
+			CreateTime:    1427325875,
 			FileSize:      0x64,
 			AllocatedSize: 0x96,
 			MessageInfo: &MessageInfo{

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -53,6 +53,7 @@ type Table struct {
 	// MessageInfo contains info for message tables.
 	MessageInfo *MessageInfo
 
+	CreateTime    int64
 	FileSize      uint64
 	AllocatedSize uint64
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -234,6 +234,7 @@ func TestStreamRowsKeyRange(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.se.Reload(context.Background())
 
 	if err := env.SetVSchema(shardedVSchema); err != nil {
 		t.Fatal(err)

--- a/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/testenv/testenv.go
@@ -137,5 +137,6 @@ func (te *Env) SetVSchema(vs string) error {
 	if err := te.TopoServ.SaveVSchema(ctx, te.KeyspaceName, &kspb); err != nil {
 		return err
 	}
+	te.SchemaEngine.Reload(ctx)
 	return te.TopoServ.RebuildSrvVSchema(ctx, te.Cells)
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/uvstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/uvstreamer_flaky_test.go
@@ -171,6 +171,7 @@ func TestVStreamCopyCompleteFlow(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	engine.se.Reload(context.Background())
 
 	defer execStatements(t, []string{
 		"drop table t1",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_flaky_test.go
@@ -172,6 +172,7 @@ func TestSetStatement(t *testing.T) {
 		log.Info("Cannot test SetStatement on this flavor")
 		return
 	}
+	engine.se.Reload(context.Background())
 
 	execStatements(t, []string{
 		"create table t1(id int, val varbinary(128), primary key(id))",
@@ -317,6 +318,7 @@ func TestMissingTables(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.se.Reload(context.Background())
 	execStatements(t, []string{
 		"create table t1(id11 int, id12 int, primary key(id11))",
 		"create table shortlived(id31 int, id32 int, primary key(id31))",
@@ -626,6 +628,7 @@ func TestFilteredInt(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.se.Reload(context.Background())
 
 	execStatements(t, []string{
 		"create table t1(id1 int, id2 int, val varbinary(128), primary key(id1))",
@@ -807,6 +810,7 @@ func TestStatements(t *testing.T) {
 		in.Flavor = "FilePos"
 		return in
 	})
+
 	defer engine.Close()
 	runCases(t, nil, testcases, "current", nil)
 }
@@ -1025,6 +1029,8 @@ func TestInKeyRangeMultiColumn(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.watcherOnce.Do(engine.setWatch)
+	engine.se.Reload(context.Background())
 
 	execStatements(t, []string{
 		"create table t1(region int, id int, val varbinary(128), primary key(id))",
@@ -1082,6 +1088,7 @@ func TestREMultiColumnVindex(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.watcherOnce.Do(engine.setWatch)
 
 	execStatements(t, []string{
 		"create table t1(region int, id int, val varbinary(128), primary key(id))",
@@ -1138,6 +1145,7 @@ func TestSelectFilter(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	engine.se.Reload(context.Background())
 
 	execStatements(t, []string{
 		"create table t1(id1 int, id2 int, val varbinary(128), primary key(id1))",
@@ -1255,7 +1263,7 @@ func TestDDLDropColumn(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-
+	env.SchemaEngine.Reload(context.Background())
 	execStatement(t, "create table ddl_test2(id int, val1 varbinary(128), val2 varbinary(128), primary key(id))")
 	defer execStatement(t, "drop table ddl_test2")
 
@@ -1268,6 +1276,7 @@ func TestDDLDropColumn(t *testing.T) {
 		"insert into ddl_test2 values(2, 'bbb')",
 	})
 	engine.se.Reload(context.Background())
+	env.SchemaEngine.Reload(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2009,6 +2018,7 @@ func runCases(t *testing.T, filter *binlogdatapb.Filter, testcases []testcase, p
 		default:
 			t.Fatalf("unexpected input: %#v", input)
 		}
+		engine.se.Reload(ctx)
 		expectLog(ctx, t, tcase.input, ch, tcase.output)
 	}
 
@@ -2197,6 +2207,7 @@ func setVSchema(t *testing.T, vschema string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if !updated {
+		log.Infof("vschema did not get updated")
 		t.Error("vschema did not get updated")
 	}
 }


### PR DESCRIPTION
## Description
This is based off of the external PR https://github.com/vitessio/vitess/pull/9306 to try to fix the failing tests

This PR addresses the following bug in schema engine reload process:
 * The schema engine depends on the `information_schema.tables create_time` field to tell when a table is updated. Unlike the name might indicate, this field is updated when a structural DDL is performed on a table (e.g. a column add/delete).
 * As an optimization, the schema engine keeps track of the last time it loaded (reloaded) the schema, and saves this timestamp (called `lastChange`).
 * When reloading schema, for each table we then check the `create_time` for that table against this saved timestamp, and if it's older, we skip examining the table further for changes.
 * Vitess online DDL swaps the tables, and a table swap does not affect the `create_time` timestamp for the table (it remains the original timestamp of when online DDL created the temporary table). If after this, but before the online DDL is done and the tables are swapped, a schema reload is run (in any of the various ways), we will record all the changes in schema at that point, and save the current time in the schema engine's `lastChange` field.
 * Now, after the online DDL completes, a schema reload is internally signaled:
   * For the table we are interested in (the one that was just DDL-ed), the `create_time` field is now older than the schema engine `lastChange` field. We therefore do not update the schema engine's view of this table's schema.

Changes:
 * Instead of keeping track of the `lastChange` time in schema engine, we track the `create_time` of every table explicitly. On a subsequent refresh, if we find the `create_time` of the table reported by MySQL differs from what we have cached in-memory, then we will assume the table has changed and reload its schema.
 * This will address the issue with tables being swapped during OnlineDDL without the `create_time` being modified.

## Related Issue(s)
Fixes #9287 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
