### PR TITLE
Online DDL: add formal 'reverted_uuid' column

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3194,6 +3194,7 @@ func (e *Executor) SubmitMigration(
 	if err != nil {
 		return nil, err
 	}
+	revertedUUID, _ := onlineDDL.GetRevertUUID()
 
 	retainArtifactsSeconds := int64((*retainOnlineDDLTables).Seconds())
 	query, err := sqlparser.ParseAndBind(sqlInsertMigration,
@@ -3212,6 +3213,7 @@ func (e *Executor) SubmitMigration(
 		sqltypes.Int64BindVariable(retainArtifactsSeconds),
 		sqltypes.BoolBindVariable(onlineDDL.StrategySetting().IsPostponeCompletion()),
 		sqltypes.BoolBindVariable(e.allowConcurrentMigration(onlineDDL)),
+		sqltypes.StringBindVariable(revertedUUID),
 	)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -3194,7 +3194,7 @@ func (e *Executor) SubmitMigration(
 	if err != nil {
 		return nil, err
 	}
-	revertedUUID, _ := onlineDDL.GetRevertUUID()
+	revertedUUID, _ := onlineDDL.GetRevertUUID() // Empty value if the migration is not actually a REVERT. Safe to ignore error.
 
 	retainArtifactsSeconds := int64((*retainOnlineDDLTables).Seconds())
 	query, err := sqlparser.ParseAndBind(sqlInsertMigration,

--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -69,6 +69,8 @@ const (
 	alterSchemaMigrationsTableExpandedColNames         = "ALTER TABLE _vt.schema_migrations add column expanded_column_names text NOT NULL"
 	alterSchemaMigrationsTableRevertibleNotes          = "ALTER TABLE _vt.schema_migrations add column revertible_notes text NOT NULL"
 	alterSchemaMigrationsTableAllowConcurrent          = "ALTER TABLE _vt.schema_migrations add column allow_concurrent tinyint unsigned NOT NULL DEFAULT 0"
+	alterSchemaMigrationsTableRevertedUUID             = "ALTER TABLE _vt.schema_migrations add column reverted_uuid varchar(64) NOT NULL DEFAULT ''"
+	alterSchemaMigrationsTableRevertedUUIDIndex        = "ALTER TABLE _vt.schema_migrations add KEY reverted_uuid_idx (reverted_uuid(64))"
 
 	sqlInsertMigration = `INSERT IGNORE INTO _vt.schema_migrations (
 		migration_uuid,
@@ -86,9 +88,10 @@ const (
 		tablet,
 		retain_artifacts_seconds,
 		postpone_completion,
-		allow_concurrent
+		allow_concurrent,
+		reverted_uuid
 	) VALUES (
-		%a, %a, %a, %a, %a, %a, %a, %a, %a, FROM_UNIXTIME(NOW()), %a, %a, %a, %a, %a, %a
+		%a, %a, %a, %a, %a, %a, %a, %a, %a, FROM_UNIXTIME(NOW()), %a, %a, %a, %a, %a, %a, %a
 	)`
 
 	sqlScheduleSingleMigration = `UPDATE _vt.schema_migrations
@@ -556,4 +559,6 @@ var ApplyDDL = []string{
 	alterSchemaMigrationsTableExpandedColNames,
 	alterSchemaMigrationsTableRevertibleNotes,
 	alterSchemaMigrationsTableAllowConcurrent,
+	alterSchemaMigrationsTableRevertedUUID,
+	alterSchemaMigrationsTableRevertedUUIDIndex,
 }


### PR DESCRIPTION

## Description

Small but useful change: add a new column in `schema_migrations` table, called `reverted_uuid`. For most migrations the value will be empty; but for `REVERT` migrations, this will indicate the UUID of the migration being reverted. We also index this column.

This makes it easier to find: "given a migration UUID has there been a REVERT on this migration? Was it successful? Have there perhaps been multiple attempts at revert? Has any attempt been successful?"

I expect these type of questions to be needed when managing reverted migrations.

endtoend tests added to validate populated column value.
 
## Related Issue(s)

#6926 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->