### PR TITLE
Fuzzing: Add native go fuzzers

### DIFF
--- a/go/test/fuzzing/nativefuzzing/ast_fuzzer_test.go
+++ b/go/test/fuzzing/nativefuzzing/ast_fuzzer_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nativefuzzing
+
+import (
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"testing"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func FuzzEqualsSQLNode(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) < 10 {
+			return
+		}
+		f := fuzz.NewConsumer(data)
+		query1, err := f.GetSQLString()
+		if err != nil {
+			return
+		}
+		query2, err := f.GetSQLString()
+		if err != nil {
+			return
+		}
+		inA, err := sqlparser.Parse(query1)
+		if err != nil {
+			return
+		}
+		inB, err := sqlparser.Parse(query2)
+		if err != nil {
+			return
+		}
+
+		// There are 3 targets in this fuzzer:
+		// 1) sqlparser.EqualsSQLNode
+		// 2) sqlparser.CloneSQLNode
+		// 3) sqlparser.VisitSQLNode
+
+		// Target 1:
+		identical := sqlparser.EqualsSQLNode(inA, inA)
+		if !identical {
+			panic("Should be identical")
+		}
+		identical = sqlparser.EqualsSQLNode(inB, inB)
+		if !identical {
+			panic("Should be identical")
+		}
+
+		// Target 2:
+		newSQLNode := sqlparser.CloneSQLNode(inA)
+		if !sqlparser.EqualsSQLNode(inA, newSQLNode) {
+			panic("These two nodes should be identical")
+		}
+
+		// Target 3:
+		_ = sqlparser.VisitSQLNode(inA, func(node sqlparser.SQLNode) (bool, error) { return false, nil })
+	})
+}

--- a/go/test/fuzzing/nativefuzzing/parser_fuzzer_test.go
+++ b/go/test/fuzzing/nativefuzzing/parser_fuzzer_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nativefuzzing
+
+import (
+	"testing"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzIsDML(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		_ = sqlparser.IsDML(data)
+	})
+}
+
+func FuzzNormalizer(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		stmt, reservedVars, err := sqlparser.Parse2(data)
+		if err != nil {
+			return
+		}
+		bv := make(map[string]*querypb.BindVariable)
+		sqlparser.Normalize(stmt, sqlparser.NewReservedVars("bv", reservedVars), bv)
+	})
+}
+
+func FuzzParser(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		_, _ = sqlparser.Parse(data)
+	})
+}
+
+func FuzzNodeFormat(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		f := fuzz.NewConsumer(data)
+		query, err := f.GetSQLString()
+		if err != nil {
+			return
+		}
+		node, err := sqlparser.Parse(query)
+		if err != nil {
+			return
+		}
+		buf := &sqlparser.TrackedBuffer{}
+		err = f.GenerateStruct(buf)
+		if err != nil {
+			return
+		}
+		node.Format(buf)
+	})
+}
+
+func FuzzSplitStatementToPieces(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		_, _ = sqlparser.SplitStatementToPieces(data)
+	})
+}

--- a/go/test/fuzzing/nativefuzzing/tablet_manager_fuzzer_test.go
+++ b/go/test/fuzzing/nativefuzzing/tablet_manager_fuzzer_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Vitess Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nativefuzzing
+
+import (
+	"context"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/mysqlctl/fakemysqldaemon"
+	"vitess.io/vitess/go/vt/vttablet/tabletmanager"
+	"vitess.io/vitess/go/vt/vttablet/tabletservermock"
+)
+
+func FuzzTabletManager_ExecuteFetchAsDba(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ctx := context.Background()
+		cp := mysql.ConnParams{}
+		db := fakesqldb.New(t)
+		db.AddQueryPattern(".*", &sqltypes.Result{})
+		daemon := fakemysqldaemon.NewFakeMysqlDaemon(db)
+
+		dbName := "dbname"
+		tm := &tabletmanager.TabletManager{
+			MysqlDaemon:         daemon,
+			DBConfigs:           dbconfigs.NewTestDBConfigs(cp, cp, dbName),
+			QueryServiceControl: tabletservermock.NewController(),
+		}
+		_, _ = tm.ExecuteFetchAsDba(ctx, data, dbName, 10, false, false)
+	})
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds fuzzers that are rewritten from the go-fuzz engine to the native fuzzing engine.
Because OSS-fuzz will support the native engine only when 1.18 is released, I suggest we wait with removing the go-fuzz version of the fuzzers and do a gradual transition. Once these fuzzers build and run in OSS-fuzz, their previous version can be removed.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
https://github.com/vitessio/vitess/issues/9479

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->