### PR TITLE
[vtadmin-web] Add colours to tailwind.config.js

### DIFF
--- a/web/vtadmin/src/components/dropdown/MenuItem.tsx
+++ b/web/vtadmin/src/components/dropdown/MenuItem.tsx
@@ -11,7 +11,7 @@ const MenuItem: React.FC<MenuItemProps> = ({ children, className, intent = 'none
         <button
             onMouseDown={(e) => e.preventDefault()}
             className={`transition-colors font-sans border-none text-left block px-6 py-4 hover:bg-gray-100 text-${intent} hover:text-${
-                intent === 'none' ? 'vitess-blue' : intent
+                intent === 'none' ? 'vtblue' : intent
             } w-full ${className || ''}`}
             role="menuitem"
             tabIndex={-1}

--- a/web/vtadmin/src/components/routes/Debug.tsx
+++ b/web/vtadmin/src/components/routes/Debug.tsx
@@ -47,6 +47,29 @@ export const Debug = () => {
                 </section>
 
                 <section>
+                    <h3 className="mt-12 mb-8">Colours</h3>
+                    {[
+                        ['danger', 'danger-50', 'danger-200'],
+                        ['success', 'success-50', 'success-200'],
+                        ['warning', 'warning-50', 'warning-200'],
+                        ['vtblue', 'vtblue-50', 'vtblue-200'],
+                        ['vtblue-dark', 'vtblue-dark-50', 'vtblue-dark-200'],
+                        ['gray-75', 'gray-100', 'gray-200', 'gray-400', 'gray-600', 'gray-800', 'gray-900'],
+                    ].map((colors, idx) => {
+                        return (
+                            <div className="flex my-8" key={idx}>
+                                {colors.map((c) => (
+                                    <div className="mr-4" key={c}>
+                                        <div className={`w-40 h-16 rounded bg-${c}`} />
+                                        <div className={`text-sm font-semibold text-${c}`}>{c}</div>
+                                    </div>
+                                ))}
+                            </div>
+                        );
+                    })}
+                </section>
+
+                <section>
                     <h3 className="mt-12 mb-8">Typography</h3>
 
                     <div className="my-16">

--- a/web/vtadmin/tailwind.config.js
+++ b/web/vtadmin/tailwind.config.js
@@ -3,20 +3,50 @@ module.exports = {
     darkMode: false,
     theme: {
         extend: {
+            colors: {
+                danger: {
+                    DEFAULT: '#D32F2F',
+                    50: '#FF6659',
+                    200: '#9a0007',
+                },
+                gray: {
+                    75: '#FAFAFA',
+                    100: '#F3F3F3',
+                    200: '#EDF2F7',
+                    400: '#CBD5E0',
+                    600: '#7A8096',
+                    800: '#2D3748',
+                    900: '#1E2531',
+                },
+                success: {
+                    DEFAULT: '#00893E',
+                    50: '#4CBA6A',
+                    200: '#005A13',
+                },
+                vtblue: {
+                    DEFAULT: '#3D5AfE',
+                    50: '#8187FF',
+                    200: '#0031CA',
+                    dark: {
+                        DEFAULT: '#8187FF',
+                        50: '#B6B7FF',
+                        200: '#4A5ACB',
+                    },
+                },
+                warning: {
+                    DEFAULT: '#FFAB40',
+                    50: '#FFDD71',
+                    200: '#C77C02',
+                },
+            },
             textColor: {
                 primary: '#17171b',
                 secondary: '#718096',
-                danger: '#D32F2F',
-                warning: '#FFAB40',
-                success: '#00893E',
                 none: '#17171b',
-                'vitess-blue': "#3D5AFE",
-                'vitess-blue-50': "#8187ff",
-                'vitess-blue-200': "#0031ca"
             },
             inset: {
-                '-3full': '-300%'
-            }
+                '-3full': '-300%',
+            },
         },
         fontFamily: {
             mono: ['NotoMono', 'source-code-pro', 'menlo', 'monaco', 'consolas', 'Courier New', 'monospace'],


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

## Description

This extends tailwind's colour palette with our own, which handily generates a bunch of utility classes for us for background colour, etc. (Eventually, we may want to replace tailwind's default palette entirely, for simplicity... but this is fine for now.) 

I also renamed "vitess-blue" to "vtblue" since it saves a few characters. :) 

At some point I'll do a pass to update everything that's presently using bespoke CSS to instead use the generated tailwind utility classes.

<img width="1792" alt="Screen Shot 2021-12-08 at 12 17 54 PM" src="https://user-images.githubusercontent.com/855595/145253948-58cd1669-5139-4764-a14b-e6e166adaa48.png">

<img width="1792" alt="Screen Shot 2021-12-08 at 12 17 58 PM" src="https://user-images.githubusercontent.com/855595/145253950-da616d8b-37cd-4f9a-b196-66a997fb6d24.png">

## Related Issue(s)

N/A

## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A