### PR TITLE
[10.0] change operator example to use v10.0.4 docker images

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v10.0.1
-    vtgate: vitess/lite:v10.0.1
-    vttablet: vitess/lite:v10.0.1
-    vtbackup: vitess/lite:v10.0.1
+    vtctld: vitess/lite:v10.0.4
+    vtgate: vitess/lite:v10.0.4
+    vttablet: vitess/lite:v10.0.4
+    vtbackup: vitess/lite:v10.0.4
     mysqld:
-      mysql56Compatible: vitess/lite:v10.0.1
+      mysql56Compatible: vitess/lite:v10.0.4
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v10.0.1
-    vtgate: vitess/lite:v10.0.1
-    vttablet: vitess/lite:v10.0.1
-    vtbackup: vitess/lite:v10.0.1
+    vtctld: vitess/lite:v10.0.4
+    vtgate: vitess/lite:v10.0.4
+    vttablet: vitess/lite:v10.0.4
+    vtbackup: vitess/lite:v10.0.4
     mysqld:
-      mysql56Compatible: vitess/lite:v10.0.1
+      mysql56Compatible: vitess/lite:v10.0.4
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v10.0.1
-    vtgate: vitess/lite:v10.0.1
-    vttablet: vitess/lite:v10.0.1
-    vtbackup: vitess/lite:v10.0.1
+    vtctld: vitess/lite:v10.0.4
+    vtgate: vitess/lite:v10.0.4
+    vttablet: vitess/lite:v10.0.4
+    vtbackup: vitess/lite:v10.0.4
     mysqld:
-      mysql56Compatible: vitess/lite:v10.0.1
+      mysql56Compatible: vitess/lite:v10.0.4
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v10.0.1
-    vtgate: vitess/lite:v10.0.1
-    vttablet: vitess/lite:v10.0.1
-    vtbackup: vitess/lite:v10.0.1
+    vtctld: vitess/lite:v10.0.4
+    vtgate: vitess/lite:v10.0.4
+    vttablet: vitess/lite:v10.0.4
+    vtbackup: vitess/lite:v10.0.4
     mysqld:
-      mysql56Compatible: vitess/lite:v10.0.1
+      mysql56Compatible: vitess/lite:v10.0.4
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/vtorc_example.yaml
+++ b/examples/operator/vtorc_example.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:v10.0.1
-    vtorc: vitess/lite:v10.0.1
-    vtgate: vitess/lite:v10.0.1
-    vttablet: vitess/lite:v10.0.1
-    vtbackup: vitess/lite:v10.0.1
+    vtctld: vitess/lite:v10.0.4
+    vtorc: vitess/lite:v10.0.4
+    vtgate: vitess/lite:v10.0.4
+    vttablet: vitess/lite:v10.0.4
+    vtbackup: vitess/lite:v10.0.4
     mysqld:
-      mysql56Compatible: vitess/lite:v10.0.1
+      mysql56Compatible: vitess/lite:v10.0.4
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
## Description

This pull request is changing the docker images used in the operator example. They will now use `v10.0.4` (latest patch release, to be released soon). Previous versions of `v10` contained (CVE-2021-44228
 & CVE-2021-45046) which will be fixed in `v10.0.4`.
