### PR TITLE
Move reparent and vtorc tests to self-hosted runners

### DIFF
--- a/.github/docker/cluster_test_14/Dockerfile
+++ b/.github/docker/cluster_test_14/Dockerfile
@@ -1,0 +1,42 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+ARG bootstrap_version=3
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
+
+FROM "${image}"
+
+USER root
+
+# Re-copy sources from working tree
+RUN rm -rf /vt/src/vitess.io/vitess/*
+COPY . /vt/src/vitess.io/vitess
+
+# install XtraBackup
+RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y gnupg2
+RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y percona-xtrabackup-24
+
+# Set the working directory
+WORKDIR /vt/src/vitess.io/vitess
+
+# Fix permissions
+RUN chown -R vitess:vitess /vt
+
+USER vitess
+
+# Set environment variables
+ENV VTROOT /vt/src/vitess.io/vitess
+# Set the vtdataroot such that it uses the volume mount
+ENV VTDATAROOT /vt/vtdataroot
+
+# create the vtdataroot directory
+RUN mkdir -p $VTDATAROOT
+
+# install goimports
+RUN go install golang.org/x/tools/cmd/goimports@latest
+
+# sleep for 50 minutes
+CMD sleep 3000

--- a/.github/docker/cluster_test_vtorc/Dockerfile
+++ b/.github/docker/cluster_test_vtorc/Dockerfile
@@ -1,0 +1,42 @@
+# DO NOT MODIFY: THIS FILE IS GENERATED USING "make generate_ci_workflows"
+
+ARG bootstrap_version=3
+ARG image="vitess/bootstrap:${bootstrap_version}-mysql57"
+
+FROM "${image}"
+
+USER root
+
+# Re-copy sources from working tree
+RUN rm -rf /vt/src/vitess.io/vitess/*
+COPY . /vt/src/vitess.io/vitess
+
+# install XtraBackup
+RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y gnupg2
+RUN dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y percona-xtrabackup-24
+
+# Set the working directory
+WORKDIR /vt/src/vitess.io/vitess
+
+# Fix permissions
+RUN chown -R vitess:vitess /vt
+
+USER vitess
+
+# Set environment variables
+ENV VTROOT /vt/src/vitess.io/vitess
+# Set the vtdataroot such that it uses the volume mount
+ENV VTDATAROOT /vt/vtdataroot
+
+# create the vtdataroot directory
+RUN mkdir -p $VTDATAROOT
+
+# install goimports
+RUN go install golang.org/x/tools/cmd/goimports@latest
+
+# sleep for 50 minutes
+CMD sleep 3000

--- a/.github/workflows/cluster_endtoend_14.yml
+++ b/.github/workflows/cluster_endtoend_14.yml
@@ -6,77 +6,36 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (14)')
   cancel-in-progress: true
 
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-
 jobs:
   build:
     name: Run endtoend tests on Cluster (14)
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set up python
-      uses: actions/setup-python@v2
+      - name: Build Docker Image
+        run: docker build -f ./.github/docker/cluster_test_14/Dockerfile -t cluster_test_14:$GITHUB_SHA  .
 
-    - name: Tune the OS
-      run: |
-        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+      - name: Run test
+        timeout-minutes: 30
+        run: docker run --name "cluster_test_14_$GITHUB_SHA" cluster_test_14:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard 14 -- -- --keep-data=true'
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Print Volume Used
+        if: ${{ always() }}
+        run: |
+          docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_14_$GITHUB_SHA
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
+      - name: Cleanup Docker Volume
+        run: |
+          docker rm -v cluster_test_14_$GITHUB_SHA
 
-        # install JUnit report formatter
-        go get -u github.com/vitessio/go-junit-report@HEAD
+      - name: Cleanup Docker Container
+        if: ${{ always() }}
+        run: |
+          docker rm -f cluster_test_14_$GITHUB_SHA
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
-    - name: Run cluster endtoend test
-      timeout-minutes: 30
-      run: |
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard 14 | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+      - name: Cleanup Docker Image
+        run: |
+          docker image rm cluster_test_14:$GITHUB_SHA

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -6,77 +6,36 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster (vtorc)')
   cancel-in-progress: true
 
-env:
-  LAUNCHABLE_ORGANIZATION: "vitess"
-  LAUNCHABLE_WORKSPACE: "vitess-app"
-  GITHUB_PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
-
 jobs:
   build:
     name: Run endtoend tests on Cluster (vtorc)
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set up python
-      uses: actions/setup-python@v2
+      - name: Build Docker Image
+        run: docker build -f ./.github/docker/cluster_test_vtorc/Dockerfile -t cluster_test_vtorc:$GITHUB_SHA  .
 
-    - name: Tune the OS
-      run: |
-        echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
+      - name: Run test
+        timeout-minutes: 30
+        run: docker run --name "cluster_test_vtorc_$GITHUB_SHA" cluster_test_vtorc:$GITHUB_SHA /bin/bash -c 'source build.env && go run test.go -keep-data=true -docker=false -print-log -follow -shard vtorc -- -- --keep-data=true'
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Print Volume Used
+        if: ${{ always() }}
+        run: |
+          docker inspect -f '{{ (index .Mounts 0).Name }}' cluster_test_vtorc_$GITHUB_SHA
 
-    - name: Get dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget eatmydata
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-        go mod download
+      - name: Cleanup Docker Volume
+        run: |
+          docker rm -v cluster_test_vtorc_$GITHUB_SHA
 
-        # install JUnit report formatter
-        go get -u github.com/vitessio/go-junit-report@HEAD
+      - name: Cleanup Docker Container
+        if: ${{ always() }}
+        run: |
+          docker rm -f cluster_test_vtorc_$GITHUB_SHA
 
-        wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get install -y gnupg2
-        sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo apt-get update
-        sudo apt-get install percona-xtrabackup-24
-
-    - name: Setup launchable dependencies
-      run: |
-        # Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
-        pip3 install --user launchable~=1.0 > /dev/null
-
-        # verify that launchable setup is all correct.
-        launchable verify || true
-
-        # Tell Launchable about the build you are producing and testing
-        launchable record build --name "$GITHUB_RUN_ID" --source .
-
-    - name: Run cluster endtoend test
-      timeout-minutes: 30
-      run: |
-        source build.env
-
-        set -x
-
-        # run the tests however you normally do, then produce a JUnit XML file
-        eatmydata -- go run test.go -docker=false -follow -shard vtorc | tee -a output.txt | go-junit-report -set-exit-code > report.xml
-
-    - name: Print test output and Record test result in launchable
-      run: |
-        # send recorded tests to launchable
-        launchable record tests --build "$GITHUB_RUN_ID" go-test . || true
-
-        # print test output
-        cat output.txt
-      if: always()
+      - name: Cleanup Docker Image
+        run: |
+          docker image rm cluster_test_vtorc:$GITHUB_SHA

--- a/test/ci_workflow_gen.go
+++ b/test/ci_workflow_gen.go
@@ -50,7 +50,6 @@ var (
 		"11",
 		"12",
 		"13",
-		"14",
 		"15",
 		"16",
 		"17",
@@ -81,7 +80,6 @@ var (
 		"tabletmanager_throttler_custom_config",
 		"tabletmanager_tablegc",
 		"tabletmanager_consul",
-		"vtorc",
 		"vtgate_buffer",
 		"vtgate_concurrentdml",
 		"vtgate_godriver",
@@ -106,8 +104,11 @@ var (
 		"vreplication_cellalias",
 	}
 
-	clusterSelfHostedList = []string{}
-	clusterDockerList     = []string{
+	clusterSelfHostedList = []string{
+		"14",
+		"vtorc",
+	}
+	clusterDockerList = []string{
 		"vreplication_basic",
 		"vreplication_v2",
 	}


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
`reparent` and `vtorc` tests have been flaky recently. This PR moves them to the self-hosted runners so that the flakiness can be traced and reproduced.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->