### PR TITLE
Remove SSL cipher customization

### DIFF
--- a/go/vt/orchestrator/ssl/ssl.go
+++ b/go/vt/orchestrator/ssl/ssl.go
@@ -17,19 +17,6 @@ import (
 	"vitess.io/vitess/go/vt/orchestrator/external/golib/log"
 )
 
-var cipherSuites = []uint16{
-	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-}
-
 // Determine if a string element is in a string array
 func HasString(elem string, arr []string) bool {
 	for _, s := range arr {
@@ -47,9 +34,6 @@ func NewTLSConfig(caFile string, verifyCert bool) (*tls.Config, error) {
 
 	// Set to TLS 1.2 as a minimum.  This is overridden for mysql communication
 	c.MinVersion = tls.VersionTLS12
-	// Remove insecure ciphers from the list
-	c.CipherSuites = cipherSuites
-	c.PreferServerCipherSuites = true
 
 	if verifyCert {
 		log.Info("verifyCert requested, client certificates will be verified")

--- a/go/vt/vttls/vttls.go
+++ b/go/vt/vttls/vttls.go
@@ -27,39 +27,6 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 )
 
-// Updated list of acceptable cipher suits to address
-// Fixed upstream in https://github.com/golang/go/issues/13385
-// This removed CBC mode ciphers that are suseptiable to Lucky13 style attacks
-func newTLSConfig(minVersion uint16) *tls.Config {
-
-	ciphers := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-	}
-
-	if minVersion < tls.VersionTLS12 {
-		ciphers = append(ciphers, []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		}...)
-	}
-
-	return &tls.Config{
-		MinVersion:   minVersion,
-		CipherSuites: ciphers,
-	}
-}
-
 // SslMode indicates the type of SSL mode to use. This matches
 // the MySQL SSL modes as mentioned at:
 // https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode
@@ -131,7 +98,9 @@ var onceByKeys = sync.Map{}
 // ClientConfig returns the TLS config to use for a client to
 // connect to a server with the provided parameters.
 func ClientConfig(mode SslMode, cert, key, ca, crl, name string, minTLSVersion uint16) (*tls.Config, error) {
-	config := newTLSConfig(minTLSVersion)
+	config := &tls.Config{
+		MinVersion: minTLSVersion,
+	}
 
 	// Load the client-side cert & key if any.
 	if cert != "" && key != "" {
@@ -206,7 +175,9 @@ func ClientConfig(mode SslMode, cert, key, ca, crl, name string, minTLSVersion u
 // ServerConfig returns the TLS config to use for a server to
 // accept client connections.
 func ServerConfig(cert, key, ca, crl, serverCA string, minTLSVersion uint16) (*tls.Config, error) {
-	config := newTLSConfig(minTLSVersion)
+	config := &tls.Config{
+		MinVersion: minTLSVersion,
+	}
 
 	var certificates *[]tls.Certificate
 	var err error


### PR DESCRIPTION
This was done long ago when upstream Go had no mitigations in place for CBC oracle attacks. For the legacy ciphers they do now, so having these different definitions isn't really suited anymore.

In general, Go has a good upstream TLS configuration so we should modify / configure as little as possible so I think it's better to remove this customization.

It has cause some issues like https://github.com/vitessio/vitess/pull/9399 before removing it also prevents similar issues in the future if Go improves cipher support.