### PR TITLE
Fix flakiness in reparent tests

### DIFF
--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -23,7 +23,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
@@ -125,7 +128,7 @@ ssl_key={{.Dir}}/server-001-key.pem
 	return tmpProcess, tmpProcess.Start()
 }
 
-// Stop executes mysqlctl command to stop mysql instance
+// Stop executes mysqlctl command to stop mysql instance and kills the mysql instance if it doesn't shutdown in 30 seconds.
 func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 	log.Infof("Shutting down MySQL: %d", mysqlctl.TabletUID)
 	defer log.Infof("MySQL shutdown complete: %d", mysqlctl.TabletUID)
@@ -133,7 +136,35 @@ func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 	if err != nil {
 		return err
 	}
-	return tmpProcess.Wait()
+	// On the CI it was noticed that MySQL shutdown hangs sometimes and
+	// on local investigation it was waiting on SEMI_SYNC acks for an internal command
+	// of Vitess even after closing the socket file.
+	// To prevent this process for hanging for 5 minutes, we will add a 30-second timeout.
+	exit := make(chan error)
+	go func() {
+		exit <- tmpProcess.Wait()
+	}()
+	select {
+	case <-time.After(30 * time.Second):
+		break
+	case err := <-exit:
+		if err == nil {
+			return nil
+		}
+		break
+	}
+	pidFile := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.pid", mysqlctl.TabletUID))
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		// We can't read the file which means the PID file does not exist
+		// The server must have stopped
+		return nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		return err
+	}
+	return syscall.Kill(pid, syscall.SIGKILL)
 }
 
 // StopProcess executes mysqlctl command to stop mysql instance and returns process reference

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -140,6 +140,7 @@ func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 func (mysqlctl *MysqlctlProcess) StopProcess() (*exec.Cmd, error) {
 	tmpProcess := exec.Command(
 		mysqlctl.Binary,
+		"-log_dir", mysqlctl.LogDirectory,
 		"-tablet_uid", fmt.Sprintf("%d", mysqlctl.TabletUID),
 	)
 	if *isCoverage {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

It was noticed that the cluster 14 tests were a little flaky and on further investigation, it turned out that the reason for this flakiness was MySQL not shutting down properly and using the full 5 minute wait time given to it. On further investigation and looking at logs with @mattlord, it turned out that the reason that MySQL was hanging was because it was waiting for a Semi-sync ack for an internal Vitess command (guess) even though the socket file had disappeared and all the connections to the replicas had been closed. We are still unsure whether this is a MySQL bug or some configuration issue.
We discussed 3 possible solutions for fixing the CI - 
1. reduce the wait_time for the semi-sync acks by reducing the value for `rpl_semi_sync_master_timeout`. But this parameter is only available in 8.0 and the CI are running 5.7. Also this parameter would have to be changed after MySQL startup since the my.cnf file is setup by mysqlctl on startup.
2. Verify that the command that we are issuing from the tests on the primary are necessarily ACKed. This isn't required since the command would not have successfully returned until it was ACKed. It would have been blocked. So my guess is that the command blocked for semi-sync ACKs isn't the one issued from the tests but is an internal Vitess command that we run on primaries when it is first setup like setting up the local_metadata table, etc.
3. Reduce the time to wait for mysql to shutdown and kill the instance after it. To me 30 seconds seems like a reasonable amount of time to provided mysql to shutdown before killing it.

This PR goes ahead with the third alternate and kills the MySQL instance by using the pid file after 30 seconds if it hasn't shutdown already.

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->


## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->