### PR TITLE
Multi column vindex support in select statement

### DIFF
--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -255,3 +255,24 @@ func TestHashJoin(t *testing.T) {
 	defer utils.Exec(t, conn, `set workload = oltp`)
 	utils.AssertMatches(t, conn, `select /*vt+ ALLOW_HASH_JOIN */ t1.id from t1 x join t1 where x.col = t1.col and x.id <= 3 and t1.id >= 3`, `[[INT64(3)]]`)
 }
+
+func TestMultiColumnVindex(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	defer utils.ExecAllowError(t, conn, `delete from user_region`)
+	utils.Exec(t, conn, `insert into user_region(id, cola, colb) values (1, 1, 2),(2, 30, 40),(3, 500, 600),(4, 30, 40),(5, 10000, 30000),(6, 422333, 40),(7, 30, 60)`)
+
+	for _, workload := range []string{"olap", "oltp"} {
+		t.Run(workload, func(t *testing.T) {
+			utils.Exec(t, conn, fmt.Sprintf(`set workload = %s`, workload))
+			utils.AssertMatches(t, conn, `select id from user_region where cola = 1 and colb = 2`, `[[INT64(1)]]`)
+			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb = 40 order by id`, `[[INT64(2)] [INT64(4)] [INT64(6)]]`)
+			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb in (40,60) order by id`, `[[INT64(2)] [INT64(4)] [INT64(6)] [INT64(7)]]`)
+			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb in (40,60) and cola = 422333`, `[[INT64(6)]]`)
+			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb in (40,60) and cola = 30 and colb = 60`, `[[INT64(7)]]`)
+		})
+	}
+}

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -52,6 +52,13 @@ create table t3(
 	tcol2 varchar(50),
 	primary key(id)
 ) Engine=InnoDB;
+
+create table user_region(
+	id bigint,
+	cola bigint,
+	colb bigint,
+	primary key(id)
+) Engine=InnoDB;
 `
 	unshardedSchemaSQL = `create table u_a(
 	id bigint,
@@ -72,6 +79,12 @@ create table u_b(
   "vindexes": {
     "xxhash": {
       "type": "xxhash"
+    },
+    "regional_vdx": {
+	  "type": "region_experimental",
+	  "params": {
+		"region_bytes": "1"
+	  }
     }
   },
   "tables": {
@@ -110,7 +123,15 @@ create table u_b(
           "type": "VARCHAR"
         }
       ]
-    }
+    },
+    "user_region": {
+	  "column_vindexes": [
+	    {
+          "columns": ["cola","colb"],
+		  "name": "regional_vdx"
+		}
+      ]
+	}
   }
 }`
 

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -662,13 +662,18 @@ func (cached *Route) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.TableName)))
 	// field FieldQuery string
 	size += hack.RuntimeAllocSize(int64(len(cached.FieldQuery)))
-	// field Vindex vitess.io/vitess/go/vt/vtgate/vindexes.SingleColumn
+	// field Vindex vitess.io/vitess/go/vt/vtgate/vindexes.Vindex
 	if cc, ok := cached.Vindex.(cachedObject); ok {
 		size += cc.CachedSize(true)
 	}
-	// field Value vitess.io/vitess/go/vt/vtgate/engine.RouteValue
-	if cc, ok := cached.Value.(cachedObject); ok {
-		size += cc.CachedSize(true)
+	// field Values []vitess.io/vitess/go/vt/vtgate/engine.RouteValue
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.Values)) * int64(16))
+		for _, elem := range cached.Values {
+			if cc, ok := elem.(cachedObject); ok {
+				size += cc.CachedSize(true)
+			}
+		}
 	}
 	// field OrderBy []vitess.io/vitess/go/vt/vtgate/engine.OrderByParams
 	{

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -88,6 +88,8 @@ type (
 		// Will replace all of the Topo functions.
 		ResolveDestinations(keyspace string, ids []*querypb.Value, destinations []key.Destination) ([]*srvtopo.ResolvedShard, [][]*querypb.Value, error)
 
+		ResolveDestinationsMultiCol(keyspace string, ids [][]sqltypes.Value, destinations []key.Destination) ([]*srvtopo.ResolvedShard, [][][]sqltypes.Value, error)
+
 		ExecuteVSchema(keyspace string, vschemaDDL *sqlparser.AlterVschema) error
 
 		SubmitOnlineDDL(onlineDDl *schema.OnlineDDL) error

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -695,10 +695,19 @@ func (route *Route) paramsSelectIn(vcursor VCursor, bindVars map[string]*querypb
 func (route *Route) paramsSelectInMultiCol(vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {
 	// gather values from all the column in the vindex
 	var multiColValues [][]sqltypes.Value
+	var err error
+	var lv []sqltypes.Value
 	for _, rvalue := range route.Values {
-		lv, err := rvalue.ResolveList(bindVars)
+		lv, err = rvalue.ResolveList(bindVars)
 		if err != nil {
 			return nil, nil, err
+		}
+		if lv == nil {
+			v, err := rvalue.ResolveValue(bindVars)
+			if err != nil {
+				return nil, nil, err
+			}
+			lv = []sqltypes.Value{v}
 		}
 		multiColValues = append(multiColValues, lv)
 	}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -651,12 +651,19 @@ func buildMultiColumnVindexValues(shardsValues [][][]sqltypes.Value) [][][]*quer
 		// cols = 2
 		cols := len(shardValues[0])
 		shardIds := make([][]*querypb.Value, cols)
+		colValSeen := make([]map[string]interface{}, cols)
 		for _, values := range shardValues {
 			for colIdx, value := range values {
+				if colValSeen[colIdx] == nil {
+					colValSeen[colIdx] = map[string]interface{}{}
+				}
+				if _, found := colValSeen[colIdx][value.String()]; found {
+					continue
+				}
 				shardIds[colIdx] = append(shardIds[colIdx], sqltypes.ValueToProto(value))
+				colValSeen[colIdx][value.String()] = nil
 			}
 		}
-		// TODO - Eliminate the duplicates in the shard values
 		shardsIds = append(shardsIds, shardIds)
 	}
 	return shardsIds

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -235,9 +235,9 @@ func TestSelectEqualUnique(t *testing.T) {
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
 
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralInt(1),
-	}
+	}}
 	vc := &loggingVCursor{
 		shards:  []string{"-20", "20-"},
 		results: []*sqltypes.Result{defaultSelectResult},
@@ -272,7 +272,7 @@ func TestSelectNone(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = nil
+	sel.Values = nil
 
 	vc := &loggingVCursor{
 		shards:  []string{"-20", "20-"},
@@ -307,9 +307,9 @@ func TestSelectEqualUniqueScatter(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralInt(1),
-	}
+	}}
 	vc := &loggingVCursor{
 		shards:       []string{"-20", "20-"},
 		shardForKsid: []string{"-20", "20-"},
@@ -349,9 +349,9 @@ func TestSelectEqual(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralInt(1),
-	}
+	}}
 	vc := &loggingVCursor{
 		shards: []string{"-20", "20-"},
 		results: []*sqltypes.Result{
@@ -402,9 +402,9 @@ func TestSelectEqualNoRoute(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralInt(1),
-	}
+	}}
 
 	vc := &loggingVCursor{shards: []string{"-20", "20-"}}
 	result, err := sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
@@ -437,13 +437,13 @@ func TestSelectINUnique(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.TupleExpr{
 			evalengine.NewLiteralInt(1),
 			evalengine.NewLiteralInt(2),
 			evalengine.NewLiteralInt(4),
 		},
-	}
+	}}
 	vc := &loggingVCursor{
 		shards:       []string{"-20", "20-"},
 		shardForKsid: []string{"-20", "-20", "20-"},
@@ -486,13 +486,13 @@ func TestSelectINNonUnique(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.TupleExpr{
 			evalengine.NewLiteralInt(1),
 			evalengine.NewLiteralInt(2),
 			evalengine.NewLiteralInt(4),
 		},
-	}
+	}}
 
 	fields := sqltypes.MakeTestFields(
 		"fromc|toc",
@@ -549,13 +549,13 @@ func TestSelectMultiEqual(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.TupleExpr{
 			evalengine.NewLiteralInt(1),
 			evalengine.NewLiteralInt(2),
 			evalengine.NewLiteralInt(4),
 		},
-	}
+	}}
 
 	vc := &loggingVCursor{
 		shards:       []string{"-20", "20-"},
@@ -600,9 +600,9 @@ func TestSelectLike(t *testing.T) {
 	)
 
 	sel.Vindex = vindex
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralString([]byte("a%"), collations.TypedCollation{}),
-	}
+	}}
 	// md5("a") = 0cc175b9c0f1b6a831c399e269772661
 	// keyspace id prefix for "a" is 0x0c
 	vc.shardForKsid = []string{"-0c80", "0c80-0d"}
@@ -630,9 +630,9 @@ func TestSelectLike(t *testing.T) {
 
 	vc.Rewind()
 
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralString([]byte("ab%"), collations.TypedCollation{}),
-	}
+	}}
 	// md5("b") = 92eb5ffee6ae2fec3ad71c777531578f
 	// keyspace id prefix for "ab" is 0x0c92
 	// adding one byte to the prefix just hit one shard
@@ -772,9 +772,9 @@ func TestRouteGetFields(t *testing.T) {
 		"dummy_select_field",
 	)
 	sel.Vindex = vindex.(vindexes.SingleColumn)
-	sel.Value = &evalengine.RouteValue{
+	sel.Values = []RouteValue{&evalengine.RouteValue{
 		Expr: evalengine.NewLiteralInt(1),
-	}
+	}}
 
 	vc := &loggingVCursor{shards: []string{"-20", "20-"}}
 	result, err := sel.TryExecute(vc, map[string]*querypb.BindVariable{}, true)

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -1424,16 +1424,16 @@ func TestSelectINMultiColumnVindex(t *testing.T) {
 	sel.Vindex = vindex
 	sel.Values = []RouteValue{
 		&evalengine.RouteValue{
-			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
-				func() evalengine.Expr { return evalengine.NewLiteralInt(1) },
-				func() evalengine.Expr { return evalengine.NewLiteralInt(2) },
-			}),
+			Expr: evalengine.NewTupleExpr(
+				evalengine.NewLiteralInt(1),
+				evalengine.NewLiteralInt(2),
+			),
 		},
 		&evalengine.RouteValue{
-			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
-				func() evalengine.Expr { return evalengine.NewLiteralInt(3) },
-				func() evalengine.Expr { return evalengine.NewLiteralInt(4) },
-			}),
+			Expr: evalengine.NewTupleExpr(
+				evalengine.NewLiteralInt(3),
+				evalengine.NewLiteralInt(4),
+			),
 		},
 	}
 
@@ -1477,10 +1477,10 @@ func TestSelectINMixedMultiColumnComparision(t *testing.T) {
 			Expr: evalengine.NewLiteralInt(1),
 		},
 		&evalengine.RouteValue{
-			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
-				func() evalengine.Expr { return evalengine.NewLiteralInt(3) },
-				func() evalengine.Expr { return evalengine.NewLiteralInt(4) },
-			}),
+			Expr: evalengine.NewTupleExpr(
+				evalengine.NewLiteralInt(3),
+				evalengine.NewLiteralInt(4),
+			),
 		},
 	}
 
@@ -1518,16 +1518,15 @@ func TestSelectMultiEqualMultiCol(t *testing.T) {
 	sel.Vindex = vindex
 	sel.Values = []RouteValue{
 		&evalengine.RouteValue{
-			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
-				func() evalengine.Expr { return evalengine.NewLiteralInt(1) },
-				func() evalengine.Expr { return evalengine.NewLiteralInt(3) },
-			}),
-		},
+			Expr: evalengine.NewTupleExpr(
+				evalengine.NewLiteralInt(1),
+				evalengine.NewLiteralInt(3),
+			)},
 		&evalengine.RouteValue{
-			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
-				func() evalengine.Expr { return evalengine.NewLiteralInt(2) },
-				func() evalengine.Expr { return evalengine.NewLiteralInt(4) },
-			}),
+			Expr: evalengine.NewTupleExpr(
+				evalengine.NewLiteralInt(2),
+				evalengine.NewLiteralInt(4),
+			),
 		},
 	}
 

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -285,7 +285,7 @@ func TestSelectEqualUniqueMultiColumnVindex(t *testing.T) {
 	result, err := sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
+		`ResolveDestinations ks [] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f)`,
 		`ExecuteMultiShard ks.-20: dummy_select {} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
@@ -294,7 +294,7 @@ func TestSelectEqualUniqueMultiColumnVindex(t *testing.T) {
 	result, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
-		`ResolveDestinations ks [type:INT64 value:"1"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
+		`ResolveDestinations ks [] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f)`,
 		`StreamExecuteMulti dummy_select ks.-20: {} `,
 	})
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -1493,7 +1493,7 @@ func TestSelectINMixedMultiColumnComparision(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(3)] [INT64(1) INT64(4)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(01d2fd8867d50d2dfe)`,
-		`ExecuteMultiShard ks.-20: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"4"}} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {__vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: dummy_select {__vals1: type:TUPLE values:{type:INT64 value:"4"}} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -1502,7 +1502,7 @@ func TestSelectINMixedMultiColumnComparision(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(3)] [INT64(1) INT64(4)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(01d2fd8867d50d2dfe)`,
-		`StreamExecuteMulti dummy_select ks.-20: {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"4"}} `,
+		`StreamExecuteMulti dummy_select ks.-20: {__vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: {__vals1: type:TUPLE values:{type:INT64 value:"4"}} `,
 	})
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -1446,7 +1446,7 @@ func TestSelectINMultiColumnVindex(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(3)] [INT64(1) INT64(4)] [INT64(2) INT64(3)] [INT64(2) INT64(4)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(01d2fd8867d50d2dfe),DestinationKeyspaceID(024eb190c9a2fa169c),DestinationKeyspaceID(02d2fd8867d50d2dfe)`,
-		`ExecuteMultiShard ks.-20: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"2"} __vals1: type:TUPLE values:{type:INT64 value:"4"} values:{type:INT64 value:"3"} values:{type:INT64 value:"4"}} false false`,
+		`ExecuteMultiShard ks.-20: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: dummy_select {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} __vals1: type:TUPLE values:{type:INT64 value:"4"} values:{type:INT64 value:"3"}} false false`,
 	})
 	expectResult(t, "sel.Execute", result, defaultSelectResult)
 
@@ -1455,7 +1455,7 @@ func TestSelectINMultiColumnVindex(t *testing.T) {
 	require.NoError(t, err)
 	vc.ExpectLog(t, []string{
 		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(3)] [INT64(1) INT64(4)] [INT64(2) INT64(3)] [INT64(2) INT64(4)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(01d2fd8867d50d2dfe),DestinationKeyspaceID(024eb190c9a2fa169c),DestinationKeyspaceID(02d2fd8867d50d2dfe)`,
-		`StreamExecuteMulti dummy_select ks.-20: {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} values:{type:INT64 value:"2"} __vals1: type:TUPLE values:{type:INT64 value:"4"} values:{type:INT64 value:"3"} values:{type:INT64 value:"4"}} `,
+		`StreamExecuteMulti dummy_select ks.-20: {__vals0: type:TUPLE values:{type:INT64 value:"1"} __vals1: type:TUPLE values:{type:INT64 value:"3"}} ks.20-: {__vals0: type:TUPLE values:{type:INT64 value:"1"} values:{type:INT64 value:"2"} __vals1: type:TUPLE values:{type:INT64 value:"4"} values:{type:INT64 value:"3"}} `,
 	})
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }
@@ -1556,7 +1556,7 @@ func TestBuildMultiColumnVindexValues(t *testing.T) {
 			output: [][][]*querypb.Value{{
 				{sqltypes.ValueToProto(sqltypes.NewInt64(10)), sqltypes.ValueToProto(sqltypes.NewInt64(20))},
 				{sqltypes.ValueToProto(sqltypes.NewInt64(10)), sqltypes.ValueToProto(sqltypes.NewInt64(20))},
-				{sqltypes.ValueToProto(sqltypes.NewInt64(1)), sqltypes.ValueToProto(sqltypes.NewInt64(1))},
+				{sqltypes.ValueToProto(sqltypes.NewInt64(1))},
 			},
 			},
 		},

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -1507,6 +1507,53 @@ func TestSelectINMixedMultiColumnComparision(t *testing.T) {
 	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
 }
 
+func TestSelectMultiEqualMultiCol(t *testing.T) {
+	vindex, _ := vindexes.NewRegionExperimental("", map[string]string{"region_bytes": "1"})
+	sel := NewRoute(
+		SelectMultiEqual,
+		&vindexes.Keyspace{Name: "ks", Sharded: true},
+		"dummy_select",
+		"dummy_select_field",
+	)
+	sel.Vindex = vindex
+	sel.Values = []RouteValue{
+		&evalengine.RouteValue{
+			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
+				func() evalengine.Expr { return evalengine.NewLiteralInt(1) },
+				func() evalengine.Expr { return evalengine.NewLiteralInt(3) },
+			}),
+		},
+		&evalengine.RouteValue{
+			Expr: evalengine.NewTupleExpr([]func() evalengine.Expr{
+				func() evalengine.Expr { return evalengine.NewLiteralInt(2) },
+				func() evalengine.Expr { return evalengine.NewLiteralInt(4) },
+			}),
+		},
+	}
+
+	vc := &loggingVCursor{
+		shards:       []string{"-20", "20-40", "40-"},
+		shardForKsid: []string{"-20", "40-"},
+		results:      []*sqltypes.Result{defaultSelectResult},
+	}
+	result, err := sel.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(2)] [INT64(3) INT64(4)]] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f),DestinationKeyspaceID(03d2fd8867d50d2dfe)`,
+		`ExecuteMultiShard ks.-20: dummy_select {} ks.40-: dummy_select {} false false`,
+	})
+	expectResult(t, "sel.Execute", result, defaultSelectResult)
+
+	vc.Rewind()
+	result, err = wrapStreamExecute(sel, vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol ks [[INT64(1) INT64(2)] [INT64(3) INT64(4)]] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f),DestinationKeyspaceID(03d2fd8867d50d2dfe)`,
+		`StreamExecuteMulti dummy_select ks.-20: {} ks.40-: {} `,
+	})
+	expectResult(t, "sel.StreamExecute", result, defaultSelectResult)
+}
+
 func TestBuildRowColValues(t *testing.T) {
 	out := buildRowColValues([][]sqltypes.Value{
 		{sqltypes.NewInt64(1), sqltypes.NewInt64(10)},

--- a/go/vt/vtgate/evalengine/expressions.go
+++ b/go/vt/vtgate/evalengine/expressions.go
@@ -265,12 +265,21 @@ func NewBindVar(key string, collation collations.TypedCollation) Expr {
 	}
 }
 
-// NewColumn returns a bind variable
+// NewColumn returns a column expression
 func NewColumn(offset int, collation collations.TypedCollation) Expr {
 	return &Column{
 		Offset:    offset,
 		collation: collation,
 	}
+}
+
+// NewTupleExpr returns a tuple expression
+func NewTupleExpr(funcs []func() Expr) Expr {
+	var tupleExpr TupleExpr
+	for _, f := range funcs {
+		tupleExpr = append(tupleExpr, f())
+	}
+	return tupleExpr
 }
 
 // Evaluate implements the Expr interface

--- a/go/vt/vtgate/evalengine/expressions.go
+++ b/go/vt/vtgate/evalengine/expressions.go
@@ -274,10 +274,10 @@ func NewColumn(offset int, collation collations.TypedCollation) Expr {
 }
 
 // NewTupleExpr returns a tuple expression
-func NewTupleExpr(funcs []func() Expr) Expr {
-	var tupleExpr TupleExpr
-	for _, f := range funcs {
-		tupleExpr = append(tupleExpr, f())
+func NewTupleExpr(exprs ...Expr) Expr {
+	tupleExpr := make(TupleExpr, 0, len(exprs))
+	for _, f := range exprs {
+		tupleExpr = append(tupleExpr, f)
 	}
 	return tupleExpr
 }

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -130,7 +130,13 @@ var executorVSchema = `
         		"to": "keyspace_id"
       		},
       		"owner": "t2_wo_lookup"
-    	}
+    	},
+		"regional_vdx": {
+			"type": "region_experimental",
+			"params": {
+				"region_bytes": "1"
+			}
+        }
 	},
 	"tables": {
 		"user": {
@@ -302,7 +308,15 @@ var executorVSchema = `
 				  	"name": "t2_lu_vdx"
 				}
             ]
-    	}
+    	},
+		"user_region": {
+			"column_vindexes": [
+				{
+					"columns": ["cola","colb"],
+					"name": "regional_vdx"
+				}
+			]
+		}
 	}
 }
 `

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -2767,8 +2767,8 @@ func TestGen4MultiColumnVindexIn(t *testing.T) {
 		query, map[string]*querypb.BindVariable{},
 	)
 	require.NoError(t, err)
-	bv1, _ := sqltypes.BuildBindVariable([]int64{1, 1, 1})
-	bv2, _ := sqltypes.BuildBindVariable([]int64{17984, 17984, 17984})
+	bv1, _ := sqltypes.BuildBindVariable([]int64{1})
+	bv2, _ := sqltypes.BuildBindVariable([]int64{17984})
 	bvtg1, _ := sqltypes.BuildBindVariable([]int64{1, 17984})
 	bvtg2, _ := sqltypes.BuildBindVariable([]int64{2, 3, 4})
 	wantQueries := []*querypb.BoundQuery{

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -860,6 +860,7 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestExecutor", "music_user_map", "lookup_hash_unique", "from=music_id; table=music_user_map; to=user_id", "music"),
 			buildVarCharRow("TestExecutor", "name_lastname_keyspace_id_map", "lookup", "from=name,lastname; table=name_lastname_keyspace_id_map; to=keyspace_id", "user2"),
 			buildVarCharRow("TestExecutor", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),
+			buildVarCharRow("TestExecutor", "regional_vdx", "region_experimental", "region_bytes=1", ""),
 			buildVarCharRow("TestExecutor", "t1_lkp_vdx", "consistent_lookup_unique", "from=unq_col; table=t1_lkp_idx; to=keyspace_id", "t1"),
 			buildVarCharRow("TestExecutor", "t2_lu_vdx", "lookup_hash_unique", "from=lu_col; table=TestUnsharded.lu_idx; to=keyspace_id", "t2_wo_lookup"),
 			buildVarCharRow("TestExecutor", "t2_wo_lu_vdx", "lookup_unique", "from=wo_lu_col; table=TestUnsharded.wo_lu_idx; to=keyspace_id; write_only=true", "t2_wo_lookup"),

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -261,8 +261,8 @@ func (pb *primitiveBuilder) buildTablePrimitive(tableExpr *sqlparser.AliasedTabl
 		// for keyspace id.
 		eroute = engine.NewSimpleRoute(engine.SelectEqualUnique, vschemaTable.Keyspace)
 		vindex, _ = vindexes.NewBinary("binary", nil)
-		eroute.Vindex, _ = vindex.(vindexes.SingleColumn)
-		eroute.Value = sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, vschemaTable.Pinned)}
+		eroute.Vindex = vindex
+		eroute.Values = []engine.RouteValue{sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.VarBinary, vschemaTable.Pinned)}}
 	}
 	eroute.TableName = sqlparser.String(vschemaTable.Name)
 	rb.eroute = eroute

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -666,7 +666,7 @@ func testFile(t *testing.T, filename, tempDir string, vschema *vschemaWrapper) {
 			testName := fmt.Sprintf("%d Gen4: %s", tcase.lineno, tcase.comments)
 			t.Run(testName, func(t *testing.T) {
 				if out != tcase.output2ndPlanner {
-					t.Errorf("Gen4 - %s:%d\nDiff:\n%s\n[%s] \n[%s]", filename, tcase.lineno, cmp.Diff(tcase.output2ndPlanner, out), tcase.output, out)
+					t.Errorf("Gen4 - %s:%d\nDiff:\n%s\n[%s] \n[%s]", filename, tcase.lineno, cmp.Diff(tcase.output2ndPlanner, out), tcase.output2ndPlanner, out)
 				}
 				if err != nil {
 					out = `"` + out + `"`

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -153,7 +153,7 @@ func (rb *route) ContainsTables() semantics.TableSet {
 // Wireup implements the logicalPlan interface
 func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 	// Precaution: update ERoute.Values only if it's not set already.
-	if rb.eroute.Value == nil {
+	if rb.eroute.Values == nil {
 		// Resolve values stored in the logical plan.
 		switch vals := rb.condition.(type) {
 		case *sqlparser.ComparisonExpr:
@@ -161,7 +161,7 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 			if err != nil {
 				return err
 			}
-			rb.eroute.Value = pv
+			rb.eroute.Values = []engine.RouteValue{pv}
 			vals.Right = sqlparser.ListArg(engine.ListVarName)
 		case nil:
 			// no-op.
@@ -170,7 +170,7 @@ func (rb *route) Wireup(plan logicalPlan, jt *jointab) error {
 			if err != nil {
 				return err
 			}
-			rb.eroute.Value = pv
+			rb.eroute.Values = []engine.RouteValue{pv}
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/routetree.go
+++ b/go/vt/vtgate/planbuilder/routetree.go
@@ -553,9 +553,9 @@ func (rp *routeTree) haveMatchingVindex(
 					continue
 				}
 				option.colsSeen[colLoweredName] = true
-				option.predicates = append(option.predicates, node)
 				option.valueExprs = append(option.valueExprs, valueExpr)
 				option.values[indexOfCol] = value
+				option.predicates[indexOfCol] = node
 				optionPresent = true
 				option.ready = len(option.colsSeen) == len(v.colVindex.Columns)
 			}
@@ -569,10 +569,12 @@ func (rp *routeTree) haveMatchingVindex(
 			vindex := vfunc(v.colVindex)
 			values := make([]evalengine.Expr, len(v.colVindex.Columns))
 			values[indexOfCol] = value
+			predicates := make([]sqlparser.Expr, len(v.colVindex.Columns))
+			predicates[indexOfCol] = node
 			v.options = append(v.options, &vindexOption{
 				values:      values,
 				valueExprs:  []sqlparser.Expr{valueExpr},
-				predicates:  []sqlparser.Expr{node},
+				predicates:  predicates,
 				colsSeen:    map[string]interface{}{colLoweredName: true},
 				opcode:      routeOpcode,
 				foundVindex: vindex,

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.txt
@@ -34,7 +34,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(*), col from `user` where 1 != 1",
     "Query": "select count(*), col from `user` where id = 1",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -51,7 +53,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(*), col from `user` where 1 != 1",
     "Query": "select count(*), col from `user` where id = 1",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -826,7 +830,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
     "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
     "Query": "select id, count(*) as c from `user` group by id having id = 1 and c = 10",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -843,7 +849,9 @@ Gen4 error: unsupported: '*' expression in cross-shard query
     "FieldQuery": "select id, count(*) as c from `user` where 1 != 1 group by id",
     "Query": "select id, count(*) as c from `user` where id = 1 group by id having c = 10",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1975,7 +1983,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.col1 as a from `user` where 1 != 1 group by a collate utf8_general_ci",
     "Query": "select `user`.col1 as a from `user` where `user`.id = 5 group by a collate utf8_general_ci",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1992,7 +2002,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.col1 as a from `user` where 1 != 1 group by a collate utf8_general_ci",
     "Query": "select `user`.col1 as a from `user` where `user`.id = 5 group by a collate utf8_general_ci",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2746,7 +2758,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from user_extra where 1 != 1",
         "Query": "select 1 from user_extra where user_id = 3 and user_id \u003c :user_id",
         "Table": "user_extra",
-        "Values": "INT64(3)",
+        "Values": [
+          "INT64(3)"
+        ],
         "Vindex": "user_index"
       }
     ]

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -51,7 +51,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = 5",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -68,7 +70,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = 5",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -103,7 +107,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = 5 + 5",
     "Table": "`user`",
-    "Values": "INT64(10)",
+    "Values": [
+      "INT64(10)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -123,7 +129,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where id = 5 and user_id = 4",
     "Table": "music",
-    "Values": 4,
+    "Values": [
+      4
+    ],
     "Vindex": "user_index"
   }
 }
@@ -140,7 +148,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where id = 5 and user_id = 4",
     "Table": "music",
-    "Values": "INT64(4)",
+    "Values": [
+      "INT64(4)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -160,7 +170,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'",
     "Table": "`user`",
-    "Values": "bb",
+    "Values": [
+      "bb"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -177,7 +189,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where costly = 'aa' and `name` = 'bb'",
     "Table": "`user`",
-    "Values": "VARBINARY(\"bb\")",
+    "Values": [
+      "VARBINARY(\"bb\")"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -198,8 +212,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where costly in ('aa', 'bb') and `name` in ::__vals",
     "Table": "`user`",
     "Values": [
-      "aa",
-      "bb"
+      [
+        "aa",
+        "bb"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -217,7 +233,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where costly in ('aa', 'bb') and `name` in ::__vals",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"aa\"), VARBINARY(\"bb\"))",
+    "Values": [
+      "(VARBINARY(\"aa\"), VARBINARY(\"bb\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -238,8 +256,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "aa",
-      "cc"
+      [
+        "aa",
+        "cc"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -257,7 +277,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (`name`, col) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"aa\"), VARBINARY(\"cc\"))",
+    "Values": [
+      "(VARBINARY(\"aa\"), VARBINARY(\"cc\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -278,8 +300,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (col, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "bb",
-      "dd"
+      [
+        "bb",
+        "dd"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -297,7 +321,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (col, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))",
+    "Values": [
+      "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -318,8 +344,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "bb",
-      "dd"
+      [
+        "bb",
+        "dd"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -337,7 +365,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))",
+    "Values": [
+      "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -358,8 +388,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (`name`, costly) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "aa",
-      "cc"
+      [
+        "aa",
+        "cc"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -377,7 +409,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (`name`, costly) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"aa\"), VARBINARY(\"cc\"))",
+    "Values": [
+      "(VARBINARY(\"aa\"), VARBINARY(\"cc\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -398,7 +432,9 @@ Gen4 plan same as above
     "Query": "select id from `user` where (col, costly) in (('aa', 'bb')) and (col, `name`) in (('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "dd"
+      [
+        "dd"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -416,7 +452,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (col, costly) in (('aa', 'bb')) and (col, `name`) in (('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"dd\"))",
+    "Values": [
+      "(VARBINARY(\"dd\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -436,7 +474,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (col, `name`) in (('aa', 'bb')) and id = 5",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -453,7 +493,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (col, `name`) in (('aa', 'bb')) and id = 5",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -474,8 +516,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
     "Values": [
-      "bb",
-      "dd"
+      [
+        "bb",
+        "dd"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -493,7 +537,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (costly, `name`) in (('aa', 'bb'), ('cc', 'dd'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))",
+    "Values": [
+      "(VARBINARY(\"bb\"), VARBINARY(\"dd\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -514,8 +560,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where ((col1, `name`), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
     "Table": "`user`",
     "Values": [
-      "bb",
-      "ee"
+      [
+        "bb",
+        "ee"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -533,7 +581,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where ((col1, `name`), col2) in ((('aa', 'bb'), 'cc'), (('dd', 'ee'), 'ff'))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"bb\"), VARBINARY(\"ee\"))",
+    "Values": [
+      "(VARBINARY(\"bb\"), VARBINARY(\"ee\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -554,8 +604,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where (`name`, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
     "Table": "`user`",
     "Values": [
-      "aa",
-      "dd"
+      [
+        "aa",
+        "dd"
+      ]
     ],
     "Vindex": "name_user_map"
   }
@@ -573,7 +625,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (`name`, (col1, col2)) in (('aa', ('bb', 'cc')), ('dd', ('ee', 'ff')))",
     "Table": "`user`",
-    "Values": "(VARBINARY(\"aa\"), VARBINARY(\"dd\"))",
+    "Values": [
+      "(VARBINARY(\"aa\"), VARBINARY(\"dd\"))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -646,7 +700,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where (col1, `name`) in (('aa', 1 + 1))",
     "Table": "`user`",
-    "Values": "(INT64(2))",
+    "Values": [
+      "(INT64(2))"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -704,7 +760,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `name` = :a",
     "Table": "`user`",
-    "Values": ":a",
+    "Values": [
+      ":a"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -725,7 +783,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `name` = 18446744073709551615",
     "Table": "`user`",
-    "Values": 18446744073709551615,
+    "Values": [
+      18446744073709551615
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -760,7 +820,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `name` in ::__vals",
     "Table": "`user`",
-    "Values": "::list",
+    "Values": [
+      "::list"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -777,7 +839,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `name` in ::__vals",
     "Table": "`user`",
-    "Values": ":list",
+    "Values": [
+      ":list"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -797,7 +861,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user` join user_extra on `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select user_extra.id from `user` join user_extra on `user`.id = user_extra.user_id where `user`.id = 5",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -814,7 +880,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.id from `user`, user_extra where `user`.id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -834,7 +902,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user` join user_extra on `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select user_extra.id from `user` join user_extra on `user`.id = user_extra.user_id where user_extra.user_id = 5",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -851,7 +921,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.id from `user`, user_extra where user_extra.user_id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -871,7 +943,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where `user`.id = 5",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -888,7 +962,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where `user`.id = 5",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -908,7 +984,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select user_extra.id from `user` left join user_extra on `user`.id = user_extra.user_id where user_extra.user_id = 5",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -925,7 +1003,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.id from `user`, user_extra where user_extra.user_id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -954,7 +1034,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -994,7 +1076,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1036,7 +1120,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1049,7 +1135,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
         "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = 5",
         "Table": "user_extra",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1068,7 +1156,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.id from `user`, user_extra where `user`.id = 5 and user_extra.user_id = 5 and `user`.col = user_extra.col",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1108,7 +1198,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
         "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = :user_col",
         "Table": "user_extra",
-        "Values": ":user_col",
+        "Values": [
+          ":user_col"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1148,7 +1240,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
         "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = :user_col",
         "Table": "user_extra",
-        "Values": ":user_col",
+        "Values": [
+          ":user_col"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1249,8 +1343,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where `user`.col = 5 and `user`.id in ::__vals",
     "Table": "`user`",
     "Values": [
-      1,
-      2
+      [
+        1,
+        2
+      ]
     ],
     "Vindex": "user_index"
   }
@@ -1268,7 +1364,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = 5 and `user`.id in ::__vals",
     "Table": "`user`",
-    "Values": "(INT64(1), INT64(2))",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1289,8 +1387,10 @@ Gen4 plan same as above
     "Query": "select id from `user` where `user`.col = case `user`.col when 'foo' then true else false end and `user`.id in ::__vals",
     "Table": "`user`",
     "Values": [
-      1,
-      2
+      [
+        1,
+        2
+      ]
     ],
     "Vindex": "user_index"
   }
@@ -1308,7 +1408,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = case `user`.col when 'foo' then true else false end and `user`.id in ::__vals",
     "Table": "`user`",
-    "Values": "(INT64(1), INT64(2))",
+    "Values": [
+      "(INT64(1), INT64(2))"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1328,7 +1430,9 @@ Gen4 plan same as above
     "FieldQuery": "select id or col as val from `user` where 1 != 1",
     "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
-    "Values": "aa",
+    "Values": [
+      "aa"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -1345,7 +1449,9 @@ Gen4 plan same as above
     "FieldQuery": "select id or col as val from `user` where 1 != 1",
     "Query": "select id or col as val from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
-    "Values": "VARBINARY(\"aa\")",
+    "Values": [
+      "VARBINARY(\"aa\")"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -1365,7 +1471,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
-    "Values": "aa",
+    "Values": [
+      "aa"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -1382,7 +1490,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = false and `user`.id in (1, 2) and `user`.`name` = 'aa'",
     "Table": "`user`",
-    "Values": "VARBINARY(\"aa\")",
+    "Values": [
+      "VARBINARY(\"aa\")"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -1402,7 +1512,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1419,7 +1531,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.col = 5 and `user`.id in (1, 2) and `user`.`name` = 'aa' and `user`.id = 1",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1439,7 +1553,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1456,7 +1572,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = 1 and `user`.`name` = 'aa' and `user`.id in (1, 2) and `user`.col = 5",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1553,7 +1671,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where `user`.id = :unsharded_id",
         "Table": "`user`",
-        "Values": ":unsharded_id",
+        "Values": [
+          ":unsharded_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1575,7 +1695,9 @@ Gen4 plan same as above
     "FieldQuery": "select col from `user` as route1 where 1 != 1",
     "Query": "select col from `user` as route1 where id = 1",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1592,7 +1714,9 @@ Gen4 plan same as above
     "FieldQuery": "select col from `user` as route1 where 1 != 1",
     "Query": "select col from `user` as route1 where id = 1",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1633,8 +1757,10 @@ Gen4 plan same as above
         "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col)",
         "Table": "`user`",
         "Values": [
-          ":user_extra_col",
-          1
+          [
+            ":user_extra_col",
+            1
+          ]
         ],
         "Vindex": "user_index"
       }
@@ -1675,7 +1801,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
         "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col) and u.id in ::__vals",
         "Table": "`user`",
-        "Values": "(:user_extra_col, INT64(1))",
+        "Values": [
+          "(:user_extra_col, INT64(1))"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1718,8 +1846,10 @@ Gen4 plan same as above
         "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id)",
         "Table": "`user`",
         "Values": [
-          ":user_extra_col",
-          1
+          [
+            ":user_extra_col",
+            1
+          ]
         ],
         "Vindex": "user_index"
       }
@@ -1760,7 +1890,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
         "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id) and u.id in ::__vals",
         "Table": "`user`",
-        "Values": "(:user_extra_col, INT64(1))",
+        "Values": [
+          "(:user_extra_col, INT64(1))"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1799,7 +1931,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
         "Query": "select u.m from `user` as u where u.id = 5 and u.id in (select m2 from `user` where `user`.id = 5)",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1835,7 +1969,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
         "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = 5) and u.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1878,8 +2014,10 @@ Gen4 plan same as above
         "Query": "select u.m from `user` as u where u.id in ::__vals and u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id))",
         "Table": "`user`",
         "Values": [
-          ":user_extra_col",
-          1
+          [
+            ":user_extra_col",
+            1
+          ]
         ],
         "Vindex": "user_index"
       }
@@ -1920,7 +2058,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.m from `user` as u where 1 != 1",
         "Query": "select u.m from `user` as u where u.id in (select m2 from `user` where `user`.id = u.id and `user`.col = :user_extra_col and `user`.id in (select m3 from user_extra where user_extra.user_id = `user`.id)) and u.id in ::__vals",
         "Table": "`user`",
-        "Values": "(:user_extra_col, INT64(1))",
+        "Values": [
+          "(:user_extra_col, INT64(1))"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1961,7 +2101,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where id = 5 and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1978,7 +2120,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where id = 5 and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1998,7 +2142,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where id = 'aa' and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
     "Table": "`user`",
-    "Values": "aa",
+    "Values": [
+      "aa"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2015,7 +2161,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where id = 'aa' and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
     "Table": "`user`",
-    "Values": "VARBINARY(\"aa\")",
+    "Values": [
+      "VARBINARY(\"aa\")"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2035,7 +2183,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where id = :a and `user`.col in (select user_extra.col from user_extra where user_extra.user_id = :a)",
     "Table": "`user`",
-    "Values": ":a",
+    "Values": [
+      ":a"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2100,7 +2250,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": "::__sq1",
+        "Values": [
+          "::__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2138,7 +2290,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2293,7 +2447,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = :__sq1",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2356,7 +2512,9 @@ Gen4 plan same as above
         "FieldQuery": "select id1 from `user` where 1 != 1",
         "Query": "select id1 from `user` where id = :__sq2",
         "Table": "`user`",
-        "Values": ":__sq2",
+        "Values": [
+          ":__sq2"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2415,7 +2573,9 @@ Gen4 plan same as above
         "FieldQuery": "select id1 from `user` where 1 != 1",
         "Query": "select id1 from `user` where id = :__sq1",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2475,7 +2635,9 @@ Gen4 plan same as above
         "FieldQuery": "select col from `user` where 1 != 1",
         "Query": "select col from `user` where id = :__sq1",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2498,7 +2660,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.Id from `user` join user_extra on `user`.iD = user_extra.User_Id where 1 != 1",
     "Query": "select user_extra.Id from `user` join user_extra on `user`.iD = user_extra.User_Id where `user`.Id = 5",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2515,7 +2679,9 @@ Gen4 plan same as above
     "FieldQuery": "select user_extra.Id from `user`, user_extra where 1 != 1",
     "Query": "select user_extra.Id from `user`, user_extra where `user`.Id = 5 and `user`.iD = user_extra.User_Id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2573,7 +2739,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where id is null",
     "Table": "music",
-    "Values": null,
+    "Values": [
+      null
+    ],
     "Vindex": "music_user_map"
   }
 }
@@ -2590,7 +2758,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where id is null",
     "Table": "music",
-    "Values": "NULL",
+    "Values": [
+      "NULL"
+    ],
     "Vindex": "music_user_map"
   }
 }
@@ -2667,7 +2837,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where user_id = 4 and id in (null, 1, 2)",
     "Table": "music",
-    "Values": 4,
+    "Values": [
+      4
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2684,7 +2856,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from music where 1 != 1",
     "Query": "select id from music where user_id = 4 and id in (null, 1, 2)",
     "Table": "music",
-    "Values": "INT64(4)",
+    "Values": [
+      "INT64(4)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2750,7 +2924,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 42",
         "Table": "user_extra",
-        "Values": 42,
+        "Values": [
+          42
+        ],
         "Vindex": "user_index"
       },
       {
@@ -2771,7 +2947,9 @@ Gen4 plan same as above
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
             "Query": "select user_extra.col from user_extra where user_extra.user_id = 411",
             "Table": "user_extra",
-            "Values": 411,
+            "Values": [
+              411
+            ],
             "Vindex": "user_index"
           },
           {
@@ -2784,7 +2962,9 @@ Gen4 plan same as above
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals and (:__sq_has_values2 = 0 or id not in ::__sq2)",
             "Table": "`user`",
-            "Values": "::__sq1",
+            "Values": [
+              "::__sq1"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -2813,7 +2993,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 411",
         "Table": "user_extra",
-        "Values": "INT64(411)",
+        "Values": [
+          "INT64(411)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -2834,7 +3016,9 @@ Gen4 plan same as above
             "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
             "Query": "select user_extra.col from user_extra where user_extra.user_id = 42",
             "Table": "user_extra",
-            "Values": "INT64(42)",
+            "Values": [
+              "INT64(42)"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -2847,7 +3031,9 @@ Gen4 plan same as above
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where (:__sq_has_values1 = 0 or id not in ::__sq1) and (:__sq_has_values2 = 1 and id in ::__vals)",
             "Table": "`user`",
-            "Values": ":__sq2",
+            "Values": [
+              ":__sq2"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -2871,7 +3057,9 @@ Gen4 plan same as above
     "FieldQuery": "select c2 from cfc_vindex_col where 1 != 1",
     "Query": "select c2 from cfc_vindex_col where c1 like 'A%'",
     "Table": "cfc_vindex_col",
-    "Values": "A%",
+    "Values": [
+      "A%"
+    ],
     "Vindex": "cfc"
   }
 }
@@ -2888,7 +3076,9 @@ Gen4 plan same as above
     "FieldQuery": "select c2 from cfc_vindex_col where 1 != 1",
     "Query": "select c2 from cfc_vindex_col where c1 like 'A%'",
     "Table": "cfc_vindex_col",
-    "Values": "VARBINARY(\"A%\")",
+    "Values": [
+      "VARBINARY(\"A%\")"
+    ],
     "Vindex": "cfc"
   }
 }
@@ -2907,7 +3097,9 @@ Gen4 plan same as above
     "FieldQuery": "select col from samecolvin where 1 != 1",
     "Query": "select col from samecolvin where col = :col",
     "Table": "samecolvin",
-    "Values": ":col",
+    "Values": [
+      ":col"
+    ],
     "Vindex": "vindex1"
   }
 }
@@ -2985,7 +3177,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": "::__sq1",
+        "Values": [
+          "::__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3023,7 +3217,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3107,7 +3303,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and u1.`name` in (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3124,7 +3322,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and u1.`name` in (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3144,7 +3344,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and exists (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3161,7 +3363,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and exists (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3181,7 +3385,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and not exists (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3198,7 +3404,9 @@ Gen4 plan same as above
     "FieldQuery": "select u1.col from `user` as u1 where 1 != 1",
     "Query": "select u1.col from `user` as u1 where u1.id = 5 and not exists (select u2.`name` from `user` as u2 where u2.id = 5)",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3226,7 +3434,9 @@ Gen4 plan same as above
         "FieldQuery": "select u2.`name` from `user` as u2 where 1 != 1",
         "Query": "select u2.`name` from `user` as u2 where u2.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3263,7 +3473,9 @@ Gen4 plan same as above
         "FieldQuery": "select u2.`name` from `user` as u2 where 1 != 1",
         "Query": "select u2.`name` from `user` as u2 where u2.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3304,7 +3516,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
         "Table": "user_extra",
-        "Values": 4,
+        "Values": [
+          4
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3317,7 +3531,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and :__sq_has_values1 = 1 and id in ::__sq1 and id not in (select user_extra.col from user_extra where user_extra.user_id = 5)",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3344,7 +3560,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
         "Table": "user_extra",
-        "Values": "INT64(4)",
+        "Values": [
+          "INT64(4)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3357,7 +3575,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and id not in (select user_extra.col from user_extra where user_extra.user_id = 5) and (:__sq_has_values2 = 1 and id in ::__sq2)",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3387,7 +3607,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
         "Table": "user_extra",
-        "Values": 4,
+        "Values": [
+          4
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3400,7 +3622,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and id in (select user_extra.col from user_extra where user_extra.user_id = 5) and (:__sq_has_values1 = 0 or id not in ::__sq1)",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3427,7 +3651,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.col from user_extra where 1 != 1",
         "Query": "select user_extra.col from user_extra where user_extra.user_id = 4",
         "Table": "user_extra",
-        "Values": "INT64(4)",
+        "Values": [
+          "INT64(4)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3440,7 +3666,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5 and (:__sq_has_values1 = 0 or id not in ::__sq1) and id in (select user_extra.col from user_extra where user_extra.user_id = 5)",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3510,7 +3738,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from `user` where 1 != 1",
     "Query": "select id from `user` where `user`.id = `user`.col and `user`.col = 5",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -3643,7 +3873,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where `user`.id = :user_extra_col",
         "Table": "`user`",
-        "Values": ":user_extra_col",
+        "Values": [
+          ":user_extra_col"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3815,7 +4047,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1",
     "Table": "multicolvin",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3832,7 +4066,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1",
     "Table": "multicolvin",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3852,7 +4088,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1 and column_c = 2",
     "Table": "multicolvin",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3869,7 +4107,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1 and column_c = 2",
     "Table": "multicolvin",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3889,7 +4129,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1 and column_c = 2 and column_a = 3",
     "Table": "multicolvin",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3906,7 +4148,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_b = 1 and column_c = 2 and column_a = 3",
     "Table": "multicolvin",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3926,7 +4170,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_a = 3 and column_b = 1",
     "Table": "multicolvin",
-    "Values": 3,
+    "Values": [
+      3
+    ],
     "Vindex": "cola_map"
   }
 }
@@ -3943,7 +4189,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from multicolvin where 1 != 1",
     "Query": "select * from multicolvin where column_a = 3 and column_b = 1",
     "Table": "multicolvin",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "colb_colc_map"
   }
 }
@@ -3965,7 +4213,26 @@ Gen4 plan same as above
     "Table": "multicol_tbl"
   }
 }
-Gen4 plan same as above
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 1 and colb = 2",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 1 and colb = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
 
 # Multi-route unique vindex constraint (with hash join)
 "select /*vt+ ALLOW_HASH_JOIN */ user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5"
@@ -3991,7 +4258,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /*vt+ ALLOW_HASH_JOIN */ `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -4029,7 +4298,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /*vt+ ALLOW_HASH_JOIN */ `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4538,6 +4538,44 @@ Gen4 plan same as above
   }
 }
 
+# multi column vindex as tuple
+"select * from multicol_tbl where (cola,colb) in ((1,2),(3,4))"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where (cola,colb) in ((1,2),(3,4))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where (cola, colb) in ((1, 2), (3, 4))",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where (cola,colb) in ((1,2),(3,4))",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectMultiEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where (cola, colb) in ((1, 2), (3, 4))",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(3))",
+      "(INT64(2), INT64(4))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
 # Multi-route unique vindex constraint (with hash join)
 "select /*vt+ ALLOW_HASH_JOIN */ user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4349,6 +4349,44 @@ Gen4 plan same as above
   }
 }
 
+# multi column vindex with different order with one IN predicate and one equality
+"select * from multicol_tbl where colb in (3,4) and cola = 1"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (3,4) and cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in (3, 4) and cola = 1",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (3,4) and cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectIN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in ::__vals1 and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "(INT64(3), INT64(4))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
 # Multi-route unique vindex constraint (with hash join)
 "select /*vt+ ALLOW_HASH_JOIN */ user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4500,6 +4500,44 @@ Gen4 plan same as above
   }
 }
 
+# multi column vindex with better plan selection
+"select * from multicol_tbl where colb in (1,2) and cola IN (3,4) and cola = 5 and colb = 6"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (1,2) and cola IN (3,4) and cola = 5 and colb = 6",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in (1, 2) and cola in (3, 4) and cola = 5 and colb = 6",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (1,2) and cola IN (3,4) and cola = 5 and colb = 6",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in (1, 2) and cola in (3, 4) and cola = 5 and colb = 6",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(5)",
+      "INT64(6)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
 # Multi-route unique vindex constraint (with hash join)
 "select /*vt+ ALLOW_HASH_JOIN */ user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5"
 {

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4272,7 +4272,6 @@ Gen4 plan same as above
   }
 }
 
-
 # multi column vindex produces IN plan in gen4 and Scatter in v3
 "select * from multicol_tbl where cola in (1,2) and colb in (3,4)"
 {
@@ -4382,6 +4381,120 @@ Gen4 plan same as above
     "Values": [
       "INT64(1)",
       "(INT64(3), INT64(4))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex with both IN predicate and equality predicate
+"select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6) and colb = 7"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6) and colb = 7",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6) and colb = 7",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6) and colb = 7",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6) and colb = 7",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(4)",
+      "INT64(7)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex with one column with equal followed by IN predicate, ordering matters for now
+"select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 4 and cola in (1, 10) and colb in (5, 6)",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectIN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 4 and cola in ::__vals0 and colb in ::__vals1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(10))",
+      "(INT64(5), INT64(6))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex with one column with IN followed by equal predicate, ordering matters for now
+"select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6)",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectIN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in ::__vals1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(4)",
+      "(INT64(5), INT64(6))"
     ],
     "Vindex": "multicolIdx"
   }

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4301,7 +4301,45 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola in ::__vals and colb in ::__vals",
+    "Query": "select * from multicol_tbl where cola in ::__vals0 and colb in ::__vals1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(2))",
+      "(INT64(3), INT64(4))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex with different order places the vindex keys in correct order in IN plan in gen4
+"select * from multicol_tbl where colb in (3,4) and cola in (1,2)"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (3,4) and cola in (1,2)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in (3, 4) and cola in (1, 2)",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb in (3,4) and cola in (1,2)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectIN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb in ::__vals1 and cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
       "(INT64(1), INT64(2))",

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -4196,7 +4196,7 @@ Gen4 plan same as above
   }
 }
 
-# multi column vindexes are not allowed to be selected as vindex option. This will be Scatter
+# multi column vindex produces Equal plan in gen4 and Scatter in v3
 "select * from multicol_tbl where cola = 1 and colb = 2"
 {
   "QueryType": "SELECT",
@@ -4229,6 +4229,83 @@ Gen4 plan same as above
     "Values": [
       "INT64(1)",
       "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex with different order places the vindex keys in correct order
+"select * from multicol_tbl where colb = 2 and cola = 1"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb = 2 and cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb = 2 and cola = 1",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where colb = 2 and cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where colb = 2 and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+
+# multi column vindex produces IN plan in gen4 and Scatter in v3
+"select * from multicol_tbl where cola in (1,2) and colb in (3,4)"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,2) and colb in (3,4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in (1, 2) and colb in (3, 4)",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola in (1,2) and colb in (3,4)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectIN",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola in ::__vals and colb in ::__vals",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(1), INT64(2))",
+      "(INT64(3), INT64(4))"
     ],
     "Vindex": "multicolIdx"
   }

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.txt
@@ -132,7 +132,9 @@ Gen4 error: Incorrect usage/placement of 'NEXT'
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": "::__sq1",
+        "Values": [
+          "::__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -441,7 +443,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where `user`.id = :music_id",
         "Table": "`user`",
-        "Values": ":music_id",
+        "Values": [
+          ":music_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -481,7 +485,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where `user`.id = :music_id",
         "Table": "`user`",
-        "Values": ":music_id",
+        "Values": [
+          ":music_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1425,7 +1431,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.col from `user` join user_extra on `user`.id = 5 and `user`.id = user_extra.user_id where 1 != 1",
     "Query": "select `user`.col from `user` join user_extra on `user`.id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1442,7 +1450,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.col from `user`, user_extra where 1 != 1",
     "Query": "select `user`.col from `user`, user_extra where `user`.id = 5 and `user`.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1546,7 +1556,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1582,7 +1594,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1621,7 +1635,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1657,7 +1673,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1748,7 +1766,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.id = :user_extra_col",
         "Table": "`user`",
-        "Values": ":user_extra_col",
+        "Values": [
+          ":user_extra_col"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1790,7 +1810,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select `user`.col from `user` where `user`.`name` = :user_extra_user_id",
         "Table": "`user`",
-        "Values": ":user_extra_user_id",
+        "Values": [
+          ":user_extra_user_id"
+        ],
         "Vindex": "name_user_map"
       }
     ]
@@ -1830,7 +1852,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from user_extra where 1 != 1",
         "Query": "select 1 from user_extra where user_extra.user_id = :user_name",
         "Table": "user_extra",
-        "Values": ":user_name",
+        "Values": [
+          ":user_name"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1952,7 +1976,9 @@ Gen4 plan same as above
     "FieldQuery": "select ref.col from ref join (select aa from `user` where 1 != 1) as `user` where 1 != 1",
     "Query": "select ref.col from ref join (select aa from `user` where `user`.id = 1) as `user`",
     "Table": "`user`, ref",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1969,7 +1995,9 @@ Gen4 plan same as above
     "FieldQuery": "select ref.col from ref, (select aa from `user` where 1 != 1) as `user` where 1 != 1",
     "Query": "select ref.col from ref, (select aa from `user` where `user`.id = 1) as `user`",
     "Table": "`user`, ref",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2027,7 +2055,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from (select id, col from `user` where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` where id = 5) as t",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2044,7 +2074,9 @@ Gen4 plan same as above
     "FieldQuery": "select id from (select id, col from `user` where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` where id = 5) as t",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2064,7 +2096,9 @@ Gen4 plan same as above
     "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Query": "select t.id from (select id from `user` where id = 5) as t join user_extra on t.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2081,7 +2115,9 @@ Gen4 plan same as above
     "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t, user_extra where 1 != 1",
     "Query": "select t.id from (select id from `user` where id = 5) as t, user_extra where t.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2101,7 +2137,9 @@ Gen4 plan same as above
     "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Query": "select t.id from (select `user`.id from `user` where `user`.id = 5) as t join user_extra on t.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2118,7 +2156,9 @@ Gen4 plan same as above
     "FieldQuery": "select t.id from (select `user`.id from `user` where 1 != 1) as t, user_extra where 1 != 1",
     "Query": "select t.id from (select `user`.id from `user` where `user`.id = 5) as t, user_extra where t.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2158,7 +2198,9 @@ Gen4 error: Duplicate column name 'id'
     "FieldQuery": "select t.id from user_extra, (select id from `user` where 1 != 1) as t where 1 != 1",
     "Query": "select t.id from user_extra, (select id from `user` where id = 5) as t where t.id = user_extra.user_id",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2187,7 +2229,9 @@ Gen4 error: Duplicate column name 'id'
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       },
       {
@@ -2227,7 +2271,9 @@ Gen4 error: Duplicate column name 'id'
         "FieldQuery": "select t.id from (select id from `user` where 1 != 1) as t where 1 != 1",
         "Query": "select t.id from (select id from `user` where id = 5) as t",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -2260,7 +2306,9 @@ Gen4 error: Duplicate column name 'id'
     "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2277,7 +2325,9 @@ Gen4 error: Duplicate column name 'id'
     "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2316,7 +2366,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` as route1) as t where id = 5",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2333,7 +2385,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select id from (select id, col from `user` as route1 where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id, col from `user` as route1 where id = 5) as t",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2438,7 +2492,9 @@ Gen4 error: symbol id not found
     "FieldQuery": "select id from (select id from (select id from `user` where 1 != 1) as u where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id from (select id from `user`) as u) as t where id = 5",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2455,7 +2511,9 @@ Gen4 error: symbol id not found
     "FieldQuery": "select id from (select id from (select id from `user` where 1 != 1) as u where 1 != 1) as t where 1 != 1",
     "Query": "select id from (select id from (select id from `user` where id = 5) as u) as t",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2475,7 +2533,9 @@ Gen4 error: symbol id not found
     "FieldQuery": "select u.col, e.col from (select col from `user` where 1 != 1) as u join (select col from user_extra where 1 != 1) as e where 1 != 1",
     "Query": "select u.col, e.col from (select col from `user` where id = 5) as u join (select col from user_extra where user_id = 5) as e",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2492,7 +2552,9 @@ Gen4 error: symbol id not found
     "FieldQuery": "select u.col, e.col from (select col from `user` where 1 != 1) as u, (select col from user_extra where 1 != 1) as e where 1 != 1",
     "Query": "select u.col, e.col from (select col from `user` where id = 5) as u, (select col from user_extra where user_id = 5) as e",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2918,7 +2980,9 @@ Gen4 plan same as above
                 "FieldQuery": "select `user`.id, `user`.col1 from `user` where 1 != 1",
                 "Query": "select `user`.id, `user`.col1 from `user` where `user`.id = :ua_id",
                 "Table": "`user`",
-                "Values": ":ua_id",
+                "Values": [
+                  ":ua_id"
+                ],
                 "Vindex": "user_index"
               },
               {
@@ -3814,7 +3878,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.id from `user` where 1 != 1",
         "Query": "select `user`.id from `user` where `user`.id = :user_extra_id",
         "Table": "`user`",
-        "Values": ":user_extra_id",
+        "Values": [
+          ":user_extra_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3856,7 +3922,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from user_extra where 1 != 1",
         "Query": "select 1 from user_extra where user_extra.assembly_id = :user_id and user_extra.user_id = 2",
         "Table": "user_extra",
-        "Values": 2,
+        "Values": [
+          2
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -3885,7 +3953,9 @@ Gen4 plan same as above
         "FieldQuery": "select user_extra.assembly_id from user_extra where 1 != 1",
         "Query": "select user_extra.assembly_id from user_extra where user_extra.user_id = 2",
         "Table": "user_extra",
-        "Values": "INT64(2)",
+        "Values": [
+          "INT64(2)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -3898,7 +3968,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.id from `user` where 1 != 1",
         "Query": "select `user`.id from `user` where `user`.id = :user_extra_assembly_id",
         "Table": "`user`",
-        "Values": ":user_extra_assembly_id",
+        "Values": [
+          ":user_extra_assembly_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -4040,7 +4112,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from music as m where 1 != 1",
         "Query": "select 1 from music as m where m.user_id = :ue_user_id",
         "Table": "music",
-        "Values": ":ue_user_id",
+        "Values": [
+          ":ue_user_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -4080,7 +4154,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` as u where 1 != 1",
         "Query": "select 1 from `user` as u where u.id = :ue_id",
         "Table": "`user`",
-        "Values": ":ue_id",
+        "Values": [
+          ":ue_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -4160,7 +4236,9 @@ Gen4 plan same as above
         "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
         "Query": "select u.id as uid from `user` as u where u.id = :ue_id",
         "Table": "`user`",
-        "Values": ":ue_id",
+        "Values": [
+          ":ue_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -4277,7 +4355,9 @@ Gen4 plan same as above
             "FieldQuery": "select `user`.id, `user`.col from `user` where 1 != 1",
             "Query": "select `user`.id, `user`.col from `user` where `user`.id = 5",
             "Table": "`user`",
-            "Values": "INT64(5)",
+            "Values": [
+              "INT64(5)"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -4359,7 +4439,9 @@ Gen4 plan same as above
     "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
     "Query": "select u.a from (select id as b, `name` from `user` where `name` = 1) as u(a, n)",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -4380,7 +4462,9 @@ Gen4 plan same as above
     "FieldQuery": "select u.a from (select id as b, `name` from `user` where 1 != 1) as u(a, n) where 1 != 1",
     "Query": "select u.a from (select id as b, `name` from `user` where b = 1 and `name` = 1) as u(a, n)",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "name_user_map"
   }
 }
@@ -4490,7 +4574,9 @@ Gen4 plan same as above
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where col = :__sq1 and :__sq_has_values2 = 1 and id in ::__vals",
             "Table": "`user`",
-            "Values": "::__sq2",
+            "Values": [
+              "::__sq2"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -4555,7 +4641,9 @@ Gen4 plan same as above
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals and col = :__sq2",
             "Table": "`user`",
-            "Values": ":__sq1",
+            "Values": [
+              ":__sq1"
+            ],
             "Vindex": "user_index"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/large_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/large_cases.txt
@@ -40,7 +40,9 @@
             "FieldQuery": "select user_extra.user_id from user_extra where 1 != 1",
             "Query": "select user_extra.user_id from user_extra where user_extra.user_id = :user_id",
             "Table": "user_extra",
-            "Values": ":user_id",
+            "Values": [
+              ":user_id"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -58,7 +60,9 @@
                 "FieldQuery": "select 1 from user_metadata where 1 != 1",
                 "Query": "select 1 from user_metadata where user_metadata.user_id = :user_extra_user_id",
                 "Table": "user_metadata",
-                "Values": ":user_extra_user_id",
+                "Values": [
+                  ":user_extra_user_id"
+                ],
                 "Vindex": "user_index"
               },
               {
@@ -157,7 +161,9 @@
                                     "FieldQuery": "select 1 from music_extra where 1 != 1",
                                     "Query": "select 1 from music_extra where music_extra.music_id = :music_id",
                                     "Table": "music_extra",
-                                    "Values": ":music_id",
+                                    "Values": [
+                                      ":music_id"
+                                    ],
                                     "Vindex": "music_user_map"
                                   }
                                 ]

--- a/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/memory_sort_cases.txt
@@ -395,7 +395,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select `user`.col1 as a, `user`.col2 as b, `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2 as b, `user`.id from `user` where `user`.id = 1",
             "Table": "`user`",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "user_index"
           },
           {
@@ -408,7 +410,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select music.col3 as c, weight_string(music.col3) from music where 1 != 1",
             "Query": "select music.col3 as c, weight_string(music.col3) from music where music.id = :user_id",
             "Table": "music",
-            "Values": ":user_id",
+            "Values": [
+              ":user_id"
+            ],
             "Vindex": "music_user_map"
           }
         ]
@@ -445,7 +449,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2 as b from `user` where 1 != 1",
             "Query": "select `user`.id, `user`.col1 as a, `user`.col2 as b from `user` where `user`.id = 1",
             "Table": "`user`",
-            "Values": "INT64(1)",
+            "Values": [
+              "INT64(1)"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -458,7 +464,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select music.col3 as c, weight_string(music.col3) from music where 1 != 1",
             "Query": "select music.col3 as c, weight_string(music.col3) from music where music.id = :user_id",
             "Table": "music",
-            "Values": ":user_id",
+            "Values": [
+              ":user_id"
+            ],
             "Vindex": "music_user_map"
           }
         ]
@@ -497,7 +505,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where 1 != 1",
             "Query": "select `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2), `user`.id from `user` where `user`.id = 1",
             "Table": "`user`",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "user_index"
           },
           {
@@ -510,7 +520,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select music.col3, weight_string(music.col3) from music where 1 != 1",
             "Query": "select music.col3, weight_string(music.col3) from music where music.id = :user_id",
             "Table": "music",
-            "Values": ":user_id",
+            "Values": [
+              ":user_id"
+            ],
             "Vindex": "music_user_map"
           }
         ]
@@ -547,7 +559,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where 1 != 1",
             "Query": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1), weight_string(`user`.col2) from `user` where `user`.id = 1",
             "Table": "`user`",
-            "Values": "INT64(1)",
+            "Values": [
+              "INT64(1)"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -560,7 +574,9 @@ Gen4 error: Expression of SELECT list is not in GROUP BY clause and contains non
             "FieldQuery": "select music.col3, weight_string(music.col3) from music where 1 != 1",
             "Query": "select music.col3, weight_string(music.col3) from music where music.id = :user_id",
             "Table": "music",
-            "Values": ":user_id",
+            "Values": [
+              ":user_id"
+            ],
             "Vindex": "music_user_map"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/oltp_cases.txt
@@ -13,7 +13,9 @@
     "FieldQuery": "select c from sbtest34 where 1 != 1",
     "Query": "select c from sbtest34 where id = 15",
     "Table": "sbtest34",
-    "Values": 15,
+    "Values": [
+      15
+    ],
     "Vindex": "hash"
   }
 }
@@ -30,7 +32,9 @@
     "FieldQuery": "select c from sbtest34 where 1 != 1",
     "Query": "select c from sbtest34 where id = 15",
     "Table": "sbtest34",
-    "Values": "INT64(15)",
+    "Values": [
+      "INT64(15)"
+    ],
     "Vindex": "hash"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.txt
@@ -213,7 +213,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` having :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": "::__sq1",
+        "Values": [
+          "::__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -251,7 +253,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -273,7 +277,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
     "FieldQuery": "select col from `user` where 1 != 1",
     "Query": "select col from `user` where id = 5 order by aa asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -290,7 +296,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
     "FieldQuery": "select col from `user` where 1 != 1",
     "Query": "select col from `user` where id = 5 order by aa asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -310,7 +318,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
     "FieldQuery": "select col from `user` where 1 != 1",
     "Query": "select col from `user` where id = 1 order by 1 asc",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -327,7 +337,9 @@ Gen4 error: Column 'col1' in field list is ambiguous
     "FieldQuery": "select col from `user` where 1 != 1",
     "Query": "select col from `user` where id = 1 order by col asc",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -667,7 +679,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
         "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by null",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -680,7 +694,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id order by null",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -709,7 +725,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2 from `user` where 1 != 1",
         "Query": "select `user`.id, `user`.col1 as a, `user`.col2 from `user` where `user`.id = 1 order by null",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -722,7 +740,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id order by null",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -753,7 +773,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
         "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by a asc",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -766,7 +788,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -796,7 +820,9 @@ Gen4 plan same as above
         "OrderBy": "(1|3) ASC",
         "Query": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1) from `user` where `user`.id = 1 order by a asc",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -809,7 +835,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -840,7 +868,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
         "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by a asc",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -853,7 +883,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -883,7 +915,9 @@ Gen4 plan same as above
         "OrderBy": "(1|3) ASC",
         "Query": "select `user`.id, `user`.col1 as a, `user`.col2, weight_string(`user`.col1) from `user` where `user`.id = 1 order by a asc",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -896,7 +930,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -986,7 +1022,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where 1 != 1",
         "Query": "select `user`.col1 as a, `user`.col2, `user`.id from `user` where `user`.id = 1 order by RAND()",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -999,7 +1037,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id order by RAND()",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -1028,7 +1068,9 @@ Gen4 plan same as above
         "FieldQuery": "select `user`.id, `user`.col1 as a, `user`.col2 from `user` where 1 != 1",
         "Query": "select `user`.id, `user`.col1 as a, `user`.col2 from `user` where `user`.id = 1 order by RAND()",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1041,7 +1083,9 @@ Gen4 plan same as above
         "FieldQuery": "select music.col3 from music where 1 != 1",
         "Query": "select music.col3 from music where music.id = :user_id order by RAND()",
         "Table": "music",
-        "Values": ":user_id",
+        "Values": [
+          ":user_id"
+        ],
         "Vindex": "music_user_map"
       }
     ]
@@ -1103,7 +1147,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by col asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1120,7 +1166,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by col asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1140,7 +1188,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.* from `user` where 1 != 1",
     "Query": "select `user`.* from `user` where id = 5 order by `user`.col asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1157,7 +1207,9 @@ Gen4 plan same as above
     "FieldQuery": "select `user`.* from `user` where 1 != 1",
     "Query": "select `user`.* from `user` where id = 5 order by `user`.col asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1177,7 +1229,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by `user`.col asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1194,7 +1248,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by `user`.col asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1326,7 +1382,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by `user`.col collate utf8_general_ci asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1343,7 +1401,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by `user`.col collate utf8_general_ci asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1363,7 +1423,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by -col1 asc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1380,7 +1442,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by -col1 asc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1400,7 +1464,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by concat(col, col1) collate utf8_general_ci desc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1417,7 +1483,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by concat(col, col1) collate utf8_general_ci desc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1437,7 +1505,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by id + col collate utf8_general_ci desc",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1454,7 +1524,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 order by id + col collate utf8_general_ci desc",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1474,7 +1546,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` as u join (select user_id from user_extra where 1 != 1) as eu on u.id = eu.user_id where 1 != 1",
     "Query": "select * from `user` as u join (select user_id from user_extra where user_id = 5) as eu on u.id = eu.user_id where u.id = 5 order by eu.user_id asc",
     "Table": "`user`, user_extra",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1491,7 +1565,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` as u, (select user_id from user_extra where 1 != 1) as eu where 1 != 1",
     "Query": "select * from `user` as u, (select user_id from user_extra where user_id = 5) as eu where u.id = 5 and u.id = eu.user_id order by eu.user_id asc",
     "Table": "`user`, user_extra",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1511,7 +1587,9 @@ Gen4 plan same as above
     "FieldQuery": "select col from `user` as route1 where 1 != 1",
     "Query": "select col from `user` as route1 where id = 1 order by col asc",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1528,7 +1606,9 @@ Gen4 plan same as above
     "FieldQuery": "select col from `user` as route1 where 1 != 1",
     "Query": "select col from `user` as route1 where id = 1 order by col asc",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1548,7 +1628,9 @@ Gen4 plan same as above
     "FieldQuery": "select col1 from `user` where 1 != 1",
     "Query": "select col1 from `user` where id = 1 limit 1",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1565,7 +1647,9 @@ Gen4 plan same as above
     "FieldQuery": "select col1 from `user` where 1 != 1",
     "Query": "select col1 from `user` where id = 1 limit 1",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/rails_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/rails_cases.txt
@@ -60,7 +60,9 @@
                     "FieldQuery": "select book6s_order2s.order2_id from book6s_order2s where 1 != 1",
                     "Query": "select book6s_order2s.order2_id from book6s_order2s where book6s_order2s.book6_id = :book6s_id",
                     "Table": "book6s_order2s",
-                    "Values": ":book6s_id",
+                    "Values": [
+                      ":book6s_id"
+                    ],
                     "Vindex": "binary_md5"
                   }
                 ]
@@ -88,7 +90,9 @@
             "FieldQuery": "select 1 from customer2s where 1 != 1",
             "Query": "select 1 from customer2s where customer2s.id = :order2s_customer2_id",
             "Table": "customer2s",
-            "Values": ":order2s_customer2_id",
+            "Values": [
+              ":order2s_customer2_id"
+            ],
             "Vindex": "binary_md5"
           }
         ]
@@ -103,7 +107,9 @@
         "FieldQuery": "select 1 from supplier5s where 1 != 1",
         "Query": "select 1 from supplier5s where supplier5s.id = :book6s_supplier5_id",
         "Table": "supplier5s",
-        "Values": ":book6s_supplier5_id",
+        "Values": [
+          ":book6s_supplier5_id"
+        ],
         "Vindex": "binary_md5"
       }
     ]
@@ -174,7 +180,9 @@
                 "FieldQuery": "select 1 from book6s_order2s where 1 != 1",
                 "Query": "select 1 from book6s_order2s where book6s_order2s.book6_id = :book6s_id and book6s_order2s.order2_id = :order2s_id",
                 "Table": "book6s_order2s",
-                "Values": ":book6s_id",
+                "Values": [
+                  ":book6s_id"
+                ],
                 "Vindex": "binary_md5"
               }
             ]
@@ -189,7 +197,9 @@
             "FieldQuery": "select 1 from supplier5s where 1 != 1",
             "Query": "select 1 from supplier5s where supplier5s.id = :book6s_supplier5_id",
             "Table": "supplier5s",
-            "Values": ":book6s_supplier5_id",
+            "Values": [
+              ":book6s_supplier5_id"
+            ],
             "Vindex": "binary_md5"
           }
         ]
@@ -260,7 +270,9 @@
                     "FieldQuery": "select book6s_order2s.order2_id from book6s_order2s where 1 != 1",
                     "Query": "select /*vt+ ALLOW_HASH_JOIN */ book6s_order2s.order2_id from book6s_order2s where book6s_order2s.book6_id = :book6s_id",
                     "Table": "book6s_order2s",
-                    "Values": ":book6s_id",
+                    "Values": [
+                      ":book6s_id"
+                    ],
                     "Vindex": "binary_md5"
                   }
                 ]
@@ -288,7 +300,9 @@
             "FieldQuery": "select 1 from customer2s where 1 != 1",
             "Query": "select /*vt+ ALLOW_HASH_JOIN */ 1 from customer2s where customer2s.id = :order2s_customer2_id",
             "Table": "customer2s",
-            "Values": ":order2s_customer2_id",
+            "Values": [
+              ":order2s_customer2_id"
+            ],
             "Vindex": "binary_md5"
           }
         ]
@@ -303,7 +317,9 @@
         "FieldQuery": "select 1 from supplier5s where 1 != 1",
         "Query": "select /*vt+ ALLOW_HASH_JOIN */ 1 from supplier5s where supplier5s.id = :book6s_supplier5_id",
         "Table": "supplier5s",
-        "Values": ":book6s_supplier5_id",
+        "Values": [
+          ":book6s_supplier5_id"
+        ],
         "Vindex": "binary_md5"
       }
     ]
@@ -370,7 +386,9 @@
                 "FieldQuery": "select book6s_order2s.order2_id from book6s_order2s where 1 != 1",
                 "Query": "select /*vt+ ALLOW_HASH_JOIN */ book6s_order2s.order2_id from book6s_order2s where book6s_order2s.book6_id = :book6s_id",
                 "Table": "book6s_order2s",
-                "Values": ":book6s_id",
+                "Values": [
+                  ":book6s_id"
+                ],
                 "Vindex": "binary_md5"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -625,7 +625,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from pin_test where 1 != 1",
     "Query": "select * from pin_test",
     "Table": "pin_test",
-    "Values": "\ufffd",
+    "Values": [
+      "\ufffd"
+    ],
     "Vindex": "binary"
   }
 }
@@ -642,7 +644,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from pin_test where 1 != 1",
     "Query": "select * from pin_test",
     "Table": "pin_test",
-    "Values": "VARBINARY(\"\\x80\")",
+    "Values": [
+      "VARBINARY(\"\\x80\")"
+    ],
     "Vindex": "binary"
   }
 }
@@ -1040,7 +1044,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where `name` = 'abc' and id = 4 limit 5",
     "Table": "`user`",
-    "Values": 4,
+    "Values": [
+      4
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1057,7 +1063,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where `name` = 'abc' and id = 4 limit 5",
     "Table": "`user`",
-    "Values": "INT64(4)",
+    "Values": [
+      "INT64(4)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1077,7 +1085,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
     "Table": "`user`",
-    "Values": 4,
+    "Values": [
+      4
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1094,7 +1104,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
     "Table": "`user`",
-    "Values": "INT64(4)",
+    "Values": [
+      "INT64(4)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1114,7 +1126,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
     "Table": "`user`",
-    "Values": 4,
+    "Values": [
+      4
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1131,7 +1145,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 4 and `name` = 'abc' limit 5",
     "Table": "`user`",
-    "Values": "INT64(4)",
+    "Values": [
+      "INT64(4)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1151,7 +1167,9 @@ Gen4 plan same as above
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
     "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 2",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1168,7 +1186,9 @@ Gen4 plan same as above
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
     "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by user0_.col desc limit 2",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1188,7 +1208,9 @@ Gen4 plan same as above
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
     "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by col0_ desc limit 3",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1205,7 +1227,9 @@ Gen4 plan same as above
     "FieldQuery": "select user0_.col as col0_ from `user` as user0_ where 1 != 1",
     "Query": "select user0_.col as col0_ from `user` as user0_ where id = 1 order by col0_ desc limit 3",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1225,7 +1249,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 1 and `name` = true limit 5",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1242,7 +1268,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 1 and `name` = true limit 5",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1262,7 +1290,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 1 and `name` limit 5",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1279,7 +1309,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 1 and `name` limit 5",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1299,7 +1331,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 and `name` = true limit 5",
     "Table": "`user`",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1316,7 +1350,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from `user` where 1 != 1",
     "Query": "select * from `user` where id = 5 and `name` = true limit 5",
     "Table": "`user`",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1541,7 +1577,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select * from music where 1 != 1 union select * from `user` where 1 != 1",
     "Query": "select * from music where user_id = 1 union select * from `user` where id = 1",
     "Table": "music",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1558,7 +1596,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select * from music where 1 != 1 union select * from `user` where 1 != 1",
     "Query": "select * from music where user_id = 1 union select * from `user` where id = 1",
     "Table": "music",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1578,7 +1618,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select *, :__lastInsertId as `last_insert_id()` from music where 1 != 1 union select * from `user` where 1 != 1",
     "Query": "select *, :__lastInsertId as `last_insert_id()` from music where user_id = 1 union select * from `user` where id = 1",
     "Table": "music",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1595,7 +1637,9 @@ Gen4 error: symbol t.col not found
     "FieldQuery": "select *, :__lastInsertId as `last_insert_id()` from music where 1 != 1 union select * from `user` where 1 != 1",
     "Query": "select *, :__lastInsertId as `last_insert_id()` from music where user_id = 1 union select * from `user` where id = 1",
     "Table": "music",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1839,7 +1883,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from music where 1 != 1",
     "Query": "select * from music where user_id = 1",
     "Table": "music",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1856,7 +1902,9 @@ Gen4 plan same as above
     "FieldQuery": "select * from music where 1 != 1",
     "Query": "select * from music where user_id = 1",
     "Table": "music",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -1970,7 +2018,9 @@ Gen4 plan same as above
         "FieldQuery": "select * from music where 1 != 1",
         "Query": "select * from music where user_id = 1 limit 2",
         "Table": "music",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -1983,7 +2033,9 @@ Gen4 plan same as above
         "FieldQuery": "select count(*) from music where 1 != 1",
         "Query": "select count(*) from music where user_id = 1",
         "Table": "music",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2005,7 +2057,9 @@ Gen4 plan same as above
         "FieldQuery": "select * from music where 1 != 1",
         "Query": "select * from music where user_id = 1 limit 2",
         "Table": "music",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -2018,7 +2072,9 @@ Gen4 plan same as above
         "FieldQuery": "select count(*) from music where 1 != 1",
         "Query": "select count(*) from music where user_id = 1",
         "Table": "music",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2216,7 +2272,9 @@ Gen4 plan same as above
     "FieldQuery": "select (select u.id from `user` as u where 1 != 1), a.id from `user` as a where 1 != 1",
     "Query": "select (select u.id from `user` as u where u.id = 1), a.id from `user` as a where a.id = 1",
     "Table": "`user`",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2233,7 +2291,9 @@ Gen4 plan same as above
     "FieldQuery": "select (select u.id from `user` as u where 1 != 1), a.id from `user` as a where 1 != 1",
     "Query": "select (select u.id from `user` as u where u.id = 1), a.id from `user` as a where a.id = 1",
     "Table": "`user`",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "user_index"
   }
 }
@@ -2784,7 +2844,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from user_extra where 1 != 1",
         "Query": "select 1 from user_extra where user_id = 3 and user_id \u003c :user_id",
         "Table": "user_extra",
-        "Values": "INT64(3)",
+        "Values": [
+          "INT64(3)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -2827,7 +2889,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from user_extra where 1 != 1",
         "Query": "select 1 from user_extra where user_id = 3 and user_id \u003c :user_id",
         "Table": "user_extra",
-        "Values": "INT64(3)",
+        "Values": [
+          "INT64(3)"
+        ],
         "Vindex": "user_index"
       }
     ]

--- a/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/systemtables_cases.txt
@@ -924,7 +924,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where `user`.id = :x_id",
         "Table": "`user`",
-        "Values": ":x_id",
+        "Values": [
+          ":x_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -964,7 +966,9 @@ Gen4 plan same as above
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where `user`.id = :x_id",
         "Table": "`user`",
-        "Values": ":x_id",
+        "Values": [
+          ":x_id"
+        ],
         "Vindex": "user_index"
       }
     ]

--- a/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpcc_cases.txt
@@ -13,7 +13,9 @@
     "FieldQuery": "select c_discount, c_last, c_credit, w_tax from customer1 as c join warehouse1 as w on c_w_id = w_id where 1 != 1",
     "Query": "select c_discount, c_last, c_credit, w_tax from customer1 as c join warehouse1 as w on c_w_id = w_id where w_id = 1 and c_d_id = 15 and c_id = 10",
     "Table": "customer1, warehouse1",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "hash"
   }
 }
@@ -30,7 +32,9 @@
     "FieldQuery": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where 1 != 1",
     "Query": "select c_discount, c_last, c_credit, w_tax from customer1 as c, warehouse1 as w where c_d_id = 15 and c_id = 10 and w_id = 1 and c_w_id = w_id",
     "Table": "customer1, warehouse1",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -50,7 +54,9 @@
     "FieldQuery": "select d_next_o_id, d_tax from district1 where 1 != 1",
     "Query": "select d_next_o_id, d_tax from district1 where d_w_id = 15 and d_id = 95 for update",
     "Table": "district1",
-    "Values": 15,
+    "Values": [
+      15
+    ],
     "Vindex": "hash"
   }
 }
@@ -67,7 +73,9 @@
     "FieldQuery": "select d_next_o_id, d_tax from district1 where 1 != 1",
     "Query": "select d_next_o_id, d_tax from district1 where d_w_id = 15 and d_id = 95 for update",
     "Table": "district1",
-    "Values": "INT64(15)",
+    "Values": [
+      "INT64(15)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -151,7 +159,9 @@ Gen4 plan same as above
     "FieldQuery": "select i_price, i_name, i_data from item1 where 1 != 1",
     "Query": "select i_price, i_name, i_data from item1 where i_id = 9654",
     "Table": "item1",
-    "Values": 9654,
+    "Values": [
+      9654
+    ],
     "Vindex": "hash"
   }
 }
@@ -168,7 +178,9 @@ Gen4 plan same as above
     "FieldQuery": "select i_price, i_name, i_data from item1 where 1 != 1",
     "Query": "select i_price, i_name, i_data from item1 where i_id = 9654",
     "Table": "item1",
-    "Values": "INT64(9654)",
+    "Values": [
+      "INT64(9654)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -188,7 +200,9 @@ Gen4 plan same as above
     "FieldQuery": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where 1 != 1",
     "Query": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where s_i_id = 2198 and s_w_id = 89 for update",
     "Table": "stock1",
-    "Values": 89,
+    "Values": [
+      89
+    ],
     "Vindex": "hash"
   }
 }
@@ -205,7 +219,9 @@ Gen4 plan same as above
     "FieldQuery": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where 1 != 1",
     "Query": "select s_quantity, s_data, s_dist_01 as s_dist from stock1 where s_i_id = 2198 and s_w_id = 89 for update",
     "Table": "stock1",
-    "Values": "INT64(89)",
+    "Values": [
+      "INT64(89)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -293,7 +309,9 @@ Gen4 plan same as above
     "FieldQuery": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where 1 != 1",
     "Query": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where w_id = 998",
     "Table": "warehouse1",
-    "Values": 998,
+    "Values": [
+      998
+    ],
     "Vindex": "hash"
   }
 }
@@ -310,7 +328,9 @@ Gen4 plan same as above
     "FieldQuery": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where 1 != 1",
     "Query": "select w_street_1, w_street_2, w_city, w_state, w_zip, w_name from warehouse1 where w_id = 998",
     "Table": "warehouse1",
-    "Values": "INT64(998)",
+    "Values": [
+      "INT64(998)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -354,7 +374,9 @@ Gen4 plan same as above
     "FieldQuery": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where 1 != 1",
     "Query": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where d_w_id = 896 and d_id = 9",
     "Table": "district1",
-    "Values": 896,
+    "Values": [
+      896
+    ],
     "Vindex": "hash"
   }
 }
@@ -371,7 +393,9 @@ Gen4 plan same as above
     "FieldQuery": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where 1 != 1",
     "Query": "select d_street_1, d_street_2, d_city, d_state, d_zip, d_name from district1 where d_w_id = 896 and d_id = 9",
     "Table": "district1",
-    "Values": "INT64(896)",
+    "Values": [
+      "INT64(896)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -391,7 +415,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
     "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 5 and c_d_id = 1 and c_last = 'last'",
     "Table": "customer1",
-    "Values": 5,
+    "Values": [
+      5
+    ],
     "Vindex": "hash"
   }
 }
@@ -408,7 +434,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
     "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 5 and c_d_id = 1 and c_last = 'last'",
     "Table": "customer1",
-    "Values": "INT64(5)",
+    "Values": [
+      "INT64(5)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -428,7 +456,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_id from customer1 where 1 != 1",
     "Query": "select c_id from customer1 where c_w_id = 8 and c_d_id = 5 and c_last = 'item_last' order by c_first asc",
     "Table": "customer1",
-    "Values": 8,
+    "Values": [
+      8
+    ],
     "Vindex": "hash"
   }
 }
@@ -445,7 +475,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_id from customer1 where 1 != 1",
     "Query": "select c_id from customer1 where c_w_id = 8 and c_d_id = 5 and c_last = 'item_last' order by c_first asc",
     "Table": "customer1",
-    "Values": "INT64(8)",
+    "Values": [
+      "INT64(8)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -465,7 +497,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where 1 != 1",
     "Query": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where c_w_id = 8965 and c_d_id = 1 and c_id = 9 for update",
     "Table": "customer1",
-    "Values": 8965,
+    "Values": [
+      8965
+    ],
     "Vindex": "hash"
   }
 }
@@ -482,7 +516,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where 1 != 1",
     "Query": "select c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since from customer1 where c_w_id = 8965 and c_d_id = 1 and c_id = 9 for update",
     "Table": "customer1",
-    "Values": "INT64(8965)",
+    "Values": [
+      "INT64(8965)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -502,7 +538,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_data from customer1 where 1 != 1",
     "Query": "select c_data from customer1 where c_w_id = 32 and c_d_id = 68 and c_id = 5",
     "Table": "customer1",
-    "Values": 32,
+    "Values": [
+      32
+    ],
     "Vindex": "hash"
   }
 }
@@ -519,7 +557,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_data from customer1 where 1 != 1",
     "Query": "select c_data from customer1 where c_w_id = 32 and c_d_id = 68 and c_id = 5",
     "Table": "customer1",
-    "Values": "INT64(32)",
+    "Values": [
+      "INT64(32)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -607,7 +647,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
     "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 870 and c_d_id = 780 and c_last = 'last'",
     "Table": "customer1",
-    "Values": 870,
+    "Values": [
+      870
+    ],
     "Vindex": "hash"
   }
 }
@@ -624,7 +666,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(c_id) as namecnt from customer1 where 1 != 1",
     "Query": "select count(c_id) as namecnt from customer1 where c_w_id = 870 and c_d_id = 780 and c_last = 'last'",
     "Table": "customer1",
-    "Values": "INT64(870)",
+    "Values": [
+      "INT64(870)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -644,7 +688,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
     "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by c_first asc",
     "Table": "customer1",
-    "Values": 840,
+    "Values": [
+      840
+    ],
     "Vindex": "hash"
   }
 }
@@ -661,7 +707,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_balance, c_first, c_middle, c_id from customer1 where 1 != 1",
     "Query": "select c_balance, c_first, c_middle, c_id from customer1 where c_w_id = 840 and c_d_id = 1 and c_last = 'test' order by c_first asc",
     "Table": "customer1",
-    "Values": "INT64(840)",
+    "Values": [
+      "INT64(840)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -681,7 +729,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_balance, c_first, c_middle, c_last from customer1 where 1 != 1",
     "Query": "select c_balance, c_first, c_middle, c_last from customer1 where c_w_id = 15 and c_d_id = 5169 and c_id = 1",
     "Table": "customer1",
-    "Values": 15,
+    "Values": [
+      15
+    ],
     "Vindex": "hash"
   }
 }
@@ -698,7 +748,9 @@ Gen4 plan same as above
     "FieldQuery": "select c_balance, c_first, c_middle, c_last from customer1 where 1 != 1",
     "Query": "select c_balance, c_first, c_middle, c_last from customer1 where c_w_id = 15 and c_d_id = 5169 and c_id = 1",
     "Table": "customer1",
-    "Values": "INT64(15)",
+    "Values": [
+      "INT64(15)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -718,7 +770,9 @@ Gen4 plan same as above
     "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
     "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by o_id desc",
     "Table": "orders1",
-    "Values": 9894,
+    "Values": [
+      9894
+    ],
     "Vindex": "hash"
   }
 }
@@ -735,7 +789,9 @@ Gen4 plan same as above
     "FieldQuery": "select o_id, o_carrier_id, o_entry_d from orders1 where 1 != 1",
     "Query": "select o_id, o_carrier_id, o_entry_d from orders1 where o_w_id = 9894 and o_d_id = 3 and o_c_id = 159 order by o_id desc",
     "Table": "orders1",
-    "Values": "INT64(9894)",
+    "Values": [
+      "INT64(9894)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -755,7 +811,9 @@ Gen4 plan same as above
     "FieldQuery": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where 1 != 1",
     "Query": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where ol_w_id = 92 and ol_d_id = 5 and ol_o_id = 1",
     "Table": "order_line1",
-    "Values": 92,
+    "Values": [
+      92
+    ],
     "Vindex": "hash"
   }
 }
@@ -772,7 +830,9 @@ Gen4 plan same as above
     "FieldQuery": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where 1 != 1",
     "Query": "select ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d from order_line1 where ol_w_id = 92 and ol_d_id = 5 and ol_o_id = 1",
     "Table": "order_line1",
-    "Values": "INT64(92)",
+    "Values": [
+      "INT64(92)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -792,7 +852,9 @@ Gen4 plan same as above
     "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
     "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by no_o_id asc limit 1 for update",
     "Table": "new_orders1",
-    "Values": 15,
+    "Values": [
+      15
+    ],
     "Vindex": "hash"
   }
 }
@@ -809,7 +871,9 @@ Gen4 plan same as above
     "FieldQuery": "select no_o_id from new_orders1 where 1 != 1",
     "Query": "select no_o_id from new_orders1 where no_d_id = 689 and no_w_id = 15 order by no_o_id asc limit 1 for update",
     "Table": "new_orders1",
-    "Values": "INT64(15)",
+    "Values": [
+      "INT64(15)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -853,7 +917,9 @@ Gen4 plan same as above
     "FieldQuery": "select o_c_id from orders1 where 1 != 1",
     "Query": "select o_c_id from orders1 where o_id = 6 and o_d_id = 1983 and o_w_id = 894605",
     "Table": "orders1",
-    "Values": 894605,
+    "Values": [
+      894605
+    ],
     "Vindex": "hash"
   }
 }
@@ -870,7 +936,9 @@ Gen4 plan same as above
     "FieldQuery": "select o_c_id from orders1 where 1 != 1",
     "Query": "select o_c_id from orders1 where o_id = 6 and o_d_id = 1983 and o_w_id = 894605",
     "Table": "orders1",
-    "Values": "INT64(894605)",
+    "Values": [
+      "INT64(894605)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -938,7 +1006,9 @@ Gen4 plan same as above
     "FieldQuery": "select SUM(ol_amount) as sm from order_line1 where 1 != 1",
     "Query": "select SUM(ol_amount) as sm from order_line1 where ol_o_id = 680 and ol_d_id = 201 and ol_w_id = 87",
     "Table": "order_line1",
-    "Values": 87,
+    "Values": [
+      87
+    ],
     "Vindex": "hash"
   }
 }
@@ -955,7 +1025,9 @@ Gen4 plan same as above
     "FieldQuery": "select SUM(ol_amount) as sm from order_line1 where 1 != 1",
     "Query": "select SUM(ol_amount) as sm from order_line1 where ol_o_id = 680 and ol_d_id = 201 and ol_w_id = 87",
     "Table": "order_line1",
-    "Values": "INT64(87)",
+    "Values": [
+      "INT64(87)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -999,7 +1071,9 @@ Gen4 plan same as above
     "FieldQuery": "select d_next_o_id from district1 where 1 != 1",
     "Query": "select d_next_o_id from district1 where d_id = 6 and d_w_id = 21",
     "Table": "district1",
-    "Values": 21,
+    "Values": [
+      21
+    ],
     "Vindex": "hash"
   }
 }
@@ -1016,7 +1090,9 @@ Gen4 plan same as above
     "FieldQuery": "select d_next_o_id from district1 where 1 != 1",
     "Query": "select d_next_o_id from district1 where d_id = 6 and d_w_id = 21",
     "Table": "district1",
-    "Values": "INT64(21)",
+    "Values": [
+      "INT64(21)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -1036,7 +1112,9 @@ Gen4 plan same as above
     "FieldQuery": "select COUNT(distinct s.s_i_id) from stock1 as s join order_line1 as ol on ol.ol_w_id = s.s_w_id and ol.ol_i_id = s.s_i_id where 1 != 1",
     "Query": "select COUNT(distinct s.s_i_id) from stock1 as s join order_line1 as ol on ol.ol_w_id = s.s_w_id and ol.ol_i_id = s.s_i_id where ol.ol_w_id = 12 and ol.ol_d_id = 1908 and ol.ol_o_id \u003c 30 and ol.ol_o_id \u003e= 15 and s.s_w_id = 12 and s.s_quantity \u003c 10",
     "Table": "stock1, order_line1",
-    "Values": 12,
+    "Values": [
+      12
+    ],
     "Vindex": "hash"
   }
 }
@@ -1053,7 +1131,9 @@ Gen4 plan same as above
     "FieldQuery": "select COUNT(distinct s.s_i_id) from stock1 as s, order_line1 as ol where 1 != 1",
     "Query": "select COUNT(distinct s.s_i_id) from stock1 as s, order_line1 as ol where s.s_w_id = 12 and s.s_quantity \u003c 10 and ol.ol_w_id = 12 and ol.ol_d_id = 1908 and ol.ol_o_id \u003c 30 and ol.ol_o_id \u003e= 15 and ol.ol_w_id = s.s_w_id and ol.ol_i_id = s.s_i_id",
     "Table": "order_line1, stock1",
-    "Values": "INT64(12)",
+    "Values": [
+      "INT64(12)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -1073,7 +1153,9 @@ Gen4 plan same as above
     "FieldQuery": "select ol_i_id from order_line1 where 1 != 1",
     "Query": "select distinct ol_i_id from order_line1 where ol_w_id = 1 and ol_d_id = 156 and ol_o_id \u003c 500 and ol_o_id \u003e= 56",
     "Table": "order_line1",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "hash"
   }
 }
@@ -1090,7 +1172,9 @@ Gen4 plan same as above
     "FieldQuery": "select ol_i_id from order_line1 where 1 != 1",
     "Query": "select distinct ol_i_id from order_line1 where ol_w_id = 1 and ol_d_id = 156 and ol_o_id \u003c 500 and ol_o_id \u003e= 56",
     "Table": "order_line1",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -1110,7 +1194,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(*) from stock1 where 1 != 1",
     "Query": "select count(*) from stock1 where s_w_id = 1 and s_i_id = 8 and s_quantity \u003c 1000",
     "Table": "stock1",
-    "Values": 1,
+    "Values": [
+      1
+    ],
     "Vindex": "hash"
   }
 }
@@ -1127,7 +1213,9 @@ Gen4 plan same as above
     "FieldQuery": "select count(*) from stock1 where 1 != 1",
     "Query": "select count(*) from stock1 where s_w_id = 1 and s_i_id = 8 and s_quantity \u003c 1000",
     "Table": "stock1",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "hash"
   }
 }
@@ -1173,7 +1261,9 @@ Gen4 plan same as above
             "FieldQuery": "select 1 from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1 group by o_c_id, o_d_id, o_w_id) as t where 1 != 1",
             "Query": "select 1 from (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id \u003e 2100 and o_id \u003c 11153 group by o_c_id, o_d_id, o_w_id having count(distinct o_id) \u003e 1 limit 1) as t where t.o_w_id = :o_o_w_id and t.o_d_id = :o_o_d_id and t.o_c_id = :o_o_c_id",
             "Table": "orders1",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "hash"
           }
         ]
@@ -1194,7 +1284,9 @@ Gen4 plan same as above
     "FieldQuery": "select o.o_id, o.o_d_id from orders1 as o, (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where 1 != 1) as t where 1 != 1",
     "Query": "select o.o_id, o.o_d_id from orders1 as o, (select o_c_id, o_w_id, o_d_id, count(distinct o_w_id), o_id from orders1 where o_w_id = 1 and o_id \u003e 2100 and o_id \u003c 11153) as t where t.o_w_id = o.o_w_id and t.o_d_id = o.o_d_id and t.o_c_id = o.o_c_id limit 1",
     "Table": "orders1",
-    "Values": "INT64(1)",
+    "Values": [
+      "INT64(1)"
+    ],
     "Vindex": "hash"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.txt
@@ -177,7 +177,9 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
             "FieldQuery": "select total_revenue from revenue0 where 1 != 1",
             "Query": "select total_revenue from revenue0 where supplier_no = :s_suppkey and total_revenue = :__sq1",
             "Table": "revenue0",
-            "Values": ":s_suppkey",
+            "Values": [
+              ":s_suppkey"
+            ],
             "Vindex": "hash"
           }
         ]
@@ -304,7 +306,9 @@ Gen4 error: unsupported: in scatter query: complex aggregate expression
                         "FieldQuery": "select p_brand, p_type, p_size, weight_string(p_brand), weight_string(p_type), weight_string(p_size) from part where 1 != 1",
                         "Query": "select p_brand, p_type, p_size, weight_string(p_brand), weight_string(p_type), weight_string(p_size) from part where p_brand != 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and p_size in (49, 14, 23, 45, 19, 3, 36, 9) and p_partkey = :ps_partkey",
                         "Table": "part",
-                        "Values": ":ps_partkey",
+                        "Values": [
+                          ":ps_partkey"
+                        ],
                         "Vindex": "hash"
                       }
                     ]
@@ -384,7 +388,9 @@ Gen4 error: unsupported: cross-shard correlated subquery
                     "OrderBy": "(3|6) DESC, (2|5) ASC",
                     "Query": "select o_custkey, o_orderkey, o_orderdate, o_totalprice, weight_string(o_orderkey), weight_string(o_orderdate), weight_string(o_totalprice) from orders where :__sq_has_values1 = 1 and o_orderkey in ::__vals order by o_totalprice desc, o_orderdate asc",
                     "Table": "orders",
-                    "Values": ":__sq1",
+                    "Values": [
+                      ":__sq1"
+                    ],
                     "Vindex": "hash"
                   },
                   {
@@ -397,7 +403,9 @@ Gen4 error: unsupported: cross-shard correlated subquery
                     "FieldQuery": "select c_name, c_custkey, weight_string(c_name), weight_string(c_custkey) from customer where 1 != 1",
                     "Query": "select c_name, c_custkey, weight_string(c_name), weight_string(c_custkey) from customer where c_custkey = :o_custkey",
                     "Table": "customer",
-                    "Values": ":o_custkey",
+                    "Values": [
+                      ":o_custkey"
+                    ],
                     "Vindex": "hash"
                   }
                 ]
@@ -412,7 +420,9 @@ Gen4 error: unsupported: cross-shard correlated subquery
                 "FieldQuery": "select sum(l_quantity) from lineitem where 1 != 1",
                 "Query": "select sum(l_quantity) from lineitem where l_orderkey = :o_orderkey",
                 "Table": "lineitem",
-                "Values": ":o_orderkey",
+                "Values": [
+                  ":o_orderkey"
+                ],
                 "Vindex": "lineitem_map"
               }
             ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.txt
@@ -94,7 +94,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 1",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -107,7 +109,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5",
         "Table": "`user`",
-        "Values": 5,
+        "Values": [
+          5
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -129,7 +133,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 1",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -142,7 +148,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 5",
         "Table": "`user`",
-        "Values": "INT64(5)",
+        "Values": [
+          "INT64(5)"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -326,7 +334,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1 union select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 1 union select id from `user` where id = 1",
         "Table": "`user`",
-        "Values": 1,
+        "Values": [
+          1
+        ],
         "Vindex": "user_index"
       },
       {
@@ -359,7 +369,9 @@ Gen4 plan same as above
         "FieldQuery": "select id from `user` where 1 != 1 union select id from `user` where 1 != 1",
         "Query": "select id from `user` where id = 1 union select id from `user` where id = 1",
         "Table": "`user`",
-        "Values": "INT64(1)",
+        "Values": [
+          "INT64(1)"
+        ],
         "Vindex": "user_index"
       },
       {
@@ -761,7 +773,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select * from music where 1 != 1",
             "Query": "select * from music where id = 1",
             "Table": "music",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "music_user_map"
           },
           {
@@ -774,7 +788,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select * from `user` where 1 != 1",
             "Query": "select * from `user` where id = 1",
             "Table": "`user`",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -801,7 +817,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select * from music where 1 != 1",
             "Query": "select distinct * from music where id = 1",
             "Table": "music",
-            "Values": "INT64(1)",
+            "Values": [
+              "INT64(1)"
+            ],
             "Vindex": "music_user_map"
           },
           {
@@ -814,7 +832,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select * from `user` where 1 != 1",
             "Query": "select distinct * from `user` where id = 1",
             "Table": "`user`",
-            "Values": "INT64(1)",
+            "Values": [
+              "INT64(1)"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -844,7 +864,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select 1 from music where 1 != 1",
             "Query": "select 1 from music where id = 1",
             "Table": "music",
-            "Values": 1,
+            "Values": [
+              1
+            ],
             "Vindex": "music_user_map"
           },
           {
@@ -857,7 +879,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select 1 from music where 1 != 1",
             "Query": "select 1 from music where id = 2",
             "Table": "music",
-            "Values": 2,
+            "Values": [
+              2
+            ],
             "Vindex": "music_user_map"
           }
         ]
@@ -884,7 +908,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select 1 from music where 1 != 1",
             "Query": "select distinct 1 from music where id = 1",
             "Table": "music",
-            "Values": "INT64(1)",
+            "Values": [
+              "INT64(1)"
+            ],
             "Vindex": "music_user_map"
           },
           {
@@ -897,7 +923,9 @@ Gen4 error: nesting of unions at the right-hand side is not yet supported
             "FieldQuery": "select 1 from music where 1 != 1",
             "Query": "select distinct 1 from music where id = 2",
             "Table": "music",
-            "Values": "INT64(2)",
+            "Values": [
+              "INT64(2)"
+            ],
             "Vindex": "music_user_map"
           }
         ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -545,7 +545,9 @@ Gen4 error: expr cannot be converted, not supported: *sqlparser.FuncExpr
     "FieldQuery": "select 1 from `user` where 1 != 1",
     "Query": "select 1 from `user` having count(id) = 10 and `name` = 'a'",
     "Table": "`user`",
-    "Values": "a",
+    "Values": [
+      "a"
+    ],
     "Vindex": "name_user_map"
   }
 }

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.txt
@@ -71,7 +71,9 @@
         "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
         "Query": "select u.id as uid from `user` as u where u.id = :e_id",
         "Table": "`user`",
-        "Values": ":e_id",
+        "Values": [
+          ":e_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -151,7 +153,9 @@
         "FieldQuery": "select u.id as uid from `user` as u where 1 != 1",
         "Query": "select u.id as uid from `user` as u where u.id = :e_id",
         "Table": "`user`",
-        "Values": ":e_id",
+        "Values": [
+          ":e_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -578,7 +582,9 @@
             "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
             "Query": "select 1 from `user` as u3 where u3.id = :u1_col",
             "Table": "`user`",
-            "Values": ":u1_col",
+            "Values": [
+              ":u1_col"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -669,7 +675,9 @@
                 "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
                 "Query": "select 1 from `user` as u3 where u3.id = :u1_col",
                 "Table": "`user`",
-                "Values": ":u1_col",
+                "Values": [
+                  ":u1_col"
+                ],
                 "Vindex": "user_index"
               }
             ]
@@ -720,7 +728,9 @@
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
             "Query": "select 1 from `user` as u2 where u2.id = :u1_col",
             "Table": "`user`",
-            "Values": ":u1_col",
+            "Values": [
+              ":u1_col"
+            ],
             "Vindex": "user_index"
           },
           {
@@ -733,7 +743,9 @@
             "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
             "Query": "select 1 from `user` as u3 where u3.id = :u1_col",
             "Table": "`user`",
-            "Values": ":u1_col",
+            "Values": [
+              ":u1_col"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -785,7 +797,9 @@
             "FieldQuery": "select 1 from `user` as u2 where 1 != 1",
             "Query": "select 1 from `user` as u2 where u2.id = :u1_col",
             "Table": "`user`",
-            "Values": ":u1_col",
+            "Values": [
+              ":u1_col"
+            ],
             "Vindex": "user_index"
           }
         ]
@@ -800,7 +814,9 @@
         "FieldQuery": "select 1 from `user` as u3 where 1 != 1",
         "Query": "select 1 from `user` as u3 where u3.id = :u1_col",
         "Table": "`user`",
-        "Values": ":u1_col",
+        "Values": [
+          ":u1_col"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -880,7 +896,9 @@
         "FieldQuery": "select `weird``name`.a from `weird``name` where 1 != 1",
         "Query": "select `weird``name`.a from `weird``name` where `weird``name`.`a``b*c` = :unsharded_id",
         "Table": "`weird``name`",
-        "Values": ":unsharded_id",
+        "Values": [
+          ":unsharded_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -960,7 +978,9 @@
         "FieldQuery": "select 1 from `weird``name` where 1 != 1",
         "Query": "select 1 from `weird``name` where `weird``name`.`a``b*c` = :unsharded_id",
         "Table": "`weird``name`",
-        "Values": ":unsharded_id",
+        "Values": [
+          ":unsharded_id"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1119,7 +1139,9 @@
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": "::__sq1",
+        "Values": [
+          "::__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]
@@ -1186,7 +1208,9 @@
         "FieldQuery": "select 1 from `user` where 1 != 1",
         "Query": "select 1 from `user` where :__sq_has_values1 = 1 and id in ::__vals",
         "Table": "`user`",
-        "Values": ":__sq1",
+        "Values": [
+          ":__sq1"
+        ],
         "Vindex": "user_index"
       }
     ]

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -558,6 +558,10 @@ func (vc *vcursorImpl) ResolveDestinations(keyspace string, ids []*querypb.Value
 	return vc.resolver.ResolveDestinations(vc.ctx, keyspace, vc.tabletType, ids, destinations)
 }
 
+func (vc *vcursorImpl) ResolveDestinationsMultiCol(keyspace string, ids [][]sqltypes.Value, destinations []key.Destination) ([]*srvtopo.ResolvedShard, [][][]sqltypes.Value, error) {
+	return vc.resolver.ResolveDestinationsMultiCol(vc.ctx, keyspace, vc.tabletType, ids, destinations)
+}
+
 func (vc *vcursorImpl) Session() engine.SessionActions {
 	return vc
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for multi-column vindex selection in select sql queries.
This only works with Gen4 planner.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #3481

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->