### PR TITLE
Move two flaky vreplication e2e tests test to docker

### DIFF
--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -2,28 +2,17 @@
 
 name: Cluster (vreplication_basic)
 on: [push, pull_request]
-concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_basic)')
-  cancel-in-progress: true
-
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_basic)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17
-
-    - name: Set up python
-      uses: actions/setup-python@v2
 
     - name: Tune the OS
       run: |
@@ -32,51 +21,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
-
-        # install JUnit report formatter
-        go get -u github.com/vitessio/go-junit-report@HEAD
-
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
     - name: Run cluster endtoend test
       timeout-minutes: 30
       run: |
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_basic | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+        go run test.go -docker=true --follow -shard vreplication_basic

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -2,28 +2,17 @@
 
 name: Cluster (vreplication_v2)
 on: [push, pull_request]
-concurrency:
-  group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vreplication_v2)')
-  cancel-in-progress: true
-
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
 
 jobs:
   build:
     name: Run endtoend tests on Cluster (vreplication_v2)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17
-
-    - name: Set up python
-      uses: actions/setup-python@v2
 
     - name: Tune the OS
       run: |
@@ -32,51 +21,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
-
-        # install JUnit report formatter
-        go get -u github.com/vitessio/go-junit-report@HEAD
-
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
     - name: Run cluster endtoend test
       timeout-minutes: 30
       run: |
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vreplication_v2 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+        go run test.go -docker=true --follow -shard vreplication_v2

--- a/test/templates/cluster_endtoend_test_docker.tpl
+++ b/test/templates/cluster_endtoend_test_docker.tpl
@@ -1,0 +1,26 @@
+name: {{.Name}}
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Run endtoend tests on {{.Name}}
+    {{if .Ubuntu20}}runs-on: ubuntu-20.04{{else}}runs-on: ubuntu-latest{{end}}
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Tune the OS
+      run: |
+        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Run cluster endtoend test
+      timeout-minutes: 30
+      run: |
+        go run test.go -docker=true --follow -shard {{.Shard}}
+


### PR DESCRIPTION

## Description

This PR is an attempt to make a couple of flaky vreplication end to end tests less flaky. 
The causes of the flakiness were the same old issues related to mysql not starting or ports not being available and it occurs at different points, like:

```
2021-12-14T12:00:51.2859900Z I1214 11:55:35.775352   18070 vtctlclient_process.go:183] Executing vtctlclient with command: vtctlclient -server localhost:15999 CreateShard customer/-60
2021-12-14T12:00:51.2861868Z I1214 11:55:35.790850   18070 cluster.go:306] Adding Primary tablet
2021-12-14T12:00:51.2863948Z I1214 11:55:35.790923   18070 mysqlctl_process.go:124] Starting mysqlctl with command: [mysqlctl -log_dir /home/runner/work/vitess/vitess/vtdataroot/vt_2025146392/vreple2e_956177/tmp -tablet_uid 1000 -mysql_port 17306 init -init_db_sql_file /home/runner/work/vitess/vitess/config/init_db.sql start]
2021-12-14T12:00:51.2865572Z I1214 11:55:35.791216   18070 cluster.go:337] Waiting for mysql process for tablet zone1-1000
2021-12-14T12:00:51.2873059Z     cluster.go:339: exit status 1 :: Unable to start mysql server for &{zone1-1000 vttablet /home/runner/work/vitess/vitess/vtdataroot/vt_2025146392/vreple2e_956177/tmp/vt_0000001000_querylog.txt 1000 zone1-0000001000  17000 17991 -60 {vtctl vtctl etcd2 localhost:2379 /vitess/global localhost:2379 /} /home/runner/work/vitess/vitess/vtdataroot/vt_2025146392/vreple2e_956177/tmp localhost customer replica 5 file /home/runner/work/vitess/vitess/vtdataroot/vt_2025146392/vreple2e_956177/backups grpc-queryservice,grpc-tabletmanager,grpc-updatestream,grpc-throttler http://localhost:15000 /home/runner/work/vitess/vitess/vtdataroot/vt_2025146392/vreple2e_956177/vt_0000001000 http://localhost:17000/debug/vars http://localhost:17000/queryz http://localhost:17000/debug/status_details false false NOT_SERVING  0 PRIMARY  utf8mb4 [-queryserver-config-schema-reload-time 5 -enable-lag-throttler -heartbeat_enable -heartbeat_interval 250ms] <nil> <nil>}
```

```
2021-12-14T13:01:16.3713681Z I1214 12:59:53.436101   17892 vttablet_process.go:134] Running vttablet with command: vttablet -topo_implementation etcd2 -topo_global_server_address localhost:2379 -topo_global_root /vitess/global -log_queries_to_file /home/runner/work/vitess/vitess/vtdataroot/vt_295846299/vreple2e_851476/tmp/vt_0000002000_querylog.txt -tablet-path zone1-0000002000 -port 18000 -grpc_port 18991 -init_shard 0 -log_dir /home/runner/work/vitess/vitess/vtdataroot/vt_295846299/vreple2e_851476/tmp -tablet_hostname localhost -init_keyspace merchant -init_tablet_type replica -health_check_interval 5s -enable_replication_reporter -backup_storage_implementation file -file_backup_storage_root /home/runner/work/vitess/vitess/vtdataroot/vt_295846299/vreple2e_851476/backups -service_map grpc-queryservice,grpc-tabletmanager,grpc-updatestream,grpc-throttler -vtctld_addr http://localhost:15000 -vtctld_addr http://localhost:15000 -vreplication_tablet_type PRIMARY -db_charset utf8mb4 -queryserver-config-schema-reload-time 5 -enable-lag-throttler -heartbeat_enable -heartbeat_interval 250ms
2021-12-14T13:01:16.3720059Z I1214 12:59:53.738807   17892 vttablet_process.go:152] vttablet error:
2021-12-14T13:01:16.3721434Z E1214 12:59:53.626190   24310 tablet.go:242] unable to connect to tablet cell:"zone1" uid:2000: node doesn't exist: /zone1/tablets/zone1-0000002000/Tablet
2021-12-14T13:01:16.3722489Z F1214 12:59:53.649762   24310 run.go:50] listen tcp :18000: bind: address already in use
2021-12-14T13:01:16.3722975Z 
```

These happen while creating new tablets. I tried breaking down the original test (which created 16 tablets in total) to two separate ones each creating a max of 10 tablets. But I continued to see flakiness in one or the other. Tried adding two retries but it only rarely recovers from the first failure (for example: https://github.com/vitessio/vitess/runs/4519953375?check_suite_focus=true). 

Moving the tests to docker seems to help: I wasn't able to reproduce any flakiness in a few attempts.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required
