### PR TITLE
[12.0] Updated the 12_0 release documents with latest known issues

### DIFF
--- a/doc/releasenotes/12_0_0_release_notes.md
+++ b/doc/releasenotes/12_0_0_release_notes.md
@@ -14,6 +14,15 @@ While `Gen4` has been under development for a few release cycles, we have now re
 
 To use `Gen4`, VTGate's `-planner_version` flag needs to be set to `gen4`.
 
+## Known Issues
+
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
+  This has been fixed in release `2.16.0`. This release, `v12.0.0`, uses a version of Log4j below `2.16.0`, for this reason we encourage you to use `v12.0.2` instead, which contains the patch for the vulnerability.
+
+- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174), has been fixed in release `>= v12.0.1`.
+
 ## Incompatible Changes
 
 ### vtctl command output

--- a/doc/releasenotes/12_0_0_summary.md
+++ b/doc/releasenotes/12_0_0_summary.md
@@ -14,6 +14,15 @@ While `Gen4` has been under development for a few release cycles, we have now re
 
 To use `Gen4`, VTGate's `-planner_version` flag needs to be set to `gen4`.
 
+## Known Issues
+
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
+  This has been fixed in release `2.16.0`. This release, `v12.0.0`, uses a version of Log4j below `2.16.0`, for this reason we encourage you to use `v12.0.2` instead, which contains the patch for the vulnerability.
+
+- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174), has been fixed in release `>= v12.0.1`.
+
 ### Query Buffering during failovers
 In order to support buffering during resharding cutovers in addition to primary failovers, a new implementation 
 of query buffering has been added. 

--- a/doc/releasenotes/12_0_1_release_notes.md
+++ b/doc/releasenotes/12_0_1_release_notes.md
@@ -4,6 +4,13 @@
 
 This patch is providing an update regarding the Apache Log4j security vulnerability (CVE-2021-44228) (#9357), along with a few bug fixes.
 
+## Known Issues
+
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
+  This has been fixed in release `2.16.0`. This release, `v12.0.1`, contains the initial patch by upgrading Log4j to `2.15.0`, we encourage you to use `v12.0.2` instead, which contains the latest patch for the vulnerability.
+
 ------------
 ## Changelog
 

--- a/doc/releasenotes/12_0_1_summary.md
+++ b/doc/releasenotes/12_0_1_summary.md
@@ -1,3 +1,10 @@
 ## Major Changes
 
 This patch is providing an update regarding the Apache Log4j security vulnerability (CVE-2021-44228) (#9357), along with a few bug fixes.
+
+## Known Issues
+
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
+  This has been fixed in release `2.16.0`. This release, `v12.0.1`, contains the initial patch by upgrading Log4j to `2.15.0`, we encourage you to use `v12.0.2` instead, which contains the latest patch for the vulnerability.


### PR DESCRIPTION
## Description

This pull request updates the release notes of the `12.0.0` and `12.0.1` releases by adding the Log4j vulnerability to the list of known issues, along with https://github.com/vitessio/vitess/issues/9174 for `12.0.0` since a fix is available in `>= 12.0.1`.
