### PR TITLE
[11.0] build(deps): bump log4j-api from 2.13.3 to 2.15.0 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
     <protobuf.java.version>3.11.4</protobuf.java.version>
     <protobuf.protoc.version>3.11.4</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->


### PR DESCRIPTION
## Description

Bumps log4j-api from 2.13.3 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

## Related Issue(s)
- Backport of #9348 #9349
