### PR TITLE
Fix how `Check Label` is run during upgrade downgrade testing

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving.yml
@@ -19,7 +19,8 @@ jobs:
       hasLabel: ${{ steps.check_label.outputs.hasLabel }}
 
     steps:
-      - name: Check Label
+      - name: Check Label for PR
+        if: github.event_name == 'pull_request'
         uses: Dreamcodeio/pr-has-label-action@master
         id: check_label
         with:


### PR DESCRIPTION
## Description

Following the release of the new automation around upgrade downgrade testing, @deepthi observed a bug in the CI. The bug appears when a commit onto a pull request created from a `vitessio/vitess` branch (instead of a remote branch). Pushing a commit on a `vitessio/vitess` branch triggers a `push` event on GitHub Actions. Since the Actions is started by a `push` and not by a `pull_request` event, previously the `get_upgrade_downgrade_label.Check Label` step would fail since there are no labels attached to push/commit.

To fix this issue, an if statement is added to `get_upgrade_downgrade_label.Check Label` (later renamed to `Check Label for PR`) to enable the step only if the event triggering the workflow is `pull_request`. 

## Related Issue(s)

- This fix should be ported to https://github.com/vitessio/vitess/pull/9473 before it is merged

## Checklist
- [x] Tests were added or are not required
- [x] Documentation was added or is not required