### PR TITLE
Fixed case-sensitive TabletType in SwitchTraffic

### DIFF
--- a/go/vt/wrangler/workflow.go
+++ b/go/vt/wrangler/workflow.go
@@ -373,7 +373,7 @@ func (vrw *VReplicationWorkflow) getTabletTypes() []topodatapb.TabletType {
 func (vrw *VReplicationWorkflow) parseTabletTypes() (hasReplica, hasRdonly, hasPrimary bool, err error) {
 	tabletTypesArr := strings.Split(vrw.params.TabletTypes, ",")
 	for _, tabletType := range tabletTypesArr {
-		switch tabletType {
+		switch strings.ToLower(tabletType) {
 		case "replica":
 			hasReplica = true
 		case "rdonly":

--- a/go/vt/wrangler/workflow_test.go
+++ b/go/vt/wrangler/workflow_test.go
@@ -173,7 +173,7 @@ func TestMoveTablesV2(t *testing.T) {
 		TargetKeyspace: "ks2",
 		Tables:         "t1,t2",
 		Cells:          "cell1,cell2",
-		TabletTypes:    "replica,rdonly,primary",
+		TabletTypes:    "REPLICA,RDONLY,PRIMARY",
 		Timeout:        DefaultActionTimeout,
 	}
 	tme := newTestTableMigrater(ctx, t)
@@ -280,7 +280,7 @@ func TestMoveTablesV2Partial(t *testing.T) {
 	expectMoveTablesQueries(t, tme)
 
 	tme.expectNoPreviousJournals()
-	wf.params.TabletTypes = "rdonly"
+	wf.params.TabletTypes = "RDONLY"
 	wf.params.Cells = "cell1"
 	require.NoError(t, testSwitchForward(t, wf))
 	require.Equal(t, "Reads partially switched. Replica not switched. Rdonly switched in cells: cell1. Writes Not Switched", wf.CurrentState())
@@ -292,7 +292,7 @@ func TestMoveTablesV2Partial(t *testing.T) {
 	require.Equal(t, "Reads partially switched. Replica not switched. All Rdonly Reads Switched. Writes Not Switched", wf.CurrentState())
 
 	tme.expectNoPreviousJournals()
-	wf.params.TabletTypes = "replica"
+	wf.params.TabletTypes = "REPLICA"
 	wf.params.Cells = "cell1,cell2"
 	require.NoError(t, testSwitchForward(t, wf))
 	require.Equal(t, WorkflowStateReadsSwitched, wf.CurrentState())


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Currently SwitchTraffic requires TabletTypes to be all lowercase. This PR makes it case-insensitive.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [X] Documentation was added or is not required https://github.com/vitessio/website/pull/919

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->