### PR TITLE
Add -mysqlctl_mycnf_retain_file to vttablet backups

### DIFF
--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -2,6 +2,8 @@
 
 - `vtctl/vtctlclient ApplySchema` now respects `-allow-zero-in-date` for `direct` strategy. For example, the following statement is now accepted: `vtctlclient ApplySchema -skip_preflight -ddl_strategy='direct -allow-zero-in-date' -sql "create table if not exists t2(id int primary key, dt datetime default '0000-00-00 00:00:00')" commerce`
 
+- `-mysqlctl_mycnf_retain_file` was added to skip recreating `my.cnf` while restoring backup
+
 ## Major Changes
 
 ### vttablet -use_super_read_only flag now defaults to true


### PR DESCRIPTION
Signed-off-by: Adam Jedro <adamjedro@gmail.com>

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This adds a new option `-mysqlctl_mycnf_retain_file` to vttablet. Now if we are restoring from backup, vttablet wipes all logs and uses default`my.cnf` file template (unless `mysqlctl_mycnf_template` is provided) before doing the restore. 

In my case the `my.cnf` is managed by an external service (puppet) and I don't want this file to be changed by vitess. This also allows me to hold `my.cnf` definition/template outside of `vttablet` configuration and manage it externally.


If `-mysqlctl_mycnf_retain_file` is set, it's up to user to provide non-coliding `server-id`.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
-- manual tests performed
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->