### PR TITLE
[11.0] change operator example to use v11.0.3 docker images

### DIFF
--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -8,12 +8,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v11.0.3
+    vtgate: vitess/lite:v11.0.3
+    vttablet: vitess/lite:v11.0.3
+    vtbackup: vitess/lite:v11.0.3
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v11.0.3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v11.0.3
+    vtgate: vitess/lite:v11.0.3
+    vttablet: vitess/lite:v11.0.3
+    vtbackup: vitess/lite:v11.0.3
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v11.0.3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v11.0.3
+    vtgate: vitess/lite:v11.0.3
+    vttablet: vitess/lite:v11.0.3
+    vtbackup: vitess/lite:v11.0.3
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v11.0.3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v11.0.3
+    vtgate: vitess/lite:v11.0.3
+    vttablet: vitess/lite:v11.0.3
+    vtbackup: vitess/lite:v11.0.3
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v11.0.3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1

--- a/examples/operator/vtorc_example.yaml
+++ b/examples/operator/vtorc_example.yaml
@@ -8,13 +8,13 @@ metadata:
   name: example
 spec:
   images:
-    vtctld: vitess/lite:latest
-    vtorc: vitess/lite:latest
-    vtgate: vitess/lite:latest
-    vttablet: vitess/lite:latest
-    vtbackup: vitess/lite:latest
+    vtctld: vitess/lite:v11.0.3
+    vtorc: vitess/lite:v11.0.3
+    vtgate: vitess/lite:v11.0.3
+    vttablet: vitess/lite:v11.0.3
+    vtbackup: vitess/lite:v11.0.3
     mysqld:
-      mysql56Compatible: vitess/lite:latest
+      mysql56Compatible: vitess/lite:v11.0.3
     mysqldExporter: prom/mysqld-exporter:v0.11.0
   cells:
   - name: zone1


### PR DESCRIPTION
## Description

This pull request is changing the docker images used in the operator example. They will now use `v11.0.3` (latest patch release, to be released soon). Previous versions of `v11` contained (CVE-2021-44228
 & CVE-2021-45046) which will be fixed in `v11.0.3`.
