### PR TITLE
[11.0] build(deps): bump log4j-api from 2.16.0 to 2.17.1 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
     <protobuf.java.version>3.11.4</protobuf.java.version>
     <protobuf.protoc.version>3.11.4</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
     <protobuf.java.version>3.11.4</protobuf.java.version>
     <protobuf.protoc.version>3.11.4</protobuf.protoc.version>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
   </properties>
 
   <!-- Add new dependencies here and then add it below or in your module. -->


### PR DESCRIPTION
## Description

This is a backport of #9423 to upgrade `log4j` to version `2.17.1`.
