### PR TITLE
WIP: VStreamer: improve representation of integers in json data types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,6 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
-	github.com/spyzhov/ajson v0.4.2
 	github.com/stretchr/testify v1.7.0
 	github.com/tchap/go-patricia v2.2.6+incompatible
 	github.com/tebeka/selenium v0.9.9

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.29.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
+	github.com/rohit-nayak-ps/ajson v0.7.3
 	github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e
 	github.com/sjmudd/stopwatch v0.0.0-20170613150411-f380bf8a9be1
 	github.com/soheilhy/cmux v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,8 @@ github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rohit-nayak-ps/ajson v0.7.3 h1:dJG+5sWk5Q0tn3tl1ltWPU3V9vA0AAsCKMJ3m/CYN1M=
+github.com/rohit-nayak-ps/ajson v0.7.3/go.mod h1:ApWx7TjNA9X23L+BVqfKKlasFe1Hknqapgz0Ue9uhi8=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/go.sum
+++ b/go.sum
@@ -723,8 +723,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/spyzhov/ajson v0.4.2 h1:JMByd/jZApPKDvNsmO90X2WWGbmT2ahDFp73QhZbg3s=
-github.com/spyzhov/ajson v0.4.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/go/mysql/binlog_event_json_test.go
+++ b/go/mysql/binlog_event_json_test.go
@@ -18,50 +18,65 @@ package mysql
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestJSONTypes(t *testing.T) {
+	// most of these test cases have been taken from open source java/python adapters
+	// like https://github.com/shyiko/mysql-binlog-connector-java/pull/119/files
 	testcases := []struct {
+		name     string
 		data     []byte
 		expected string
 		isMap    bool
 	}{{
+		name:     "null",
 		data:     []byte{},
 		expected: `null`,
 	}, {
+		name:     "map, string value",
 		data:     []byte{0, 1, 0, 14, 0, 11, 0, 1, 0, 12, 12, 0, 97, 1, 98},
 		expected: `{"a":"b"}`,
 	}, {
+		name:     "map, int value",
 		data:     []byte{0, 1, 0, 12, 0, 11, 0, 1, 0, 5, 2, 0, 97},
 		expected: `{"a":2}`,
 	}, {
+		name:     "map, object value",
 		data:     []byte{0, 1, 0, 29, 0, 11, 0, 4, 0, 0, 15, 0, 97, 115, 100, 102, 1, 0, 14, 0, 11, 0, 3, 0, 5, 123, 0, 102, 111, 111},
 		expected: `{"asdf":{"foo":123}}`,
 	}, {
+		name:     "list of ints",
 		data:     []byte{2, 2, 0, 10, 0, 5, 1, 0, 5, 2, 0},
 		expected: `[1,2]`,
 	}, {
+		name:     "list of maps",
 		data:     []byte{0, 4, 0, 60, 0, 32, 0, 1, 0, 33, 0, 1, 0, 34, 0, 2, 0, 36, 0, 2, 0, 12, 38, 0, 12, 40, 0, 12, 42, 0, 2, 46, 0, 97, 99, 97, 98, 98, 99, 1, 98, 1, 100, 3, 97, 98, 99, 2, 0, 14, 0, 12, 10, 0, 12, 12, 0, 1, 120, 1, 121},
 		expected: `{"a":"b","c":"d","ab":"abc","bc":["x","y"]}`,
 		isMap:    true,
 	}, {
+		name:     "list with one string",
 		data:     []byte{2, 1, 0, 37, 0, 12, 8, 0, 0, 4, 104, 101, 114, 101},
 		expected: `["here"]`,
 	}, {
+		name:     "list varied",
 		data:     []byte{2, 3, 0, 37, 0, 12, 13, 0, 2, 18, 0, 12, 33, 0, 4, 104, 101, 114, 101, 2, 0, 15, 0, 12, 10, 0, 12, 12, 0, 1, 73, 2, 97, 109, 3, 33, 33, 33},
 		expected: `["here",["I","am"],"!!!"]`,
 	}, {
+		name:     "string",
 		data:     []byte{12, 13, 115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
 		expected: `"scalar string"`,
 	}, {
+		name:     "map, long string value",
 		data:     []byte{0, 1, 0, 149, 0, 11, 0, 6, 0, 12, 17, 0, 115, 99, 111, 112, 101, 115, 130, 1, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 69, 65, 65, 65, 65, 65, 65, 56, 65, 65, 65, 66, 103, 65, 65, 65, 65, 65, 65, 66, 65, 65, 65, 65, 67, 65, 65, 65, 65, 65, 65, 65, 65, 65, 84, 216, 142, 184},
 		expected: `{"scopes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAEAAAAAAEAAAAAA8AAABgAAAAAABAAAACAAAAAAAAA"}`,
 	}, {
 		// repeat the same string 10 times, to test the case where length of string
 		// requires 2 bytes to store
+		name: "long string",
 		data: []byte{12, 130, 1,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103,
@@ -75,89 +90,139 @@ func TestJSONTypes(t *testing.T) {
 			115, 99, 97, 108, 97, 114, 32, 115, 116, 114, 105, 110, 103},
 		expected: `"scalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar stringscalar string"`,
 	}, {
+		name:     "bool true",
 		data:     []byte{4, 1},
 		expected: `true`,
 	}, {
+		name:     "bool false",
 		data:     []byte{4, 2},
 		expected: `false`,
 	}, {
+		name:     "bool null",
 		data:     []byte{4, 0},
 		expected: `null`,
 	}, {
+		name:     "uint16 max",
+		data:     []byte{6, 255, 255},
+		expected: `65535`,
+	}, {
+		name:     "uint32 max",
+		data:     []byte{8, 255, 255, 255, 255},
+		expected: `4294967295`,
+	}, {
+		name:     "uint64 max",
+		data:     []byte{10, 255, 255, 255, 255, 255, 255, 255, 255},
+		expected: `18446744073709551615`,
+	}, {
+		name:     "int16 -1",
 		data:     []byte{5, 255, 255},
 		expected: `-1`,
 	}, {
-		data:     []byte{6, 1, 0},
-		expected: `1`,
+		name:     "int32 -1",
+		data:     []byte{7, 255, 255, 255, 255},
+		expected: `-1`,
 	}, {
+		name:     "int64 -1",
+		data:     []byte{9, 255, 255, 255, 255, 255, 255, 255, 255},
+		expected: `-1`,
+	}, {
+		name:     "int16 max",
 		data:     []byte{5, 255, 127},
 		expected: `32767`,
 	}, {
+		name:     "int32 max",
+		data:     []byte{7, 255, 255, 255, 127},
+		expected: `2147483647`,
+	}, {
+		name:     "int64 max",
+		data:     []byte{9, 255, 255, 255, 255, 255, 255, 255, 127},
+		expected: `9223372036854775807`,
+	}, {
+		name:     "uint16/1",
+		data:     []byte{6, 1, 0},
+		expected: `1`,
+	}, {
+		name:     "int32/32768",
 		data:     []byte{7, 0, 128, 0, 0},
 		expected: `32768`,
 	}, {
+		name:     "int16/neg",
 		data:     []byte{5, 0, 128},
 		expected: `-32768`,
 	}, {
+		name:     "int32/neg",
 		data:     []byte{7, 255, 127, 255, 255},
 		expected: `-32769`,
 	}, {
-		data:     []byte{7, 255, 255, 255, 127},
-		expected: `2.147483647e+09`,
-	}, {
+		name:     "uint32",
 		data:     []byte{8, 0, 128, 0, 0},
 		expected: `32768`,
 	}, {
+		name:     "int64",
 		data:     []byte{9, 0, 0, 0, 128, 0, 0, 0, 0},
-		expected: `2.147483648e+09`,
+		expected: `2147483648`,
 	}, {
+		name:     "int32/neg",
 		data:     []byte{7, 0, 0, 0, 128},
-		expected: `-2.147483648e+09`,
+		expected: `-2147483648`,
 	}, {
+		name:     "int64/neg",
 		data:     []byte{9, 255, 255, 255, 127, 255, 255, 255, 255},
-		expected: `-2.147483649e+09`,
+		expected: `-2147483649`,
 	}, {
+		name:     "uint64",
 		data:     []byte{10, 255, 255, 255, 255, 255, 255, 255, 255},
-		expected: `1.8446744073709552e+19`,
+		expected: `18446744073709551615`,
 	}, {
+		name:     "int64/neg",
 		data:     []byte{9, 0, 0, 0, 0, 0, 0, 0, 128},
-		expected: `-9.223372036854776e+18`,
+		expected: `-9223372036854775808`,
 	}, {
+		name:     "double",
 		data:     []byte{11, 110, 134, 27, 240, 249, 33, 9, 64},
 		expected: `3.14159`,
 	}, {
+		name:     "empty map",
 		data:     []byte{0, 0, 0, 4, 0},
 		expected: `{}`,
 	}, {
+		name:     "empty list",
 		data:     []byte{2, 0, 0, 4, 0},
 		expected: `[]`,
 	}, {
 		// opaque, datetime
+		name:     "datetime",
 		data:     []byte{15, 12, 8, 0, 0, 0, 25, 118, 31, 149, 25},
 		expected: `"2015-01-15 23:24:25.000000"`,
 	}, {
 		// opaque, time
+		name:     "time",
 		data:     []byte{15, 11, 8, 0, 0, 0, 25, 118, 1, 0, 0},
 		expected: `"23:24:25.000000"`,
 	}, {
 		// opaque, time
+		name:     "time2",
 		data:     []byte{15, 11, 8, 192, 212, 1, 25, 118, 1, 0, 0},
 		expected: `"23:24:25.120000"`,
 	}, {
 		// opaque, date
+		name:     "date",
 		data:     []byte{15, 10, 8, 0, 0, 0, 0, 0, 30, 149, 25},
 		expected: `"2015-01-15"`,
 	}, {
 		// opaque, decimal
+		name:     "decimal",
 		data:     []byte{15, 246, 8, 13, 4, 135, 91, 205, 21, 4, 210},
 		expected: `1.234567891234e+08`,
 	}, {
 		// opaque, bit field. Not yet implemented.
+		name:     "bitfield: unimplemented",
 		data:     []byte{15, 16, 2, 202, 254},
 		expected: `opaque type 16 is not supported yet, data [2 202 254]`,
 	}}
 	for _, tc := range testcases {
-		t.Run(tc.expected, func(t *testing.T) {
+		name := fmt.Sprintf("%s (%s)", tc.name, tc.expected)
+		t.Run(name, func(t *testing.T) {
 			val, err := getJSONValue(tc.data)
 			if err != nil {
 				require.Equal(t, tc.expected, err.Error())

--- a/go/test/endtoend/vreplication/unsharded_init_data.sql
+++ b/go/test/endtoend/vreplication/unsharded_init_data.sql
@@ -1,6 +1,6 @@
 insert into customer(cid, name, typ, sport, meta) values(1, 'john',1,'football,baseball','{}');
 insert into customer(cid, name, typ, sport, meta) values(2, 'paul','soho','cricket',convert(x'7b7d' using utf8mb4));
-insert into customer(cid, name, typ, sport) values(3, 'ringo','enterprise','');
+insert into customer(cid, name, typ, sport, meta) values(3, 'ringo','enterprise','',null);
 insert into merchant(mname, category) values('monoprice', 'electronics');
 insert into merchant(mname, category) values('newegg', 'electronics');
 insert into product(pid, description) values(1, 'keyboard');
@@ -13,5 +13,3 @@ insert into customer2(cid, name, typ, sport) values(2, 'paul','soho','cricket');
 insert into customer2(cid, name, typ, sport) values(3, 'ringo','enterprise','');
 -- for testing edge case where inserted binary value is 15 bytes, field is 16, mysql adds a null while storing but binlog returns 15 bytes
 insert into tenant(tenant_id, name) values (x'02BD00987932461E8820C908E84BAE', 'abc');
-
-

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -340,9 +340,11 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 		productTab := vc.Cells[defaultCell.Name].Keyspaces["product"].Shards["0"].Tablets["zone1-100"].Vttablet
 		query := "select * from customer"
 		require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", query, query))
-		insertQuery1 := "insert into customer(cid, name) values(1001, 'tempCustomer1')"
-		matchInsertQuery1 := "insert into customer(cid, `name`) values (:vtg1, :vtg2)"
-		require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery1))
+		insertQuery1 := "insert into customer(cid, name, meta) values(1001, 'tempCustomer1', '{\"a\": 1629849600, \"b\": 930701976723823}')"
+
+		matchInsertQuery0 := "insert into customer(cid, `name`) values (:vtg1, :vtg2)"
+		matchInsertQuery1 := "insert into customer(cid, `name`, meta) values (:vtg1, :vtg2, :vtg3)"
+		validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery1)
 		execVtgateQuery(t, vtgateConn, "product", "update tenant set name='xyz'")
 		vdiff(t, ksWorkflow, "")
 		switchReadsDryRun(t, allCellNames, ksWorkflow, dryRunResultsReadCustomerShard)
@@ -376,12 +378,12 @@ func shardCustomer(t *testing.T, testReverse bool, cells []*Cell, sourceCellOrAl
 			require.Contains(t, output, "'customer.bmd5'")
 
 			insertQuery1 = "insert into customer(cid, name) values(1002, 'tempCustomer5')"
-			require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery1))
+			require.True(t, validateThatQueryExecutesOnTablet(t, vtgateConn, productTab, "product", insertQuery1, matchInsertQuery0))
 			// both inserts go into 80-, this tests the edge-case where a stream (-80) has no relevant new events after the previous switch
 			insertQuery1 = "insert into customer(cid, name) values(1003, 'tempCustomer6')"
-			require.False(t, validateThatQueryExecutesOnTablet(t, vtgateConn, customerTab1, "customer", insertQuery1, matchInsertQuery1))
+			require.False(t, validateThatQueryExecutesOnTablet(t, vtgateConn, customerTab1, "customer", insertQuery1, matchInsertQuery0))
 			insertQuery1 = "insert into customer(cid, name) values(1004, 'tempCustomer7')"
-			require.False(t, validateThatQueryExecutesOnTablet(t, vtgateConn, customerTab2, "customer", insertQuery1, matchInsertQuery1))
+			require.False(t, validateThatQueryExecutesOnTablet(t, vtgateConn, customerTab2, "customer", insertQuery1, matchInsertQuery0))
 
 			//Go forward again
 			switchReads(t, allCellNames, ksWorkflow)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -28,7 +28,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 
-	"github.com/spyzhov/ajson"
+	"github.com/rohit-nayak-ps/ajson"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/log"
@@ -1308,7 +1308,7 @@ func TestPlayerRowMove(t *testing.T) {
 
 func TestPlayerTypes(t *testing.T) {
 	log.Errorf("TestPlayerTypes: flavor is %s", env.Flavor)
-	enableJSONColumnTesting := false
+	enableJSONColumnTesting := true
 	flavor := strings.ToLower(env.Flavor)
 	// Disable tests on percona (which identifies as mysql56) and mariadb platforms in CI since they
 	// either don't support JSON or JSON support is not enabled by default
@@ -1435,21 +1435,21 @@ func TestPlayerTypes(t *testing.T) {
 	}}
 	if enableJSONColumnTesting {
 		testcases = append(testcases, testcase{
-			input: "insert into vitess_json(val1,val2,val3,val4,val5) values (null,'{}','123','{\"a\":[42,100]}', '{\"foo\":\"bar\"}')",
+			input: "insert into vitess_json(val1,val2,val3,val4,val5) values (null,'{}','1629849600','{\"a\":[42,-1,3.1415,-128,127,-9223372036854775808,9223372036854775807,18446744073709551615]}', '{\"foo\":\"bar\"}')",
 			output: "insert into vitess_json(id,val1,val2,val3,val4,val5) values (1," +
-				"convert(null using utf8mb4)," + "convert('{}' using utf8mb4)," + "convert('123' using utf8mb4)," +
-				"convert('{\\\"a\\\":[42,100]}' using utf8mb4)," + "convert('{\\\"foo\\\":\\\"bar\\\"}' using utf8mb4))",
+				"convert(null using utf8mb4)," + "convert('{}' using utf8mb4)," + "convert('1629849600' using utf8mb4)," +
+				"convert('{\\\"a\\\":[42,-1,3.1415,-128,127,-9223372036854775808,9223372036854775807,18446744073709551615]}' using utf8mb4)," + "convert('{\\\"foo\\\":\\\"bar\\\"}' using utf8mb4))",
 			table: "vitess_json",
 			data: [][]string{
-				{"1", "", "{}", "123", `{"a": [42, 100]}`, `{"foo": "bar"}`},
+				{"1", "", "{}", "1629849600", `{"a": [42, -1, 3.1415, -128, 127, -9223372036854775808, 9223372036854775807, 18446744073709551615]}`, `{"foo": "bar"}`},
 			},
 		})
 		testcases = append(testcases, testcase{
-			input:  "update vitess_json set val4 = '{\"a\": [98, 123]}', val5 = convert(x'7b7d' using utf8mb4)",
-			output: "update vitess_json set val1=convert(null using utf8mb4), val2=convert('{}' using utf8mb4), val3=convert('123' using utf8mb4), val4=convert('{\\\"a\\\":[98,123]}' using utf8mb4), val5=convert('{}' using utf8mb4) where id=1",
+			input:  "update vitess_json set val4 = '{\"a\": [-9223372036854775808, -2147483648]}', val5 = convert(x'7b7d' using utf8mb4)",
+			output: "update vitess_json set val1=convert(null using utf8mb4), val2=convert('{}' using utf8mb4), val3=convert('1629849600' using utf8mb4), val4=convert('{\\\"a\\\":[-9223372036854775808,-2147483648]}' using utf8mb4), val5=convert('{}' using utf8mb4) where id=1",
 			table:  "vitess_json",
 			data: [][]string{
-				{"1", "", "{}", "123", `{"a": [98, 123]}`, `{}`},
+				{"1", "", "{}", "1629849600", `{"a": [-9223372036854775808, -2147483648]}`, `{}`},
 			},
 		})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1308,7 +1308,7 @@ func TestPlayerRowMove(t *testing.T) {
 
 func TestPlayerTypes(t *testing.T) {
 	log.Errorf("TestPlayerTypes: flavor is %s", env.Flavor)
-	enableJSONColumnTesting := true
+	enableJSONColumnTesting := false
 	flavor := strings.ToLower(env.Flavor)
 	// Disable tests on percona (which identifies as mysql56) and mariadb platforms in CI since they
 	// either don't support JSON or JSON support is not enabled by default


### PR DESCRIPTION
## Description
The binlog parser in vstreamer uses the github.com/spyzhov/ajson module to decode the value from the binlog image to its json value. However the library only supports a single type Numeric (float64) as a catchall for all numeric types including signed and unsigned integers. Due to this the generated JSON represents integers as floats and the string representation in a vevent can contain decimals or values in a scientific notation. So integers can be stored as floats on the target and larger ints sent with scientific notation in vstream events. 

This results in VDiff failures since the json strings stored are different. Also parsing the vevents sent using the VStream API can result in errors if, for example, the json is being parsed by golang. See https://github.com/vitessio/vitess/issues/8686. 

Note: This PR uses a forked version of the library https://github.com/rohit-nayak-ps/ajson that adds Integer and UnsignedInteger data type json Nodes. The Draft PR is pointing to that fork. More work (including more tests, addition of these types to the parsing flow) needs to be done before submitting a PR to upstream repo. 

## Related Issue(s)
https://github.com/vitessio/vitess/issues/8686

## Checklist
- [ ] Should this PR be backported?
- [X] Tests were added or are not required
- [ ] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->