### PR TITLE
Remove deprecated call for TLS config

### DIFF
--- a/go/vt/orchestrator/ssl/ssl.go
+++ b/go/vt/orchestrator/ssl/ssl.go
@@ -60,7 +60,6 @@ func NewTLSConfig(caFile string, verifyCert bool) (*tls.Config, error) {
 		return &c, err
 	}
 	c.ClientCAs = caPool
-	c.BuildNameToCertificate() //nolint SA1019: c.BuildNameToCertificate is deprecated
 	return &c, nil
 }
 

--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -372,8 +372,6 @@ func dialZk(ctx context.Context, addr string) (*zk.Conn, <-chan zk.Event, error)
 			ServerName:   serverName,
 		}
 
-		tlsConfig.BuildNameToCertificate()
-
 		dialer = zk.WithDialer(func(network, address string, timeout time.Duration) (net.Conn, error) {
 			d := net.Dialer{Timeout: timeout}
 


### PR DESCRIPTION
This call tries to setup a single name for the validation, but this call is deprecated as the built in logic now iterates through the available certificates and picks the right one.

There's no reason to keep this call because of the improved logic in Go itself, so it's best to remove it.