### PR TITLE
Multicolumn vindex support in update and delete queries

### DIFF
--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -249,11 +249,11 @@ func (del *Delete) deleteVindexEntries(vcursor VCursor, bindVars map[string]*que
 	}
 
 	for _, row := range subQueryResults.Rows {
-		colnum := 1
-		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex.(vindexes.SingleColumn), row[0:del.KsidLength])
+		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex, row[0:del.KsidLength])
 		if err != nil {
 			return err
 		}
+		colnum := del.KsidLength
 		for _, colVindex := range del.Table.Owned {
 			// Fetch the column values. colnum must keep incrementing.
 			fromIds := make([]sqltypes.Value, 0, len(colVindex.Columns))
@@ -265,7 +265,6 @@ func (del *Delete) deleteVindexEntries(vcursor VCursor, bindVars map[string]*que
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -129,7 +129,7 @@ func (del *Delete) execDeleteEqual(vcursor VCursor, bindVars map[string]*querypb
 	if err != nil {
 		return nil, err
 	}
-	rs, ksid, err := resolveSingleShard(vcursor, del.Vindex, del.Keyspace, key.Value())
+	rs, ksid, err := resolveSingleShard(vcursor, del.Vindex.(vindexes.SingleColumn), del.Keyspace, key.Value())
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (del *Delete) execDeleteEqual(vcursor VCursor, bindVars map[string]*querypb
 }
 
 func (del *Delete) execDeleteIn(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	rss, queries, err := resolveMultiValueShards(vcursor, del.Keyspace, del.Query, bindVars, del.Values[0], del.Vindex)
+	rss, queries, err := resolveMultiValueShards(vcursor, del.Keyspace, del.Query, bindVars, del.Values[0], del.Vindex.(vindexes.SingleColumn))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (del *Delete) deleteVindexEntries(vcursor VCursor, bindVars map[string]*que
 
 	for _, row := range subQueryResults.Rows {
 		colnum := 1
-		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex, row[0])
+		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex.(vindexes.SingleColumn), row[0])
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -215,7 +215,7 @@ func (del *Delete) deleteVindexEntries(vcursor VCursor, bindVars map[string]*que
 
 	for _, row := range subQueryResults.Rows {
 		colnum := 1
-		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex.(vindexes.SingleColumn), row[0])
+		ksid, err := resolveKeyspaceID(vcursor, del.KsidVindex.(vindexes.SingleColumn), row[0:del.KsidLength])
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -262,6 +262,7 @@ func addFieldsIfNotEmpty(dml DML, other map[string]interface{}) {
 	}
 	if dml.KsidVindex != nil {
 		other["KsidVindex"] = dml.KsidVindex.String()
+		other["KsidLength"] = dml.KsidLength
 	}
 	if len(dml.Values) > 0 {
 		s := []string{}

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -186,7 +186,7 @@ func (del *Delete) execDeleteEqualMultiCol(vcursor VCursor, bindVars map[string]
 }
 
 func (del *Delete) execDeleteIn(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	rss, queries, err := resolveMultiValueShards(vcursor, del.Keyspace, del.Query, bindVars, del.Values[0], del.Vindex.(vindexes.SingleColumn))
+	rss, queries, err := resolveMultiValueShards(vcursor, del.Keyspace, del.Query, bindVars, del.Values, del.Vindex)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -71,7 +71,7 @@ func TestDeleteEqual(t *testing.T) {
 				Sharded: true,
 			},
 			Query:  "dummy_delete",
-			Vindex: vindex.(vindexes.SingleColumn),
+			Vindex: vindex,
 			Values: []evalengine.Expr{evalengine.NewLiteralInt(1)},
 		},
 	}
@@ -105,7 +105,7 @@ func TestDeleteEqualNoRoute(t *testing.T) {
 				Sharded: true,
 			},
 			Query:  "dummy_delete",
-			Vindex: vindex.(vindexes.SingleColumn),
+			Vindex: vindex,
 			Values: []evalengine.Expr{evalengine.NewLiteralInt(1)},
 		},
 	}
@@ -134,7 +134,7 @@ func TestDeleteEqualNoScatter(t *testing.T) {
 				Sharded: true,
 			},
 			Query:  "dummy_delete",
-			Vindex: vindex.(vindexes.SingleColumn),
+			Vindex: vindex,
 			Values: []evalengine.Expr{evalengine.NewLiteralInt(1)},
 		},
 	}
@@ -151,11 +151,12 @@ func TestDeleteOwnedVindex(t *testing.T) {
 			Opcode:           Equal,
 			Keyspace:         ks.Keyspace,
 			Query:            "dummy_delete",
-			Vindex:           ks.Vindexes["hash"].(vindexes.SingleColumn),
+			Vindex:           ks.Vindexes["hash"],
 			Values:           []evalengine.Expr{evalengine.NewLiteralInt(1)},
 			Table:            ks.Tables["t1"],
 			OwnedVindexQuery: "dummy_subquery",
-			KsidVindex:       ks.Vindexes["hash"].(vindexes.SingleColumn),
+			KsidVindex:       ks.Vindexes["hash"],
+			KsidLength:       1,
 		},
 	}
 
@@ -283,7 +284,8 @@ func TestDeleteScatterOwnedVindex(t *testing.T) {
 			Query:            "dummy_delete",
 			Table:            ks.Tables["t1"],
 			OwnedVindexQuery: "dummy_subquery",
-			KsidVindex:       ks.Vindexes["hash"].(vindexes.SingleColumn),
+			KsidVindex:       ks.Vindexes["hash"],
+			KsidLength:       1,
 		},
 	}
 

--- a/go/vt/vtgate/engine/delete_test.go
+++ b/go/vt/vtgate/engine/delete_test.go
@@ -468,3 +468,52 @@ func TestDeleteScatterOwnedVindex(t *testing.T) {
 		`ExecuteMultiShard sharded.-20: dummy_delete {} sharded.20-: dummy_delete {} true false`,
 	})
 }
+
+func TestDeleteInChangedVindexMultiCol(t *testing.T) {
+	ks := buildTestVSchema().Keyspaces["sharded"]
+	del := &Delete{
+		DML: DML{
+			Opcode:   In,
+			Keyspace: ks.Keyspace,
+			Query:    "dummy_update",
+			Vindex:   ks.Vindexes["rg_vdx"],
+			Values: []evalengine.Expr{
+				&evalengine.TupleExpr{evalengine.NewLiteralInt(1), evalengine.NewLiteralInt(2)},
+				evalengine.NewLiteralInt(3),
+			},
+			Table:            ks.Tables["rg_tbl"],
+			OwnedVindexQuery: "dummy_subquery",
+			KsidVindex:       ks.Vindexes["rg_vdx"],
+			KsidLength:       2,
+		},
+	}
+
+	results := []*sqltypes.Result{sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"cola|colb|colc",
+			"int64|int64|int64",
+		),
+		"1|3|4",
+		"2|3|5",
+		"1|3|6",
+		"2|3|7",
+	)}
+	vc := newDMLTestVCursor("-20", "20-")
+	vc.results = results
+
+	_, err := del.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(3)] [INT64(2) INT64(3)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(024eb190c9a2fa169c)`,
+		// ResolveDestinations is hard-coded to return -20.
+		// It gets used to perform the subquery to fetch the changing column values.
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		// Those values are returned as 4,5,6 and 7 for colc
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"5" toc: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		// Finally, the actual delete, which is also sent to -20, same route as the subquery.
+		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+	})
+}

--- a/go/vt/vtgate/engine/dml.go
+++ b/go/vt/vtgate/engine/dml.go
@@ -41,14 +41,14 @@ type DML struct {
 	Query string
 
 	// Vindex specifies the vindex to be used.
-	Vindex vindexes.SingleColumn
+	Vindex vindexes.Vindex
 
 	// Values specifies the vindex values to use for routing.
 	// For now, only one value is specified.
 	Values []evalengine.Expr
 
 	// Keyspace Id Vindex
-	KsidVindex vindexes.SingleColumn
+	KsidVindex vindexes.Vindex
 
 	// Table specifies the table for the update.
 	Table *vindexes.Table

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -140,7 +140,7 @@ func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb
 	if err != nil {
 		return nil, err
 	}
-	rs, ksid, err := resolveSingleShard(vcursor, upd.Vindex, upd.Keyspace, key.Value())
+	rs, ksid, err := resolveSingleShard(vcursor, upd.Vindex.(vindexes.SingleColumn), upd.Keyspace, key.Value())
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb
 }
 
 func (upd *Update) execUpdateIn(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	rss, queries, err := resolveMultiValueShards(vcursor, upd.Keyspace, upd.Query, bindVars, upd.Values[0], upd.Vindex)
+	rss, queries, err := resolveMultiValueShards(vcursor, upd.Keyspace, upd.Query, bindVars, upd.Values[0], upd.Vindex.(vindexes.SingleColumn))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (upd *Update) updateVindexEntries(vcursor VCursor, bindVars map[string]*que
 	env := evalengine.EnvWithBindVars(bindVars)
 
 	for _, row := range subQueryResult.Rows {
-		ksid, err := resolveKeyspaceID(vcursor, upd.KsidVindex, row[0])
+		ksid, err := resolveKeyspaceID(vcursor, upd.KsidVindex.(vindexes.SingleColumn), row[0])
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -91,7 +91,12 @@ func (upd *Update) TryExecute(vcursor VCursor, bindVars map[string]*querypb.Bind
 	case Unsharded:
 		return upd.execUpdateUnsharded(vcursor, bindVars)
 	case Equal:
-		return upd.execUpdateEqual(vcursor, bindVars)
+		switch upd.Vindex.(type) {
+		case vindexes.MultiColumn:
+			return upd.execUpdateEqualMultiCol(vcursor, bindVars)
+		default:
+			return upd.execUpdateEqual(vcursor, bindVars)
+		}
 	case In:
 		return upd.execUpdateIn(vcursor, bindVars)
 	case Scatter:
@@ -203,6 +208,35 @@ func (upd *Update) execUpdateByDestination(vcursor VCursor, bindVars map[string]
 	return execMultiShard(vcursor, rss, queries, upd.MultiShardAutocommit)
 }
 
+func (upd *Update) execUpdateEqualMultiCol(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	env := evalengine.EnvWithBindVars(bindVars)
+	var rowValue []sqltypes.Value
+	for _, rvalue := range upd.Values {
+		v, err := env.Evaluate(rvalue)
+		if err != nil {
+			return nil, err
+		}
+		rowValue = append(rowValue, v.Value())
+	}
+	rss, _, err := resolveShardsMultiCol(vcursor, upd.Vindex.(vindexes.MultiColumn), upd.Keyspace, [][]sqltypes.Value{rowValue}, false /* shardIdsNeeded */)
+	if err != nil {
+		return nil, err
+	}
+	if len(rss) != 1 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "vindex mapped id to multi shards: %d", len(rss))
+	}
+	err = allowOnlyPrimary(rss...)
+	if err != nil {
+		return nil, err
+	}
+	if len(upd.ChangedVindexValues) != 0 {
+		if err := upd.updateVindexEntries(vcursor, bindVars, rss); err != nil {
+			return nil, err
+		}
+	}
+	return execShard(vcursor, upd.Query, bindVars, rss[0], true /* rollbackOnError */, true /* canAutocommit */)
+}
+
 // updateVindexEntries performs an update when a vindex is being modified
 // by the statement.
 // Note: the commit order may be different from the DML order because it's possible
@@ -232,7 +266,7 @@ func (upd *Update) updateVindexEntries(vcursor VCursor, bindVars map[string]*que
 	env := evalengine.EnvWithBindVars(bindVars)
 
 	for _, row := range subQueryResult.Rows {
-		ksid, err := resolveKeyspaceID(vcursor, upd.KsidVindex.(vindexes.SingleColumn), row[0])
+		ksid, err := resolveKeyspaceID(vcursor, upd.KsidVindex, row[0:upd.KsidLength])
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -165,7 +165,7 @@ func (upd *Update) execUpdateEqual(vcursor VCursor, bindVars map[string]*querypb
 }
 
 func (upd *Update) execUpdateIn(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	rss, queries, err := resolveMultiValueShards(vcursor, upd.Keyspace, upd.Query, bindVars, upd.Values[0], upd.Vindex.(vindexes.SingleColumn))
+	rss, queries, err := resolveMultiValueShards(vcursor, upd.Keyspace, upd.Query, bindVars, upd.Values, upd.Vindex)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -402,8 +402,8 @@ func TestUpdateEqualMultiColChangedVindex(t *testing.T) {
 		// It gets used to perform the subquery to fetch the changing column values.
 		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
 		// 4 has to be replaced by 5.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
-		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -442,11 +442,11 @@ func TestUpdateEqualMultiColChangedVindex(t *testing.T) {
 		// It gets used to perform the subquery to fetch the changing column values.
 		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
 		// 4 has to be replaced by 5.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
-		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
 		// 6 has to be replaced by 5.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
-		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -471,8 +471,8 @@ func TestUpdateEqualMultiColChangedVindex(t *testing.T) {
 		// It gets used to perform the subquery to fetch the changing column values.
 		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
 		// 7 has to be replaced by 5.
-		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
-		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
@@ -800,7 +800,7 @@ func buildTestVSchema() *vindexes.VSchema {
 					"lkp_rg": {
 						Type: "lookup",
 						Params: map[string]string{
-							"table": "lkp1",
+							"table": "lkp_rg_tbl",
 							"from":  "from",
 							"to":    "toc",
 						},

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -407,6 +407,75 @@ func TestUpdateEqualMultiColChangedVindex(t *testing.T) {
 		// Finally, the actual update, which is also sent to -20, same route as the subquery.
 		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
 	})
+
+	// No rows changing
+	vc.Rewind()
+	vc.results = nil
+	_, err = upd.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(2)]] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f)`,
+		// ResolveDestinations is hard-coded to return -20.
+		// It gets used to perform the subquery to fetch the changing column values.
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		// Subquery returns no rows. So, no vindexes are updated. We still pass-through the original update.
+		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+	})
+
+	// multiple rows changing.
+	results = []*sqltypes.Result{sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"cola|colb|colc|colc=5",
+			"int64|int64|int64|int64",
+		),
+		"1|2|4|0",
+		"1|2|6|0",
+	)}
+	vc.Rewind()
+	vc.results = results
+
+	_, err = upd.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(2)]] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f)`,
+		// ResolveDestinations is hard-coded to return -20.
+		// It gets used to perform the subquery to fetch the changing column values.
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		// 4 has to be replaced by 5.
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		// 6 has to be replaced by 5.
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		// Finally, the actual update, which is also sent to -20, same route as the subquery.
+		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+	})
+
+	// multiple rows changing, but only some rows actually changes
+	results = []*sqltypes.Result{sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"cola|colb|colc|colc=5",
+			"int64|int64|int64|int64",
+		),
+		"1|2|5|1",
+		"1|2|7|0",
+	)}
+	vc.Rewind()
+	vc.results = results
+
+	_, err = upd.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(2)]] Destinations:DestinationKeyspaceID(0106e7ea22ce92708f)`,
+		// ResolveDestinations is hard-coded to return -20.
+		// It gets used to perform the subquery to fetch the changing column values.
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		// 7 has to be replaced by 5.
+		`Execute delete from lkp1 where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		`Execute insert into lkp1(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01\x06\xe7\xea\"Βp\x8f" true`,
+		// Finally, the actual update, which is also sent to -20, same route as the subquery.
+		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+	})
 }
 
 func TestUpdateScatterChangedVindex(t *testing.T) {

--- a/go/vt/vtgate/engine/update_test.go
+++ b/go/vt/vtgate/engine/update_test.go
@@ -787,6 +787,65 @@ func TestUpdateInChangedVindex(t *testing.T) {
 	})
 }
 
+func TestUpdateInChangedVindexMultiCol(t *testing.T) {
+	ks := buildTestVSchema().Keyspaces["sharded"]
+	upd := &Update{
+		DML: DML{
+			Opcode:   In,
+			Keyspace: ks.Keyspace,
+			Query:    "dummy_update",
+			Vindex:   ks.Vindexes["rg_vdx"],
+			Values: []evalengine.Expr{
+				&evalengine.TupleExpr{evalengine.NewLiteralInt(1), evalengine.NewLiteralInt(2)},
+				evalengine.NewLiteralInt(3),
+			},
+			Table:            ks.Tables["rg_tbl"],
+			OwnedVindexQuery: "dummy_subquery",
+			KsidVindex:       ks.Vindexes["rg_vdx"],
+			KsidLength:       2,
+		},
+		ChangedVindexValues: map[string]*VindexValues{
+			"lkp_rg": {
+				PvMap: map[string]evalengine.Expr{
+					"colc": evalengine.NewLiteralInt(5),
+				},
+				Offset: 3,
+			},
+		},
+	}
+
+	results := []*sqltypes.Result{sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"cola|colb|colc|colc=5",
+			"int64|int64|int64|int64",
+		),
+		"1|3|4|0",
+		"2|3|5|1",
+		"1|3|6|0",
+		"2|3|7|0",
+	)}
+	vc := newDMLTestVCursor("-20", "20-")
+	vc.results = results
+
+	_, err := upd.TryExecute(vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinationsMultiCol sharded [[INT64(1) INT64(3)] [INT64(2) INT64(3)]] Destinations:DestinationKeyspaceID(014eb190c9a2fa169c),DestinationKeyspaceID(024eb190c9a2fa169c)`,
+		// ResolveDestinations is hard-coded to return -20.
+		// It gets used to perform the subquery to fetch the changing column values.
+		`ExecuteMultiShard sharded.-20: dummy_subquery {} false false`,
+		// Those values are returned as 4,5,6 and 7 for colc, but 5 is unchanged so only 3 rows will be updated.
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"4" toc: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"6" toc: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x01N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute delete from lkp_rg_tbl where from = :from and toc = :toc from: type:INT64 value:"7" toc: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		`Execute insert into lkp_rg_tbl(from, toc) values(:from_0, :toc_0) from_0: type:INT64 value:"5" toc_0: type:VARBINARY value:"\x02N\xb1\x90ɢ\xfa\x16\x9c" true`,
+		// Finally, the actual update, which is also sent to -20, same route as the subquery.
+		`ExecuteMultiShard sharded.-20: dummy_update {} true true`,
+	})
+}
+
 func buildTestVSchema() *vindexes.VSchema {
 	invschema := &vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -64,6 +64,7 @@ func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedV
 		tblExpr := &sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: edel.Table.Name}, As: aTblExpr.As}
 		edel.OwnedVindexQuery = generateDMLSubquery(tblExpr, del.Where, del.OrderBy, del.Limit, edel.Table, ksidVindex.Columns)
 		edel.KsidVindex = ksidVindex.Vindex
+		edel.KsidLength = len(ksidVindex.Columns)
 	}
 
 	return edel, nil

--- a/go/vt/vtgate/planbuilder/delete.go
+++ b/go/vt/vtgate/planbuilder/delete.go
@@ -36,7 +36,7 @@ func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedV
 			return nil, err
 		}
 	}
-	dml, ksidVindex, ksidCol, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
+	dml, ksidVindex, err := buildDMLPlan(vschema, "delete", del, reservedVars, del.TableExprs, del.Where, del.OrderBy, del.Limit, del.Comments, del.Targets)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func buildDeletePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedV
 			return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: delete on complex table expression")
 		}
 		tblExpr := &sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: edel.Table.Name}, As: aTblExpr.As}
-		edel.OwnedVindexQuery = generateDMLSubquery(tblExpr, del.Where, del.OrderBy, del.Limit, edel.Table, ksidCol)
-		edel.KsidVindex = ksidVindex
+		edel.OwnedVindexQuery = generateDMLSubquery(tblExpr, del.Where, del.OrderBy, del.Limit, edel.Table, ksidVindex.Columns)
+		edel.KsidVindex = ksidVindex.Vindex
 	}
 
 	return edel, nil

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -27,6 +27,34 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
+type (
+	// costDML is used to compare the cost of vindexOptionDML
+	costDML struct {
+		vindexCost int
+		isUnique   bool
+		opCode     engine.DMLOpcode
+	}
+
+	// vindexPlusPredicatesDML is a struct used to store all the predicates that the vindex can be used to query
+	vindexPlusPredicatesDML struct {
+		colVindex *vindexes.ColumnVindex
+
+		// during planning, we store the alternatives found for this DML in this slice
+		options []*vindexOptionDML
+	}
+
+	// vindexOptionDML stores the information needed to know if we have all the information needed to use a vindex
+	vindexOptionDML struct {
+		ready  bool
+		values []evalengine.Expr
+		// columns that we have seen so far. Used only for multi-column vindexes so that we can track how many columns part of the vindex we have seen
+		colsSeen    map[string]interface{}
+		opcode      engine.DMLOpcode
+		foundVindex vindexes.Vindex
+		cost        costDML
+	}
+)
+
 // getDMLRouting returns the vindex and values for the DML,
 // If it cannot find a unique vindex match, it returns an error.
 func getDMLRouting(where *sqlparser.Where, table *vindexes.Table) (
@@ -46,48 +74,60 @@ func getDMLRouting(where *sqlparser.Where, table *vindexes.Table) (
 		return engine.Scatter, ksidVindex, nil, nil, nil
 	}
 
-	for _, index := range table.Ordered {
-		if !index.IsUnique() {
+	filters := sqlparser.SplitAndExpression(nil, where.Expr)
+	// go over the vindexes in the order of increasing cost
+	for _, colVindex := range table.Ordered {
+		if !colVindex.IsUnique() {
 			continue
 		}
-		// TODO: Fix getMatch to take all columns of the vindex
-		if expr, op := getMatch(where.Expr, index.Columns[0]); expr != nil {
-			opcode := engine.Equal
-			if op == sqlparser.InOp {
-				opcode = engine.In
-			} else if lu, isLu := index.Vindex.(vindexes.LookupBackfill); isLu && lu.IsBackfilling() {
-				// Checking if the Vindex is currently backfilling or not, if it isn't we can read from the vindex table
-				// and we will be able to do a delete equal. Otherwise, we continue to look for next best vindex.
-				continue
-			}
-			return opcode, ksidVindex, index.Vindex, []evalengine.Expr{expr}, nil
+		if lu, isLu := colVindex.Vindex.(vindexes.LookupBackfill); isLu && lu.IsBackfilling() {
+			// Checking if the Vindex is currently backfilling or not, if it isn't we can read from the vindex table
+			// and we will be able to do a delete equal. Otherwise, we continue to look for next best vindex.
+			continue
+		}
+		// get the best vindex option that can be used for this vindexes.ColumnVindex
+		if vindexOption := getBestVindexOption(filters, colVindex); vindexOption != nil {
+			return vindexOption.opcode, ksidVindex, colVindex.Vindex, vindexOption.values, nil
 		}
 	}
 	return engine.Scatter, ksidVindex, nil, nil, nil
 }
 
-// getMatch returns the matched value if there is an equality
-// constraint on the specified column that can be used to
-// decide on a route.
-func getMatch(node sqlparser.Expr, col sqlparser.ColIdent) (evalengine.Expr, sqlparser.ComparisonExprOperator) {
-	filters := sqlparser.SplitAndExpression(nil, node)
-	for _, filter := range filters {
+// getBestVindexOption returns the best vindex option that can be used for this vindexes.ColumnVindex
+// It returns nil if there is no suitable way to use the ColumnVindex
+func getBestVindexOption(exprs []sqlparser.Expr, index *vindexes.ColumnVindex) *vindexOptionDML {
+	vindexPlusPredicates := &vindexPlusPredicatesDML{
+		colVindex: index,
+	}
+	for _, filter := range exprs {
 		comparison, ok := filter.(*sqlparser.ComparisonExpr)
 		if !ok {
 			continue
 		}
-		if !nameMatch(comparison.Left, col) {
+		var colName *sqlparser.ColName
+		var valExpr sqlparser.Expr
+		if col, ok := comparison.Left.(*sqlparser.ColName); ok {
+			colName = col
+			valExpr = comparison.Right
+		} else if col, ok := comparison.Right.(*sqlparser.ColName); ok {
+			colName = col
+			valExpr = comparison.Left
+		} else {
 			continue
 		}
+
+		var opcode engine.DMLOpcode
 		switch comparison.Operator {
 		case sqlparser.EqualOp:
-			if !sqlparser.IsValue(comparison.Right) {
+			if !sqlparser.IsValue(valExpr) {
 				continue
 			}
+			opcode = engine.Equal
 		case sqlparser.InOp:
-			if !sqlparser.IsSimpleTuple(comparison.Right) {
+			if !sqlparser.IsSimpleTuple(valExpr) {
 				continue
 			}
+			opcode = engine.In
 		default:
 			continue
 		}
@@ -95,14 +135,147 @@ func getMatch(node sqlparser.Expr, col sqlparser.ColIdent) (evalengine.Expr, sql
 		if err != nil {
 			continue
 		}
-		return expr, comparison.Operator
+		addVindexOptions(colName, expr, opcode, vindexPlusPredicates)
 	}
-	return nil, 0
+	return vindexPlusPredicates.bestOption()
 }
 
-func nameMatch(node sqlparser.Expr, col sqlparser.ColIdent) bool {
-	colName, ok := node.(*sqlparser.ColName)
-	return ok && colName.Name.Equal(col)
+// bestOption returns the option which is ready and has the lowest associated cost
+func (vpp *vindexPlusPredicatesDML) bestOption() *vindexOptionDML {
+	var best *vindexOptionDML
+	for _, option := range vpp.options {
+		if option.ready {
+			if best == nil || lessCostDML(option.cost, best.cost) {
+				best = option
+			}
+		}
+	}
+	return best
+}
+
+// lessCostDML compares two costDML and returns true if the first cost is cheaper than the second
+func lessCostDML(c1, c2 costDML) bool {
+	switch {
+	case c1.opCode != c2.opCode:
+		return c1.opCode < c2.opCode
+	case c1.isUnique == c2.isUnique:
+		return c1.vindexCost <= c2.vindexCost
+	default:
+		return c1.isUnique
+	}
+}
+
+// addVindexOptions adds new vindexOptionDML if it matches any column of the vindexes.ColumnVindex
+func addVindexOptions(column *sqlparser.ColName, value evalengine.Expr, opcode engine.DMLOpcode, v *vindexPlusPredicatesDML) {
+	switch v.colVindex.Vindex.(type) {
+	case vindexes.SingleColumn:
+		col := v.colVindex.Columns[0]
+		if column.Name.Equal(col) {
+			// single column vindex - just add the option
+			vindex := v.colVindex
+			v.options = append(v.options, &vindexOptionDML{
+				values:      []evalengine.Expr{value},
+				opcode:      opcode,
+				foundVindex: vindex.Vindex,
+				cost:        costForDML(v.colVindex, opcode),
+				ready:       true,
+			})
+		}
+	case vindexes.MultiColumn:
+		colLoweredName := ""
+		indexOfCol := -1
+		for idx, col := range v.colVindex.Columns {
+			if column.Name.Equal(col) {
+				colLoweredName = column.Name.Lowered()
+				indexOfCol = idx
+				break
+			}
+		}
+		if colLoweredName == "" {
+			break
+		}
+
+		var newOption []*vindexOptionDML
+		for _, op := range v.options {
+			if op.ready {
+				continue
+			}
+			_, isPresent := op.colsSeen[colLoweredName]
+			if isPresent {
+				continue
+			}
+			option := copyOptionDML(op)
+			option.updateWithNewColumn(colLoweredName, indexOfCol, value, v.colVindex, opcode)
+			newOption = append(newOption, option)
+		}
+		v.options = append(v.options, newOption...)
+
+		// multi column vindex - just always add as new option
+		option := createOptionDML(v.colVindex)
+		option.updateWithNewColumn(colLoweredName, indexOfCol, value, v.colVindex, opcode)
+		v.options = append(v.options, option)
+	}
+}
+
+// copyOptionDML is used to copy vindexOptionDML
+func copyOptionDML(orig *vindexOptionDML) *vindexOptionDML {
+	colsSeen := make(map[string]interface{}, len(orig.colsSeen))
+	values := make([]evalengine.Expr, len(orig.values))
+
+	copy(values, orig.values)
+	for k, v := range orig.colsSeen {
+		colsSeen[k] = v
+	}
+	vo := &vindexOptionDML{
+		values:      values,
+		colsSeen:    colsSeen,
+		opcode:      orig.opcode,
+		foundVindex: orig.foundVindex,
+		cost:        orig.cost,
+	}
+	return vo
+}
+
+// updateWithNewColumn is used to update vindexOptionDML with a new column that matches one of its unseen columns
+func (option *vindexOptionDML) updateWithNewColumn(colLoweredName string, indexOfCol int, value evalengine.Expr, colVindex *vindexes.ColumnVindex, opcode engine.DMLOpcode) {
+	option.colsSeen[colLoweredName] = true
+	option.values[indexOfCol] = value
+	option.ready = len(option.colsSeen) == len(colVindex.Columns)
+	if option.opcode < opcode {
+		option.opcode = opcode
+		option.cost = costForDML(colVindex, opcode)
+	}
+}
+
+// createOptionDML is used to create a vindexOptionDML
+func createOptionDML(
+	colVindex *vindexes.ColumnVindex,
+) *vindexOptionDML {
+	values := make([]evalengine.Expr, len(colVindex.Columns))
+	vindex := colVindex.Vindex
+
+	return &vindexOptionDML{
+		values:      values,
+		colsSeen:    map[string]interface{}{},
+		foundVindex: vindex,
+	}
+}
+
+// costForDML returns a cost struct to make route choices easier to compare
+func costForDML(foundVindex *vindexes.ColumnVindex, opcode engine.DMLOpcode) costDML {
+	switch opcode {
+	// For these opcodes, we should not have a vindex, so we just return the opcode as the cost
+	case engine.Unsharded, engine.Scatter:
+		return costDML{
+			opCode: opcode,
+		}
+	}
+
+	return costDML{
+		vindexCost: foundVindex.Cost(),
+		isUnique:   foundVindex.IsUnique(),
+		opCode:     opcode,
+	}
 }
 
 func buildDMLPlan(vschema ContextVSchema, dmlType string, stmt sqlparser.Statement, reservedVars *sqlparser.ReservedVars, tableExprs sqlparser.TableExprs, where *sqlparser.Where, orderBy sqlparser.OrderBy, limit *sqlparser.Limit, comments sqlparser.Comments, nodes ...sqlparser.SQLNode) (*engine.DML, *vindexes.ColumnVindex, error) {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -296,6 +296,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "email_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 for update",
@@ -331,6 +332,7 @@ Gen4 plan same as above
       "address_user_map:4",
       "email_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io', address = '155 5th street' from user_metadata where user_id = 1 for update",
@@ -360,6 +362,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "email_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, email, address, email = 'juan@vitess.io' from user_metadata where user_id = 1 order by user_id asc limit 10 for update",
@@ -434,6 +437,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id = 1 for update",
@@ -517,6 +521,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as route1 where id = 1 for update",
@@ -624,6 +629,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
@@ -1500,6 +1506,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select kid, column_a, column_b, column_c from multicolvin where kid = 1 for update",
@@ -1529,6 +1536,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "colb_colc_map:4"
     ],
+    "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
@@ -1559,6 +1567,7 @@ Gen4 plan same as above
       "cola_map:4",
       "colb_colc_map:5"
     ],
+    "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_a = 0, column_b = 1 and column_c = 2 from multicolvin where kid = 1 for update",
@@ -1956,6 +1965,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id = 1 for update",
@@ -2005,6 +2015,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id in (1, 2, 3) for update",
@@ -2034,6 +2045,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` for update",
@@ -2059,6 +2071,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = null from `user` where id + 1 = 2 for update",
@@ -2081,6 +2094,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id in (1, 2, 3) for update",
@@ -2107,6 +2121,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where id + 1 = 2 for update",
@@ -2129,6 +2144,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
@@ -2151,6 +2167,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select user_id, id from music where id = 1 for update",
@@ -2197,6 +2214,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
@@ -2222,6 +2240,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "colb_colc_map:4"
     ],
+    "KsidLength": 1,
     "KsidVindex": "kid_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select kid, column_a, column_b, column_c, column_c = 2 from multicolvin where kid = 1 for update",
@@ -2251,6 +2270,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = _binary 'abc' from `user` where id = 1 for update",
@@ -2277,6 +2297,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `name` = _binary 'abc' for update",
@@ -2299,6 +2320,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` for update",
@@ -2324,6 +2346,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, `name` = 'myname' from `user` for update",
@@ -2366,6 +2389,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` where `user`.id * `user`.col = `user`.foo for update",
@@ -2422,6 +2446,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 20 for update",
@@ -2447,6 +2472,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "lookup_t1:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 20 for update",
@@ -2469,6 +2495,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 = 20 for update",
@@ -2498,6 +2525,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "lookup_t1:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 = 20 for update",
@@ -2524,6 +2552,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3 from t1 where c2 = 10 and c3 in (20, 21) for update",
@@ -2553,6 +2582,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "lookup_t1:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "xxhash",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select c1, c2, c3, c2 = 1 from t1 where c2 = 10 and c3 in (20, 21) for update",
@@ -2582,6 +2612,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "name_user_map:3"
     ],
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly, u.`name` = 'john' from `user` as u where u.col \u003e 20 for update",
@@ -2604,6 +2635,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 1,
     "KsidVindex": "user_index",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select Id, `Name`, Costly from `user` as u where u.col \u003e 20 for update",
@@ -2726,6 +2758,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where cola = 1 and colb = 2 for update",
@@ -2753,6 +2786,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb = 2 and cola = 1 for update",
@@ -2780,6 +2814,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola = 1 for update",
@@ -2807,6 +2842,7 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
@@ -2837,6 +2873,7 @@ Gen4 plan same as above
     "ChangedVindexValues": [
       "colc_map:3"
     ],
+    "KsidLength": 2,
     "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
     "OwnedVindexQuery": "select cola, colb, colc, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
@@ -2850,4 +2887,3 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
-

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2612,3 +2612,203 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# update with a multicol vindex
+"update multicol_tbl set x = 1 where cola = 1 and colb = 2"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where cola = 1 and colb = 2",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 1 where cola = 1 and colb = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with a multicol vindex - reverse order
+"update multicol_tbl set x = 1 where colb = 2 and cola = 1"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where colb = 2 and cola = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 1 where colb = 2 and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with a multicol vindex using an IN clause
+"update multicol_tbl set x = 1 where colb IN (1,2) and cola = 1"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where colb IN (1,2) and cola = 1",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "In",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 1 where colb in (1, 2) and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# update with a multicol vindex using an IN clause
+"update multicol_tbl set x = 1 where colb IN (1,2) and cola IN (3,4)"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set x = 1 where colb IN (1,2) and cola IN (3,4)",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "In",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "update multicol_tbl set x = 1 where colb in (1, 2) and cola in (3, 4)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(3), INT64(4))",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with a multicol vindex
+"delete from multicol_tbl where cola = 1 and colb = 2"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where cola = 1 and colb = 2",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from multicol_tbl where cola = 1 and colb = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with a multicol vindex - reverse order
+"delete from multicol_tbl where colb = 2 and cola = 1"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where colb = 2 and cola = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from multicol_tbl where colb = 2 and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with a multicol vindex using an IN clause
+"delete from multicol_tbl where colb IN (1,2) and cola = 1"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where colb IN (1,2) and cola = 1",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "In",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from multicol_tbl where colb in (1, 2) and cola = 1",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+
+# delete with a multicol vindex using an IN clause
+"delete from multicol_tbl where colb IN (1,2) and cola IN (3,4)"
+{
+  "QueryType": "DELETE",
+  "Original": "delete from multicol_tbl where colb IN (1,2) and cola IN (3,4)",
+  "Instructions": {
+    "OperatorType": "Delete",
+    "Variant": "In",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "MultiShardAutocommit": false,
+    "Query": "delete from multicol_tbl where colb in (1, 2) and cola in (3, 4)",
+    "Table": "multicol_tbl",
+    "Values": [
+      "(INT64(3), INT64(4))",
+      "(INT64(1), INT64(2))"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.txt
@@ -2726,7 +2726,9 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where cola = 1 and colb = 2 for update",
     "Query": "delete from multicol_tbl where cola = 1 and colb = 2",
     "Table": "multicol_tbl",
     "Values": [
@@ -2751,7 +2753,9 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb = 2 and cola = 1 for update",
     "Query": "delete from multicol_tbl where colb = 2 and cola = 1",
     "Table": "multicol_tbl",
     "Values": [
@@ -2776,7 +2780,9 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola = 1 for update",
     "Query": "delete from multicol_tbl where colb in (1, 2) and cola = 1",
     "Table": "multicol_tbl",
     "Values": [
@@ -2801,7 +2807,9 @@ Gen4 plan same as above
       "Sharded": true
     },
     "TargetTabletType": "PRIMARY",
+    "KsidVindex": "multicolIdx",
     "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc from multicol_tbl where colb in (1, 2) and cola in (3, 4) for update",
     "Query": "delete from multicol_tbl where colb in (1, 2) and cola in (3, 4)",
     "Table": "multicol_tbl",
     "Values": [
@@ -2812,3 +2820,34 @@ Gen4 plan same as above
   }
 }
 Gen4 plan same as above
+
+# update with multicol and an owned vindex which changes
+"update multicol_tbl set colc = 1 where cola = 1 and colb = 2"
+{
+  "QueryType": "UPDATE",
+  "Original": "update multicol_tbl set colc = 1 where cola = 1 and colb = 2",
+  "Instructions": {
+    "OperatorType": "Update",
+    "Variant": "Equal",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "TargetTabletType": "PRIMARY",
+    "ChangedVindexValues": [
+      "colc_map:3"
+    ],
+    "KsidVindex": "multicolIdx",
+    "MultiShardAutocommit": false,
+    "OwnedVindexQuery": "select cola, colb, colc, colc = 1 from multicol_tbl where cola = 1 and colb = 2 for update",
+    "Query": "update multicol_tbl set colc = 1 where cola = 1 and colb = 2",
+    "Table": "multicol_tbl",
+    "Values": [
+      "INT64(1)",
+      "INT64(2)"
+    ],
+    "Vindex": "multicolIdx"
+  }
+}
+Gen4 plan same as above
+

--- a/go/vt/vtgate/planbuilder/testdata/schema_test.json
+++ b/go/vt/vtgate/planbuilder/testdata/schema_test.json
@@ -87,6 +87,10 @@
         },
         "multicolIdx": {
           "type": "multiCol_test"
+        },
+        "colc_map": {
+          "type": "lookup_test",
+          "owner": "multicol_tbl"
         }
       },
       "tables": {
@@ -300,6 +304,10 @@
             {
               "columns": ["cola", "colb"],
               "name": "multicolIdx"
+            },
+            {
+              "column": "colc",
+              "name": "colc_map"
             }
           ]
         }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.txt
@@ -631,25 +631,7 @@ Gen4 plan same as above
     "Vindex": "binary"
   }
 }
-{
-  "QueryType": "SELECT",
-  "Original": "select * from pin_test",
-  "Instructions": {
-    "OperatorType": "Route",
-    "Variant": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "FieldQuery": "select * from pin_test where 1 != 1",
-    "Query": "select * from pin_test",
-    "Table": "pin_test",
-    "Values": [
-      "VARBINARY(\"\\x80\")"
-    ],
-    "Vindex": "binary"
-  }
-}
+Gen4 plan same as above
 
 # select from dual on sharded keyspace
 "select @@session.auto_increment_increment from user.dual"

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt
@@ -203,6 +203,11 @@ Gen4 plan same as above
 "unsupported: You can't update primary vindex columns. Invalid update on vindex: user_index"
 Gen4 plan same as above
 
+# update change in multicol vindex column
+"update multicol_tbl set colc = 5, colb = 4 where cola = 1 and colb = 2"
+"unsupported: You can't update primary vindex columns. Invalid update on vindex: multicolIdx"
+Gen4 plan same as above
+
 # update changes non owned vindex column
 "update music_extra set music_id = 1 where user_id = 1"
 "unsupported: You can only update owned vindexes. Invalid update on vindex: music_user_map"

--- a/go/vt/vtgate/planbuilder/update.go
+++ b/go/vt/vtgate/planbuilder/update.go
@@ -53,6 +53,7 @@ func buildUpdatePlan(stmt sqlparser.Statement, reservedVars *sqlparser.ReservedV
 	eupd.OwnedVindexQuery = ovq
 	if len(eupd.ChangedVindexValues) != 0 {
 		eupd.KsidVindex = ksidVindex.Vindex
+		eupd.KsidLength = len(ksidVindex.Columns)
 	}
 	return eupd, nil
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR adds support for multi-column vindex selection and execution in update and delete queries.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

- #3481 

## Checklist
- [X] Tests were added or are not required
- [X] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->