### PR TITLE
Tablet throttler: check replicas via HTTP rather than via MySQL

### DIFF
--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -186,7 +186,7 @@ func TestLag(t *testing.T) {
 		{
 			resp, err := throttleCheck(primaryTablet)
 			assert.NoError(t, err)
-			assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		}
 		{
 			resp, err := throttleCheckSelf(primaryTablet)

--- a/go/test/endtoend/tabletmanager/throttler/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler/throttler_test.go
@@ -186,7 +186,7 @@ func TestLag(t *testing.T) {
 		{
 			resp, err := throttleCheck(primaryTablet)
 			assert.NoError(t, err)
-			assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+			assert.NotEqual(t, http.StatusOK, resp.StatusCode)
 		}
 		{
 			resp, err := throttleCheckSelf(primaryTablet)

--- a/go/vt/vttablet/tabletserver/throttle/mysql/mysql_throttle_metric.go
+++ b/go/vt/vttablet/tabletserver/throttle/mysql/mysql_throttle_metric.go
@@ -73,7 +73,7 @@ func GetMetricsQueryType(query string) MetricsQueryType {
 }
 
 // MySQLThrottleMetric has the probed metric for a mysql instance
-type MySQLThrottleMetric struct {
+type MySQLThrottleMetric struct { // nolint:revive
 	ClusterName string
 	Key         InstanceKey
 	Value       float64

--- a/go/vt/vttablet/tabletserver/throttle/mysql/probe.go
+++ b/go/vt/vttablet/tabletserver/throttle/mysql/probe.go
@@ -21,6 +21,8 @@ type Probe struct {
 	User            string
 	Password        string
 	MetricQuery     string
+	TabletHost      string
+	TabletPort      int
 	CacheMillis     int
 	QueryInProgress int64
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -550,7 +550,7 @@ func (throttler *Throttler) generateTabletHTTPProbeFunction(ctx context.Context,
 		}
 		mySQLThrottleMetric.Value = checkResult.Value
 
-		if checkResult.StatusCode != http.StatusOK {
+		if checkResult.StatusCode == http.StatusInternalServerError {
 			mySQLThrottleMetric.Err = fmt.Errorf("Status code: %d", checkResult.StatusCode)
 		}
 		return mySQLThrottleMetric

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -40,10 +40,10 @@ import (
 
 const (
 	leaderCheckInterval         = 5 * time.Second
-	mysqlCollectInterval        = 100 * time.Millisecond
+	mysqlCollectInterval        = 250 * time.Millisecond
 	mysqlDormantCollectInterval = 5 * time.Second
 	mysqlRefreshInterval        = 10 * time.Second
-	mysqlAggregateInterval      = 100 * time.Millisecond
+	mysqlAggregateInterval      = 125 * time.Millisecond
 
 	aggregatedMetricsExpiration   = 5 * time.Second
 	aggregatedMetricsCleanup      = 10 * time.Second

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -8,8 +8,10 @@ package throttle
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -83,7 +85,7 @@ var (
 )
 
 // ThrottleCheckType allows a client to indicate what type of check it wants to issue. See available types below.
-type ThrottleCheckType int
+type ThrottleCheckType int // nolint:revive
 
 const (
 	// ThrottleCheckPrimaryWrite indicates a check before making a write on a primary server
@@ -186,7 +188,7 @@ func NewThrottler(env tabletenv.Env, ts *topo.Server, tabletTypeFunc func() topo
 		throttler.tickers = [](*timer.SuspendableTicker){}
 		throttler.nonLowPriorityAppRequestsThrottled = cache.New(nonDeprioritizedAppMapExpiration, nonDeprioritizedAppMapInterval)
 
-		throttler.httpClient = base.SetupHTTPClient(0)
+		throttler.httpClient = base.SetupHTTPClient(2 * mysqlCollectInterval)
 		throttler.initThrottleTabletTypes()
 		throttler.ThrottleApp("abusing-app", time.Now().Add(time.Hour*24*365*10), defaultThrottleRatio)
 		throttler.check = NewThrottlerCheck(throttler)
@@ -518,6 +520,43 @@ func (throttler *Throttler) Operate(ctx context.Context) {
 	}
 }
 
+func (throttler *Throttler) generateTabletHTTPProbeFunction(ctx context.Context, clusterName string, probe *mysql.Probe) (probeFunc func() *mysql.MySQLThrottleMetric) {
+	if probe.TabletHost == "" {
+		// nil function means no override; throttler will use default probe behavior, which is to open a direct
+		// connection to mysql and run a query
+		return nil
+	}
+	return func() *mysql.MySQLThrottleMetric {
+		// Hit a tablet's `check-self` via HTTP, and convert its CheckResult JSON output into a MySQLThrottleMetric
+		mySQLThrottleMetric := mysql.NewMySQLThrottleMetric()
+		mySQLThrottleMetric.ClusterName = clusterName
+		mySQLThrottleMetric.Key = probe.Key
+
+		tabletCheckSelfURL := fmt.Sprintf("http://%s:%d/throttler/check-self?app=vitess", probe.TabletHost, probe.TabletPort)
+		resp, err := throttler.httpClient.Get(tabletCheckSelfURL)
+		if err != nil {
+			mySQLThrottleMetric.Err = err
+			return mySQLThrottleMetric
+		}
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			mySQLThrottleMetric.Err = err
+			return mySQLThrottleMetric
+		}
+		checkResult := &CheckResult{}
+		if err := json.Unmarshal(b, checkResult); err != nil {
+			mySQLThrottleMetric.Err = err
+			return mySQLThrottleMetric
+		}
+		mySQLThrottleMetric.Value = checkResult.Value
+
+		if checkResult.StatusCode != http.StatusOK {
+			mySQLThrottleMetric.Err = fmt.Errorf("Status code: %d", checkResult.StatusCode)
+		}
+		return mySQLThrottleMetric
+	}
+}
+
 func (throttler *Throttler) collectMySQLMetrics(ctx context.Context) error {
 	// synchronously, get lists of probes
 	for clusterName, probes := range throttler.mysqlInventory.ClustersProbes {
@@ -540,7 +579,7 @@ func (throttler *Throttler) collectMySQLMetrics(ctx context.Context) error {
 					// (where we incidentally know there's a single probe)
 					overrideGetMySQLThrottleMetricFunc := throttler.readSelfMySQLThrottleMetric
 					if clusterName != selfStoreName {
-						overrideGetMySQLThrottleMetricFunc = nil
+						overrideGetMySQLThrottleMetricFunc = throttler.generateTabletHTTPProbeFunction(ctx, clusterName, probe)
 					}
 					throttleMetrics := mysql.ReadThrottleMetric(probe, clusterName, overrideGetMySQLThrottleMetricFunc)
 					throttler.mysqlThrottleMetricChan <- throttleMetrics
@@ -554,7 +593,7 @@ func (throttler *Throttler) collectMySQLMetrics(ctx context.Context) error {
 // refreshMySQLInventory will re-structure the inventory based on reading config settings
 func (throttler *Throttler) refreshMySQLInventory(ctx context.Context) error {
 
-	addInstanceKey := func(key *mysql.InstanceKey, clusterName string, clusterSettings *config.MySQLClusterConfigurationSettings, probes *mysql.Probes) {
+	addInstanceKey := func(tabletHost string, tabletPort int, key *mysql.InstanceKey, clusterName string, clusterSettings *config.MySQLClusterConfigurationSettings, probes *mysql.Probes) {
 		for _, ignore := range clusterSettings.IgnoreHosts {
 			if strings.Contains(key.StringCode(), ignore) {
 				log.Infof("Throttler: instance key ignored: %+v", key)
@@ -570,6 +609,8 @@ func (throttler *Throttler) refreshMySQLInventory(ctx context.Context) error {
 			Key:         *key,
 			User:        clusterSettings.User,
 			Password:    clusterSettings.Password,
+			TabletHost:  tabletHost,
+			TabletPort:  tabletPort,
 			MetricQuery: clusterSettings.MetricQuery,
 			CacheMillis: clusterSettings.CacheMillis,
 		}
@@ -592,7 +633,7 @@ func (throttler *Throttler) refreshMySQLInventory(ctx context.Context) error {
 			if clusterName == selfStoreName {
 				// special case: just looking at this tablet's MySQL server
 				// We will probe this "cluster" (of one server) is a special way.
-				addInstanceKey(mysql.SelfInstanceKey, clusterName, clusterSettings, clusterProbes.InstanceProbes)
+				addInstanceKey("", 0, mysql.SelfInstanceKey, clusterName, clusterSettings, clusterProbes.InstanceProbes)
 				throttler.mysqlClusterProbesChan <- clusterProbes
 				return
 			}
@@ -613,7 +654,7 @@ func (throttler *Throttler) refreshMySQLInventory(ctx context.Context) error {
 					}
 					if throttler.throttleTabletTypesMap[tablet.Type] {
 						key := mysql.InstanceKey{Hostname: tablet.MysqlHostname, Port: int(tablet.MysqlPort)}
-						addInstanceKey(&key, clusterName, clusterSettings, clusterProbes.InstanceProbes)
+						addInstanceKey(tablet.Hostname, int(tablet.PortMap["vt"]), &key, clusterName, clusterSettings, clusterProbes.InstanceProbes)
 					}
 				}
 				throttler.mysqlClusterProbesChan <- clusterProbes


### PR DESCRIPTION

## Description

In this PR we override the existing throttler behavior for shard health checks.
A shard is considered healthy if all replicas are lagging within a certain threshold. 

Today, the primary tablet acquires the identities of all shard's tablets, filters the relevant tablets, then records the hostname.port of the **MySQL** servers of those tablets. It continuously polls these MySQL servers directly for replication lag.

In this PR, the primary tablet no longer accesses those MySQL servers directly (the code to do that is still here, but never used). Instead, it accesses the tablet's HTTP interface for `/throttler/check-self`. On each replica tablet, that check already reflects the replication lag status of the tablet. So now the primary tablet acquires lag information indirectly via HTTP requests.

## Related Issue(s)

- https://github.com/vitessio/vitess/issues/9213


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required


