### PR TITLE
vtctl: Allow ALTER VITESS_MIGRATION commands in sharded environment

### DIFF
--- a/go/test/endtoend/onlineddl/vtctlutil.go
+++ b/go/test/endtoend/onlineddl/vtctlutil.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package onlineddl
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// CheckCancelAllMigrations cancels all pending migrations. There is no validation for affected migrations.
+func CheckCancelAllMigrationsViaVtctl(t *testing.T, vtctlclient *cluster.VtctlClientProcess, keyspace string) {
+	cancelQuery := "alter vitess_migration cancel all"
+
+	_, err := vtctlclient.ApplySchemaWithOutput(keyspace, cancelQuery, cluster.VtctlClientParams{SkipPreflight: true})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Description

Followup to #9303, which added support for `ALTER VITESS_MIGRATION` in `vtctl ApplySchema`. 

Unfortunately, on sharded keyspaces an internal validation fails the statement. This PR fixes the validation to allow `ALTER VITESS_MIGRATION` even in sharded (multi-shard) environments.

## Related Issue(s)

- Tracking: #6926 

## Checklist
- [ ] Should this PR be backported?
- [ ] Tests were added or are not required
- [ ] Documentation was added or is not required

