### PR TITLE
mysql: Add ConnectionReady callback to Handler interface

### DIFF
--- a/go/mysql/conn_flaky_test.go
+++ b/go/mysql/conn_flaky_test.go
@@ -820,6 +820,10 @@ func (t testRun) NewConnection(c *Conn) {
 	panic("implement me")
 }
 
+func (t testRun) ConnectionReady(c *Conn) {
+	panic("implement me")
+}
+
 func (t testRun) ConnectionClosed(c *Conn) {
 	panic("implement me")
 }

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -308,6 +308,11 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.connections[c.ConnectionID] = c
 }
 
+// ConnectionReady is part of the mysql.Handler interface.
+func (db *DB) ConnectionReady(c *mysql.Conn) {
+
+}
+
 // ConnectionClosed is part of the mysql.Handler interface.
 func (db *DB) ConnectionClosed(c *mysql.Conn) {
 	db.mu.Lock()

--- a/go/mysql/mysql_fuzzer.go
+++ b/go/mysql/mysql_fuzzer.go
@@ -87,6 +87,9 @@ type fuzztestRun struct{}
 func (t fuzztestRun) NewConnection(c *Conn) {
 }
 
+func (t fuzztestRun) ConnectionReady(c *Conn) {
+}
+
 func (t fuzztestRun) ConnectionClosed(c *Conn) {
 }
 
@@ -273,6 +276,9 @@ func (th *fuzzTestHandler) NewConnection(c *Conn) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 	th.lastConn = c
+}
+
+func (th *fuzzTestHandler) ConnectionReady(_ *Conn) {
 }
 
 func (th *fuzzTestHandler) ConnectionClosed(_ *Conn) {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -94,6 +94,10 @@ type Handler interface {
 	// In particular, ServerStatusAutocommit might be set.
 	NewConnection(c *Conn)
 
+	// ConnectionReady is called after the connection handshake, but
+	// before we begin to process commands.
+	ConnectionReady(c *Conn)
+
 	// ConnectionClosed is called when a connection is closed.
 	ConnectionClosed(c *Conn)
 
@@ -469,6 +473,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		connSlow.Add(1)
 		log.Warningf("Slow connection from %s: %v", c, connectTime)
 	}
+
+	// Tell our handler that we're finished handshake and are ready to
+	// process commands.
+	l.handler.ConnectionReady(c)
 
 	for {
 		kontinue := c.handleNextCommand(l.handler)

--- a/go/mysql/server_flaky_test.go
+++ b/go/mysql/server_flaky_test.go
@@ -110,6 +110,9 @@ func (th *testHandler) NewConnection(c *Conn) {
 	th.lastConn = c
 }
 
+func (th *testHandler) ConnectionReady(_ *Conn) {
+}
+
 func (th *testHandler) ConnectionClosed(_ *Conn) {
 }
 

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -102,6 +102,8 @@ func (vh *vtgateHandler) NewConnection(c *mysql.Conn) {
 	vh.connections[c] = true
 }
 
+func (vh *vtgateHandler) ConnectionReady(_ *mysql.Conn) {}
+
 func (vh *vtgateHandler) numConnections() int {
 	vh.mu.Lock()
 	defer vh.mu.Unlock()

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -46,6 +46,9 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 	th.lastConn = c
 }
 
+func (th *testHandler) ConnectionReady(c *mysql.Conn) {
+}
+
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 


### PR DESCRIPTION
This is is useful to determine the intermediate state after
NewConnection and before ConnectionClosed, basically for a handler to
know if authentication, etc, were successful. NewConnection is way too
soon in the process to determine if the connection got fully
established.

Signed-off-by: Matt Robenolt <matt@ydekproductions.com>

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required