### PR TITLE
Do Not Merge: MoveTables: open transactions causes data loss after a SwitchWrites

### DIFF
--- a/go/test/endtoend/vreplication/cluster.go
+++ b/go/test/endtoend/vreplication/cluster.go
@@ -238,6 +238,7 @@ func (vc *VitessCluster) AddTablet(t testing.TB, cell *Cell, keyspace *Keyspace,
 		"-enable-lag-throttler",
 		"-heartbeat_enable",
 		"-heartbeat_interval", "250ms",
+		"-shutdown_grace_period", "5",
 	} //FIXME: for multi-cell initial schema doesn't seem to load without "-queryserver-config-schema-reload-time"
 
 	if mainClusterConfig.vreplicationCompressGTID {
@@ -504,4 +505,24 @@ func (vc *VitessCluster) getPrimaryTablet(t *testing.T, ksName, shardName string
 	}
 	require.FailNow(t, "no primary found for %s:%s", ksName, shardName)
 	return nil
+}
+func (vc *VitessCluster) startQuery(t *testing.T, query string) (func(t *testing.T), func(t *testing.T)) {
+	conn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
+	_, err := conn.ExecuteFetch("begin", 1000, false)
+	require.NoError(t, err)
+	_, err = conn.ExecuteFetch(query, 1000, false)
+	require.NoError(t, err)
+
+	commit := func(t *testing.T) {
+		_, err = conn.ExecuteFetch("commit", 1000, false)
+		log.Infof("startQuery:commit:err: %+v", err)
+		conn.Close()
+		log.Infof("startQuery:after closing connection")
+	}
+	rollback := func(t *testing.T) {
+		defer conn.Close()
+		_, err = conn.ExecuteFetch("rollback", 1000, false)
+		log.Infof("startQuery:rollback:err: %+v", err)
+	}
+	return commit, rollback
 }

--- a/go/test/endtoend/vreplication/helper.go
+++ b/go/test/endtoend/vreplication/helper.go
@@ -53,7 +53,9 @@ func execVtgateQuery(t *testing.T, conn *mysql.Conn, database string, query stri
 	if strings.TrimSpace(query) == "" {
 		return nil
 	}
-	execQuery(t, conn, "use `"+database+"`;")
+	if database != "" {
+		execQuery(t, conn, "use `"+database+"`;")
+	}
 	execQuery(t, conn, "begin")
 	qr := execQuery(t, conn, query)
 	execQuery(t, conn, "commit")

--- a/go/vt/vttablet/customrule/topocustomrule/topocustomrule_test.go
+++ b/go/vt/vttablet/customrule/topocustomrule/topocustomrule_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
@@ -52,7 +54,8 @@ var customRule2 = `
 func waitForValue(t *testing.T, qsc *tabletservermock.Controller, expected *rules.Rules) {
 	start := time.Now()
 	for {
-		val := qsc.GetQueryRules(topoCustomRuleSource)
+		val, err := qsc.GetQueryRules(topoCustomRuleSource)
+		require.NoError(t, err)
 		if val != nil {
 			if val.Equal(expected) {
 				return

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -127,7 +127,9 @@ func TestStateDenyList(t *testing.T) {
 	tm.tmState.mu.Unlock()
 
 	qsc := tm.QueryServiceControl.(*tabletservermock.Controller)
-	b, _ := json.Marshal(qsc.GetQueryRules(denyListQueryList))
+	rules, err := qsc.GetQueryRules(denyListQueryList)
+	require.NoError(t, err)
+	b, _ := json.Marshal(rules)
 	assert.Equal(t, `[{"Description":"enforce denied tables","Name":"denied_table","TableNames":["t1"],"Action":"FAIL_RETRY"}]`, string(b))
 }
 

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -73,11 +73,14 @@ type Controller interface {
 	// RegisterQueryRuleSource adds a query rule source
 	RegisterQueryRuleSource(ruleSource string)
 
-	// RegisterQueryRuleSource removes a query rule source
+	// UnRegisterQueryRuleSource removes a query rule source
 	UnRegisterQueryRuleSource(ruleSource string)
 
 	// SetQueryRules sets the query rules for this QueryService
 	SetQueryRules(ruleSource string, qrs *rules.Rules) error
+
+	// GetQueryRules sets the query rules for this QueryService
+	GetQueryRules(ruleSource string) (*rules.Rules, error)
 
 	// QueryService returns the QueryService object used by this Controller
 	QueryService() queryservice.QueryService

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -288,6 +288,15 @@ func (tsv *TabletServer) UnRegisterQueryRuleSource(ruleSource string) {
 	tsv.qe.queryRuleSources.UnRegisterSource(ruleSource)
 }
 
+// GetQueryRules gets the query rules for a registered ruleSource.
+func (tsv *TabletServer) GetQueryRules(ruleSource string) (*rules.Rules, error) {
+	rules, err := tsv.qe.queryRuleSources.Get(ruleSource)
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
 // SetQueryRules sets the query rules for a registered ruleSource.
 func (tsv *TabletServer) SetQueryRules(ruleSource string, qrs *rules.Rules) error {
 	err := tsv.qe.queryRuleSources.SetRules(ruleSource, qrs)

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -243,8 +243,8 @@ func (tqsc *Controller) SetQueryServiceEnabledForTests(enabled bool) {
 }
 
 // GetQueryRules allows a test to check what was set.
-func (tqsc *Controller) GetQueryRules(ruleSource string) *rules.Rules {
+func (tqsc *Controller) GetQueryRules(ruleSource string) (*rules.Rules, error) {
 	tqsc.mu.Lock()
 	defer tqsc.mu.Unlock()
-	return tqsc.queryRulesMap[ruleSource]
+	return tqsc.queryRulesMap[ruleSource], nil
 }


### PR DESCRIPTION
## Description

There is a bug today where open DMLs can cause data consistency after SwitchWrites in a MoveTables workflow.  This PR confirms this by extending the TestMultiCellVreplicationWorkflow e2e test, which adds a transaction that stays open across SwitchWrites to mimic a long-running transaction. This test is currently failing because an extra row gets created in the source (corresponding to the row inserted in the long-running transaction).

This is not an issue for Reshard workflows because open transactions are closed (either by waiting for a grace period or finally cancelled) as part of the primary tablet shutting down since the source shards stop serving in SwitchWrites.

For MoveTables the source shard continues to serve: the moved tables are first added to the denied tables list in the source shards' tablet controls and the vschema of the source and target keyspaces updated to reflect the move. This is not enough for transactions that insert into or update the moved tables which stay open across the SwitchWrites and commit after SwitchWrites is done. At this time the forward replication streams have been frozen and the source table updated after that. So now we have data inconsistency: the source now has changes that have not been replicated to the target.

If the open transaction inserted a new row, reverse replication was turned on and an autoincrement PK is used then reverse replication is broken as reported by https://github.com/vitessio/vitess/issues/9400. Otherwise the data loss will be silent.
 
Also see https://github.com/vitessio/vitess/pull/9450 for a WIP fix.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>

## Related Issue(s)


## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->