### PR TITLE
Deprecate and ignore `gateway_implementation` flag to vtgate.

### DIFF
--- a/doc/releasenotes/13_0_0_summary.md
+++ b/doc/releasenotes/13_0_0_summary.md
@@ -4,6 +4,9 @@
 
 ## Major Changes
 
+### vtgate -gateway_implementation flag is deprecated (and ignored)
+Support for `discoverygateway` is being dropped. `tabletgateway` is now the only supported implementation. Scripts using this flag should be updated to remove the flag as it will be deleted in the next release.
+
 ### vttablet -use_super_read_only flag now defaults to true
 The default value used to be false. What this means is that during a failover, we will set `super_read_only` on database flavors that support them (MySQL 5.7+ and Percona 5.7+).
 In addition, all Vitess-managed databases will be started with `super-read-only` in the cnf file.

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -37,8 +37,8 @@ import (
 var (
 	_ = flag.String("gateway_implementation", "", "Deprecated. Only tabletgateway is now supported, discoverygateway is no longer available")
 	// We cannot reference tabletGatewayImplementation directly because it is const
-	DefaultGatewayImplementation = tabletGatewayImplementation
-	GatewayImplementation        = &DefaultGatewayImplementation
+	defaultGatewayImplementation = tabletGatewayImplementation
+	GatewayImplementation        = &defaultGatewayImplementation
 	bufferImplementation         = flag.String("buffer_implementation", "keyspace_events", "Allowed values: healthcheck (legacy implementation), keyspace_events (default)")
 	initialTabletTimeout         = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
 	// RetryCount is the number of times a query will be retried on error

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -35,8 +35,8 @@ import (
 // a query targeted to a keyspace/shard/tablet_type and send it off.
 
 var (
-	// GatewayImplementation allows you to choose which gateway to use for vtgate routing. Defaults to tabletgateway, other option is discoverygateway
-	GatewayImplementation = flag.String("gateway_implementation", "tabletgateway", "Allowed values: discoverygateway (deprecated), tabletgateway (default)")
+	_                     = flag.String("gateway_implementation", "", "Deprecated. Only tabletgateway is now supported, discoverygateway is no longer available")
+	GatewayImplementation = new(string)
 	bufferImplementation  = flag.String("buffer_implementation", "keyspace_events", "Allowed values: healthcheck (legacy implementation), keyspace_events (default)")
 	initialTabletTimeout  = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
 	// RetryCount is the number of times a query will be retried on error

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -35,10 +35,12 @@ import (
 // a query targeted to a keyspace/shard/tablet_type and send it off.
 
 var (
-	_                     = flag.String("gateway_implementation", "", "Deprecated. Only tabletgateway is now supported, discoverygateway is no longer available")
-	GatewayImplementation = new(string)
-	bufferImplementation  = flag.String("buffer_implementation", "keyspace_events", "Allowed values: healthcheck (legacy implementation), keyspace_events (default)")
-	initialTabletTimeout  = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
+	_ = flag.String("gateway_implementation", "", "Deprecated. Only tabletgateway is now supported, discoverygateway is no longer available")
+	// We cannot reference tabletGatewayImplementation directly because it is const
+	DefaultGatewayImplementation = tabletGatewayImplementation
+	GatewayImplementation        = &DefaultGatewayImplementation
+	bufferImplementation         = flag.String("buffer_implementation", "keyspace_events", "Allowed values: healthcheck (legacy implementation), keyspace_events (default)")
+	initialTabletTimeout         = flag.Duration("gateway_initial_tablet_timeout", 30*time.Second, "At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype")
 	// RetryCount is the number of times a query will be retried on error
 	// Make this unexported after DiscoveryGateway is deprecated
 	RetryCount = flag.Int("retry-count", 2, "retry count")

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -46,7 +46,6 @@ const (
 )
 
 func init() {
-	*GatewayImplementation = tabletGatewayImplementation
 	RegisterGatewayCreator(tabletGatewayImplementation, createTabletGateway)
 }
 

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -46,6 +46,7 @@ const (
 )
 
 func init() {
+	*GatewayImplementation = tabletGatewayImplementation
 	RegisterGatewayCreator(tabletGatewayImplementation, createTabletGateway)
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
VTGate's `gateway_implementation` flag is now deprecated, and any value provided is ignored. `tabletgateway` is now the only supported implementation.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
#9218 

## Checklist
- [ ] Should this PR be backported? NO
- [x] Tests were added or are not required
- [ ] Documentation was added or is not required - release note has been added. Website PR will be created

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
Scripts used to run `vtgate` will need to be updated to drop this flag. It will be removed in a future release (14.0)