### PR TITLE
Throttler: cleaning up legacy remote MySQL connection logic

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/config/mysql_config.go
+++ b/go/vt/vttablet/tabletserver/throttle/config/mysql_config.go
@@ -13,8 +13,6 @@ package config
 // MySQLClusterConfigurationSettings has the settings for a specific MySQL cluster. It derives its information
 // from MySQLConfigurationSettings
 type MySQLClusterConfigurationSettings struct {
-	User                 string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Password             string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	MetricQuery          string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	CacheMillis          int      // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	ThrottleThreshold    float64  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
@@ -33,8 +31,6 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 
 // MySQLConfigurationSettings has the general configuration for all MySQL clusters
 type MySQLConfigurationSettings struct {
-	User                 string
-	Password             string
 	MetricQuery          string
 	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold    float64
@@ -58,12 +54,6 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 	for _, clusterSettings := range settings.Clusters {
 		if err := clusterSettings.postReadAdjustments(); err != nil {
 			return err
-		}
-		if clusterSettings.User == "" {
-			clusterSettings.User = settings.User
-		}
-		if clusterSettings.Password == "" {
-			clusterSettings.Password = settings.Password
 		}
 		if clusterSettings.MetricQuery == "" {
 			clusterSettings.MetricQuery = settings.MetricQuery

--- a/go/vt/vttablet/tabletserver/throttle/mysql/probe.go
+++ b/go/vt/vttablet/tabletserver/throttle/mysql/probe.go
@@ -8,18 +8,11 @@ package mysql
 
 import (
 	"fmt"
-	"net"
 )
-
-const maxPoolConnections = 3
-const maxIdleConnections = 3
-const timeoutMillis = 1000
 
 // Probe is the minimal configuration required to connect to a MySQL server
 type Probe struct {
 	Key             InstanceKey
-	User            string
-	Password        string
 	MetricQuery     string
 	TabletHost      string
 	TabletPort      int
@@ -51,38 +44,12 @@ func NewProbe() *Probe {
 	return config
 }
 
-// DuplicateCredentials creates a new connection config with given key and with same credentials as this config
-func (p *Probe) DuplicateCredentials(key InstanceKey) *Probe {
-	config := &Probe{
-		Key:      key,
-		User:     p.User,
-		Password: p.Password,
-	}
-	return config
-}
-
-// Duplicate duplicates this probe, including credentials
-func (p *Probe) Duplicate() *Probe {
-	return p.DuplicateCredentials(p.Key)
-}
-
 // String returns a human readable string of this struct
 func (p *Probe) String() string {
-	return fmt.Sprintf("%s, user=%s", p.Key.DisplayString(), p.User)
+	return fmt.Sprintf("%s, tablet=%s:%d", p.Key.DisplayString(), p.TabletHost, p.TabletPort)
 }
 
 // Equals checks if this probe has same instance key as another
 func (p *Probe) Equals(other *Probe) bool {
 	return p.Key.Equals(&other.Key)
-}
-
-// GetDBUri returns the DB URI for the mysql server indicated by this probe
-func (p *Probe) GetDBUri(databaseName string) string {
-	hostname := p.Key.Hostname
-	var ip = net.ParseIP(hostname)
-	if (ip != nil) && (ip.To4() == nil) {
-		// Wrap IPv6 literals in square brackets
-		hostname = fmt.Sprintf("[%s]", hostname)
-	}
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=%dms", p.User, p.Password, hostname, p.Key.Port, databaseName, timeoutMillis)
 }

--- a/go/vt/vttablet/tabletserver/throttle/mysql/probe_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/mysql/probe_test.go
@@ -16,32 +16,4 @@ func TestNewProbe(t *testing.T) {
 	c := NewProbe()
 	assert.Equal(t, "", c.Key.Hostname)
 	assert.Equal(t, 0, c.Key.Port)
-	assert.Equal(t, "", c.User)
-	assert.Equal(t, "", c.Password)
-}
-
-func TestDuplicateCredentials(t *testing.T) {
-	c := NewProbe()
-	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
-	c.User = "gromit"
-	c.Password = "penguin"
-
-	dup := c.DuplicateCredentials(InstanceKey{Hostname: "otherhost", Port: 3310})
-	assert.Equal(t, "otherhost", dup.Key.Hostname)
-	assert.Equal(t, 3310, dup.Key.Port)
-	assert.Equal(t, "gromit", dup.User)
-	assert.Equal(t, "penguin", dup.Password)
-}
-
-func TestDuplicate(t *testing.T) {
-	c := NewProbe()
-	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
-	c.User = "gromit"
-	c.Password = "penguin"
-
-	dup := c.Duplicate()
-	assert.Equal(t, "myhost", dup.Key.Hostname)
-	assert.Equal(t, 3306, dup.Key.Port)
-	assert.Equal(t, "gromit", dup.User)
-	assert.Equal(t, "penguin", dup.Password)
 }

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -229,15 +229,11 @@ func (throttler *Throttler) initConfig() {
 	throttler.metricsQueryType = mysql.GetMetricsQueryType(throttler.metricsQuery)
 
 	config.Instance.Stores.MySQL.Clusters[selfStoreName] = &config.MySQLClusterConfigurationSettings{
-		User:              "", // running on local tablet server, will use vttablet DBA user
-		Password:          "", // running on local tablet server, will use vttablet DBA user
 		MetricQuery:       throttler.metricsQuery,
 		ThrottleThreshold: throttler.MetricsThreshold.Get(),
 		IgnoreHostsCount:  0,
 	}
 	config.Instance.Stores.MySQL.Clusters[shardStoreName] = &config.MySQLClusterConfigurationSettings{
-		User:              "", // running on local tablet server, will use vttablet DBA user
-		Password:          "", // running on local tablet server, will use vttablet DBA user
 		MetricQuery:       throttler.metricsQuery,
 		ThrottleThreshold: throttler.MetricsThreshold.Get(),
 		IgnoreHostsCount:  0,

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -384,7 +384,7 @@ func (throttler *Throttler) Operate(ctx context.Context) {
 					atomic.StoreInt64(&throttler.isLeader, shouldBeLeader)
 
 					if shouldCreateThrottlerUser {
-						throttler.initConfig()
+						// throttler.initConfig()
 						shouldCreateThrottlerUser = false
 						// transitioned into leadership, let's speed up the next 'refresh' and 'collect' ticks
 						go mysqlRefreshTicker.TickNow()


### PR DESCRIPTION
## Description

Followup to #9334 
Since #9334 is merged, the throttler no longer directly accesses MySQL on other tablets. As such, there's no longer need in:

- A special throttler user account 
- Any user/password configuration
- logic to open a remote connection
- any special logic upon promotion to leader (other than generate a Tick)
This PR cleans up all the above with minor refactoring/changes.

## Related Issue(s)

#9334 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required

