### PR TITLE
Use uint64 for sequence in-memory structure

### DIFF
--- a/go/vt/vttablet/endtoend/sequence_test.go
+++ b/go/vt/vttablet/endtoend/sequence_test.go
@@ -35,14 +35,14 @@ func TestSequence(t *testing.T) {
 	want := &sqltypes.Result{
 		Fields: []*querypb.Field{{
 			Name: "nextval",
-			Type: sqltypes.Int64,
+			Type: sqltypes.Uint64,
 		}},
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(0),
+			sqltypes.NewUint64(0),
 		}},
 	}
-	for wantval := int64(1); wantval < 10; wantval += 2 {
-		want.Rows[0][0] = sqltypes.NewInt64(wantval)
+	for wantval := uint64(1); wantval < 10; wantval += 2 {
+		want.Rows[0][0] = sqltypes.NewUint64(wantval)
 		qr, err := framework.NewClient().Execute("select next 2 values from vitess_seq", nil)
 		require.NoError(t, err)
 		utils.MustMatch(t, want, qr)
@@ -56,8 +56,8 @@ func TestSequence(t *testing.T) {
 
 	want = &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(13),
-			sqltypes.NewInt64(3),
+			sqltypes.NewUint64(13),
+			sqltypes.NewUint64(3),
 		}},
 		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit,
 	}
@@ -73,7 +73,7 @@ func TestSequence(t *testing.T) {
 	// Next value generated should be based on the LastVal
 	want = &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(13),
+			sqltypes.NewUint64(13),
 		}},
 	}
 	utils.MustMatch(t, want, qr)
@@ -85,8 +85,8 @@ func TestSequence(t *testing.T) {
 
 	want = &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(16),
-			sqltypes.NewInt64(3),
+			sqltypes.NewUint64(16),
+			sqltypes.NewUint64(3),
 		}},
 		StatusFlags: sqltypes.ServerStatusNoIndexUsed | sqltypes.ServerStatusAutocommit,
 	}
@@ -102,7 +102,7 @@ func TestSequence(t *testing.T) {
 	// Next value should jump to the high value
 	want = &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(100),
+			sqltypes.NewUint64(100),
 		}},
 	}
 	utils.MustMatch(t, want, qr)
@@ -113,10 +113,10 @@ func TestResetSequence(t *testing.T) {
 	want := sqltypes.Result{
 		Fields: []*querypb.Field{{
 			Name: "nextval",
-			Type: sqltypes.Int64,
+			Type: sqltypes.Uint64,
 		}},
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(1),
+			sqltypes.NewUint64(1),
 		}},
 	}
 	qr, err := client.Execute("select next value from vitess_reset_seq", nil)
@@ -136,7 +136,7 @@ func TestResetSequence(t *testing.T) {
 	}
 
 	// Ensure the next value skips previously cached values.
-	want.Rows[0][0] = sqltypes.NewInt64(4)
+	want.Rows[0][0] = sqltypes.NewUint64(4)
 	qr, err = client.Execute("select next value from vitess_reset_seq", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -530,7 +530,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 	}
 	tableName := qre.plan.TableName()
 	v := result.Value()
-	inc, err := v.ToInt64()
+	inc, err := v.ToUint64()
 	if err != nil || inc < 1 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid increment for sequence %s: %s", tableName, v.String())
 	}
@@ -548,7 +548,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 			if len(qr.Rows) != 1 {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected rows from reading sequence %s (possible mis-route): %d", tableName, len(qr.Rows))
 			}
-			nextID, err := evalengine.ToInt64(qr.Rows[0][0])
+			nextID, err := evalengine.ToUint64(qr.Rows[0][0])
 			if err != nil {
 				return nil, vterrors.Wrapf(err, "error loading sequence %s", tableName)
 			}
@@ -563,7 +563,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 				t.SequenceInfo.NextVal = nextID
 				t.SequenceInfo.LastVal = nextID
 			}
-			cache, err := evalengine.ToInt64(qr.Rows[0][1])
+			cache, err := evalengine.ToUint64(qr.Rows[0][1])
 			if err != nil {
 				return nil, vterrors.Wrapf(err, "error loading sequence %s", tableName)
 			}
@@ -592,7 +592,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 	return &sqltypes.Result{
 		Fields: sequenceFields,
 		Rows: [][]sqltypes.Value{{
-			sqltypes.NewInt64(ret),
+			sqltypes.NewUint64(ret),
 		}},
 	}, nil
 }

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -65,8 +65,8 @@ type Table struct {
 // which will trigger caching on first use.
 type SequenceInfo struct {
 	sync.Mutex
-	NextVal int64
-	LastVal int64
+	NextVal uint64
+	LastVal uint64
 }
 
 // MessageInfo contains info specific to message tables.


### PR DESCRIPTION
## Description
This then allows us to support `BIGINT UNSIGNED` columns in the backing MySQL table. When using a `SIGNED` value we're effectively wasting half of the ID space since negative values are not used.

## Related Issue(s)
I can then update the example in the improved docs here to use `BIGINT UNSIGNED` for the `user_seq` table: https://github.com/vitessio/website/pull/928


## Checklist
- [x] Should this PR be backported? NO
- [x] New tests are not required
- [x] Documentation was added