### PR TITLE
Allow source columns to be specified multiple times in a vreplication rule filter

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -492,3 +492,21 @@ func (vc *VitessCluster) getVttabletsInKeyspace(t *testing.T, cell *Cell, ksName
 	}
 	return tablets
 }
+
+func (vc *VitessCluster) getPrimaryTablet(t *testing.T, ksName, shardName string) *cluster.VttabletProcess {
+	for _, cell := range vc.Cells {
+		keyspace := cell.Keyspaces[ksName]
+		for _, shard := range keyspace.Shards {
+			if shard.Name != shardName {
+				continue
+			}
+			for _, tablet := range shard.Tablets {
+				if tablet.Vttablet.GetTabletStatus() == "SERVING" && strings.EqualFold(tablet.Vttablet.VreplicationTabletType, "primary") {
+					return tablet.Vttablet
+				}
+			}
+		}
+	}
+	require.FailNow(t, "no primary found for %s:%s", ksName, shardName)
+	return nil
+}

--- a/go/test/endtoend/vreplication/materialize_test.go
+++ b/go/test/endtoend/vreplication/materialize_test.go
@@ -96,3 +96,136 @@ func TestShardedMaterialize(t *testing.T) {
 	validateQuery(t, vtgateConn, "ks2:-", "select id, val from tx",
 		`[[INT64(3) VARBINARY("def")] [INT64(5) VARBINARY("def")]]`)
 }
+
+/*
+ * The following sections are related to TestMaterialize. TestMaterialize is intended to test some edge cases. Currently
+ * it tests
+ * - the case where the same column is referred to multiple times
+ * - use of mysql functions in the filter
+ * - use of a custom function in the filter
+ */
+
+const smMaterializeSchemaSource = `
+	CREATE TABLE mat (
+	id bigint NOT NULL,
+	val varbinary(10) NOT NULL,
+	ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`
+
+const smMaterializeVSchemaSource = `
+{
+  "sharded": true,
+  "tables": {
+      "mat": {
+          "column_vindexes": [
+              {
+                  "column": "id",
+                  "name": "hash"
+              }
+          ]
+      }
+  },
+  "vindexes": {
+      "hash": {
+          "type": "hash"
+      }
+  }
+}
+`
+const smMaterializeSchemaTarget = `
+	CREATE TABLE mat2 (
+	id bigint NOT NULL,
+	val varbinary(10) NOT NULL,
+	ts timestamp NOT NULL,
+	day int NOT NULL,
+	month int NOT NULL,
+    x int not null,
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`
+
+const smMaterializeVSchemaTarget = `
+{
+  "sharded": true,
+  "tables": {
+      "mat2": {
+          "column_vindexes": [
+              {
+                  "column": "id",
+                  "name": "hash"
+              }
+          ]
+      }
+  },
+  "vindexes": {
+      "hash": {
+          "type": "hash"
+      }
+  }
+}
+`
+const smMaterializeSpec2 = `{"workflow": "wf1", "source_keyspace": "ks1", "target_keyspace": "ks2", "table_settings": [ {"target_table": "mat2", "source_expression": "select id, val, ts, dayofmonth(ts) as day, month(ts) as month, custom1(id, val) as x from mat"  }] }`
+
+const materializeInitDataQuery = `insert into ks1.mat(id, val, ts) values (1, 'abc', '2021-10-9 16:17:36'), (2, 'def', '2021-11-10 16:17:36')`
+
+const customFunc = `
+CREATE FUNCTION custom1(id int, val varbinary(10))
+RETURNS int
+DETERMINISTIC
+RETURN id * length(val);
+`
+
+// TestMaterialize: details mentioned above
+func TestMaterialize(t *testing.T) {
+	defaultCellName := "zone1"
+	allCells := []string{"zone1"}
+	allCellNames = "zone1"
+	vc = NewVitessCluster(t, "TestMaterialize", allCells, mainClusterConfig)
+	ks1 := "ks1"
+	ks2 := "ks2"
+	require.NotNil(t, vc)
+	defaultReplicas = 0 // because of CI resource constraints we can only run this test with primary tablets
+	defer func() { defaultReplicas = 1 }()
+
+	defer vc.TearDown(t)
+
+	defaultCell = vc.Cells[defaultCellName]
+	vc.AddKeyspace(t, []*Cell{defaultCell}, ks1, "-", smMaterializeVSchemaSource, smMaterializeSchemaSource, defaultReplicas, defaultRdonly, 100)
+	vtgate = defaultCell.Vtgates[0]
+	require.NotNil(t, vtgate)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", ks1, "0"), 1)
+
+	vc.AddKeyspace(t, []*Cell{defaultCell}, ks2, "-", smMaterializeVSchemaTarget, smMaterializeSchemaTarget, defaultReplicas, defaultRdonly, 200)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", ks2, "0"), 1)
+
+	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	defer vtgateConn.Close()
+	verifyClusterHealth(t, vc)
+
+	_, err := vtgateConn.ExecuteFetch(materializeInitDataQuery, 0, false)
+	require.NoError(t, err)
+
+	ks2Keyspace := vc.Cells[defaultCell.Name].Keyspaces["ks2"]
+	ks2Primary := ks2Keyspace.Shards["-"].Tablets["zone1-200"].Vttablet
+	_, err = ks2Primary.QueryTablet(customFunc, "ks2", true)
+	require.NoError(t, err)
+
+	materialize(t, smMaterializeSpec2)
+	tab := vc.Cells[defaultCell.Name].Keyspaces[ks2].Shards["-"].Tablets["zone1-200"].Vttablet
+	catchup(t, tab, "wf1", "Materialize")
+
+	// validate data after the copy phase
+	validateCount(t, vtgateConn, ks2, "mat2", 2)
+	want := `[[INT64(1) VARBINARY("abc") TIMESTAMP("2021-10-09 16:17:36") INT32(9) INT32(10) INT32(3)] [INT64(2) VARBINARY("def") TIMESTAMP("2021-11-10 16:17:36") INT32(10) INT32(11) INT32(6)]]`
+	validateQuery(t, vtgateConn, "ks2:-", "select id, val, ts, day, month, x from mat2", want)
+
+	// insert data to test the replication phase
+	execVtgateQuery(t, vtgateConn, "ks1", "insert into ks1.mat(id, val, ts) values (3, 'ghi', '2021-12-11 16:17:36')")
+
+	// validate data after the replication phase
+	waitForQueryToExecute(t, vtgateConn, "ks2", "select count(*) from mat2", "[[INT64(3)]]")
+	want = `[[INT64(1) VARBINARY("abc") TIMESTAMP("2021-10-09 16:17:36") INT32(9) INT32(10) INT32(3)] [INT64(2) VARBINARY("def") TIMESTAMP("2021-11-10 16:17:36") INT32(10) INT32(11) INT32(6)] [INT64(3) VARBINARY("ghi") TIMESTAMP("2021-12-11 16:17:36") INT32(11) INT32(12) INT32(9)]]`
+	validateQuery(t, vtgateConn, "ks2:-", "select id, val, ts, day, month, x from mat2", want)
+}

--- a/go/test/endtoend/vreplication/materialize_test.go
+++ b/go/test/endtoend/vreplication/materialize_test.go
@@ -61,7 +61,7 @@ const smMaterializeSpec = `{"workflow": "wf1", "source_keyspace": "ks1", "target
 const initDataQuery = `insert into ks1.tx(id, typ, val) values (1, 1, 'abc'), (2, 1, 'def'), (3, 2, 'def'), (4, 2, 'abc'), (5, 3, 'def'), (6, 3, 'abc')`
 
 // TestShardedMaterialize tests a materialize from a sharded (single shard) using comparison filters
-func TestShardedMaterialize(t *testing.T) {
+func testShardedMaterialize(t *testing.T) {
 	defaultCellName := "zone1"
 	allCells := []string{"zone1"}
 	allCellNames = "zone1"
@@ -166,9 +166,9 @@ const smMaterializeVSchemaTarget = `
   }
 }
 `
-const smMaterializeSpec2 = `{"workflow": "wf1", "source_keyspace": "ks1", "target_keyspace": "ks2", "table_settings": [ {"target_table": "mat2", "source_expression": "select id, val, ts, dayofmonth(ts) as day, month(ts) as month, custom1(id, val) as x from mat"  }] }`
+const smMaterializeSpec2 = `{"workflow": "wf1", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [ {"target_table": "mat2", "source_expression": "select id, val, ts, dayofmonth(ts) as day, month(ts) as month, custom1(id, val) as x from mat"  }] }`
 
-const materializeInitDataQuery = `insert into ks1.mat(id, val, ts) values (1, 'abc', '2021-10-9 16:17:36'), (2, 'def', '2021-11-10 16:17:36')`
+const materializeInitDataQuery = `insert into mat(id, val, ts) values (1, 'abc', '2021-10-9 16:17:36'), (2, 'def', '2021-11-10 16:17:36')`
 
 const customFunc = `
 CREATE FUNCTION custom1(id int, val varbinary(10))
@@ -178,13 +178,13 @@ RETURN id * length(val);
 `
 
 // TestMaterialize: details mentioned above
-func TestMaterialize(t *testing.T) {
+func testMaterialize(t *testing.T) {
 	defaultCellName := "zone1"
 	allCells := []string{"zone1"}
 	allCellNames = "zone1"
 	vc = NewVitessCluster(t, "TestMaterialize", allCells, mainClusterConfig)
-	ks1 := "ks1"
-	ks2 := "ks2"
+	sourceKs := "source"
+	targetKs := "target"
 	require.NotNil(t, vc)
 	defaultReplicas = 0 // because of CI resource constraints we can only run this test with primary tablets
 	defer func() { defaultReplicas = 1 }()
@@ -192,13 +192,13 @@ func TestMaterialize(t *testing.T) {
 	defer vc.TearDown(t)
 
 	defaultCell = vc.Cells[defaultCellName]
-	vc.AddKeyspace(t, []*Cell{defaultCell}, ks1, "-", smMaterializeVSchemaSource, smMaterializeSchemaSource, defaultReplicas, defaultRdonly, 100)
+	vc.AddKeyspace(t, []*Cell{defaultCell}, sourceKs, "-", smMaterializeVSchemaSource, smMaterializeSchemaSource, defaultReplicas, defaultRdonly, 300)
 	vtgate = defaultCell.Vtgates[0]
 	require.NotNil(t, vtgate)
-	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", ks1, "0"), 1)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", sourceKs, "0"), 1)
 
-	vc.AddKeyspace(t, []*Cell{defaultCell}, ks2, "-", smMaterializeVSchemaTarget, smMaterializeSchemaTarget, defaultReplicas, defaultRdonly, 200)
-	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", ks2, "0"), 1)
+	vc.AddKeyspace(t, []*Cell{defaultCell}, targetKs, "-", smMaterializeVSchemaTarget, smMaterializeSchemaTarget, defaultReplicas, defaultRdonly, 400)
+	vtgate.WaitForStatusOfTabletInShard(fmt.Sprintf("%s.%s.primary", targetKs, "0"), 1)
 
 	vtgateConn = getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
 	defer vtgateConn.Close()
@@ -207,25 +207,33 @@ func TestMaterialize(t *testing.T) {
 	_, err := vtgateConn.ExecuteFetch(materializeInitDataQuery, 0, false)
 	require.NoError(t, err)
 
-	ks2Keyspace := vc.Cells[defaultCell.Name].Keyspaces["ks2"]
-	ks2Primary := ks2Keyspace.Shards["-"].Tablets["zone1-200"].Vttablet
-	_, err = ks2Primary.QueryTablet(customFunc, "ks2", true)
+	ks2Keyspace := vc.Cells[defaultCell.Name].Keyspaces[targetKs]
+	ks2Primary := ks2Keyspace.Shards["-"].Tablets["zone1-400"].Vttablet
+	_, err = ks2Primary.QueryTablet(customFunc, targetKs, true)
 	require.NoError(t, err)
 
 	materialize(t, smMaterializeSpec2)
-	tab := vc.Cells[defaultCell.Name].Keyspaces[ks2].Shards["-"].Tablets["zone1-200"].Vttablet
-	catchup(t, tab, "wf1", "Materialize")
+	catchup(t, ks2Primary, "wf1", "Materialize")
 
 	// validate data after the copy phase
-	validateCount(t, vtgateConn, ks2, "mat2", 2)
+	validateCount(t, vtgateConn, targetKs, "mat2", 2)
 	want := `[[INT64(1) VARBINARY("abc") TIMESTAMP("2021-10-09 16:17:36") INT32(9) INT32(10) INT32(3)] [INT64(2) VARBINARY("def") TIMESTAMP("2021-11-10 16:17:36") INT32(10) INT32(11) INT32(6)]]`
-	validateQuery(t, vtgateConn, "ks2:-", "select id, val, ts, day, month, x from mat2", want)
+	validateQuery(t, vtgateConn, targetKs, "select id, val, ts, day, month, x from mat2", want)
 
 	// insert data to test the replication phase
-	execVtgateQuery(t, vtgateConn, "ks1", "insert into ks1.mat(id, val, ts) values (3, 'ghi', '2021-12-11 16:17:36')")
+	execVtgateQuery(t, vtgateConn, sourceKs, "insert into mat(id, val, ts) values (3, 'ghi', '2021-12-11 16:17:36')")
 
 	// validate data after the replication phase
-	waitForQueryToExecute(t, vtgateConn, "ks2", "select count(*) from mat2", "[[INT64(3)]]")
+	waitForQueryToExecute(t, vtgateConn, targetKs, "select count(*) from mat2", "[[INT64(3)]]")
 	want = `[[INT64(1) VARBINARY("abc") TIMESTAMP("2021-10-09 16:17:36") INT32(9) INT32(10) INT32(3)] [INT64(2) VARBINARY("def") TIMESTAMP("2021-11-10 16:17:36") INT32(10) INT32(11) INT32(6)] [INT64(3) VARBINARY("ghi") TIMESTAMP("2021-12-11 16:17:36") INT32(11) INT32(12) INT32(9)]]`
-	validateQuery(t, vtgateConn, "ks2:-", "select id, val, ts, day, month, x from mat2", want)
+	validateQuery(t, vtgateConn, targetKs, "select id, val, ts, day, month, x from mat2", want)
+}
+
+func TestMaterialize(t *testing.T) {
+	t.Run("Materialize", func(t *testing.T) {
+		testMaterialize(t)
+	})
+	t.Run("ShardedMaterialize", func(t *testing.T) {
+		testShardedMaterialize(t)
+	})
 }

--- a/go/test/endtoend/vreplication/materialize_test.go
+++ b/go/test/endtoend/vreplication/materialize_test.go
@@ -60,7 +60,7 @@ const smMaterializeSpec = `{"workflow": "wf1", "source_keyspace": "ks1", "target
 
 const initDataQuery = `insert into ks1.tx(id, typ, val) values (1, 1, 'abc'), (2, 1, 'def'), (3, 2, 'def'), (4, 2, 'abc'), (5, 3, 'def'), (6, 3, 'abc')`
 
-// TestShardedMaterialize tests a materialize from a sharded (single shard) using comparison filters
+// testShardedMaterialize tests a materialize workflow for a sharded cluster (single shard) using comparison filters
 func testShardedMaterialize(t *testing.T) {
 	defaultCellName := "zone1"
 	allCells := []string{"zone1"}
@@ -98,7 +98,7 @@ func testShardedMaterialize(t *testing.T) {
 }
 
 /*
- * The following sections are related to TestMaterialize. TestMaterialize is intended to test some edge cases. Currently
+ * The following sections are related to testMaterialize, which is intended to test these edge cases:
  * it tests
  * - the case where the same column is referred to multiple times
  * - use of mysql functions in the filter
@@ -177,7 +177,6 @@ DETERMINISTIC
 RETURN id * length(val);
 `
 
-// TestMaterialize: details mentioned above
 func testMaterialize(t *testing.T) {
 	defaultCellName := "zone1"
 	allCells := []string{"zone1"}
@@ -228,6 +227,7 @@ func testMaterialize(t *testing.T) {
 	validateQuery(t, vtgateConn, targetKs, "select id, val, ts, day, month, x from mat2", want)
 }
 
+// TestMaterialize runs all the individual materialize tests defined above
 func TestMaterialize(t *testing.T) {
 	t.Run("Materialize", func(t *testing.T) {
 		testMaterialize(t)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -327,7 +327,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			VStreamFilter: &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{
 					Match:  "t1",
-					Filter: "select a, b, c from t1",
+					Filter: "select a, a, b, c from t1",
 				}},
 			},
 			TargetTables: []string{"t1"},
@@ -348,7 +348,7 @@ func TestBuildPlayerPlan(t *testing.T) {
 			VStreamFilter: &binlogdatapb.Filter{
 				Rules: []*binlogdatapb.Rule{{
 					Match:  "t1",
-					Filter: "select a, b, c, pk1, pk2 from t1",
+					Filter: "select a, a, b, c, pk1, pk2 from t1",
 				}},
 			},
 			TargetTables: []string{"t1"},

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -47,7 +47,6 @@ type tablePlanBuilder struct {
 	// selColumns keeps track of the columns we want to pull from source.
 	// If Lastpk is set, we compare this list against the table's pk and
 	// add missing references.
-	selColumns        map[string]bool
 	colExprs          []*colExpr
 	onInsert          insertType
 	pkCols            []*colExpr
@@ -246,10 +245,9 @@ func buildTablePlan(tableName string, rule *binlogdatapb.Rule, colInfos []*Colum
 			From:  sel.From,
 			Where: sel.Where,
 		},
-		selColumns: make(map[string]bool),
-		lastpk:     lastpk,
-		colInfos:   colInfos,
-		stats:      stats,
+		lastpk:   lastpk,
+		colInfos: colInfos,
+		stats:    stats,
 	}
 
 	if err := tpb.analyzeExprs(sel.SelectExprs); err != nil {
@@ -493,10 +491,6 @@ func (tpb *tablePlanBuilder) analyzeExpr(selExpr sqlparser.SelectExpr) (*colExpr
 // addCol adds the specified column to the send query
 // if it's not already present.
 func (tpb *tablePlanBuilder) addCol(ident sqlparser.ColIdent) {
-	if tpb.selColumns[ident.Lowered()] {
-		return
-	}
-	tpb.selColumns[ident.Lowered()] = true
 	tpb.sendSelect.SelectExprs = append(tpb.sendSelect.SelectExprs, &sqlparser.AliasedExpr{
 		Expr: &sqlparser.ColName{Name: ident},
 	})

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -482,7 +482,7 @@ func TestPlayerFilters(t *testing.T) {
 		"create table src5(id1 int, id2 int, val varbinary(128), primary key(id1))",
 		fmt.Sprintf("create table %s.dst5(id1 int, val varbinary(128), primary key(id1))", vrepldb),
 		"create table srcCharset(id1 int, val varchar(128) character set utf8mb4 collate utf8mb4_bin, primary key(id1))",
-		fmt.Sprintf("create table %s.dstCharset(id1 int, val varchar(128) character set utf8mb4 collate utf8mb4_bin, primary key(id1))", vrepldb),
+		fmt.Sprintf("create table %s.dstCharset(id1 int, val varchar(128) character set utf8mb4 collate utf8mb4_bin, val2 varchar(128) character set utf8mb4 collate utf8mb4_bin, primary key(id1))", vrepldb),
 	})
 	defer execStatements(t, []string{
 		"drop table src1",
@@ -527,7 +527,7 @@ func TestPlayerFilters(t *testing.T) {
 			Filter: "select id1, val from src5 where val = 'abc'",
 		}, {
 			Match:  "dstCharset",
-			Filter: "select id1, concat(substr(_utf8mb4 val collate utf8mb4_bin,1,1),'abcxyz') val from srcCharset",
+			Filter: "select id1, concat(substr(_utf8mb4 val collate utf8mb4_bin,1,1),'abcxyz') val, concat(substr(_utf8mb4 val collate utf8mb4_bin,1,1),'abcxyz') val2 from srcCharset",
 		}},
 	}
 	bls := &binlogdatapb.BinlogSource{
@@ -778,12 +778,12 @@ func TestPlayerFilters(t *testing.T) {
 		input: "insert into srcCharset values (1,'木元')",
 		output: []string{
 			"begin",
-			"insert into dstCharset(id1,val) values (1,concat(substr(_utf8mb4 '木元' collate utf8mb4_bin, 1, 1), 'abcxyz'))",
+			"insert into dstCharset(id1,val,val2) values (1,concat(substr(_utf8mb4 '木元' collate utf8mb4_bin, 1, 1), 'abcxyz'),concat(substr(_utf8mb4 '木元' collate utf8mb4_bin, 1, 1), 'abcxyz'))",
 			"/update _vt.vreplication set pos=",
 			"commit",
 		},
 		table: "dstCharset",
-		data:  [][]string{{"1", "木abcxyz"}},
+		data:  [][]string{{"1", "木abcxyz", "木abcxyz"}},
 	}}
 
 	for _, tcase := range testcases {

--- a/test/config.json
+++ b/test/config.json
@@ -997,7 +997,7 @@
 		},
 		"vreplication_materialize": {
 			"File": "unused.go",
-			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "ShardedMaterialize"],
+			"Args": ["vitess.io/vitess/go/test/endtoend/vreplication", "-run", "TestMaterialize"],
 			"Command": [],
 			"Manual": false,
 			"Shard": "vreplication_multicell",


### PR DESCRIPTION

## Description
This PR fixes a bug where a column cannot be referred to multiple times in a Filter. There was an incorrect optimization in vstreamer where a column was being ignored while creating the source query if it was already seen.

So a materialize `source_expression` like `select id, val, ts, dayofmonth(ts) as day from mat` would fail since `ts` was mentioned twice in the select list. 

In addition, a new test has been added that confirms that Materialize filters can contain user-defined functions: we can define a `source_expression` like `select id, val, ts, customFunc1(id, val) as x from mat`. This is more an observation rather than a new feature, since, to our query parser, a custom function looks like just a pre-defined mysql function.  It is being stated explicitly since we had earlier assumed we did not yet support custom functions because a user had earlier reported failures with such a filter. It now looks as if that report was caused by this same bug with multiple columns. 

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)
#9314 

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required
