### PR TITLE
vttablet: Better use of vtprotobuf memory pool

### DIFF
--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -743,8 +743,9 @@ func (conn *gRPCQueryClient) VStreamRows(ctx context.Context, target *querypb.Ta
 	if err != nil {
 		return err
 	}
+	r := binlogdatapb.VStreamRowsResponseFromVTPool()
+	defer r.ReturnToVTPool()
 	for {
-		r := binlogdatapb.VStreamRowsResponseFromVTPool()
 		err := stream.RecvMsg(r)
 		if err != nil {
 			return tabletconn.ErrorFromGRPC(err)
@@ -755,7 +756,7 @@ func (conn *gRPCQueryClient) VStreamRows(ctx context.Context, target *querypb.Ta
 		if err := send(r); err != nil {
 			return err
 		}
-		r.ReturnToVTPool()
+		r.ResetVT()
 	}
 }
 


### PR DESCRIPTION
In the previous implementation, the last iteration of the for loop
leaves behind an object to get GC'd since it never gets released back to
the pool when the function returns.

Also should be a minor optimization by re-using the VStreamRowsResponse
rather than returning it to the pool each iteration.

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required