### PR TITLE
CI: Simplify Changes to Explicitly Install and Configure MySQL8

### DIFF
--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -34,33 +34,16 @@ jobs:
 
     - name: Get dependencies
       run: |
-
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-        # Uninstall any previously installed MySQL first
-        sudo systemctl stop apparmor
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-        sudo apt-get -y autoremove
-        sudo apt-get -y autoclean
-        sudo deluser mysql
-        sudo rm -rf /var/lib/mysql
-        sudo rm -rf /etc/mysql
-
-        # Install mysql80
+        # Setup MySQL 8.0
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
         echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
         # Install everything else we need, and configure
-        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
-
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
         # install JUnit report formatter

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -29,12 +29,6 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out code
       uses: actions/checkout@v2
 

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -71,6 +71,8 @@ jobs:
 
         # Install everything else we need, and configure
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -63,32 +63,16 @@ jobs:
       run: |
         # This prepares general purpose binary dependencies
         # as well as latest version specific go modules
-
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-        # Uninstall any previously installed MySQL first
-        sudo systemctl stop apparmor
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-        sudo apt-get -y autoremove
-        sudo apt-get -y autoclean
-        sudo deluser mysql
-        sudo rm -rf /var/lib/mysql
-        sudo rm -rf /etc/mysql
-
-        # Install mysql80
+        # Setup MySQL 8.0
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
         echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
         # Install everything else we need, and configure
-        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -21,33 +21,16 @@ jobs:
 
     - name: Get dependencies
       run: |
-
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-        # Uninstall any previously installed MySQL first
-        sudo systemctl stop apparmor
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-        sudo apt-get -y autoremove
-        sudo apt-get -y autoclean
-        sudo deluser mysql
-        sudo rm -rf /var/lib/mysql
-        sudo rm -rf /etc/mysql
-
-        # Install mysql80
+        # Setup MySQL 8.0
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
         echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
         # Install everything else we need, and configure
-        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
-
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -29,6 +29,8 @@ jobs:
 
         # Install everything else we need, and configure
         sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo service mysql stop
+        sudo service etcd stop
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
         sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -27,32 +27,16 @@ jobs:
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
-
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-          # Uninstall any previously installed MySQL first
-          sudo systemctl stop apparmor
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-          sudo apt-get -y autoremove
-          sudo apt-get -y autoclean
-          sudo deluser mysql
-          sudo rm -rf /var/lib/mysql
-          sudo rm -rf /etc/mysql
-
-          # Install mysql80
+          # Setup MySQL 8.0
           wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
           # Install everything else we need, and configure
-          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-          sudo service mysql stop
-          sudo service etcd stop
-          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -35,6 +35,8 @@ jobs:
 
           # Install everything else we need, and configure
           sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo service mysql stop
+          sudo service etcd stop
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -27,32 +27,16 @@ jobs:
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
-
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-          # Uninstall any previously installed MySQL first
-          sudo systemctl stop apparmor
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-          sudo apt-get -y autoremove
-          sudo apt-get -y autoclean
-          sudo deluser mysql
-          sudo rm -rf /var/lib/mysql
-          sudo rm -rf /etc/mysql
-
-          # Install mysql80
+          # Setup MySQL 8.0
           wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
           # Install everything else we need, and configure
-          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-          sudo service mysql stop
-          sudo service etcd stop
-          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -35,6 +35,8 @@ jobs:
 
           # Install everything else we need, and configure
           sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo service mysql stop
+          sudo service etcd stop
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -27,32 +27,16 @@ jobs:
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
-
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
-
-          # Uninstall any previously installed MySQL first
-          sudo systemctl stop apparmor
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
-          sudo apt-get -y autoremove
-          sudo apt-get -y autoclean
-          sudo deluser mysql
-          sudo rm -rf /var/lib/mysql
-          sudo rm -rf /etc/mysql
-
-          # Install mysql80
+          # Setup MySQL 8.0
           wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
 
           # Install everything else we need, and configure
-          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
-          sudo service mysql stop
-          sudo service etcd stop
-          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -35,6 +35,8 @@ jobs:
 
           # Install everything else we need, and configure
           sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo service mysql stop
+          sudo service etcd stop
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         elif [ ${{matrix.os}} = "macos-latest" ]; then

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -32,7 +32,9 @@ const (
 	unitTestTemplate  = "templates/unit_test.tpl"
 	unitTestDatabases = "mysql57, mariadb103, mysql80, mariadb102"
 
-	clusterTestTemplate = "templates/cluster_endtoend_test.tpl"
+	// An empty string will cause the default non platform specific template
+	// to be used.
+	clusterTestTemplateFormatStr = "templates/cluster_endtoend_test%s.tpl"
 
 	unitTestSelfHostedTemplate    = "templates/unit_test_self_hosted.tpl"
 	unitTestSelfHostedDatabases   = ""
@@ -125,7 +127,7 @@ type unitTest struct {
 }
 
 type clusterTest struct {
-	Name, Shard                  string
+	Name, Shard, Platform        string
 	MakeTools, InstallXtraBackup bool
 	Ubuntu20                     bool
 }
@@ -255,6 +257,7 @@ func generateSelfHostedClusterWorkflows() error {
 		if err != nil {
 			return err
 		}
+
 		filePath := fmt.Sprintf("%s/cluster_endtoend_%s.yml", workflowConfigDir, cluster)
 		err = writeFileFromTemplate(clusterTestSelfHostedTemplate, filePath, test)
 		if err != nil {
@@ -289,12 +292,18 @@ func generateClusterWorkflows() {
 		for _, ubuntu20Cluster := range ubuntu20Clusters {
 			if ubuntu20Cluster == cluster {
 				test.Ubuntu20 = true
+				test.Platform = "mysql80"
 				break
 			}
 		}
 
 		path := fmt.Sprintf("%s/cluster_endtoend_%s.yml", workflowConfigDir, cluster)
-		err := writeFileFromTemplate(clusterTestTemplate, path, test)
+		var tplPlatform string
+		if test.Platform != "" {
+			tplPlatform = "_" + test.Platform
+		}
+		template := fmt.Sprintf(clusterTestTemplateFormatStr, tplPlatform)
+		err := writeFileFromTemplate(template, path, test)
 		if err != nil {
 			log.Print(err)
 		}


### PR DESCRIPTION
## Description
Limiting the new/additional work we do in the CI in order to limit the time and effort required to meet the primary objective: ensure that we deterministically install the latest MySQL 8.0 release from the official MySQL APT repo. 

## Related Issue(s)
Follow-up on: https://github.com/vitessio/vitess/pull/9368
Caused by: https://github.com/actions/virtual-environments/pull/4674

## Checklist
- [x] Should this PR be backported? 12.0 maybe?
- [x] Tests were added or are not required
- [x] Documentation is not required