### PR TITLE
[10.0] CI: ubuntu-latest now has MySQL 8.0.26, let us override it with latest 8.0.x

### DIFF
--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -12,17 +12,18 @@ jobs:
       with:
         go-version: 1.15
 
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Get dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo service mysql stop
+        sudo apt-get install -y make unzip g++ etcd curl git wget
         sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -21,7 +21,6 @@ jobs:
         sudo apt-get install -y make unzip g++ etcd curl git wget
         sudo service etcd stop
         go mod download
-        go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
       run: |

--- a/.github/workflows/check_make_sizegen.yml
+++ b/.github/workflows/check_make_sizegen.yml
@@ -7,29 +7,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.15
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
 
-      - name: Check out code
-        uses: actions/checkout@v2
+    - name: Check out code
+      uses: actions/checkout@v2
 
-      - name: Get dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-          sudo service mysql stop
-          sudo service etcd stop
-          sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-          go mod download
+    - name: Get dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make unzip g++ etcd curl git wget
+        sudo service etcd stop
+        go mod download
+        go install golang.org/x/tools/cmd/goimports@latest
 
-      - name: Run make minimaltools
-        run: |
-          make minimaltools
+    - name: Run make minimaltools
+      run: |
+        make minimaltools
 
-      - name: check_make_sizegen
-        run: |
-          tools/check_make_sizegen.sh
+    - name: check_make_sizegen
+      run: |
+        tools/check_make_sizegen.sh
 

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -18,12 +18,10 @@ jobs:
     - name: Get dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo service mysql stop
+        sudo apt-get install -y make unzip g++ etcd curl git wget
         sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
+        go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
       run: |

--- a/.github/workflows/check_make_visitor.yml
+++ b/.github/workflows/check_make_visitor.yml
@@ -21,7 +21,6 @@ jobs:
         sudo apt-get install -y make unzip g++ etcd curl git wget
         sudo service etcd stop
         go mod download
-        go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Run make minimaltools
       run: |

--- a/.github/workflows/cluster_endtoend_mysql80.yml
+++ b/.github/workflows/cluster_endtoend_mysql80.yml
@@ -29,12 +29,33 @@ jobs:
 
     - name: Get dependencies
       run: |
+
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+        # Uninstall any previously installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+
+        # Install mysql80
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
         sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
         go mod download
 
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb

--- a/.github/workflows/cluster_endtoend_upgrade.yml
+++ b/.github/workflows/cluster_endtoend_upgrade.yml
@@ -32,12 +32,32 @@ jobs:
       run: |
         # This prepares general purpose binary dependencies
         # as well as v9.0.0 specific go modules
+
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+        # Uninstall any previously installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+
+        # Install mysql80
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
         sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
         go mod download
 
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -16,23 +16,38 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Get dependencies
       run: |
+
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+        # Uninstall any previously installed MySQL first
+        sudo systemctl stop apparmor
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+        sudo apt-get -y autoremove
+        sudo apt-get -y autoclean
+        sudo deluser mysql
+        sudo rm -rf /var/lib/mysql
+        sudo rm -rf /etc/mysql
+
+        # Install mysql80
+        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
+        sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+        # Install everything else we need, and configure
+        sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
         sudo service mysql stop
         sudo service etcd stop
+        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
         sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/legacy_local_example.yml
+++ b/.github/workflows/legacy_local_example.yml
@@ -21,24 +21,38 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
+
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+          # Uninstall any previously installed MySQL first
+          sudo systemctl stop apparmor
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+          sudo apt-get -y autoremove
+          sudo apt-get -y autoclean
+          sudo deluser mysql
+          sudo rm -rf /var/lib/mysql
+          sudo rm -rf /etc/mysql
+
+          # Install mysql80
+          wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+          echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
-          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+          # Install everything else we need, and configure
+          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
           sudo service mysql stop
           sudo service etcd stop
+          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -27,12 +27,32 @@ jobs:
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
+
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+          # Uninstall any previously installed MySQL first
+          sudo systemctl stop apparmor
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+          sudo apt-get -y autoremove
+          sudo apt-get -y autoclean
+          sudo deluser mysql
+          sudo rm -rf /var/lib/mysql
+          sudo rm -rf /etc/mysql
+
+          # Install mysql80
+          wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+          echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+          # Install everything else we need, and configure
           sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
           sudo service mysql stop
           sudo service etcd stop
+          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -21,12 +21,6 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out code
       uses: actions/checkout@v2
 
@@ -34,7 +28,7 @@ jobs:
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
           sudo apt-get update
-          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
           sudo service mysql stop
           sudo service etcd stop
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -21,24 +21,38 @@ jobs:
       run: |
         echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
-    # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
-    - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-      run: |
-        echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    # DON'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Get dependencies
       run: |
         if [ ${{matrix.os}} = "ubuntu-latest" ]; then
+
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get update
+
+          # Uninstall any previously installed MySQL first
+          sudo systemctl stop apparmor
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get remove -y --purge mysql-server mysql-client mysql-common
+          sudo apt-get -y autoremove
+          sudo apt-get -y autoclean
+          sudo deluser mysql
+          sudo rm -rf /var/lib/mysql
+          sudo rm -rf /etc/mysql
+
+          # Install mysql80
+          wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.20-1_all.deb
+          echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
-          sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+
+          # Install everything else we need, and configure
+          sudo apt-get install -y make unzip g++ etcd curl git wget eatmydata
           sudo service mysql stop
           sudo service etcd stop
+          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
           sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
         elif [ ${{matrix.os}} = "macos-latest" ]; then
           brew install mysql@5.7 make unzip etcd curl git wget
         fi


### PR DESCRIPTION
## Description

This is a backport of #9368 to fix the CI build by overriding ubuntu-latest MySQL version.

## Related Issue(s)
- #9368 
