### PR TITLE
Addition of v11.0.4 and v12.0.3 release notes to main

### DIFF
--- a/doc/releasenotes/11_0_0_release_notes.md
+++ b/doc/releasenotes/11_0_0_release_notes.md
@@ -2,398 +2,398 @@ This release complies with VEP-3 which removes the upgrade order requirement. Co
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v11.0.0`, uses a version of Log4j below `2.16.0`, for this reason, we encourage you to use `v11.0.3` instead, which contains the patch for the vulnerability.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.0`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
 
-## Bug fixes 
+## Bug fixes
 ### Build/CI
- * update moby/term to fix darwin build issue #7787
- * Removing Linux/amd64 specific subdependencies #7796
- * CI: run some tests inside docker to workaround GH Actions issue #7868
- * Fix flaky race condition in vtexplain #7930
- * Fixing flaky endtoend/tablegc tests #7947
- * Add libwww-perl to allow pt-osc wrapper to work in vitess/lite #8141 
+* update moby/term to fix darwin build issue #7787
+* Removing Linux/amd64 specific subdependencies #7796
+* CI: run some tests inside docker to workaround GH Actions issue #7868
+* Fix flaky race condition in vtexplain #7930
+* Fixing flaky endtoend/tablegc tests #7947
+* Add libwww-perl to allow pt-osc wrapper to work in vitess/lite #8141
 ### Cluster management
- * Add missing return on a failed `GetShard` call in `FindAllShardsInKeyspace` #7992
- * Increase the default srv_topo_timeout #8011
- * parser: support index name in FOREIGN KEY clause; Online DDL to reject FK clauses #8058
- * Correctly parse cell names with dashes in tablet aliases #8167
- * /healthz should not report ok when vttablet is not connected to mysql #8238
- * [topo] Refactor `ExpandCells` to not error on valid aliases #8291 
- * tm state: don't populate metadata in updateLocked  #8362
- * [grpcvtctldserver] Fix backup detail limit math #8402 
+* Add missing return on a failed `GetShard` call in `FindAllShardsInKeyspace` #7992
+* Increase the default srv_topo_timeout #8011
+* parser: support index name in FOREIGN KEY clause; Online DDL to reject FK clauses #8058
+* Correctly parse cell names with dashes in tablet aliases #8167
+* /healthz should not report ok when vttablet is not connected to mysql #8238
+* [topo] Refactor `ExpandCells` to not error on valid aliases #8291
+* tm state: don't populate metadata in updateLocked  #8362
+* [grpcvtctldserver] Fix backup detail limit math #8402
 ### Query Serving
- * fix select star, col1 orderby col1 bug. #7743
- * VTExplain: Add support for multi table join query #7829
- * Routing of Information Schema Queries #7841
- * Fix + integration test for `keyspaces_to_watch` routing regression [fixes #7882] #7873
- * Revert "[tablet, queryrules] Extend query rules to check comments" #7897
- * vtctl: return error on invalid ddl_strategy #7923
- * Panic when EOF after @ symbol #7925
- * Fixes encoding of sql strings #8033
- * Make TwoPC engine initialization async. #8048
- * Fix for issue with information_schema queries with both table name and schema name predicates #8087
- * Fix for transactions not allowed to finish during PlannedReparentShard #8089
- * Set fully parsed to false when ignoring errors #8094
- * Fix for query and sub query with limits #8097
- * Fix buffering when using reserved connections #8102
- * Parse generated columns in DDL #8117
- * More explicit message on online DDL parsing error #8118
- * healthcheck: attempt to update primary only if the current tablet is serving #8121
- * PRIMARY in index hint list for master #8160
- * Signed int parse #8189 
- * Delete table reference alias support #8393 
- * Fix for function calls in DEFAULT value of CREATE TABLE statement in release-11.0 #8476
- * Backport: Fixing multiple issues related to onlineddl/lifecycle #8517
- * boolean values should not be parenthesised in default clause - release 11 #8531
+* fix select star, col1 orderby col1 bug. #7743
+* VTExplain: Add support for multi table join query #7829
+* Routing of Information Schema Queries #7841
+* Fix + integration test for `keyspaces_to_watch` routing regression [fixes #7882] #7873
+* Revert "[tablet, queryrules] Extend query rules to check comments" #7897
+* vtctl: return error on invalid ddl_strategy #7923
+* Panic when EOF after @ symbol #7925
+* Fixes encoding of sql strings #8033
+* Make TwoPC engine initialization async. #8048
+* Fix for issue with information_schema queries with both table name and schema name predicates #8087
+* Fix for transactions not allowed to finish during PlannedReparentShard #8089
+* Set fully parsed to false when ignoring errors #8094
+* Fix for query and sub query with limits #8097
+* Fix buffering when using reserved connections #8102
+* Parse generated columns in DDL #8117
+* More explicit message on online DDL parsing error #8118
+* healthcheck: attempt to update primary only if the current tablet is serving #8121
+* PRIMARY in index hint list for master #8160
+* Signed int parse #8189
+* Delete table reference alias support #8393
+* Fix for function calls in DEFAULT value of CREATE TABLE statement in release-11.0 #8476
+* Backport: Fixing multiple issues related to onlineddl/lifecycle #8517
+* boolean values should not be parenthesised in default clause - release 11 #8531
 
 
 ### VReplication
- * VDiff: Use byte compare if weight_string() returns null for either source or target #7696
- * Rowlog: Update rowlog for the API change made for the vstream skew alignment feature #7809
- * Pad binlog values for binary() columns to match the value returned by mysql selects #7969
- * Change vreplication error metric name to start with a string to pass prometheus validations #7983
- * Pass the provided keyspace through to `UpdateDisableQueryService` rather than hard-coding the sourceKeyspace #8020
- * Fix vreplication timing metrics #8024
- * Switchwrites: error if no tablets available on target for reverse replication #8142
- * Remove noisy vexec logs #8144
- * VReplicationExec: don't create new stats objects on a select #8166
- * Binlog JSON Parser: handle inline types correctly for large documents #8187
- * Schema Tracking Flaky Test: Ignore unrelated gtid progress events #8283
- * Adds padding to keyrange comparison #8296 
- * VReplication Reverse Workflows: add keyspace scope to vindex while creating reverse vreplication streams #8385
- * OnlineDDL/Vreplication stress test: investigating failures #8390
- * Ignore SBR statements from pt-table-checksum #8396
- * Return from throttler goroutine if context is cancelled to prevent goroutine leaks #8489
- * VDiff: Add BIT datatype to list of byte comparable types #8401
- * Fix excessive VReplication logging to file and db #8521
+* VDiff: Use byte compare if weight_string() returns null for either source or target #7696
+* Rowlog: Update rowlog for the API change made for the vstream skew alignment feature #7809
+* Pad binlog values for binary() columns to match the value returned by mysql selects #7969
+* Change vreplication error metric name to start with a string to pass prometheus validations #7983
+* Pass the provided keyspace through to `UpdateDisableQueryService` rather than hard-coding the sourceKeyspace #8020
+* Fix vreplication timing metrics #8024
+* Switchwrites: error if no tablets available on target for reverse replication #8142
+* Remove noisy vexec logs #8144
+* VReplicationExec: don't create new stats objects on a select #8166
+* Binlog JSON Parser: handle inline types correctly for large documents #8187
+* Schema Tracking Flaky Test: Ignore unrelated gtid progress events #8283
+* Adds padding to keyrange comparison #8296
+* VReplication Reverse Workflows: add keyspace scope to vindex while creating reverse vreplication streams #8385
+* OnlineDDL/Vreplication stress test: investigating failures #8390
+* Ignore SBR statements from pt-table-checksum #8396
+* Return from throttler goroutine if context is cancelled to prevent goroutine leaks #8489
+* VDiff: Add BIT datatype to list of byte comparable types #8401
+* Fix excessive VReplication logging to file and db #8521
 
 ### VTAdmin
- * Add missing return in `vtctld-*` DSN case, and log any flag that gets ignored #7872
- * [vtadmin-web] Do not parse numbers/booleans in URL query parameters by default #8100
- * [vtadmin-web] Small bugfix where stream source displayed instead of target #8311
-## CI/Build 
+* Add missing return in `vtctld-*` DSN case, and log any flag that gets ignored #7872
+* [vtadmin-web] Do not parse numbers/booleans in URL query parameters by default #8100
+* [vtadmin-web] Small bugfix where stream source displayed instead of target #8311
+## CI/Build
 ### Build/CI
- * Planbuilder: Fix fuzzer #7952
- * java: Bump SNAPSHOT version to 11.0.0-SNAPSHOT after Vitess release v10 #7968
- * Add optional TLS feature to gRPC servers #8049
- * Add image and base image arguments to build.sh #8064
- * [fuzzing] Add report #8128
- * CI: fail PR if it does not have required labels #8147
- * trigger pr-labels workflow when labels added/removed from PR #8157
- * Add vmg as a maintainer #8186
- * Refactor vtorc endtoend tests #8215
- * Use shared testing helper which guards against races in tmclient construction #8300
- * moved multiple vtgate and tabletgateway to individual shards #8305
- * include squashed PRs in release notes #8326
- * pr-labels workflow: only check actual PRs #8327
- * Heuristic fix for a flaky test: allow for some noise to pass through #8339
- * ci: upgrade to Go 1.16 #8274
- * mod: upgrade etcd to stable version #8357
- * Resolve go.mod issue with direct dependency on planetscale/tengo #8383
- * Initial GitHub Docker Build Setup #8399 
- 
+* Planbuilder: Fix fuzzer #7952
+* java: Bump SNAPSHOT version to 11.0.0-SNAPSHOT after Vitess release v10 #7968
+* Add optional TLS feature to gRPC servers #8049
+* Add image and base image arguments to build.sh #8064
+* [fuzzing] Add report #8128
+* CI: fail PR if it does not have required labels #8147
+* trigger pr-labels workflow when labels added/removed from PR #8157
+* Add vmg as a maintainer #8186
+* Refactor vtorc endtoend tests #8215
+* Use shared testing helper which guards against races in tmclient construction #8300
+* moved multiple vtgate and tabletgateway to individual shards #8305
+* include squashed PRs in release notes #8326
+* pr-labels workflow: only check actual PRs #8327
+* Heuristic fix for a flaky test: allow for some noise to pass through #8339
+* ci: upgrade to Go 1.16 #8274
+* mod: upgrade etcd to stable version #8357
+* Resolve go.mod issue with direct dependency on planetscale/tengo #8383
+* Initial GitHub Docker Build Setup #8399
+
 ### Cluster management
- * make: build vitess as static binaries by default #7795
- * Fix TableGC flaky test by reducing check interval #8270 
+* make: build vitess as static binaries by default #7795
+* Fix TableGC flaky test by reducing check interval #8270
 ### Java
- * Bump commons-io from 2.6 to 2.7 in /java #7953 
+* Bump commons-io from 2.6 to 2.7 in /java #7953
 ### Other
- * Bump MySQL version for docker builds to 8.0.23 #7811 
+* Bump MySQL version for docker builds to 8.0.23 #7811
 ### Query Serving
- * Online DDL Vreplication test suite: adding tests #8213
- * Online DDL/VReplication: more passing tests (no UK/PK) #8225
- * Online DDL: reject ALTER TABLE...RENAME statements #8227
- * Online DDL/VReplication: fail on existence of FOREIGN KEY #8228 
- * Online DDL/VReplication: test PK column case change #8336
- * Online DDL/VReplication: add PK DATETIME->TIMESTAMP test #8338
- * Bugfix: assign cexpr.references for column CONVERTed to utf8mb4 #8355
+* Online DDL Vreplication test suite: adding tests #8213
+* Online DDL/VReplication: more passing tests (no UK/PK) #8225
+* Online DDL: reject ALTER TABLE...RENAME statements #8227
+* Online DDL/VReplication: fail on existence of FOREIGN KEY #8228
+* Online DDL/VReplication: test PK column case change #8336
+* Online DDL/VReplication: add PK DATETIME->TIMESTAMP test #8338
+* Bugfix: assign cexpr.references for column CONVERTed to utf8mb4 #8355
 
 
 ### VReplication
- * Towards a VReplication/OnlineDDL testing suite #8181
- * Online DDL/Vreplication: column type awareness #8239
- * remove duplicate ReadMigrations, fixing build #8258
- * VReplication (and by product, Online DDL): support GENERATED column as part of PRIMARY KEY #8335 
+* Towards a VReplication/OnlineDDL testing suite #8181
+* Online DDL/Vreplication: column type awareness #8239
+* remove duplicate ReadMigrations, fixing build #8258
+* VReplication (and by product, Online DDL): support GENERATED column as part of PRIMARY KEY #8335
 ### vttestserver
- * docker/vttestserver:  Set max_connections in default-fast.cnf at container build time #7810
-## Documentation 
+* docker/vttestserver:  Set max_connections in default-fast.cnf at container build time #7810
+## Documentation
 ### Cluster management
- * Enhance k8stopo flag documentation #8458
+* Enhance k8stopo flag documentation #8458
 ### Build/CI
- * Update version for latest snapshot #7801
- * v10 GA Release Notes #7964
- * Updates and Corrections to v9 Release Notes #8295
+* Update version for latest snapshot #7801
+* v10 GA Release Notes #7964
+* Updates and Corrections to v9 Release Notes #8295
 ### Query Serving
- * Update link to 'Why FK not supported in Online DDL' blog post #8372
+* Update link to 'Why FK not supported in Online DDL' blog post #8372
 ### Other
- * correct several wrong words #7822
- * MAINTAINERS.md: Update enisoc's email. #7909
- * Modification of the Markdown list format in the release notes template #7962
- * Update vreplicator docs #8014
- * Release notes: add Known Issues #8027
+* correct several wrong words #7822
+* MAINTAINERS.md: Update enisoc's email. #7909
+* Modification of the Markdown list format in the release notes template #7962
+* Update vreplicator docs #8014
+* Release notes: add Known Issues #8027
 ## Enhancement
 ### Observability
- * [trace] Add logging support to opentracing plugins #8289 
+* [trace] Add logging support to opentracing plugins #8289
 
 
 ### Build/CI
- * Makefile: add cross-build target for cross-compiling client binaries #7806
- * git: improve signoff detection #7852
- * Release notes generation #7932
- * vitess/lite docker build fails for mysql80 #7943
- * Fix a gofmt warning #7959
- * docker/vttestserver/run.sh:  Add $CHARSET environment variable #7970
- * docker/lite/install_dependencies.sh:  If the dependency install loop reaches its max number of retries, consider that a failure; exit the script nonzero so the build halts. #7976
- * Add commit count and authors to the release notes #7982
- * Automate version naming and release tagging #8034
- * Make sure to only allow codegen when the rest of the code compiles #8169
- * Add options to vttestserver to pass -foreign_key_mode, -enable_online_ddl, and -enable_direct_ddl through to vtcombo #8177 
+* Makefile: add cross-build target for cross-compiling client binaries #7806
+* git: improve signoff detection #7852
+* Release notes generation #7932
+* vitess/lite docker build fails for mysql80 #7943
+* Fix a gofmt warning #7959
+* docker/vttestserver/run.sh:  Add $CHARSET environment variable #7970
+* docker/lite/install_dependencies.sh:  If the dependency install loop reaches its max number of retries, consider that a failure; exit the script nonzero so the build halts. #7976
+* Add commit count and authors to the release notes #7982
+* Automate version naming and release tagging #8034
+* Make sure to only allow codegen when the rest of the code compiles #8169
+* Add options to vttestserver to pass -foreign_key_mode, -enable_online_ddl, and -enable_direct_ddl through to vtcombo #8177
 ### Cluster management
- * Dynamic throttle metric threshold #7742
- * Bump Bootstrap version, per CVE-2018-14040 (orchestrator/vtorc) #7824
- * Check tablet alias before removing after error stream #7915
- * vttablet/tabletmanager - add additional test for tmstate.Open() #7993
- * Add `vttablet_restore_done` hook #8007
- * Added ValidateVSchema #8012
- * Add RemoteOperationTimeout to both legacy and grpc `ChangeTabletType` implementations. #8052
- * [vtctldserver] Add guard against self-reparent, plus misc updates #8084
- * [tm_state] updateLocked should re-populate local metadata tables to reflect promotion rule changes #8107
- * [vtctld] Migrate `ApplyVSchema` to `VtctldServer` #8113
- * vtctl.generateShardRanges -> key.GenerateShardRanges #8134
- * etcd: add grpc.WithBlock to client config #8205
- * [workflow] Add tracing to `GetWorkflows` endpoint #8266
- * [vtctldclient] Add legacy shim #8284
- * [vtctldserver] Add tracing #8285
- * [vtctldserver] Add additional backup info fields #8321
- * [workflow] Call `scanWorkflow` concurrently #8272  
+* Dynamic throttle metric threshold #7742
+* Bump Bootstrap version, per CVE-2018-14040 (orchestrator/vtorc) #7824
+* Check tablet alias before removing after error stream #7915
+* vttablet/tabletmanager - add additional test for tmstate.Open() #7993
+* Add `vttablet_restore_done` hook #8007
+* Added ValidateVSchema #8012
+* Add RemoteOperationTimeout to both legacy and grpc `ChangeTabletType` implementations. #8052
+* [vtctldserver] Add guard against self-reparent, plus misc updates #8084
+* [tm_state] updateLocked should re-populate local metadata tables to reflect promotion rule changes #8107
+* [vtctld] Migrate `ApplyVSchema` to `VtctldServer` #8113
+* vtctl.generateShardRanges -> key.GenerateShardRanges #8134
+* etcd: add grpc.WithBlock to client config #8205
+* [workflow] Add tracing to `GetWorkflows` endpoint #8266
+* [vtctldclient] Add legacy shim #8284
+* [vtctldserver] Add tracing #8285
+* [vtctldserver] Add additional backup info fields #8321
+* [workflow] Call `scanWorkflow` concurrently #8272
 ### Query Serving
- * [Gen4] Implemented table alias functionality in the semantic analysis #7629
- * Improved error messages (tabletserver) #7747
- * Allow modification of tablet unhealthy_threshold via debugEnv #7753
- * [Gen4] Initial Horizon Planning #7775
- * [tablet, queryrules] Extend query rules to check comments #7784
- * Add support for showing global gtid executed per shard #7856
- * Minor cleanups around errors on the vtgate #7864
- * log unsupported queries #7865
- * Show databases like #7912
- * Add rank as reserved keyword #7944
- * Online DDL: introducing ddl_strategy `-singleton-context` flag #7946
- * Ignore the error and log as warn if not able to validate the current system setting for check and ignore case #8004
- * Detect and signal schema changes on vttablets #8005
- * DDL bypass plan #8013
- * Online DDL: progress & ETA for Vreplication migrations #8015
- * Scatter errors as warning in olap query #8018
- * livequeryz: livequeryz/terminate link should be relative #8025
- * Handle online DDL user creation if we do not have SUPER privs (e.g. AWS Aurora) #8038
- * Update the schema copy with minimal changes #8067
- * Gen4: Support for order by column not present in projection #8070
- * Schema tracking in vtgate #8074
- * protobuf: upgrade #8075
- * added mysql 8.0 reserved keywords #8086
- * Fix ghost/pt-osc in the external DB case where MySQL might be reporting #8115
- * Support for vtgate -enable_direct_ddl flag #8116
- * add transaction ID to query log for acquisition and analysis #8133
- * Inline reference #8136
- * Improve ScatterErrorsAsWarnings functionality #8139
- * Gen4: planning Select IN #8155
- * Primary key name #8188
- * Online DDL: read and publish gh-ost FATAL message where possible #8192
- * Expose inner net.Conn to be able to write better unit tests #8217
- * vtgate: validate important flags during startup #8218
- * Online DDL/VReplication: AUTO_INCREMENT support and tests #8223
- * [Gen4] some renaming from v4 to Gen4  #8234
- * Schema Tracking: Optimize and Bug Fix #8243
- * gen4: minor refactoring to improve readability #8245
- * gen4: plan more opcodes #8254
- * Online DDL: report rows_copied for migration (initial support in gh-ost) #8255
- * Schema tracking: new tables in sharded keyspace #8256
- * [parser] use table_alias for ENGINE option in CREATE TABLE stmt #8307
- * Add /debug/env for vtgate #8292
- * gen4: outer joins #8312
- * Gen4: expand star in projection list #8325
- * gen4: Fail all queries not handled well by gen4 #8359
- * Gen4 fail more2 #8382  
- * SHOW VITESS_MIGRATION '...' LOGS, retain logs for 24 hours #8532
- * [11.0] query serving to continue when topo server restarts #8533
- * [11.0] Disable allowing set statements on system settings by default #8540
+* [Gen4] Implemented table alias functionality in the semantic analysis #7629
+* Improved error messages (tabletserver) #7747
+* Allow modification of tablet unhealthy_threshold via debugEnv #7753
+* [Gen4] Initial Horizon Planning #7775
+* [tablet, queryrules] Extend query rules to check comments #7784
+* Add support for showing global gtid executed per shard #7856
+* Minor cleanups around errors on the vtgate #7864
+* log unsupported queries #7865
+* Show databases like #7912
+* Add rank as reserved keyword #7944
+* Online DDL: introducing ddl_strategy `-singleton-context` flag #7946
+* Ignore the error and log as warn if not able to validate the current system setting for check and ignore case #8004
+* Detect and signal schema changes on vttablets #8005
+* DDL bypass plan #8013
+* Online DDL: progress & ETA for Vreplication migrations #8015
+* Scatter errors as warning in olap query #8018
+* livequeryz: livequeryz/terminate link should be relative #8025
+* Handle online DDL user creation if we do not have SUPER privs (e.g. AWS Aurora) #8038
+* Update the schema copy with minimal changes #8067
+* Gen4: Support for order by column not present in projection #8070
+* Schema tracking in vtgate #8074
+* protobuf: upgrade #8075
+* added mysql 8.0 reserved keywords #8086
+* Fix ghost/pt-osc in the external DB case where MySQL might be reporting #8115
+* Support for vtgate -enable_direct_ddl flag #8116
+* add transaction ID to query log for acquisition and analysis #8133
+* Inline reference #8136
+* Improve ScatterErrorsAsWarnings functionality #8139
+* Gen4: planning Select IN #8155
+* Primary key name #8188
+* Online DDL: read and publish gh-ost FATAL message where possible #8192
+* Expose inner net.Conn to be able to write better unit tests #8217
+* vtgate: validate important flags during startup #8218
+* Online DDL/VReplication: AUTO_INCREMENT support and tests #8223
+* [Gen4] some renaming from v4 to Gen4  #8234
+* Schema Tracking: Optimize and Bug Fix #8243
+* gen4: minor refactoring to improve readability #8245
+* gen4: plan more opcodes #8254
+* Online DDL: report rows_copied for migration (initial support in gh-ost) #8255
+* Schema tracking: new tables in sharded keyspace #8256
+* [parser] use table_alias for ENGINE option in CREATE TABLE stmt #8307
+* Add /debug/env for vtgate #8292
+* gen4: outer joins #8312
+* Gen4: expand star in projection list #8325
+* gen4: Fail all queries not handled well by gen4 #8359
+* Gen4 fail more2 #8382
+* SHOW VITESS_MIGRATION '...' LOGS, retain logs for 24 hours #8532
+* [11.0] query serving to continue when topo server restarts #8533
+* [11.0] Disable allowing set statements on system settings by default #8540
 ### VReplication
- * Change local example to use v2 vreplication flows and make v2 flows as the default #8527
- * Use Dba user when Vexec is runAsAdmin #7731
- * Add table for logging stream errors, state changes and key workflow steps #7831
- * Fix some static check warning #7960
- * VSchema Validation on ReshardWorkflow Creation #7977
- * Tracking `rows_copied` #7980
- * Vdiff formatting improvements #8079
- * Ignore generated columns in workflows #8129
- * VReplication Copy Phase: Increase default replica lag tolerance. Also make it and copy timeout modifiable via flags #8130
- * Materialize: Add additional comparison operators in Materialize and fix bug where they not applied for sharded keyspaces #8247
- * Copy Phase: turn on OptimizeInserts by default #8248
- * Tracker/VStreamer: only reload schema for tables in current database and not for internal table artifacts #8257
- * Online DDL/Vreplication suite: support ENUM->VARCHAR/TEXT type change #8275
- * Added TableName to DiffReport struct. #8279
- * New VReplication lag metric  #8306
- * VStream API: add heartbeat for idle streams #8244
- * Online DDL/VReplication: support non-UTF8 character sets #8322
- * Online DDL/Vreplication suite: fix test for no shared UK #8334
- * Online DDL/VReplication: support DROP+ADD column of same name #8337
- * Online DDL/VReplication test suite: support ENUM as part of PRIMARY KEY #8345  
- * Change local example to use v2 vreplication flows #8527
- * Tablet Picker: add metric to record lack of available tablets #8403
+* Change local example to use v2 vreplication flows and make v2 flows as the default #8527
+* Use Dba user when Vexec is runAsAdmin #7731
+* Add table for logging stream errors, state changes and key workflow steps #7831
+* Fix some static check warning #7960
+* VSchema Validation on ReshardWorkflow Creation #7977
+* Tracking `rows_copied` #7980
+* Vdiff formatting improvements #8079
+* Ignore generated columns in workflows #8129
+* VReplication Copy Phase: Increase default replica lag tolerance. Also make it and copy timeout modifiable via flags #8130
+* Materialize: Add additional comparison operators in Materialize and fix bug where they not applied for sharded keyspaces #8247
+* Copy Phase: turn on OptimizeInserts by default #8248
+* Tracker/VStreamer: only reload schema for tables in current database and not for internal table artifacts #8257
+* Online DDL/Vreplication suite: support ENUM->VARCHAR/TEXT type change #8275
+* Added TableName to DiffReport struct. #8279
+* New VReplication lag metric  #8306
+* VStream API: add heartbeat for idle streams #8244
+* Online DDL/VReplication: support non-UTF8 character sets #8322
+* Online DDL/Vreplication suite: fix test for no shared UK #8334
+* Online DDL/VReplication: support DROP+ADD column of same name #8337
+* Online DDL/VReplication test suite: support ENUM as part of PRIMARY KEY #8345
+* Change local example to use v2 vreplication flows #8527
+* Tablet Picker: add metric to record lack of available tablets #8403
 ### VTAdmin
- * [vtadmin-web] Add useSyncedURLParam hook to persist filter parameter in the URL #7857
- * [vtadmin-web] Display more data on /gates view and add filtering #7876
- * [vtadmin] Promote ErrNoSchema to a TypedError which returns http 404 #7885
- * [vtadmin] gate/tablet/vtctld FQDNs #7886
- * [vtadmin-web] Display vindex data on Schema view #7917
- * [vtadmin-web] Add filtering and source/target shards to Workflows view #7948
- * [vtadmin-web] Add filtering + shard counts/status to Keyspaces view #7991
- * [vtadmin-web] Display shard state on Tablets view + extract tablet utilities  #7999
- * [vtadmin] experimental tabletdebug #8003
- * [vtadmin-web] Display timestamps + stream counts on Workflows view #8009
- * [vtadmin-web] Updates to table styling + other CSS #8072
- * [vtadmin-web] Add Tab components #8119
- * [vtadmin-api] Update GetTablet to use alias instead of hostname #8163
- * [vtadmin-api] Rename flag 'http-tablet-fqdn-tmpl' to 'http-tablet-url-tmpl' + update vtadmin flags for local example #8164
- * Add `--tracer` flag to vtadmin and actually start tracing #8165
- * [vtadmin-web] The hastiest Tablet view (+ experimental debug vars) #8170
- * [vtadmin-web] Add tabs to Workflow view #8203
- * [vtctld] Add GetSrvVSchemas command #8221
- * [vtadmin-api] Add HTTP endpoints for /api/srvvschemas and /api/srvvschema/{cluster}/{cell} #8226
- * [vtadmin-web] Add QPS and VReplicationQPS charts to Tablet view #8263
- * [vtadmin-web] Add client-side error handling interface + Bugsnag implementation #8287 
- * [vtadmin-web] Add chart for stream vreplication lag across all streams in a workflow #8331
- * [vtctldproxy] Add more annotations to vtctld Dial calls #8346
+* [vtadmin-web] Add useSyncedURLParam hook to persist filter parameter in the URL #7857
+* [vtadmin-web] Display more data on /gates view and add filtering #7876
+* [vtadmin] Promote ErrNoSchema to a TypedError which returns http 404 #7885
+* [vtadmin] gate/tablet/vtctld FQDNs #7886
+* [vtadmin-web] Display vindex data on Schema view #7917
+* [vtadmin-web] Add filtering and source/target shards to Workflows view #7948
+* [vtadmin-web] Add filtering + shard counts/status to Keyspaces view #7991
+* [vtadmin-web] Display shard state on Tablets view + extract tablet utilities  #7999
+* [vtadmin] experimental tabletdebug #8003
+* [vtadmin-web] Display timestamps + stream counts on Workflows view #8009
+* [vtadmin-web] Updates to table styling + other CSS #8072
+* [vtadmin-web] Add Tab components #8119
+* [vtadmin-api] Update GetTablet to use alias instead of hostname #8163
+* [vtadmin-api] Rename flag 'http-tablet-fqdn-tmpl' to 'http-tablet-url-tmpl' + update vtadmin flags for local example #8164
+* Add `--tracer` flag to vtadmin and actually start tracing #8165
+* [vtadmin-web] The hastiest Tablet view (+ experimental debug vars) #8170
+* [vtadmin-web] Add tabs to Workflow view #8203
+* [vtctld] Add GetSrvVSchemas command #8221
+* [vtadmin-api] Add HTTP endpoints for /api/srvvschemas and /api/srvvschema/{cluster}/{cell} #8226
+* [vtadmin-web] Add QPS and VReplicationQPS charts to Tablet view #8263
+* [vtadmin-web] Add client-side error handling interface + Bugsnag implementation #8287
+* [vtadmin-web] Add chart for stream vreplication lag across all streams in a workflow #8331
+* [vtctldproxy] Add more annotations to vtctld Dial calls #8346
 
 
 ### vttestserver
- * Vttest create db #7989
- * Adds an environment variable to set the MySQL max connections limit in vttestserver docker image #8210
-## Feature Request 
+* Vttest create db #7989
+* Adds an environment variable to set the MySQL max connections limit in vttestserver docker image #8210
+## Feature Request
 ### Build/CI
- * [trace] Add optional flags to support flexible jaeger configs #8199 
+* [trace] Add optional flags to support flexible jaeger configs #8199
 ### Cluster management
- * Add VtctldServer to vtcombo #7896
- * [vtctldserver] Migrate routing rules RPCs, and also `RebuildVSchemaGraph` #8197
- * [vtctldserver] Migrate `CellInfo`, `CellAlias` rw RPCs #8219
- * [vtctldserver] Add RefreshState RPCs #8232 
+* Add VtctldServer to vtcombo #7896
+* [vtctldserver] Migrate routing rules RPCs, and also `RebuildVSchemaGraph` #8197
+* [vtctldserver] Migrate `CellInfo`, `CellAlias` rw RPCs #8219
+* [vtctldserver] Add RefreshState RPCs #8232
 ### Query Serving
- * VTGate grpc implementation of Prepare and CloseSession #8211
- * Schema tracking: One schema load at a time per keyspace #8224 
+* VTGate grpc implementation of Prepare and CloseSession #8211
+* Schema tracking: One schema load at a time per keyspace #8224
 ### VTAdmin
- * [vtadmin-web] Add DataFilter + Workspace layout components #8032
- * [vtadmin-web] Add Tooltip + HelpTooltip components #8076
- * [vtadmin-web] Add initial Stream view, render streams on Workflow view #8091
- * [vtadmin-web] The hastiest-ever VTExplain UI #8092
- * [vtadmin-web] Add source-map-explorer util #8093
- * [vtadmin-web] Add Keyspace detail view #8111
- * [vtadmin-api] Add GetKeyspace endpoint #8125
- * [workflow] Add vreplication_log data to workflow protos, and `VtctldServer.GetWorkflows` method #8261
- * [vtadmin] Add debug endpoints #8268
-## Internal Cleanup 
+* [vtadmin-web] Add DataFilter + Workspace layout components #8032
+* [vtadmin-web] Add Tooltip + HelpTooltip components #8076
+* [vtadmin-web] Add initial Stream view, render streams on Workflow view #8091
+* [vtadmin-web] The hastiest-ever VTExplain UI #8092
+* [vtadmin-web] Add source-map-explorer util #8093
+* [vtadmin-web] Add Keyspace detail view #8111
+* [vtadmin-api] Add GetKeyspace endpoint #8125
+* [workflow] Add vreplication_log data to workflow protos, and `VtctldServer.GetWorkflows` method #8261
+* [vtadmin] Add debug endpoints #8268
+## Internal Cleanup
 ### Build/CI
- * Makefile: fix cross-build comments #8246
- * remove unused hooks with refs to master branch #8250
- * [vtctldserver] Update tests to prevent races during tmclient init #8320 
- * sks-keyservers.net seems to be finally dead, replace with #8363
- * endtoend: change log level of etcd start from error to info #8370
+* Makefile: fix cross-build comments #8246
+* remove unused hooks with refs to master branch #8250
+* [vtctldserver] Update tests to prevent races during tmclient init #8320
+* sks-keyservers.net seems to be finally dead, replace with #8363
+* endtoend: change log level of etcd start from error to info #8370
 ### Cluster management
- * Online DDL: code cleanup #7589
- * [wrangler|topotools] Migrate `UpdateShardRecords`, `RefreshTabletsByShard`, and `{Get,Save}RoutingRules` #7965
- * Tear down old stream_migrater shim, now that we're fully in `package workflow` #8073
- * [mysqlctl] Restructure `MetadataManager` to reduce public API surface area #8152
- * naming: master to primary #8251
- * vtorc: code cleanup #8269 
+* Online DDL: code cleanup #7589
+* [wrangler|topotools] Migrate `UpdateShardRecords`, `RefreshTabletsByShard`, and `{Get,Save}RoutingRules` #7965
+* Tear down old stream_migrater shim, now that we're fully in `package workflow` #8073
+* [mysqlctl] Restructure `MetadataManager` to reduce public API surface area #8152
+* naming: master to primary #8251
+* vtorc: code cleanup #8269
 ### Query Serving
- * Plan StreamExecute Queries #7941 
+* Plan StreamExecute Queries #7941
 ### VReplication
- * [workflow] extract migration targets from wrangler #7934
- * [wrangler|workflow] Extract vrStream type to workflow.VReplicationStream #7966
- * [wrangler|workflow] Extract `workflowState` and `workflowType` out to `package workflow` #7967
- * [wrangler|workflow] extract `*wrangler.streamMigrater` to `workflow.StreamMigrator` #8008
- * [workflow] Migrate `getCellsWith{Shard,Table}ReadsSwitched`, `TrafficSwitchDirection` and `TableRemovalType` to package workflow #8190
- * [workflow] Cleanup wrangler wrappers, migrate `checkIfJournalExistsOnTablet` to package workflow #8193
- * Backports of #8403 #8483 #8489 #8401 #8521 #8396 from main into release 11.0 #8536
+* [workflow] extract migration targets from wrangler #7934
+* [wrangler|workflow] Extract vrStream type to workflow.VReplicationStream #7966
+* [wrangler|workflow] Extract `workflowState` and `workflowType` out to `package workflow` #7967
+* [wrangler|workflow] extract `*wrangler.streamMigrater` to `workflow.StreamMigrator` #8008
+* [workflow] Migrate `getCellsWith{Shard,Table}ReadsSwitched`, `TrafficSwitchDirection` and `TableRemovalType` to package workflow #8190
+* [workflow] Cleanup wrangler wrappers, migrate `checkIfJournalExistsOnTablet` to package workflow #8193
+* Backports of #8403 #8483 #8489 #8401 #8521 #8396 from main into release 11.0 #8536
 ### VTAdmin
- * [vtadmin-api] Replace magic numbers with `net/http` constants #8127
- * [vtadmin-web] Move single-entity view components into subfolders #8202
- * [vtadmin] Ensure we log any errors when closing the tracer #8262
-## Other 
+* [vtadmin-api] Replace magic numbers with `net/http` constants #8127
+* [vtadmin-web] Move single-entity view components into subfolders #8202
+* [vtadmin] Ensure we log any errors when closing the tracer #8262
+## Other
 ### Build/CI
- * add vtctldclient to binary directory #7889 
+* add vtctldclient to binary directory #7889
 ### Cluster management
- * vttablet/tabletmanager: add isInSRVKeyspace/isShardServing #7929 
+* vttablet/tabletmanager: add isInSRVKeyspace/isShardServing #7929
 ### Other
- * Change VitessInputFormat key type #199
- * Online DDL plan via Send; "singleton" migrations on tablets #7785
- * flaky onlineddl tests: reduce -online_ddl_check_interval #7847
- * Looking into flaky endtoend upgrade test #7900
- * fixing flaky upgrade test #7901 
+* Change VitessInputFormat key type #199
+* Online DDL plan via Send; "singleton" migrations on tablets #7785
+* flaky onlineddl tests: reduce -online_ddl_check_interval #7847
+* Looking into flaky endtoend upgrade test #7900
+* fixing flaky upgrade test #7901
 ### Query Serving
- * Introduce Concatenated Fixed-width Composite or CFC vindex #7537
- * Add common tags for stats backends that support it #7651
- * Add support for showing global vgtid executed #7797
- * perf: vttablet/mysql optimizations #7800
- * Fix bug with reserved connections to stale tablets #7879
- * Memory Sort to close the goroutines when callback returns error  #7903
- * OnlineDDL: more migration check ticks upon migration start #7961
- * Update gh-ost binary to v1.1.3 #8021
- * VReplication Online DDL: fix classification of virtual columns #8043 
+* Introduce Concatenated Fixed-width Composite or CFC vindex #7537
+* Add common tags for stats backends that support it #7651
+* Add support for showing global vgtid executed #7797
+* perf: vttablet/mysql optimizations #7800
+* Fix bug with reserved connections to stale tablets #7879
+* Memory Sort to close the goroutines when callback returns error  #7903
+* OnlineDDL: more migration check ticks upon migration start #7961
+* Update gh-ost binary to v1.1.3 #8021
+* VReplication Online DDL: fix classification of virtual columns #8043
 ### VReplication
- * VReplicationErrors metric: use . as delimiter instead of _ to behave well with Prometheus #7807 
+* VReplicationErrors metric: use . as delimiter instead of _ to behave well with Prometheus #7807
 ### VTAdmin
- * Update `GetSchema` filtering to exclude shards where `IsMasterServing` but no `MasterAlias` #7805
- * [vtadmin-api] Reintroduce include_non_serving_shards opt to GetSchema #7814
- * [vtadmin-web] Add DataCell component #7817
- * Rewrite useTableDefinitions hook as getTableDefinitions util #7821
- * [vtadmin-web] Display (approximate) table sizes + row count on /schemas view #7826
- * [vtadmin-web] Add Pip + TabletServingPip components #7827
-## Performance 
+* Update `GetSchema` filtering to exclude shards where `IsMasterServing` but no `MasterAlias` #7805
+* [vtadmin-api] Reintroduce include_non_serving_shards opt to GetSchema #7814
+* [vtadmin-web] Add DataCell component #7817
+* Rewrite useTableDefinitions hook as getTableDefinitions util #7821
+* [vtadmin-web] Display (approximate) table sizes + row count on /schemas view #7826
+* [vtadmin-web] Add Pip + TabletServingPip components #7827
+## Performance
 ### Query Serving
- * vttablet: stream consolidation #7752
- * perf: optimize bind var generation #7828 
+* vttablet: stream consolidation #7752
+* perf: optimize bind var generation #7828
 ### VReplication
- * Optimize the catchup phases by filtering out rows which not within range of copied pks during inserts #7708
- * Ability to compress gtid when stored in _vt.vreplication's pos column #7877
- * Performance & benchmarks (table copying) #7881
- * Dynamic packet sizing #7933
- * perf: vreplication client CPU usage #7951
- * VDIff: fix performance regression introduced by progress logging  #8016
- * proto: Generate faster code using vtprotobuf #8173
- * proto: enable pooling for vreplication #8273
-## Testing 
+* Optimize the catchup phases by filtering out rows which not within range of copied pks during inserts #7708
+* Ability to compress gtid when stored in _vt.vreplication's pos column #7877
+* Performance & benchmarks (table copying) #7881
+* Dynamic packet sizing #7933
+* perf: vreplication client CPU usage #7951
+* VDIff: fix performance regression introduced by progress logging  #8016
+* proto: Generate faster code using vtprotobuf #8173
+* proto: enable pooling for vreplication #8273
+## Testing
 ### Build/CI
- * Attempt to fix TLS Server Flaky test #7842
- * TestMakeCommonTags Flaky Test: match elements  #7843
- * upgrade tests: test against v9.0.0 #7848
- * FOSSA scan added #7862
- * ci: fix all racy tests #7904
- * CI: Revert docker change for unit tests from #7868 #7940 
- * Add online ddl on start queries to schema list in vtexplain tablet #8397 
+* Attempt to fix TLS Server Flaky test #7842
+* TestMakeCommonTags Flaky Test: match elements  #7843
+* upgrade tests: test against v9.0.0 #7848
+* FOSSA scan added #7862
+* ci: fix all racy tests #7904
+* CI: Revert docker change for unit tests from #7868 #7940
+* Add online ddl on start queries to schema list in vtexplain tablet #8397
 ### Java
- * [Java] JDBC mysql driver test #8154 
+* [Java] JDBC mysql driver test #8154
 ### Other
- * Fuzzing: Fixup oss-fuzz build script #7782
- * Wrangler tests: Return a fake tablet in the wrangler test dialer to avoid tablet picker errors spamming the test logs #7863 
+* Fuzzing: Fixup oss-fuzz build script #7782
+* Wrangler tests: Return a fake tablet in the wrangler test dialer to avoid tablet picker errors spamming the test logs #7863
 ### Query Serving
- * clean up test #7816
- * tabletserver: fix flaky test #7851
- * Planbuilder: Add fuzzer #7902
- * mysql: Small adjustments to fuzzer #7907
- * vtgate/engine: Add fuzzer #7914
- * Adding Fuzzer Test Cases #8106
- * Addition of fuzzer issues #8195 
+* clean up test #7816
+* tabletserver: fix flaky test #7851
+* Planbuilder: Add fuzzer #7902
+* mysql: Small adjustments to fuzzer #7907
+* vtgate/engine: Add fuzzer #7914
+* Adding Fuzzer Test Cases #8106
+* Addition of fuzzer issues #8195
 ### VReplication
- * vstreamer: Add fuzzer #7918 
+* vstreamer: Add fuzzer #7918
 ### vttestserver
- * Speedup new vttestserver tests #8229
- * Vttestserver docker test #8253
+* Speedup new vttestserver tests #8229
+* Vttestserver docker test #8253
 ### Cluster management
- * Make timestamp authoritative for master information #8381
+* Make timestamp authoritative for master information #8381
 
 
 The release includes 1080 commits (excluding merges)

--- a/doc/releasenotes/11_0_1_release_notes.md
+++ b/doc/releasenotes/11_0_1_release_notes.md
@@ -1,27 +1,27 @@
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v11.0.1`, uses a version of Log4j below `2.16.0`, for this reason, we encourage you to use `v11.0.3` instead, which contains the patch for the vulnerability.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.1`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
 
 
 ## Bug fixes
- ### Cluster management
-  * Port #8422 to 11.0 branch #8744
- ### Query Serving
-  * Handle subquery merging with references correctly #8661
-  * onlineddl Executor: build schema with DBA user #8667
-  * Backport to 11: Fixing a panic in vtgate with OLAP mode #8746
-  * Backport into 11: default to primary tablet if not set in VStream api #8766
- ### VReplication
-  * Refresh SrvVSchema after an ExternalizeVindex: was missing #8669
- ## CI/Build
- ### Build/CI
-  * Vitess  Release 11.0.0 #8549
-  * Backport to 11: Updated Makefile do_release script to include godoc steps #8787
+### Cluster management
+* Port #8422 to 11.0 branch #8744
+### Query Serving
+* Handle subquery merging with references correctly #8661
+* onlineddl Executor: build schema with DBA user #8667
+* Backport to 11: Fixing a panic in vtgate with OLAP mode #8746
+* Backport into 11: default to primary tablet if not set in VStream api #8766
+### VReplication
+* Refresh SrvVSchema after an ExternalizeVindex: was missing #8669
+## CI/Build
+### Build/CI
+* Vitess  Release 11.0.0 #8549
+* Backport to 11: Updated Makefile do_release script to include godoc steps #8787
 
- The release includes 18 commits (excluding merges)
- Thanks to all our contributors: @aquarapid, @askdba, @frouioui, @harshit-gangal, @rohit-nayak-ps, @shlomi-noach, @systay
+The release includes 18 commits (excluding merges)
+Thanks to all our contributors: @aquarapid, @askdba, @frouioui, @harshit-gangal, @rohit-nayak-ps, @shlomi-noach, @systay

--- a/doc/releasenotes/11_0_2_release_notes.md
+++ b/doc/releasenotes/11_0_2_release_notes.md
@@ -5,12 +5,12 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v11.0.2`, uses a version of Log4j below `2.16.0`, for this reason, we encourage you to use `v11.0.3` instead, which contains the patch for the vulnerability.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.2`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
 
 ------------
 ## Changelog

--- a/doc/releasenotes/11_0_2_summary.md
+++ b/doc/releasenotes/11_0_2_summary.md
@@ -4,9 +4,9 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v11.0.2`, uses a version of Log4j below `2.16.0`, for this reason, we encourage you to use `v11.0.3` instead, which contains the patch for the vulnerability.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.2`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.

--- a/doc/releasenotes/11_0_3_release_notes.md
+++ b/doc/releasenotes/11_0_3_release_notes.md
@@ -5,7 +5,12 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.3`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
+
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
 
 ------------
 ## Changelog

--- a/doc/releasenotes/11_0_3_summary.md
+++ b/doc/releasenotes/11_0_3_summary.md
@@ -4,4 +4,9 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v11.0.3`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v11.0.4` instead, to benefit from the vulnerability patches.
+
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.

--- a/doc/releasenotes/11_0_4_release_notes.md
+++ b/doc/releasenotes/11_0_4_release_notes.md
@@ -7,7 +7,7 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 - An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
 
- ------------
+------------
 ## Changelog
 
 ### Dependabot

--- a/doc/releasenotes/11_0_4_release_notes.md
+++ b/doc/releasenotes/11_0_4_release_notes.md
@@ -1,0 +1,19 @@
+# Release of Vitess v11.0.4
+## Announcement
+
+This patch is providing an update regarding the Apache Log4j security vulnerability ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) (#9464).
+
+## Known Issues
+
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.
+
+ ------------
+## Changelog
+
+### Dependabot
+#### Java
+* build(deps): bump log4j-api from 2.16.0 to 2.17.1 in /java #9464
+
+The release includes 6 commits (excluding merges)
+
+Thanks to all our contributors: @dbussink, @frouioui

--- a/doc/releasenotes/11_0_4_summary.md
+++ b/doc/releasenotes/11_0_4_summary.md
@@ -1,0 +1,7 @@
+## Announcement
+
+This patch is providing an update regarding the Apache Log4j security vulnerability ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) (#9464).
+
+## Known Issues
+
+- An issue where the value of the `-force` flag is used instead of `-keep_data` flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174.

--- a/doc/releasenotes/12_0_0_release_notes.md
+++ b/doc/releasenotes/12_0_0_release_notes.md
@@ -4,51 +4,82 @@
 This release includes the following major changes or new features.
 
 ### Inclusive Naming
-A number of commands and RPCs have been deprecated as we move from `master` to `primary`.
+A number of CLI commands and vttablet RPCs have been deprecated as we move from `master` to `primary`.
 All functionality is backwards compatible except as noted under Incompatible Changes.
+**Deprecated commands and flags will be removed in the next release (13.0).
+Deprecated vttablet RPCs will be removed in the subsequent release (14.0).**
 
 ### Gen4 Planner
-
 The newest version of the query planner, `Gen4`, becomes an experimental feature as part of this release.
 While `Gen4` has been under development for a few release cycles, we have now reached parity with its predecessor, `v3`.
 
-To use `Gen4`, VTGate's `-planner_version` flag needs to be set to `gen4`.
+To use `Gen4`, VTGate's `-planner_version` flag needs to be set to `Gen4Fallback`.
+
+### Query Buffering during failovers
+In order to support buffering during resharding cutovers in addition to primary failovers, a new implementation
+of query buffering has been added.
+This is considered experimental. To enable it the flag `buffer_implementation` should be set to `keyspace_events`.
+The existing implementation (flag value `healthcheck`) will be deprecated in a future release.
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v12.0.0`, uses a version of Log4j below `2.16.0`, for this reason we encourage you to use `v12.0.2` instead, which contains the patch for the vulnerability.
+- A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  CVE-2021-45046 and CVE-2021-44832 followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.0`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174), has been fixed in release `>= v12.0.1`.
+- An issue where the value of the -force flag is used instead of -keep_data flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174. This issue is fixed in release >= `v12.0.1`.
 
 ## Incompatible Changes
 
-### vtctl command output
-Wherever vtctl commands produced `master` or `MASTER` for tablet type, they now produce `primary` or `PRIMARY`.
+### CLI command output
+Wherever CLI commands produced `master` or `MASTER` for tablet type, they now produce `primary` or `PRIMARY`.
 Scripts and tools that depend on parsing command output will need to change.
 
 Example:
 ```sh
-$ vtctlclient -server localhost:15999 ListAllTablets
+$ vtctlclient -server localhost:15999 ListAllTablets 
 zone1-0000000100 sourcekeyspace 0 primary 192.168.0.134:15100 192.168.0.134:17100 [] 2021-09-24T01:12:00Z
 zone1-0000000101 sourcekeyspace 0 rdonly 192.168.0.134:15101 192.168.0.134:17101 [] <null>
 zone1-0000000102 sourcekeyspace 0 replica 192.168.0.134:15102 192.168.0.134:17102 [] <null>
 zone1-0000000103 sourcekeyspace 0 rdonly 192.168.0.134:15103 192.168.0.134:17103 [] <null>
 ```
 
+## Default Behaviour Changes
+
+### Enabling reserved connections
+Use of reserved connections is controlled by the vtgate flag `-enable_system_settings`. This flag has in the past defaulted to `false` (or `OFF`) in release versions (i.e. x.0 and x.0.y) of Vitess, and to `true` (or `ON`) in development versions.
+
+From Vitess 12.0.0 onwards, it defaults to ***true*** in all release and development versions. You can read more about this [here](https://github.com/vitessio/vitess/issues/9125). Hence you should specify this flag explicitly, so that you are sure whether it is enabled or not, regardless of which Vitess release/build/version you are running.
+
+If you have reserved connections disabled, you will get the ***old*** Vitess behavior: where most system settings (e.g. `sql_mode`) are just silently ignored by Vitess. In situations where you know your backend MySQL defaults are acceptable, this may be the correct setting to ensure the best possible performance of the vttablet <-> MySQL connection pools. This comes down to a trade-off between compatibility and performance/scalability. You should also review [this section](https://vitess.io/docs/reference/query-serving/reserved-conn/#number-of-vttablet---mysql-connections) of the documentation when deciding whether or not to enable reserved connections.
+
 ## Deprecations
 
-The command `vtctl VExec` is deprecated and removed. All Online DDL commands should run through `vtctl OnlineDDL`.
+### CLI commands
+`VExec` is deprecated and removed. All Online DDL commands should be run through `OnlineDDL`.
 
-The command `vtctl OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `vtctl ApplySchema` or via `vtgate`.
+`OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION '...'` SQL command either via `ApplySchema` or via `vtgate`.
 
+`InitShardMaster` is deprecated, use `InitShardPrimary` instead.
+
+`SetShardIsMasterServing` is deprecated, use `SetShardIsPrimaryServing` instead.
+
+Various command flags have been deprecated and new variants provided.
+* `DeleteTablet` flag `allow_master` replaced with `allow_primary`
+* `PlannedReparentShard` flag `avoid_master` replaced with `avoid_tablet`
+* `PlannedReparentShard` flag `new_master` replaced with `new_primary`
+* `BackupShard` flag `allow_master` replaced with `allow_primary`
+* `Backup` flag `allow_master` replaced with `allow_primary`
+* `EmergencyReparentShard` flag `new_master` replaced with `new_primary`
+* `ReloadSchemeShard` flag `include_master` replaced with `include_primary`
+* `ReloadSchemaKeyspace` flag `include_master` replaced with `include_primary`
+* `ValidateSchemaKeyspace` flag `skip-no-master` replaced with `skip-no-primary`
 
 ## Minor Changes
 
 ### Query Serving
-* Add `SHOW VITESS_REPLICATION_STATUS` Query Support #8900 
+* Add `SHOW VITESS_REPLICATION_STATUS` Query Support #8900
   * The new `SHOW VITESS_REPLICATION_STATUS` command/query shows the MySQL replica/replication (not `vreplication`) health for the vitess deployment.
 
 ## Governance
@@ -59,245 +90,245 @@ The command `vtctl OnlineDDL revert` is deprecated. Use `REVERT VITESS_MIGRATION
 
 ### Bug fixes
 #### Build/CI
- * Update golang/x dependencies #8688
- * tests: use AtomicInt32 instead of int to fix races #8696
+* Update golang/x dependencies #8688
+* tests: use AtomicInt32 instead of int to fix races #8696
 #### Cluster management
- * Use consul lock properly #8310
- * Trivial: mysqlctl reinit_config -h  was not showing help #8369
- * Port #8422 to main branch #8745
- * [vtctl] Add missing call to `flag.Parse` in `commandGetRoutingRules` #8795
- * Fix for padding in OrderAndCheckPartitions  #8873
- * tabletmanager: correct implementations of deprecated RPCs for backwards compatibility #9059
+* Use consul lock properly #8310
+* Trivial: mysqlctl reinit_config -h  was not showing help #8369
+* Port #8422 to main branch #8745
+* [vtctl] Add missing call to `flag.Parse` in `commandGetRoutingRules` #8795
+* Fix for padding in OrderAndCheckPartitions  #8873
+* tabletmanager: correct implementations of deprecated RPCs for backwards compatibility #9059
 #### General
- * Avoid some pollution of CLI argument namespace across vtgate and vttablet #9026
+* Avoid some pollution of CLI argument namespace across vtgate and vttablet #9026
 #### Observability
- * schema engine: reset table size stats when a table is dropped #8634
+* schema engine: reset table size stats when a table is dropped #8634
 #### Query Serving
- * Fix for function calls in DEFAULT value of CREATE TABLE statement in main #8477
- * Fixing multiple issues related to onlineddl/lifecycle #8500
- * boolean values should not be parenthesised in default clause #8502
- * mysql/server: abort connection if secure transport is required #8504
- * Clear only the current shard's schemacopy rows  during schema reload #8519
- * go/mysql/auth: fix error message for wrong auth method. #8525
- * Fix handshake protocol with MySQL client #8537
- * Copy parameter data from byte buffer in COM_STMT_SEND_LONG_DATA #8562
- * Negative float default #8587
- * [vtexplain] prevent panic on show tables/show full tables #8601
- * OnlineDDL: better scheduling/cancellation logic #8603
- * Fix parsing of FIRST clause in ALTER TABLE #8614
- * onlineddl Executor: build schema with DBA user #8624
- * Handle subquery merging with references correctly #8662
- * Fixing error on deletes from owning table for a lookup being populated by CreateLookupVindex after a SwitchWrites #8701
- * Fixing a panic in vtgate with OLAP mode #8722
- * default to primary tablet if not set in VStream api #8755
- * Fix bug in parsing of version comments #8770
- * Proper merge of the SysTableTableName fields when joining two routes #8771
- * fix parsing of MySQL Server Version flag #8791
- * Fix typo in pool config syntax.  Fixes #8819 #8820
- * VtGate schema tracker to use provided user #8857
- * fix merging dba query as a subquery both in v3 and gen4 #8871
- * sql_select_limit support #9027
- * [12.0] Handle sql_mode setting to compare modes in any order #9041
- * [12.0] Fix for schema tracker not recognizing RENAME for schema reloading #9043
- * [12.0] Fix savepoint support with reserved connections #9047
- * [12.0] Gen4: Handle single column vindex correctly with multi column #9061
+* Fix for function calls in DEFAULT value of CREATE TABLE statement in main #8477
+* Fixing multiple issues related to onlineddl/lifecycle #8500
+* boolean values should not be parenthesised in default clause #8502
+* mysql/server: abort connection if secure transport is required #8504
+* Clear only the current shard's schemacopy rows  during schema reload #8519
+* go/mysql/auth: fix error message for wrong auth method. #8525
+* Fix handshake protocol with MySQL client #8537
+* Copy parameter data from byte buffer in COM_STMT_SEND_LONG_DATA #8562
+* Negative float default #8587
+* [vtexplain] prevent panic on show tables/show full tables #8601
+* OnlineDDL: better scheduling/cancellation logic #8603
+* Fix parsing of FIRST clause in ALTER TABLE #8614
+* onlineddl Executor: build schema with DBA user #8624
+* Handle subquery merging with references correctly #8662
+* Fixing error on deletes from owning table for a lookup being populated by CreateLookupVindex after a SwitchWrites #8701
+* Fixing a panic in vtgate with OLAP mode #8722
+* default to primary tablet if not set in VStream api #8755
+* Fix bug in parsing of version comments #8770
+* Proper merge of the SysTableTableName fields when joining two routes #8771
+* fix parsing of MySQL Server Version flag #8791
+* Fix typo in pool config syntax.  Fixes #8819 #8820
+* VtGate schema tracker to use provided user #8857
+* fix merging dba query as a subquery both in v3 and gen4 #8871
+* sql_select_limit support #9027
+* [12.0] Handle sql_mode setting to compare modes in any order #9041
+* [12.0] Fix for schema tracker not recognizing RENAME for schema reloading #9043
+* [12.0] Fix savepoint support with reserved connections #9047
+* [12.0] Gen4: Handle single column vindex correctly with multi column #9061
 #### VReplication
- * MoveTables: don't create unnecessary streams on the target for non-intersecting sources and targets #8090
- * VDiff: Add BIT datatype to list of byte comparable types #8401
- * Fix vreplication error metric #8483
- * Return from throttler goroutine if context is cancelled to prevent goroutine leaks #8489
- * Fix VReplication logging to file and db #8521
- * Fix passing the wrong cell/cells variable to CreateLookupVindex #8590
- * Refresh SrvVSchema after an ExternalizeVindex: was missing #8670
- * Fixing missing argument in function call #8692
- * Fix how we identify MySQL generated columns #8763
+* MoveTables: don't create unnecessary streams on the target for non-intersecting sources and targets #8090
+* VDiff: Add BIT datatype to list of byte comparable types #8401
+* Fix vreplication error metric #8483
+* Return from throttler goroutine if context is cancelled to prevent goroutine leaks #8489
+* Fix VReplication logging to file and db #8521
+* Fix passing the wrong cell/cells variable to CreateLookupVindex #8590
+* Refresh SrvVSchema after an ExternalizeVindex: was missing #8670
+* Fixing missing argument in function call #8692
+* Fix how we identify MySQL generated columns #8763
 #### VTAdmin
- * [vtadmin-web] Set Backup status indicators to the correct colours  #8410
- * [vtadmin] Fix bad copy-paste in pool config flag parsing #8518
+* [vtadmin-web] Set Backup status indicators to the correct colours  #8410
+* [vtadmin] Fix bad copy-paste in pool config flag parsing #8518
 #### vtctl
- * Print actual current datetime for vtctl dry run commands #8778
+* Print actual current datetime for vtctl dry run commands #8778
 #### vttestserver
- * Remove lingering mysqld sock files on vttestserver container startup #8463
- * Fixed filename for the configuration file in Vttestserver #8809
+* Remove lingering mysqld sock files on vttestserver container startup #8463
+* Fixed filename for the configuration file in Vttestserver #8809
 ### CI/Build
 #### Build/CI
- * Update release process #7759
- * [ci] Add `errcheck` to golangci-lint #7996
- * gomod: do not replace GRPC #8416
- * consolidation: Fix flaky test #8417
- * Small build improvements #8418
- * proto: upgrade vtprotobuf version #8454
- * Automatically use the latest tag of Vitess for cluster upgrade E2E test #8471
- * Addition of known issues to release notes #8482
- * Fix Cluster 14 flakiness #8494
- * add question on backporting back to PR template #8541
- * Enable GitHub Actions concurrency feature #8546
- * Updated Makefile do_release script to include godoc steps #8550
- * Changing codahale/hdrhistogram import path #8637
- * Upgrade to Go 1.17 #8640
- * Fixes for reparent endtoend test flakiness #8642
- * hooks: remove govet because it already runs as part of golangci-lint #8674
- * Enhancement of the release instructions #8790
- * Remove consul-api usage in favor of official consul/api #8794
- * Enhancement of the release notes generation #8877
+* Update release process #7759
+* [ci] Add `errcheck` to golangci-lint #7996
+* gomod: do not replace GRPC #8416
+* consolidation: Fix flaky test #8417
+* Small build improvements #8418
+* proto: upgrade vtprotobuf version #8454
+* Automatically use the latest tag of Vitess for cluster upgrade E2E test #8471
+* Addition of known issues to release notes #8482
+* Fix Cluster 14 flakiness #8494
+* add question on backporting back to PR template #8541
+* Enable GitHub Actions concurrency feature #8546
+* Updated Makefile do_release script to include godoc steps #8550
+* Changing codahale/hdrhistogram import path #8637
+* Upgrade to Go 1.17 #8640
+* Fixes for reparent endtoend test flakiness #8642
+* hooks: remove govet because it already runs as part of golangci-lint #8674
+* Enhancement of the release instructions #8790
+* Remove consul-api usage in favor of official consul/api #8794
+* Enhancement of the release notes generation #8877
 #### Governance
- * update MAINTAINERS and CODEOWNERS for deepthi, pH14 and vmg #8675
+* update MAINTAINERS and CODEOWNERS for deepthi, pH14 and vmg #8675
 #### Query Serving
- * Cleanup: import of gh-ost test suite is complete #8459
+* Cleanup: import of gh-ost test suite is complete #8459
 #### VReplication
- * VReplication support for non-PRIMARY KEY (Online DDL context) #8364
+* VReplication support for non-PRIMARY KEY (Online DDL context) #8364
 ### Documentation
 #### Build/CI
- * maintainers: add Messaging as area of expertise #8578
+* maintainers: add Messaging as area of expertise #8578
 #### Cluster management
- * Enhance k8stopo flag documentation  #8464
- * Update some vtctl/vtctlclient command help #8560
- * Trivial:  fix the GenerateShardRanges vtctl[client] help #8586
+* Enhance k8stopo flag documentation  #8464
+* Update some vtctl/vtctlclient command help #8560
+* Trivial:  fix the GenerateShardRanges vtctl[client] help #8586
 #### Examples
- * examples: update README to use new vreplication command syntax #8825
+* examples: update README to use new vreplication command syntax #8825
 #### Governance
- * update governance #8609
+* update governance #8609
 #### Query Serving
- * vtexplain examples #8652
+* vtexplain examples #8652
 #### VReplication
- * vtctl help/usage update #8879
+* vtctl help/usage update #8879
 #### VTAdmin
- * [vtadmin] Remove outdated commands from vtadmin-web README #8496
- * Initial pass at some vtadmin docs #8526
+* [vtadmin] Remove outdated commands from vtadmin-web README #8496
+* Initial pass at some vtadmin docs #8526
 ### Enhancement
 #### Backup and Restore
- * Add Support for Restoring Specific Backups #8824
+* Add Support for Restoring Specific Backups #8824
 #### Build/CI
- * Initial support for stress testing in end-to-end tests #8406
- * CI: Remove mariadb101 which is well past eol and no longer available in distributions #8446
- * Adding GitHub Self Hosted Runner tests #8721
+* Initial support for stress testing in end-to-end tests #8406
+* CI: Remove mariadb101 which is well past eol and no longer available in distributions #8446
+* Adding GitHub Self Hosted Runner tests #8721
 #### Cluster management
- * Vitess mixin improvements #7499
- * Expose topo_consul_lock_session_checks to allow customized consul session check #8298
- * Handle lock release with SIGHUP in VTGR #8472
- * Enhance PRS error message #8529
- * srvtopo: resilient watcher #8583
- * Add `-restart_before_backup` parameter for vtbackup #8608
- * srvtopo: allow unwatching from watch callbacks #8633
- * introduced cluster_operation as a new error code in vtrpc #8646
- * servenv: add `--onclose_timeout` flag #8651
- * Improve determinism of bootstrap #8840
- * OnlineDDL in v12: remove legacy code deprecated in earlier version #8972
+* Vitess mixin improvements #7499
+* Expose topo_consul_lock_session_checks to allow customized consul session check #8298
+* Handle lock release with SIGHUP in VTGR #8472
+* Enhance PRS error message #8529
+* srvtopo: resilient watcher #8583
+* Add `-restart_before_backup` parameter for vtbackup #8608
+* srvtopo: allow unwatching from watch callbacks #8633
+* introduced cluster_operation as a new error code in vtrpc #8646
+* servenv: add `--onclose_timeout` flag #8651
+* Improve determinism of bootstrap #8840
+* OnlineDDL in v12: remove legacy code deprecated in earlier version #8972
 #### Observability
- * [vtadmin] cluster debug pages #8427
- * Export memstats for statsd backend #8777
+* [vtadmin] cluster debug pages #8427
+* Export memstats for statsd backend #8777
 #### Query Serving
- * [tablet, queryrules] Extend query rules to check comments #8233
- * Add "show global status" support #8344
- * added batch lookup param to lookup vindex #8398
- * Online DDL/VReplication: able to read from replica #8405
- * multishard autocommit should work for bypass routing #8428
- * Add "no-scatter" flag to prohibit the use of scatter queries #8439
- * OnlineDDL: -skip-topo is always 'true' #8450
- * Add `rows` as keyword in sqlparser #8467
- * Periodic update of gh-ost binary #8470
- * fix when show tables record too much error log "Got unhandled packet.." #8478
- * SHOW VITESS_MIGRATION '...' LOGS, retain logs for 24 hours #8493
- * NativeDDL: analyzing added&removed unique keys #8495
- * Refactor authentication server plugin mechanism #8503
- * Update to planetscale/tengo v0.10.1-ps.v4 #8516
- * query serving to continue when topo server restarts - main #8534
- * support grpc reflection on APIs #8551
- * Customized CreateLookUpVindex to be Compatible with non-consistent Lookup Vindex #8570
- * Add additional options for configuring SSL modes as a client #8588
- * Fail plan for unsupported aggregate function #8593
- * gateway: use keyspace events when buffering requests #8700
- * Add optional query annotations, i.e. prefix SQL comments indicating the #8783
- * Slight improvement of the ACL error message #8805
- * Changed parsing for unions #8821
- * Use vt_dba user for online schema migration cutover phase #8836
- * Add parsing support for column list with subquery alias #8884
- * Add planner-version flag to vtexplain #8979
- * [Backport 12.0]: Add planner-version flag to vtexplain #9003
+* [tablet, queryrules] Extend query rules to check comments #8233
+* Add "show global status" support #8344
+* added batch lookup param to lookup vindex #8398
+* Online DDL/VReplication: able to read from replica #8405
+* multishard autocommit should work for bypass routing #8428
+* Add "no-scatter" flag to prohibit the use of scatter queries #8439
+* OnlineDDL: -skip-topo is always 'true' #8450
+* Add `rows` as keyword in sqlparser #8467
+* Periodic update of gh-ost binary #8470
+* fix when show tables record too much error log "Got unhandled packet.." #8478
+* SHOW VITESS_MIGRATION '...' LOGS, retain logs for 24 hours #8493
+* NativeDDL: analyzing added&removed unique keys #8495
+* Refactor authentication server plugin mechanism #8503
+* Update to planetscale/tengo v0.10.1-ps.v4 #8516
+* query serving to continue when topo server restarts - main #8534
+* support grpc reflection on APIs #8551
+* Customized CreateLookUpVindex to be Compatible with non-consistent Lookup Vindex #8570
+* Add additional options for configuring SSL modes as a client #8588
+* Fail plan for unsupported aggregate function #8593
+* gateway: use keyspace events when buffering requests #8700
+* Add optional query annotations, i.e. prefix SQL comments indicating the #8783
+* Slight improvement of the ACL error message #8805
+* Changed parsing for unions #8821
+* Use vt_dba user for online schema migration cutover phase #8836
+* Add parsing support for column list with subquery alias #8884
+* Add planner-version flag to vtexplain #8979
+* [Backport 12.0]: Add planner-version flag to vtexplain #9003
 #### TabletManager
- * Allow min TLS version for tablet to mysqld conns #8757
+* Allow min TLS version for tablet to mysqld conns #8757
 #### VReplication
- * VReplication: Add ability to tag workflows #8388
- * Ignore SBR statements from pt-table-checksum #8396
- * Tablet Picker: add metric to record lack of available tablets #8403
- * VReplication: support different keys on source and target tables (different covered columns) #8423
- * VStream API: handle reparenting and unhealthy tablets #8445
- * Change local example to use v2 vreplication flows and change default to v2 from v1 #8553
- * Customized CreateLookUpVindex to Include a Flag to Continue Vreplication After Backfill with an Owner Provided #8572
- * Update MoveTables CLI help to reflect change we made at the beginning of #8597
- * VStreamer Field/Row Events: add Keyspace/Shard #8598
- * VStream API: Add flag to stop streaming on a reshard #8628
+* VReplication: Add ability to tag workflows #8388
+* Ignore SBR statements from pt-table-checksum #8396
+* Tablet Picker: add metric to record lack of available tablets #8403
+* VReplication: support different keys on source and target tables (different covered columns) #8423
+* VStream API: handle reparenting and unhealthy tablets #8445
+* Change local example to use v2 vreplication flows and change default to v2 from v1 #8553
+* Customized CreateLookUpVindex to Include a Flag to Continue Vreplication After Backfill with an Owner Provided #8572
+* Update MoveTables CLI help to reflect change we made at the beginning of #8597
+* VStreamer Field/Row Events: add Keyspace/Shard #8598
+* VStream API: Add flag to stop streaming on a reshard #8628
 #### VTAdmin
- * [vtadmin] cluster rpc pools #8421
- * Add support for passing custom interceptors to vtadmin grpcserver #8507
+* [vtadmin] cluster rpc pools #8421
+* Add support for passing custom interceptors to vtadmin grpcserver #8507
 ### Feature Request
 #### Cluster management
- * [vtctldserver] Migrate remaining ServingGraph rpcs to VtctldServer #8249
- * [grpctmclient] Add support for (bounded) per-host connection reuse #8368
- * VTGR: Vitess + MySQL group replication #8387
- * Add isActive flag to vtgr to support multi-cell topology #8780
- * [vtctld] Add `SetWritable`, `StartReplication` and `StopReplication` rpcs #8816
- * [vtctld] sleep/ping tablets #8826
- * [vtctld] migrate more util rpcs #8843
- * [vtctld] migrate validator rpcs #8849
- * [vtctld] localvtctldclient #8882
- * [vtctldserver] Migrate RunHealthCheck #8892
- * [vtctl] run new commands as standalone binary #8893
+* [vtctldserver] Migrate remaining ServingGraph rpcs to VtctldServer #8249
+* [grpctmclient] Add support for (bounded) per-host connection reuse #8368
+* VTGR: Vitess + MySQL group replication #8387
+* Add isActive flag to vtgr to support multi-cell topology #8780
+* [vtctld] Add `SetWritable`, `StartReplication` and `StopReplication` rpcs #8816
+* [vtctld] sleep/ping tablets #8826
+* [vtctld] migrate more util rpcs #8843
+* [vtctld] migrate validator rpcs #8849
+* [vtctld] localvtctldclient #8882
+* [vtctldserver] Migrate RunHealthCheck #8892
+* [vtctl] run new commands as standalone binary #8893
 #### VTAdmin
- * [vtadmin] [experimental] add per-api RBAC implementation #8515
- * [vtadmin] shard replication positions #8775
- * [vtadmin] GetVtctlds #8792
+* [vtadmin] [experimental] add per-api RBAC implementation #8515
+* [vtadmin] shard replication positions #8775
+* [vtadmin] GetVtctlds #8792
 ### Internal Cleanup
 #### Build/CI
- * Bump aws-sdk-go to v1.34.2 #8632
- * Upgrade consul api: `go get github.com/hashicorp/consul/api@v1.10.1` #8784
+* Bump aws-sdk-go to v1.34.2 #8632
+* Upgrade consul api: `go get github.com/hashicorp/consul/api@v1.10.1` #8784
 #### Cluster management
- * topodata: remove deprecated field 'ServedTypes' #8566
- * Upgrade to k8s 1.18 client #8762
- * [vtctl] command deprecations #8967
+* topodata: remove deprecated field 'ServedTypes' #8566
+* Upgrade to k8s 1.18 client #8762
+* [vtctl] command deprecations #8967
 #### Deployments
- * Remove the deprecated Helm charts and related code #8868
+* Remove the deprecated Helm charts and related code #8868
 #### Examples
- * Bump ini from 1.3.5 to 1.3.8 in /vitess-mixin/e2e #8823
- * backport operator updates to v12 branch . #9057
+* Bump ini from 1.3.5 to 1.3.8 in /vitess-mixin/e2e #8823
+* backport operator updates to v12 branch . #9057
 #### General
- * Migrate k8s topo CRD to v1 api (v12 branch) #9046
+* Migrate k8s topo CRD to v1 api (v12 branch) #9046
 #### Governance
- * fix copyright #8611
+* fix copyright #8611
 #### Query Serving
- * Adds flag to vttablet to disallow online DDL statements #8433
- * Remove vtrpc.LegacyErrorCode #8456
- * Allow for configuration of the minimal TLS version #8460
- * engine: allow retrying partial primitives #8727
- * srvtopo: expose WatchSrvKeyspace #8752
- * Clean up Primitive interface implementations #8901
+* Adds flag to vttablet to disallow online DDL statements #8433
+* Remove vtrpc.LegacyErrorCode #8456
+* Allow for configuration of the minimal TLS version #8460
+* engine: allow retrying partial primitives #8727
+* srvtopo: expose WatchSrvKeyspace #8752
+* Clean up Primitive interface implementations #8901
 #### VReplication
- * LegacySplitCloneWorker is no longer used in any code paths #8867
+* LegacySplitCloneWorker is no longer used in any code paths #8867
 #### VTAdmin
- * [vtadmin] Add Options struct to wrap grpc/http options #8461
- * Update vtadmin local scripts to enable basic rbac #8801
+* [vtadmin] Add Options struct to wrap grpc/http options #8461
+* Update vtadmin local scripts to enable basic rbac #8801
 #### vtctl
- * Correctly identify backup timestamp var as a string #8891
+* Correctly identify backup timestamp var as a string #8891
 ### Other
 #### Examples
- * Improve the Docker local and compose examples #8685
+* Improve the Docker local and compose examples #8685
 ### Performance
 #### Cluster management
- * throttler: don't allocate any resources unless it is actually enabled #8643
+* throttler: don't allocate any resources unless it is actually enabled #8643
 #### Query Serving
- * cache: track memory usage more closely #8804
+* cache: track memory usage more closely #8804
 #### VTAdmin
- * Use `fmt.Fprintf` instead of `fmt.Sprintf` #8922
+* Use `fmt.Fprintf` instead of `fmt.Sprintf` #8922
 ### Testing
 #### Cluster management
- * Alter tests to reuse cluster components #8276
- * Adds some more orchestrator tests to vtorc #8535
+* Alter tests to reuse cluster components #8276
+* Adds some more orchestrator tests to vtorc #8535
 #### Query Serving
- * increase conn killer check to double the tx timeout value #8649
- * Added UNION testcases and auxilary code for running tests #8797
- * fixed regression in v3 for grouping by integer functions #8856
+* increase conn killer check to double the tx timeout value #8649
+* Added UNION testcases and auxilary code for running tests #8797
+* fixed regression in v3 for grouping by integer functions #8856
 #### VTAdmin
- * [vtadmin] Add a vtctld Dialer unit test #8455
+* [vtadmin] Add a vtctld Dialer unit test #8455
 
 
 The release includes 1351 commits (excluding merges)

--- a/doc/releasenotes/12_0_0_summary.md
+++ b/doc/releasenotes/12_0_0_summary.md
@@ -23,12 +23,12 @@ The existing implementation (flag value `healthcheck`) will be deprecated in a f
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v12.0.0`, uses a version of Log4j below `2.16.0`, for this reason we encourage you to use `v12.0.2` instead, which contains the patch for the vulnerability.
+- A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  CVE-2021-45046 and CVE-2021-44832 followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.0`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.
 
-- An issue related to `-keep_data` being ignored in v2 vreplication workflows (#9174), has been fixed in release `>= v12.0.1`.
+- An issue where the value of the -force flag is used instead of -keep_data flag's value in v2 vreplication workflows (#9174) is known to be present in this release. A workaround is available in the description of issue #9174. This issue is fixed in release >= `v12.0.1`.
 
 ## Incompatible Changes
 

--- a/doc/releasenotes/12_0_1_release_notes.md
+++ b/doc/releasenotes/12_0_1_release_notes.md
@@ -6,10 +6,10 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v12.0.1`, contains the initial patch by upgrading Log4j to `2.15.0`, we encourage you to use `v12.0.2` instead, which contains the latest patch for the vulnerability.
+* A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  CVE-2021-45046 and CVE-2021-44832 followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.1`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.
 
 ------------
 ## Changelog
@@ -26,7 +26,7 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 * Take MySQL Column Type Into Account in VStreamer #9355
 #### Cluster management
 * Restoring 'vtctl VExec' command #9227
-    * This change restores vtctl VExec functionality. It was removed based on the assumption the only uses for this command were for Online DDL command. This was wrong, and VExec is also used as a wrapper around VReplication.
+  * This change restores vtctl VExec functionality. It was removed based on the assumption the only uses for this command were for Online DDL command. This was wrong, and VExec is also used as a wrapper around VReplication.
 
 ### CI/Build
 #### Build/CI

--- a/doc/releasenotes/12_0_1_summary.md
+++ b/doc/releasenotes/12_0_1_summary.md
@@ -4,7 +4,7 @@ This patch is providing an update regarding the Apache Log4j security vulnerabil
 
 ## Known Issues
 
-- A critical vulnerability [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in the Apache Log4j logging library was disclosed on Dec 9.
-  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and an additional CVE
-  [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) followed.
-  This has been fixed in release `2.16.0`. This release, `v12.0.1`, contains the initial patch by upgrading Log4j to `2.15.0`, we encourage you to use `v12.0.2` instead, which contains the latest patch for the vulnerability.
+* A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs
+  CVE-2021-45046 and CVE-2021-44832 followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.1`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.

--- a/doc/releasenotes/12_0_2_release_notes.md
+++ b/doc/releasenotes/12_0_2_release_notes.md
@@ -3,6 +3,12 @@
 
 This patch is providing an update regarding the Apache Log4j security vulnerability (CVE-2021-45046) (#9396).
 
+## Known Issues
+
+* A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs (CVE-2021-45046 and CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.2`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.
+
  ------------
 ## Changelog
 

--- a/doc/releasenotes/12_0_2_summary.md
+++ b/doc/releasenotes/12_0_2_summary.md
@@ -1,3 +1,9 @@
 ## Major Changes
 
 This patch is providing an update regarding the Apache Log4j security vulnerability (CVE-2021-45046) (#9396).
+
+## Known Issues
+
+* A critical vulnerability CVE-2021-44228 in the Apache Log4j logging library was disclosed on Dec 9 2021.
+  The project provided release `2.15.0` with a patch that mitigates the impact of this CVE. It was quickly found that the initial patch was insufficient, and additional CVEs (CVE-2021-45046 and CVE-2021-44832) followed.
+  These have been fixed in release `2.17.1`. This release of Vitess, `v12.0.2`, uses a version of Log4j below `2.17.1`, for this reason, we encourage you to use version `v12.0.3` instead, to benefit from the vulnerability patches.

--- a/doc/releasenotes/12_0_3_release_notes.md
+++ b/doc/releasenotes/12_0_3_release_notes.md
@@ -1,0 +1,16 @@
+# Release of Vitess v12.0.3
+## Announcement
+
+This patch is providing an update regarding the Apache Log4j security vulnerability ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) (#9465).
+
+ ------------
+## Changelog
+
+### Dependabot
+#### Java
+* build(deps): bump log4j-api from 2.16.0 to 2.17.1 in /java #9465
+
+
+The release includes 4 commits (excluding merges)
+
+Thanks to all our contributors: @dbussink, @frouioui

--- a/doc/releasenotes/12_0_3_summary.md
+++ b/doc/releasenotes/12_0_3_summary.md
@@ -1,0 +1,3 @@
+## Major Changes
+
+This patch is providing an update regarding the Apache Log4j security vulnerability ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) (#9465).


### PR DESCRIPTION
## Description

This pull request follows the release of `v11.0.4` and `v12.0.3`. The release notes related to these releases are added to `main` through this pull request.

`v10.0.5`'s notes are not included in this pull request. An older pull request (https://github.com/vitessio/vitess/pull/9472) is already taking care of updating all `v10.0.*` release notes on main.

All the previous release notes for `11.0` and `12.0` were updated through this pull request to mirror what's written on both the releases page and the corresponding release branches.

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required
