### PR TITLE
Add stats to track when a pool's waiter queue is full

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -242,9 +242,7 @@ func (cp *Pool) StatsJSON() string {
 	if closingBraceIndex == -1 { // unexpected...
 		return res
 	}
-	res = res[:closingBraceIndex]
-	res += fmt.Sprintf(`, "WaiterQueueFull": %v}`, cp.waiterQueueFull.Get())
-	return res
+	return fmt.Sprintf(`%s, "WaiterQueueFull": %v}`, res[:closingBraceIndex], cp.waiterQueueFull.Get())
 }
 
 // Capacity returns the pool capacity.

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -17,7 +17,9 @@ limitations under the License.
 package connpool
 
 import (
+	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -235,7 +237,14 @@ func (cp *Pool) StatsJSON() string {
 	if p == nil {
 		return "{}"
 	}
-	return p.StatsJSON()
+	res := p.StatsJSON()
+	closingBraceIndex := strings.LastIndex(res, "}")
+	if closingBraceIndex == -1 { // unexpected...
+		return res
+	}
+	res = res[:closingBraceIndex]
+	res += fmt.Sprintf(`, "WaiterQueueFull": %v}`, cp.waiterQueueFull.Get())
+	return res
 }
 
 // Capacity returns the pool capacity.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Stats should be available at the tablet's `/debug/vars` page

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Follow-up to: https://github.com/vitessio/vitess/pull/9484

## Checklist
- [x] Should this PR be backported? No
- [x] Tests are not required
- [x] Documentation is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->