### PR TITLE
Fixed legacy vreplication data that may be using master tablet type

### DIFF
--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -167,9 +167,6 @@ var AllTabletTypes = []topodatapb.TabletType{
 
 // ParseTabletType parses the tablet type into the enum.
 func ParseTabletType(param string) (topodatapb.TabletType, error) {
-	if strings.ToUpper(param) == "MASTER" {
-		param = "PRIMARY"
-	}
 	value, ok := topodatapb.TabletType_value[strings.ToUpper(param)]
 	if !ok {
 		return topodatapb.TabletType_UNKNOWN, fmt.Errorf("unknown TabletType %v", param)

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -66,9 +66,7 @@ func TestControllerKeyRange(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -105,9 +103,7 @@ func TestControllerTables(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -201,9 +197,7 @@ func TestControllerOverrides(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -269,16 +263,12 @@ func TestControllerRetry(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", nil, errors.New("(expected error)"))
 	dbClient.ExpectRequest("update _vt.vreplication set state='Error', message='error (expected error) in selecting vreplication settings select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1' where id=1", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -310,9 +300,7 @@ func TestControllerStopPosition(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	withStop := &sqltypes.Result{

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -66,6 +66,9 @@ func TestControllerKeyRange(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -102,6 +105,9 @@ func TestControllerTables(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -195,6 +201,9 @@ func TestControllerOverrides(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -260,10 +269,16 @@ func TestControllerRetry(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", nil, errors.New("(expected error)"))
 	dbClient.ExpectRequest("update _vt.vreplication set state='Error', message='error (expected error) in selecting vreplication settings select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1' where id=1", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -295,6 +310,9 @@ func TestControllerStopPosition(t *testing.T) {
 	}
 
 	dbClient := binlogplayer.NewMockDBClient(t)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	withStop := &sqltypes.Result{

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -67,7 +67,10 @@ var withDDL *withddl.WithDDL
 var withDDLInitialQueries []string
 
 const (
-	throttlerAppName = "vreplication"
+	throttlerAppName               = "vreplication"
+	changeMasterToPrimary          = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')`
+	changeLowercaseMasterToPrimary = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')`
+	changeCamelcaseMasterToPrimary = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')`
 )
 
 func init() {
@@ -77,6 +80,7 @@ func init() {
 	allddls = append(allddls, createVReplicationLogTable)
 	withDDL = withddl.New(allddls)
 
+	withDDLInitialQueries = append(withDDLInitialQueries, changeMasterToPrimary, changeLowercaseMasterToPrimary, changeCamelcaseMasterToPrimary)
 	withDDLInitialQueries = append(withDDLInitialQueries, binlogplayer.WithDDLInitialQueries...)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -67,10 +67,8 @@ var withDDL *withddl.WithDDL
 var withDDLInitialQueries []string
 
 const (
-	throttlerAppName               = "vreplication"
-	changeMasterToPrimary          = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')`
-	changeLowercaseMasterToPrimary = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')`
-	changeCamelcaseMasterToPrimary = `UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')`
+	throttlerAppName      = "vreplication"
+	changeMasterToPrimary = `update _vt.vreplication set tablet_types = replace(lower(convert(tablet_types using utf8mb4)), 'master', 'primary') where instr(convert(tablet_types using utf8mb4), 'master');`
 )
 
 func init() {
@@ -80,7 +78,7 @@ func init() {
 	allddls = append(allddls, createVReplicationLogTable)
 	withDDL = withddl.New(allddls)
 
-	withDDLInitialQueries = append(withDDLInitialQueries, changeMasterToPrimary, changeLowercaseMasterToPrimary, changeCamelcaseMasterToPrimary)
+	withDDLInitialQueries = append(withDDLInitialQueries, changeMasterToPrimary)
 	withDDLInitialQueries = append(withDDLInitialQueries, binlogplayer.WithDDLInitialQueries...)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -163,9 +163,7 @@ func TestEngineExec(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}|PRIMARY,REPLICA`, env.KeyspaceName),
 	), nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -208,9 +206,7 @@ func TestEngineExec(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	), nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -531,9 +527,7 @@ func TestCreateDBAndTable(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	), nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
-	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest(changeMasterToPrimary, testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)

--- a/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine_test.go
@@ -50,10 +50,10 @@ func TestEngineOpen(t *testing.T) {
 
 	dbClient.ExpectRequest("select * from _vt.vreplication where db_name='db'", sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
-			"id|state|source",
-			"int64|varchar|varchar",
+			"id|state|source|tablet_types",
+			"int64|varchar|varchar|varbinary",
 		),
-		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
+		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}|PRIMARY,REPLICA`, env.KeyspaceName),
 	), nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
@@ -158,11 +158,14 @@ func TestEngineExec(t *testing.T) {
 	dbClient.ExpectRequest("insert into _vt.vreplication values(null)", &sqltypes.Result{InsertID: 1}, nil)
 	dbClient.ExpectRequest("select * from _vt.vreplication where id = 1", sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
-			"id|state|source",
-			"int64|varchar|varchar",
+			"id|state|source|tablet_types",
+			"int64|varchar|varchar|varbinary",
 		),
-		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
+		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}|PRIMARY,REPLICA`, env.KeyspaceName),
 	), nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -205,6 +208,9 @@ func TestEngineExec(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	), nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)
@@ -525,6 +531,9 @@ func TestCreateDBAndTable(t *testing.T) {
 		),
 		fmt.Sprintf(`1|Running|keyspace:"%s" shard:"0" key_range:{end:"\x80"}`, env.KeyspaceName),
 	), nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'MASTER', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'master', 'PRIMARY')", testDMLResponse, nil)
+	dbClient.ExpectRequest("UPDATE _vt.vreplication SET tablet_types=REPLACE(tablet_types, 'Master', 'PRIMARY')", testDMLResponse, nil)
 	dbClient.ExpectRequestRE("update _vt.vreplication set message='Picked source tablet.*", testDMLResponse, nil)
 	dbClient.ExpectRequest("update _vt.vreplication set state='Running', message='' where id=1", testDMLResponse, nil)
 	dbClient.ExpectRequest("select pos, stop_pos, max_tps, max_replication_lag, state from _vt.vreplication where id=1", testSettingsResponse, nil)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When people update to a new version, any instances of "master" in the vreplication table should be changed to "primary".

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->