### PR TITLE
Multicolumn partial vindex selection

### DIFF
--- a/go/test/endtoend/vtgate/gen4/gen4_test.go
+++ b/go/test/endtoend/vtgate/gen4/gen4_test.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"vitess.io/vitess/go/test/endtoend/vtgate/utils"
@@ -274,5 +275,57 @@ func TestMultiColumnVindex(t *testing.T) {
 			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb in (40,60) and cola = 422333`, `[[INT64(6)]]`)
 			utils.AssertMatches(t, conn, `select id from user_region where cola in (30,422333) and colb in (40,60) and cola = 30 and colb = 60`, `[[INT64(7)]]`)
 		})
+	}
+}
+
+func TestFanoutVindex(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tcases := []struct {
+		regionID int
+		exp      string
+	}{{
+		regionID: 24,
+		exp:      `[[INT64(24) INT64(1) VARCHAR("shard--19a0")]]`,
+	}, {
+		regionID: 25,
+		exp:      `[[INT64(25) INT64(2) VARCHAR("shard--19a0")] [INT64(25) INT64(7) VARCHAR("shard-19a0-20")]]`,
+	}, {
+		regionID: 31,
+		exp:      `[[INT64(31) INT64(8) VARCHAR("shard-19a0-20")]]`,
+	}, {
+		regionID: 32,
+		exp:      `[[INT64(32) INT64(14) VARCHAR("shard-20-20c0")] [INT64(32) INT64(19) VARCHAR("shard-20c0-")]]`,
+	}, {
+		regionID: 33,
+		exp:      `[[INT64(33) INT64(20) VARCHAR("shard-20c0-")]]`,
+	}}
+
+	defer utils.ExecAllowError(t, conn, `delete from region_tbl`)
+	uid := 1
+	// insert data in all shards to know where the query fan-out
+	for _, s := range shardedKsShards {
+		utils.Exec(t, conn, fmt.Sprintf("use `%s:%s`", shardedKs, s))
+		for _, tcase := range tcases {
+			utils.Exec(t, conn, fmt.Sprintf("insert into region_tbl(rg,uid,msg) values(%d,%d,'shard-%s')", tcase.regionID, uid, s))
+			uid++
+		}
+	}
+
+	newConn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer newConn.Close()
+
+	for _, workload := range []string{"olap", "oltp"} {
+		utils.Exec(t, newConn, fmt.Sprintf(`set workload = %s`, workload))
+		for _, tcase := range tcases {
+			t.Run(workload+strconv.Itoa(tcase.regionID), func(t *testing.T) {
+				sql := fmt.Sprintf("select rg, uid, msg from region_tbl where rg = %d order by uid", tcase.regionID)
+				assert.Equal(t, tcase.exp, fmt.Sprintf("%v", utils.Exec(t, newConn, sql).Rows))
+			})
+		}
 	}
 }

--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -32,6 +32,7 @@ var (
 	vtParams         mysql.ConnParams
 	shardedKs        = "ks"
 	unshardedKs      = "uks"
+	shardedKsShards  = []string{"-19a0", "19a0-20", "20-20c0", "20c0-"}
 	Cell             = "test"
 	shardedSchemaSQL = `create table t1(
 	id bigint,
@@ -58,6 +59,13 @@ create table user_region(
 	cola bigint,
 	colb bigint,
 	primary key(id)
+) Engine=InnoDB;
+
+create table region_tbl(
+	rg bigint,
+	uid bigint,
+	msg varchar(50),
+	primary key(uid)
 ) Engine=InnoDB;
 `
 	unshardedSchemaSQL = `create table u_a(
@@ -131,6 +139,14 @@ create table u_b(
 		  "name": "regional_vdx"
 		}
       ]
+    },
+    "region_tbl": {
+	  "column_vindexes": [
+	    {
+          "columns": ["rg","uid"],
+		  "name": "regional_vdx"
+		}
+      ]
 	}
   }
 }`
@@ -174,7 +190,7 @@ func TestMain(m *testing.M) {
 			SchemaSQL: shardedSchemaSQL,
 			VSchema:   shardedVSchema,
 		}
-		err = clusterInstance.StartKeyspace(*sKs, []string{"-80", "80-"}, 0, false)
+		err = clusterInstance.StartKeyspace(*sKs, shardedKsShards, 0, false)
 		if err != nil {
 			return 1
 		}

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -367,9 +367,20 @@ func (ins *Insert) getInsertShardedRoute(vcursor VCursor, bindVars map[string]*q
 	vindexRowsValues := make([][][]sqltypes.Value, len(ins.VindexValues))
 	rowCount := 0
 	env := evalengine.EnvWithBindVars(bindVars)
+	var colVindexes []*vindexes.ColumnVindex
+	for idx, colVindex := range ins.Table.ColumnVindexes {
+		if idx == 0 {
+			colVindexes = append(colVindexes, colVindex)
+			continue
+		}
+		if multiColV, isMultiColV := colVindex.Vindex.(vindexes.MultiColumn); isMultiColV && multiColV.PartialVindex() {
+			continue
+		}
+		colVindexes = append(colVindexes, colVindex)
+	}
 	for vIdx, vColValues := range ins.VindexValues {
-		if len(vColValues) != len(ins.Table.ColumnVindexes[vIdx].Columns) {
-			return nil, nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] supplied vindex column values don't match vschema: %v %v", vColValues, ins.Table.ColumnVindexes[vIdx].Columns)
+		if len(vColValues) != len(colVindexes[vIdx].Columns) {
+			return nil, nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] supplied vindex column values don't match vschema: %v %v", vColValues, colVindexes[vIdx].Columns)
 		}
 		for colIdx, colValues := range vColValues {
 			rowsResolvedValues := make([]sqltypes.Value, 0, len(colValues))
@@ -404,16 +415,16 @@ func (ins *Insert) getInsertShardedRoute(vcursor VCursor, bindVars map[string]*q
 	// keyspace ids. For regular inserts, a failure to find a route
 	// results in an error. For 'ignore' type inserts, the keyspace
 	// id is returned as nil, which is used later to drop the corresponding rows.
-	if len(vindexRowsValues) == 0 || len(ins.Table.ColumnVindexes) == 0 {
+	if len(vindexRowsValues) == 0 || len(colVindexes) == 0 {
 		return nil, nil, vterrors.NewErrorf(vtrpcpb.Code_FAILED_PRECONDITION, vterrors.RequiresPrimaryKey, vterrors.PrimaryVindexNotSet, ins.Table.Name)
 	}
-	keyspaceIDs, err := ins.processPrimary(vcursor, vindexRowsValues[0], ins.Table.ColumnVindexes[0])
+	keyspaceIDs, err := ins.processPrimary(vcursor, vindexRowsValues[0], colVindexes[0])
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for vIdx := 1; vIdx < len(ins.Table.ColumnVindexes); vIdx++ {
-		colVindex := ins.Table.ColumnVindexes[vIdx]
+	for vIdx := 1; vIdx < len(colVindexes); vIdx++ {
+		colVindex := colVindexes[vIdx]
 		var err error
 		if colVindex.Owned {
 			err = ins.processOwned(vcursor, vindexRowsValues[vIdx], colVindex, keyspaceIDs)
@@ -427,7 +438,7 @@ func (ins *Insert) getInsertShardedRoute(vcursor VCursor, bindVars map[string]*q
 
 	// Build 3-d bindvars. Skip rows with nil keyspace ids in case
 	// we're executing an insert ignore.
-	for vIdx, colVindex := range ins.Table.ColumnVindexes {
+	for vIdx, colVindex := range colVindexes {
 		for rowNum, rowColumnKeys := range vindexRowsValues[vIdx] {
 			if keyspaceIDs[rowNum] == nil {
 				// InsertShardedIgnore: skip the row.

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -701,6 +701,12 @@ func TestInsertShardedGeo(t *testing.T) {
 		[]string{" mid1", " mid2"},
 		" suffix",
 	)
+	for _, colVindex := range ks.Tables["t1"].ColumnVindexes {
+		if colVindex.IgnoreInDML() {
+			continue
+		}
+		ins.ColVindexes = append(ins.ColVindexes, colVindex)
+	}
 
 	vc := newDMLTestVCursor("-20", "20-")
 	vc.shardForKsid = []string{"20-", "-20"}

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -460,7 +460,7 @@ func createLegacyExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandb
 
 func createExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandboxconn.SandboxConn) {
 	// Use legacy gateway until we can rewrite these tests to use new tabletgateway
-	*GatewayImplementation = GatewayImplementationDiscovery
+	*GatewayImplementation = tabletGatewayImplementation
 	cell := "aa"
 	hc := discovery.NewFakeHealthCheck(nil)
 	s := createSandbox("TestExecutor")

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -40,7 +40,7 @@ func getDMLRouting(where *sqlparser.Where, table *vindexes.Table) (
 	var ksidVindex vindexes.SingleColumn
 	var ksidCol string
 	for _, index := range table.Ordered {
-		if !index.Vindex.IsUnique() {
+		if !index.IsUnique() {
 			continue
 		}
 		single, ok := index.Vindex.(vindexes.SingleColumn)

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -167,12 +167,8 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (engin
 
 	// Fill out the 3-d Values structure. Please see documentation of Insert.Values for details.
 	var colVindexes []*vindexes.ColumnVindex
-	for idx, colVindex := range eins.Table.ColumnVindexes {
-		if idx == 0 {
-			colVindexes = append(colVindexes, colVindex)
-			continue
-		}
-		if multiColV, isMultiColV := colVindex.Vindex.(vindexes.MultiColumn); isMultiColV && multiColV.PartialVindex() {
+	for _, colVindex := range eins.Table.ColumnVindexes {
+		if colVindex.IgnoreInDML() {
 			continue
 		}
 		colVindexes = append(colVindexes, colVindex)
@@ -202,6 +198,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (engin
 		}
 	}
 	eins.VindexValues = routeValues
+	eins.ColVindexes = colVindexes
 	eins.Query = generateQuery(ins)
 	generateInsertShardedQuery(ins, eins, rows)
 	return eins, nil

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -166,8 +166,19 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (engin
 	}
 
 	// Fill out the 3-d Values structure. Please see documentation of Insert.Values for details.
-	routeValues := make([][][]evalengine.Expr, len(eins.Table.ColumnVindexes))
-	for vIdx, colVindex := range eins.Table.ColumnVindexes {
+	var colVindexes []*vindexes.ColumnVindex
+	for idx, colVindex := range eins.Table.ColumnVindexes {
+		if idx == 0 {
+			colVindexes = append(colVindexes, colVindex)
+			continue
+		}
+		if multiColV, isMultiColV := colVindex.Vindex.(vindexes.MultiColumn); isMultiColV && multiColV.PartialVindex() {
+			continue
+		}
+		colVindexes = append(colVindexes, colVindex)
+	}
+	routeValues := make([][][]evalengine.Expr, len(colVindexes))
+	for vIdx, colVindex := range colVindexes {
 		routeValues[vIdx] = make([][]evalengine.Expr, len(colVindex.Columns))
 		for colIdx, col := range colVindex.Columns {
 			routeValues[vIdx][colIdx] = make([]evalengine.Expr, len(rows))
@@ -181,7 +192,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (engin
 			}
 		}
 	}
-	for _, colVindex := range eins.Table.ColumnVindexes {
+	for _, colVindex := range colVindexes {
 		for _, col := range colVindex.Columns {
 			colNum := findOrAddColumn(ins, col)
 			for rowNum, row := range rows {

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -170,6 +170,10 @@ func (m *multiColIndex) Verify(vcursor vindexes.VCursor, rowsColValues [][]sqlty
 	return []bool{}, nil
 }
 
+func (m *multiColIndex) PartialVindex() bool {
+	return true
+}
+
 func init() {
 	vindexes.Register("hash_test", newHashIndex)
 	vindexes.Register("lookup_test", newLookupIndex)

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.txt
@@ -3622,10 +3622,10 @@ Gen4 plan same as above
 }
 
 # multi column vindex with different order with one IN predicate and one equality
-"select * from multicol_tbl where colb in (3,4) and cola = 1"
+"select * from multicol_tbl where colb = 1 and cola in (3,4)"
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where colb in (3,4) and cola = 1",
+  "Original": "select * from multicol_tbl where colb = 1 and cola in (3,4)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectScatter",
@@ -3634,13 +3634,13 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb in (3, 4) and cola = 1",
+    "Query": "select * from multicol_tbl where colb = 1 and cola in (3, 4)",
     "Table": "multicol_tbl"
   }
 }
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where colb in (3,4) and cola = 1",
+  "Original": "select * from multicol_tbl where colb = 1 and cola in (3,4)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectIN",
@@ -3649,11 +3649,11 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where colb in ::__vals1 and cola = 1",
+    "Query": "select * from multicol_tbl where colb = 1 and cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
-      "INT64(1)",
-      "(INT64(3), INT64(4))"
+      "(INT64(3), INT64(4))",
+      "INT64(1)"
     ],
     "Vindex": "multicolIdx"
   }
@@ -3698,10 +3698,10 @@ Gen4 plan same as above
 }
 
 # multi column vindex with one column with equal followed by IN predicate, ordering matters for now
-"select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)"
+"select * from multicol_tbl where colb = 4 and colb in (1,10) and cola in (5,6)"
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)",
+  "Original": "select * from multicol_tbl where colb = 4 and colb in (1,10) and cola in (5,6)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectScatter",
@@ -3710,13 +3710,13 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola = 4 and cola in (1, 10) and colb in (5, 6)",
+    "Query": "select * from multicol_tbl where colb = 4 and colb in (1, 10) and cola in (5, 6)",
     "Table": "multicol_tbl"
   }
 }
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where cola = 4 and cola in (1,10) and colb in (5,6)",
+  "Original": "select * from multicol_tbl where colb = 4 and colb in (1,10) and cola in (5,6)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectIN",
@@ -3725,21 +3725,21 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola = 4 and cola in ::__vals0 and colb in ::__vals1",
+    "Query": "select * from multicol_tbl where colb = 4 and colb in ::__vals1 and cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
-      "(INT64(1), INT64(10))",
-      "(INT64(5), INT64(6))"
+      "(INT64(5), INT64(6))",
+      "(INT64(1), INT64(10))"
     ],
     "Vindex": "multicolIdx"
   }
 }
 
 # multi column vindex with one column with IN followed by equal predicate, ordering matters for now
-"select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)"
+"select * from multicol_tbl where colb in (1,10) and colb = 4 and cola in (5,6)"
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)",
+  "Original": "select * from multicol_tbl where colb in (1,10) and colb = 4 and cola in (5,6)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectScatter",
@@ -3748,13 +3748,13 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in (5, 6)",
+    "Query": "select * from multicol_tbl where colb in (1, 10) and colb = 4 and cola in (5, 6)",
     "Table": "multicol_tbl"
   }
 }
 {
   "QueryType": "SELECT",
-  "Original": "select * from multicol_tbl where cola in (1,10) and cola = 4 and colb in (5,6)",
+  "Original": "select * from multicol_tbl where colb in (1,10) and colb = 4 and cola in (5,6)",
   "Instructions": {
     "OperatorType": "Route",
     "Variant": "SelectIN",
@@ -3763,11 +3763,11 @@ Gen4 plan same as above
       "Sharded": true
     },
     "FieldQuery": "select * from multicol_tbl where 1 != 1",
-    "Query": "select * from multicol_tbl where cola in (1, 10) and cola = 4 and colb in ::__vals1",
+    "Query": "select * from multicol_tbl where colb in (1, 10) and colb = 4 and cola in ::__vals0",
     "Table": "multicol_tbl",
     "Values": [
-      "INT64(4)",
-      "(INT64(5), INT64(6))"
+      "(INT64(5), INT64(6))",
+      "INT64(4)"
     ],
     "Vindex": "multicolIdx"
   }
@@ -4006,5 +4006,79 @@ Gen4 plan same as above
         "Table": "user_extra"
       }
     ]
+  }
+}
+
+# multi column vindex, partial vindex with SelectEqual
+"select * from multicol_tbl where cola = 1"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 1",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 1",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+
+# multi column vindex, partial vindex with SelectEqual over full vindex with SelectIN
+"select * from multicol_tbl where cola = 1 and colb in (2,3)"
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 1 and colb in (2,3)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 1 and colb in (2, 3)",
+    "Table": "multicol_tbl"
+  }
+}
+{
+  "QueryType": "SELECT",
+  "Original": "select * from multicol_tbl where cola = 1 and colb in (2,3)",
+  "Instructions": {
+    "OperatorType": "Route",
+    "Variant": "SelectEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "FieldQuery": "select * from multicol_tbl where 1 != 1",
+    "Query": "select * from multicol_tbl where cola = 1 and colb in (2, 3)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)"
+    ],
+    "Vindex": "multicolIdx"
   }
 }

--- a/go/vt/vtgate/vindexes/region_experimental.go
+++ b/go/vt/vtgate/vindexes/region_experimental.go
@@ -91,7 +91,7 @@ func (ge *RegionExperimental) NeedsVCursor() bool {
 func (ge *RegionExperimental) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
 	destinations := make([]key.Destination, 0, len(rowsColValues))
 	for _, row := range rowsColValues {
-		if len(row) != 2 {
+		if len(row) > 2 {
 			destinations = append(destinations, key.DestinationNone{})
 			continue
 		}
@@ -104,20 +104,25 @@ func (ge *RegionExperimental) Map(vcursor VCursor, rowsColValues [][]sqltypes.Va
 		r := make([]byte, 2, 2+8)
 		binary.BigEndian.PutUint16(r, uint16(rn))
 
-		// Compute hash.
-		hn, err := evalengine.ToUint64(row[1])
-		if err != nil {
-			destinations = append(destinations, key.DestinationNone{})
-			continue
-		}
-		h := vhash(hn)
-
 		// Concatenate and add to destinations.
 		if ge.regionBytes == 1 {
 			r = r[1:]
 		}
-		dest := append(r, h...)
-		destinations = append(destinations, key.DestinationKeyspaceID(dest))
+
+		dest := r
+		if len(row) == 2 {
+			// Compute hash.
+			hn, err := evalengine.ToUint64(row[1])
+			if err != nil {
+				destinations = append(destinations, key.DestinationNone{})
+				continue
+			}
+			h := vhash(hn)
+			dest = append(dest, h...)
+			destinations = append(destinations, key.DestinationKeyspaceID(dest))
+		} else {
+			destinations = append(destinations, NewKeyRangeFromPrefix(dest))
+		}
 	}
 	return destinations, nil
 }

--- a/go/vt/vtgate/vindexes/region_experimental.go
+++ b/go/vt/vtgate/vindexes/region_experimental.go
@@ -135,3 +135,7 @@ func (ge *RegionExperimental) Verify(vcursor VCursor, rowsColValues [][]sqltypes
 	}
 	return result, nil
 }
+
+func (ge *RegionExperimental) PartialVindex() bool {
+	return true
+}

--- a/go/vt/vtgate/vindexes/region_experimental_test.go
+++ b/go/vt/vtgate/vindexes/region_experimental_test.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"testing"
 
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -47,7 +49,7 @@ func TestRegionExperimentalMap(t *testing.T) {
 	}, {
 		sqltypes.NewInt64(256), sqltypes.NewInt64(1),
 	}, {
-		// Invalid length.
+		// only region id provided, partial column for key range mapping.
 		sqltypes.NewInt64(1),
 	}, {
 		// Invalid region.
@@ -62,7 +64,7 @@ func TestRegionExperimentalMap(t *testing.T) {
 		key.DestinationKeyspaceID([]byte("\x01\x16k@\xb4J\xbaK\xd6")),
 		key.DestinationKeyspaceID([]byte("\xff\x16k@\xb4J\xbaK\xd6")),
 		key.DestinationKeyspaceID([]byte("\x00\x16k@\xb4J\xbaK\xd6")),
-		key.DestinationNone{},
+		key.DestinationKeyRange{KeyRange: &topodatapb.KeyRange{Start: []byte("\x01"), End: []byte("\x02")}},
 		key.DestinationNone{},
 		key.DestinationNone{},
 	}

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -101,6 +101,11 @@ func (rv *RegionJSON) IsUnique() bool {
 	return true
 }
 
+// NeedsVCursor satisfies the Vindex interface.
+func (rv *RegionJSON) NeedsVCursor() bool {
+	return false
+}
+
 // Map satisfies MultiColumn.
 func (rv *RegionJSON) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
 	destinations := make([]key.Destination, 0, len(rowsColValues))
@@ -149,7 +154,6 @@ func (rv *RegionJSON) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, 
 	return result, nil
 }
 
-// NeedsVCursor satisfies the Vindex interface.
-func (rv *RegionJSON) NeedsVCursor() bool {
-	return false
+func (rv *RegionJSON) PartialVindex() bool {
+	return true
 }

--- a/go/vt/vtgate/vindexes/region_json.go
+++ b/go/vt/vtgate/vindexes/region_json.go
@@ -155,5 +155,5 @@ func (rv *RegionJSON) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, 
 }
 
 func (rv *RegionJSON) PartialVindex() bool {
-	return true
+	return false
 }

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -89,6 +89,8 @@ type MultiColumn interface {
 	Vindex
 	Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error)
 	Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error)
+	// PartialVindex returns true if subset of columns can be passed in to the vindex Map and Verify function.
+	PartialVindex() bool
 }
 
 // A Reversible vindex is one that can perform a

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -103,11 +103,26 @@ type Keyspace struct {
 
 // ColumnVindex contains the index info for each index of a table.
 type ColumnVindex struct {
-	Columns []sqlparser.ColIdent `json:"columns"`
-	Type    string               `json:"type"`
-	Name    string               `json:"name"`
-	Owned   bool                 `json:"owned,omitempty"`
-	Vindex  Vindex               `json:"vindex"`
+	Columns  []sqlparser.ColIdent `json:"columns"`
+	Type     string               `json:"type"`
+	Name     string               `json:"name"`
+	Owned    bool                 `json:"owned,omitempty"`
+	Vindex   Vindex               `json:"vindex"`
+	isUnique bool
+	cost     int
+}
+
+// IsUnique is used to tell whether the ColumnVindex
+// will return a unique shard value or not when queried with
+// the given column list
+func (c *ColumnVindex) IsUnique() bool {
+	return c.isUnique
+}
+
+// Cost represents the cost associated with using the
+// ColumnVindex
+func (c *ColumnVindex) Cost() int {
+	return c.cost
 }
 
 // Column describes a column.
@@ -306,11 +321,13 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 				}
 			}
 			columnVindex := &ColumnVindex{
-				Columns: columns,
-				Type:    vindexInfo.Type,
-				Name:    ind.Name,
-				Owned:   owned,
-				Vindex:  vindex,
+				Columns:  columns,
+				Type:     vindexInfo.Type,
+				Name:     ind.Name,
+				Owned:    owned,
+				Vindex:   vindex,
+				isUnique: vindex.IsUnique(),
+				cost:     vindex.Cost(),
 			}
 			if i == 0 {
 				// Perform Primary vindex check.
@@ -338,14 +355,18 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 			if i != 0 {
 				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "multi-column vindex %s should be a primary vindex for table %s", ind.Name, tname)
 			}
+			cost := vindex.Cost()
 			for i := len(columns) - 1; i > 0; i-- {
 				columnSubset := columns[:i]
+				cost++
 				columnVindex = &ColumnVindex{
-					Columns: columnSubset,
-					Type:    vindexInfo.Type,
-					Name:    ind.Name,
-					Owned:   owned,
-					Vindex:  vindex,
+					Columns:  columnSubset,
+					Type:     vindexInfo.Type,
+					Name:     ind.Name,
+					Owned:    owned,
+					Vindex:   vindex,
+					isUnique: false,
+					cost:     cost,
 				}
 				t.ColumnVindexes = append(t.ColumnVindexes, columnVindex)
 			}
@@ -593,7 +614,7 @@ type ByCost []*ColumnVindex
 
 func (bc ByCost) Len() int           { return len(bc) }
 func (bc ByCost) Swap(i, j int)      { bc[i], bc[j] = bc[j], bc[i] }
-func (bc ByCost) Less(i, j int) bool { return bc[i].Vindex.Cost() < bc[j].Vindex.Cost() }
+func (bc ByCost) Less(i, j int) bool { return bc[i].Cost() < bc[j].Cost() }
 
 func colVindexSorted(cvs []*ColumnVindex) (sorted []*ColumnVindex) {
 	sorted = append(sorted, cvs...)
@@ -659,10 +680,10 @@ func FindBestColVindex(table *Table) (*ColumnVindex, error) {
 		if cv.Vindex.NeedsVCursor() {
 			continue
 		}
-		if !cv.Vindex.IsUnique() {
+		if !cv.IsUnique() {
 			continue
 		}
-		if result == nil || result.Vindex.Cost() > cv.Vindex.Cost() {
+		if result == nil || result.Cost() > cv.Cost() {
 			result = cv
 		}
 	}
@@ -687,11 +708,11 @@ func FindVindexForSharding(tableName string, colVindexes []*ColumnVindex) (*Colu
 		if _, ok := colVindex.Vindex.(SingleColumn); !ok {
 			continue
 		}
-		if colVindex.Vindex.Cost() < result.Vindex.Cost() && colVindex.Vindex.IsUnique() {
+		if colVindex.Cost() < result.Cost() && colVindex.IsUnique() {
 			result = colVindex
 		}
 	}
-	if result.Vindex.Cost() > 1 || !result.Vindex.IsUnique() {
+	if result.Cost() > 1 || !result.IsUnique() {
 		return nil, fmt.Errorf("could not find a vindex to use for sharding table %v", tableName)
 	}
 	return result, nil

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -330,6 +330,25 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 				}
 				t.Owned = append(t.Owned, columnVindex)
 			}
+
+			_, isMultiColumn := vindex.(MultiColumn)
+			if !isMultiColumn {
+				continue
+			}
+			if i != 0 {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "multi-column vindex %s should be a primary vindex for table %s", ind.Name, tname)
+			}
+			for i := len(columns) - 1; i > 0; i-- {
+				columnSubset := columns[:i]
+				columnVindex = &ColumnVindex{
+					Columns: columnSubset,
+					Type:    vindexInfo.Type,
+					Name:    ind.Name,
+					Owned:   owned,
+					Vindex:  vindex,
+				}
+				t.ColumnVindexes = append(t.ColumnVindexes, columnVindex)
+			}
 		}
 		t.Ordered = colVindexSorted(t.ColumnVindexes)
 

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -103,13 +103,14 @@ type Keyspace struct {
 
 // ColumnVindex contains the index info for each index of a table.
 type ColumnVindex struct {
-	Columns  []sqlparser.ColIdent `json:"columns"`
-	Type     string               `json:"type"`
-	Name     string               `json:"name"`
-	Owned    bool                 `json:"owned,omitempty"`
-	Vindex   Vindex               `json:"vindex"`
-	isUnique bool
-	cost     int
+	Columns     []sqlparser.ColIdent `json:"columns"`
+	Type        string               `json:"type"`
+	Name        string               `json:"name"`
+	Owned       bool                 `json:"owned,omitempty"`
+	Vindex      Vindex               `json:"vindex"`
+	isUnique    bool
+	cost        int
+	ignoreInDML bool
 }
 
 // IsUnique is used to tell whether the ColumnVindex
@@ -123,6 +124,11 @@ func (c *ColumnVindex) IsUnique() bool {
 // ColumnVindex
 func (c *ColumnVindex) Cost() int {
 	return c.cost
+}
+
+// IgnoreInDML is used to let planner and engine know that they need to be ignored for dml queries.
+func (c *ColumnVindex) IgnoreInDML() bool {
+	return c.ignoreInDML
 }
 
 // Column describes a column.
@@ -365,13 +371,13 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 				columnSubset := columns[:i]
 				cost++
 				columnVindex = &ColumnVindex{
-					Columns:  columnSubset,
-					Type:     vindexInfo.Type,
-					Name:     ind.Name,
-					Owned:    owned,
-					Vindex:   vindex,
-					isUnique: false,
-					cost:     cost,
+					Columns:     columnSubset,
+					Type:        vindexInfo.Type,
+					Name:        ind.Name,
+					Owned:       owned,
+					Vindex:      vindex,
+					cost:        cost,
+					ignoreInDML: true,
 				}
 				t.ColumnVindexes = append(t.ColumnVindexes, columnVindex)
 			}

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -348,12 +348,17 @@ func buildTables(ks *vschemapb.Keyspace, vschema *VSchema, ksvschema *KeyspaceSc
 				t.Owned = append(t.Owned, columnVindex)
 			}
 
-			_, isMultiColumn := vindex.(MultiColumn)
+			mcv, isMultiColumn := vindex.(MultiColumn)
 			if !isMultiColumn {
 				continue
 			}
 			if i != 0 {
 				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "multi-column vindex %s should be a primary vindex for table %s", ind.Name, tname)
+			}
+			if !mcv.PartialVindex() {
+				// Partial column selection not allowed.
+				// Do not create subset column vindex.
+				continue
 			}
 			cost := vindex.Cost()
 			for i := len(columns) - 1; i > 0; i-- {

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"vitess.io/vitess/go/test/utils"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
@@ -175,6 +177,26 @@ func NewSTLO(name string, _ map[string]string) (Vindex, error) {
 var _ SingleColumn = (*stLO)(nil)
 var _ Lookup = (*stLO)(nil)
 
+// mcFU is a multi-column Functional, Unique Vindex.
+type mcFU struct {
+	name   string
+	Params map[string]string
+}
+
+func (v *mcFU) String() string                                                      { return v.name }
+func (*mcFU) Cost() int                                                             { return 1 }
+func (*mcFU) IsUnique() bool                                                        { return true }
+func (*mcFU) NeedsVCursor() bool                                                    { return false }
+func (*mcFU) Verify(VCursor, [][]sqltypes.Value, [][]byte) ([]bool, error)          { return []bool{}, nil }
+func (*mcFU) Map(cursor VCursor, ids [][]sqltypes.Value) ([]key.Destination, error) { return nil, nil }
+func (*mcFU) PartialVindex() bool                                                   { return false }
+
+func NewMCFU(name string, params map[string]string) (Vindex, error) {
+	return &mcFU{name: name, Params: params}, nil
+}
+
+var _ MultiColumn = (*mcFU)(nil)
+
 func init() {
 	Register("cheap", NewCheapVindex)
 	Register("stfu", NewSTFU)
@@ -183,6 +205,7 @@ func init() {
 	Register("stlu", NewSTLU)
 	Register("stlo", NewSTLO)
 	Register("region_experimental_test", NewRegionExperimental)
+	Register("mcfu", NewMCFU)
 }
 
 func TestUnshardedVSchemaValid(t *testing.T) {
@@ -504,17 +527,21 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
-				Type:    "stln",
-				Name:    "stln1",
-				Owned:   true,
-				Vindex:  vindex2,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
+				Type:     "stln",
+				Name:     "stln1",
+				Owned:    true,
+				Vindex:   vindex2,
+				isUnique: vindex2.IsUnique(),
+				cost:     vindex2.Cost(),
 			},
 		},
 	}
@@ -552,11 +579,7 @@ func TestShardedVSchemaOwned(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		gotjson, _ := json.Marshal(got)
-		wantjson, _ := json.Marshal(want)
-		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
-	}
+	utils.MustMatch(t, want, got)
 }
 
 func TestShardedVSchemaOwnerInfo(t *testing.T) {
@@ -728,10 +751,12 @@ func TestVSchemaRoutingRules(t *testing.T) {
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: ks1,
 		ColumnVindexes: []*ColumnVindex{{
-			Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-			Type:    "stfu",
-			Name:    "stfu1",
-			Vindex:  vindex1,
+			Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+			Type:     "stfu",
+			Name:     "stfu1",
+			Vindex:   vindex1,
+			isUnique: vindex1.IsUnique(),
+			cost:     vindex1.Cost(),
 		}},
 	}
 	t1.Ordered = []*ColumnVindex{
@@ -1038,17 +1063,21 @@ func TestFindVindexForSharding(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
-				Type:    "stln",
-				Name:    "stln1",
-				Owned:   true,
-				Vindex:  vindex2,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
+				Type:     "stln",
+				Name:     "stln1",
+				Owned:    true,
+				Vindex:   vindex2,
+				isUnique: vindex2.IsUnique(),
+				cost:     vindex2.Cost(),
 			},
 		},
 	}
@@ -1071,17 +1100,21 @@ func TestFindVindexForShardingError(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stlu",
-				Name:    "stlu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stlu",
+				Name:     "stlu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
-				Type:    "stln",
-				Name:    "stln1",
-				Owned:   true,
-				Vindex:  vindex2,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
+				Type:     "stln",
+				Name:     "stln1",
+				Owned:    true,
+				Vindex:   vindex2,
+				isUnique: vindex2.IsUnique(),
+				cost:     vindex2.Cost(),
 			},
 		},
 	}
@@ -1112,17 +1145,21 @@ func TestFindVindexForSharding2(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stlu",
-				Name:    "stlu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stlu",
+				Name:     "stlu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Owned:   true,
-				Vindex:  vindex2,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Owned:    true,
+				Vindex:   vindex2,
+				isUnique: vindex2.IsUnique(),
+				cost:     vindex2.Cost(),
 			},
 		},
 	}
@@ -1178,10 +1215,12 @@ func TestShardedVSchemaMultiColumnVindex(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1"), sqlparser.NewColIdent("c2")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1"), sqlparser.NewColIdent("c2")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 		},
 	}
@@ -1267,18 +1306,22 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stlu",
-				Name:    "stlu1",
-				Owned:   false,
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stlu",
+				Name:     "stlu1",
+				Owned:    false,
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Owned:   false,
-				Vindex:  vindex2,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c2")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Owned:    false,
+				Vindex:   vindex2,
+				isUnique: vindex2.IsUnique(),
+				cost:     vindex2.Cost(),
 			},
 		},
 	}
@@ -1593,11 +1636,13 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 		Keyspace: ksa,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stlu",
-				Name:    "stlu1",
-				Owned:   false,
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stlu",
+				Name:     "stlu1",
+				Owned:    false,
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 		},
 	}
@@ -1609,11 +1654,13 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 		Keyspace: ksb,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stlu",
-				Name:    "stlu1",
-				Owned:   false,
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stlu",
+				Name:     "stlu1",
+				Owned:    false,
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 		},
 	}
@@ -1904,10 +1951,12 @@ func TestSequence(t *testing.T) {
 		Keyspace: kss,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 		},
 		AutoIncrement: &AutoIncrement{
@@ -1923,10 +1972,12 @@ func TestSequence(t *testing.T) {
 		Keyspace: kss,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
-				Type:    "stfu",
-				Name:    "stfu1",
-				Vindex:  vindex1,
+				Columns:  []sqlparser.ColIdent{sqlparser.NewColIdent("c1")},
+				Type:     "stfu",
+				Name:     "stfu1",
+				Vindex:   vindex1,
+				isUnique: vindex1.IsUnique(),
+				cost:     vindex1.Cost(),
 			},
 		},
 		AutoIncrement: &AutoIncrement{
@@ -2643,7 +2694,7 @@ func TestFindSingleKeyspace(t *testing.T) {
 	}
 }
 
-func TestRegionalExperimental(t *testing.T) {
+func TestMultiColVindexPartialAllowed(t *testing.T) {
 	input := vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
 			"ksa": {
@@ -2677,4 +2728,35 @@ func TestRegionalExperimental(t *testing.T) {
 	require.False(t, table.ColumnVindexes[1].IsUnique())
 	require.EqualValues(t, 1, table.ColumnVindexes[0].Cost())
 	require.EqualValues(t, 2, table.ColumnVindexes[1].Cost())
+}
+
+func TestMultiColVindexPartialNotAllowed(t *testing.T) {
+	input := vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ksa": {
+				Sharded: true,
+				Vindexes: map[string]*vschemapb.Vindex{
+					"multicol_vdx": {
+						Type: "mcfu",
+					},
+				},
+				Tables: map[string]*vschemapb.Table{
+					"multiColTbl": {
+						ColumnVindexes: []*vschemapb.ColumnVindex{
+							{
+								Columns: []string{"cola", "colb", "colc"},
+								Name:    "multicol_vdx",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vschema := BuildVSchema(&input)
+	table, err := vschema.FindTable("ksa", "multiColTbl")
+	require.NoError(t, err)
+	require.Len(t, table.ColumnVindexes, 1)
+	require.True(t, table.ColumnVindexes[0].IsUnique())
+	require.EqualValues(t, 1, table.ColumnVindexes[0].Cost())
 }

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -2673,4 +2673,8 @@ func TestRegionalExperimental(t *testing.T) {
 	table, err := vschema.FindTable("ksa", "user_region")
 	require.NoError(t, err)
 	require.Len(t, table.ColumnVindexes, 2)
+	require.True(t, table.ColumnVindexes[0].IsUnique())
+	require.False(t, table.ColumnVindexes[1].IsUnique())
+	require.EqualValues(t, 1, table.ColumnVindexes[0].Cost())
+	require.EqualValues(t, 2, table.ColumnVindexes[1].Cost())
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a new function to MultiColumn Vindex interface to provide information that the multi-column vindex supports partial vindex selection (i.e. fanout to subset of shards if part of the column values are provided).

Eg.
```
cola, colb, colc forms a multicolumn vindex
then providing values for cola or (cola and colb) the vindex should be able to fan out the query to subset of shards.
```

The user does not have to provide any additional information in the VSchema. Based on the table that uses multi-column vindex which allows partial vindex column selection, Vitess will handle it internally and the planner will be able to utilize those columns for vindex selection.

This PR also modifies the existing `region_experimental` vindex to handle partial column values i.e. if only `region_id` is provided to Map function.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- https://github.com/vitessio/vitess/issues/3481

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->