### PR TITLE
Subsharding vindex

### DIFF
--- a/go/test/endtoend/vtgate/gen4/main_test.go
+++ b/go/test/endtoend/vtgate/gen4/main_test.go
@@ -67,6 +67,14 @@ create table region_tbl(
 	msg varchar(50),
 	primary key(uid)
 ) Engine=InnoDB;
+
+create table multicol_tbl(
+	cola bigint,
+	colb varbinary(50),
+	colc varchar(50),
+	msg varchar(50),
+	primary key(cola, colb, colc)
+) Engine=InnoDB;
 `
 	unshardedSchemaSQL = `create table u_a(
 	id bigint,
@@ -92,6 +100,14 @@ create table u_b(
 	  "type": "region_experimental",
 	  "params": {
 		"region_bytes": "1"
+	  }
+    },
+    "multicol_vdx": {
+	  "type": "multicol",
+	  "params": {
+		"column_count": "3",
+		"column_bytes": "1,3,4",
+		"column_vindex": "hash,binary,unicode_loose_xxhash"
 	  }
     }
   },
@@ -145,6 +161,14 @@ create table u_b(
 	    {
           "columns": ["rg","uid"],
 		  "name": "regional_vdx"
+		}
+      ]
+    },
+    "multicol_tbl": {
+	  "column_vindexes": [
+	    {
+          "columns": ["cola","colb","colc"],
+		  "name": "multicol_vdx"
 		}
       ]
 	}

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -136,6 +136,14 @@ var executorVSchema = `
 			"params": {
 				"region_bytes": "1"
 			}
+    	},
+		"multicol_vdx": {
+			"type": "multicol",
+			"params": {
+				"column_count": "3",
+				"column_bytes": "1,3,4",
+				"column_vindex": "hash,binary,unicode_loose_xxhash"
+			}
         }
 	},
 	"tables": {
@@ -314,6 +322,14 @@ var executorVSchema = `
 				{
 					"columns": ["cola","colb"],
 					"name": "regional_vdx"
+				}
+			]
+    	},
+		"multicoltbl": {
+			"column_vindexes": [
+				{
+					"columns": ["cola","colb","colc"],
+					"name": "multicol_vdx"
 				}
 			]
 		}

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -857,6 +857,7 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestExecutor", "keyspace_id", "numeric", "", ""),
 			buildVarCharRow("TestExecutor", "krcol_unique_vdx", "keyrange_lookuper_unique", "", ""),
 			buildVarCharRow("TestExecutor", "krcol_vdx", "keyrange_lookuper", "", ""),
+			buildVarCharRow("TestExecutor", "multicol_vdx", "multicol", "column_bytes=1,3,4; column_count=3; column_vindex=hash,binary,unicode_loose_xxhash", ""),
 			buildVarCharRow("TestExecutor", "music_user_map", "lookup_hash_unique", "from=music_id; table=music_user_map; to=user_id", "music"),
 			buildVarCharRow("TestExecutor", "name_lastname_keyspace_id_map", "lookup", "from=name,lastname; table=name_lastname_keyspace_id_map; to=keyspace_id", "user2"),
 			buildVarCharRow("TestExecutor", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -27,6 +27,7 @@ import (
 var (
 	_ SingleColumn = (*Binary)(nil)
 	_ Reversible   = (*Binary)(nil)
+	_ Hashing      = (*Binary)(nil)
 )
 
 // Binary is a vindex that converts binary bits to a keyspace id.
@@ -61,28 +62,32 @@ func (vind *Binary) NeedsVCursor() bool {
 
 // Verify returns true if ids maps to ksids.
 func (vind *Binary) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
-	out := make([]bool, len(ids))
-	for i := range ids {
-		idBytes, err := ids[i].ToBytes()
+	out := make([]bool, 0, len(ids))
+	for i, id := range ids {
+		idBytes, err := vind.Hash(id)
 		if err != nil {
 			return out, err
 		}
-		out[i] = bytes.Equal(idBytes, ksids[i])
+		out = append(out, bytes.Equal(idBytes, ksids[i]))
 	}
 	return out, nil
 }
 
 // Map can map ids to key.Destination objects.
 func (vind *Binary) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
-	out := make([]key.Destination, len(ids))
-	for i, id := range ids {
-		idBytes, err := id.ToBytes()
+	out := make([]key.Destination, 0, len(ids))
+	for _, id := range ids {
+		idBytes, err := vind.Hash(id)
 		if err != nil {
 			return out, err
 		}
-		out[i] = key.DestinationKeyspaceID(idBytes)
+		out = append(out, key.DestinationKeyspaceID(idBytes))
 	}
 	return out, nil
+}
+
+func (vind *Binary) Hash(id sqltypes.Value) ([]byte, error) {
+	return id.ToBytes()
 }
 
 // ReverseMap returns the associated ids for the ksids.

--- a/go/vt/vtgate/vindexes/cfc.go
+++ b/go/vt/vtgate/vindexes/cfc.go
@@ -1,15 +1,19 @@
 /*
 Copyright 2021 The Vitess Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package vindexes
 
 import (

--- a/go/vt/vtgate/vindexes/cfc_test.go
+++ b/go/vt/vtgate/vindexes/cfc_test.go
@@ -1,15 +1,19 @@
 /*
 Copyright 2021 The Vitess Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package vindexes
 
 import (

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -34,6 +34,7 @@ import (
 var (
 	_ SingleColumn = (*Hash)(nil)
 	_ Reversible   = (*Hash)(nil)
+	_ Hashing      = (*Hash)(nil)
 )
 
 // Hash defines vindex that hashes an int64 to a KeyspaceId

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -46,7 +46,7 @@ type Hash struct {
 }
 
 // NewHash creates a new Hash.
-func NewHash(name string, m map[string]string) (Vindex, error) {
+func NewHash(name string, _ map[string]string) (Vindex, error) {
 	return &Hash{name: name}, nil
 }
 
@@ -71,27 +71,15 @@ func (vind *Hash) NeedsVCursor() bool {
 }
 
 // Map can map ids to key.Destination objects.
-func (vind *Hash) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+func (vind *Hash) Map(_ VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, len(ids))
 	for i, id := range ids {
-		var num uint64
-		var err error
-
-		if id.IsSigned() {
-			// This is ToUint64 with no check on negative values.
-			str := id.ToString()
-			var ival int64
-			ival, err = strconv.ParseInt(str, 10, 64)
-			num = uint64(ival)
-		} else {
-			num, err = evalengine.ToUint64(id)
-		}
-
+		ksid, err := vind.Hash(id)
 		if err != nil {
 			out[i] = key.DestinationNone{}
 			continue
 		}
-		out[i] = key.DestinationKeyspaceID(vhash(num))
+		out[i] = key.DestinationKeyspaceID(ksid)
 	}
 	return out, nil
 }
@@ -122,6 +110,26 @@ func (vind *Hash) ReverseMap(_ VCursor, ksids [][]byte) ([]sqltypes.Value, error
 	return reverseIds, nil
 }
 
+func (vind *Hash) Hash(id sqltypes.Value) ([]byte, error) {
+	var num uint64
+	var err error
+
+	if id.IsSigned() {
+		// This is ToUint64 with no check on negative values.
+		str := id.ToString()
+		var ival int64
+		ival, err = strconv.ParseInt(str, 10, 64)
+		num = uint64(ival)
+	} else {
+		num, err = evalengine.ToUint64(id)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return vhash(num), nil
+}
+
 var blockDES cipher.Block
 
 func init() {
@@ -137,7 +145,7 @@ func vhash(shardKey uint64) []byte {
 	var keybytes, hashed [8]byte
 	binary.BigEndian.PutUint64(keybytes[:], shardKey)
 	blockDES.Encrypt(hashed[:], keybytes[:])
-	return []byte(hashed[:])
+	return hashed[:]
 }
 
 func vunhash(k []byte) (uint64, error) {

--- a/go/vt/vtgate/vindexes/multicol.go
+++ b/go/vt/vtgate/vindexes/multicol.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"strconv"
+	"strings"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+var _ MultiColumn = (*MultiCol)(nil)
+
+type MultiCol struct {
+	name      string
+	cost      int
+	noOfCols  int
+	columnVdx map[int]Vindex
+}
+
+const (
+	paramColumnCount  = "column_count"
+	paramColumnVindex = "column_vindex"
+	defaultVindex     = "hash"
+)
+
+// NewMultiCol creates a new MultiCol.
+func NewMultiCol(name string, m map[string]string) (Vindex, error) {
+	colCountStr, ok := m[paramColumnCount]
+	if !ok {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of columns not provided in the parameter '%s'", paramColumnCount)
+	}
+	colCount, err := strconv.Atoi(colCountStr)
+	if err != nil {
+		return nil, err
+	}
+	var colVdxs []string
+	colVdxsStr, ok := m[paramColumnVindex]
+	if ok {
+		colVdxs = strings.Split(colVdxsStr, ",")
+	}
+	if len(colVdxs) > colCount {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of vindex function provided are more than column count in the parameter '%s'", paramColumnVindex)
+	}
+	columnVdx := map[int]Vindex{}
+	vindexCost := 0
+	for i := 0; i < colCount; i++ {
+		selVdx := defaultVindex
+		if len(colVdxs) > i {
+			providedVdx := strings.TrimSpace(colVdxs[i])
+			if providedVdx != "" {
+				selVdx = providedVdx
+			}
+		}
+		// TODO: reuse vindex. avoid creating same vindex.
+		vdx, err := CreateVindex(selVdx, selVdx, m)
+		if err != nil {
+			return nil, err
+		}
+		if !vdx.IsUnique() || vdx.NeedsVCursor() {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "multicol vindex supports only unique and non-vcursor vindex function, passed vindex '%s' is invalid", selVdx)
+		}
+		vindexCost = vindexCost + vdx.Cost()
+		columnVdx[i] = vdx
+	}
+	return &MultiCol{
+		name:      name,
+		cost:      vindexCost,
+		noOfCols:  colCount,
+		columnVdx: columnVdx,
+	}, nil
+}
+
+func init() {
+	Register("multicol", NewMultiCol)
+}
+
+func (m *MultiCol) String() string {
+	return m.name
+}
+
+func (m *MultiCol) Cost() int {
+	return m.cost
+}
+
+func (m *MultiCol) IsUnique() bool {
+	return true
+}
+
+func (m *MultiCol) NeedsVCursor() bool {
+	return false
+}
+
+func (m *MultiCol) Map(vcursor VCursor, rowsColValues [][]sqltypes.Value) ([]key.Destination, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MultiCol) Verify(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *MultiCol) PartialVindex() bool {
+	return true
+}

--- a/go/vt/vtgate/vindexes/multicol.go
+++ b/go/vt/vtgate/vindexes/multicol.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vindexes
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -29,37 +30,54 @@ import (
 var _ MultiColumn = (*MultiCol)(nil)
 
 type MultiCol struct {
-	name      string
-	cost      int
-	noOfCols  int
-	columnVdx map[int]Vindex
+	name        string
+	cost        int
+	noOfCols    int
+	columnVdx   map[int]Vindex
+	columnBytes map[int]int
 }
 
 const (
 	paramColumnCount  = "column_count"
+	paramColumnBytes  = "column_bytes"
 	paramColumnVindex = "column_vindex"
 	defaultVindex     = "hash"
 )
 
 // NewMultiCol creates a new MultiCol.
 func NewMultiCol(name string, m map[string]string) (Vindex, error) {
-	colCountStr, ok := m[paramColumnCount]
-	if !ok {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of columns not provided in the parameter '%s'", paramColumnCount)
-	}
-	colCount, err := strconv.Atoi(colCountStr)
+	colCount, err := getColumnCount(m)
 	if err != nil {
 		return nil, err
 	}
+	columnBytes, err := getColumnBytes(m, colCount)
+	if err != nil {
+		return nil, err
+	}
+	columnVdx, vindexCost, err := getColumnVindex(m, colCount)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MultiCol{
+		name:        name,
+		cost:        vindexCost,
+		noOfCols:    colCount,
+		columnVdx:   columnVdx,
+		columnBytes: columnBytes,
+	}, nil
+}
+
+func getColumnVindex(m map[string]string, colCount int) (map[int]Vindex, int, error) {
 	var colVdxs []string
 	colVdxsStr, ok := m[paramColumnVindex]
 	if ok {
 		colVdxs = strings.Split(colVdxsStr, ",")
 	}
 	if len(colVdxs) > colCount {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of vindex function provided are more than column count in the parameter '%s'", paramColumnVindex)
+		return nil, 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of vindex function provided are more than column count in the parameter '%s'", paramColumnVindex)
 	}
-	columnVdx := map[int]Vindex{}
+	columnVdx := make(map[int]Vindex, colCount)
 	vindexCost := 0
 	for i := 0; i < colCount; i++ {
 		selVdx := defaultVindex
@@ -72,20 +90,75 @@ func NewMultiCol(name string, m map[string]string) (Vindex, error) {
 		// TODO: reuse vindex. avoid creating same vindex.
 		vdx, err := CreateVindex(selVdx, selVdx, m)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if !vdx.IsUnique() || vdx.NeedsVCursor() {
-			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "multicol vindex supports only unique and non-vcursor vindex function, passed vindex '%s' is invalid", selVdx)
+			return nil, 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "multicol vindex supports only unique and non-vcursor vindex function, passed vindex '%s' is invalid", selVdx)
 		}
 		vindexCost = vindexCost + vdx.Cost()
 		columnVdx[i] = vdx
+
 	}
-	return &MultiCol{
-		name:      name,
-		cost:      vindexCost,
-		noOfCols:  colCount,
-		columnVdx: columnVdx,
-	}, nil
+	return columnVdx, vindexCost, nil
+}
+
+func getColumnBytes(m map[string]string, colCount int) (map[int]int, error) {
+	var colByteStr []string
+	colBytesStr, ok := m[paramColumnBytes]
+	if ok {
+		colByteStr = strings.Split(colBytesStr, ",")
+	}
+	if len(colByteStr) > colCount {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of column bytes provided are more than column count in the parameter '%s'", paramColumnBytes)
+	}
+	// validate bytes count
+	bytesUsed := 0
+	columnBytes := make(map[int]int, colCount)
+	for idx, byteStr := range colByteStr {
+		if byteStr == "" {
+			continue
+		}
+		colByte, err := strconv.Atoi(byteStr)
+		if err != nil {
+			return nil, err
+		}
+		bytesUsed = bytesUsed + colByte
+		columnBytes[idx] = colByte
+	}
+	pendingCol := colCount - len(columnBytes)
+	remainingBytes := 8 - bytesUsed
+	if pendingCol > remainingBytes {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "column bytes count exceeds the keyspace id length (total bytes count cannot exceed 8 bytes) in the parameter '%s'", paramColumnBytes)
+	}
+	if pendingCol <= 0 {
+		return columnBytes, nil
+	}
+	colIdx := 0
+	for idx := 0; idx < colCount; idx++ {
+		if _, defined := columnBytes[colIdx]; defined {
+			continue
+		}
+		bytesToAssign := int(math.Ceil(float64(remainingBytes) / float64(pendingCol)))
+		columnBytes[idx] = bytesToAssign
+		remainingBytes = remainingBytes - bytesToAssign
+		pendingCol--
+	}
+	return columnBytes, nil
+}
+
+func getColumnCount(m map[string]string) (int, error) {
+	colCountStr, ok := m[paramColumnCount]
+	if !ok {
+		return 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of columns not provided in the parameter '%s'", paramColumnCount)
+	}
+	colCount, err := strconv.Atoi(colCountStr)
+	if err != nil {
+		return 0, err
+	}
+	if colCount > 8 || colCount < 1 {
+		return 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "number of columns should be between 1 and 8 in the parameter '%s'", paramColumnCount)
+	}
+	return colCount, nil
 }
 
 func init() {

--- a/go/vt/vtgate/vindexes/multicol_test.go
+++ b/go/vt/vtgate/vindexes/multicol_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiColMisc(t *testing.T) {
+	vindex, err := CreateVindex("multicol", "multicol", map[string]string{
+		"column_count": "3",
+	})
+	require.NoError(t, err)
+
+	multiColVdx, isMultiColVdx := vindex.(*MultiCol)
+	assert.True(t, isMultiColVdx)
+
+	assert.Equal(t, 3, multiColVdx.Cost())
+	assert.Equal(t, "multicol", multiColVdx.String())
+	assert.True(t, multiColVdx.IsUnique())
+	assert.False(t, multiColVdx.NeedsVCursor())
+	assert.True(t, multiColVdx.PartialVindex())
+}
+
+func TestMultiColMap(t *testing.T) {
+	vindex, err := CreateVindex("multicol", "multicol", map[string]string{
+		"column_count": "3",
+	})
+	require.NoError(t, err)
+	mutiCol := vindex.(MultiColumn)
+
+	got, err := mutiCol.Map(nil, [][]sqltypes.Value{{
+		sqltypes.NewInt64(1), sqltypes.NewInt64(1), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewInt64(255), sqltypes.NewInt64(1), sqltypes.NewInt64(1),
+	}, {
+		sqltypes.NewInt64(256), sqltypes.NewInt64(1), sqltypes.NewInt64(1),
+	}, {
+		// only one column provided, partial column for key range mapping.
+		sqltypes.NewInt64(1),
+	}, {
+		// only two column provided, partial column for key range mapping.
+		sqltypes.NewInt64(1), sqltypes.NewInt64(1),
+	}, {
+		// Invalid column value type.
+		sqltypes.NewVarBinary("abcd"), sqltypes.NewInt64(256), sqltypes.NewInt64(256),
+	}, {
+		// Invalid column value type.
+		sqltypes.NewInt64(256), sqltypes.NewInt64(256), sqltypes.NewVarBinary("abcd"),
+	}})
+	assert.NoError(t, err)
+
+	want := []key.Destination{
+		key.DestinationKeyspaceID("\x16\x6b\x40\x16\x6b\x40\x16\x6b"),
+		key.DestinationKeyspaceID("\x25\x4e\x88\x16\x6b\x40\x16\x6b"),
+		key.DestinationKeyspaceID("\xdd\x7c\x0b\x16\x6b\x40\x16\x6b"),
+		key.DestinationKeyRange{KeyRange: &topodatapb.KeyRange{Start: []byte("\x16\x6b\x40"), End: []byte("\x16\x6b\x41")}},
+		key.DestinationKeyRange{KeyRange: &topodatapb.KeyRange{Start: []byte("\x16\x6b\x40\x16\x6b\x40"), End: []byte("\x16\x6b\x40\x16\x6b\x41")}},
+		key.DestinationNone{},
+		key.DestinationNone{},
+	}
+	assert.Equal(t, want, got)
+}

--- a/go/vt/vtgate/vindexes/numeric.go
+++ b/go/vt/vtgate/vindexes/numeric.go
@@ -30,6 +30,7 @@ import (
 var (
 	_ SingleColumn = (*Numeric)(nil)
 	_ Reversible   = (*Numeric)(nil)
+	_ Hashing      = (*Numeric)(nil)
 )
 
 // Numeric defines a bit-pattern mapping of a uint64 to the KeyspaceId.
@@ -64,32 +65,28 @@ func (*Numeric) NeedsVCursor() bool {
 }
 
 // Verify returns true if ids and ksids match.
-func (*Numeric) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
-	out := make([]bool, len(ids))
-	for i := range ids {
-		var keybytes [8]byte
-		num, err := evalengine.ToUint64(ids[i])
+func (vind *Numeric) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	out := make([]bool, 0, len(ids))
+	for i, id := range ids {
+		ksid, err := vind.Hash(id)
 		if err != nil {
 			return nil, err
 		}
-		binary.BigEndian.PutUint64(keybytes[:], num)
-		out[i] = bytes.Equal(keybytes[:], ksids[i])
+		out = append(out, bytes.Equal(ksid, ksids[i]))
 	}
 	return out, nil
 }
 
 // Map can map ids to key.Destination objects.
-func (*Numeric) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
+func (vind *Numeric) Map(_ VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, 0, len(ids))
 	for _, id := range ids {
-		num, err := evalengine.ToUint64(id)
+		ksid, err := vind.Hash(id)
 		if err != nil {
 			out = append(out, key.DestinationNone{})
 			continue
 		}
-		var keybytes [8]byte
-		binary.BigEndian.PutUint64(keybytes[:], num)
-		out = append(out, key.DestinationKeyspaceID(keybytes[:]))
+		out = append(out, key.DestinationKeyspaceID(ksid))
 	}
 	return out, nil
 }
@@ -101,10 +98,20 @@ func (*Numeric) ReverseMap(_ VCursor, ksids [][]byte) ([]sqltypes.Value, error) 
 		if len(keyspaceID) != 8 {
 			return nil, fmt.Errorf("Numeric.ReverseMap: length of keyspaceId is not 8: %d", len(keyspaceID))
 		}
-		val := binary.BigEndian.Uint64([]byte(keyspaceID))
+		val := binary.BigEndian.Uint64(keyspaceID)
 		reverseIds[i] = sqltypes.NewUint64(val)
 	}
 	return reverseIds, nil
+}
+
+func (*Numeric) Hash(id sqltypes.Value) ([]byte, error) {
+	num, err := evalengine.ToUint64(id)
+	if err != nil {
+		return nil, err
+	}
+	var keybytes [8]byte
+	binary.BigEndian.PutUint64(keybytes[:], num)
+	return keybytes[:], nil
 }
 
 func init() {

--- a/go/vt/vtgate/vindexes/reverse_bits.go
+++ b/go/vt/vtgate/vindexes/reverse_bits.go
@@ -32,6 +32,7 @@ import (
 var (
 	_ SingleColumn = (*ReverseBits)(nil)
 	_ Reversible   = (*ReverseBits)(nil)
+	_ Hashing      = (*ReverseBits)(nil)
 )
 
 // ReverseBits defines vindex that reverses the bits of a number.
@@ -67,27 +68,27 @@ func (vind *ReverseBits) NeedsVCursor() bool {
 
 // Map returns the corresponding KeyspaceId values for the given ids.
 func (vind *ReverseBits) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
-	out := make([]key.Destination, len(ids))
-	for i, id := range ids {
-		num, err := evalengine.ToUint64(id)
+	out := make([]key.Destination, 0, len(ids))
+	for _, id := range ids {
+		num, err := vind.Hash(id)
 		if err != nil {
-			out[i] = key.DestinationNone{}
+			out = append(out, key.DestinationNone{})
 			continue
 		}
-		out[i] = key.DestinationKeyspaceID(reverse(num))
+		out = append(out, key.DestinationKeyspaceID(num))
 	}
 	return out, nil
 }
 
 // Verify returns true if ids maps to ksids.
 func (vind *ReverseBits) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
-	out := make([]bool, len(ids))
-	for i := range ids {
-		num, err := evalengine.ToUint64(ids[i])
+	out := make([]bool, 0, len(ids))
+	for i, id := range ids {
+		num, err := vind.Hash(id)
 		if err != nil {
 			return nil, err
 		}
-		out[i] = bytes.Equal(reverse(num), ksids[i])
+		out = append(out, bytes.Equal(num, ksids[i]))
 	}
 	return out, nil
 }
@@ -103,6 +104,14 @@ func (vind *ReverseBits) ReverseMap(_ VCursor, ksids [][]byte) ([]sqltypes.Value
 		reverseIds = append(reverseIds, sqltypes.NewUint64(val))
 	}
 	return reverseIds, nil
+}
+
+func (vind *ReverseBits) Hash(id sqltypes.Value) ([]byte, error) {
+	num, err := evalengine.ToUint64(id)
+	if err != nil {
+		return nil, err
+	}
+	return reverse(num), nil
 }
 
 func init() {

--- a/go/vt/vtgate/vindexes/unicodeloosexxhash.go
+++ b/go/vt/vtgate/vindexes/unicodeloosexxhash.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	_ SingleColumn = (*UnicodeLooseXXHash)(nil)
+	_ Hashing      = (*UnicodeLooseXXHash)(nil)
 )
 
 // UnicodeLooseXXHash is a vindex that normalizes and hashes unicode strings
@@ -64,13 +65,13 @@ func (vind *UnicodeLooseXXHash) NeedsVCursor() bool {
 
 // Verify returns true if ids maps to ksids.
 func (vind *UnicodeLooseXXHash) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
-	out := make([]bool, len(ids))
-	for i := range ids {
-		data, err := unicodeHash(vXXHash, ids[i])
+	out := make([]bool, 0, len(ids))
+	for i, id := range ids {
+		data, err := vind.Hash(id)
 		if err != nil {
 			return nil, fmt.Errorf("UnicodeLooseXXHash.Verify: %v", err)
 		}
-		out[i] = bytes.Equal(data, ksids[i])
+		out = append(out, bytes.Equal(data, ksids[i]))
 	}
 	return out, nil
 }
@@ -79,13 +80,17 @@ func (vind *UnicodeLooseXXHash) Verify(_ VCursor, ids []sqltypes.Value, ksids []
 func (vind *UnicodeLooseXXHash) Map(cursor VCursor, ids []sqltypes.Value) ([]key.Destination, error) {
 	out := make([]key.Destination, 0, len(ids))
 	for _, id := range ids {
-		data, err := unicodeHash(vXXHash, id)
+		data, err := vind.Hash(id)
 		if err != nil {
 			return nil, fmt.Errorf("UnicodeLooseXXHash.Map: %v", err)
 		}
 		out = append(out, key.DestinationKeyspaceID(data))
 	}
 	return out, nil
+}
+
+func (vind *UnicodeLooseXXHash) Hash(id sqltypes.Value) ([]byte, error) {
+	return unicodeHash(vXXHash, id)
 }
 
 func init() {

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -93,6 +93,11 @@ type MultiColumn interface {
 	PartialVindex() bool
 }
 
+// Hashing defined the interface for the vindexes that export the Hash function to be used by multi-column vindex.
+type Hashing interface {
+	Hash(id sqltypes.Value) ([]byte, error)
+}
+
 // A Reversible vindex is one that can perform a
 // reverse lookup from a keyspace id to an id. This
 // is optional. If present, VTGate can use it to


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress Please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds a new generic MultiColumn Vindex that can be used only as a primary vindex.

This Vindex takes in 3 inputs
1. `column_count` - the number of columns that would be provided for using the vindex.
2. `column_vindex` - hashing function each column will use to provide hash value for that column
3. `column_bytes` - bytes to be used from each column's hash value after applying hashing function on it to produce keyspace id.

Usage in VSchema:

```json
"vindexes": {
    "multicol_vdx": {
	  "type": "multicol",
	  "params": {
		"column_count": "3",
		"column_bytes": "1,3,4",
		"column_vindex": "hash,binary,unicode_loose_xxhash"
	  }
    }
}
```
```json
"tables": {
   "multicol_tbl": {
	  "column_vindexes": [
	    {
                "columns": ["cola","colb","colc"],
		"name": "multicol_vdx"
	    }
      ]
   }
}
```
`column_count` is the mandatory parameter that needs to be provided.
A maximum of 8 columns can be used in this vindex i.e. `column_count <= 8`

`column_vindex` should contain the vindex name in a comma-separated list. It should be less than equal to column_count.
Default vindex is `hash` vindex, any column for which vindex is not provided, the default vindex will be used.
Vindex in `column_vindex` should implement the below interface otherwise the initialization will fail.

```go
// Hashing defined the interface for the vindexes that export the Hash function to be used by multi-column vindex.
type Hashing interface {
	Hash(id sqltypes.Value) ([]byte, error)
}
```

`column_bytes` should contain bytes in a comma-separated list. The total count should be equal to 8 bytes.
If for some columns bytes are not represented then it is calculated by assigning equal bytes to remaining unassigned columns.

Eg:
```
Given:
column_count = 5
column_bytes = 1, , 3

col 1 -> 1
col 2 -> not-provided
col 3 -> 3
col 4 -> not-provided
col 5 -> not-provided

Calculated:
remaining bytes = 8 - 1 - 3 -> 4
remaining columns = 5 - 2 -> 3
col 2 -> 2
col 4 -> 1
col 5 -> 1
```

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- Closes #7332 
- Related to #3481 

## Checklist
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required