### PR TITLE
sizegen: add support for arrays

### DIFF
--- a/go/mysql/collations/cached_size.go
+++ b/go/mysql/collations/cached_size.go
@@ -31,6 +31,10 @@ func (cached *eightbitWildcard) CachedSize(alloc bool) int64 {
 	if alloc {
 		size += int64(32)
 	}
+	// field sort *[256]byte
+	if cached.sort != nil {
+		size += hack.RuntimeAllocSize(int64(cap(*cached.sort)))
+	}
 	// field pattern []int16
 	{
 		size += hack.RuntimeAllocSize(int64(cap(cached.pattern)) * int64(2))

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -285,7 +285,7 @@ func (cached *Insert) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(144)
+		size += int64(176)
 	}
 	// field Keyspace *vitess.io/vitess/go/vt/vtgate/vindexes.Keyspace
 	size += cached.Keyspace.CachedSize(true)
@@ -308,6 +308,13 @@ func (cached *Insert) CachedSize(alloc bool) int64 {
 					}
 				}
 			}
+		}
+	}
+	// field ColVindexes []*vitess.io/vitess/go/vt/vtgate/vindexes.ColumnVindex
+	{
+		size += hack.RuntimeAllocSize(int64(cap(cached.ColVindexes)) * int64(8))
+		for _, elem := range cached.ColVindexes {
+			size += elem.CachedSize(true)
 		}
 	}
 	// field Table *vitess.io/vitess/go/vt/vtgate/vindexes.Table

--- a/go/vt/vtgate/vindexes/cached_size.go
+++ b/go/vt/vtgate/vindexes/cached_size.go
@@ -107,7 +107,7 @@ func (cached *ColumnVindex) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(80)
+		size += int64(112)
 	}
 	// field Columns []vitess.io/vitess/go/vt/sqlparser.ColIdent
 	{
@@ -256,6 +256,47 @@ func (cached *LookupUnique) CachedSize(alloc bool) int64 {
 	size += hack.RuntimeAllocSize(int64(len(cached.name)))
 	// field lkp vitess.io/vitess/go/vt/vtgate/vindexes.lookupInternal
 	size += cached.lkp.CachedSize(false)
+	return size
+}
+
+//go:nocheckptr
+func (cached *MultiCol) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(48)
+	}
+	// field name string
+	size += hack.RuntimeAllocSize(int64(len(cached.name)))
+	// field columnVdx map[int]vitess.io/vitess/go/vt/vtgate/vindexes.Hashing
+	if cached.columnVdx != nil {
+		size += int64(48)
+		hmap := reflect.ValueOf(cached.columnVdx)
+		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
+		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
+		size += hack.RuntimeAllocSize(int64(numOldBuckets * 208))
+		if len(cached.columnVdx) > 0 || numBuckets > 1 {
+			size += hack.RuntimeAllocSize(int64(numBuckets * 208))
+		}
+		for _, v := range cached.columnVdx {
+			if cc, ok := v.(cachedObject); ok {
+				size += cc.CachedSize(true)
+			}
+		}
+	}
+	// field columnBytes map[int]int
+	if cached.columnBytes != nil {
+		size += int64(48)
+		hmap := reflect.ValueOf(cached.columnBytes)
+		numBuckets := int(math.Pow(2, float64((*(*uint8)(unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
+		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
+		size += hack.RuntimeAllocSize(int64(numOldBuckets * 144))
+		if len(cached.columnBytes) > 0 || numBuckets > 1 {
+			size += hack.RuntimeAllocSize(int64(numBuckets * 144))
+		}
+	}
 	return size
 }
 func (cached *Null) CachedSize(alloc bool) int64 {


### PR DESCRIPTION
## Description

We never got around to implementing support for Array types in `sizegen`, so the size of the wildcard struct, which kept a pointer to an array inside, was slightly off.

cc @systay 

## Related Issue(s)


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->