### PR TITLE
Trivial: remove redundant import

### DIFF
--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -29,7 +29,6 @@ import (
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
-	"vitess.io/vitess/go/vt/proto/vtrpc"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
@@ -221,7 +220,7 @@ func (vf *VindexFunc) buildRow(id sqltypes.Value, ksid []byte, kr *topodatapb.Ke
 				row = append(row, sqltypes.NULL)
 			}
 		default:
-			return row, vterrors.NewErrorf(vtrpc.Code_OUT_OF_RANGE, vterrors.BadFieldError, "column %v out of range", col)
+			return row, vterrors.NewErrorf(vtrpcpb.Code_OUT_OF_RANGE, vterrors.BadFieldError, "column %v out of range", col)
 		}
 	}
 	return row, nil


### PR DESCRIPTION
## Description
Trivial follow-up to https://github.com/vitessio/vitess/pull/9426. I didn't notice the double import (because I had used vtrpc vs. vtrpcpb in one spot) before it was merged. 

## Related Issue(s)
https://github.com/vitessio/vitess/pull/9426

## Checklist
- [x] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required