### PR TITLE
Fix parsing table name starting with a number.

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -48,6 +48,9 @@ var (
 		input:  "create table x (e enum('red','yellow') null collate 'utf8_bin')",
 		output: "create table x (\n\te enum('red', 'yellow') collate 'utf8_bin' null\n)",
 	}, {
+		input:  "create table 3t2 (c1 bigint not null, c2 text, primary key(c1))",
+		output: "create table 3t2 (\n\tc1 bigint not null,\n\tc2 text,\n\tprimary key (c1)\n)",
+	}, {
 		input:  "select 1 from t1 where exists (select 1) = TRUE",
 		output: "select 1 from t1 where exists (select 1 from dual) = true",
 	}, {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -49,7 +49,7 @@ var (
 		output: "create table x (\n\te enum('red', 'yellow') collate 'utf8_bin' null\n)",
 	}, {
 		input:  "create table 3t2 (c1 bigint not null, c2 text, primary key(c1))",
-		output: "create table 3t2 (\n\tc1 bigint not null,\n\tc2 text,\n\tprimary key (c1)\n)",
+		output: "create table `3t2` (\n\tc1 bigint not null,\n\tc2 text,\n\tprimary key (c1)\n)",
 	}, {
 		input:  "select 1 from t1 where exists (select 1) = TRUE",
 		output: "select 1 from t1 where exists (select 1 from dual) = true",
@@ -3495,9 +3495,6 @@ var (
 	}{{
 		input:  "select : from t",
 		output: "syntax error at position 9 near ':'",
-	}, {
-		input:  "select 0xH from t",
-		output: "syntax error at position 10 near '0x'",
 	}, {
 		input:  "select x'78 from t",
 		output: "syntax error at position 12 near '78'",

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -3594,13 +3594,21 @@ var (
 		input:        "select /* aa",
 		output:       "syntax error at position 13 near '/* aa'",
 		excludeMulti: true,
+	}, {
+		// This is a valid MySQL query but does not yet work with Vitess.
+		// The problem is that the tokenizer takes .3 as a single token which causes parsing error
+		// We should instead be using . as a separate token and then 3t2 as an identifier.
+		// This highlights another problem, the tokenization has to be aware of the context of parsing!
+		// Since in an alternate query like `select .3e3t`, we should use .3e3 as a single token FLOAT and then t as ID.
+		input:  "create table 2t.3t2 (c1 bigint not null, c2 text, primary key(c1))",
+		output: "syntax error at position 18 near '.3'",
 	}}
 )
 
 func TestErrors(t *testing.T) {
 	for _, tcase := range invalidSQL {
 		t.Run(tcase.input, func(t *testing.T) {
-			_, err := Parse(tcase.input)
+			_, err := ParseStrictDDL(tcase.input)
 			require.Error(t, err, tcase.output)
 			require.Equal(t, err.Error(), tcase.output)
 		})

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -3600,8 +3600,9 @@ var (
 		// We should instead be using . as a separate token and then 3t2 as an identifier.
 		// This highlights another problem, the tokenization has to be aware of the context of parsing!
 		// Since in an alternate query like `select .3e3t`, we should use .3e3 as a single token FLOAT and then t as ID.
-		input:  "create table 2t.3t2 (c1 bigint not null, c2 text, primary key(c1))",
-		output: "syntax error at position 18 near '.3'",
+		input:        "create table 2t.3t2 (c1 bigint not null, c2 text, primary key(c1))",
+		output:       "syntax error at position 18 near '.3'",
+		excludeMulti: true,
 	}}
 )
 

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -502,9 +502,21 @@ exponent:
 	}
 
 exit:
-	// A letter cannot immediately follow a number.
 	if isLetter(tkn.cur()) {
-		return LEX_ERROR, tkn.buf[start:tkn.Pos]
+		// A letter cannot immediately follow a float number.
+		if token == FLOAT {
+			return LEX_ERROR, tkn.buf[start:tkn.Pos]
+		}
+		// A letter seen after a few numbers means that we should parse this
+		// as an identifier and not a number.
+		for {
+			ch := tkn.cur()
+			if !isLetter(ch) && !isDigit(ch) {
+				break
+			}
+			tkn.skip(1)
+		}
+		return ID, tkn.buf[start:tkn.Pos]
 	}
 
 	return token, tkn.buf[start:tkn.Pos]

--- a/go/vt/sqlparser/token_test.go
+++ b/go/vt/sqlparser/token_test.go
@@ -269,3 +269,53 @@ func TestExtractMySQLComment(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegerAndID(t *testing.T) {
+	testcases := []struct {
+		in  string
+		id  int
+		out string
+	}{{
+		in: "334",
+		id: INTEGRAL,
+	}, {
+		in: "33.4",
+		id: FLOAT,
+	}, {
+		in: "0x33",
+		id: HEXNUM,
+	}, {
+		in: "33e4",
+		id: FLOAT,
+	}, {
+		in: "33.4e-3",
+		id: FLOAT,
+	}, {
+		in: "33t4",
+		id: ID,
+	}, {
+		in: "0x2et3",
+		id: ID,
+	}, {
+		in:  "3e2t3",
+		id:  LEX_ERROR,
+		out: "3e2",
+	}, {
+		in:  "3.2t",
+		id:  LEX_ERROR,
+		out: "3.2",
+	}}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.in, func(t *testing.T) {
+			tkn := NewStringTokenizer(tcase.in)
+			id, out := tkn.Scan()
+			require.Equal(t, tcase.id, id)
+			expectedOut := tcase.out
+			if expectedOut == "" {
+				expectedOut = tcase.in
+			}
+			require.Equal(t, expectedOut, out)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the tokeniser to return an `ID` token when we see letters after numbers instead of returning errors, since this is closer to MySQL. `3t2` is a valid `ID` and should be parsed correctly. It can be a table name too. This means that the following query is valid and should work correctly in Vitess - 

```sql
create table 3t2 (c1 bigint not null, c2 text, primary key(c1))
```


Even after the changes the following query does not work with Vitess - 
```sql
create table 2t.3t2 (c1 bigint not null, c2 text, primary key(c1))
```
This is a valid MySQL query but does not yet work with Vitess. The problem is that the tokenizer takes `.3` as a single token which causes parsing error. We should instead be using `.` as a separate token and then `3t2` as an identifier. This highlights another problem, the tokenization has to be aware of the context of parsing! Since in an alternate query like `select .3e3t`, we should use `.3e3` as a single token FLOAT and then `t` as ID.
		  

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #4069 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->