### PR TITLE
Support redacting statements in timed out transaction log records

### DIFF
--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,13 +175,11 @@ func (sc *StatefulConnection) Renew() error {
 }
 
 // String returns a printable version of the connection info.
-// It will redact query parameters if the -queryserver-config-terse-errors
-// flag is enabled.
 func (sc *StatefulConnection) String() string {
 	return fmt.Sprintf(
 		"%v\t%s",
 		sc.ConnID,
-		sc.txProps.String(sc.env.Config().TerseErrors),
+		sc.txProps.String(),
 	)
 }
 

--- a/go/vt/vttablet/tabletserver/stateful_connection.go
+++ b/go/vt/vttablet/tabletserver/stateful_connection.go
@@ -175,11 +175,13 @@ func (sc *StatefulConnection) Renew() error {
 }
 
 // String returns a printable version of the connection info.
+// It will redact query parameters if the -queryserver-config-terse-errors
+// flag is enabled.
 func (sc *StatefulConnection) String() string {
 	return fmt.Sprintf(
 		"%v\t%s",
 		sc.ConnID,
-		sc.txProps.String(),
+		sc.txProps.String(sc.env.Config().TerseErrors),
 	)
 }
 

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -57,6 +57,9 @@ type (
 		Autocommit      bool
 		Conclusion      string
 		LogToFile       bool
+		// Redact query parameters in generic struct output such as .String()
+		// that may be logged or returned to the client
+		RedactQueries bool
 
 		Stats *servenv.TimingsWrapper
 	}
@@ -126,7 +129,7 @@ func (p *Properties) RecordQuery(query string) {
 func (p *Properties) InTransaction() bool { return p != nil }
 
 // String returns a printable version of the transaction
-func (p *Properties) String(redactQueries bool) string {
+func (p *Properties) String() string {
 	if p == nil {
 		return ""
 	}
@@ -134,7 +137,7 @@ func (p *Properties) String(redactQueries bool) string {
 	printQueries := func() string {
 		sb := strings.Builder{}
 		for _, query := range p.Queries {
-			if redactQueries {
+			if p.RedactQueries {
 				query, _ = sqlparser.RedactSQLQuery(query)
 			}
 			sb.WriteString(query)

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -24,6 +24,7 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/sqlparser"
 )
 
 type (
@@ -130,6 +131,12 @@ func (p *Properties) String() string {
 		return ""
 	}
 
+	redactedQueries := make([]string, len(p.Queries))
+	for i, query := range p.Queries {
+		rq, _ := sqlparser.RedactSQLQuery(query)
+		redactedQueries[i] = rq
+	}
+
 	return fmt.Sprintf(
 		"'%v'\t'%v'\t%v\t%v\t%.6f\t%v\t%v\t\n",
 		p.EffectiveCaller,
@@ -138,6 +145,6 @@ func (p *Properties) String() string {
 		p.EndTime.Format(time.StampMicro),
 		p.EndTime.Sub(p.StartTime).Seconds(),
 		p.Conclusion,
-		strings.Join(p.Queries, ";"),
+		strings.Join(redactedQueries, ";"),
 	)
 }

--- a/go/vt/vttablet/tabletserver/tx/api.go
+++ b/go/vt/vttablet/tabletserver/tx/api.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"vitess.io/vitess/go/streamlog"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
@@ -127,7 +126,7 @@ func (p *Properties) RecordQuery(query string) {
 func (p *Properties) InTransaction() bool { return p != nil }
 
 // String returns a printable version of the transaction
-func (p *Properties) String() string {
+func (p *Properties) String(redactQueries bool) string {
 	if p == nil {
 		return ""
 	}
@@ -135,7 +134,7 @@ func (p *Properties) String() string {
 	printQueries := func() string {
 		sb := strings.Builder{}
 		for _, query := range p.Queries {
-			if *streamlog.RedactDebugUIQueries {
+			if redactQueries {
 				query, _ = sqlparser.RedactSQLQuery(query)
 			}
 			sb.WriteString(query)

--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -159,6 +159,9 @@ func (tp *TxPool) NewTxProps(immediateCaller *querypb.VTGateCallerID, effectiveC
 		ImmediateCaller: immediateCaller,
 		Autocommit:      autocommit,
 		Stats:           tp.txStats,
+		// -queryserver-config-terse-errors controls whether or not messages about the tranasaction that are sent to logs and/or clients
+		// have their query parameters redacted.
+		RedactQueries: tp.env.Config().TerseErrors,
 	}
 }
 


### PR DESCRIPTION
## Description
This redacts potentially sensitive query parameters — if you have the `-queryserver-config-terse-errors` tablet flag enabled — from the transaction related log messages while still printing the statement shapes (normalized queries) which can still be helpful in debugging.

Before:
```
W0105 17:18:53.558389    3783 tx_pool.go:126] killing transaction (exceeded timeout: 30s): 1641402138560038177  'principal:"vitess" component:"127.0.0.1:56294" subcomponent:"VTGate MySQL Connector"'  'username:"userData1"'  Jan  5 17:18:22.025067  Jan  1 00:00:00.000000  -9223372036.854776              insert into customer(email) values ('PROBLEM@LOGGING.WHY');insert into customer(email) values ('PROBLEM2@LOGGING.WHY')
```

After:
```
W0105 17:36:01.783113     693 tx_pool.go:126] killing transaction (exceeded timeout: 30s): 1641404066211055126	'principal:"vitess" component:"127.0.0.1:56520" subcomponent:"VTGate MySQL Connector"'	'username:"userData1"'	Jan  5 17:35:30.360499	Jan  1 00:00:00.000000	-9223372036.854776		insert into customer(email) values (:redacted1);insert into customer(email) values (:redacted1)
```

## Related Issue(s)
Fixes: https://github.com/vitessio/vitess/issues/9469

## Checklist
- [x] Should this PR be backported? No
- [x] Tests were are not required
- [x] Documentation is not required