### PR TITLE
[vtadmin-web] Add RadioCard component + .hotkey component class.

### DIFF
--- a/web/vtadmin/src/components/inputs/RadioCard.module.scss
+++ b/web/vtadmin/src/components/inputs/RadioCard.module.scss
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.card {
+    @apply border border-vtblue;
+    @apply cursor-pointer;
+    @apply flex;
+    @apply h-full;
+    @apply gap-4;
+    @apply outline-none;
+    @apply p-6;
+    @apply rounded-md;
+}
+
+.checked {
+    @apply bg-vtblue-50 bg-opacity-10;
+}
+
+.card:focus,
+.card:hover,
+.card.active {
+    @apply ring-2;
+}
+
+.circle {
+    @apply border border-gray-400;
+    @apply flex-none;
+    @apply mt-1;
+    @apply rounded-full;
+
+    height: 16px;
+    width: 16px;
+}
+
+.checked .circle {
+    @apply border-gray-600;
+}
+
+.checked .circle::before {
+    @apply bg-vtblue;
+    @apply block;
+    @apply rounded-full;
+
+    content: '';
+    height: 8px;
+    margin: 3px;
+    width: 8px;
+}

--- a/web/vtadmin/src/components/inputs/RadioCard.tsx
+++ b/web/vtadmin/src/components/inputs/RadioCard.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import cx from 'classnames';
+import { RadioGroup } from '@headlessui/react';
+
+import style from './RadioCard.module.scss';
+
+interface RadioCardProps {
+    description: string;
+    label: string;
+    value: string;
+}
+
+export const RadioCard: React.FC<RadioCardProps> = ({ description, label, value }) => {
+    return (
+        <RadioGroup.Option className="outline-none" value={value}>
+            {({ active, checked }) => (
+                <div className={cx(style.card, checked && style.checked, active && style.active)}>
+                    <div className={style.circle} />
+                    <div>
+                        <RadioGroup.Label className="font-semibold">{label}</RadioGroup.Label>
+                        <RadioGroup.Description className="mb-0 mt-2 text-sm">{description}</RadioGroup.Description>
+                    </div>
+                </div>
+            )}
+        </RadioGroup.Option>
+    );
+};

--- a/web/vtadmin/src/components/routes/Debug.tsx
+++ b/web/vtadmin/src/components/routes/Debug.tsx
@@ -1,7 +1,9 @@
+import { RadioGroup } from '@headlessui/react';
 import * as React from 'react';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { Theme, useTheme } from '../../hooks/useTheme';
 import { Icon, Icons } from '../Icon';
+import { RadioCard } from '../inputs/RadioCard';
 import { Select } from '../inputs/Select';
 import { ContentContainer } from '../layout/ContentContainer';
 import { Tab } from '../tabs/Tab';
@@ -320,6 +322,46 @@ export const Debug = () => {
                         );
                     })}
                 </section>
+
+                <section>
+                    <h3 className="mt-12 mb-8">Radio Groups</h3>
+                    <RadioGroup
+                        value={formData.radioGroupValue}
+                        onChange={(radioGroupValue) => {
+                            setFormData({ ...formData, radioGroupValue });
+                        }}
+                    >
+                        <RadioGroup.Label className="block font-semibold my-6">Types of Cats</RadioGroup.Label>
+                        <div className="grid gap-4 max-w-7xl md:grid-flow-col md:auto-cols-fr">
+                            {CATS.map(({ breed, description }) => (
+                                <RadioCard label={breed} description={description} value={breed} />
+                            ))}
+                        </div>
+
+                        <div className="mt-6 text-secondary">
+                            <span className="hidden md:inline-block">
+                                <div className="hotkey">←</div> <div className="hotkey">→</div>
+                            </span>
+                            <span className="md:hidden">
+                                <div className="hotkey">↑</div> <div className="hotkey">↓</div>
+                            </span>{' '}
+                            to change selection.
+                        </div>
+                    </RadioGroup>
+                </section>
+
+                <section>
+                    <h3 className="mt-12 mb-8">Keyboard shortcuts</h3>
+                    {['hotkey-lg', ''].map((size) => (
+                        <div className="flex gap-2 mb-6" key={size}>
+                            {['A', 'B', 'C', '/', '←', '↑', '→', '↓', '⌘', 'ctrl', 'cmd', 'shift'].map((k) => (
+                                <div className={`hotkey ${size}`} key={k}>
+                                    {k}
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                </section>
             </div>
         </ContentContainer>
     );
@@ -344,3 +386,19 @@ const FRUITS: { emoji: string; name: string; id: string }[] = [
 ];
 
 const FRUIT_NAMES = FRUITS.map((f) => f.name).slice(0, 5);
+
+const CATS: { breed: string; description: string }[] = [
+    {
+        breed: 'Maine Coon',
+        description:
+            'Known for its large stature and thick fur coat, the Maine coon is a cat that is difficult to ignore.',
+    },
+    {
+        breed: 'Ragdoll',
+        description: 'Ragdoll cats get their name from their docile temperament.',
+    },
+    {
+        breed: 'Bengal',
+        description: 'Bengals have a wild appearance; their golden shimmer comes from their leopard cat ancestry.',
+    },
+];

--- a/web/vtadmin/src/style/components.css
+++ b/web/vtadmin/src/style/components.css
@@ -130,4 +130,22 @@
     .btn-warning.btn-secondary:visited {
         @apply text-warning;
     }
+
+    .hotkey {
+        @apply border border-gray-300;
+        @apply flex-none;
+        @apply font-mono;
+        @apply inline-block;
+        @apply px-3 py-1;
+        @apply rounded;
+        @apply text-secondary;
+        @apply text-sm;
+        @apply uppercase;
+        @apply w-max;
+    }
+
+    .hotkey-lg {
+        @apply px-4 py-2;
+        @apply text-base;
+    }
 }


### PR DESCRIPTION
## Description

- Adds the RadioCard component, which integrates with @headless/ui's [RadioGroup](https://headlessui.dev/react/radio-group)
- Adds a `.hotkey` component class

I still don't have a great feel for when it's best to use inline styles vs. `@apply` so please let me know if this can be more readable. :) 

Here's what it looks like. (The gif is a little bit janky; the responsive layout is smoother IRL.) It's both responsive + keyboard accessible:

![radio-cards](https://user-images.githubusercontent.com/855595/145445787-71a644cc-2a4a-45f6-b5e5-a177bb017d56.gif)

This will conflict with https://github.com/vitessio/vitess/pull/9342, which also adds a `style/components.css` file, so I might need an additional +1 after that one is merged in + I can rebase.


## Related Issue(s)

- Prerequisite for #8703 


## Checklist
- [x] Should this PR be backported? **No**
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes

N/A