### PR TITLE
Fix Ers to be used for initialization as well

### DIFF
--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -304,4 +304,5 @@ func TestERSForInitialization(t *testing.T) {
 	strArray := utils.GetShardReplicationPositions(t, clusterInstance, utils.KeyspaceName, utils.ShardName, true)
 	assert.Equal(t, len(tablets), len(strArray))
 	assert.Contains(t, strArray[0], "primary") // primary first
+	utils.ConfirmReplication(t, tablets[0], tablets[1:])
 }

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -235,3 +235,73 @@ func TestTwoReplicasNoReplicationStatus(t *testing.T) {
 	out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
 	require.NoError(t, err, out)
 }
+
+// TestERSForInitialization tests whether calling ERS in the beginning sets up the cluster properly or not
+func TestERSForInitialization(t *testing.T) {
+	var tablets []*cluster.Vttablet
+	clusterInstance := cluster.NewCluster("zone1", "localhost")
+	keyspace := &cluster.Keyspace{Name: utils.KeyspaceName}
+	// Start topo server
+	err := clusterInstance.StartTopo()
+	require.NoError(t, err)
+	err = clusterInstance.TopoProcess.ManageTopoDir("mkdir", "/vitess/"+"zone1")
+	require.NoError(t, err)
+	for i := 0; i < 4; i++ {
+		tablet := clusterInstance.NewVttabletInstance("replica", 100+i, "zone1")
+		tablets = append(tablets, tablet)
+	}
+
+	shard := &cluster.Shard{Name: utils.ShardName}
+	shard.Vttablets = tablets
+	clusterInstance.VtTabletExtraArgs = []string{
+		"-lock_tables_timeout", "5s",
+		"-enable_semi_sync",
+		"-init_populate_metadata",
+		"-track_schema_versions=true",
+	}
+
+	// Initialize Cluster
+	err = clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard})
+	require.NoError(t, err)
+
+	//Start MySql
+	var mysqlCtlProcessList []*exec.Cmd
+	for _, shard := range clusterInstance.Keyspaces[0].Shards {
+		for _, tablet := range shard.Vttablets {
+			log.Infof("Starting MySql for tablet %v", tablet.Alias)
+			proc, err := tablet.MysqlctlProcess.StartProcess()
+			require.NoError(t, err)
+			mysqlCtlProcessList = append(mysqlCtlProcessList, proc)
+		}
+	}
+	// Wait for mysql processes to start
+	for _, proc := range mysqlCtlProcessList {
+		if err := proc.Wait(); err != nil {
+			t.Fatalf("Error starting mysql: %s", err.Error())
+		}
+	}
+
+	for _, tablet := range tablets {
+		// Start the tablet
+		err = tablet.VttabletProcess.Setup()
+		require.NoError(t, err)
+	}
+	for _, tablet := range tablets {
+		err := tablet.VttabletProcess.WaitForTabletStatuses([]string{"SERVING", "NOT_SERVING"})
+		require.NoError(t, err)
+	}
+
+	// Force the replica to reparent assuming that all the datasets are identical.
+	res, err := utils.Ers(clusterInstance, tablets[0], "60s", "30s")
+	require.NoError(t, err, res)
+
+	utils.ValidateTopology(t, clusterInstance, true)
+	// create Tables
+	utils.RunSQL(context.Background(), t, "create table vt_insert_test (id bigint, msg varchar(64), primary key (id)) Engine=InnoDB", tablets[0])
+	utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
+	utils.ValidateTopology(t, clusterInstance, false)
+	time.Sleep(100 * time.Millisecond) // wait for replication to catchup
+	strArray := utils.GetShardReplicationPositions(t, clusterInstance, utils.KeyspaceName, utils.ShardName, true)
+	assert.Equal(t, len(tablets), len(strArray))
+	assert.Contains(t, strArray[0], "primary") // primary first
+}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -712,9 +712,16 @@ func (erp *EmergencyReparenter) promoteNewPrimary(
 	tabletMap map[string]*topo.TabletInfo,
 	statusMap map[string]*replicationdatapb.StopReplicationStatus,
 ) error {
-	erp.logger.Infof("starting promotion for the new primary - %v", newPrimary.Alias)
-	// we call PromoteReplica which changes the tablet type, fixes the semi-sync, set the primary to read-write and flushes the binlogs
-	_, err := erp.tmc.PromoteReplica(ctx, newPrimary)
+	var err error
+	if ev.ShardInfo.PrimaryAlias == nil {
+		erp.logger.Infof("setting up %v as new primary for an uninitialized cluster", newPrimary.Alias)
+		// we call InitPrimary when the PrimaryAlias in the ShardInfo is empty. This happens when we have an uninitialized cluster.
+		_, err = erp.tmc.InitPrimary(ctx, newPrimary)
+	} else {
+		erp.logger.Infof("starting promotion for the new primary - %v", newPrimary.Alias)
+		// we call PromoteReplica which changes the tablet type, fixes the semi-sync, set the primary to read-write and flushes the binlogs
+		_, err = erp.tmc.PromoteReplica(ctx, newPrimary)
+	}
 	if err != nil {
 		return vterrors.Wrapf(err, "primary-elect tablet %v failed to be upgraded to primary: %v", newPrimary.Alias, err)
 	}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -204,6 +204,12 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				{
 					Keyspace: "testkeyspace",
 					Name:     "-",
+					Shard: &topodatapb.Shard{
+						PrimaryAlias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -320,6 +326,12 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				{
 					Keyspace: "testkeyspace",
 					Name:     "-",
+					Shard: &topodatapb.Shard{
+						PrimaryAlias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -957,6 +969,12 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				{
 					Keyspace: "testkeyspace",
 					Name:     "-",
+					Shard: &topodatapb.Shard{
+						PrimaryAlias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -1068,6 +1086,12 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 				{
 					Keyspace: "testkeyspace",
 					Name:     "-",
+					Shard: &topodatapb.Shard{
+						PrimaryAlias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
 				},
 			},
 			tablets: []*topodatapb.Tablet{
@@ -1891,7 +1915,7 @@ func TestEmergencyReparenter_promoteNewPrimary(t *testing.T) {
 				Shard: &topodatapb.Shard{
 					PrimaryAlias: &topodatapb.TabletAlias{
 						Cell: "zone1",
-						Uid:  301,
+						Uid:  100,
 					},
 				},
 			}}
@@ -2268,6 +2292,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 				Cell: "zone1",
 				Uid:  100,
 			},
+			Type:     topodatapb.TabletType_PRIMARY,
 			Keyspace: "testkeyspace",
 			Shard:    "-",
 		},
@@ -2276,6 +2301,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 				Cell: "zone1",
 				Uid:  101,
 			},
+			Type:     topodatapb.TabletType_REPLICA,
 			Keyspace: "testkeyspace",
 			Shard:    "-",
 		},
@@ -2284,6 +2310,7 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 				Cell: "zone1",
 				Uid:  102,
 			},
+			Type:     topodatapb.TabletType_REPLICA,
 			Keyspace: "testkeyspace",
 			Shard:    "-",
 			Hostname: "most up-to-date position, wins election",
@@ -2296,13 +2323,11 @@ func TestEmergencyReparenterCounters(t *testing.T) {
 	ctx := context.Background()
 	logger := logutil.NewMemoryLogger()
 
-	for i, tablet := range tablets {
-		tablet.Type = topodatapb.TabletType_REPLICA
-		tablets[i] = tablet
-	}
-
 	testutil.AddShards(ctx, t, ts, shards...)
-	testutil.AddTablets(ctx, t, ts, nil, tablets...)
+	testutil.AddTablets(ctx, t, ts, &testutil.AddTabletOptions{
+		AlsoSetShardPrimary: true,
+		SkipShardCreation:   false,
+	}, tablets...)
 
 	erp := NewEmergencyReparenter(ts, tmc, logger)
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds support in `EmergencyReparentShard` to be used for initializing the shard too instead of `InitShardPrimary` or `PlannedReparentShard`. There were 2 fixes that were needed for the end to end test to work -
1. In `EmergencyReparentShard` we should be calling `InitPrimary` instead of `PromoteReplica` the first time around so that the initial database and tables are created before semi-sync settings are fixed. Otherwise the call just blocks and times out. This change is very similar to the one made in `PlannedReparentShard` in #9276. We are using the same criterion of `PrimaryAlias` in `ShardInfo` being nil to know that this is the first time a primary is being setup for the shard.
2. There is a bug that I found in `InitPrimary` RPC. In case we call `DemotePrimary` on one of the tablets, we will set `super_read_only` to true according to the default in the flag. This will cause the DDL commands in `InitPrimary` to fail. The fix is to turn off `super_read_only` before issuing those DDL commands.


## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
 - #8975 

## Checklist
- [ ] Should this PR be backported?
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->