### PR TITLE
vtctl: delete deprecated flag

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1666,17 +1666,6 @@ func commandSetShardTabletControl(ctx context.Context, wr *wrangler.Wrangler, su
 	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
 	deniedTablesStr := subFlags.String("denied_tables", "", "Specifies a comma-separated list of tables to add to the denylist (used for vertical split). Each is either an exact match, or a regular expression of the form '/regexp/'.")
 
-	// DEPRECATION START: remove after 12.0
-	blacklistedTablesStr := subFlags.String("blacklisted_tables", "", "Specifies a comma-separated list of tables to add to the denylist (used for vertical split). Each is either an exact match, or a regular expression of the form '/regexp/'.")
-
-	if *deniedTablesStr != "" && *blacklistedTablesStr != "" {
-		return fmt.Errorf("cannot specify both denied_tables and blacklisted_tables")
-	}
-	if *deniedTablesStr == "" && *blacklistedTablesStr != "" {
-		*deniedTablesStr = *blacklistedTablesStr
-	}
-	// DEPRECATION ends
-
 	remove := subFlags.Bool("remove", false, "Removes cells for vertical splits.")
 	disableQueryService := subFlags.Bool("disable_query_service", false, "Disables query service on the provided nodes. This flag requires 'denied_tables' and 'remove' to be unset, otherwise it's ignored.")
 	if err := subFlags.Parse(args); err != nil {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Missed one in #9179
This is a breaking change.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#8838

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [x] Documentation was added or is not required https://github.com/vitessio/website/pull/914

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
Anyone using the old flag should change their scripts to use the new flag.