### PR TITLE
Handle race condition during vtgate shutdown

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -531,11 +531,15 @@ func rollbackAtShutdown() {
 	// Close all open connections. If they're waiting for reads, this will cause
 	// them to error out, which will automatically rollback open transactions.
 	func() {
-		vtgateHandle.mu.Lock()
-		defer vtgateHandle.mu.Unlock()
-		for c := range vtgateHandle.connections {
-			log.Infof("Rolling back transactions associated with connection ID: %v", c.ConnectionID)
-			c.Close()
+		if vtgateHandle != nil {
+			vtgateHandle.mu.Lock()
+			defer vtgateHandle.mu.Unlock()
+			for c := range vtgateHandle.connections {
+				if c != nil {
+					log.Infof("Rolling back transactions associated with connection ID: %v", c.ConnectionID)
+					c.Close()
+				}
+			}
 		}
 	}()
 


### PR DESCRIPTION
## Description
Occasionally we will see CI test failures due to a `vtgate` segfaulting during shutdown, e.g.:
```
vitess.io/vitess/go/event.(*Hooks).Fire.func1(0xc000b2e0c0)
vitess.io/vitess/go/vt/vtgate/plugin_mysql_server.go:540 +0x3f
vitess.io/vitess/go/vt/vtgate.rollbackAtShutdown()
vitess.io/vitess/go/vt/vtgate/plugin_mysql_server.go:534 +0x48
vitess.io/vitess/go/vt/vtgate.rollbackAtShutdown.func1()
goroutine 408 [running]:
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xef5b08]
panic: runtime error: invalid memory address or nil pointer dereference
I1222 12:37:17.231378       1 servenv.go:199] OnClose hooks timed out
I1222 12:37:17.231330       1 servenv.go:183] Firing OnClose hooks and waiting up to 1ns for them
I1222 12:37:17.231308       1 run.go:71] Shutting down gracefully
```

A race condition appears possible during shutdown where [the `vtgateHandle` gets set to nil before the goroutine completes](https://github.com/vitessio/vitess/blob/9eeadd647f47adcf2f7be67fc13f076f663a0b84/go/vt/vtgate/plugin_mysql_server.go#L533-L540).

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [x] Should this PR be backported? No
- [x] Tests are not required
- [x] Documentation is not required
